### PR TITLE
Use MAX_ITEMS_PER_GET as the upper bound of items per get

### DIFF
--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -111,7 +111,7 @@ def submit_listen(user_id):
 
 @api_bp.route("/listen/user/<user_id>")
 def get_listens(user_id):
-    count = max(request.args.get('count') or DEFAULT_ITEMS_PER_GET, MAX_ITEMS_PER_GET)
+    count = min(request.args.get('count') or DEFAULT_ITEMS_PER_GET, MAX_ITEMS_PER_GET)
     max_ts = request.args.get('max_ts') or None
 
     cassandra = webserver.create_cassandra()


### PR DESCRIPTION
Calling min here makes sure that MAX_ITEMS_PER_GET is used instead of
DEFAULT_ITEMS_PER_GET or request.args.get('count') when either of them
is larger than MAX_ITEMS_PER_GET.

Fixes LB-12.

This commit is untested because I don't want to fight VirtualBox right now.