### PR TITLE
Use the length of listen_data as count

### DIFF
--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -124,7 +124,7 @@ def get_listens(user_id):
 
     return jsonify({'payload': {
         'user_id': user_id,
-        'count': count,
+        'count': len(listen_data),
         'listens': listen_data,
     }})
 


### PR DESCRIPTION
Nothing guarantees the user has actually listened to `count` (which is
defined by either count in the URL, DEFAULT_ITEMS_PER_GET or
MAX_ITEMS_PER_GET) tracks, so use the number of listens fetched earlier
as the count in the payload.

Fixes LB-7.

This commit is untested.