### PR TITLE
Remove space before period on homepage

### DIFF
--- a/webserver/templates/index/index.html
+++ b/webserver/templates/index/index.html
@@ -48,7 +48,7 @@
           need to be built and improved before this project will be useful to the general
           public. If you are a hacker and interested in helping out, please have a look
           at the <a href="https://github.com/metabrainz/listenbrainz-server">code repository</a>
-          or come visit us in the #metabrainz IRC channel on irc.freenode.net .
+          or come visit us in the #metabrainz IRC channel on irc.freenode.net.
         </p>
     </div>
 


### PR DESCRIPTION
Otherwise it goes to the next line.