### PR TITLE
Date fix for scraper

### DIFF
--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -53,7 +53,9 @@ var Scrobble = (function() {
 
         this.scrobbledAt = function() {
             var dateContainer = rootScrobbleElement.getElementsByClassName("chartlist-timestamp")[0]
-                var dateElement = dateContainer.getElementsByTagName("span")[0];
+            if (!dateContainer)
+                return 0;
+            var dateElement = dateContainer.getElementsByTagName("span")[0];
             var dateString = dateElement.getAttribute("title");
             //we have to do this because javascript's date parse method doesn't
             //directly accept lastfm's new date format but it does if we add the
@@ -166,7 +168,7 @@ function reportPage(response) {
 }
 
 function reportPageAndGetNext(response) {
-  document.getElementById("listen-progress-container").innerHTML = "<img src='https://i.imgur.com/7g0M2fW.jpg' height='75'><br><br><i class='fa fa-cog fa-spin'></i> Sending page " + page + " of " + numberOfPages + " to ListenBrainz<br> [completed: " + numCompleted + "]<br><span style='font-size:8pt'>Please don't navigate while this is running</span><br>";
+  document.getElementById("listen-progress-container").innerHTML = "<img src='{{ url_for('static', filename='img/listenbrainz-logo.svg', _external=True) }}' height='75'><br><br><i class='fa fa-cog fa-spin'></i> Sending page " + page + " of " + numberOfPages + " to ListenBrainz<br> [completed: " + numCompleted + "]<br><span style='font-size:8pt'>Please don't navigate while this is running</span><br>";
     reportPage(response);
     page += 1;
 


### PR DESCRIPTION
Fix the error where an invalid date would throw an error. Now it sets the
timestamp to zero, which is invalid. This is actually a decent solution,
since it allows us to find these and fix them later. Kepstin pointed out
that the data via the API is correct, but via the web pages in incorrect.
This shows the data is still there, but this is caused by a bug in last.fm.

This may fix LB-16. Maybe not.