### PR TITLE
Return cors headers on error pages, submit queue

### DIFF
--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -1,24 +1,36 @@
-from flask import render_template
+from flask import render_template, make_response
 
 
 def init_error_handlers(app):
 
     @app.errorhandler(400)
     def bad_request(error):
-        return render_template('errors/400.html', error=error), 400
+        resp = make_response(render_template('errors/400.html', error=error))
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp, 400
+
+    # TODO: 401 handler
 
     @app.errorhandler(403)
     def forbidden(error):
-        return render_template('errors/403.html', error=error), 403
+        resp = make_response(render_template('errors/403.html', error=error))
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp, 403
 
     @app.errorhandler(404)
     def not_found(error):
-        return render_template('errors/404.html', error=error), 404
+        resp = make_response(render_template('errors/404.html', error=error))
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp, 404
 
     @app.errorhandler(500)
     def internal_server_error(error):
-        return render_template('errors/500.html', error=error), 500
+        resp = make_response(render_template('errors/500.html', error=error))
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp, 500
 
     @app.errorhandler(503)
     def service_unavailable(error):
-        return render_template('errors/503.html', error=error), 503
+        resp = make_response(render_template('errors/503.html', error=error))
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp, 503

--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -3,34 +3,31 @@ from flask import render_template, make_response
 
 def init_error_handlers(app):
 
+    def error_wrapper(template, error, code):
+        resp = make_response(render_template(template, error=error))
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp, code
+
     @app.errorhandler(400)
     def bad_request(error):
-        resp = make_response(render_template('errors/400.html', error=error))
-        resp.headers['Access-Control-Allow-Origin'] = '*'
-        return resp, 400
+        return error_wrapper('errors/400.html', error, 400)
 
-    # TODO: 401 handler
+    @app.errorhandler(401)
+    def unauthorized(error):
+        return error_wrapper('errors/401.html', error, 401)
 
     @app.errorhandler(403)
     def forbidden(error):
-        resp = make_response(render_template('errors/403.html', error=error))
-        resp.headers['Access-Control-Allow-Origin'] = '*'
-        return resp, 403
+        return error_wrapper('errors/403.html', error, 403)
 
     @app.errorhandler(404)
     def not_found(error):
-        resp = make_response(render_template('errors/404.html', error=error))
-        resp.headers['Access-Control-Allow-Origin'] = '*'
-        return resp, 404
+        return error_wrapper('errors/404.html', error, 404)
 
     @app.errorhandler(500)
     def internal_server_error(error):
-        resp = make_response(render_template('errors/500.html', error=error))
-        resp.headers['Access-Control-Allow-Origin'] = '*'
-        return resp, 500
+        return error_wrapper('errors/500.html', error, 500)
 
     @app.errorhandler(503)
     def service_unavailable(error):
-        resp = make_response(render_template('errors/503.html', error=error))
-        resp.headers['Access-Control-Allow-Origin'] = '*'
-        return resp, 503
+        return error_wrapper('errors/503.html', error, 503)

--- a/webserver/templates/errors/401.html
+++ b/webserver/templates/errors/401.html
@@ -1,0 +1,3 @@
+{% extends 'errors/base.html' %}
+{% block error_title %}Unauthorized{% endblock %}
+

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -154,8 +154,8 @@ function reportScrobbles(struct) {
     xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
     xhr.timeout = 10 * 1000; // 10 seconds
     xhr.onload = function(content) {
-        numCompleted++;
         if (this.status >= 200 && this.status < 300) {
+            numCompleted++;
             console.log("successfully reported page");
         } else if (this.status >= 400 && this.status < 500) {
             console.log("4xx error, skipping");
@@ -164,7 +164,6 @@ function reportScrobbles(struct) {
             enqueueReport(struct);
         }
         getNextPageIfSlots();
-        console.log("successfully reported page");
     };
     xhr.ontimeout = function(context) {
         console.log("timeout, req'ing");

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -156,6 +156,11 @@ function reportScrobbles(struct) {
     xhr.onload = function(content) {
         if (this.status >= 200 && this.status < 300) {
             numCompleted++;
+            if (numCompleted >= numberOfPages) {
+                updateMessage("<i class='fa fa-check'></i> Import finished<br><span style='font-size:8pt'>Thank you for using ListenBrainz</span>");
+            } else {
+                updateMessage("<i class='fa fa-cog fa-spin'></i> Sending page " + numCompleted + " of " + numberOfPages + " to ListenBrainz<br><span style='font-size:8pt'>Please don't navigate while this is running</span>");
+            }
             console.log("successfully reported page");
         } else if (this.status >= 400 && this.status < 500) {
             console.log("4xx error, skipping");

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -200,7 +200,6 @@ function reportPageAndGetNext(response) {
       updateMessage("<i class='fa fa-cog fa-spin'></i> working<br><span style='font-size:8pt'>Please don't navigate away from this page while the process is running</span>");
     }
     reportPage(response);
-    page += 1;
 
     getNextPageIfSlots();
 }
@@ -208,6 +207,7 @@ function reportPageAndGetNext(response) {
 function getNextPageIfSlots() {
     // Get a new lastfm page and queue it only if there are more pages to download and we have
     // less than 10 pages waiting to submit
+    page += 1;
     if (page <= numberOfPages && activeSubmissions < 10) {
         setTimeout(function() { getLastFMPage(page, reportPageAndGetNext) }, 0 + Math.random()*100);
     }

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -133,7 +133,7 @@ function dispatch() {
     for (var i = 0; i < toReport.length; i++) {
         reportScrobbles(toReport[i]);
     }
-    toReport = []
+    toReport = [];
 }
 
 function enqueueReport(struct) {

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -130,7 +130,7 @@ var numCompleted = 0;
 var activeSubmissions = 0;
 
 function dispatch() {
-    for (var i = 0; i < toReport.length; i++) {
+    for (var i = 0; i < toReport.length; ++i) {
         reportScrobbles(toReport[i]);
     }
     toReport = [];

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -152,20 +152,27 @@ function reportScrobbles(struct) {
     xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
     xhr.onload = function(content) {
         numCompleted++;
-        if (numCompleted >= numberOfPages) {
-            updateMessage("<i class='fa fa-check'></i> Import finished<br><span style='font-size:8pt'>Thank you for using ListenBrainz</span>");
+        if (this.status >= 200 && this.status < 300) {
+            console.log("successfully reported page");
         } else {
-            updateMessage("<i class='fa fa-cog fa-spin'></i> Sending page " + numCompleted + " of " + numberOfPages + " to ListenBrainz<br><span style='font-size:8pt'>Please don't navigate while this is running</span>");
+            console.log("received http error " + this.status + " but continuing");
         }
-        console.log("successfully reported page");
     };
+    // TODO: Error cases to catch: 400, 500, 401, timeout
+    // On 400, 401 we don't retru
+    // on timeout retry
+    // on 50x???
     xhr.onabort = function(context) {
         console.log("abort, req'ing");
-        enqueueReport(struct);
+        console.debug(context);
+        console.debug(context.target.status);
+        //enqueueReport(struct);
     };
     xhr.onerror = function(context) {
         console.log("error, req'ing");
-        enqueueReport(struct);
+        console.debug(context);
+        console.debug(context.target.status);
+        //enqueueReport(struct);
     };
     xhr.send(JSON.stringify(struct));
 }


### PR DESCRIPTION
The scraper xhr request to listenbrainz fails on http 4xx and 5xx error pages because the response doesn't include any cors headers.
We should set these headers on the request and check the status code in the javascript on the "success" callback.
We should not retry if the error is 4xx (bad data, bad auth), but retry if it's 5xx (possibly a transient server error)

Still to be done:

 - [x] implement 401 handler
 - [x] retry on the right error codes in the scraper 
 - [x] refactor error handlers to use a helper function

This is http://tickets.musicbrainz.org/browse/LB-21