### PR TITLE
Fix the disappearance of `data` in Listen.from_json

### DIFF
--- a/listenstore/listenstore/listen.py
+++ b/listenstore/listenstore/listen.py
@@ -12,20 +12,21 @@ class Listen(object):
         self.artist_msid = artist_msid
         self.album_msid = album_msid
         self.recording_msid = recording_msid
-        self.data = {}
+        if data is None:
+            self.data = {}
+        else:
+            self.data = data
 
     @classmethod
     def from_json(cls, j):
         """Factory to make Listen() objects from a dict"""
-        woo =  cls(  uid=j['user_id']
-                   , timestamp=j['listened_at']
-                   , artist_msid=j['track_metadata']['additional_info'].get('artist_msid')
-                   , album_msid=j['track_metadata']['additional_info'].get('album_msid')
-                   , recording_msid=j.get('recording_msid')
-                   )
-        # Uhm, if I pass data as the call above, the data vanishes. Setting it seperately is ok.
-        woo.data = j['track_metadata']
-        return woo
+        return cls(  uid=j['user_id']
+                  , timestamp=j['listened_at']
+                  , artist_msid=j['track_metadata']['additional_info'].get('artist_msid')
+                  , album_msid=j['track_metadata']['additional_info'].get('album_msid')
+                  , recording_msid=j.get('recording_msid')
+                  , data=j.get('track_metadata')
+                  )
 
     def validate(self):
         return (self.uid is not None and self.timestamp is not None and self.artist_msid is not None


### PR DESCRIPTION
Listen.__init__ now correctly sets data to an empty dictionary if no
data was passed in and uses the passed in data if it's not None.