### PR TITLE
Remove unnecessary part of root URL in API docs

### DIFF
--- a/docs/dev/api.rst
+++ b/docs/dev/api.rst
@@ -5,7 +5,7 @@ The ListenBrainz server supports the following end-points for submitting and fet
 
 All endpoints have this root URL:
 
-**Root URL**: ``https://api.listenbrainz.org/1``
+**Root URL**: ``https://api.listenbrainz.org``
 
 NOTE: All of ListenBrainz services are available on **HTTPS** only!
 


### PR DESCRIPTION
Paths for endpoints already include it. See https://listenbrainz.readthedocs.org/en/latest/dev/api.html#api. :scissors: 