### PR TITLE
Create connections to external services on each flask request

### DIFF
--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -1,10 +1,8 @@
-from flask import Flask, current_app, g
+from flask import Flask, current_app
 import sys
 import os
 import messybrainz
 import messybrainz.db
-import kafka_connection
-import listenstore_connection
 
 
 def create_app():

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -25,13 +25,6 @@ def create_app():
     init_db_connection(app)
     messybrainz.db.init_db_engine(app.config['MESSYBRAINZ_SQLALCHEMY_DATABASE_URI'])
 
-    # Connections to external servers
-    @app.before_request
-    def before_reqeust():
-        g.kafka = kafka_connection.init_kafka_connection(app.config['KAFKA_CONNECT'])
-        g.listenstore = listenstore_connection.init_listenstore(current_app.config['CASSANDRA_SERVER'], current_app.config['CASSANDRA_KEYSPACE'])
-
-
     # OAuth
     from webserver.login import login_manager, provider
     login_manager.init_app(app)

--- a/webserver/cassandra_connection.py
+++ b/webserver/cassandra_connection.py
@@ -1,8 +1,0 @@
-from listenstore.listenstore import ListenStore
-
-
-def init_cassandra_connection(server, keyspace):
-    return ListenStore({
-        'cassandra_server': server,
-        'cassandra_keyspace': keyspace,
-    })

--- a/webserver/kafka_connection.py
+++ b/webserver/kafka_connection.py
@@ -1,9 +1,5 @@
-from kafka import KafkaClient
-
-_kafka = None
-
+import kafka
 
 def init_kafka_connection(hosts):
     """Create a connection to the Kafka server."""
-    global _kafka
-    _kafka = KafkaClient(hosts)
+    return kafka.KafkaClient(hosts)

--- a/webserver/kafka_connection.py
+++ b/webserver/kafka_connection.py
@@ -1,5 +1,7 @@
 import kafka
+from flask import current_app
 
-def init_kafka_connection(hosts):
+def get_kafka_client():
     """Create a connection to the Kafka server."""
-    return kafka.KafkaClient(hosts)
+    host = current_app.config['KAFKA_CONNECT']
+    return kafka.KafkaClient(host)

--- a/webserver/listenstore_connection.py
+++ b/webserver/listenstore_connection.py
@@ -2,9 +2,7 @@ from listenstore import listenstore
 from flask import current_app
 
 def get_listenstore():
-    server = current_app.config['CASSANDRA_SERVER']
-    keyspace = current_app.config['CASSANDRA_KEYSPACE']
     return listenstore.ListenStore({
-        'cassandra_server': server,
-        'cassandra_keyspace': keyspace,
+        'cassandra_server': current_app.config['CASSANDRA_SERVER'],
+        'cassandra_keyspace': current_app.config['CASSANDRA_KEYSPACE'],
     })

--- a/webserver/listenstore_connection.py
+++ b/webserver/listenstore_connection.py
@@ -1,6 +1,9 @@
-import listenstore
+from listenstore import listenstore
+from flask import current_app
 
-def init_listenstore(server, keyspace):
+def get_listenstore():
+    server = current_app.config['CASSANDRA_SERVER']
+    keyspace = current_app.config['CASSANDRA_KEYSPACE']
     return listenstore.ListenStore({
         'cassandra_server': server,
         'cassandra_keyspace': keyspace,

--- a/webserver/listenstore_connection.py
+++ b/webserver/listenstore_connection.py
@@ -1,0 +1,7 @@
+import listenstore
+
+def init_listenstore(server, keyspace):
+    return listenstore.ListenStore({
+        'cassandra_server': server,
+        'cassandra_keyspace': keyspace,
+    })

--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -3,9 +3,11 @@ import urllib2
 import ujson
 import socket
 import uuid
-from flask import Blueprint, request, current_app, jsonify, g
+from flask import Blueprint, request, current_app, jsonify
 from werkzeug.exceptions import BadRequest, InternalServerError, Unauthorized, ServiceUnavailable
 from kafka import SimpleProducer
+from webserver import kafka_connection
+from webserver import listenstore_connection
 from webserver.decorators import crossdomain
 import webserver
 import db.user
@@ -76,13 +78,15 @@ def submit_listen():
 @api_bp.route("/1/user/<user_id>/listens")
 def get_listens(user_id):
 
+    listenstore = listenstore_connection.get_listenstore()
+
     max_ts = _parse_int_arg("max_ts")
     min_ts = _parse_int_arg("min_ts")
 
     if max_ts and min_ts:
         _log_and_raise_400("You may only specify max_ts or min_ts, not both.")
 
-    listens = g.listenstore.fetch_listens(
+    listens = listenstore.fetch_listens(
         user_id,
         limit=min(_parse_int_arg("count", DEFAULT_ITEMS_PER_GET), MAX_ITEMS_PER_GET),
         from_id=min_ts,
@@ -135,7 +139,7 @@ def _validate_auth_header():
 
 def _send_listens_to_kafka(listen_type, listens):
 
-    producer = SimpleProducer(g.kafka)
+    producer = SimpleProducer(kafka_connection.get_kafka_client())
 
     for listen in listens:
         if listen_type == 'playing_now':

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from flask import Blueprint, render_template, request, url_for, Response
+from flask import Blueprint, render_template, request, url_for, Response, g
 from flask_login import current_user, login_required
 from werkzeug.exceptions import NotFound, BadRequest
 from webserver.decorators import crossdomain
@@ -28,8 +28,6 @@ def lastfmscraper(user_id):
 
 @user_bp.route("/<user_id>")
 def profile(user_id):
-    cassandra = webserver.create_cassandra()
-
     # Getting data for current page
     max_ts = request.args.get("max_ts")
     if max_ts is not None:
@@ -39,7 +37,7 @@ def profile(user_id):
             raise BadRequest("Incorrect timestamp argument to_id:" %
                              request.args.get("to_id"))
     listens = []
-    for listen in cassandra.fetch_listens(user_id, limit=25, to_id=max_ts):
+    for listen in g.listenstore.fetch_listens(user_id, limit=25, to_id=max_ts):
         listens.append({
             "track_metadata": listen.data,
             "listened_at": listen.timestamp,
@@ -48,7 +46,7 @@ def profile(user_id):
 
     if listens:
         # Checking if there is a "previous" page...
-        previous_listens = list(cassandra.fetch_listens(user_id, limit=25, from_id=listens[0]["listened_at"]))
+        previous_listens = list(g.listenstore.fetch_listens(user_id, limit=25, from_id=listens[0]["listened_at"]))
         if previous_listens:
             # Getting from the last item because `fetch_listens` returns in ascending
             # order when `from_id` is used.
@@ -57,7 +55,7 @@ def profile(user_id):
             previous_listen_ts = None
 
         # Checking if there is a "next" page...
-        next_listens = list(cassandra.fetch_listens(user_id, limit=1, to_id=listens[-1]["listened_at"]))
+        next_listens = list(g.listenstore.fetch_listens(user_id, limit=1, to_id=listens[-1]["listened_at"]))
         if next_listens:
             next_listen_ts = listens[-1]["listened_at"]
         else:

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
-from flask import Blueprint, render_template, request, url_for, Response, g
+from flask import Blueprint, render_template, request, url_for, Response
 from flask_login import current_user, login_required
 from werkzeug.exceptions import NotFound, BadRequest
 from webserver.decorators import crossdomain
 from datetime import datetime
 import webserver
 import db.user
+from webserver import listenstore_connection
 
 user_bp = Blueprint("user", __name__)
 
@@ -28,6 +29,7 @@ def lastfmscraper(user_id):
 
 @user_bp.route("/<user_id>")
 def profile(user_id):
+    listenstore = listenstore_connection.get_listenstore()
     # Getting data for current page
     max_ts = request.args.get("max_ts")
     if max_ts is not None:
@@ -37,7 +39,7 @@ def profile(user_id):
             raise BadRequest("Incorrect timestamp argument to_id:" %
                              request.args.get("to_id"))
     listens = []
-    for listen in g.listenstore.fetch_listens(user_id, limit=25, to_id=max_ts):
+    for listen in listenstore.fetch_listens(user_id, limit=25, to_id=max_ts):
         listens.append({
             "track_metadata": listen.data,
             "listened_at": listen.timestamp,
@@ -46,7 +48,7 @@ def profile(user_id):
 
     if listens:
         # Checking if there is a "previous" page...
-        previous_listens = list(g.listenstore.fetch_listens(user_id, limit=25, from_id=listens[0]["listened_at"]))
+        previous_listens = list(listenstore.fetch_listens(user_id, limit=25, from_id=listens[0]["listened_at"]))
         if previous_listens:
             # Getting from the last item because `fetch_listens` returns in ascending
             # order when `from_id` is used.
@@ -55,7 +57,7 @@ def profile(user_id):
             previous_listen_ts = None
 
         # Checking if there is a "next" page...
-        next_listens = list(g.listenstore.fetch_listens(user_id, limit=1, to_id=listens[-1]["listened_at"]))
+        next_listens = list(listenstore.fetch_listens(user_id, limit=1, to_id=listens[-1]["listened_at"]))
         if next_listens:
             next_listen_ts = listens[-1]["listened_at"]
         else:


### PR DESCRIPTION
Instead of having a single connection open for the life of the
server, make a new connection to kafka and listenstore on each
request (this was already the case for listenstore). Store
the connections in flask.g, as that's what it's designed for

A kafka threaded example does basically the same thing: https://github.com/mumrah/kafka-python/blob/master/example.py, creating a connection and producer in each thread. As far as I'm aware, this is about the same kind of thing we get with multiple requests in flask.

Renamed cassandra to listenstore, as it better reflects what we are connecting to. I removed the `from listenstore.listenstore import ...`, so we will then have to actually install listenstore into the virtualenv each time we update it. Either with `setup.py develop`, or we add an install command into `fab deploy`

I've still not tested it, therefore marking as WIP.

I'm unsure if any connections have to be closed after connections are shut down. There is a `producer.stop` method in kafka, so perhaps we should be calling this.