### PR TITLE
LB-55, LB-64: Show options on completion of import

### DIFF
--- a/webserver/templates/user/import.html
+++ b/webserver/templates/user/import.html
@@ -31,8 +31,8 @@
              Go to your Last.fm library page and click the bookmarklet you just added to your toolbar.
           </p>
           <p>
-             This will start the import of your listens. Please leave the page open and don't navigate away
-             from it until the import process is complete. After that, you're done. Thanks!
+          This will start the import of your listens. Please leave the page open and <b>don't navigate away</b>
+          from it until the import process is complete. We recommend that you <b>do not scrobble to Last.fm</b> during this process. After that, you're done. Thanks!
           </p>
           <p>
              <span class="btn btn-warning btn-lg" style="width: 400px"><a href="http://last.fm/user/{{lastfm_username}}/library"

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -146,7 +146,7 @@ function getLastFMPage(page) {
     xhr.send();
 }
 
-var version = "1.3";
+var version = "1.4";
 var page = 1;
 var numberOfPages = parseInt(document.getElementsByClassName("pages")[0].innerHTML.trim().split(" ")[3]);
 
@@ -192,7 +192,13 @@ function reportScrobbles(struct) {
             pageDone();
         }
         if (numCompleted >= numberOfPages) {
-            updateMessage("<i class='fa fa-check'></i> Import finished<br><span style='font-size:8pt'>Thank you for using ListenBrainz</span>");
+            updateMessage("<i class='fa fa-check'></i> Import finished<br><span><a href='https://listenbrainz.org/user/{{user_id}}'>Go to your ListenBrainz profile</a> | <a href='' id='close-progress-container'>Close</a></span><br><span style='font-size:8pt'>Thank you for using ListenBrainz</span>");
+            var close = document.getElementById('close-progress-container');
+            close.addEventListener('click', function(ev) {
+                ev.preventDefault();
+                var el = document.getElementById('listen-progress-container');
+                el.parentNode.removeChild(el);
+            }, false);
         } else {
             updateMessage("<i class='fa fa-cog fa-spin'></i> Sending page " + numCompleted + " of " + numberOfPages + " to ListenBrainz<br><span style='font-size:8pt'>Please don't navigate while this is running</span>");
         }

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -22,6 +22,7 @@ def lastfmscraper(user_id):
         base_url=url_for("api_v1.submit_listen", user_id=user_id, _external=True),
         user_token=user_token,
         lastfm_username=lastfm_username,
+        user_id=user_id,
     )
     return Response(scraper, content_type="text/javascript")
 


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/LB-55
http://tickets.musicbrainz.org/browse/LB-64

Add some notes to the import page to remind users to not navigate from
the page, and to not be scrobbling while they import

After the importer finishes, show a link to close the dialog, and
another to go to the profile page on listenbrainz

![lb-finished](https://cloud.githubusercontent.com/assets/19217/10460622/687a3a64-71d5-11e5-8867-e27902404f09.png)