### PR TITLE
[WIP] LB-73: Return json error messages from API

### DIFF
--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -1,4 +1,5 @@
-from flask import render_template, make_response
+from flask import render_template, make_response, jsonify
+import webserver.exceptions
 
 
 def init_error_handlers(app):
@@ -7,6 +8,12 @@ def init_error_handlers(app):
         resp = make_response(render_template(template, error=error))
         resp.headers['Access-Control-Allow-Origin'] = '*'
         return resp, code
+
+    @app.errorhandler(webserver.exceptions.APIError)
+    def api_error(error):
+        response = jsonify(error.to_dict())
+        response.status_code = error.status_code
+        return response
 
     @app.errorhandler(400)
     def bad_request(error):

--- a/webserver/exceptions.py
+++ b/webserver/exceptions.py
@@ -1,0 +1,33 @@
+class APIError(Exception):
+
+    def __init__(self, message, status_code, payload=None):
+        super(APIError, self).__init__()
+        self.message = message
+        self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        rv = dict(self.payload or ())
+        rv['message'] = self.message
+        return rv
+
+class APIBadRequest(APIError):
+    def __init__(self, message, payload=None):
+        super(APIBadRequest, self).__init__(message, 400, payload)
+
+class APIUnauthorized(APIError):
+    def __init__(self, message, payload=None):
+        super(APIUnauthorized, self).__init__(message, 401, payload)
+
+class APINotFound(APIError):
+    def __init__(self, message, payload=None):
+        super(APINotFound, self).__init__(message, 404, payload)
+
+class APIInternalServerError(APIError):
+    def __init__(self, message, payload=None):
+        super(APIInternalServerError, self).__init__(message, 500, payload)
+
+class APIServiceUnavailable(APIError):
+    def __init__(self, message, payload=None):
+        super(APIServiceUnavailable, self).__init__(message, 503, payload)
+


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/LB-73

I have only tested these responses so far:

no header:
```
HTTP/1.0 401 UNAUTHORIZED
Content-Type: application/json
Content-Length: 63
Server: Werkzeug/0.10.4 Python/2.7.6
Date: Tue, 13 Oct 2015 16:38:23 GMT

{
  "message": "You need to provide an Authorization header."
}
```

Invalid header:
```
HTTP/1.0 401 UNAUTHORIZED
Content-Type: application/json
Content-Length: 60
Server: Werkzeug/0.10.4 Python/2.7.6
Date: Tue, 13 Oct 2015 16:38:41 GMT

{
  "message": "Provided Authorization header is invalid."
}
```

Bad token:
```
HTTP/1.0 401 UNAUTHORIZED
Content-Type: application/json
Content-Length: 47
Server: Werkzeug/0.10.4 Python/2.7.6
Date: Tue, 13 Oct 2015 16:38:03 GMT

{
  "message": "Invalid authorization token."
}
```

No track name:
```
HTTP/1.0 400 BAD REQUEST
Content-Type: application/json
Content-Length: 112
Server: Werkzeug/0.10.4 Python/2.7.6
Date: Tue, 13 Oct 2015 16:41:39 GMT

{
  "message": "JSON document does not contain a valid metadata.track_name and/or track_metadata.artist_name."
}
```

I still want to add some tests for the 400 errors that we return on validation, and 5xx errors we return when messybrainz or kafka are unavailable