### PR TITLE
Fix query parameter name in api.py documentation

### DIFF
--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -101,7 +101,7 @@ def get_listens(user_id):
 
     :param max_ts: If you specify a ``max_ts`` timestamp, listens with listened_at less than (but not including) this value will be returned.
     :param min_ts: If you specify a ``min_ts`` timestamp, listens with listened_at greter than (but not including) this value will be returned.
-    :param limit: Optional, number of listens to return. Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET` . Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
+    :param count: Optional, number of listens to return. Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET` . Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
     :statuscode 200: Yay, you have data!
     :resheader Content-Type: *application/json*
     """


### PR DESCRIPTION
The limiting parameter seems to be "count", rather than "limit".