### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ file.*
 
 ## Documentation
 
-Documentation for the ListenBrainz API is available at https://listenbrainz.rtfd.org.
+Documentation for the ListenBrainz API is available at [https://listenbrainz.readthedocs.org](https://listenbrainz.readthedocs.org).
 You can build the documentation yourself:
 
     $ cd docs


### PR DESCRIPTION
This fixes the link to the API documentation.  The previous URL at rtfd.org was giving me an SSL error.