### PR TITLE
Fix 'document.getElementByClassName(...) is null'

### DIFF
--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -149,7 +149,7 @@ function getLastFMPage(page) {
 var version = "1.4";
 var page = 1;
 var numberOfPages = 1;
-if (document.querySelector('.pages') != null) {
+if (document.getElementsByClassName("pages").length > 0) {
     numberOfPages = parseInt(document.getElementsByClassName("pages")[0].innerHTML.trim().split(" ")[3]);
 }
 

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -149,8 +149,9 @@ function getLastFMPage(page) {
 var version = "1.4";
 var page = 1;
 var numberOfPages = 1;
-if (document.getElementsByClassName("pages").length > 0) {
-    numberOfPages = parseInt(document.getElementsByClassName("pages")[0].innerHTML.trim().split(" ")[3]);
+var pages = document.getElementsByClassName("pages");
+if (pages.length > 0) {
+    numberOfPages = parseInt(pages[0].innerHTML.trim().split(" ")[3]);
 }
 
 var toReport = [];

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -148,7 +148,10 @@ function getLastFMPage(page) {
 
 var version = "1.4";
 var page = 1;
-var numberOfPages = parseInt(document.getElementsByClassName("pages")[0].innerHTML.trim().split(" ")[3]);
+var numberOfPages = 1;
+if (document.querySelector('.pages') != null) {
+    numberOfPages = parseInt(document.getElementsByClassName("pages")[0].innerHTML.trim().split(" ")[3]);
+}
 
 var toReport = [];
 var numCompleted = 0;


### PR DESCRIPTION
When the no of listens in library are less than maximum in a page, then the library is not divided into pages. Hence, class `pages` is not there.
Thus, <code>TypeError: document.getElementsByClassName(...)[0] is undefined on line 151 </code>