### PR TITLE
Fix [LB-68] Memory Leak | Scraper

### DIFF
--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -144,7 +144,7 @@ function getLastFMPage(page) {
         retry('error');
     };
     xhr.send();
-		xhr = null;
+    xhr = null;
 }
 
 var version = "1.4";
@@ -217,7 +217,7 @@ function reportScrobbles(struct) {
         reportScrobbles(struct);
     };
     xhr.send(JSON.stringify(struct));
-		xhr = null;
+    xhr = null;
 }
 
 function reportPageAndGetNext(response) {

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -144,7 +144,7 @@ function getLastFMPage(page) {
         retry('error');
     };
     xhr.send();
-		delete(xhr);
+		xhr = null;
 }
 
 var version = "1.4";
@@ -217,6 +217,7 @@ function reportScrobbles(struct) {
         reportScrobbles(struct);
     };
     xhr.send(JSON.stringify(struct));
+		xhr = null;
 }
 
 function reportPageAndGetNext(response) {

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -144,6 +144,7 @@ function getLastFMPage(page) {
         retry('error');
     };
     xhr.send();
+		delete(xhr);
 }
 
 var version = "1.4";


### PR DESCRIPTION
![LB-68](http://tickets.musicbrainz.org/browse/LB-68) - <b>importer uses lots of ram</b>
GC takes its own time to clean up the xhr variables in closure, which is slower than the amount at which requests were happening. By manually deleting the reference, ram usage is reduced.