### PR TITLE
Fix [LB-41] - Upload lastfm backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ config.py
 *.log
 .cache
 env
-lastfm-backup-upload

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.py
 *.log
 .cache
 env
+lastfm-backup-upload

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.pyc
 config.py
 *.log
+.cache
+env

--- a/config.py.sample
+++ b/config.py.sample
@@ -56,4 +56,8 @@ COMPILE_LESS = True
 
 # MAX file size to be allowed for the lastfm-backup import, default is infinite
 # Size is in bytes
-MAX_CONTENT_LENGTH = 2 * 1024
+MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB
+
+# Specify the upload folder where all the lastfm-backup will be stored
+# The path must be absolute path
+UPLOAD_FOLDER = "METABRAINZ/listenbrainz-server/lastfm-backup-upload"

--- a/config.py.sample
+++ b/config.py.sample
@@ -53,3 +53,7 @@ LASTFM_API_KEY = "USE_LASTFM_API_KEY"
 
 # Set to True if Less should be compiled in browser. Set to False if styling is pre-compiled.
 COMPILE_LESS = True
+
+# MAX file size to be allowed for the lastfm-backup import, default is infinite
+# Size is in bytes
+MAX_CONTENT_LENGTH = 2 * 1024

--- a/config.py.sample
+++ b/config.py.sample
@@ -60,4 +60,4 @@ MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB
 
 # Specify the upload folder where all the lastfm-backup will be stored
 # The path must be absolute path
-UPLOAD_FOLDER = "METABRAINZ/listenbrainz-server/lastfm-backup-upload"
+UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"

--- a/redis-consumer/redis-consumer.py
+++ b/redis-consumer/redis-consumer.py
@@ -47,7 +47,7 @@ class RedisConsumer(object):
 
                 # We've fetched them, now submit and if successful, clear the pending items
                 try:
-                    ls.insert_postgres(submit)
+                    ls.insert_postgresql(submit)
                     r.ltrim("listens-pending", 1, 0)
                 except ValueError:
                     pass

--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -24,6 +24,10 @@ def init_error_handlers(app):
     def not_found(error):
         return error_wrapper('errors/404.html', error, 404)
 
+    @app.errorhandler(413)
+    def file_size_too_large(error):
+        return error_wrapper('errors/413.html', error, 413)
+
     @app.errorhandler(500)
     def internal_server_error(error):
         return error_wrapper('errors/500.html', error, 500)

--- a/webserver/templates/errors/413.html
+++ b/webserver/templates/errors/413.html
@@ -1,0 +1,2 @@
+{% extends 'errors/base.html' %}
+{% block error_title %}Filesize limit exceeded{% endblock %}

--- a/webserver/templates/user/import.html
+++ b/webserver/templates/user/import.html
@@ -57,7 +57,7 @@
 
      <p><b> or </b></p>
      <p>Import your listens from the lastfm backup file.</p>
-     <div>
+     <div class="well">
          <form action="upload" method="POST" enctype=multipart/form-data>
              <input type=file name=file>
              <input type=submit value=Upload>

--- a/webserver/templates/user/import.html
+++ b/webserver/templates/user/import.html
@@ -55,6 +55,13 @@
         {{ user.auth_token }}
      </div>
 
+     <p><b> or </b></p>
+     <p>Import your listens from the lastfm backup file.</p>
+     <div>
+         <form action="upload" method="POST" enctype=multipart/form-data>
+             <input type=file name=file>
+             <input type=submit value=Upload>
+         </form>
+     </div>
   {% endif %}
-
 {% endblock %}

--- a/webserver/templates/user/import.html
+++ b/webserver/templates/user/import.html
@@ -56,7 +56,7 @@
      </div>
 
      <p><b> or </b></p>
-     <p>Import your listens from the lastfm backup file.</p>
+     <p>Import your listens from a Last.fm backup file (.zip)</p>
      <div class="well">
          <form action="upload" method="POST" enctype=multipart/form-data>
              <input type=file name=file>

--- a/webserver/utils.py
+++ b/webserver/utils.py
@@ -9,6 +9,16 @@ def generate_string(length):
     ) for _ in range(length)])
 
 
+def sizeof_readable(num, suffix='B'):
+    """ Converts the size in human readable format """
+
+    for unit in ['','K','M','G','T','P','E','Z']:
+        if abs(num) < 1024.0:
+            return "%3.1f %s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yb', suffix)
+
+
 def reformat_date(value, fmt="%b %d, %Y"):
     return value.strftime(fmt)
 

--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -127,7 +127,7 @@ def get_listens(user_id):
 
 def insert_json(jsonlist, user):
     payload = _convert_to_native_format(jsonlist)
-    _send_listens_to_kafka("import", _payload_to_augmented_list(payload, user))
+    _send_listens_to_redis("import", _payload_to_augmented_list(payload, user))
 
 
 def _parse_int_arg(name, default=None):

--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -36,7 +36,7 @@ MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP = 10
 @ratelimit()
 def submit_listen():
     """
-    Submit listens to the server. A user token (found on https://listenbrainz.org/user/import ) must 
+    Submit listens to the server. A user token (found on https://listenbrainz.org/user/import ) must
     be provided in the Authorization header!
 
     For complete details on the format of the JSON to be POSTed to this endpoint, see :ref:`json-doc`.
@@ -99,7 +99,7 @@ def get_listens(user_id):
     Get listens for user ``user_id``. The format for the JSON returned is defined in our :ref:`json-doc`.
 
     If none of the optional arguments are given, this endpoint will return the :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET` most recent listens.
-    The optional ``max_ts`` and ``min_ts`` UNIX epoch timestamps control at which point in time to start returning listens. You may specify max_ts or 
+    The optional ``max_ts`` and ``min_ts`` UNIX epoch timestamps control at which point in time to start returning listens. You may specify max_ts or
     min_ts, but not both in one call. Listens are always returned in descending timestamp order.
 
     :param max_ts: If you specify a ``max_ts`` timestamp, listens with listened_at less than (but not including) this value will be returned.

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -148,6 +148,9 @@ def upload():
     if request.method == 'POST':
         try:
             f = request.files['file']
+            if f.filename == '':
+                flash('No file selected.')
+                return redirect(request.url)
         except RequestEntityTooLarge:
             raise RequestEntityTooLarge('Maximum filesize upload limit exceeded. File must be <=' + \
                   sizeof_readable(current_app.config['MAX_CONTENT_LENGTH']))

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -13,7 +13,7 @@ from webserver.views.api import _validate_listen, _messybrainz_lookup, _send_lis
 from webserver.views.api import _messybrainz_lookup, insert_json, MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP
 from webserver.utils import sizeof_readable
 from os import path, makedirs
-import json, zipfile, re
+import json, zipfile, re, os
 
 user_bp = Blueprint("user", __name__)
 
@@ -188,7 +188,8 @@ def upload():
                 success += 1
         except Exception, e:
             raise BadRequest('Not a valid lastfm-backup-file.')
-
+        finally:
+            os.remove(filename)
         flash('Congratulations! Your listens from %d  files have been uploaded successfully.' % (success))
     return redirect(url_for("user.import_data"))
 

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -167,17 +167,13 @@ def upload():
         if not zipfile.is_zipfile(filename):
             raise BadRequest('Not a valid zip file.')
 
-        success = 0
-        failure = 0
+        success = failure = 0
         regex = re.compile('json/scrobbles/scrobbles-*')
         try:
             zf = zipfile.ZipFile(filename, 'r')
             files = zf.namelist()
-            for f in files:
-                # Skip if it does not lie in 'json/scrobbles/'
-                if not regex.match(f):
-                    continue
-
+            # Iterate over file that match the regex
+            for f in [f for f in files if regex.match(f)]:
                 try:
                     # Load listens file
                     jsonlist = json.loads(zf.read(f))

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -138,7 +138,7 @@ def export_data():
         return render_template("user/export.html", user=current_user)
 
 
-@user_bp.route("/upload", methods=['POST'])
+@user_bp.route("/upload", methods=['GET', 'POST'])
 @login_required
 def upload():
     if request.method == 'POST':

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from flask import Blueprint, render_template, request, url_for, Response, current_app
+from flask import Blueprint, render_template, request, url_for, Response, redirect, flash, current_app
 from flask_login import current_user, login_required
 from werkzeug.exceptions import NotFound, BadRequest
 from webserver.decorators import crossdomain
@@ -165,7 +165,8 @@ def upload():
                 augmented_listens.extend(_messybrainz_lookup(msb_listens))
 
             _send_listens_to_kafka("import", augmented_listens)
-    return render_template('user/import.html', user=current_user)
+            flash('Congratulations !! Your listens have been uploaded successfully.')
+    return redirect(url_for("user.import_data"))
 
 
 def _convert_to_native_format(data):

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -145,7 +145,13 @@ def upload():
         if f:
             augmented_listens = []
             msb_listens = []
-            jsonlist = json.load(f)
+            try:
+                jsonlist = json.load(f)
+                if not isinstance(jsonlist, list):
+                    raise ValueError
+            except ValueError:
+                raise BadRequest("Not a valid lastfmbackup file.")
+
             for listen in jsonlist:
                 dic = _convert_to_native_format(listen)
                 _validate_listen(dic)


### PR DESCRIPTION
Fix  	<a href="http://tickets.musicbrainz.org/browse/LB-41">#LB-41</a>
- Upload lastfm backup `json` file
- Supports uploading **.ZIP** files
- ZIP has to be in the same format as downloaded from lastfm.
- Sample file for testing - 
[21192540-QD3jC21IfeW40cZFN7AJ5AY7upcq49FR.zip](https://github.com/metabrainz/listenbrainz-server/files/294122/21192540-QD3jC21IfeW40cZFN7AJ5AY7upcq49FR.zip)





- Screenshots
![Screenshot](http://i.imgur.com/IlLzFIO.png)
<hr/>
![image](http://i.imgur.com/MNfNgHN.png)
<hr/>
![Screenshot](http://i.imgur.com/XMnBB00.png)