### PR TITLE
[Fix: LB-96] Show listen time as per the user's timezone

### DIFF
--- a/listenstore/listenstore/listen.py
+++ b/listenstore/listenstore/listen.py
@@ -23,7 +23,7 @@ class Listen(object):
     def from_json(cls, j):
         """Factory to make Listen() objects from a dict"""
         return cls(  user_id=j['user_id']
-                  , timestamp=datetime.utcfromtimestamp(j['listened_at'])
+                  , timestamp=datetime.utcfromtimestamp(float(j['listened_at']))
                   , artist_msid=j['track_metadata']['additional_info'].get('artist_msid')
                   , album_msid=j['track_metadata']['additional_info'].get('album_msid')
                   , recording_msid=j.get('recording_msid')

--- a/listenstore/listenstore/listen.py
+++ b/listenstore/listenstore/listen.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from __future__ import division, absolute_import, print_function, unicode_literals
-import datetime
 import ujson
+from datetime import datetime
+import calendar
 
 class Listen(object):
     """ Represents a listen object """
@@ -9,6 +10,7 @@ class Listen(object):
                  recording_msid=None, data=None):
         self.user_id = user_id
         self.timestamp = timestamp
+        self.ts_since_epoch = calendar.timegm(self.timestamp.utctimetuple())
         self.artist_msid = artist_msid
         self.album_msid = album_msid
         self.recording_msid = recording_msid
@@ -21,7 +23,7 @@ class Listen(object):
     def from_json(cls, j):
         """Factory to make Listen() objects from a dict"""
         return cls(  user_id=j['user_id']
-                  , timestamp=j['listened_at']
+                  , timestamp=datetime.utcfromtimestamp(j['listened_at'])
                   , artist_msid=j['track_metadata']['additional_info'].get('artist_msid')
                   , album_msid=j['track_metadata']['additional_info'].get('album_msid')
                   , recording_msid=j.get('recording_msid')
@@ -42,11 +44,11 @@ class Listen(object):
 
     @property
     def date(self):
-        return datetime.datetime.fromtimestamp(self.timestamp)
+        return self.timestamp
 
     def __repr__(self):
         return unicode(self).encode("utf-8")
 
     def __unicode__(self):
         return u"<Listen: user_id: %s, time: %s, artist_msid: %s, album_msid: %s, recording_msid: %s>" % \
-               (self.user_id, self.timestamp, self.artist_msid, self.album_msid, self.recording_msid)
+               (self.user_id, self.ts_since_epoch, self.artist_msid, self.album_msid, self.recording_msid)

--- a/listenstore/listenstore/listen.py
+++ b/listenstore/listenstore/listen.py
@@ -10,7 +10,7 @@ class Listen(object):
                  recording_msid=None, data=None):
         self.user_id = user_id
         self.timestamp = timestamp
-        self.ts_since_epoch = calendar.timegm(self.timestamp.utctimetuple())
+        self.ts_since_epoch = calendar.timegm(self.timestamp.utctimetuple()) if self.timestamp else None
         self.artist_msid = artist_msid
         self.album_msid = album_msid
         self.recording_msid = recording_msid

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -83,7 +83,7 @@ class PostgresListenStore(ListenStore):
                 try:
                     params = {
                         'user_id': listen.user_id,
-                        'ts': listen.timestamp,
+                        'ts': listen.ts_since_epoch,
                         'artist_msid': uuid.UUID(listen.artist_msid),
                         'album_msid': uuid.UUID(listen.album_msid) if listen.album_msid is not None else None,
                         'recording_msid': uuid.UUID(listen.recording_msid),

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -124,7 +124,7 @@ class PostgresListenStore(ListenStore):
             results = connection.execute(text("""
                 SELECT listen.id
                      , user_id
-                     , extract(epoch from ts)
+                     , ts AT TIME ZONE 'UTC'
                      , artist_msid
                      , album_msid
                      , recording_msid

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -162,5 +162,5 @@ class RedisListenStore(ListenStore):
         if not data:
             return None
         data = ujson.loads(data)
-        data.update({'listened_at': datetime.utcnow()})
+        data.update({'listened_at': MIN_ID+1})
         return Listen.from_json(data)

--- a/listenstore/listenstore/tests/test_postgreslistenstore.py
+++ b/listenstore/listenstore/tests/test_postgreslistenstore.py
@@ -42,9 +42,11 @@ class TestPostgresListenStore(DatabaseTestCase):
         self.assertEquals(len(listens), count)
 
     def test_convert_row(self):
-        data = [('id', 1), ('user_id', self.testuser_id), ('timestamp', 123456789), ('artist_msid', str(uuid.uuid4())), ('album_msid',
-                str(uuid.uuid4())), ('recording_msid', str(uuid.uuid4())), ('data', "{'additional_info':{}}")]
-        row = OrderedDict([(k, v) for (k, v) in data[1:]])
+        now = datetime.utcnow()
+        data = [('id', 1), ('user_id', self.testuser_id), ('timestamp', now), ('artist_msid', str(uuid.uuid4())),
+                ('album_msid', str(uuid.uuid4())), ('recording_msid', str(uuid.uuid4())), ('data', "{'additional_info':{}}"),
+                ('ts_since_epoch', to_epoch(now))]
+        row = OrderedDict([(str(k), v) for (k, v) in data[1:]])
         listen = self.logstore.convert_row([1] + row.values())
         self.assertIsInstance(listen, Listen)
-        self.assertEquals(listen.__dict__, dict(row))
+        self.assertDictEqual(listen.__dict__, dict(row))

--- a/listenstore/listenstore/tests/util.py
+++ b/listenstore/listenstore/tests/util.py
@@ -11,7 +11,7 @@ def generate_data(test_user_id, from_ts, num_records):
 
     for i in range(num_records):
         from_ts += 1   # Add one second
-        item = Listen(user_id=test_user_id, timestamp=from_ts, artist_msid=artist_msid,
+        item = Listen(user_id=test_user_id, timestamp=datetime.utcfromtimestamp(from_ts), artist_msid=artist_msid,
                       recording_msid=str(uuid.uuid4()))
         test_data.append(item)
     return test_data

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,7 @@ import uuid
 import pytz
 import db.user
 
+
 def generate_data(from_date, num_records):
     test_data = []
     current_date = to_epoch(from_date)
@@ -27,7 +28,6 @@ def generate_data(from_date, num_records):
                       recording_msid=str(uuid.uuid4()))
         test_data.append(item)
     return test_data
-
 
 def to_epoch(date):
     return int(time.mktime(date.timetuple()))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,7 @@ def generate_data(from_date, num_records):
 
     for i in range(num_records):
         current_date += 1   # Add one second
-        item = Listen(user_id=user['id'], timestamp=current_date, artist_msid=artist_msid,
+        item = Listen(user_id=user['id'], timestamp=datetime.utcfromtimestamp(current_date), artist_msid=artist_msid,
                       recording_msid=str(uuid.uuid4()))
         test_data.append(item)
     return test_data

--- a/webserver/templates/user/profile.html
+++ b/webserver/templates/user/profile.html
@@ -75,8 +75,18 @@
   {{ super() }}
   <script src="{{ url_for('static', filename='js/lib/jquery.timeago.js') }}"></script>
   <script type="text/javascript">
+    var offset = parseInt(new Date().getTimezoneOffset())*-1;
+    var sign = offset < 0 ? "-" : "+";
+    offset = offset < 0 ? offset*-1 : offset;
+    var hours = (parseInt(offset/60) < 10 ? "0" : "") + parseInt(offset/60).toString();
+    var minutes = (parseInt(offset%60) < 10 ? "0" : "") + parseInt(offset%60).toString();
+
     $(document).ready(function() {
       var times = $("abbr.timeago");
+      times.each(function(index, value) {
+        value.innerText = value.innerText + sign + hours + minutes;
+        value.setAttribute("title", value.getAttribute("title") + sign + hours + minutes);
+      });
       times.timeago();
     });
   </script>

--- a/webserver/templates/user/profile.html
+++ b/webserver/templates/user/profile.html
@@ -75,19 +75,8 @@
   {{ super() }}
   <script src="{{ url_for('static', filename='js/lib/jquery.timeago.js') }}"></script>
   <script type="text/javascript">
-    var offset = parseInt(new Date().getTimezoneOffset())*-1;
-    var sign = offset < 0 ? "-" : "+";
-    offset = offset < 0 ? offset*-1 : offset;
-    var hours = (parseInt(offset/60) < 10 ? "0" : "") + parseInt(offset/60).toString();
-    var minutes = (parseInt(offset%60) < 10 ? "0" : "") + parseInt(offset%60).toString();
-
     $(document).ready(function() {
-      var times = $("abbr.timeago");
-      times.each(function(index, value) {
-        value.innerText = value.innerText + sign + hours + minutes;
-        value.setAttribute("title", value.getAttribute("title") + sign + hours + minutes);
-      });
-      times.timeago();
+      $("abbr.timeago").timeago();
     });
   </script>
 {% endblock %}

--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -98,7 +98,7 @@ def get_listens(user_id):
     for listen in listens:
         listen_data.append({
             "track_metadata": listen.data,
-            "listened_at": listen.timestamp,
+            "listened_at": listen.ts_since_epoch,
             "recording_msid": listen.recording_msid,
         })
 

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -71,7 +71,7 @@ def profile(user_name):
         if previous_listens:
             # Getting from the last item because `fetch_listens` returns in ascending
             # order when `from_ts` is used.
-            previous_listen_ts = previous_listens[-1].timestamp + 1
+            previous_listen_ts = previous_listens[-1].ts_since_epoch + 1
         else:
             previous_listen_ts = None
 

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -61,8 +61,8 @@ def profile(user_name):
     for listen in db_conn.fetch_listens(user.id, limit=25, to_ts=max_ts):
         listens.append({
             "track_metadata": listen.data,
-            "listened_at": listen.timestamp,
-            "listened_at_iso": pytz.utc.localize(datetime.utcfromtimestamp(int(listen.timestamp))).isoformat(),
+            "listened_at": listen.ts_since_epoch,
+            "listened_at_iso": listen.timestamp.isoformat() + "Z",
         })
 
     if listens:
@@ -144,7 +144,7 @@ def export_data():
         output = []
         for index, obj in enumerate(db_conn.fetch_listens(current_user.id)):
             dic = obj.data
-            dic['timestamp'] = obj.timestamp
+            dic['timestamp'] = obj.ts_since_epoch
             dic['album_msid'] = None if obj.album_msid is None else str(obj.album_msid)
             dic['artist_msid'] = None if obj.artist_msid is None else str(obj.artist_msid)
             dic['recording_msid'] = None if obj.recording_msid is None else str(obj.recording_msid)


### PR DESCRIPTION
Fixes [LB-96](http://tickets.musicbrainz.org/browse/LB-96)  
Fix 2 issues:
- The listens should be displayed as per the user's timezone settings of the browser.
- Listenstore must return datetime objects not timestamps.