### PR TITLE
[Fix: LB-89] BadRequest error when importing while now_playing

### DIFF
--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -15,7 +15,10 @@ function select(selector, collection) {
 function map(applicable, collection) {
     var newCollection = [];
     for (var i = 0; i < collection.length; i++) {
-        newCollection.push(applicable(collection[i]));
+      var result = applicable(collection[i]);
+      if ('listened_at' in result) {
+        newCollection.push(result);
+      };
     }
     return newCollection;
 }

--- a/webserver/templates/user/scraper.js
+++ b/webserver/templates/user/scraper.js
@@ -17,6 +17,8 @@ function map(applicable, collection) {
     for (var i = 0; i < collection.length; i++) {
       var result = applicable(collection[i]);
       if ('listened_at' in result) {
+        // If there is no 'listened_at' attribute then either the listen is invalid or the
+        // listen is currently playing. In both cases we need to skip the submission.
         newCollection.push(result);
       };
     }
@@ -68,6 +70,13 @@ Scrobble.prototype.scrobbledAt = function () {
     if ('date' in this.rootScrobbleElement && 'uts' in this.rootScrobbleElement['date']) {
         return this.rootScrobbleElement['date']['uts'];
     } else {
+        /*
+        The audioscrobbler API's output differs when the user is playing song.
+        In case, when the user is playing song, the API returns 1st listen with
+        attribute as {"@attr": {"now_playing":"true"}} while other listens with
+        attribute as {"date": {"utc":"12345756", "#text":"21 Jul 2016, 10:22"}}
+        We need to only submit listens which were played in the past.
+        */
         return "";
     }
 };


### PR DESCRIPTION
Fixes [LB-89](http://tickets.musicbrainz.org/browse/LB-89)
The audioscrobbler API's output differs when requesting listens using getrecenttracks method in case when the user is playing song. In case of `now_playing` to be true, the API outputs 1st listen as the now_playing.  
When listening: `{"@attr": {"now_playing":"true"}}`
When not listening: `{"date": {"utc":"12345756", "#text":"21 Jul 2016, 10:22"}}`