### PR TITLE
Add pytest.ini file

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = db webserver listenstore redis-consumer


### PR DESCRIPTION
Running py.test outside docker fails with the following error.
![elua](https://cloud.githubusercontent.com/assets/14854424/17251476/9ac33374-55c6-11e6-8a3f-2eda3dceb835.png)