### PR TITLE
fix PG_version for docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
 # PostgreSQL client
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 ENV PG_MAJOR 9.5
-ENV PG_VERSION 9.5.4-1.pgdg80+1
+ENV PG_VERSION 9.5.4-1.pgdg80+2
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR=$PG_VERSION \


### PR DESCRIPTION
On doing the docker-compose build , I saw 

E: Version '9.5.4-1.pgdg80+1' for 'postgresql-client-9.5' was not found

which ultimately failed to build the Service "web" . 

I found that the[ postgres version on docker-library ](https://github.com/docker-library/postgres/blob/master/9.5/Dockerfile)was updated to the one I've listed on the PR. 

This fixed the issue . 
