### PR TITLE
[LB-102] Improve Select query and constructor of Session

### DIFF
--- a/db/lastfm_session.py
+++ b/db/lastfm_session.py
@@ -36,8 +36,7 @@ class Session(object):
             })
             row = result.fetchone()
             if row:
-                id, userid, sid, api_key, timestamp = row
-                return Session(id, userid, sid, api_key, timestamp)
+                return Session(row["id"], row["user_id"], row["sid"], row["api_key"], row["ts"])
             return None
 
     @staticmethod
@@ -57,5 +56,5 @@ class Session(object):
                 'api_key': token.api_key
             })
             token.consume()
-            id, user_id, sid, api_key, ts, = result.fetchone()
-            return Session(id, user_id, sid, api_key, ts)
+            row = result.fetchone()
+            return Session(row["id"], row["user_id"], row["sid"], row["api_key"], row["ts"])


### PR DESCRIPTION
Fix for LB-102. Removed some of the "magic" by making the Session constructor take all 5 values explicitly as arguments and the select query now names all the columns it requires.

I think I've done everything talked about [here](https://github.com/metabrainz/listenbrainz-server/pull/82#discussion-diff-71160085R31).