### PR TITLE
Fix call to auth.getsessioninfo method of API

### DIFF
--- a/webserver/views/api_compat.py
+++ b/webserver/views/api_compat.py
@@ -91,7 +91,7 @@ def api_methods():
     elif method == 'user.getinfo':
         return user_info(request, data)
     elif method == 'auth.getsessioninfo':
-        return session_info
+        return session_info(request, data)
     else:
         # Invalid Method
         raise InvalidAPIUsage(3, output_format=data.get('format', "xml"))


### PR DESCRIPTION
The function session_info did not get called leading to a bug where
requests with method auth.getsessioninfo wouldn't work correctly.