### PR TITLE
[LB-115] Fix bug which didn't allow submission of scrobbles if api_sig was in request

### DIFF
--- a/webserver/views/api_compat.py
+++ b/webserver/views/api_compat.py
@@ -246,7 +246,7 @@ def record_listens(request, data):
 
     lookup = defaultdict(dict)
     for key, value in data.items():
-        if key == "sk" or key == "token" or key == "api_key" or key == "method":
+        if key == "sk" or key == "token" or key == "api_key" or key == "method" or key == "api_sig":
             continue
         matches = re.match('(.*)\[(\d+)\]', key)
         if matches:

--- a/webserver/views/api_compat.py
+++ b/webserver/views/api_compat.py
@@ -246,7 +246,7 @@ def record_listens(request, data):
 
     lookup = defaultdict(dict)
     for key, value in data.items():
-        if key == "sk" or key == "token" or key == "api_key" or key == "method" or key == "api_sig":
+        if key in ["sk", "token", "api_key", "method", "api_sig"]:
             continue
         matches = re.match('(.*)\[(\d+)\]', key)
         if matches:


### PR DESCRIPTION
Small fix for LB-115.

Because the loop didn't skip api_sig, an extra "empty" track gets added to the lookup defaultdict, leading to errors in  messybrainz lookups later.

Fixed this by adding a continue for "api_sig" also. :)