### PR TITLE
Import current_app to api.py so that get_listens doesn't throw error

### DIFF
--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import ujson
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, current_app
 from werkzeug.exceptions import BadRequest, InternalServerError, Unauthorized
 from webserver.decorators import crossdomain
 import webserver


### PR DESCRIPTION
Right now, calls to the get_listens api function throws NameError
because current_app is not imported from flask. Fix this by
importing current_app

Found this bug while writing tests for the api. :)