### PR TITLE
Integration tests

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -1,20 +1,13 @@
 version: "2"
 services:
 
-  db_test:
+  db:
     image: postgres:9.5.3
-    environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_USER: listenbrainz
-      POSTGRES_PASSWD: listenbrainz
-      POSTGRES_DB: listenbrainz
-    network_mode: bridge
 
-  redis_test:
+  redis:
     image: redis:3.2.1
-    network_mode: bridge
 
-  influx_test:
+  influx:
     image: influxdb:1.0.0
     environment:
       INFLUXDB_REPORTING_DISABLED: 'true'
@@ -24,31 +17,30 @@ services:
       INFLUXDB_DATA_DATA_LOGGING_ENABLED: 'false'
       INFLUXDB_HTTP_LOG_ENABLED: 'true'
       INFLUXDB_CONTINUOUS_QUERIES_LOG_ENABLED: 'false'
-    network_mode: bridge
 
-  influx_writer_test:
+  influx_writer:
     build:
       context: ..
-      dockerfile: ./docker/influx-writer/Dockerfile.test
+      dockerfile: ./docker/influx-writer/Dockerfile
     command: python influx-writer/influx-writer.py
     depends_on:
-      - redis_test
-      - influx_test
+      - redis
+      - influx
 
-  bigquery_test:
+  bigquery:
     build:
       context: ..
       dockerfile: ./docker/bigquery-writer/Dockerfile
     command: python bigquery-writer/bigquery-writer.py
     links:
-      - redis_test
+      - redis
 
-  listenbrainz_test:
+  listenbrainz:
     build:
       context: ..
-      dockerfile: ./docker/Dockerfile.test
+      dockerfile: ./docker/Dockerfile
+    command: py.test
     depends_on:
-      - redis_test
-      - db_test
-      - web_test
-      - influx_test
+      - redis
+      - db
+      - influx

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+COMPOSE_FILE_LOC=docker/docker-compose.integration.yml
+COMPOSE_PROJECT_NAME_ORIGINAL=listenbrainz_int
+
+# Project name is sanitized by Compose, so we need to do the same thing.
+# See https://github.com/docker/compose/issues/2119.
+COMPOSE_PROJECT_NAME=$(echo $COMPOSE_PROJECT_NAME_ORIGINAL | awk '{print tolower($0)}' | sed 's/[^a-z0-9]*//g')
+TEST_CONTAINER_NAME=listenbrainz
+TEST_CONTAINER_REF="${COMPOSE_PROJECT_NAME}_${TEST_CONTAINER_NAME}_1"
+
+if [[ ! -d "docker" ]]; then
+    echo "This script must be run from the top level directory of the listenbrainz-server source."
+    exit -1
+fi
+
+echo "Take down old containers"
+docker-compose -f $COMPOSE_FILE_LOC -p $COMPOSE_PROJECT_NAME down
+
+echo "Build current setup"
+docker-compose -f $COMPOSE_FILE_LOC -p $COMPOSE_PROJECT_NAME build
+
+echo "Running setup"
+docker-compose -f $COMPOSE_FILE_LOC -p $COMPOSE_PROJECT_NAME run --rm listenbrainz dockerize -wait tcp://db:5432 -timeout 60s \
+                  -wait tcp://influx:8086 -timeout 60s \
+                bash -c "python manage.py init_db --create-db && python manage.py init_msb_db --create-db && python admin/influx/create_db.py"
+
+echo "Bring containers up and run integration tests"
+docker-compose -f docker/docker-compose.integration.yml -p $COMPOSE_PROJECT_NAME up


### PR DESCRIPTION
Basic framework for integration tests is up and running. Given the current trend I expect the integration-test.sh to be wrapped into develop.sh/test.sh or whatever that morphs into.

For the time being this script is good enough for ilikecomputers to start on writing actual integration tests.