### PR TITLE
Import time to fix bug in get_listens.

### DIFF
--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -8,6 +8,7 @@ import db
 from webserver.rate_limiter import ratelimit
 from api_tools import insert_payload, log_raise_400, validate_listen, MAX_LISTEN_SIZE, MAX_ITEMS_PER_GET,\
     DEFAULT_ITEMS_PER_GET, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
+import time
 
 api_bp = Blueprint('api_v1', __name__)
 
@@ -94,7 +95,7 @@ def get_listens(user_name):
 
     # If none are given, start with now and go down
     if max_ts == None and min_ts == None:
-        max_ts = int(time())
+        max_ts = int(time.time())
 
     db_conn = webserver.create_influx(current_app)
     listens = db_conn.fetch_listens(


### PR DESCRIPTION
When a request was made to get_listens with no timestamp, time() is
used to start from the current time. However it wasn't imported
leading to 500 internal server errors on these requests.