### PR TITLE
Fix internal server errors due to None returned from influx.

### DIFF
--- a/listen.py
+++ b/listen.py
@@ -47,34 +47,34 @@ class Listen(object):
     def from_influx(cls, row):
         """ Factory to make Listen objects from an influx row
         """
-        dt = datetime.strptime(row['time'] , "%Y-%m-%dT%H:%M:%SZ")
+        dt = datetime.strptime(row['time'] , '%Y-%m-%dT%H:%M:%SZ')
         t = int(dt.strftime('%s'))
         mbids = []
         if row.get('artist_mbids'):
-            for mbid in row.get('artist_mbids').split(","):
-                mbids.append(mbid) 
+            for mbid in row.get('artist_mbids').split(','):
+                mbids.append(mbid)
         tags = []
         if row.get('tags'):
-            for tag in row.get('tags').split(","):
+            for tag in row.get('tags').split(','):
                 tags.append(tag)
 
         data = {
-            'artist_mbids' : mbids,
-            'album_msid' : row.get('album_msid'),
-            'album_mbid' : row.get('album_mbid'),
-            'album_name' : row.get('album_name'),
-            'recording_mbid' : row.get('recording_mbid'),
-            'tags' : tags,
+            'artist_mbids': mbids,
+            'album_msid': row.get('album_msid'),
+            'album_mbid': row.get('album_mbid'),
+            'album_name': row.get('album_name'),
+            'recording_mbid': row.get('recording_mbid'),
+            'tags': tags,
         }
         return cls(
-            timestamp = t,
-            user_name = row.get('user_name'),
-            artist_msid = row.get('artist_msid'),
-            recording_msid = row.get('recording_msid'),
-            data = { 
-                'additional_info' : data,
-                'artist_name' : row.get('artist_name'),
-                'track_name' : row.get('track_name'),
+            timestamp=t,
+            user_name=row.get('user_name'),
+            artist_msid=row.get('artist_msid'),
+            recording_msid=row.get('recording_msid'),
+            data={
+                'additional_info': data,
+                'artist_name': row.get('artist_name'),
+                'track_name': row.get('track_name'),
             }
         )
 

--- a/listen.py
+++ b/listen.py
@@ -43,6 +43,41 @@ class Listen(object):
             data=j.get('track_metadata')
         )
 
+    @classmethod
+    def from_influx(cls, row):
+        """ Factory to make Listen objects from an influx row
+        """
+        dt = datetime.strptime(row['time'] , "%Y-%m-%dT%H:%M:%SZ")
+        t = int(dt.strftime('%s'))
+        mbids = []
+        if row.get('artist_mbids'):
+            for mbid in row.get('artist_mbids').split(","):
+                mbids.append(mbid) 
+        tags = []
+        if row.get('tags'):
+            for tag in row.get('tags').split(","):
+                tags.append(tag)
+
+        data = {
+            'artist_mbids' : mbids,
+            'album_msid' : row.get('album_msid'),
+            'album_mbid' : row.get('album_mbid'),
+            'album_name' : row.get('album_name'),
+            'recording_mbid' : row.get('recording_mbid'),
+            'tags' : tags,
+        }
+        return cls(
+            timestamp = t,
+            user_name = row.get('user_name'),
+            artist_msid = row.get('artist_msid'),
+            recording_msid = row.get('recording_msid'),
+            data = { 
+                'additional_info' : data,
+                'artist_name' : row.get('artist_name'),
+                'track_name' : row.get('track_name'),
+            }
+        )
+
     def to_json(self):
         return {
             'user_id': self.user_id,

--- a/listen.py
+++ b/listen.py
@@ -50,12 +50,15 @@ class Listen(object):
         dt = datetime.strptime(row['time'] , '%Y-%m-%dT%H:%M:%SZ')
         t = int(dt.strftime('%s'))
         mbids = []
-        if row.get('artist_mbids'):
-            for mbid in row.get('artist_mbids').split(','):
+        artist_mbids = row.get('artist_mbids')
+        if artist_mbids:
+            for mbid in artist_mbids.split(','):
                 mbids.append(mbid)
+
         tags = []
-        if row.get('tags'):
-            for tag in row.get('tags').split(','):
+        influx_tags = row.get('tags')
+        if influx_tags:
+            for tag in influx_tags.split(','):
                 tags.append(tag)
 
         data = {

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -336,6 +336,10 @@ class InfluxListenStore(ListenStore):
 
         listens = []
         for result in results.get_points(measurement='listen'):
+            # make sure that result does not contain value None for any key
+            for key in result:
+                if result[key] is None:
+                    result[key] = ''
             dt = datetime.strptime(result['time'] , "%Y-%m-%dT%H:%M:%SZ")
             t = int(dt.strftime('%s'))
             mbids = []

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -336,39 +336,7 @@ class InfluxListenStore(ListenStore):
 
         listens = []
         for result in results.get_points(measurement='listen'):
-            # make sure that result does not contain value None for any key
-            for key in result:
-                if result[key] is None:
-                    result[key] = ''
-            dt = datetime.strptime(result['time'] , "%Y-%m-%dT%H:%M:%SZ")
-            t = int(dt.strftime('%s'))
-            mbids = []
-            for id in result.get('artist_mbids', '').split(","):
-                if id:
-                    mbids.append(id)
-            tags = []
-            for tag in result.get('tags', '').split(","):
-                if tag:
-                    tags.append(tag)
-
-            data = {
-                'artist_mbids' : mbids,
-                'album_msid' : result.get('album_msid', ''),
-                'album_mbid' : result.get('album_mbid', ''),
-                'album_name' : result.get('album_name', ''),
-                'recording_mbid' : result.get('recording_mbid', ''),
-                'tags' : tags
-            }
-            l = Listen(timestamp=t,
-                user_name=result.get('user_name', '<unknown>'),
-                artist_msid=result.get('artist_msid', ''),
-                recording_msid=result.get('recording_msid', ''),
-                data={
-                    'additional_info' : data,
-                    'artist_name' : result.get('artist_name', ''),
-                    'track_name' : result.get('track_name', '')
-                })
-            listens.append(l)
+            listens.append(Listen.from_influx(result))
 
         if order == ORDER_ASC:
             listens.reverse()


### PR DESCRIPTION
Right now, if there is no mbid in a field, influx returns null which
leads to internal server errors on call to fetch_listens because
fetch_listens expects strings everywhere.