### PR TITLE
Fix MusicBrainz link to artists on user profile page.

### DIFF
--- a/webserver/templates/user/profile.html
+++ b/webserver/templates/user/profile.html
@@ -41,7 +41,7 @@
                 <tr>
                   <td>
                       {% if listen.track_metadata.additional_info.artist_mbids %}
-                        <a href="http://musicbrainz.org/recording/{{ listen.track_metadata.additional_info.artist_mbids }}">
+                        <a href="http://musicbrainz.org/artist/{{ listen.track_metadata.additional_info.artist_mbids[0] }}">
                       {% endif %}
                       {{ listen.track_metadata.artist_name }}
                       {% if listen.track_metadata.additional_info.artist_mbids %}


### PR DESCRIPTION
The link to artists in listens that contained artist mbids was
incorrect previously. I've linked to the first artist in the list
of artist mbids to fix this.