### PR TITLE
LB-122: Fix the issue of album_msid and album_name getting dropped during influx write

### DIFF
--- a/listen.py
+++ b/listen.py
@@ -38,7 +38,7 @@ class Listen(object):
             user_name=j.get('user_name', ""),
             timestamp=datetime.utcfromtimestamp(float(j['listened_at'])),
             artist_msid=j['track_metadata']['additional_info'].get('artist_msid'),
-            album_msid=j['track_metadata']['additional_info'].get('album_msid'),
+            album_msid=j['track_metadata']['additional_info'].get('release_msid'),
             recording_msid=j.get('recording_msid'),
             data=j.get('track_metadata')
         )

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -278,7 +278,7 @@ class InfluxListenStore(ListenStore):
                     'artist_name' : listen.data['artist_name'],
                     'artist_msid' : listen.artist_msid,
                     'artist_mbids' : ",".join(listen.data['additional_info'].get('artist_mbids', [])),
-                    'album_name' : listen.data['additional_info'].get('release_name', ''),
+                    'album_name' : listen.data.get('release_name', ''),
                     'album_msid' : listen.album_msid,
                     'album_mbid' : listen.data['additional_info'].get('release_mbid', ''),
                     'track_name' : listen.data['track_name'],


### PR DESCRIPTION
The code was looking for `album_msid` instead of `release_msid`
leading to nothing being stored in the album_msid field in influx.

