### PR TITLE
Make redis port a configurable option in config.py

### DIFF
--- a/alpha_importer.py
+++ b/alpha_importer.py
@@ -10,7 +10,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 import os
 
-redis_connection = Redis(host = config.REDIS_HOST)
+redis_connection = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
 
 # create a logger to log messages into LOG_FILE
 logger = logging.getLogger('alpha_importer')

--- a/bigquery-writer/bigquery-writer.py
+++ b/bigquery-writer/bigquery-writer.py
@@ -131,7 +131,7 @@ class BigQueryWriterSubscriber(RedisPubSubSubscriber):
                 self.time = 0
 
 if __name__ == "__main__":
-    r = Redis(config.REDIS_HOST)
+    r = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
     bq = BigQueryWriterSubscriber(r)
     while True:
         # If the start fails, try again in a few

--- a/config.py.sample
+++ b/config.py.sample
@@ -22,6 +22,7 @@ PG_ASYNC_LISTEN_COMMIT = False
 
 # Redis
 REDIS_HOST = "redis"
+REDIS_PORT = 6379
 
 # Influx DB (main listen store)
 INFLUX_HOST    = "influx"

--- a/influx-writer/influx-writer.py
+++ b/influx-writer/influx-writer.py
@@ -143,10 +143,11 @@ class InfluxWriterSubscriber(RedisPubSubSubscriber):
 
 if __name__ == "__main__":
     ls = InfluxListenStore({ 'REDIS_HOST' : config.REDIS_HOST,
+                             'REDIS_PORT' : config.REDIS_PORT,
                              'INFLUX_HOST': config.INFLUX_HOST,
                              'INFLUX_PORT': config.INFLUX_PORT,
                              'INFLUX_DB_NAME': config.INFLUX_DB_NAME})
     i = InfluxDBClient(host=config.INFLUX_HOST, port=config.INFLUX_PORT, database=config.INFLUX_DB_NAME)
-    r = Redis(config.REDIS_HOST)
+    r = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
     rc = InfluxWriterSubscriber(ls, i, r)
     rc.start()

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -172,8 +172,8 @@ class PostgresListenStore(ListenStore):
 class RedisListenStore(ListenStore):
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
-        self.log.info('Connecting to redis: %s', conf['REDIS_HOST'])
-        self.redis = Redis(conf['REDIS_HOST'])
+        self.log.info('Connecting to redis: %s:%s', conf['REDIS_HOST'], conf['REDIS_PORT'])
+        self.redis = Redis(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'])
 
     def get_playing_now(self, user_id):
         """ Return the current playing song of the user """
@@ -190,7 +190,7 @@ REDIS_INFLUX_USER_LISTEN_COUNT = "ls.listencount." # append username
 class InfluxListenStore(ListenStore):
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
-        self.redis = Redis(conf['REDIS_HOST'])
+        self.redis = Redis(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'])
         self.influx = InfluxDBClient(host=conf['INFLUX_HOST'], port=conf['INFLUX_PORT'], database=conf['INFLUX_DB_NAME'])
 
 

--- a/listenstore/listenstore/tests/test_influxlistenstore.py
+++ b/listenstore/listenstore/tests/test_influxlistenstore.py
@@ -109,6 +109,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         super(TestInfluxListenStore, self).setUp()
         self.log = logging.getLogger(__name__)
         self.logstore = init_influx_connection({ 'REDIS_HOST' : config.REDIS_HOST,
+                                                 'REDIS_PORT' : config.REDIS_PORT,
                                                  'INFLUX_HOST': config.INFLUX_HOST,
                                                  'INFLUX_PORT': config.INFLUX_PORT,
                                                  'INFLUX_DB_NAME': config.INFLUX_DB_NAME} )

--- a/listenstore/listenstore/tests/test_redislistenstore.py
+++ b/listenstore/listenstore/tests/test_redislistenstore.py
@@ -17,7 +17,7 @@ class TestRedisListenStore(DatabaseTestCase):
     def setUp(self):
         super(TestRedisListenStore, self).setUp()
         self.log = logging.getLogger(__name__)
-        self._redis = init_redis_connection(self.config.REDIS_HOST)
+        self._redis = init_redis_connection(self.config.REDIS_HOST, self.config.REDIS_PORT)
         self.testuser_id = db.user.create("test")
         self._create_test_data()
 

--- a/redis-consumer/redis-consumer.py
+++ b/redis-consumer/redis-consumer.py
@@ -67,6 +67,6 @@ class RedisConsumer(RedisPubSubSubscriber):
                 self.time = 0
 
 if __name__ == "__main__":
-    r = Redis(config.REDIS_HOST)
+    r = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
     rc = RedisConsumer(r,config.SQLALCHEMY_DATABASE_URI)
     rc.start()

--- a/set_rate_limits.py
+++ b/set_rate_limits.py
@@ -18,7 +18,7 @@ RATELIMIT_WINDOW_KEY = "rate_limit_window"
 # to figure out how to do this. So, we have this script. If you want to see it part of manage.py, you'll
 # have to do it.
 
-r = Redis(config.REDIS_HOST)
+r = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
 if len(sys.argv) < 4:
     print "Usage: %s <per ip limit> <per token limit> <window in s>" % (sys.argv[0])
     print "Current values:"

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -28,7 +28,7 @@ class PubSubTestCase(unittest.TestCase):
     def setUp(self):
         self.results1 = []
         self.results2 = []
-        self.redis = Redis(config.REDIS_HOST)
+        self.redis = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
         self.pub = RedisPubSubPublisher(self.redis, KEYSPACE)
         self.sub1 = Subscriber(self.redis, KEYSPACE, "one", self.results1)
         self.sub2 = Subscriber(self.redis, KEYSPACE, "two", self.results2)

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -8,7 +8,8 @@ def create_influx(app):
     return init_influx_connection({ 'INFLUX_HOST':app.config['INFLUX_HOST'],
                                     'INFLUX_PORT':app.config['INFLUX_PORT'],
                                     'INFLUX_DB_NAME':app.config['INFLUX_DB_NAME'],
-                                    'REDIS_HOST':app.config['REDIS_HOST']})
+                                    'REDIS_HOST':app.config['REDIS_HOST'],
+                                    'REDIS_PORT':app.config['REDIS_PORT']})
 
 def create_postgres(app):
     from postgres_connection import init_postgres_connection
@@ -16,7 +17,7 @@ def create_postgres(app):
 
 def create_redis(app):
     from redis_connection import init_redis_connection
-    return init_redis_connection(app.config['REDIS_HOST'])
+    return init_redis_connection(app.config['REDIS_HOST'], app.config['REDIS_PORT'])
 
 def schedule_jobs(app):
     """ Init all the scheduled jobs """

--- a/webserver/redis_connection.py
+++ b/webserver/redis_connection.py
@@ -3,10 +3,11 @@ from listenstore.listenstore import RedisListenStore
 
 _redis = None
 
-def init_redis_connection(host):
+def init_redis_connection(host, port):
     """Create a connection to the Redis server."""
     global _redis
     _redis = RedisListenStore({
         'REDIS_HOST': host,
+        'REDIS_PORT': port
     })
     return _redis


### PR DESCRIPTION
I've made appropriate changes in influx-writer, bigquery-writer,
the webserver and other places so that now we can run redis from
non-standard ports also.