### PR TITLE
Add links to site, beta site, bug tracker at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Server for the ListenBrainz project.
 
+[Website](https://listenbrainz.org) | [Beta website](https://beta.listenbrainz.org) | [Bug tracker](https://tickets.metabrainz.org/projects/LB/issues)
+
 ## Installation
 
 *These instructions are meant to get you started quickly with development


### PR DESCRIPTION
This is a simple PR that adds links to the main site, the beta site URL, and most importantly, the bug tracker. I was looking through the README and noticed that no URL or instructions for reporting bugs was linked anywhere, so hopefully this makes it easier for someone to figure out where to go to see bugs or to report something.