### PR TITLE
Add stats about LB to current status page

### DIFF
--- a/db/user.py
+++ b/db/user.py
@@ -124,7 +124,24 @@ def get_by_token(token):
         return dict(row) if row else None
 
 
+def get_user_count():
+    """ Get total number of users in database.
 
+    Returns:
+        int: user count
+    """
+
+    with db.engine.connect() as connection:
+        try:
+            result = connection.execute(sqlalchemy.text("""
+                SELECT count(*) AS user_count
+                  FROM "user"
+            """))
+            row = result.fetchone()
+            return row['user_count']
+        except DatabaseException as e:
+            logger.error(e)
+            raise
 
 def get_or_create(musicbrainz_id):
     """Get user with a specified MusicBrainz ID, or create if there's no account.

--- a/webserver/templates/index/current-status.html
+++ b/webserver/templates/index/current-status.html
@@ -7,6 +7,20 @@
   <div class="row">
 
     <div class="col-md-7 col-lg-8">
+      <h3>ListenBrainz Stats</h3>
+      {% if user_count %}
+        Number of users registered: {{ user_count }}
+      {% endif %}
+      <br/>
+      {% if listen_count %}
+        Total number of listens: {{ listen_count }}
+      {% endif %}
+      <br/>
+        Number of people in queue for alpha imports: {{ alpha_importer_size }}
+      <br/>
+    </div>
+
+    <div class="col-md-7 col-lg-8">
       {% for s in stats %}
           <h3>{{ s.desc }}</h3>
           <table class="table table-border table-condensed table-striped">

--- a/webserver/views/index.py
+++ b/webserver/views/index.py
@@ -6,9 +6,16 @@ from redis_pubsub import RedisPubSubPublisher
 import os
 import subprocess
 import locale
+import db.user
+from db.exceptions import DatabaseException
+import webserver
+from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 
 index_bp = Blueprint('index', __name__)
 locale.setlocale(locale.LC_ALL, '')
+
+STATS_PREFIX = 'listenbrainz.stats' # prefix used in key to cache stats
+CACHE_TIME = 10 * 60 # time in seconds we cache the stats
 
 @index_bp.route("/")
 def index():
@@ -66,4 +73,53 @@ def current_status():
     stats_dict = pubsub.get_stats()
     stats.append({ 'data' : stats_dict, 'desc' : "Unique listens" })
 
-    return render_template("index/current-status.html", load=load, stats = stats)
+    try:
+        user_count = _get_user_count()
+    except DatabaseException as e:
+        user_count = None
+
+    db_conn = webserver.influx_connection._influx
+    try:
+        listen_count = db_conn.get_total_listen_count()
+    except (InfluxDBServerError, InfluxDBClientError):
+        listen_count = None
+
+    return render_template(
+        "index/current-status.html",
+        load=load,
+        stats=stats,
+        user_count=user_count,
+        listen_count=listen_count,
+        alpha_importer_size=_get_alpha_importer_queue_size(),
+    )
+
+
+def _get_user_count():
+    """ Gets user count from either the redis cache or from the database.
+        If not present in the cache, it makes a query to the db and stores the
+        result in the cache for 10 minutes.
+    """
+    redis_connection = _redis.redis
+    user_count_key = "{}.{}".format(STATS_PREFIX, 'user_count')
+    if redis_connection.exists(user_count_key):
+        return redis_connection.get(user_count_key)
+    else:
+        try:
+            user_count = db.user.get_user_count()
+        except DatabaseException as e:
+            raise
+        redis_connection.setex(user_count_key, user_count, CACHE_TIME)
+        return user_count
+
+def _get_alpha_importer_queue_size():
+    """ Returns the number of people in queue for an import from LB alpha
+    """
+    redis_connection = _redis.redis
+    alpha_importer_size_key = "{}.{}".format(STATS_PREFIX, "alpha_importer_queue_size")
+    if redis_connection.exists(alpha_importer_size_key):
+        return redis_connection.get(alpha_importer_size_key)
+    else:
+        count = redis_connection.llen(current_app.config['IMPORTER_QUEUE_KEY'])
+        count = 0 if not count else count
+        redis_connection.setex(alpha_importer_size_key, count, CACHE_TIME)
+        return count


### PR DESCRIPTION
Stats include the total number of users registered, the total
number of listens present in the listen store and the number of
people in the queue waiting for an import from alpha_importer.