### PR TITLE
Move utils.py back to tests/ so that lastfm tests don't fail

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import time
 import sys
 import os
 
-sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../listenstore"))
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../listenstore"))
 from listen import Listen
 import uuid
 import pytz


### PR DESCRIPTION
Because of some stray .pyc files, it did not come to my attention that changes in #122 had started causing failures in last.fm tests which used `utils.py`. I have fixed this here by moving `utils.py` back to where it was.