### PR TITLE
Modify pytest.ini so that test.sh doesn't run integration tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = . db webserver listenstore redis-consumer
+testpaths = db webserver listenstore redis-consumer


### PR DESCRIPTION
`./test.sh` now only runs tests in db, webserver, listenstore and redis-consumer.