### PR TITLE
LB-117: Add test for checking that additional_info remains intact

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -21,7 +21,7 @@ services:
   influx_writer:
     build:
       context: ..
-      dockerfile: ./docker/influx-writer/Dockerfile
+      dockerfile: Dockerfile
     command: python influx-writer/influx-writer.py
     depends_on:
       - redis
@@ -30,7 +30,7 @@ services:
   bigquery:
     build:
       context: ..
-      dockerfile: ./docker/bigquery-writer/Dockerfile
+      dockerfile: Dockerfile
     command: python bigquery-writer/bigquery-writer.py
     links:
       - redis
@@ -38,7 +38,7 @@ services:
   listenbrainz:
     build:
       context: ..
-      dockerfile: ./docker/Dockerfile
+      dockerfile: Dockerfile
     command: py.test tests/integration
     depends_on:
       - redis

--- a/testdata/additional_info.json
+++ b/testdata/additional_info.json
@@ -10,7 +10,10 @@
                     "link1": "https://genius.com/Majid-jordan-every-step-every-way-lyrics",
                     "best_song": "definitely",
                     "link2": "https://www.last.fm/music/Majid+Jordan/_/Every+Step+Every+Way",
-                    "other_stuff": "teststuffplsignore"
+                    "other_stuff": "teststuffplsignore",
+                    "nested": {
+                        "info": "here",
+                    }
                 }
             }
         }

--- a/testdata/additional_info.json
+++ b/testdata/additional_info.json
@@ -12,7 +12,7 @@
                     "link2": "https://www.last.fm/music/Majid+Jordan/_/Every+Step+Every+Way",
                     "other_stuff": "teststuffplsignore",
                     "nested": {
-                        "info": "here",
+                        "info": "here"
                     }
                 }
             }

--- a/testdata/additional_info.json
+++ b/testdata/additional_info.json
@@ -1,0 +1,19 @@
+{
+    "payload": [
+        {
+            "listened_at": 1489671410,
+            "track_metadata": {
+                "release_name": "Majid Jordan",
+                "track_name": "Every Step Every Way",
+                "artist_name": "Majid Jordan",
+                "additional_info": {
+                    "link1": "https://genius.com/Majid-jordan-every-step-every-way-lyrics",
+                    "best_song": "definitely",
+                    "link2": "https://www.last.fm/music/Majid+Jordan/_/Every+Step+Every+Way",
+                    "other_stuff": "teststuffplsignore"
+                }
+            }
+        }
+    ],
+    "listen_type": "import"
+}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -224,6 +224,7 @@ class APITestCase(IntegrationTestCase):
         self.assertEquals(sent_additional_info['link1'], received_additional_info['link1'])
         self.assertEquals(sent_additional_info['link2'], received_additional_info['link2'])
         self.assertEquals(sent_additional_info['other_stuff'], received_additional_info['other_stuff'])
+        self.assertEquals(sent_additional_info['nested']['info'], received_additional_info['nested.info'])
 
     def path_to_data_file(self, fn):
         """ Returns the path of the test data file relative to the test file.


### PR DESCRIPTION
See this: https://github.com/metabrainz/listenbrainz-server/pull/122#pullrequestreview-26536417

Add a test that checks to see that user generated data in `additional_info` field of listens does not get dropped anywhere in the process of submission.