### PR TITLE
LB-140: Catch relevant errors during write to influx

### DIFF
--- a/influx-writer/influx-writer.py
+++ b/influx-writer/influx-writer.py
@@ -127,7 +127,7 @@ class InfluxWriterSubscriber(RedisPubSubSubscriber):
                 return
             except WriteFailException as e:
                 self.log.error("InfluxWriterSubscriber failed to write: %s" % str(e))
-                return
+                count = 0
 
             if not count:
                 continue

--- a/influx-writer/influx-writer.py
+++ b/influx-writer/influx-writer.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", 
 from redis import Redis
 from redis_pubsub import RedisPubSubSubscriber, RedisPubSubPublisher, NoSubscriberNameSetException, WriteFailException, NoSubscribersException
 from influxdb import InfluxDBClient
+from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 import ujson
 import logging
 from listen import Listen
@@ -103,7 +104,7 @@ class InfluxWriterSubscriber(RedisPubSubSubscriber):
             t0 = time()
             self.ls.insert(submit)
             self.time += time() - t0
-        except ValueError as e:
+        except (InfluxDBClientError, InfluxDBServerError, ValueError) as e:
             self.log.error("Cannot write data to listenstore: %s" % str(e))
             return False
 

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -327,7 +327,7 @@ class InfluxListenStore(ListenStore):
         try:
             if not self.influx.write_points(submit, time_precision='s'):
                 self.log.error("Cannot write data to influx. (write_points returned False)")
-        except ValueError as e:
+        except (InfluxDBServerError, InfluxDBClientError, ValueError) as e:
             self.log.error("Cannot write data to influx: %s" % str(e))
             raise
 

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -17,6 +17,7 @@ import sqlalchemy.exc
 import pytz
 from redis import Redis
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
+import json
 
 MIN_ID = 1033430400     # approx when audioscrobbler was created
 ORDER_DESC = 0
@@ -329,6 +330,8 @@ class InfluxListenStore(ListenStore):
                 self.log.error("Cannot write data to influx. (write_points returned False)")
         except (InfluxDBServerError, InfluxDBClientError, ValueError) as e:
             self.log.error("Cannot write data to influx: %s" % str(e))
+            self.log.error("Data that was being written when the error occurred: ")
+            self.log.error(json.dumps(submit, indent=4))
             raise
 
         # Invalidate cached data for user

--- a/redis_pubsub.py
+++ b/redis_pubsub.py
@@ -194,12 +194,6 @@ class RedisPubSubSubscriber(object):
             sleep(WRITE_FAIL_TIMEOUT)
             print("write timeout. sleep")
 
-
-        # We've tried to write repeatedly, but no luck. :(
-        if broken:
-            print("Raising write fail exception")
-            raise WriteFailException
-
         # Use a pipeline to clean up
         p = r.pipeline()
 
@@ -216,6 +210,11 @@ class RedisPubSubSubscriber(object):
 
         # Flush everything we stuffed into the redis pipeline
         p.execute()
+
+        # We've tried to write repeatedly, but no luck. :(
+        if broken:
+            print("Raising write fail exception")
+            raise WriteFailException
 
         print("Wrote messages.")
         return len(messages)


### PR DESCRIPTION
InfluxDB raises InfluxDBClientError or InfluxDBServerError if
something goes kaput during a write. Catch these exceptions so
that scripts like influx-writer don't crash on a failed write.
See LB-140.