### PR TITLE
LB-140: Upgrade influxdb-python to 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,6 @@ apscheduler == 3.1.0
 yattag == 1.6.0
 xmltodict == 0.10.2
 unittest2 == 1.1.0
-influxdb == 3.0.0
+influxdb == 4.0.0
 requests == 2.13.0
 google-api-python-client==1.5.2


### PR DESCRIPTION
3.0.0 has bugs causing problems in adding listens with track names with `\` in them. 4.0.0 has fixed that. See [this](https://github.com/influxdata/influxdb-python/commit/97952ba1bb0858774a2c10c073db9377adfe57a3) commit.

https://chatlogs.metabrainz.org/brainzbot/metabrainz/2017-03-20/?msg=3861171&page=2