### PR TITLE
LB-141: Handle bad data in a better way in redis_pubsub

### DIFF
--- a/bigquery-writer/bigquery-writer.py
+++ b/bigquery-writer/bigquery-writer.py
@@ -26,11 +26,8 @@ APP_CREDENTIALS_FILE = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
 
 class BigQueryWriterSubscriber(RedisPubSubSubscriber):
     def __init__(self, redis):
-        RedisPubSubSubscriber.__init__(self, redis, KEYSPACE_NAME_UNIQUE)
+        RedisPubSubSubscriber.__init__(self, redis, KEYSPACE_NAME_UNIQUE, __name__)
 
-        self.log = logging.getLogger(__name__)
-        self.log.setLevel(logging.INFO)
-        logging.basicConfig()
         self.total_inserts = 0
         self.inserts = 0
         self.time = 0

--- a/influx-writer/influx-writer.py
+++ b/influx-writer/influx-writer.py
@@ -24,15 +24,12 @@ KEYSPACE_NAME_UNIQUE = "ulisten"
 
 class InfluxWriterSubscriber(RedisPubSubSubscriber):
     def __init__(self, ls, influx, redis):
-        RedisPubSubSubscriber.__init__(self, redis, KEYSPACE_NAME_INCOMING)
+        RedisPubSubSubscriber.__init__(self, redis, KEYSPACE_NAME_INCOMING, __name__)
 
         self.publisher = RedisPubSubPublisher(redis, KEYSPACE_NAME_UNIQUE)
 
         self.influx = influx
         self.ls = ls
-        self.log = logging.getLogger(__name__)
-        logging.basicConfig()
-        self.log.setLevel(logging.INFO)
         self.total_inserts = 0
         self.inserts = 0
         self.time = 0
@@ -129,7 +126,7 @@ class InfluxWriterSubscriber(RedisPubSubSubscriber):
                 return
             except WriteFailException as e:
                 self.print_and_log_error("InfluxWriterSubscriber failed to write: %s" % str(e))
-                count = 0
+                count = e.written
 
             if not count:
                 continue

--- a/redis-consumer/redis-consumer.py
+++ b/redis-consumer/redis-consumer.py
@@ -20,9 +20,8 @@ KEYSPACE_NAME = "listen"
 
 class RedisConsumer(RedisPubSubSubscriber):
     def __init__(self, redis, database_uri):
-        RedisPubSubSubscriber.__init__(self, redis, KEYSPACE_NAME)
+        RedisPubSubSubscriber.__init__(self, redis, KEYSPACE_NAME, __name__)
 
-        self.log = logging.getLogger(__name__)
         self.total_inserts = 0
         self.inserts = 0
         self.time = 0

--- a/tests/unit/test_pubsub.py
+++ b/tests/unit/test_pubsub.py
@@ -13,7 +13,7 @@ NUM_POINTS = 100
 
 class Subscriber(RedisPubSubSubscriber):
     def __init__(self, redis, keyspace, name, results):
-        RedisPubSubSubscriber.__init__(self, redis, keyspace)
+        RedisPubSubSubscriber.__init__(self, redis, keyspace, __name__)
 
         self.register(name)
         self.results = results


### PR DESCRIPTION
Previously, if there was a single bad listen, our pubsub would
discard an entire batch of messages. Fix this by making the code
break the batch into half and try to write these halves. This goes
on recursively. See LB-141 for more details.

Also, moved the logger into the RedisPubSubSubscriber class
because previously, error or info messages were just being printed
to stdout.