### PR TITLE
LB-144: Increment user listen counts in redis when writing in InfluxListenStore

### DIFF
--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -207,12 +207,7 @@ class InfluxListenStore(ListenStore):
 
     REDIS_INFLUX_TOTAL_LISTEN_COUNT = "ls.listencount.total"
     TOTAL_LISTEN_COUNT_CACHE_TIME = 10 * 60
-    # variables which define how much time to cache listen count in redis
-    LISTENCOUNT_CACHE_TIME_LOW = 15 * 60 # in seconds. 15 minutes
-    LISTENCOUNT_CACHE_TIME_MEDIUM = 60 * 60 # in seconds. 1 hour
-    LISTENCOUNT_CACHE_TIME_HIGH = 24 * 60 * 60 # in seconds. 1 day
-    LOW_LISTEN_THRESHOLD = 1000
-    MEDIUM_LISTEN_THRESHOLD = 10000
+    USER_LISTEN_COUNT_CACHE_TIME = 15 * 60 # in seconds. 15 minutes
 
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
@@ -247,18 +242,12 @@ class InfluxListenStore(ListenStore):
         # get the number of listens from the json
         try:
             count = results.get_points(measurement = 'listen').next()['count_recording_msid']
-        except KeyError:
+        except (KeyError, StopIteration):
             count = 0
 
-        # put this value into redis with expiry time based on the number of listens
-        # that the user has
+        # put this value into redis with an expiry time
         user_key = "{}{}".format(REDIS_INFLUX_USER_LISTEN_COUNT, user_name)
-        if count <= InfluxListenStore.LOW_LISTEN_THRESHOLD:
-            self.redis.setex(user_key, count, InfluxListenStore.LISTENCOUNT_CACHE_TIME_LOW)
-        elif count <= InfluxListenStore.MEDIUM_LISTEN_THRESHOLD:
-            self.redis.setex(user_key, count, InfluxListenStore.LISTENCOUNT_CACHE_TIME_MEDIUM)
-        else:
-            self.redis.setex(user_key, count, InfluxListenStore.LISTENCOUNT_CACHE_TIME_HIGH)
+        self.redis.setex(user_key, count, InfluxListenStore.USER_LISTEN_COUNT_CACHE_TIME)
         return int(count)
 
 

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -387,6 +387,13 @@ class InfluxListenStore(ListenStore):
             self.log.error(json.dumps(submit, indent=4))
             raise
 
+        # If we reach this point, we were able to write the listens to the InfluxListenStore.
+        # So update the listen counts of the users cached in redis.
+        for data in submit:
+            user_key = "{}{}".format(REDIS_INFLUX_USER_LISTEN_COUNT, data['tags']['user_name'])
+            if self.redis.exists(user_key):
+                self.redis.incr(user_key)
+
         # Invalidate cached data for user
         for user_name in user_names.keys():
             self.redis.delete(REDIS_USER_TIMESTAMPS % user_name)

--- a/webserver/templates/user/profile.html
+++ b/webserver/templates/user/profile.html
@@ -13,7 +13,6 @@
 
     {% if have_listen_count %}
       <h3> Listen Count: {{ listen_count }}  </h3>
-      <p> Note: This is an approximate value. <a href = "{{ url_for("user.profile", user_name=user.musicbrainz_id, exact = 'y') }}">Get exact listen count!</a> </p>
     {% else %}
       We were not able to get listen count for {{ user.musicbrainz_id }} due to an error. Please reload to try again.
     {% endif %}

--- a/webserver/views/user.py
+++ b/webserver/views/user.py
@@ -26,9 +26,6 @@ import pytz
 
 LISTENS_PER_PAGE = 25
 
-# this variable is sent as a parameter to round and used to make the listen count approximate
-LISTEN_COUNT_APPROXIMATION_ROUND = -1
-
 user_bp = Blueprint("user", __name__)
 
 
@@ -83,16 +80,12 @@ def profile(user_name):
 
     user = _get_user(user_name)
 
-    need_exact_listen_count = request.args.get("exact") == 'y'
     try:
         have_listen_count = True
-        listen_count = db_conn.get_listen_count_for_user(user_name, need_exact = need_exact_listen_count)
+        listen_count = db_conn.get_listen_count_for_user(user_name)
     except (InfluxDBServerError, InfluxDBClientError):
         have_listen_count = False
         listen_count = 0
-
-    if have_listen_count and not need_exact_listen_count:
-        listen_count = int(round(listen_count, LISTEN_COUNT_APPROXIMATION_ROUND))
 
     # Getting data for current page
     max_ts = request.args.get("max_ts")
@@ -162,7 +155,6 @@ def profile(user_name):
         spotify_uri=_get_spotify_uri_for_listens(listens),
         have_listen_count=have_listen_count,
         listen_count=format(int(listen_count), ",d"),
-        have_exact_listen_count=need_exact_listen_count,
     )
 
 


### PR DESCRIPTION
User's listen counts stored in redis now get incremented after write to listenstore has been done.

Also, remove the approximations we were making because ideally with increments we'll have the correct values in redis cache always.