### PR TITLE
LB-145: Add artist_msid to data received from api

### DIFF
--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -106,8 +106,10 @@ def get_listens(user_name):
     )
     listen_data = []
     for listen in listens:
+        track_metadata = listen.data.copy()
+        track_metadata['additional_info']['artist_msid'] = listen.artist_msid
         listen_data.append({
-            "track_metadata": listen.data,
+            "track_metadata": track_metadata,
             "listened_at": listen.ts_since_epoch,
             "recording_msid": listen.recording_msid,
         })


### PR DESCRIPTION
`artist_msid`s were not being returned by the api, leading to a failed test in #148. This PR fixes that.