### PR TITLE
LB-139: Make sure user-generated data doesn't get dropped.

### DIFF
--- a/listen.py
+++ b/listen.py
@@ -4,6 +4,28 @@ import ujson
 from datetime import datetime
 import calendar
 
+def flatten_dict(d, seperator='', parent_key=''):
+    """
+    Flattens a dictionary if it contains dictionaries inside it.
+
+    Args:
+        d: the dict to be flattened
+        seperator: the seperator used in keys in the flattened dict
+        parent_key: the key that is prefixed to all keys generated during flattening
+
+    Returns:
+        Flattened dict with keys such as key1.key2
+    """
+    result = []
+    for key, value in d.items():
+        new_key = "{}{}{}".format(parent_key, seperator, str(key))
+        if isinstance(value, dict):
+            result.extend(flatten_dict(value, '.', new_key).items())
+        else:
+            result.append((new_key, value))
+    return dict(result)
+
+
 class Listen(object):
     """ Represents a listen object """
     def __init__(self, user_id=None, user_name=None, timestamp=None, artist_msid=None, album_msid=None,
@@ -29,6 +51,7 @@ class Listen(object):
         if data is None:
             self.data = {'additional_info': {}}
         else:
+            data['additional_info'] = flatten_dict(data['additional_info'])
             self.data = data
 
     @classmethod
@@ -69,6 +92,11 @@ class Listen(object):
             'recording_mbid': row.get('recording_mbid'),
             'tags': tags,
         }
+
+        for key, value in row.items():
+            if key != 'time' and value is not None:
+                data[key] = value
+
         return cls(
             timestamp=t,
             user_name=row.get('user_name'),

--- a/listen.py
+++ b/listen.py
@@ -68,7 +68,13 @@ class Listen(object):
         if data is None:
             self.data = {'additional_info': {}}
         else:
-            data['additional_info'] = flatten_dict(data['additional_info'])
+            try:
+                data['additional_info'] = flatten_dict(data['additional_info'])
+            except TypeError:
+                # TypeError may occur here because PostgresListenStore passes strings
+                # to data sometimes. If that occurs, we don't need to do anything.
+                pass
+
             self.data = data
 
     @classmethod

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -209,6 +209,22 @@ class InfluxListenStore(ListenStore):
     TOTAL_LISTEN_COUNT_CACHE_TIME = 10 * 60
     USER_LISTEN_COUNT_CACHE_TIME = 15 * 60 # in seconds. 15 minutes
 
+    # keys in additional_info that we support explicitly and are not superfluous
+    SUPPORTED_KEYS = [
+        'artist_mbids',
+        'release_group_mbid',
+        'release_mbid',
+        'recording_mbid',
+        'track_mbid',
+        'work_mbids',
+        'tracknumber',
+        'isrc',
+        'spotify_id',
+        'tags',
+        'artist_msid',
+        'release_msid',
+    ]
+
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
         self.redis = Redis(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'])
@@ -364,6 +380,9 @@ class InfluxListenStore(ListenStore):
                     'tags' : ",".join(listen.data['additional_info'].get('tags', [])),
                 }
             }
+            for key, value in listen.data['additional_info'].items():
+                if key not in InfluxListenStore.SUPPORTED_KEYS:
+                    data['fields'][key] = value
             submit.append(data)
 
 

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -209,21 +209,6 @@ class InfluxListenStore(ListenStore):
     TOTAL_LISTEN_COUNT_CACHE_TIME = 10 * 60
     USER_LISTEN_COUNT_CACHE_TIME = 15 * 60 # in seconds. 15 minutes
 
-    # keys in additional_info that we support explicitly and are not superfluous
-    SUPPORTED_KEYS = [
-        'artist_mbids',
-        'release_group_mbid',
-        'release_mbid',
-        'recording_mbid',
-        'track_mbid',
-        'work_mbids',
-        'tracknumber',
-        'isrc',
-        'spotify_id',
-        'tags',
-        'artist_msid',
-        'release_msid',
-    ]
 
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
@@ -361,29 +346,7 @@ class InfluxListenStore(ListenStore):
         user_names = {}
         for listen in listens:
             user_names[listen.user_name] = 1
-            data = {
-                'measurement' : 'listen',
-                'time' : listen.ts_since_epoch,
-                'tags' : {
-                    'user_name' : listen.user_name,
-                },
-                'fields' : {
-                    'artist_name' : listen.data['artist_name'],
-                    'artist_msid' : listen.artist_msid,
-                    'artist_mbids' : ",".join(listen.data['additional_info'].get('artist_mbids', [])),
-                    'album_name' : listen.data.get('release_name', ''),
-                    'album_msid' : listen.album_msid,
-                    'album_mbid' : listen.data['additional_info'].get('release_mbid', ''),
-                    'track_name' : listen.data['track_name'],
-                    'recording_msid' : listen.recording_msid,
-                    'recording_mbid' : listen.data['additional_info'].get('recording_mbid', ''),
-                    'tags' : ",".join(listen.data['additional_info'].get('tags', [])),
-                }
-            }
-            for key, value in listen.data['additional_info'].items():
-                if key not in InfluxListenStore.SUPPORTED_KEYS:
-                    data['fields'][key] = value
-            submit.append(data)
+            submit.append(listen.to_influx())
 
 
         try:

--- a/listenstore/listenstore/listenstore.py
+++ b/listenstore/listenstore/listenstore.py
@@ -209,7 +209,6 @@ class InfluxListenStore(ListenStore):
     TOTAL_LISTEN_COUNT_CACHE_TIME = 10 * 60
     USER_LISTEN_COUNT_CACHE_TIME = 15 * 60 # in seconds. 15 minutes
 
-
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
         self.redis = Redis(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'])

--- a/webserver/views/api.py
+++ b/webserver/views/api.py
@@ -106,13 +106,7 @@ def get_listens(user_name):
     )
     listen_data = []
     for listen in listens:
-        track_metadata = listen.data.copy()
-        track_metadata['additional_info']['artist_msid'] = listen.artist_msid
-        listen_data.append({
-            "track_metadata": track_metadata,
-            "listened_at": listen.ts_since_epoch,
-            "recording_msid": listen.recording_msid,
-        })
+        listen_data.append(listen.to_api())
 
     if min_ts:
         listen_data = listen_data[::-1]


### PR DESCRIPTION
I've done this by flattening the `additional_info` dict in the listen class constructor and then making changes to InfluxListenStore so that it writes all fields present in the `additional_info` of a listen.

