### PR TITLE
LB-159: Change influx-writer so that dedup works correctly for multiple users in same batch

### DIFF
--- a/tests/integration/test_influx_writer.py
+++ b/tests/integration/test_influx_writer.py
@@ -59,7 +59,9 @@ class InfluxWriterTestCase(IntegrationTestCase):
         user2 = db.user.get_or_create('testuser2')
 
         r = self.send_single_listen(user1)
+        self.assert200(r)
         r = self.send_single_listen(user2)
+        self.assert200(r)
 
         time.sleep(5) # sleep to allow influx-writer to do its thing
 

--- a/tests/integration/test_influx_writer.py
+++ b/tests/integration/test_influx_writer.py
@@ -48,3 +48,24 @@ class InfluxWriterTestCase(IntegrationTestCase):
         to_ts = int(time.time())
         listens = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
+
+    def test_dedup_different_users(self):
+        """
+        Test to make sure influx writer doesn't confuse listens with same timestamps
+        but different users to be duplicates
+        """
+
+        user1 = db.user.get_or_create('testuser1')
+        user2 = db.user.get_or_create('testuser2')
+
+        r = self.send_single_listen(user1)
+        r = self.send_single_listen(user2)
+
+        time.sleep(5) # sleep to allow influx-writer to do its thing
+
+        to_ts = int(time.time())
+        listens = self.ls.fetch_listens(user1['musicbrainz_id'], to_ts=to_ts)
+        self.assertEqual(len(listens), 1)
+
+        listens = self.ls.fetch_listens(user2['musicbrainz_id'], to_ts=to_ts)
+        self.assertEqual(len(listens), 1)


### PR DESCRIPTION
Previously, if there was more than one user in the same batch of
listens, influx-writer would count listens with the same timestamps
as a duplicate (even though they were from different users). This
change fixes that.