### PR TITLE
LB-153: Make api_compat use generic ListenStore objects to get play counts

### DIFF
--- a/db/lastfm_user.py
+++ b/db/lastfm_user.py
@@ -64,10 +64,8 @@ class User(object):
             return None
 
     @staticmethod
-    def get_play_count(user_id):
+    def get_play_count(user_id, listenstore):
         """ Get playcount from the given user name.
         """
-        with db.engine.connect() as connection:
-            result = connection.execute(text(""" SELECT COUNT(*) FROM listen WHERE
-                                            user_id = :user_id """), {"user_id": user_id})
-            return int(result.fetchone()[0])
+        user = User.load_by_id(user_id)
+        return listenstore.get_listen_count_for_user(user.name, need_exact=False)

--- a/db/tests/test_lastfm_user.py
+++ b/db/tests/test_lastfm_user.py
@@ -24,7 +24,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
         })
 
         # Create a user
-        uid = db.user.create("test")
+        uid = db.user.create("test_api_compat_user")
         self.assertIsNotNone(db.user.get(uid))
         with db.engine.connect() as connection:
             result = connection.execute(text("""
@@ -40,7 +40,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
         # Insert some listens
         date = datetime(2015, 9, 3, 0, 0, 0)
         self.log.info("Inserting test data...")
-        test_data = generate_data(date, 100)
+        test_data = generate_data(date, 100, self.user.name)
         self.logstore.insert(test_data)
         self.log.info("Test data inserted")
 
@@ -60,3 +60,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
         user = User.load_by_id(self.user.id)
         assert isinstance(user, User) == True
         self.assertDictEqual(user.__dict__, self.user.__dict__)
+
+    def test_user_get_play_count(self):
+        count = User.get_play_count(self.user.id, self.logstore)
+        self.assertEqual(count, 100)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,21 +11,21 @@ import pytz
 import db.user
 
 
-def generate_data(from_date, num_records):
+def generate_data(from_date, num_records, user_name):
     test_data = []
     current_date = to_epoch(from_date)
     artist_msid = str(uuid.uuid4())
 
-    user = db.user.get_by_mb_id("test")
+    user = db.user.get_by_mb_id(user_name)
     if not user:
-        db.user.create("test")
-        user = db.user.get_by_mb_id("test")
+        db.user.create(user_name)
+        user = db.user.get_by_mb_id(user_name)
 
     for i in range(num_records):
         current_date += 1   # Add one second
         item = Listen(
             user_id=user['id'],
-            user_name='testuserplsignore',
+            user_name=user_name,
             timestamp=datetime.utcfromtimestamp(current_date),
             artist_msid=artist_msid,
             recording_msid=str(uuid.uuid4()),

--- a/webserver/views/api_compat.py
+++ b/webserver/views/api_compat.py
@@ -16,6 +16,7 @@ from db.lastfm_session import Session
 from db.lastfm_token import Token
 import calendar
 from datetime import datetime
+from webserver.influx_connection import _influx
 
 api_bp = Blueprint('api_compat', __name__)
 
@@ -395,7 +396,7 @@ def user_info(request, data):
             with tag('url'):
                 text('http://listenbrainz.org/user/' + query_user.name)
             with tag('playcount'):
-                text(User.get_play_count(query_user.id))
+                text(User.get_play_count(query_user.id, _influx))
             with tag('registered', unixtime=str(query_user.created.strftime("%s"))):
                 text(str(query_user.created))
 


### PR DESCRIPTION
Instead of using the PostgresListenStore directly, we now take
a listenstore as argument and get listen count from there.