### PR TITLE
LB-157: Handle bad listens in a smarter way in influx-writer

### DIFF
--- a/influx-writer/influx-writer.py
+++ b/influx-writer/influx-writer.py
@@ -101,7 +101,6 @@ class InfluxWriterSubscriber(object):
         if not data:
             return 0
 
-        done = False
         failure_count = 0
         while True:
             try:

--- a/influx-writer/influx-writer.py
+++ b/influx-writer/influx-writer.py
@@ -106,8 +106,7 @@ class InfluxWriterSubscriber(object):
         while True:
             try:
                 self.ls.insert(data)
-                done = True
-                break
+                return len(data)
             except (InfluxDBServerError, InfluxDBClientError, ValueError) as e:
                 failure_count += 1
                 if failure_count >= retries:
@@ -117,9 +116,8 @@ class InfluxWriterSubscriber(object):
                 self.log.error("Cannot write data to listenstore: %s. Sleep." % str(e))
                 sleep(ERROR_RETRY_DELAY)
 
-        if done:
-            return len(data)
-        elif not done and len(data) == 1:
+        # if we get here, we failed on trying to write the data
+        if len(data) == 1:
             # try to send the bad listen one more time and if it doesn't work
             # log the error
             try:

--- a/influx-writer/influx-writer.py
+++ b/influx-writer/influx-writer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+from __future__ import print_function, division
 
 import sys
 import os
@@ -86,6 +86,60 @@ class InfluxWriterSubscriber(object):
         return ret
 
 
+    def insert_to_listenstore(self, data, retries=5):
+        """
+        Inserts a batch of listens to the ListenStore. If this fails, then breaks the data into
+        two parts and recursively tries to insert them, until we find the culprit listen
+
+        Args:
+            data: the data to be inserted into the ListenStore
+            retries: the number of retries to make before deciding that we've failed
+
+        Returns: number of listens successfully sent
+        """
+
+        if not data:
+            return 0
+
+        done = False
+        failure_count = 0
+        while True:
+            try:
+                self.ls.insert(data)
+                done = True
+                break
+            except (InfluxDBServerError, InfluxDBClientError, ValueError) as e:
+                failure_count += 1
+                if failure_count >= retries:
+                    break
+                sleep(ERROR_RETRY_DELAY)
+            except ConnectionError as e:
+                self.log.error("Cannot write data to listenstore: %s. Sleep." % str(e))
+                sleep(ERROR_RETRY_DELAY)
+
+        if done:
+            return len(data)
+        elif not done and len(data) == 1:
+            # try to send the bad listen one more time and if it doesn't work
+            # log the error
+            try:
+                self.ls.insert(data)
+                return 1
+            except (InfluxDBServerError, InfluxDBClientError, ValueError, ConnectionError) as e:
+                self.log.error("Unable to insert bad listen to listenstore: %s" % str(e))
+                if DUMP_JSON_WITH_ERRORS:
+                    self.log.error("Was writing the following data: ")
+                    self.log.error(json.dumps(data, indent=4))
+                return 0
+        else:
+            slice_index = len(data) // 2
+            # send first half
+            sent = self.insert_to_listenstore(data[:slice_index], retries)
+            # send second half
+            sent += self.insert_to_listenstore(data[slice_index:], retries)
+            return sent
+
+
     def write(self, listen_dicts):
         submit = []
         unique = []
@@ -141,26 +195,11 @@ class InfluxWriterSubscriber(object):
             submit.append(Listen().from_json(listen))
             unique.append(listen)
 
-        while True:
-            try:
-                t0 = time()
-                self.ls.insert(submit)
-                self.time += time() - t0
-                break
+        t0 = time()
+        submitted_count = self.insert_to_listenstore(submit)
+        self.time += time() - t0
 
-            except ConnectionError as e:
-                self.log.error("Cannot write data to listenstore: %s. Sleep." % str(e))
-                sleep(ERROR_RETRY_DELAY)
-                continue
-
-            except (InfluxDBClientError, InfluxDBServerError, ValueError) as e:
-                self.log.error("Cannot write data to listenstore: %s" % str(e))
-                if DUMP_JSON_WITH_ERRORS:
-                    self.log.error("Was writing the following data: ")
-                    self.log.error(json.dumps(submit, indent=4))
-                return False
-
-        self.log.error("dups: %d, unique %d" % (duplicate_count, unique_count))
+        self.log.error("dups: %d, unique: %d, submitted: %d" % (duplicate_count, unique_count, submitted_count))
         if not unique_count:
             return True
 


### PR DESCRIPTION
Recursively divide the data into two parts until we find the listen
that was failing. This means that only the bad listen gets rejected
and not an entire batch.