### PR TITLE
LB-128: Install less and clean-css using npm so that compiling css works

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -11,8 +11,6 @@ RUN apt-get update \
                        libpq-dev \
                        libffi-dev \
                        libssl-dev \
-                       node-less \
-                       node-clean-css \
                        redis-tools \
     && rm -rf /var/lib/apt/lists/*
 
@@ -48,14 +46,15 @@ COPY . /code/listenbrainz
 WORKDIR /code/listenbrainz
 
 # Node
-#RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-#RUN apt-get install -y nodejs
-#RUN npm install less-plugin-clean-css
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g less less-plugin-clean-css
 
 # Compile the CSS
-# TODO: Bring this back
-# RUN lessc --clean-css webserver/static/css/main.less > webserver/static/css/main.css 
-RUN lessc webserver/static/css/main.less > webserver/static/css/main.css 
+# Note: this will not persist because /code/listenbrainz is a volume
+# After bringing up a container, run this again inside the container
+# to compile the less files
+RUN lessc --clean-css listenbrainz/webserver/static/css/main.less > listenbrainz/webserver/static/css/main.css
 
 # Consul Template service is already set up with the base image.
 # Just need to copy the configuration.


### PR DESCRIPTION
Need to compile css manually inside the container again, because of `/code/listenbrainz/` being a volume. Added a comment in `Dockerfile.prod`.