### PR TITLE
Remove broken stats

### DIFF
--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -9,7 +9,6 @@ import pika
 from time import time, sleep
 import listenbrainz.config as config
 from redis import Redis
-from listenbrainz.redis_keys import UNIQUE_QUEUE_SIZE_KEY
 
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
@@ -114,7 +113,6 @@ class BigQueryWriter(object):
             except pika.exceptions.ConnectionClosed:
                 self.connect_to_rabbitmq()
 
-        self.redis.decr(UNIQUE_QUEUE_SIZE_KEY, count)
         self.log.info("inserted %d listens." % count)
 
         # collect and occasionally print some stats

--- a/listenbrainz/influx-writer/influx-writer.py
+++ b/listenbrainz/influx-writer/influx-writer.py
@@ -16,7 +16,6 @@ from listenbrainz.listenstore import InfluxListenStore
 from listenbrainz.listenstore.utils import escape, get_measurement_name
 from requests.exceptions import ConnectionError
 from redis import Redis
-from listenbrainz.redis_keys import INCOMING_QUEUE_SIZE_KEY, UNIQUE_QUEUE_SIZE_KEY
 
 REPORT_FREQUENCY = 5000
 DUMP_JSON_WITH_ERRORS = False
@@ -70,7 +69,6 @@ class InfluxWriterSubscriber(object):
                 self.connect_to_rabbitmq()
 
         count = len(listens)
-        self.redis.decr(INCOMING_QUEUE_SIZE_KEY, count)
 
         # collect and occasionally print some stats
         self.inserts += count
@@ -220,8 +218,6 @@ class InfluxWriterSubscriber(object):
                 break
             except pika.exceptions.ConnectionClosed:
                 self.connect_to_rabbitmq()
-
-        self.redis.incr(UNIQUE_QUEUE_SIZE_KEY, unique_count)
 
         return True
 

--- a/listenbrainz/redis_keys.py
+++ b/listenbrainz/redis_keys.py
@@ -1,4 +1,3 @@
 # This module should be used to keep all the of the keys used with redis
 
-INCOMING_QUEUE_SIZE_KEY = "lb.incoming_q_size"
-UNIQUE_QUEUE_SIZE_KEY = "lb.unique_q_size"
+# <crickets> LOL

--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -29,12 +29,12 @@
           </tr>
         {% endif %}
           <tr>
-            <td>Number of incoming listens / items queued</td>
-            <td>{{ incoming_count }} / {{ incoming_len }}</td>
+            <td>Number of incoming batches queued</td>
+            <td>{{ incoming_len }}</td>
           </tr>
           <tr>
-            <td>Number of unique (new) listens / items queued</td>
-            <td>{{ unique_count }} / {{ unique_len }}</td>
+            <td>Number of unique incoming batches queued</td>
+            <td>{{ unique_len }}</td>
           </tr>
           <tr>
             <td>Number of people in queue for alpha imports</td>

--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -18,7 +18,7 @@
         <tbody>
         {% if user_count %}
           <tr>
-            <td>Number of Users</td>
+            <td>Number of users</td>
             <td>{{ user_count }}</td>
           </tr>
         {% endif %}

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -6,7 +6,6 @@ import ujson
 import pika
 import pika.exceptions
 from listenbrainz import config
-from listenbrainz.redis_keys import INCOMING_QUEUE_SIZE_KEY
 
 from listenbrainz.webserver.external import messybrainz
 import listenbrainz.webserver.redis_connection as redis_connection
@@ -92,7 +91,6 @@ def _send_listens_to_queue(listen_type, listens):
             current_app.logger.error("Cannot publish to rabbitmq channel: %s" % str(e))
             raise ServiceUnavailable("Cannot submit listens to queue, please try again later.")
 
-        _redis.redis.incr(INCOMING_QUEUE_SIZE_KEY, len(submit))
         rabbitmq_connection._rabbitmq.return_channel()
 
 

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -9,6 +9,7 @@ import listenbrainz.db.user as db_user
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz import webserver
 from listenbrainz.listenstore import InfluxListenStore
+from listenbrainz.webserver.influx_connection import _influx
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from listenbrainz import config
 import pika
@@ -83,13 +84,7 @@ def current_status():
     except (pika.exceptions.ConnectionClosed, AttributeError):
         pass
 
-    ls = InfluxListenStore({ 'REDIS_HOST' : config.REDIS_HOST,
-        'REDIS_PORT' : config.REDIS_PORT,
-        'INFLUX_HOST': config.INFLUX_HOST,
-        'INFLUX_PORT': config.INFLUX_PORT,
-        'INFLUX_DB_NAME': config.INFLUX_DB_NAME})
-    listen_count = ls.get_total_listen_count()
-
+    listen_count = _influx.get_total_listen_count()
     try:
         user_count = _get_user_count()
     except DatabaseException as e:

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -82,9 +82,6 @@ def current_status():
     except (pika.exceptions.ConnectionClosed, AttributeError):
         pass
 
-    incoming_count = _redis.redis.get("lb.incoming_q_size") or 0
-    unique_count = _redis.redis.get("lb.unique_q_size") or 0
-
     try:
         user_count = _get_user_count()
     except DatabaseException as e:
@@ -92,11 +89,9 @@ def current_status():
 
     return render_template(
         "index/current-status.html",
-        load=load,
+        _count=format(int(unique_count), ",d"),
         incoming_len=format(int(incoming_len), ",d"),
-        incoming_count=format(int(incoming_count), ",d"),
         unique_len=format(int(unique_len), ",d"),
-        unique_count=format(int(unique_count), ",d"),
         user_count=format(int(user_count), ",d"),
         alpha_importer_size=_get_alpha_importer_queue_size(),
     )


### PR DESCRIPTION
I tried to count the actual number of items in rabbitmq (as opposed to a number of batches, which may contain more than 1 listen) but the system is brittle and prone to showing the wrong results. It is unclear that we even need this, so I am removing it.