### PR TITLE
LB-171 / LB-172: Fix bugs in influx-writer

### DIFF
--- a/listenbrainz/influx-writer/influx-writer.py
+++ b/listenbrainz/influx-writer/influx-writer.py
@@ -122,8 +122,9 @@ class InfluxWriterSubscriber(object):
             except (InfluxDBServerError, InfluxDBClientError, ValueError, ConnectionError) as e:
                 self.log.error("Unable to insert bad listen to listenstore: %s" % str(e))
                 if DUMP_JSON_WITH_ERRORS:
-                    self.log.error("Was writing the following data: ")
-                    self.log.error(json.dumps(data, indent=4))
+                    self.log.error("Was writing the following data:")
+                    influx_dict = data[0].to_influx(get_measurement_name(data[0].user_name))
+                    self.log.error(ujson.dumps(influx_dict))
                 return 0
         else:
             slice_index = len(data) // 2

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -196,7 +196,7 @@ class Listen(object):
         # add the user generated keys present in additional info to fields
         for key, value in self.data['additional_info'].items():
             if key not in Listen.SUPPORTED_KEYS:
-                data['fields'][key] = value
+                data['fields'][key] = str(value)
 
         return data
 

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -42,6 +42,7 @@ class Listen(object):
         'tags',
         'artist_msid',
         'release_msid',
+        'recording_msid',
     ]
 
     def __init__(self, user_id=None, user_name=None, timestamp=None, artist_msid=None, release_msid=None,

--- a/listenbrainz/testdata/additional_info.json
+++ b/listenbrainz/testdata/additional_info.json
@@ -13,7 +13,11 @@
                     "other_stuff": "teststuffplsignore",
                     "nested": {
                         "info": "here"
-                    }
+                    },
+                    "release_type": [
+                        "ALBUM",
+                        "REMIX"
+                    ]
                 }
             }
         }

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -215,3 +215,4 @@ class APITestCase(IntegrationTestCase):
         self.assertEqual(sent_additional_info['link2'], received_additional_info['link2'])
         self.assertEqual(sent_additional_info['other_stuff'], received_additional_info['other_stuff'])
         self.assertEqual(sent_additional_info['nested']['info'], received_additional_info['nested.info'])
+        self.assertEqual(str(sent_additional_info['release_type']), received_additional_info['release_type'])


### PR DESCRIPTION
LB-171: marc2k3's listens weren't being inserted because they contained a list in their additional_info field which led to parse errors (this seems to be a bug in influx because other non-string entities like uuids were inserted correctly). Converting all new fields in additional info to strings explicitly now fixes that. Also added tests for listens like this.

LB-172: While doing this, I found a problem that might be causing [LB-172](https://tickets.metabrainz.org/browse/LB-172). Influx-writer was dying because the debug message tried to serialize an array of Listen objects. However this would only trouble us if `DUMP_JSON_WITH_ERRORS` was `True` in production, and I'm not sure that it was.