### PR TITLE
LB-175: Fix retry when submit request to api times out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
                        redis-tools \
                        git \
                        libpq-dev \
+                       libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client

--- a/listenbrainz/webserver/templates/user/scraper.js
+++ b/listenbrainz/webserver/templates/user/scraper.js
@@ -264,7 +264,7 @@ function submitListens() {
                     pageDone();
                 } else if (this.status == 429) {
                     // This should never happen, but if it does, toss it back in and try again.
-                    submitQueue.unshift();
+                    submitQueue.unshift(struct);
                     pageDone();
                 } else if (this.status >= 400 && this.status < 500) {
                     times4Error++;
@@ -290,15 +290,18 @@ function submitListens() {
             };
             xhr.ontimeout = function(context) {
                 console.log("timeout, req'ing");
-                submitListens(struct);
+                submitQueue.unshift(struct);
+                submitListens();
             }
             xhr.onabort = function(context) {
                 console.log("abort, req'ing");
-                submitListens(struct);
+                submitQueue.unshift(struct);
+                submitListens();
             };
             xhr.onerror = function(context) {
                 console.log("error, req'ing");
-                submitListens(struct);
+                submitQueue.unshift(struct);
+                submitListens();
             };
             xhr.send(JSON.stringify(struct));
         }, delay);


### PR DESCRIPTION
Passing data to submitListens() doesn't do anything as
we pop data from the submitQueue. Eventually, the queue becomes
empty leading to the error in LB-175.

