### PR TITLE
move the redis keys to the correct module, fix a print issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update \
 RUN mkdir /code
 WORKDIR /code
 
+RUN pip3 install setuptools==36.0.1
+
 # MessyBrainz
 RUN git clone https://github.com/metabrainz/messybrainz-server.git messybrainz
 WORKDIR /code/messybrainz

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -38,6 +38,7 @@ RUN python3 setup.py install
 WORKDIR /code/listenbrainz
 COPY ./requirements.txt .
 RUN pip3 install -r requirements.txt
+RUN pip3 install setuptools==36.0.1
 
 COPY . /code/listenbrainz
 WORKDIR /code/listenbrainz

--- a/listenbrainz/redis_keys.py
+++ b/listenbrainz/redis_keys.py
@@ -1,3 +1,5 @@
 # This module should be used to keep all the of the keys used with redis
 
-# <crickets> LOL
+RATELIMIT_PER_TOKEN_KEY = "rate_limit_per_token_limit"
+RATELIMIT_PER_IP_KEY = "rate_limit_per_ip_limit"
+RATELIMIT_WINDOW_KEY = "rate_limit_window"

--- a/listenbrainz/set_rate_limits.py
+++ b/listenbrainz/set_rate_limits.py
@@ -2,15 +2,8 @@
 
 import sys
 from redis import Redis
-#from webserver.rate_limiter import RATELIMIT_PER_TOKEN_KEY
-#from webserver.rate_limiter import RATELIMIT_PER_IP_KEY
-#from webserver.rate_limiter import RATELIMIT_WINDOW_KEY
+from listenbrainz.redis_keys import RATELIMIT_PER_TOKEN_KEY, RATELIMIT_PER_IP_KEY, RATELIMIT_WINDOW_KEY
 from listenbrainz import config
-
-# TODO: Do not duplicate these. Import from webserver when doing the source tree re-org
-RATELIMIT_PER_TOKEN_KEY = "rate_limit_per_token_limit"
-RATELIMIT_PER_IP_KEY = "rate_limit_per_ip_limit"
-RATELIMIT_WINDOW_KEY = "rate_limit_window"
 
 # Yes, I could use getoptgetargparsewtfbbw, but then I would spend 20 mimnutes re-learning the stupid syntax.
 # Or, I could just do it myself in the space of seconds.
@@ -22,9 +15,9 @@ r = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
 if len(sys.argv) < 4:
     print("Usage: %s <per ip limit> <per token limit> <window in s>" % (sys.argv[0]))
     print("Current values:")
-    print("      Requests per ip: ", r.get(RATELIMIT_PER_IP_KEY))
-    print("   Requests per token: ", r.get(RATELIMIT_PER_TOKEN_KEY))
-    print("          window size: ", r.get(RATELIMIT_WINDOW_KEY))
+    print("      Requests per ip: ", int(r.get(RATELIMIT_PER_IP_KEY) or -1))
+    print("   Requests per token: ", int(r.get(RATELIMIT_PER_TOKEN_KEY) or -1))
+    print("          window size: ", int(r.get(RATELIMIT_WINDOW_KEY) or -1))
     sys.exit(-1)
 
 try:

--- a/listenbrainz/webserver/rate_limiter.py
+++ b/listenbrainz/webserver/rate_limiter.py
@@ -9,11 +9,7 @@ from functools import update_wrapper
 from flask import request, g
 from listenbrainz.webserver.redis_connection import _redis
 import listenbrainz.db.user as db_user
-
-# Using _ and not - here so I can re-use these keys for use in the g object
-RATELIMIT_PER_TOKEN_KEY = "rate_limit_per_token_limit"
-RATELIMIT_PER_IP_KEY = "rate_limit_per_ip_limit"
-RATELIMIT_WINDOW_KEY = "rate_limit_window"
+from listenbrainz.redis_keys import RATELIMIT_PER_TOKEN_KEY, RATELIMIT_PER_IP_KEY, RATELIMIT_WINDOW_KEY
 
 # Defaults
 RATELIMIT_PER_TOKEN_DEFAULT = 50


### PR DESCRIPTION
The set rate limit script was barfing on the prints (I think). While I was at it, I moved the redis keys to the right places.