### PR TITLE
LB-177: Make influx-writer account for a range of time when looking for duplicates

### DIFF
--- a/listenbrainz/influx-writer/influx-writer.py
+++ b/listenbrainz/influx-writer/influx-writer.py
@@ -22,7 +22,7 @@ DUMP_JSON_WITH_ERRORS = False
 ERROR_RETRY_DELAY = 3 # number of seconds to wait until retrying an operation
 
 # the difference in timestamps which we consider to be duplicates if same artist msid and recording msid
-TIMESTAMP_DUPLICATE_DIFF = 21
+TIMESTAMP_DUPLICATE_DIFF = 31
 
 
 class InfluxWriterSubscriber(object):
@@ -206,21 +206,16 @@ class InfluxWriterSubscriber(object):
                 # This will check if timestamps in the range (t - TIMESTAMP_DUPLICATE_DIFF, t + TIMESTAMP_DUPLICATE_DIFF)
                 # exist in the database for the user, with the same artist msid and recording msid. If it does, we
                 # consider this listen to be a duplicate and skip it.
-                for delta in range(TIMESTAMP_DUPLICATE_DIFF):
+                deltas = [0] + [sign * val for val in range(1, TIMESTAMP_DUPLICATE_DIFF) for sign in (+1, -1)]
+                for delta in deltas:
                     fuzzed = t + delta
-                    if fuzzed in timestamps:
-                        if artist_msid == timestamps[fuzzed]['artist_msid'] and recording_msid == timestamps[fuzzed]['recording_msid']:
-                            duplicate_count += 1
-                            break
-
-                    fuzzed = t - delta
                     if fuzzed in timestamps:
                         if artist_msid == timestamps[fuzzed]['artist_msid'] and recording_msid == timestamps[fuzzed]['recording_msid']:
                             duplicate_count += 1
                             break
                 else:
                     unique_count += 1
-                    submit.append(Listen().from_json(listen))
+                    submit.append(Listen.from_json(listen))
                     unique.append(listen)
 
         t0 = time()

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import calendar
-from listenbrainz.utils import escape
+from listenbrainz.utils import escape, convert_to_unix_timestamp
 
 def flatten_dict(d, seperator='', parent_key=''):
     """
@@ -94,8 +94,7 @@ class Listen(object):
     def from_influx(cls, row):
         """ Factory to make Listen objects from an influx row
         """
-        dt = datetime.strptime(row['time'] , '%Y-%m-%dT%H:%M:%SZ')
-        t = int(dt.strftime('%s'))
+        t = convert_to_unix_timestamp(row['time'])
         mbids = []
         artist_mbids = row.get('artist_mbids')
         if artist_mbids:

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -11,7 +11,7 @@ import json
 from datetime import datetime
 from listenbrainz.listenstore import ORDER_DESC, ORDER_ASC, ORDER_TEXT, \
     USER_CACHE_TIME, REDIS_USER_TIMESTAMPS
-from listenbrainz.utils import quote, get_escaped_measurement_name, get_measurement_name
+from listenbrainz.utils import quote, get_escaped_measurement_name, get_measurement_name, get_influx_query_timestamp
 
 REDIS_INFLUX_USER_LISTEN_COUNT = "ls.listencount." # append username
 
@@ -191,9 +191,9 @@ class InfluxListenStore(ListenStore):
         query = 'SELECT * FROM ' + get_escaped_measurement_name(user_name)
 
         if from_ts != None:
-            query += "WHERE time > " + str(from_ts) + "000000000"
+            query += "WHERE time > " + get_influx_query_timestamp(from_ts)
         else:
-            query += "WHERE time < " + str(to_ts) + "000000000"
+            query += "WHERE time < " + get_influx_query_timestamp(to_ts)
 
         query += " ORDER BY time " + ORDER_TEXT[order] + " LIMIT " + str(limit)
         try:

--- a/listenbrainz/testdata/fuzzed_ts_valid_single.json
+++ b/listenbrainz/testdata/fuzzed_ts_valid_single.json
@@ -1,0 +1,13 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": 1486449400,
+            "track_metadata": {
+                "artist_name": "Kanye West",
+                "track_name": "Fade",
+                "release_name": "The Life of Pablo"
+            }
+        }
+    ]
+}

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 
 def escape(value):
     """ Escapes backslashes, quotes and new lines present in the string value
@@ -27,3 +28,12 @@ def get_escaped_measurement_name(user_name):
     # must be replaced by 4 backslashes. Yes, this is hacky and ugly.
     return '"\\"{}\\""'.format(user_name.replace('\\', '\\\\\\\\').replace('"', '\\"').replace('\n', '\\\\\\\\n'))
 
+
+def get_influx_query_timestamp(ts):
+    """ Influx queries require timestamps in nanoseconds so convert ts into nanoseconds and return a string"""
+    return "{}000000000".format(ts)
+
+def convert_to_unix_timestamp(influx_row_time):
+    """ Converts time retreived from influxdb into unix timestamp """
+    dt = datetime.strptime(influx_row_time, "%Y-%m-%dT%H:%M:%SZ")
+    return int(dt.strftime('%s'))


### PR DESCRIPTION
LB alpha has data with low precision timestamps, so if a person does both an alpha import and a last.fm import on LB Beta, the data gets duplicated. I've made influx-writer now consider a listen a duplicate if a listen of the same recording exists in a range of that timestamp.

Here's some examples of time differences I found for the same listen in last.fm and LB alpha.

```
listenbrainz	lastfm	        diff
-----------------------------------------
1463598180	1463598185	5
1463597940	1463597956	16
1463597640	1463597671	31
1463597400	1463597440	40
1463597280	1463597323	43
1463597040	1463597061	21
1463596740	1463596794	54
1463596380	1463596385	5
1463596020	1463596024	4
```

The time differences can go as high as 54, as we see. But if we increase the range of time we consider to be duplicates, it can lead to certain use cases not working. For example, if a person listens to a 15-second song consecutively for many times, it will get considered a duplicate here. Not sure if this is something we want to allow?

What is the way forward here? A reasonable compromise by adjusting the value of the time range in which we consider two listens to be duplicates?
