### PR TITLE
LB-176: Create a stats module and add functions to run queries on Google BigQuery

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -30,6 +30,8 @@ services:
       context: ..
       dockerfile: Dockerfile
     command: py.test
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: '/code/credentials/bigquery-credentials.json'
     volumes:
       - ..:/code/listenbrainz
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,6 +53,9 @@ services:
     image: web
     volumes:
       - ..:/code/listenbrainz
+      - ../credentials:/code/credentials
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: '/code/credentials/bigquery-credentials.json'
     ports:
       - "80:80"
     depends_on:

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -52,6 +52,8 @@ BIGQUERY_PROJECT_ID = "listenbrainz"
 BIGQUERY_DATASET_ID = "listenbrainz_test"
 BIGQUERY_TABLE_ID = "listen"
 
+# Stats
+STATS_ENTITY_LIMIT = 100 # the number of entities to calculate at max with BQ
 
 # Max time in seconds after which the playing_now stream will expire.
 PLAYING_NOW_MAX_DURATION = 10 * 60

--- a/listenbrainz/stats/__init__.py
+++ b/listenbrainz/stats/__init__.py
@@ -23,6 +23,6 @@ def init_bigquery_connection():
         logger.error("The BigQuery credentials file does not exist, cannot connect to BigQuery")
         raise NoCredentialsFileException
 
-    global _bigquery
+    global bigquery
     credentials = GoogleCredentials.get_application_default()
     bigquery = discovery.build('bigquery', 'v2', credentials=credentials)

--- a/listenbrainz/stats/__init__.py
+++ b/listenbrainz/stats/__init__.py
@@ -3,6 +3,10 @@ from oauth2client.client import GoogleCredentials
 import os
 import logging
 from listenbrainz.stats.exceptions import NoCredentialsVariableException, NoCredentialsFileException
+import listenbrainz.config as config
+import time
+
+JOB_COMPLETION_CHECK_DELAY = 5 # seconds
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -26,3 +30,114 @@ def init_bigquery_connection():
     global bigquery
     credentials = GoogleCredentials.get_application_default()
     bigquery = discovery.build('bigquery', 'v2', credentials=credentials)
+
+
+def get_parameters_dict(parameters):
+    """ Converts a list of parameters to be passed to BigQuery into the standard format that the API requires.
+        The format can be seen here:
+        https://developers.google.com/resources/api-libraries/documentation/bigquery/v2/python/latest/bigquery_v2.jobs.html#query
+
+        Args: parameters: a list of dictionaries of the following form
+                {
+                    "name" (str): name of the parameter,
+                    "type" (str): type of the parameter,
+                    "value" (str): value of the parameter
+                }
+
+        Returns: A list of dictionaries that can be passed to the API call
+    """
+
+    bq_params = []
+    for param in parameters:
+        # construct parameter dict
+        temp = {}
+        temp["name"] = param["name"]
+        temp["parameterType"] = {
+            "type": param["type"],
+        }
+        temp["parameterValue"] = {
+            "value": param["value"],
+        }
+
+        # append parameter dict to main list
+        bq_params.append(temp)
+
+    return bq_params
+
+
+def wait_for_completion(projectId, jobId):
+    """ Make requests periodically until the passed job has been completed """
+
+    while True:
+        job = bigquery.jobs().get(projectId=projectId, jobId=jobId).execute(num_retries=5)
+        if job["status"]["state"] == "DONE":
+            return
+        else:
+            time.sleep(JOB_COMPLETION_CHECK_DELAY)
+
+
+def run_query(query, parameters):
+    """ Run provided query on Google BigQuery and return the results in the form of a dictionary
+
+        Note: This is a synchronous action
+    """
+
+    # Run the query
+    query_body = {
+        "kind": "bigquery#queryRequest",
+        "parameterMode": "NAMED",
+        "default_dataset": {
+            "projectId": config.BIGQUERY_PROJECT_ID,
+            "datasetId": config.BIGQUERY_DATASET_ID,
+        },
+        "useLegacySql": False,
+        "queryParameters": get_parameters_dict(parameters),
+        "query": query,
+        "maxResults": 10000
+    }
+
+    response = bigquery.jobs().query(
+        projectId=config.BIGQUERY_PROJECT_ID,
+        body=query_body).execute(num_retries=5)
+
+    job_reference = response['jobReference']
+
+    # Check response to see if query was completed before request timeout.
+    # If it wasn't, wait until it has been completed.
+
+    if not response['jobComplete']:
+        wait_for_completion(**job_reference)
+    else:
+        have_results = True
+
+    data = {}
+    prev_token = None
+    if have_results:
+        data['schema'] = response['schema']
+        data['rows'] = response['rows']
+        try:
+            prev_token = response['pageToken']
+        except KeyError:
+            # if there is no page token, we have all the results
+            # so just return the data
+            return data
+    else:
+        query_result = bigquery.jobs().getQueryResults(**job_reference).execute(num_retries=5)
+        data['schema'] = query_result['schema']
+        data['rows'] = query_result['rows']
+        try:
+            prev_token = query_result['pageToken']
+        except KeyError:
+            # if there is no page token, we have all the results
+            # so just return the data
+            return data
+
+    # keep making requests until we reach the last page and return the data
+    # as soon as we do
+    while True:
+        query_result = bigquery.jobs().getQueryResults(pageToken=prev_token, **job_reference).execute(num_retries=5)
+        data['rows'].extend(query_result['rows'])
+        try:
+            prev_token = query_result['pageToken']
+        except KeyError:
+            return data

--- a/listenbrainz/stats/__init__.py
+++ b/listenbrainz/stats/__init__.py
@@ -9,7 +9,7 @@ logger.setLevel(logging.INFO)
 
 APP_CREDENTIALS_FILE = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
 
-_bigquery = None
+bigquery = None
 
 
 def init_bigquery_connection():
@@ -25,4 +25,4 @@ def init_bigquery_connection():
 
     global _bigquery
     credentials = GoogleCredentials.get_application_default()
-    _bigquery = discovery.build('bigquery', 'v2', credentials=credentials)
+    bigquery = discovery.build('bigquery', 'v2', credentials=credentials)

--- a/listenbrainz/stats/__init__.py
+++ b/listenbrainz/stats/__init__.py
@@ -93,7 +93,6 @@ def run_query(query, parameters):
         "useLegacySql": False,
         "queryParameters": get_parameters_dict(parameters),
         "query": query,
-        "maxResults": 10000
     }
 
     response = bigquery.jobs().query(

--- a/listenbrainz/stats/__init__.py
+++ b/listenbrainz/stats/__init__.py
@@ -1,0 +1,28 @@
+from googleapiclient import discovery
+from oauth2client.client import GoogleCredentials
+import os
+import logging
+from listenbrainz.stats.exceptions import NoCredentialsVariableException, NoCredentialsFileException
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+APP_CREDENTIALS_FILE = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
+
+_bigquery = None
+
+
+def init_bigquery_connection():
+    """ Initiates the connection to Google BigQuery """
+
+    if not APP_CREDENTIALS_FILE:
+        logger.error("The GOOGLE_APPLICATIONS_CREDENTIALS variable is undefined, cannot connect to BigQuery")
+        raise NoCredentialsVariableException
+
+    if not os.path.exists(APP_CREDENTIALS_FILE):
+        logger.error("The BigQuery credentials file does not exist, cannot connect to BigQuery")
+        raise NoCredentialsFileException
+
+    global _bigquery
+    credentials = GoogleCredentials.get_application_default()
+    _bigquery = discovery.build('bigquery', 'v2', credentials=credentials)

--- a/listenbrainz/stats/__init__.py
+++ b/listenbrainz/stats/__init__.py
@@ -48,6 +48,9 @@ def get_parameters_dict(parameters):
         Returns: A list of dictionaries that can be passed to the API call
     """
 
+    if not parameters:
+        return None
+
     bq_params = []
     for param in parameters:
         # construct parameter dict
@@ -98,7 +101,7 @@ def format_results(data):
     return formatted_data
 
 
-def run_query(query, parameters):
+def run_query(query, parameters=None):
     """ Run provided query on Google BigQuery and return the results in the form of a dictionary
 
         Note: This is a synchronous action

--- a/listenbrainz/stats/exceptions.py
+++ b/listenbrainz/stats/exceptions.py
@@ -1,0 +1,9 @@
+
+class StatisticsException(Exception):
+    pass
+
+class NoCredentialsVariableException(StatisticsException):
+    pass
+
+class NoCredentialsFileException(StatisticsException):
+    pass

--- a/listenbrainz/stats/sitewide.py
+++ b/listenbrainz/stats/sitewide.py
@@ -1,0 +1,42 @@
+# listenbrainz-server - Server for the ListenBrainz project
+#
+# Copyright (C) 2017 Param Singh
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+This module contains functions to run queries for sitewide statistics
+on Google BigQuery.
+"""
+
+from listenbrainz import stats
+from listenbrainz import config
+
+
+def get_artist_count():
+    """ Calculates the total number of artists submitted to ListenBrainz.
+
+        Returns:
+            artist_count (int)
+    """
+
+    query = """SELECT COUNT(DISTINCT(artist_msid)) as artist_count
+                 FROM {dataset_id}.{table_id}
+            """.format(
+                dataset_id=config.BIGQUERY_DATASET_ID,
+                table_id=config.BIGQUERY_TABLE_ID,
+            )
+
+    return stats.run_query(query)[0]['artist_count']

--- a/listenbrainz/stats/tests/test_stats.py
+++ b/listenbrainz/stats/tests/test_stats.py
@@ -39,3 +39,53 @@ class StatsTestCase(unittest.TestCase):
         self.assertEqual(modified_params[0]['parameterType']['type'], params[0]['type'])
         self.assertIsInstance(modified_params[0]['parameterValue'], dict)
         self.assertEqual(modified_params[0]['parameterValue']['value'], params[0]['value'])
+
+    def test_format_results(self):
+
+        # this is the format of the data returned by Google BigQuery
+        data = {
+            'schema': {
+                'fields': [
+                    {
+                        'name': 'artist_name',
+                        'type': 'STRING',
+                        'mode': 'NULLABLE'
+                    },
+                    {
+                        'name': 'artist_msid',
+                        'type': 'STRING',
+                        'mode': 'NULLABLE'
+                    }
+                ]
+            },
+            'rows': [
+                {
+                    'f': [
+                        {
+                            'v': 'Daft Punk'
+                        },
+                        {
+                            'v': '72c41851-d1eb-441c-a1fa-046f996f36b0'
+                        }
+                    ]
+                },
+                {
+                    'f': [
+                        {
+                            'v': 'Animal Collective'
+                        },
+                        {
+                            'v': '1a586268-204a-4691-9ee4-96269ff3cace'
+                        }
+                    ]
+                }
+            ]
+        }
+
+        formatted_data = stats.format_results(data)
+
+        self.assertEqual(len(formatted_data), 2)
+        self.assertEqual(formatted_data[0]['artist_name'], data['rows'][0]['f'][0]['v'])
+        self.assertEqual(formatted_data[0]['artist_msid'], data['rows'][0]['f'][1]['v'])
+        self.assertEqual(formatted_data[1]['artist_name'], data['rows'][1]['f'][0]['v'])
+        self.assertEqual(formatted_data[1]['artist_msid'], data['rows'][1]['f'][1]['v'])

--- a/listenbrainz/stats/tests/test_stats.py
+++ b/listenbrainz/stats/tests/test_stats.py
@@ -1,0 +1,20 @@
+import unittest
+import os
+from listenbrainz import stats
+from listenbrainz.stats.exceptions import NoCredentialsVariableException, NoCredentialsFileException
+
+
+class StatsTestCase(unittest.TestCase):
+
+    def test_init_bigquery(self):
+        """ Test for BigQuery connection initialization """
+
+        if not stats.APP_CREDENTIALS_FILE:
+            with self.assertRaises(NoCredentialsVariableException):
+                stats.init_bigquery_connection()
+        elif not os.path.exists(stats.APP_CREDENTIALS_FILE):
+            with self.assertRaises(NoCredentialsFileException):
+                stats.init_bigquery_connection()
+        else:
+            stats.init_bigquery_connection()
+            self.assertIsNotNone(stats.bigquery)

--- a/listenbrainz/stats/tests/test_stats.py
+++ b/listenbrainz/stats/tests/test_stats.py
@@ -1,23 +1,72 @@
 import unittest
+from unittest.mock import patch
 import os
 from listenbrainz import stats
 from listenbrainz.stats.exceptions import NoCredentialsVariableException, NoCredentialsFileException
+import listenbrainz.config as config
+
+bigquery_responses = {
+    "done": {
+        "jobReference": {
+            "projectId": "test_project_id",
+            "jobId": "test_job_id",
+        },
+        "totalRows": "2",
+        "jobComplete": True,
+        "rows": [
+            {
+                "f": [
+                    {
+                        "v": "Daft Punk"
+                    },
+                    {
+                        "v": "72c41851-d1eb-441c-a1fa-046f996f36b0"
+                    }
+                ]
+            },
+            {
+                "f": [
+                    {
+                        "v": "Animal Collective"
+                    },
+                    {
+                        "v": "1a586268-204a-4691-9ee4-96269ff3cace"
+                    }
+                ]
+            }
+        ],
+        "schema": {
+            "fields": [
+                {
+                    "type": "STRING",
+                    "name": "artist_name",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "type": "STRING",
+                    "name": "artist_msid",
+                    "mode": "NULLABLE"
+                }
+            ]
+        }
+    }
+}
+
+expected_results = {
+    'done': [
+        {
+            "artist_name": "Daft Punk",
+            "artist_msid": "72c41851-d1eb-441c-a1fa-046f996f36b0"
+        },
+        {
+            "artist_name": "Animal Collective",
+            "artist_msid": "1a586268-204a-4691-9ee4-96269ff3cace"
+        }
+    ]
+}
 
 
 class StatsTestCase(unittest.TestCase):
-
-    def test_init_bigquery(self):
-        """ Test for BigQuery connection initialization """
-
-        if not stats.APP_CREDENTIALS_FILE:
-            with self.assertRaises(NoCredentialsVariableException):
-                stats.init_bigquery_connection()
-        elif not os.path.exists(stats.APP_CREDENTIALS_FILE):
-            with self.assertRaises(NoCredentialsFileException):
-                stats.init_bigquery_connection()
-        else:
-            stats.init_bigquery_connection()
-            self.assertIsNotNone(stats.bigquery)
 
     def test_get_parameters(self):
 
@@ -41,51 +90,32 @@ class StatsTestCase(unittest.TestCase):
         self.assertEqual(modified_params[0]['parameterValue']['value'], params[0]['value'])
 
     def test_format_results(self):
-
-        # this is the format of the data returned by Google BigQuery
-        data = {
-            'schema': {
-                'fields': [
-                    {
-                        'name': 'artist_name',
-                        'type': 'STRING',
-                        'mode': 'NULLABLE'
-                    },
-                    {
-                        'name': 'artist_msid',
-                        'type': 'STRING',
-                        'mode': 'NULLABLE'
-                    }
-                ]
-            },
-            'rows': [
-                {
-                    'f': [
-                        {
-                            'v': 'Daft Punk'
-                        },
-                        {
-                            'v': '72c41851-d1eb-441c-a1fa-046f996f36b0'
-                        }
-                    ]
-                },
-                {
-                    'f': [
-                        {
-                            'v': 'Animal Collective'
-                        },
-                        {
-                            'v': '1a586268-204a-4691-9ee4-96269ff3cace'
-                        }
-                    ]
-                }
-            ]
-        }
-
+        data = bigquery_responses['done']
         formatted_data = stats.format_results(data)
-
         self.assertEqual(len(formatted_data), 2)
         self.assertEqual(formatted_data[0]['artist_name'], data['rows'][0]['f'][0]['v'])
         self.assertEqual(formatted_data[0]['artist_msid'], data['rows'][0]['f'][1]['v'])
         self.assertEqual(formatted_data[1]['artist_name'], data['rows'][1]['f'][0]['v'])
         self.assertEqual(formatted_data[1]['artist_msid'], data['rows'][1]['f'][1]['v'])
+
+    @patch.object(stats, 'bigquery')
+    def test_run_query_done(self, mock_bigquery):
+        """ Test run_query when the result is directly returned by the first api call to bigquery.jobs.query """
+
+        # set the value returned by call to bigquery to a response which signifies completed query
+        mock_bigquery.jobs.return_value.query.return_value.execute.return_value = bigquery_responses['done']
+
+        # construct query and parameters
+        query = """SELECT artist_msid, artist_name
+                     FROM {dataset_id}.{table_id}
+                    WHERE user_name = @username
+                """.format(dataset_id=config.BIGQUERY_DATASET_ID, table_id=config.BIGQUERY_TABLE_ID)
+
+        parameters = [{
+            'name': 'username',
+            'type': 'STRING',
+            'value': 'testuser'
+        }]
+
+        result = stats.run_query(query, parameters)
+        self.assertListEqual(result, expected_results['done'])

--- a/listenbrainz/stats/tests/test_stats.py
+++ b/listenbrainz/stats/tests/test_stats.py
@@ -18,3 +18,24 @@ class StatsTestCase(unittest.TestCase):
         else:
             stats.init_bigquery_connection()
             self.assertIsNotNone(stats.bigquery)
+
+    def test_get_parameters(self):
+
+        params = [
+            {
+                'name': 'param1',
+                'type': 'STRING',
+                'value': '12312'
+            }
+        ]
+
+        modified_params = stats.get_parameters_dict(params)
+
+        self.assertIsInstance(modified_params, list)
+        self.assertEqual(len(modified_params), 1)
+        self.assertIsInstance(modified_params[0], dict)
+        self.assertEqual(modified_params[0]['name'], params[0]['name'])
+        self.assertIsInstance(modified_params[0]['parameterType'], dict)
+        self.assertEqual(modified_params[0]['parameterType']['type'], params[0]['type'])
+        self.assertIsInstance(modified_params[0]['parameterValue'], dict)
+        self.assertEqual(modified_params[0]['parameterValue']['value'], params[0]['value'])

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -30,7 +30,7 @@ def get_top_tracks(musicbrainz_id, time_interval=None):
 
     filter_str = ""
     if time_interval:
-        filter_str = "AND TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {}".format(time_interval)
+        filter_str = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {})".format(time_interval)
 
     # construct the query string
     query = """SELECT artist_name

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -1,0 +1,65 @@
+"""
+This module contains functions that create jobs and retrieve stats about users
+from Google BigQuery
+"""
+import listenbrainz.config as config
+import json
+from listenbrainz import stats
+
+
+def get_top_tracks(musicbrainz_id, time_interval=None):
+    """ Get top tracks of user with given MusicBrainz ID over a particular time interval
+
+        Args:
+            musicbrainz_id (str): The MusicBrainz ID of the user
+            time_interval  (str): Interval in the BigQuery interval format which can be seen here:
+            https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#timestamp_sub
+
+        Returns:
+            sorted list of the following format
+            [
+                {
+                    "track_name" (str)
+                    "recording_msid" (uuid)
+                    "artist_name" (str)
+                    "artist_msid" (uuid)
+                    "listen_count" (int)
+                }
+            ]
+    """
+
+    filter_str = ""
+    if time_interval:
+        filter_str = "AND TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {}".format(time_interval)
+
+    # construct the query string
+    query = """SELECT artist_name
+                    , artist_msid
+                    , recording_msid
+                    , track_name
+                    , COUNT(recording_msid) as listen_count
+                 FROM {dataset_id}.{table_id}
+                WHERE user_name = @username
+                {time_filter_clause}
+             GROUP BY recording_msid, track_name, artist_name, artist_msid
+             ORDER BY listen_count DESC
+            """.format(
+                dataset_id=config.BIGQUERY_DATASET_ID,
+                table_id=config.BIGQUERY_TABLE_ID,
+                time_filter_clause=filter_str,
+            )
+
+    # construct the parameters that must be passed to the Google BigQuery API
+
+    # start with a list of parameters to pass and then convert it to standard format
+    # required by Google BigQuery
+    parameters = [
+        {
+            "name": "username",
+            "type": "STRING",
+            "value": musicbrainz_id,
+        },
+    ]
+
+    return stats.run_query(query, parameters)
+

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -1,19 +1,35 @@
-"""
-This module contains functions that create jobs and retrieve stats about users
-from Google BigQuery
-"""
+# coding=utf-8
+#
+# listenbrainz-server - Server for the ListenBrainz project
+# Copyright (C) 2017 Param Singh
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 import listenbrainz.config as config
 import json
 from listenbrainz import stats
 
 
-def get_top_tracks(musicbrainz_id, time_interval=None):
-    """ Get top tracks of user with given MusicBrainz ID over a particular time interval
+def get_top_recordings(musicbrainz_id, time_interval=None):
+    """ Get top recordings of user with given MusicBrainz ID over a particular time interval
 
         Args:
             musicbrainz_id (str): The MusicBrainz ID of the user
-            time_interval  (str): Interval in the BigQuery interval format which can be seen here:
-            https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#timestamp_sub
+            time_interval  (str): Interval in the BigQuery interval format
+                                  which can be seen here:
+                                  https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#timestamp_sub
 
         Returns:
             sorted list of the following format
@@ -28,9 +44,9 @@ def get_top_tracks(musicbrainz_id, time_interval=None):
             ]
     """
 
-    filter_str = ""
+    filter_clause = ""
     if time_interval:
-        filter_str = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {})".format(time_interval)
+        filter_clause = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {})".format(time_interval)
 
     # construct the query string
     query = """SELECT artist_name
@@ -39,14 +55,14 @@ def get_top_tracks(musicbrainz_id, time_interval=None):
                     , track_name
                     , COUNT(recording_msid) as listen_count
                  FROM {dataset_id}.{table_id}
-                WHERE user_name = @username
+                WHERE user_name = @musicbrainz_id
                 {time_filter_clause}
              GROUP BY recording_msid, track_name, artist_name, artist_msid
              ORDER BY listen_count DESC
             """.format(
                 dataset_id=config.BIGQUERY_DATASET_ID,
                 table_id=config.BIGQUERY_TABLE_ID,
-                time_filter_clause=filter_str,
+                time_filter_clause=filter_clause,
             )
 
     # construct the parameters that must be passed to the Google BigQuery API
@@ -55,10 +71,106 @@ def get_top_tracks(musicbrainz_id, time_interval=None):
     # required by Google BigQuery
     parameters = [
         {
-            "name": "username",
             "type": "STRING",
+            "name": "musicbrainz_id",
             "value": musicbrainz_id,
         },
+    ]
+
+    return stats.run_query(query, parameters)
+
+def get_top_artists(musicbrainz_id, time_interval=None):
+    """ Get top artists for user with given MusicBrainz ID over a particular period of time
+
+        Args: musicbrainz_id (str): the MusicBrainz ID of the user
+              time_interval  (str): the time interval over which top artists should be returned
+                                    (defaults to all time)
+
+        Returns: A sorted list of dicts with the following structure
+                [
+                    {
+                        'artist_name' (str),
+                        'artist_msid' (uuid),
+                        'listen_count' (int)
+                    }
+                ]
+    """
+
+    filter_clause = ""
+    if time_interval:
+        filter_clause = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIME(), INTERVAL {})".format(time_interval)
+
+
+    query = """SELECT artist_name
+                    , artist_msid
+                    , COUNT(artist_msid) as listen_count
+                 FROM {dataset_id}.{table_id}
+                WHERE user_name = @musicbrainz_id
+                {time_filter_clause}
+             GROUP BY artist_msid, artist_name
+             ORDER BY listen_count DESC
+            """.format(
+                    dataset_id=config.BIGQUERY_DATASET_ID,
+                    table_id=config.BIGQUERY_TABLE_ID,
+                    time_filter_clause=filter_clause,
+                )
+
+    parameters = [
+        {
+            'type': 'STRING',
+            'name': 'musicbrainz_id',
+            'value': musicbrainz_id
+        }
+    ]
+
+    return stats.run_query(query, parameters)
+
+def get_top_releases(musicbrainz_id, time_interval=None):
+    """ Get top releases for user with given MusicBrainz ID over a particular period of time
+
+        Args: musicbrainz_id (str): the MusicBrainz ID of the user
+              time_interval  (str): the time interval over which top artists should be returned
+                                    (defaults to all time)
+
+        Returns: A sorted list of dicts with the following structure
+                [
+                    {
+                        'artist_name' (str),
+                        'artist_msid' (uuid),
+                        'release_name' (str),
+                        'release_msid' (uuid),
+                        'listen_count' (int)
+                    }
+                ]
+    """
+
+    filter_clause = ""
+    if time_interval:
+        filter_clause = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIME(), INTERVAL {})".format(time_interval)
+
+
+    query = """SELECT artist_name
+                    , artist_msid
+                    , release_name
+                    , release_msid
+                    , COUNT(release_msid) as listen_count
+                 FROM {dataset_id}.{table_id}
+                WHERE user_name = @musicbrainz_id
+                {time_filter_clause}
+             GROUP BY artist_msid, artist_name, release_name, release_msid
+             ORDER BY listen_count DESC
+            """.format(
+                    dataset_id=config.BIGQUERY_DATASET_ID,
+                    table_id=config.BIGQUERY_TABLE_ID,
+                    time_filter_clause=filter_clause,
+                )
+
+    parameters = [
+        {
+            'type': 'STRING',
+            'name': 'musicbrainz_id',
+            'value': musicbrainz_id
+        }
     ]
 
     return stats.run_query(query, parameters)

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -45,7 +45,7 @@ def get_top_recordings(musicbrainz_id, time_interval=None):
 
     filter_clause = ""
     if time_interval:
-        filter_clause = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {})".format(time_interval)
+        filter_clause = "AND listened_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {})".format(time_interval)
 
     # construct the query string
     query = """SELECT artist_name
@@ -99,7 +99,7 @@ def get_top_artists(musicbrainz_id, time_interval=None):
 
     filter_clause = ""
     if time_interval:
-        filter_clause = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIME(), INTERVAL {})".format(time_interval)
+        filter_clause = "AND listened_at >= TIMESTAMP_SUB(CURRENT_TIME(), INTERVAL {})".format(time_interval)
 
 
     query = """SELECT artist_name
@@ -149,7 +149,7 @@ def get_top_releases(musicbrainz_id, time_interval=None):
 
     filter_clause = ""
     if time_interval:
-        filter_clause = "AND listened_at > TIMESTAMP_SUB(CURRENT_TIME(), INTERVAL {})".format(time_interval)
+        filter_clause = "AND listened_at >= TIMESTAMP_SUB(CURRENT_TIME(), INTERVAL {})".format(time_interval)
 
 
     query = """SELECT artist_name

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -58,10 +58,12 @@ def get_top_recordings(musicbrainz_id, time_interval=None):
                 {time_filter_clause}
              GROUP BY recording_msid, track_name, artist_name, artist_msid
              ORDER BY listen_count DESC
+                LIMIT {limit}
             """.format(
                 dataset_id=config.BIGQUERY_DATASET_ID,
                 table_id=config.BIGQUERY_TABLE_ID,
                 time_filter_clause=filter_clause,
+                limit=config.STATS_ENTITY_LIMIT
             )
 
     # construct the parameters that must be passed to the Google BigQuery API
@@ -108,10 +110,12 @@ def get_top_artists(musicbrainz_id, time_interval=None):
                 {time_filter_clause}
              GROUP BY artist_msid, artist_name
              ORDER BY listen_count DESC
+                LIMIT {limit}
             """.format(
                     dataset_id=config.BIGQUERY_DATASET_ID,
                     table_id=config.BIGQUERY_TABLE_ID,
                     time_filter_clause=filter_clause,
+                    limit=config.STATS_ENTITY_LIMIT,
                 )
 
     parameters = [
@@ -158,10 +162,12 @@ def get_top_releases(musicbrainz_id, time_interval=None):
                 {time_filter_clause}
              GROUP BY artist_msid, artist_name, release_name, release_msid
              ORDER BY listen_count DESC
+                LIMIT {limit}
             """.format(
                     dataset_id=config.BIGQUERY_DATASET_ID,
                     table_id=config.BIGQUERY_TABLE_ID,
                     time_filter_clause=filter_clause,
+                    limit=config.STATS_ENTITY_LIMIT,
                 )
 
     parameters = [

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -36,6 +36,7 @@ def get_top_recordings(musicbrainz_id, time_interval=None):
                 {
                     'track_name' (str)
                     'recording_msid' (uuid)
+                    'recording_mbid' (uuid)
                     'artist_name' (str)
                     'artist_msid' (uuid)
                     'artist_mbids' (string of comma-seperated uuids)
@@ -147,6 +148,7 @@ def get_top_releases(musicbrainz_id, time_interval=None):
                         'artist_mbids' (string of comma seperated uuids),
                         'release_name' (str),
                         'release_msid' (uuid),
+                        'release_mbid' (uuid),
                         'listen_count' (int)
                     }
                 ]

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -18,7 +18,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import listenbrainz.config as config
-import json
 from listenbrainz import stats
 
 

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -34,11 +34,12 @@ def get_top_recordings(musicbrainz_id, time_interval=None):
             sorted list of the following format
             [
                 {
-                    "track_name" (str)
-                    "recording_msid" (uuid)
-                    "artist_name" (str)
-                    "artist_msid" (uuid)
-                    "listen_count" (int)
+                    'track_name' (str)
+                    'recording_msid' (uuid)
+                    'artist_name' (str)
+                    'artist_msid' (uuid)
+                    'artist_mbids' (string of comma-seperated uuids)
+                    'listen_count' (int)
                 }
             ]
     """
@@ -47,16 +48,17 @@ def get_top_recordings(musicbrainz_id, time_interval=None):
     if time_interval:
         filter_clause = "AND listened_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {})".format(time_interval)
 
-    # construct the query string
     query = """SELECT artist_name
                     , artist_msid
+                    , artist_mbids
                     , recording_msid
+                    , recording_mbid
                     , track_name
                     , COUNT(recording_msid) as listen_count
                  FROM {dataset_id}.{table_id}
                 WHERE user_name = @musicbrainz_id
                 {time_filter_clause}
-             GROUP BY recording_msid, track_name, artist_name, artist_msid
+             GROUP BY recording_msid, recording_mbid, track_name, artist_name, artist_msid, artist_mbids
              ORDER BY listen_count DESC
                 LIMIT {limit}
             """.format(
@@ -92,7 +94,8 @@ def get_top_artists(musicbrainz_id, time_interval=None):
                     {
                         'artist_name' (str),
                         'artist_msid' (uuid),
-                        'listen_count' (int)
+                        'artist_mbids' (string of comma-seperated uuids),
+                        'listen_count' (int),
                     }
                 ]
     """
@@ -104,11 +107,12 @@ def get_top_artists(musicbrainz_id, time_interval=None):
 
     query = """SELECT artist_name
                     , artist_msid
+                    , artist_mbids
                     , COUNT(artist_msid) as listen_count
                  FROM {dataset_id}.{table_id}
                 WHERE user_name = @musicbrainz_id
                 {time_filter_clause}
-             GROUP BY artist_msid, artist_name
+             GROUP BY artist_msid, artist_name, artist_mbids
              ORDER BY listen_count DESC
                 LIMIT {limit}
             """.format(
@@ -140,6 +144,7 @@ def get_top_releases(musicbrainz_id, time_interval=None):
                     {
                         'artist_name' (str),
                         'artist_msid' (uuid),
+                        'artist_mbids' (string of comma seperated uuids),
                         'release_name' (str),
                         'release_msid' (uuid),
                         'listen_count' (int)
@@ -154,13 +159,15 @@ def get_top_releases(musicbrainz_id, time_interval=None):
 
     query = """SELECT artist_name
                     , artist_msid
+                    , artist_mbids
                     , release_name
                     , release_msid
+                    , release_mbid
                     , COUNT(release_msid) as listen_count
                  FROM {dataset_id}.{table_id}
                 WHERE user_name = @musicbrainz_id
                 {time_filter_clause}
-             GROUP BY artist_msid, artist_name, release_name, release_msid
+             GROUP BY artist_msid, artist_mbids, artist_name, release_name, release_msid, release_mbid
              ORDER BY listen_count DESC
                 LIMIT {limit}
             """.format(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = listenbrainz/db listenbrainz/webserver listenbrainz/listenstore listenbrainz/tests/unit
+testpaths = listenbrainz/db listenbrainz/webserver listenbrainz/listenstore listenbrainz/tests/unit listenbrainz/stats


### PR DESCRIPTION
This PR adds a stats module that contains `run_query` - a function that takes queries in BigQuery Standard SQL and parameters and then runs them as a synchronous job. It doesn't really depend on #192 but I was waiting on that to get merged before opening this, but now this seemed like a significant amount of work and I thought it best to get some reviews first before continuing further. I've also added a function that uses `run_query` to get the top tracks for a user. Other statistics would be added in a similar way. 

Hopefully, we can ignore the schema changes in this PR for now. Once #192 gets merged, I'll rebase and remove those changes from this PR.