### PR TITLE
LB-180: Account for duplicates in same RabbitMQ batch for influx-writer

### DIFF
--- a/listenbrainz/influx-writer/influx-writer.py
+++ b/listenbrainz/influx-writer/influx-writer.py
@@ -13,7 +13,8 @@ from time import time, sleep
 import listenbrainz.config as config
 from listenbrainz.listenstore import InfluxListenStore
 from listenbrainz.utils import escape, get_measurement_name, get_escaped_measurement_name, \
-                               get_influx_query_timestamp, convert_to_unix_timestamp
+                               get_influx_query_timestamp, convert_to_unix_timestamp, \
+                               convert_timestamp_to_influx_row_format
 from requests.exceptions import ConnectionError
 from redis import Redis
 
@@ -216,6 +217,11 @@ class InfluxWriterSubscriber(object):
                     unique_count += 1
                     submit.append(Listen.from_json(listen))
                     unique.append(listen)
+                    timestamps[t] = {
+                        'time': convert_timestamp_to_influx_row_format(t),
+                        'artist_msid': artist_msid,
+                        'recording_msid': recording_msid
+                    }
 
         t0 = time()
         submitted_count = self.insert_to_listenstore(submit)

--- a/listenbrainz/testdata/same_batch_duplicates.json
+++ b/listenbrainz/testdata/same_batch_duplicates.json
@@ -1,0 +1,29 @@
+{
+    "listen_type": "import",
+    "payload": [
+        {
+            "track_metadata": {
+                "track_name": "Fade",
+                "artist_name": "Kanye West",
+                "release_name": "The Life of Pablo"
+            },
+            "listened_at": 1486466946
+        },
+        {
+            "track_metadata": {
+                "track_name": "Fade",
+                "artist_name": "Kanye West",
+                "release_name": "The Life of Pablo"
+            },
+            "listened_at": 1486466946
+        },
+        {
+            "track_metadata": {
+                "track_name": "Fade",
+                "artist_name": "Kanye West",
+                "release_name": "The Life of Pablo"
+            },
+            "listened_at": 1486466940
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_influx_writer.py
+++ b/listenbrainz/tests/integration/test_influx_writer.py
@@ -84,6 +84,17 @@ class InfluxWriterTestCase(IntegrationTestCase):
         listens = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
+    def test_dedup_same_batch(self):
+
+        user = db_user.get_or_create('phifedawg')
+        r = self.send_listen(user, 'same_batch_duplicates.json')
+        self.assert200(r)
+        time.sleep(2)
+
+        to_ts = int(time.time())
+        listens = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
+        self.assertEqual(len(listens), 1)
+
 
     def test_dedup_different_users(self):
         """

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+INFLUX_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
 def escape(value):
     """ Escapes backslashes, quotes and new lines present in the string value
     """
@@ -35,5 +37,8 @@ def get_influx_query_timestamp(ts):
 
 def convert_to_unix_timestamp(influx_row_time):
     """ Converts time retreived from influxdb into unix timestamp """
-    dt = datetime.strptime(influx_row_time, "%Y-%m-%dT%H:%M:%SZ")
+    dt = datetime.strptime(influx_row_time, INFLUX_TIME_FORMAT)
     return int(dt.strftime('%s'))
+
+def convert_timestamp_to_influx_row_format(ts):
+    return datetime.fromtimestamp(ts).strftime(INFLUX_TIME_FORMAT)


### PR DESCRIPTION
Just add every timestamp we consider to come from a unique listen to the dict, and then later duplicates from the same batch will get detected.