### PR TITLE
LB-20 / LB-31 / LB-182: Incremental imports

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -5,7 +5,8 @@ CREATE TABLE "user" (
   created        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   musicbrainz_id VARCHAR NOT NULL,
   auth_token     VARCHAR,
-  last_login     TIMESTAMP WITH TIME ZONE
+  last_login     TIMESTAMP WITH TIME ZONE,
+  latest_import  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch'
 );
 ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_id_key UNIQUE (musicbrainz_id);
 

--- a/admin/sql/updates/add_latest_import.sql
+++ b/admin/sql/updates/add_latest_import.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- Add latest_import timestamp column to "user" table
+ALTER TABLE "user" ADD COLUMN latest_import TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch';
+
+COMMIT;

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -23,3 +23,20 @@ class UserTestCase(DatabaseTestCase):
         db_user.update_last_login(user['musicbrainz_id'], val)
         user = db_user.get_by_mb_id(user['musicbrainz_id'])
         self.assertEqual(val, int(user['last_login'].strftime('%s')))
+
+    def test_update_latest_import(self):
+        user = db_user.get_or_create('testlatestimportuser')
+
+        val = int(time.time())
+        db_user.update_latest_import(user['musicbrainz_id'], val)
+        user = db_user.get_by_mb_id(user['musicbrainz_id'])
+        self.assertEqual(val, int(user['latest_import'].strftime('%s')))
+
+        db_user.update_latest_import(user['musicbrainz_id'], val - 10)
+        user = db_user.get_by_mb_id(user['musicbrainz_id'])
+        self.assertEqual(val, int(user['latest_import'].strftime('%s')))
+
+        val += 10
+        db_user.update_latest_import(user['musicbrainz_id'], val)
+        user = db_user.get_by_mb_id(user['musicbrainz_id'])
+        self.assertEqual(val, int(user['latest_import'].strftime('%s')))

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -51,6 +51,9 @@ def update_token(id):
             raise
 
 
+USER_GET_COLUMNS = ['id', 'created', 'musicbrainz_id', 'auth_token', 'last_login', 'latest_import']
+
+
 def get(id):
     """Get user with a specified ID.
 
@@ -68,10 +71,10 @@ def get(id):
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT id, created, musicbrainz_id, auth_token, last_login
+            SELECT {columns}
               FROM "user"
              WHERE id = :id
-        """), {"id": id})
+        """.format(columns=','.join(USER_GET_COLUMNS))), {"id": id})
         row = result.fetchone()
         return dict(row) if row else None
 
@@ -93,10 +96,10 @@ def get_by_mb_id(musicbrainz_id):
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT id, created, musicbrainz_id, auth_token, last_login
+            SELECT {columns}
               FROM "user"
              WHERE LOWER(musicbrainz_id) = LOWER(:mb_id)
-        """), {"mb_id": musicbrainz_id})
+        """.format(columns=','.join(USER_GET_COLUMNS))), {"mb_id": musicbrainz_id})
         row = result.fetchone()
         return dict(row) if row else None
 
@@ -118,10 +121,10 @@ def get_by_token(token):
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT id, created, musicbrainz_id, last_login
+            SELECT {columns}
               FROM "user"
              WHERE auth_token = :auth_token
-        """), {"auth_token": token})
+        """.format(columns=','.join(USER_GET_COLUMNS))), {"auth_token": token})
         row = result.fetchone()
         return dict(row) if row else None
 

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -190,3 +190,28 @@ def update_last_login(musicbrainz_id, ts=int(time.time())):
         except sqlalchemy.exc.ProgrammingError as e:
             logger.error(e)
             raise
+
+def update_latest_import(musicbrainz_id, ts):
+    """ Update the value of latest_import field for user with specified MusicBrainz ID
+        If the field already contains a bigger value, no change take place.
+
+    Args:
+        musicbrainz_id (str): MusicBrainz username of user
+        ts (int): Timestamp value with which to update the database
+    """
+
+    user = get_by_mb_id(musicbrainz_id)
+    if ts > int(user['latest_import'].strftime('%s')):
+        with db.engine.connect() as connection:
+            try:
+                result = connection.execute(sqlalchemy.text("""
+                    UPDATE "user"
+                       SET latest_import = to_timestamp(:ts)
+                     WHERE musicbrainz_id = :musicbrainz_id
+                    """), {
+                        'ts': ts,
+                        'musicbrainz_id': musicbrainz_id
+                    })
+            except sqlalchemy.exc.ProgrammingError as e:
+                logger.error(e)
+                raise DatabaseException

--- a/listenbrainz/webserver/templates/user/scraper.js
+++ b/listenbrainz/webserver/templates/user/scraper.js
@@ -213,6 +213,8 @@ var latestImportTime = 0;
 // the latest listen found in this import, we'll report back to the server with this
 var maximumTimestampForImport = 0;
 
+var showNumberOfPages = true; // should we show number of pages in the user message or not
+
 function reportPageAndGetNext(response, page) {
     timesGetPage++;
     if (page == 1) {
@@ -314,7 +316,16 @@ function submitListens() {
                     updateLatestImportTimeOnLB();
 
                 } else {
-                    updateMessage("<i class='fa fa-cog fa-spin'></i> Sending page " + numCompleted + " to ListenBrainz<br><span style='font-size:8pt'>Please don't navigate while this is running</span>");
+                    var msg = "<i class='fa fa-cog fa-spin'></i> Sending page " + numCompleted;
+                    if (showNumberOfPages) {
+                        msg += " of " + numberOfPages;
+                    }
+                    msg += " to ListenBrainz.<br><span style='font-size:8pt'>";
+                    if (!showNumberOfPages) {
+                        msg += "Note: This import will stop at the starting point of your last import. :)<br>";
+                    }
+                    msg += "Please don't navigate while this is running</span>"
+                    updateMessage(msg);
                 }
             };
             xhr.ontimeout = function(context) {
@@ -359,6 +370,11 @@ function getLatestImportTime() {
     xhr.onload = function(content) {
         if (this.status == 200) {
             latestImportTime = parseInt(JSON.parse(this.response)['latest_import']);
+
+            // if this is the first import for this user ever, show the number of pages
+            // in the progress, otherwise don't
+            showNumberOfPages = latestImportTime == 0;
+
             getNextPagesIfSlots();
         }
         else {

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -3,9 +3,10 @@ from listenbrainz.webserver.testing import ServerTestCase
 from flask import url_for
 import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
+import time
+import ujson
 
 class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
-
     def setUp(self):
         ServerTestCase.setUp(self)
         DatabaseTestCase.setUp(self)
@@ -14,6 +15,43 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
     def test_user_page(self):
         response = self.client.get(url_for('user.profile', user_name=self.user['musicbrainz_id']))
         self.assert200(response)
+
+    def test_latest_import(self):
+        """ Test for user.latest_import """
+
+        # initially the value of latest_import will be 0
+        response = self.client.get(url_for('user.latest_import'), query_string={'user_name': self.user['musicbrainz_id']})
+        self.assert200(response)
+        data = ujson.loads(response.data)
+        self.assertEqual(data['musicbrainz_id'], self.user['musicbrainz_id'])
+        self.assertEqual(data['latest_import'], 0)
+
+        # now an update
+        val = int(time.time())
+        response = self.client.post(
+            url_for('user.latest_import'),
+            data=ujson.dumps({'ts': val}),
+            headers={'Authorization': 'Token {token}'.format(token=self.user['auth_token'])}
+        )
+        self.assert200(response)
+
+        # now the value must have changed
+        response = self.client.get(url_for('user.latest_import'), query_string={'user_name': self.user['musicbrainz_id']})
+        self.assert200(response)
+        data = ujson.loads(response.data)
+        self.assertEqual(data['musicbrainz_id'], self.user['musicbrainz_id'])
+        self.assertEqual(data['latest_import'], val)
+
+    def test_latest_import_unauthorized(self):
+        """ Test for invalid tokens passed to user.latest_import view"""
+
+        val = int(time.time())
+        response = self.client.post(
+            url_for('user.latest_import'),
+            data=ujson.dumps({'ts': val}),
+            headers={'Authorization': 'Token thisisinvalid'}
+        )
+        self.assert401(response)
 
     def tearDown(self):
         ServerTestCase.tearDown(self)

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -358,6 +358,7 @@ def latest_import():
         try:
             db_user.update_latest_import(user['musicbrainz_id'], int(ts))
         except DatabaseException as e:
+            current_app.logger.error("Error while updating latest import: {}".format(e))
             raise InternalServerError('Could not update latest_import, try again')
 
         return 'success'

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -1,5 +1,5 @@
 
-from flask import Blueprint, render_template, request, url_for, Response, redirect, flash, current_app
+from flask import Blueprint, render_template, request, url_for, Response, redirect, flash, current_app, jsonify
 from flask_login import current_user, login_required
 from werkzeug.exceptions import NotFound, BadRequest, RequestEntityTooLarge, InternalServerError
 from werkzeug.utils import secure_filename
@@ -17,6 +17,7 @@ from listenbrainz.webserver.views.api_tools import convert_backup_to_native_form
 from listenbrainz.webserver.utils import sizeof_readable
 from listenbrainz.webserver.login import User
 from listenbrainz.webserver.redis_connection import _redis
+from listenbrainz.webserver.views.api import _validate_auth_header
 from os import path, makedirs
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 import ujson
@@ -329,3 +330,33 @@ def import_from_alpha():
     # push username into redis so that we know that this user is in waiting
     redis_connection.set("{} {}".format(current_app.config['IMPORTER_SET_KEY_PREFIX'], current_user.musicbrainz_id), "WAITING")
     return redirect(url_for("user.import_data"))
+
+
+@user_bp.route('/latest_import', methods=['GET', 'POST'])
+@crossdomain(headers='Authorization, Content-Type')
+def latest_import():
+    """ If a POST request, authenticate and update the latest_import field for current_user in db
+        If a GET request, return a json object containing user_name and latest_import unix timestamp
+    """
+    if request.method == 'GET':
+        user = db_user.get_by_mb_id(request.args.get('user_name', ''))
+        if user is None:
+            raise NotFound("Cannot find user: {user_name}".format(user_name=user_name))
+        return jsonify({
+                'musicbrainz_id': user['musicbrainz_id'],
+                'latest_import': 0 if not user['latest_import'] else int(user['latest_import'].strftime('%s'))
+            })
+    elif request.method == 'POST':
+        user = _validate_auth_header()
+
+        try:
+            ts = ujson.loads(request.get_data()).get('ts', 0)
+        except ValueError:
+            raise BadRequest('Invalid data sent')
+
+        try:
+            db_user.update_latest_import(user['musicbrainz_id'], int(ts))
+        except DatabaseException as e:
+            raise InternalServerError('Could not update latest_import, try again')
+
+        return 'success'

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -44,6 +44,7 @@ def lastfmscraper(user_name):
     scraper = render_template(
         "user/scraper.js",
         base_url="{}/1/submit-listens".format(config.BETA_URL),
+        import_url="{}/user/latest-import".format(config.BETA_URL),
         user_token=user_token,
         lastfm_username=lastfm_username,
         user_name=user_name,
@@ -332,7 +333,7 @@ def import_from_alpha():
     return redirect(url_for("user.import_data"))
 
 
-@user_bp.route('/latest_import', methods=['GET', 'POST'])
+@user_bp.route('/latest-import', methods=['GET', 'POST'])
 @crossdomain(headers='Authorization, Content-Type')
 def latest_import():
     """ If a POST request, authenticate and update the latest_import field for current_user in db


### PR DESCRIPTION
* Add a latest_import column to the user table
* Add function in `db` for updating this value
* Add view which can be used to get this value for users and update this value (with authorization the same as API auth)
* Make the alpha importer and last.fm importer get the latest_import value from the server before starting 
* Make the alpha importer and last.fm importer stop at the value they got above
* Make the two importers report the latest import back to the LB server at the end of the import

Had to remove the total number of pages being shown in the last.fm importer because we don't know the number of pages we'll have to get anymore.