### PR TITLE
Add artist and recording MSID checks to dedup

### DIFF
--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -38,13 +38,6 @@ class TestAPICompatUserClass(DatabaseTestCase):
             row = result.fetchone()
             self.user = User(row['id'], row['created'], row['musicbrainz_id'], row['auth_token'])
 
-        # Insert some listens
-        date = datetime(2015, 9, 3, 0, 0, 0)
-        self.log.info("Inserting test data...")
-        test_data = generate_data(date, 100, self.user.name)
-        self.logstore.insert(test_data)
-        self.log.info("Test data inserted")
-
     def tearDown(self):
         super(TestAPICompatUserClass, self).tearDown()
 
@@ -63,5 +56,9 @@ class TestAPICompatUserClass(DatabaseTestCase):
         self.assertDictEqual(user.__dict__, self.user.__dict__)
 
     def test_user_get_play_count(self):
+        date = datetime(2015, 9, 3, 0, 0, 0)
+        test_data = generate_data(date, 100, self.user.name)
+        self.assertEqual(len(test_data), 100)
+        self.logstore.insert(test_data)
         count = User.get_play_count(self.user.id, self.logstore)
         self.assertEqual(count, 100)

--- a/listenbrainz/influx-writer/influx-writer.py
+++ b/listenbrainz/influx-writer/influx-writer.py
@@ -178,8 +178,7 @@ class InfluxWriterSubscriber(object):
             min_time = users[user_name]['min_time']
             max_time = users[user_name]['max_time']
 
-            # quering for artist name here, since a field must be included in the query.
-            query = """SELECT time, artist_name
+            query = """SELECT time, artist_msid, recording_msid
                          FROM %s
                         WHERE time >= %s
                           AND time <= %s
@@ -196,20 +195,28 @@ class InfluxWriterSubscriber(object):
             # collect all the timestamps for this given time range.
             timestamps = {}
             for result in results.get_points(measurement=get_measurement_name(user_name)):
-                timestamps[convert_to_unix_timestamp(result['time'])] = 1
+                timestamps[convert_to_unix_timestamp(result['time'])] = result
 
             for listen in users[user_name]['listens']:
                 # Check if this listen is already present in Influx DB and if it is
                 # mark current listen as duplicate
                 t = int(listen['listened_at'])
+                artist_msid = listen['track_metadata']['additional_info']['artist_msid']
+                recording_msid = listen['recording_msid']
+
                 if t in timestamps:
-                    duplicate_count += 1
-                    continue
-                else:
-                    unique_count += 1
-                    submit.append(Listen.from_json(listen))
-                    unique.append(listen)
-                    timestamps[t] = 1
+                    if timestamps[t]['artist_msid'] == artist_msid and timestamps[t]['recording_msid'] == recording_msid:
+                        duplicate_count += 1
+                        continue
+
+                unique_count += 1
+                submit.append(Listen.from_json(listen))
+                unique.append(listen)
+                timestamps[t] = {
+                    'time': convert_timestamp_to_influx_row_format(t),
+                    'artist_msid': artist_msid,
+                    'recording_msid': recording_msid
+                }
 
         t0 = time()
         submitted_count = self.insert_to_listenstore(submit)

--- a/listenbrainz/influx-writer/influx-writer.py
+++ b/listenbrainz/influx-writer/influx-writer.py
@@ -178,7 +178,7 @@ class InfluxWriterSubscriber(object):
             min_time = users[user_name]['min_time']
             max_time = users[user_name]['max_time']
 
-            query = """SELECT time, artist_msid, recording_msid
+            query = """SELECT time, recording_msid
                          FROM %s
                         WHERE time >= %s
                           AND time <= %s
@@ -201,22 +201,18 @@ class InfluxWriterSubscriber(object):
                 # Check if this listen is already present in Influx DB and if it is
                 # mark current listen as duplicate
                 t = int(listen['listened_at'])
-                artist_msid = listen['track_metadata']['additional_info']['artist_msid']
                 recording_msid = listen['recording_msid']
 
-                if t in timestamps:
-                    if timestamps[t]['artist_msid'] == artist_msid and timestamps[t]['recording_msid'] == recording_msid:
-                        duplicate_count += 1
-                        continue
-
-                unique_count += 1
-                submit.append(Listen.from_json(listen))
-                unique.append(listen)
-                timestamps[t] = {
-                    'time': convert_timestamp_to_influx_row_format(t),
-                    'artist_msid': artist_msid,
-                    'recording_msid': recording_msid
-                }
+                if t in timestamps and timestamps[t]['recording_msid'] == recording_msid:
+                    duplicate_count += 1
+                else:
+                    unique_count += 1
+                    submit.append(Listen.from_json(listen))
+                    unique.append(listen)
+                    timestamps[t] = {
+                        'time': convert_timestamp_to_influx_row_format(t),
+                        'recording_msid': recording_msid
+                    }
 
         t0 = time()
         submitted_count = self.insert_to_listenstore(submit)

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -179,6 +179,8 @@ class Listen(object):
             'time' : self.ts_since_epoch,
             'tags' : {
                 'user_name' : escape(self.user_name),
+                'artist_msid' : self.artist_msid,
+                'recording_msid' : self.recording_msid,
             },
             'fields' : {
                 'artist_name' : self.data['artist_name'],

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -179,7 +179,6 @@ class Listen(object):
             'time' : self.ts_since_epoch,
             'tags' : {
                 'user_name' : escape(self.user_name),
-                'artist_msid' : self.artist_msid,
                 'recording_msid' : self.recording_msid,
             },
             'fields' : {

--- a/listenbrainz/testdata/same_timestamp_diff_track_valid_single.json
+++ b/listenbrainz/testdata/same_timestamp_diff_track_valid_single.json
@@ -1,0 +1,12 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": 1486449409,
+            "track_metadata": {
+                "artist_name": "Radiohead",
+                "track_name": "I Promise"
+            }
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_influx_writer.py
+++ b/listenbrainz/tests/integration/test_influx_writer.py
@@ -97,3 +97,21 @@ class InfluxWriterTestCase(IntegrationTestCase):
 
         listens = self.ls.fetch_listens(user2['musicbrainz_id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
+
+    def test_dedup_same_timestamp_different_tracks(self):
+        """ Test to check that if there are two tracks w/ the same timestamp,
+            they don't get considered as duplicates
+        """
+
+        user = db_user.get_or_create('difftracksametsuser')
+
+        r = self.send_listen(user, 'valid_single.json')
+        self.assert200(r)
+
+        r = self.send_listen(user, 'same_timestamp_diff_track_valid_single.json')
+        self.assert200(r)
+        time.sleep(2)
+
+        to_ts = int(time.time())
+        listens = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
+        self.assertEqual(len(listens), 2)

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -86,7 +86,7 @@ class ListenTestCase(unittest.TestCase):
         self.assertEqual(data['measurement'], quote(listen.user_name))
         self.assertEqual(data['time'], listen.ts_since_epoch)
         self.assertEqual(data['tags']['user_name'], listen.user_name)
-        self.assertEqual(data['tags']['artist_msid'], listen.artist_msid)
+        self.assertEqual(data['fields']['artist_msid'], listen.artist_msid)
         self.assertEqual(data['tags']['recording_msid'], listen.recording_msid)
         self.assertEqual(data['fields']['track_name'], listen.data['track_name'])
         self.assertEqual(data['fields']['artist_name'], listen.data['artist_name'])

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -80,14 +80,13 @@ class ListenTestCase(unittest.TestCase):
         # Make sure every value that we don't explicitly support is a string
         for key in data['fields']:
             if key not in Listen.SUPPORTED_KEYS:
-                print(key)
                 self.assertIsInstance(data['fields'][key], str)
 
         # Check values
         self.assertEqual(data['measurement'], quote(listen.user_name))
         self.assertEqual(data['time'], listen.ts_since_epoch)
         self.assertEqual(data['tags']['user_name'], listen.user_name)
-        self.assertEqual(data['fields']['artist_msid'], listen.artist_msid)
-        self.assertEqual(data['fields']['recording_msid'], listen.recording_msid)
+        self.assertEqual(data['tags']['artist_msid'], listen.artist_msid)
+        self.assertEqual(data['tags']['recording_msid'], listen.recording_msid)
         self.assertEqual(data['fields']['track_name'], listen.data['track_name'])
         self.assertEqual(data['fields']['artist_name'], listen.data['artist_name'])


### PR DESCRIPTION
To allow rows with the same timestamp, we have to add `artist_msid` and `recording_msid` to the influx tags too.