### PR TITLE
Do not put user name into the tags anymore since tags are optional now.

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -177,11 +177,11 @@ class Listen(object):
         data = {
             'measurement' : measurement,
             'time' : self.ts_since_epoch,
-            'tags' : {
-                'user_name' : escape(self.user_name),
-                'recording_msid' : self.recording_msid,
+            'tags' : { 
+                'recording_msid' : self.recording_msid
             },
             'fields' : {
+                'user_name' : escape(self.user_name),
                 'artist_name' : self.data['artist_name'],
                 'artist_msid' : self.artist_msid,
                 'artist_mbids' : ",".join(self.data['additional_info'].get('artist_mbids', [])),

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -187,7 +187,7 @@ class InfluxListenStore(ListenStore):
         # If we reach this point, we were able to write the listens to the InfluxListenStore.
         # So update the listen counts of the users cached in redis.
         for data in submit:
-            user_key = "{}{}".format(REDIS_INFLUX_USER_LISTEN_COUNT, data['tags']['user_name'])
+            user_key = "{}{}".format(REDIS_INFLUX_USER_LISTEN_COUNT, data['fields']['user_name'])
             if self.redis.exists(user_key):
                 self.redis.incr(user_key)
 

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -85,8 +85,7 @@ class ListenTestCase(unittest.TestCase):
         # Check values
         self.assertEqual(data['measurement'], quote(listen.user_name))
         self.assertEqual(data['time'], listen.ts_since_epoch)
-        self.assertEqual(data['tags']['user_name'], listen.user_name)
+        self.assertEqual(data['fields']['user_name'], listen.user_name)
         self.assertEqual(data['fields']['artist_msid'], listen.artist_msid)
-        self.assertEqual(data['tags']['recording_msid'], listen.recording_msid)
         self.assertEqual(data['fields']['track_name'], listen.data['track_name'])
         self.assertEqual(data['fields']['artist_name'], listen.data['artist_name'])


### PR DESCRIPTION
This should avoid the 100k tags limit for users -- the user name was in the tags only because tags were previously required. I've moved user_name to the fields -- not 100% sure we need it. Thoughts?