### PR TITLE
LB-194: Fix error in importer due to spaces in usernames

### DIFF
--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -92,7 +92,8 @@
     function lastfm_import() {
       var lastfm_username = document.getElementById("lastfm_input").value;
       var xhr = new XMLHttpRequest();
-      xhr.open('GET', encodeURI('{{ scraper_url }}?user_token={{ user.auth_token }}&lastfm_username='+ lastfm_username));
+      // do not need to encode scraper_url because it is the result of a url_for call on the server
+      xhr.open('GET', '{{ scraper_url }}?user_token={{ user.auth_token }}&lastfm_username='+ encodeURIComponent(lastfm_username));
       xhr.onload = function(content) {
         eval(xhr.response);
       };

--- a/listenbrainz/webserver/templates/user/scraper.js
+++ b/listenbrainz/webserver/templates/user/scraper.js
@@ -215,6 +215,7 @@ function getLastFMPage(page) {
     xhr.send();
 }
 
+var user_name = "{{ user_name }}";
 var version = "1.7.1";
 var page = 1;
 var numberOfPages = 1;
@@ -416,7 +417,9 @@ function getLatestImportTime() {
 
     var delay = getRateLimitDelay();
     setTimeout(function() {
-        var url = "{{ import_url }}" + "?" + "user_name=" + encodeURIComponent("{{ user_name }}");
+        // user_name has already been uri encoded on the server
+        var url = "{{ import_url }}?user_name=" + user_name;
+
         var xhr = new XMLHttpRequest();
         xhr.open("GET", url);
         xhr.onload = function(content) {
@@ -457,7 +460,7 @@ function updateLatestImportTimeOnLB() {
             updateRateLimitParameters(xhr);
             if (this.status == 200) {
                 var final_msg = "<i class='fa fa-check'></i> Import finished<br>";
-                final_msg += "<span><a href={{ url_for('user.profile', user_name = user_name) }}>Close and go to your ListenBrainz profile</a></span><br>";
+                final_msg += "<span><a href={{ profile_url }}>Close and go to your ListenBrainz profile</a></span><br>";
                 final_msg += "<span style='font-size:8pt'>Successfully submitted " + countReceived + " listens to ListenBrainz."
                     + " Please note that some of these listens might be duplicates leading to a lower listen count on LB.</span></br>";
 

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -28,7 +28,7 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
             }
         )
         self.assert200(response)
-        self.assertIn('var user_name = "{}";'.format(urllib.parse.quote_plus(self.user['musicbrainz_id'])), response.data.decode('utf-8'))
+        self.assertIn('var user_name = "iliekcomputers";', response.data.decode('utf-8'))
 
         response = self.client.get(
             url_for('user.lastfmscraper', user_name=self.weirduser['musicbrainz_id']),
@@ -38,7 +38,7 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
             }
         )
         self.assert200(response)
-        self.assertIn('var user_name = "{}";'.format(urllib.parse.quote_plus(self.weirduser['musicbrainz_id'])), response.data.decode('utf-8'))
+        self.assertIn('var user_name = "weird%5Cuser%20name";', response.data.decode('utf-8'))
 
     def tearDown(self):
         ServerTestCase.tearDown(self)

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -3,6 +3,7 @@ from listenbrainz.webserver.testing import ServerTestCase
 from flask import url_for
 import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
+import urllib
 import time
 import ujson
 
@@ -11,10 +12,34 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         ServerTestCase.setUp(self)
         DatabaseTestCase.setUp(self)
         self.user = db_user.get_or_create('iliekcomputers')
+        self.weirduser = db_user.get_or_create('weird\\user name')
 
     def test_user_page(self):
         response = self.client.get(url_for('user.profile', user_name=self.user['musicbrainz_id']))
         self.assert200(response)
+
+    def test_scraper_username(self):
+        response = self.client.get(
+            url_for('user.lastfmscraper', user_name=self.user['musicbrainz_id']),
+            query_string={
+                'user_token': self.user['auth_token'],
+                'lastfm_username': 'dummy',
+            }
+        )
+        self.assert200(response)
+        self.assertIn('var user_name = "{}";'.format(urllib.parse.quote_plus(self.user['musicbrainz_id'])), response.data.decode('utf-8'))
+
+        print(url_for('user.lastfmscraper', user_name=self.weirduser['musicbrainz_id']))
+        response = self.client.get(
+            url_for('user.lastfmscraper', user_name=self.weirduser['musicbrainz_id']),
+            query_string={
+                'user_token': self.weirduser['auth_token'],
+                'lastfm_username': 'dummy',
+            }
+        )
+        self.assert200(response)
+        # the username should be escaped in the template because it is in quotes
+        self.assertIn('var user_name = "{}";'.format(urllib.parse.quote_plus(self.weirduser['musicbrainz_id'])), response.data.decode('utf-8'))
 
     def tearDown(self):
         ServerTestCase.tearDown(self)

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -1,11 +1,7 @@
-
 from listenbrainz.webserver.testing import ServerTestCase
 from flask import url_for
 import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
-import urllib
-import time
-import ujson
 
 class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
     def setUp(self):

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -19,6 +19,7 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assert200(response)
 
     def test_scraper_username(self):
+        """ Tests that the username is correctly rendered in the last.fm importer """
         response = self.client.get(
             url_for('user.lastfmscraper', user_name=self.user['musicbrainz_id']),
             query_string={
@@ -29,7 +30,6 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assert200(response)
         self.assertIn('var user_name = "{}";'.format(urllib.parse.quote_plus(self.user['musicbrainz_id'])), response.data.decode('utf-8'))
 
-        print(url_for('user.lastfmscraper', user_name=self.weirduser['musicbrainz_id']))
         response = self.client.get(
             url_for('user.lastfmscraper', user_name=self.weirduser['musicbrainz_id']),
             query_string={
@@ -38,7 +38,6 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
             }
         )
         self.assert200(response)
-        # the username should be escaped in the template because it is in quotes
         self.assertIn('var user_name = "{}";'.format(urllib.parse.quote_plus(self.weirduser['musicbrainz_id'])), response.data.decode('utf-8'))
 
     def tearDown(self):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -17,7 +17,6 @@ from listenbrainz.webserver.views.api_tools import convert_backup_to_native_form
 from listenbrainz.webserver.utils import sizeof_readable
 from listenbrainz.webserver.login import User
 from listenbrainz.webserver.redis_connection import _redis
-from listenbrainz.utils import escape
 from os import path, makedirs
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 import ujson
@@ -25,6 +24,7 @@ import zipfile
 import re
 import os
 import pytz
+import urllib
 
 LISTENS_PER_PAGE = 25
 EXPORT_FETCH_COUNT= 5000
@@ -47,7 +47,9 @@ def lastfmscraper(user_name):
         import_url="{}/1/latest-import".format(config.BETA_URL),
         user_token=user_token,
         lastfm_username=lastfm_username,
-        user_name=escape(user_name), # need to escape user_name here because other wise jinja doesn't handle usernames with backslashes correctly
+        # need to escape user_name here because other wise jinja doesn't handle usernames with backslashes correctly
+        user_name=urllib.parse.quote_plus(user_name),
+        profile_url=url_for('user.profile', user_name=user_name),
         lastfm_api_key=current_app.config['LASTFM_API_KEY'],
         lastfm_api_url=current_app.config['LASTFM_API_URL'],
     )

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -17,6 +17,7 @@ from listenbrainz.webserver.views.api_tools import convert_backup_to_native_form
 from listenbrainz.webserver.utils import sizeof_readable
 from listenbrainz.webserver.login import User
 from listenbrainz.webserver.redis_connection import _redis
+from listenbrainz.utils import escape
 from os import path, makedirs
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 import ujson
@@ -46,7 +47,7 @@ def lastfmscraper(user_name):
         import_url="{}/1/latest-import".format(config.BETA_URL),
         user_token=user_token,
         lastfm_username=lastfm_username,
-        user_name=user_name,
+        user_name=escape(user_name), # need to escape user_name here because other wise jinja doesn't handle usernames with backslashes correctly
         lastfm_api_key=current_app.config['LASTFM_API_KEY'],
         lastfm_api_url=current_app.config['LASTFM_API_URL'],
     )

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -48,7 +48,7 @@ def lastfmscraper(user_name):
         user_token=user_token,
         lastfm_username=lastfm_username,
         # need to escape user_name here because other wise jinja doesn't handle usernames with backslashes correctly
-        user_name=urllib.parse.quote_plus(user_name),
+        user_name=urllib.parse.quote(user_name),
         profile_url=url_for('user.profile', user_name=user_name),
         lastfm_api_key=current_app.config['LASTFM_API_KEY'],
         lastfm_api_url=current_app.config['LASTFM_API_URL'],


### PR DESCRIPTION
Fix for [LB-194](https://tickets.metabrainz.org/projects/LB/issues/LB-194?filter=allopenissues)

The value of scraper_url is already encoded because it is a
result of call to flask's url_for [here](https://github.com/metabrainz/listenbrainz-server/blob/1c31970ba549d7b053430794511ec9567c6c0a81/listenbrainz/webserver/views/user.py#L182). Encoding it again in the scraper causes
an already escaped user_name being passed to the scraper
which led to LB-194.

Also, now after this, we need to escape the user name because `param\singh` shows up as `paramsingh` when passed to the template.