### PR TITLE
Make the API blueprint use a url prefix when registering

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -1,9 +1,10 @@
-
 from flask import Flask, current_app
 import sys
 import os
 from shutil import copyfile
 from listenbrainz.webserver.scheduler import ScheduledJobs
+
+API_PREFIX = '/1'
 
 def create_influx(app):
     from listenbrainz.webserver.influx_connection import init_influx_connection
@@ -106,5 +107,5 @@ def _register_blueprints(app):
     app.register_blueprint(index_bp)
     app.register_blueprint(login_bp, url_prefix='/login')
     app.register_blueprint(user_bp, url_prefix='/user')
-    app.register_blueprint(api_bp)
+    app.register_blueprint(api_bp, url_prefix=API_PREFIX)
     app.register_blueprint(api_bp_compat)

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -3,6 +3,7 @@ from yattag import Doc
 import yattag
 import ujson
 import collections
+from listenbrainz.webserver import API_PREFIX
 
 LastFMError = collections.namedtuple('LastFMError', ['code', 'message'])
 
@@ -73,7 +74,7 @@ def init_error_handlers(app):
                 A Response which will be a json error if request was made to the LB api and an html page
                 otherwise
         """
-        if request.path.startswith('/1/'):
+        if request.path.startswith(API_PREFIX):
             return json_error_wrapper(error, code)
         else:
             return error_wrapper(f'errors/{code}.html', error, code)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -14,7 +14,7 @@ import time
 api_bp = Blueprint('api_v1', __name__)
 
 
-@api_bp.route("/1/submit-listens", methods=["POST", "OPTIONS"])
+@api_bp.route("/submit-listens", methods=["POST", "OPTIONS"])
 @crossdomain(headers="Authorization, Content-Type")
 @ratelimit()
 def submit_listen():
@@ -75,7 +75,7 @@ def submit_listen():
     return jsonify({'status': 'ok'})
 
 
-@api_bp.route("/1/user/<user_name>/listens")
+@api_bp.route("/user/<user_name>/listens")
 @ratelimit()
 def get_listens(user_name):
     """
@@ -125,7 +125,7 @@ def get_listens(user_name):
     }})
 
 
-@api_bp.route('/1/latest-import', methods=['GET', 'POST', 'OPTIONS'])
+@api_bp.route('/latest-import', methods=['GET', 'POST', 'OPTIONS'])
 @crossdomain(headers='Authorization, Content-Type')
 @ratelimit()
 def latest_import():


### PR DESCRIPTION
Also, use this prefix variable in the error handling

Addresses https://github.com/metabrainz/listenbrainz-server/pull/234#discussion_r128540071

