### PR TITLE
Fix user export bug caused due to listens with timestamp 0

### DIFF
--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -40,7 +40,7 @@ class ListenStore(object):
         if from_ts and to_ts:
             raise ValueError("You cannot specify from_ts and to_ts at the same time.")
 
-        if not from_ts and not to_ts:
+        if from_ts is None and to_ts is None:
             raise ValueError("You must specify either from_ts or to_ts.")
 
         if from_ts:

--- a/listenbrainz/testdata/user_export_test.json
+++ b/listenbrainz/testdata/user_export_test.json
@@ -1,0 +1,29 @@
+{
+    "listen_type": "import",
+    "payload": [
+        {
+            "track_metadata": {
+                "track_name": "Fade",
+                "artist_name": "Kanye West",
+                "release_name": "The Life of Pablo"
+            },
+            "listened_at": 1486466946
+        },
+        {
+            "track_metadata": {
+                "track_name": "Sister",
+                "artist_name": "The Black Keys",
+                "release_name": "El Camino"
+            },
+            "listened_at": 1486466992
+        },
+        {
+            "track_metadata": {
+                "track_name": "Sister",
+                "artist_name": "The Black Keys",
+                "release_name": "El Camino"
+            },
+            "listened_at": 0
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_user_views.py
+++ b/listenbrainz/tests/integration/test_user_views.py
@@ -15,7 +15,7 @@ class UserViewsTestCase(IntegrationTestCase):
         self.user = db_user.get_or_create('iliekcomputers')
 
     def send_listens(self):
-        with open(self.path_to_data_file('valid_import.json')) as f:
+        with open(self.path_to_data_file('user_export_test.json')) as f:
             payload = json.load(f)
         return self.client.post(
             url_for('api_v1.submit_listen'),
@@ -43,4 +43,4 @@ class UserViewsTestCase(IntegrationTestCase):
         resp = self.client.post(url_for('user.export_data'))
         self.assert200(resp)
         data = json.loads(resp.data)
-        self.assertEqual(len(data), 2)
+        self.assertEqual(len(data), 3)


### PR DESCRIPTION
listens with timestamp 0 caused `to_ts` to be 0 leading to a bug.