### PR TITLE
Schedule calculations and show artist count on user page.

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -49,7 +49,7 @@ CREATE TABLE statistics.user (
     artists                 JSONB,
     releases                JSONB,
     recordings              JSONB,
-    last_updated            TIMESTAMP WITH TIME ZONE
+    last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE statistics.artist (
@@ -60,7 +60,7 @@ CREATE TABLE statistics.artist (
     recordings              JSONB,
     users                   JSONB,
     listen_count            JSONB,
-    last_updated            TIMESTAMP WITH TIME ZONE
+    last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 ALTER TABLE statistics.artist ADD CONSTRAINT artist_stats_msid_uniq UNIQUE (msid);
 
@@ -71,7 +71,7 @@ CREATE TABLE statistics.release (
     recordings              JSONB,
     users                   JSONB,
     listen_count            JSONB,
-    last_updated            TIMESTAMP WITH TIME ZONE
+    last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 ALTER TABLE statistics.release ADD CONSTRAINT release_stats_msid_uniq UNIQUE (msid);
 
@@ -81,7 +81,7 @@ CREATE TABLE statistics.recording (
     name                    VARCHAR,
     users_all_time          JSONB,
     listen_count            JSONB,
-    last_updated            TIMESTAMP WITH TIME ZONE
+    last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 
 );
 ALTER TABLE statistics.recording ADD CONSTRAINT recording_stats_msid_uniq UNIQUE (msid);

--- a/admin/sql/updates/2017-08-03-make-stats-updated-not-null.sql
+++ b/admin/sql/updates/2017-08-03-make-stats-updated-not-null.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+-- XXX(param): What should values that are null already be set to here now?
+-- timestamp 0 or NOW() ?
+
 ALTER TABLE statistics.user ALTER COLUMN last_updated SET NOT NULL;
 ALTER TABLE statistics.user ALTER COLUMN last_updated SET DEFAULT NOW();
 

--- a/admin/sql/updates/2017-08-03-make-stats-updated-not-null.sql
+++ b/admin/sql/updates/2017-08-03-make-stats-updated-not-null.sql
@@ -1,7 +1,9 @@
 BEGIN;
 
--- XXX(param): What should values that are null already be set to here now?
--- timestamp 0 or NOW() ?
+UPDATE statistics.user SET last_updated = to_timestamp(0) WHERE last_updated IS NULL;
+UPDATE statistics.artist SET last_updated = to_timestamp(0) WHERE last_updated IS NULL;
+UPDATE statistics.release SET last_updated = to_timestamp(0) WHERE last_updated IS NULL;
+UPDATE statistics.recording SET last_updated = to_timestamp(0) WHERE last_updated IS NULL;
 
 ALTER TABLE statistics.user ALTER COLUMN last_updated SET NOT NULL;
 ALTER TABLE statistics.user ALTER COLUMN last_updated SET DEFAULT NOW();

--- a/admin/sql/updates/2017-08-03-make-stats-updated-not-null.sql
+++ b/admin/sql/updates/2017-08-03-make-stats-updated-not-null.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+ALTER TABLE statistics.user ALTER COLUMN last_updated SET NOT NULL;
+ALTER TABLE statistics.user ALTER COLUMN last_updated SET DEFAULT NOW();
+
+ALTER TABLE statistics.artist ALTER COLUMN last_updated SET NOT NULL;
+ALTER TABLE statistics.artist ALTER COLUMN last_updated SET DEFAULT NOW();
+
+
+ALTER TABLE statistics.release ALTER COLUMN last_updated SET NOT NULL;
+ALTER TABLE statistics.release ALTER COLUMN last_updated SET DEFAULT NOW();
+
+ALTER TABLE statistics.recording ALTER COLUMN last_updated SET NOT NULL;
+ALTER TABLE statistics.recording ALTER COLUMN last_updated SET DEFAULT NOW();
+
+COMMIT;

--- a/listenbrainz/bigquery.py
+++ b/listenbrainz/bigquery.py
@@ -1,0 +1,33 @@
+import os
+from googleapiclient import discovery
+import googleapiclient
+from oauth2client.client import GoogleCredentials
+
+APP_CREDENTIALS_FILE = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
+
+def create_bigquery_object():
+    """ Initiates the connection to Google BigQuery. Returns a BigQuery object. """
+
+    if not APP_CREDENTIALS_FILE:
+        logger.error("The GOOGLE_APPLICATIONS_CREDENTIALS variable is undefined, cannot connect to BigQuery")
+        raise NoCredentialsVariableException
+
+    if not os.path.exists(APP_CREDENTIALS_FILE):
+        logger.error("The BigQuery credentials file does not exist, cannot connect to BigQuery")
+        raise NoCredentialsFileException
+
+    credentials = GoogleCredentials.get_application_default()
+    return discovery.build('bigquery', 'v2', credentials=credentials)
+
+
+# Exceptions
+class BigQueryException(Exception):
+    pass
+
+
+class NoCredentialsVariableException(BigQueryException):
+    pass
+
+
+class NoCredentialsFileException(BigQueryException):
+    pass

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -56,7 +56,8 @@ BIGQUERY_TABLE_ID = "listen"
 STATS_ENTITY_LIMIT = 100 # the number of entities to calculate at max with BQ
 
 # Stats
-STATS_CALCULATE_LOGIN = 7
+STATS_CALCULATE_LOGIN = 30
+STATS_CALCULATION_INTERVAL = 7
 
 
 # Max time in seconds after which the playing_now stream will expire.

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -55,6 +55,10 @@ BIGQUERY_TABLE_ID = "listen"
 # Stats
 STATS_ENTITY_LIMIT = 100 # the number of entities to calculate at max with BQ
 
+# Stats
+STATS_CALCULATE_LOGIN = 7
+
+
 # Max time in seconds after which the playing_now stream will expire.
 PLAYING_NOW_MAX_DURATION = 10 * 60
 

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -54,8 +54,8 @@ BIGQUERY_TABLE_ID = "listen"
 
 # Stats
 STATS_ENTITY_LIMIT = 100 # the number of entities to calculate at max with BQ
-STATS_CALCULATE_LOGIN = 30
-STATS_CALCULATION_INTERVAL = 7
+STATS_CALCULATION_LOGIN_TIME = 30 # users must have logged in to LB in the past 30 days for stats to be calculated
+STATS_CALCULATION_INTERVAL = 7 # stats are calculated every 7 days
 
 
 # Max time in seconds after which the playing_now stream will expire.

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -54,8 +54,6 @@ BIGQUERY_TABLE_ID = "listen"
 
 # Stats
 STATS_ENTITY_LIMIT = 100 # the number of entities to calculate at max with BQ
-
-# Stats
 STATS_CALCULATE_LOGIN = 30
 STATS_CALCULATION_INTERVAL = 7
 

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -1,0 +1,47 @@
+"""This module contains functions to insert and retrieve statistics
+   calculated from Google BigQuery into the database.
+"""
+
+import sqlalchemy
+import ujson
+from listenbrainz import db
+
+
+# XXX(param): think about the names of these variables
+# should they be artist_stats and so on instead?
+# Note: names are used in tests and stats/calculate.py also
+
+def insert_user_stats(user_id, artists, recordings, releases):
+    # XXX(param): should this name be upsert_user_stats?
+
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            INSERT INTO statistics.user (user_id, artists, recordings, releases)
+                 VALUES (:user_id, :artists, :recordings, :releases)
+            ON CONFLICT (user_id)
+          DO UPDATE SET artists = :artists,
+                        recordings = :recordings,
+                        releases = :releases,
+                        last_updated = NOW()
+            """), {
+                'user_id': user_id,
+                'artists': ujson.dumps(artists),
+                'recordings': ujson.dumps(recordings),
+                'releases': ujson.dumps(releases)
+            }
+        )
+
+
+def get_user_stats(user_id):
+
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT user_id, artists, releases, recordings
+              FROM statistics.user
+             WHERE user_id = :user_id
+            """), {
+                'user_id': user_id
+            }
+        )
+        row = result.fetchone()
+        return dict(row) if row else None

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -7,12 +7,20 @@ import ujson
 from listenbrainz import db
 
 
-# XXX(param): think about the names of these variables
+# XXX(param): think about the names of these stats variables
 # should they be artist_stats and so on instead?
 # Note: names are used in tests and stats/calculate.py also
 
-def insert_user_stats(user_id, artists, recordings, releases):
+def insert_user_stats(user_id, artists, recordings, releases, artist_count):
     # XXX(param): should this name be upsert_user_stats?
+
+    # put all artist stats into one dict which will then be inserted
+    # into the artist column of the stats.user table
+    # XXX(param): This makes the schema of the stats very variable though.
+    artist_stats = {
+        'count': artist_count,
+        'all_time': artists
+    }
 
     with db.engine.connect() as connection:
         connection.execute(sqlalchemy.text("""
@@ -25,7 +33,7 @@ def insert_user_stats(user_id, artists, recordings, releases):
                         last_updated = NOW()
             """), {
                 'user_id': user_id,
-                'artists': ujson.dumps(artists),
+                'artists': ujson.dumps(artist_stats),
                 'recordings': ujson.dumps(recordings),
                 'releases': ujson.dumps(releases)
             }

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -36,12 +36,14 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             user_id=self.user['id'],
             artists=artists,
             recordings=recordings,
-            releases=releases
+            releases=releases,
+            artist_count=2,
         )
 
         # TODO(param): test the last_updated values too
         result = db_stats.get_user_stats(user_id=self.user['id'])
-        self.assertDictEqual(result['artists'], artists)
+        self.assertDictEqual(result['artists']['all_time'], artists)
+        self.assertEqual(result['artists']['count'], 2)
         self.assertDictEqual(result['releases'], releases)
         self.assertDictEqual(result['recordings'], recordings)
 

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import time
+import uuid
+import json
+import os
+import listenbrainz.db.user as db_user
+import listenbrainz.db.stats as db_stats
+from listenbrainz.db.testing import DatabaseTestCase
+
+
+class StatsDatabaseTestCase(DatabaseTestCase):
+
+    TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'testdata')
+
+    def setUp(self):
+        DatabaseTestCase.setUp(self)
+        self.user = db_user.get_or_create('stats_user')
+
+    def path_to_data_file(self, filename):
+        # XXX(param): we have this function in IntegrationTestCase also,
+        # maybe find some way to share it
+        # ListenBrainzTestCase?
+       return os.path.join(StatsDatabaseTestCase.TEST_DATA_PATH, filename)
+
+    def test_insert_user_stats(self):
+
+        with open(self.path_to_data_file('user_top_artists.json')) as f:
+            artists = json.load(f)
+        with open(self.path_to_data_file('user_top_releases.json')) as f:
+            releases = json.load(f)
+        with open(self.path_to_data_file('user_top_recordings.json')) as f:
+            recordings = json.load(f)
+
+
+        db_stats.insert_user_stats(
+            user_id=self.user['id'],
+            artists=artists,
+            recordings=recordings,
+            releases=releases
+        )
+
+        # TODO(param): test the last_updated values too
+        result = db_stats.get_user_stats(user_id=self.user['id'])
+        self.assertDictEqual(result['artists'], artists)
+        self.assertDictEqual(result['releases'], releases)
+        self.assertDictEqual(result['recordings'], recordings)
+

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import time
-import uuid
 import json
 import os
 import listenbrainz.db.user as db_user
@@ -17,9 +15,6 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         self.user = db_user.get_or_create('stats_user')
 
     def path_to_data_file(self, filename):
-        # XXX(param): we have this function in IntegrationTestCase also,
-        # maybe find some way to share it
-        # ListenBrainzTestCase?
        return os.path.join(StatsDatabaseTestCase.TEST_DATA_PATH, filename)
 
     def test_insert_user_stats(self):
@@ -40,10 +35,10 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             artist_count=2,
         )
 
-        # TODO(param): test the last_updated values too
         result = db_stats.get_user_stats(user_id=self.user['id'])
         self.assertDictEqual(result['artists']['all_time'], artists)
         self.assertEqual(result['artists']['count'], 2)
         self.assertDictEqual(result['releases'], releases)
         self.assertDictEqual(result['recordings'], recordings)
+        self.assertGreater(int(result['last_updated'].strftime('%s')), 0)
 

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -225,7 +225,6 @@ def get_recently_logged_in_users():
                   FROM "user"
                  WHERE last_login >= NOW() - INTERVAL ':x days'
                 """.format(columns=','.join(USER_GET_COLUMNS))), {
-                    #TODO(param): think about the name of this variable in config
-                    'x': config.STATS_CALCULATE_LOGIN
+                    'x': config.STATS_CALCULATION_LOGIN_TIME
                 })
         return [dict(row) for row in result]

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -1,10 +1,10 @@
-
-from listenbrainz import db
 import uuid
 import sqlalchemy
-from listenbrainz.db.exceptions import DatabaseException
 import logging
 import time
+from listenbrainz import db
+from listenbrainz.db.exceptions import DatabaseException
+from listenbrainz import config
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -213,3 +213,19 @@ def update_latest_import(musicbrainz_id, ts):
             except sqlalchemy.exc.ProgrammingError as e:
                 logger.error(e)
                 raise DatabaseException
+
+
+def get_recently_logged_in_users():
+    """Returns a list of users who have logged-in in the last X days, X is
+       defined in the config.
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+                SELECT {columns}
+                  FROM "user"
+                 WHERE last_login >= NOW() - INTERVAL ':x days'
+                """.format(columns=','.join(USER_GET_COLUMNS))), {
+                    #TODO(param): think about the name of this variable in config
+                    'x': config.STATS_CALCULATE_LOGIN
+                })
+        return [dict(row) for row in result]

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -216,8 +216,8 @@ def update_latest_import(musicbrainz_id, ts):
 
 
 def get_recently_logged_in_users():
-    """Returns a list of users who have logged-in in the last X days, X is
-       defined in the config.
+    """Returns a list of users who have logged-in in the
+    last config.STATS_CALCULATION_LOGIN_TIME days
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""

--- a/listenbrainz/stats/__init__.py
+++ b/listenbrainz/stats/__init__.py
@@ -1,9 +1,6 @@
-from googleapiclient import discovery
-import googleapiclient
-from oauth2client.client import GoogleCredentials
 import os
 import logging
-from listenbrainz.stats.exceptions import NoCredentialsVariableException, NoCredentialsFileException
+from listenbrainz.bigquery import create_bigquery_object
 import listenbrainz.config as config
 import time
 
@@ -12,25 +9,14 @@ JOB_COMPLETION_CHECK_DELAY = 5 # seconds
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-APP_CREDENTIALS_FILE = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
-
 bigquery = None
 
 
 def init_bigquery_connection():
     """ Initiates the connection to Google BigQuery """
 
-    if not APP_CREDENTIALS_FILE:
-        logger.error("The GOOGLE_APPLICATIONS_CREDENTIALS variable is undefined, cannot connect to BigQuery")
-        raise NoCredentialsVariableException
-
-    if not os.path.exists(APP_CREDENTIALS_FILE):
-        logger.error("The BigQuery credentials file does not exist, cannot connect to BigQuery")
-        raise NoCredentialsFileException
-
     global bigquery
-    credentials = GoogleCredentials.get_application_default()
-    bigquery = discovery.build('bigquery', 'v2', credentials=credentials)
+    bigquery = create_bigquery_object()
 
 
 def get_parameters_dict(parameters):

--- a/listenbrainz/stats/calculate.py
+++ b/listenbrainz/stats/calculate.py
@@ -1,0 +1,21 @@
+import listenbrainz.stats.user as stats_user
+import listenbrainz.db.user as db_user
+import listenbrainz.db.stats as db_stats
+
+
+def calculate_user_stats():
+    for user in get_recently_logged_in_users():
+        recordings = stats_user.get_top_recordings(musicbrainz_id=user['musicbrainz_id'])
+        artists    = stats_user.get_top_artists(musicbrainz_id=user['musicbrainz_id'])
+        releases   = stats_user.get_top_releases(musicbrainz_id=user['musicbrainz_id'])
+
+        db_stats.insert_user_stats(
+            user_id=user['id'],
+            artists=artists,
+            recordings=recordings,
+            releases=releases,
+        )
+
+def calculate():
+    pass
+

--- a/listenbrainz/stats/calculate.py
+++ b/listenbrainz/stats/calculate.py
@@ -16,6 +16,6 @@ def calculate_user_stats():
             releases=releases,
         )
 
-def calculate():
-    pass
+def calculate_stats():
+    calculate_user_stats()
 

--- a/listenbrainz/stats/calculate.py
+++ b/listenbrainz/stats/calculate.py
@@ -9,8 +9,8 @@ from listenbrainz import stats
 def calculate_user_stats():
     for user in db_user.get_recently_logged_in_users():
         recordings = stats_user.get_top_recordings(musicbrainz_id=user['musicbrainz_id'])
-        artists    = stats_user.get_top_artists(musicbrainz_id=user['musicbrainz_id'])
-        releases   = stats_user.get_top_releases(musicbrainz_id=user['musicbrainz_id'])
+        artists = stats_user.get_top_artists(musicbrainz_id=user['musicbrainz_id'])
+        releases = stats_user.get_top_releases(musicbrainz_id=user['musicbrainz_id'])
         artist_count = stats_user.get_artist_count(musicbrainz_id=user['musicbrainz_id'])
 
         db_stats.insert_user_stats(

--- a/listenbrainz/stats/calculate.py
+++ b/listenbrainz/stats/calculate.py
@@ -1,10 +1,13 @@
 import listenbrainz.stats.user as stats_user
 import listenbrainz.db.user as db_user
 import listenbrainz.db.stats as db_stats
+from listenbrainz import db
+from listenbrainz import config
+from listenbrainz import stats
 
 
 def calculate_user_stats():
-    for user in get_recently_logged_in_users():
+    for user in db_user.get_recently_logged_in_users():
         recordings = stats_user.get_top_recordings(musicbrainz_id=user['musicbrainz_id'])
         artists    = stats_user.get_top_artists(musicbrainz_id=user['musicbrainz_id'])
         releases   = stats_user.get_top_releases(musicbrainz_id=user['musicbrainz_id'])
@@ -19,3 +22,12 @@ def calculate_user_stats():
 def calculate_stats():
     calculate_user_stats()
 
+if __name__ == '__main__':
+    print('Connecting to Google BigQuery...')
+    stats.init_bigquery_connection()
+    print('Connecting to database...')
+    db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
+    print('Connected!')
+    print('Calculating statistics using Google BigQuery...')
+    calculate_stats()
+    print('Calculations done!')

--- a/listenbrainz/stats/calculate.py
+++ b/listenbrainz/stats/calculate.py
@@ -11,12 +11,14 @@ def calculate_user_stats():
         recordings = stats_user.get_top_recordings(musicbrainz_id=user['musicbrainz_id'])
         artists    = stats_user.get_top_artists(musicbrainz_id=user['musicbrainz_id'])
         releases   = stats_user.get_top_releases(musicbrainz_id=user['musicbrainz_id'])
+        artist_count = stats_user.get_artist_count(musicbrainz_id=user['musicbrainz_id'])
 
         db_stats.insert_user_stats(
             user_id=user['id'],
             artists=artists,
             recordings=recordings,
             releases=releases,
+            artist_count=artist_count
         )
 
 def calculate_stats():

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -167,7 +167,7 @@ def get_artist_count(musicbrainz_id, time_interval=None):
         }
     ]
 
-    return stats.run_query(query, parameters)['listen_count']
+    return stats.run_query(query, parameters)[0]['artist_count']
 
 
 

--- a/listenbrainz/stats/user.py
+++ b/listenbrainz/stats/user.py
@@ -133,11 +133,49 @@ def get_top_artists(musicbrainz_id, time_interval=None):
 
     return stats.run_query(query, parameters)
 
+
+def get_artist_count(musicbrainz_id, time_interval=None):
+    """ Get artist count for user with given MusicBrainz ID over a particular period of time 
+        
+        Args: musicbrainz_id (str): the MusicBrainz ID of the user
+              time_interval  (str): the time interval over which artist count should be returned
+                                    (defaults to all time)
+
+        Returns: artist_count (int): total number of artists listened to by the user in that
+                                     period of time
+    """
+
+    filter_clause = ""
+    if time_interval:
+        filter_clause = "AND listened_at >= TIMESTAMP_SUB(CURRENT_TIME(), INTERVAL {})".format(time_interval)
+
+    query = """SELECT COUNT(DISTINCT(artist_msid)) as artist_count
+                 FROM {dataset_id}.{table_id}
+                WHERE user_name = @musicbrainz_id
+                {time_filter_clause}
+            """.format(
+                    dataset_id=config.BIGQUERY_DATASET_ID,
+                    table_id=config.BIGQUERY_TABLE_ID,
+                    time_filter_clause=filter_clause,
+                )
+
+    parameters = [
+        {
+            'name': 'musicbrainz_id',
+            'type': 'STRING',
+            'value': musicbrainz_id,
+        }
+    ]
+
+    return stats.run_query(query, parameters)['listen_count']
+
+
+
 def get_top_releases(musicbrainz_id, time_interval=None):
     """ Get top releases for user with given MusicBrainz ID over a particular period of time
 
         Args: musicbrainz_id (str): the MusicBrainz ID of the user
-              time_interval  (str): the time interval over which top artists should be returned
+              time_interval  (str): the time interval over which top releases should be returned
                                     (defaults to all time)
 
         Returns: A sorted list of dicts with the following structure

--- a/listenbrainz/testdata/user_top_artists.json
+++ b/listenbrainz/testdata/user_top_artists.json
@@ -1,0 +1,14 @@
+{
+    "all_time": [
+        {
+            "listen_count": 230,
+            "artist_msid": "ed6c388e-ea65-431f-8be5-4959239d8c65",
+            "name": "Kanye West"
+        },
+        {
+            "listen_count": 229,
+            "artist_msid": "80ca06c7-07fb-4b3a-a315-ad584cc8eeb0",
+            "name": "Frank Ocean"
+        }
+    ]
+}

--- a/listenbrainz/testdata/user_top_recordings.json
+++ b/listenbrainz/testdata/user_top_recordings.json
@@ -1,0 +1,14 @@
+{
+    "all_time": [
+        {
+            "listen_count": 230,
+            "artist_msid": "59f4d2c6-ca76-4dc7-80de-c3fef6b51211",
+            "name": "Fade"
+        },
+        {
+            "listen_count": 229,
+            "artist_msid": "c2375e2e-e98a-4c6b-a139-3aae0a831ebf",
+            "name": "Nikes"
+        }
+    ]
+}

--- a/listenbrainz/testdata/user_top_releases.json
+++ b/listenbrainz/testdata/user_top_releases.json
@@ -1,0 +1,14 @@
+{
+    "all_time": [
+        {
+            "listen_count": 230,
+            "artist_msid": "19eadc02-1f64-48fe-bb4c-33732b96f7b1",
+            "name": "The Life Of Pablo"
+        },
+        {
+            "listen_count": 229,
+            "artist_msid": "155fa8f8-ef04-471d-ab14-dd21838338d7",
+            "name": "Blonde"
+        }
+    ]
+}

--- a/listenbrainz/webserver/scheduler.py
+++ b/listenbrainz/webserver/scheduler.py
@@ -1,9 +1,10 @@
 """ This module contains code that triggers jobs we want to run
     on regular intervals.
 """
-import logging
 from apscheduler.schedulers.background import BackgroundScheduler
+from listenbrainz import stats
 from listenbrainz.stats.calculate import calculate_stats
+import logging
 
 class ScheduledJobs():
     """Schedule the scripts that need to be run at regular intervals """
@@ -15,6 +16,7 @@ class ScheduledJobs():
 
         self.conf = conf
         self.scheduler = BackgroundScheduler()
+        stats.init_bigquery_connection()
         self.add_jobs()
         self.run()
 

--- a/listenbrainz/webserver/scheduler.py
+++ b/listenbrainz/webserver/scheduler.py
@@ -27,4 +27,4 @@ class ScheduledJobs():
 
     def add_jobs(self):
         """Add the jobs that need to be run to the scheduler"""
-        self.scheduler.add_job(calculate_stats, 'interval', days=conf['STATS_CALCULATION_INTERVAL'])
+        self.scheduler.add_job(calculate_stats, 'interval', days=self.conf['STATS_CALCULATION_INTERVAL'])

--- a/listenbrainz/webserver/scheduler.py
+++ b/listenbrainz/webserver/scheduler.py
@@ -1,74 +1,29 @@
-from sqlalchemy import create_engine, text
-from sqlalchemy.pool import NullPool
-import sqlalchemy.exc
-from apscheduler.schedulers.background import BackgroundScheduler
+""" This module contains code that triggers jobs we want to run
+    on regular intervals.
+"""
 import logging
+from apscheduler.schedulers.background import BackgroundScheduler
 
-# Create a cron job to clean postgres database
 class ScheduledJobs():
     """ Schedule the scripts that need to be run at scheduled intervals """
 
     def __init__(self, conf):
+        self.log = logging.getLogger(__name__)
+        logging.basicConfig()
+        self.log.setLevel(logging.INFO)
+
         self.conf = conf
         self.scheduler = BackgroundScheduler()
         self.add_jobs()
         self.run()
 
     def run(self):
+        """ Start the scheduler but stop on KeyboardInterrupts and such"""
         try:
             self.scheduler.start()
         except (KeyboardInterrupt, SystemExit):
-            self.shutdown()
+            self.scheduler.shutdown()
 
     def add_jobs(self):
-        args = {}
-        if 'MAX_POSTGRES_LISTEN_HISTORY' in self.conf:
-            args['max_days'] = int(self.conf['MAX_POSTGRES_LISTEN_HISTORY'])
-
-        self.scheduler.add_job(self._clean_postgres, 'interval', hours=24, \
-                kwargs=args)
-
-    def _clean_postgres(self, max_days=90):
-        """ Clean all the listens that are older than a set no of days
-            Default: 90 days
-        """
-
-        # If max days is set to a negative number, don't throw anything out
-        if max_days < 0:
-            return
-
-        seconds = max_days*24*3600
-        engine = create_engine(self.conf['SQLALCHEMY_DATABASE_URI'], poolclass=NullPool)
-        connection = engine.connect()
-        # query = """
-        #          WITH max_table as (
-        #              SELECT user_id, max(extract(epoch from ts)) - %s as mx
-        #              FROM listens
-        #              GROUP BY user_id
-        #          )
-        #          DELETE FROM listens
-        #          WHERE extract(epoch from ts) < (SELECT mx
-        #                                          FROM max_table
-        #                                          WHERE max_table.user_id = listens.user_id)
-        #         RETURNING *
-        #         """
-
-        query = """
-                DELETE FROM listen
-                WHERE id in (
-                    SELECT id FROM listen
-                    JOIN (
-                        SELECT user_id, extract(epoch from max(ts)) as max
-                        FROM listens
-                        GROUP BY user_id
-                    ) max_table on listens.user_id = max_table.user_id AND extract(epoch from listens.ts) <= max_table.max - %s
-                ) RETURNING *
-                """
-
-        deleted = connection.execute(query % (seconds))
-        log = logging.getLogger(__name__)
-        log.info('(Scheduled Job) CleanPostgres: ' + str(len(deleted.fetchall())) + " records deleted successfully")
-        connection.close()
-
-    def shutdown(self):
-        self.scheduler.shutdown()
+        """ Add the jobs that need to be run to the scheduler """
+        pass

--- a/listenbrainz/webserver/scheduler.py
+++ b/listenbrainz/webserver/scheduler.py
@@ -3,9 +3,10 @@
 """
 import logging
 from apscheduler.schedulers.background import BackgroundScheduler
+from listenbrainz.stats.calculate import calculate_stats
 
 class ScheduledJobs():
-    """ Schedule the scripts that need to be run at scheduled intervals """
+    """Schedule the scripts that need to be run at regular intervals """
 
     def __init__(self, conf):
         self.log = logging.getLogger(__name__)
@@ -25,5 +26,5 @@ class ScheduledJobs():
             self.scheduler.shutdown()
 
     def add_jobs(self):
-        """ Add the jobs that need to be run to the scheduler """
-        pass
+        """Add the jobs that need to be run to the scheduler"""
+        self.scheduler.add_job(calculate_stats, 'interval', days=conf['STATS_CALCULATION_INTERVAL'])

--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -12,28 +12,28 @@
     </div>
 
 
-	<h3> Statistics </h3>
+  <h3> Statistics </h3>
 
-	<div class="row">
-	  <div class="col-md-8">
-		<table class="table table-border table-condensed table-striped">
-	      <tbody>
-		  {% if listen_count %}
-			<tr>
-			  <td>Listen count</td>
-			  <td>{{ listen_count }}</td>
-			</tr>
-		  {% endif %}
+  <div class="row">
+    <div class="col-md-8">
+    <table class="table table-border table-condensed table-striped">
+        <tbody>
+      {% if listen_count %}
+      <tr>
+        <td>Listen count</td>
+        <td>{{ listen_count }}</td>
+      </tr>
+      {% endif %}
 
-		  {% if artist_count %}
-			<tr>
-			  <td>Artist count</td>
-			  <td>{{ artist_count }}</td>
-			</tr>
-		  {% endif %}
-		</table>
-	  </div>
-	</div>
+      {% if artist_count %}
+      <tr>
+        <td>Artist count</td>
+        <td>{{ artist_count }}</td>
+      </tr>
+      {% endif %}
+    </table>
+    </div>
+  </div>
 
     <h3>Recent listens</h3>
 

--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -17,6 +17,8 @@
       We were not able to get listen count for {{ user.musicbrainz_id }} due to an error. Please reload to try again.
     {% endif %}
 
+	<h3> Artist Count: {{ artist_count }} </h3>
+
     <h3>Recent listens</h3>
 
     {% if not listens %}

--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -11,13 +11,29 @@
       <b><a href="https://musicbrainz.org/user/{{ user.musicbrainz_id }}">See profile on MusicBrainz</a></b>
     </div>
 
-    {% if have_listen_count %}
-      <h3> Listen Count: {{ listen_count }}  </h3>
-    {% else %}
-      We were not able to get listen count for {{ user.musicbrainz_id }} due to an error. Please reload to try again.
-    {% endif %}
 
-	<h3> Artist Count: {{ artist_count }} </h3>
+	<h3> Statistics </h3>
+
+	<div class="row">
+	  <div class="col-md-8">
+		<table class="table table-border table-condensed table-striped">
+	      <tbody>
+		  {% if listen_count %}
+			<tr>
+			  <td>Listen count</td>
+			  <td>{{ listen_count }}</td>
+			</tr>
+		  {% endif %}
+
+		  {% if artist_count %}
+			<tr>
+			  <td>Artist count</td>
+			  <td>{{ artist_count }}</td>
+			</tr>
+		  {% endif %}
+		</table>
+	  </div>
+	</div>
 
     <h3>Recent listens</h3>
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -165,7 +165,7 @@ def profile(user_name):
         spotify_uri=_get_spotify_uri_for_listens(listens),
         have_listen_count=have_listen_count,
         listen_count=format(int(listen_count), ",d"),
-        artist_count=format(len(user_stats.get("artists", [])), ",d")
+        artist_count=format(int(user_stats['artists']['count']), ",d")
     )
 
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -153,6 +153,8 @@ def profile(user_name):
             listens.insert(0, listen)
 
     user_stats = db_stats.get_user_stats(user.id)
+    if not user_stats:
+        user_stats = {}
 
     return render_template(
         "user/profile.html",

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -153,8 +153,10 @@ def profile(user_name):
             listens.insert(0, listen)
 
     user_stats = db_stats.get_user_stats(user.id)
-    if not user_stats:
-        user_stats = {}
+    try:
+        artist_count = int(user_stats['artists']['count'])
+    except (KeyError, TypeError):
+        artist_count = 0
 
     return render_template(
         "user/profile.html",
@@ -165,7 +167,7 @@ def profile(user_name):
         spotify_uri=_get_spotify_uri_for_listens(listens),
         have_listen_count=have_listen_count,
         listen_count=format(int(listen_count), ",d"),
-        artist_count=format(int(user_stats['artists']['count']), ",d")
+        artist_count=format(artist_count, ",d")
     )
 
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -1,4 +1,3 @@
-
 from flask import Blueprint, render_template, request, url_for, Response, redirect, flash, current_app, jsonify
 from flask_login import current_user, login_required
 from werkzeug.exceptions import NotFound, BadRequest, RequestEntityTooLarge, InternalServerError
@@ -9,6 +8,7 @@ from time import time
 from listenbrainz import webserver
 from listenbrainz.webserver import flash
 import listenbrainz.db.user as db_user
+import listenbrainz.db.stats as db_stats
 import listenbrainz.config as config
 from listenbrainz.db.exceptions import DatabaseException
 from flask import make_response
@@ -152,6 +152,8 @@ def profile(user_name):
             }
             listens.insert(0, listen)
 
+    user_stats = db_stats.get_user_stats(user.id)
+
     return render_template(
         "user/profile.html",
         user=user,
@@ -161,6 +163,7 @@ def profile(user_name):
         spotify_uri=_get_spotify_uri_for_listens(listens),
         have_listen_count=have_listen_count,
         listen_count=format(int(listen_count), ",d"),
+        artist_count=format(len(user_stats.get("artists", [])), ",d")
     )
 
 


### PR DESCRIPTION
This PR is based on #202 .

It does the following things.

* Removes unneeded code from a time when listens were store in postgres in `webserver.scheduler`.
* Add a function to get recently logged in users (timeframe defined by a variable in config.py)
* Makes the last_updated field in the stats tables NOT NULL (**schema change**)
* Adds functions that calculate user stats and store them in the db
* Schedule these functions according to a variable in config.py
* Show artist counts as proof-of-concept on the user page.

