### PR TITLE
LB-203: Add support for v1.2 of the AudioScrobbler API

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,6 +61,19 @@ services:
       - influx
       - rabbitmq
 
+  api_compat:
+    image: web
+    command: python3 /code/listenbrainz/manage.py run_api_compat_server -h 0.0.0.0 -p 8080 -d
+    ports:
+      - "8080:8080"
+    volumes:
+      - ..:/code/listenbrainz
+    depends_on:
+      - redis
+      - db
+      - influx
+      - rabbitmq
+
   influx_writer:
     build:
       context: ..

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -91,3 +91,6 @@ BETA_URL = 'https://api.listenbrainz.org'
 LISTENS_PER_GET = 100
 IMPORTER_LOG_FILE = '-'
 IMPORTER_DELAY = 3 # delay if requests don't return http 200
+
+
+LASTFM_PROXY_URL = 'http://0.0.0.0:8080/'

--- a/listenbrainz/db/lastfm_session.py
+++ b/listenbrainz/db/lastfm_session.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import os
+import uuid
 import binascii
+import string
+import random
 from listenbrainz import db
 from sqlalchemy import text
 from listenbrainz.db.lastfm_user import User
@@ -10,15 +13,16 @@ from listenbrainz.db.lastfm_user import User
 class Session(object):
     """ Session class required by the api-compat """
 
-    def __init__(self, id, userid, sid, api_key, timestamp):
+    def __init__(self, id, user_id, sid, api_key, timestamp):
         self.id = id
         self.sid = sid
         self.api_key = api_key
         self.timestamp = timestamp
-        self.user = User.load_by_id(userid)
+        self.user_id = user_id
+        self.user = User.load_by_id(user_id)
 
     @staticmethod
-    def load(session_key, api_key):
+    def load(session_key):
         """ Load the session details from the database.
             API_key and Session_key are required for a session.
         """
@@ -30,32 +34,50 @@ class Session(object):
                      , api_key
                      , ts
                   FROM api_compat.session
-                 WHERE sid=:sid AND api_key=:api_key
+                 WHERE sid = :sid
             """), {
                 'sid': session_key,
-                'api_key': api_key
             })
             row = result.fetchone()
             if row:
                 return Session(row["id"], row["user_id"], row["sid"], row["api_key"], row["ts"])
             return None
 
+
     @staticmethod
-    def create(token):
-        """ Create a new session for the user by consuming the token.
-            If session already exists for the user then renew the session_key(sid).
-        """
-        session = binascii.b2a_hex(os.urandom(20))
+    def generate(user_id, sid, api_key):
         with db.engine.connect() as connection:
             result = connection.execute(text("""
                 INSERT INTO api_compat.session (user_id, sid, api_key)
                      VALUES (:user_id, :sid, :api_key)
                   RETURNING id, user_id, sid, api_key, ts
                  """), {
-                'user_id': token.user.id,
-                'sid': session,
-                'api_key': token.api_key
+                'user_id': user_id,
+                'sid': sid,
+                'api_key': api_key
             })
-            token.consume()
             row = result.fetchone()
             return Session(row["id"], row["user_id"], row["sid"], row["api_key"], row["ts"])
+
+    @staticmethod
+    def create(token):
+        """ Create a new session for the user by consuming the token.
+            If session already exists for the user then renew the session_key(sid).
+        """
+        sid = binascii.b2a_hex(os.urandom(20))
+        session = Session.generate(token.user.id, sid, token.api_key)
+        token.consume()
+        return session
+
+
+
+    @staticmethod
+    def create_by_user_id(user_id):
+        """ Create a new session for the user for the deprecated audioscrobbler API v1.2.
+            This only requires a user_id, so we use random values for api_key and other things
+        """
+
+        # sids for audioscrobbler v1.2 are of length 32
+        sid = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(32))
+        api_key = str(uuid.uuid4())
+        return Session.generate(user_id, sid, api_key)

--- a/listenbrainz/db/lastfm_token.py
+++ b/listenbrainz/db/lastfm_token.py
@@ -37,15 +37,15 @@ class Token(object):
     def load(token, api_key=None):
         """ Load the token from database. Check api_key as well if present.
         """
-        query = "SELECT id, user_id, token, api_key, ts \
-                   FROM api_compat.token \
-                  WHERE token=:token"
+        query = """SELECT id, user_id, token, api_key, ts
+                     FROM api_compat.token
+                    WHERE token = :token"""
         params = {'token': token}
         if api_key:
-            query = "SELECT id, user_id, token, api_key, ts \
-                       FROM api_compat.token \
-                      WHERE token=:token \
-                        AND api_key=:api_key"
+            query = """SELECT id, user_id, token, api_key, ts
+                         FROM api_compat.token
+                        WHERE token = :token
+                          AND api_key = :api_key"""
             params['api_key'] = api_key
 
         with db.engine.connect() as connection:

--- a/listenbrainz/db/tests/test_lastfm_session.py
+++ b/listenbrainz/db/tests/test_lastfm_session.py
@@ -34,7 +34,7 @@ class TestAPICompatSessionClass(DatabaseTestCase):
         session.user = None
 
         # Load with session_key + api_key
-        session2 = Session.load(session.sid, session.api_key)
+        session2 = Session.load(session.sid)
         self.assertDictEqual(user.__dict__, session2.__dict__['user'].__dict__)
         session2.user = None
         self.assertDictEqual(session.__dict__, session2.__dict__)

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -2,7 +2,7 @@
 import sys
 import os
 
-from listenbrainz.webserver.testing import ServerTestCase
+from listenbrainz.webserver.testing import ServerTestCase, APICompatServerTestCase
 from listenbrainz.db.testing import DatabaseTestCase
 
 class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
@@ -23,3 +23,24 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
                 fn: the name of the data file
         """
         return os.path.join(IntegrationTestCase.TEST_DATA_PATH, fn)
+
+
+class APICompatIntegrationTestCase(APICompatServerTestCase, DatabaseTestCase):
+
+    TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'testdata')
+
+    def setUp(self):
+        APICompatServerTestCase.setUp(self)
+        DatabaseTestCase.setUp(self)
+
+    def tearDown(self):
+        APICompatServerTestCase.tearDown(self)
+        DatabaseTestCase.tearDown(self)
+
+    def path_to_data_file(self, fn):
+        """ Returns the path of the test data file relative to the test file.
+
+            Args:
+                fn: the name of the data file
+        """
+        return os.path.join(APICompatIntegrationTestCase.TEST_DATA_PATH, fn)

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -103,8 +103,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         """ Tests the root url when there's no handshaking taking place """
 
         r = self.client.get('/')
-        self.assertTemplateUsed('api_compat/index.html')
-        self.assert200(r)
+        self.assertStatus(r, 302)
 
 
     def test_handshake_unknown_user(self):

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -76,6 +76,29 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.assertEqual(response[0], 'OK')
         self.assertEqual(len(response[1]), 32)
 
+    def test_handshake_post(self):
+        """ Tests POST requests to handshake endpoint """
+
+        ts = int(time.time())
+        args = {
+            'hs': 'true',
+            'p': '1.2',
+            'c': 'tst',
+            'v': '0.1',
+            'u': self.user['musicbrainz_id'],
+            't': ts,
+            'a': _get_audioscrobbler_auth_token(self.user['auth_token'], ts)
+        }
+
+        r = self.client.post('/', query_string=args)
+
+        self.assert200(r)
+        response = r.data.decode('utf-8').split('\n')
+        self.assertEqual(len(response), 4)
+        self.assertEqual(response[0], 'OK')
+        self.assertEqual(len(response[1]), 32)
+
+
     def test_root_url_when_no_handshake(self):
         """ Tests the root url when there's no handshaking taking place """
 

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -1,0 +1,193 @@
+""" This module tests AudioScrobbler v1.2 compatibility features """
+
+# listenbrainz-server - Server for the ListenBrainz project.
+#
+# Copyright (C) 2017 Param Singh <paramsingh258@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+
+import time
+import listenbrainz.config as config
+import listenbrainz.db.user as db_user
+
+from hashlib import md5
+from flask import url_for
+from listenbrainz.listenstore import InfluxListenStore
+from listenbrainz.tests.integration import APICompatIntegrationTestCase
+from listenbrainz.webserver.views.api_compat_deprecated import _get_audioscrobbler_auth_token
+
+
+class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
+
+    def setUp(self):
+        super(APICompatDeprecatedTestCase, self).setUp()
+        self.user = db_user.get_or_create('apicompatoldtestuser')
+        self.ls = InfluxListenStore({
+            'REDIS_HOST' : config.REDIS_HOST,
+            'REDIS_PORT' : config.REDIS_PORT,
+            'INFLUX_HOST': config.INFLUX_HOST,
+            'INFLUX_PORT': config.INFLUX_PORT,
+            'INFLUX_DB_NAME': config.INFLUX_DB_NAME,
+        })
+
+
+    def handshake(self, user_name, auth_token, timestamp):
+        """ Makes a request to the handshake endpoint of the AudioScrobbler API and
+            returns the response.
+        """
+
+        args = {
+            'hs': 'true',
+            'p': '1.2',
+            'c': 'tst',
+            'v': '0.1',
+            'u': user_name,
+            't': timestamp,
+            'a': auth_token
+        }
+
+        return self.client.get('/', query_string=args)
+
+
+    def test_handshake(self):
+        """ Tests handshake for a user that exists """
+
+        timestamp = int(time.time())
+        audioscrobbler_auth_token = _get_audioscrobbler_auth_token(self.user['auth_token'], timestamp)
+
+        r = self.handshake(self.user['musicbrainz_id'], audioscrobbler_auth_token, timestamp)
+
+        self.assert200(r)
+        response = r.data.decode('utf-8').split('\n')
+        self.assertEqual(len(response), 4)
+        self.assertEqual(response[0], 'OK')
+        self.assertEqual(len(response[1]), 32)
+
+    def test_root_url_when_no_handshake(self):
+        """ Tests the root url when there's no handshaking taking place """
+
+        r = self.client.get('/')
+        self.assertTemplateUsed('api_compat/index.html')
+        self.assert200(r)
+
+
+    def test_handshake_unknown_user(self):
+        """ Tests handshake for user that is not in the db """
+
+        r = self.handshake('', '', '')
+        self.assert401(r)
+
+
+    def test_handshake_invalid_auth(self):
+        """ Tests handshake when invalid authorization token is sent """
+
+        r = self.handshake(self.user['musicbrainz_id'], '', int(time.time()))
+        self.assert401(r)
+
+
+    def test_submit_listen(self):
+        """ Sends a valid listen after handshaking and checks if it is present in the
+            listenstore
+        """
+
+        timestamp = int(time.time())
+        audioscrobbler_auth_token = _get_audioscrobbler_auth_token(self.user['auth_token'], timestamp)
+
+        r = self.handshake(self.user['musicbrainz_id'], audioscrobbler_auth_token, timestamp)
+        self.assert200(r)
+        response = r.data.decode('utf-8').split('\n')
+        self.assertEqual(response[0], 'OK')
+
+        sid = response[1]
+        data = {
+            's': sid,
+            'a[0]': 'Kishore Kumar',
+            't[0]': 'Saamne Ye Kaun Aya',
+            'o[0]': 'P',
+            'l[0]': 300,
+            'b[0]': 'Jawani Diwani',
+            'i[0]': int(time.time()),
+        }
+
+        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        self.assert200(r)
+        self.assertEqual(r.data.decode('utf-8'), 'OK\n')
+
+        time.sleep(1)
+        to_ts = int(time.time())
+        listens = self.ls.fetch_listens(self.user['musicbrainz_id'], to_ts=to_ts)
+        self.assertEqual(len(listens), 1)
+
+
+    def test_submit_listen_invalid_sid(self):
+        """ Tests endpoint for 400 Bad Request if invalid session id is sent """
+
+        sid = ''
+        data = {
+            's': sid,
+            'a[0]': 'Kishore Kumar',
+            't[0]': 'Saamne Ye Kaun Aya',
+            'o[0]': 'P',
+            'l[0]': 300,
+            'b[0]': 'Jawani Diwani',
+            'i[0]': int(time.time()),
+        }
+
+        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        self.assert401(r)
+        self.assertEqual(r.data.decode('utf-8'), 'BADSESSION\n')
+
+
+    def test_submit_listen_invalid_data(self):
+        """ Tests endpoint for 400 Bad Request if invalid data is sent """
+
+        timestamp = int(time.time())
+        audioscrobbler_auth_token = _get_audioscrobbler_auth_token(self.user['auth_token'], timestamp)
+
+        r = self.handshake(self.user['musicbrainz_id'], audioscrobbler_auth_token, timestamp)
+        self.assert200(r)
+        response = r.data.decode('utf-8').split('\n')
+        self.assertEqual(response[0], 'OK')
+
+        sid = response[1]
+
+        # no artist in data
+        data = {
+            's': sid,
+            't[0]': 'Saamne Ye Kaun Aya',
+            'o[0]': 'P',
+            'l[0]': 300,
+            'b[0]': 'Jawani Diwani',
+            'i[0]': int(time.time()),
+        }
+
+        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        self.assert400(r)
+        self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')
+
+        # add artist and remove track name
+        data['a[0]'] = 'Kishore Kumar'
+        del data['t[0]']
+        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        self.assert400(r)
+        self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')
+
+        # add track name and remove timestamp
+        data['t[0]'] = 'Saamne Ye Kaun Aya'
+        del data['i[0]']
+        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        self.assert400(r)
+        self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -29,7 +29,11 @@ def schedule_jobs(app):
     app.scheduledJobs = ScheduledJobs(app.config)
 
 
-def create_app():
+def gen_app():
+    """ Generate a Flask app for LB with all configurations done and connections established.
+
+    In the Flask app returned, blueprints are not registered.
+    """
     app = Flask(__name__)
 
     # Configuration
@@ -76,7 +80,29 @@ def create_app():
     app.jinja_env.filters['date'] = utils.reformat_date
     app.jinja_env.filters['datetime'] = utils.reformat_datetime
 
+    return app
+
+
+def create_app():
+
+    app = gen_app()
     _register_blueprints(app)
+    return app
+
+
+def create_api_compat_app():
+    """ Creates application for the AudioScrobbler API.
+
+    The AudioScrobbler API v1.2 requires special views for the root URL so we
+    need to create a different app and only register the api_compat blueprints
+    """
+
+    app = gen_app()
+
+    from listenbrainz.webserver.views.api_compat import api_bp as api_compat_bp
+    from listenbrainz.webserver.views.api_compat_deprecated import api_compat_old_bp
+    app.register_blueprint(api_compat_bp)
+    app.register_blueprint(api_compat_old_bp)
 
     return app
 

--- a/listenbrainz/webserver/templates/api_compat/index.html
+++ b/listenbrainz/webserver/templates/api_compat/index.html
@@ -1,5 +1,0 @@
-<html>
-  <head> <title> LB API Compat Index Page </title> </head>
-
-  <body> Please visit https://listenbrainz.org </body>
-</html>

--- a/listenbrainz/webserver/templates/api_compat/index.html
+++ b/listenbrainz/webserver/templates/api_compat/index.html
@@ -1,0 +1,5 @@
+<html>
+  <head> <title> LB API Compat Index Page </title> </head>
+
+  <body> Please visit https://listenbrainz.org </body>
+</html>

--- a/listenbrainz/webserver/templates/index/lastfm-proxy.html
+++ b/listenbrainz/webserver/templates/index/lastfm-proxy.html
@@ -1,0 +1,22 @@
+{%- extends 'base.html' -%}
+{%- block title -%}Proxy Last.FM APIs - ListenBrainz{%- endblock -%}
+{%- block content -%}
+  <h2 class="page-title">Proxy Last.FM APIs</h2>
+
+  <p>ListenBrainz supports the Last.FM API and v1.2 of the AudioScrobbler API (used by clients like VLC and Spotify). So, current Last.FM clients can be pointed to the <a href="http://proxy.listenbrainz.org">ListenBrainz
+  proxy URL</a> and they should submit listens to ListenBrainz instead of Last.FM.
+  </p>
+
+
+  <h2>Instructions</h3>
+
+  <h3>Last.FM API</h3>
+    <p>Clients supporting the current Last.FM API (such as Audacious) should be able to submit listens to ListenBrainz after some configuration as instructed in <a href="https://github.com/metabrainz/listenbrainz-server/blob/master/API_compatible_README.md">the API Compatible README</a>.</p>
+
+  <h3>AudioScrobbler API v1.2</h3>
+
+    <p> Clients supporting the old version of the <a href="http://www.audioscrobbler.net/development/protocol/">
+    AudioScrobbler API</a> (such as VLC) can be configured to work with ListenBrainz by making the client point
+    to <a href="http://proxy.listenbrainz.org">http://proxy.listenbrainz.org</a> and using MusicBrainz ID as username and the <a href="{{ url_for('user.info') }}">LB auth token</a> as password. </p>
+
+{%- endblock -%}

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -1,5 +1,5 @@
 import flask_testing
-from listenbrainz.webserver import create_app
+from listenbrainz.webserver import create_app, create_api_compat_app
 
 
 class ServerTestCase(flask_testing.TestCase):
@@ -13,3 +13,11 @@ class ServerTestCase(flask_testing.TestCase):
         with self.client.session_transaction() as session:
             session['user_id'] = user_id
             session['_fresh'] = True
+
+
+class APICompatServerTestCase(flask_testing.TestCase):
+
+    def create_app(self):
+        app = create_api_compat_app()
+        app.config['TESTING'] = True
+        return app

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -108,7 +108,7 @@ def session_info(request, data):
     except KeyError:
         raise InvalidAPIUsage(CompatError.INVALID_PARAMETERS, output_format=output_format)        # Missing Required Params
 
-    session = Session.load(sk, api_key)
+    session = Session.load(sk)
     if (not session) or User.load_by_name(username).id != session.user.id:
         raise InvalidAPIUsage(CompatError.INVALID_SESSION_KEY, output_format=output_format)       # Invalid Session KEY
 
@@ -240,7 +240,7 @@ def record_listens(request, data):
     except KeyError:
         raise InvalidAPIUsage(CompatError.INVALID_PARAMETERS, output_format=output_format)    # Invalid parameters
 
-    session = Session.load(sk, api_key)
+    session = Session.load(sk)
     if not session:
         if not Token.is_valid_api_key(api_key):
             raise InvalidAPIUsage(CompatError.INVALID_API_KEY, output_format=output_format)   # Invalid API_KEY

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -1,0 +1,163 @@
+""" This module adds compatibility for clients using the deprecated AudioScrobbler 1.2
+    protocol.
+
+    See the protocol details here: http://www.audioscrobbler.net/development/protocol/
+"""
+
+# listenbrainz-server - Server for the ListenBrainz project.
+#
+# Copyright (C) 2017 Param Singh <paramsingh258@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import listenbrainz.config as config
+import listenbrainz.db.user as db_user
+
+from hashlib import md5
+from time import time
+
+from flask import Blueprint, request, render_template
+from listenbrainz.db.lastfm_session import Session
+from listenbrainz.webserver.views.api_tools import insert_payload
+
+
+api_compat_old_bp = Blueprint('api_compat_old', __name__)
+
+
+@api_compat_old_bp.route('/')
+def handshake():
+    """ View to handshake with the client.
+
+        Creates a new session stored in api_compat.session and then later uses it
+        to submit listens. We do auth assuming the LB auth_tokens to be
+        passwords, so this should work when users enter their LB auth tokens as passwords
+        in clients.
+    """
+
+    if not request.args.get('hs', '') == 'true':
+        return render_template('api_compat/index.html')
+
+    user = db_user.get_by_mb_id(request.args.get('u'))
+    if user is None:
+        return 'BADAUTH\n', 401
+
+    auth_token = request.args.get('a', '')
+    timestamp = request.args.get('t', 0)
+
+    correct = _get_audioscrobbler_auth_token(user['auth_token'], timestamp)
+
+    if auth_token != _get_audioscrobbler_auth_token(user['auth_token'], timestamp):
+        return 'BADAUTH\n', 401
+
+    session = Session.create_by_user_id(user['id'])
+
+    return '\n'.join([
+        'OK',
+        session.sid,
+        '{}/np_1.2'.format(config.LASTFM_PROXY_URL),
+        '{}/protocol_1.2'.format(config.LASTFM_PROXY_URL)
+    ])
+
+
+@api_compat_old_bp.route('/protocol_1.2', methods=['POST', 'OPTIONS'])
+@api_compat_old_bp.route('/np_1.2', methods=['POST', 'OPTIONS'] )
+def submit_listens():
+    """ Submit listens received from clients into the listenstore after validating them. """
+
+
+    session = Session.load(request.form.get('s', ''))
+    if session is None:
+        return "BADSESSION\n", 401
+
+    listens = []
+    index = 0
+    while True:
+        listen = _to_native_api(request.form, index)
+        if listen is None:
+            break
+        else:
+            listens.append(listen)
+            index += 1
+
+    if not listens:
+        return "FAILED No data submitted!\n", 400
+
+
+
+    user = db_user.get(session.user_id)
+    insert_payload(listens, user)
+
+    return "OK\n"
+
+
+def _to_native_api(data, index):
+    """ Converts the scrobble submitted at given index to the audioscrobbler api into
+        a listen of the native api format. Returns None if no scrobble exists at that
+        index.
+
+        Returns: dict of form
+            {
+                'listened_at': (int)
+                'track_metadata': {
+                    'artist_name': (str),
+                    'track_name': (str)
+                }
+            }
+    """
+
+    try:
+        listen = {
+            'listened_at': data['i[{}]'.format(index)],
+            'track_metadata': {
+                'artist_name': data['a[{}]'.format(index)],
+                'track_name': data['t[{}]'.format(index)],
+                'release_name': data['b[{}]'.format(index)],
+                'additional_info': {
+                    'source': data['o[{}]'.format(index)]
+                }
+            }
+        }
+    except KeyError:
+        return None
+
+    if 'r[{}]'.format(index) in data:
+        listen['track_metadata']['additional_info']['rating'] = data['r[{}]'.format(index)]
+
+    if 'n[{}]'.format(index) in data:
+        listen['track_metadata']['additional_info']['track_number'] = data['n[{}]'.format(index)]
+
+    if 'm[{}]'.format(index) in data:
+        listen['track_metadata']['additional_info']['recording_mbid'] = data['m[{}]'.format(index)]
+
+    return listen
+
+def _get_audioscrobbler_auth_token(lb_auth_token, timestamp):
+    """ Gets the correct auth token for checking against the token sent by client
+        during handshake.
+
+        The token is calculated using the formula:
+
+            md5(md5(password) + timestamp)
+
+        where md5 returns the md5sum with hex characters in lowercase and + is the
+        concatenation operator.
+
+        We use auth_token as password here, so users can just put their LB auth tokens
+        as passwords in clients and it should work.
+    """
+
+    token_md5 = md5(lb_auth_token.encode('utf-8')).hexdigest()
+    concatenated = '{}{}'.format(token_md5, timestamp)
+    return md5(concatenated.encode('utf-8')).hexdigest()

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -36,7 +36,7 @@ from listenbrainz.webserver.views.api_tools import insert_payload
 api_compat_old_bp = Blueprint('api_compat_old', __name__)
 
 
-@api_compat_old_bp.route('/')
+@api_compat_old_bp.route('/', methods=['GET', 'POST', 'OPTIONS'])
 def handshake():
     """ View to handshake with the client.
 

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -57,6 +57,11 @@ def api_docs():
     return render_template("index/api-docs.html")
 
 
+@index_bp.route("/lastfm-proxy")
+def proxy():
+    return render_template("index/lastfm-proxy.html")
+
+
 @index_bp.route("/roadmap")
 def roadmap():
     return render_template("index/roadmap.html")

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -37,3 +37,7 @@ class IndexViewsTestCase(ServerTestCase):
         resp = self.client.get('/canyoufindthis')
         self.assert404(resp)
         self.assertIn('Not Found', resp.data.decode('utf-8'))
+
+    def test_lastfm_proxy(self):
+        resp = self.client.get(url_for('index.proxy'))
+        self.assert200(resp)

--- a/manage.py
+++ b/manage.py
@@ -37,6 +37,24 @@ def runserver(host, port, debug=False):
 
 
 @cli.command()
+@click.option("--host", "-h", default="0.0.0.0", show_default=True)
+@click.option("--port", "-p", default=8080, show_default=True)
+@click.option("--debug", "-d", is_flag=True,
+              help="Turns debugging mode on or off. If specified, overrides "
+                   "'DEBUG' value in the config file.")
+def run_api_compat_server(host, port, debug=False):
+    application = webserver.create_api_compat_app()
+    run_simple(
+        hostname=host,
+        port=port,
+        application=application,
+        use_debugger=debug,
+        use_reloader=debug,
+        processes=5
+    )
+
+
+@cli.command()
 @click.option("--force", "-f", is_flag=True, help="Drop existing database and user.")
 @click.option("--create-db", is_flag=True, help="Create the database and user.")
 def init_db(force, create_db):


### PR DESCRIPTION
Auth works via LB auth token, we create a new Flask app for
this API because it needs views mounted at /, this new app
is run in a new docker container in development. Also, session
information is stored in the api_compat.session table, so
there are some modifications in the lastfm_session code too.

Also, added tests for the new endpoints added.