### PR TITLE
LB-209: Add a config property to mark the api_compat app

### DIFF
--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -255,3 +255,8 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
         with self.assertRaises(BadRequest):
             session = _get_session('')
+
+    def test_404(self):
+
+        r = self.client.get('/thisurldoesnotexist')
+        self.assert404(r)

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -104,6 +104,10 @@ def create_api_compat_app():
     app.register_blueprint(api_compat_bp)
     app.register_blueprint(api_compat_old_bp)
 
+    # add a value into the config dict of the app to note that this is the
+    # app for api_compat. This is later used in error handling.
+    app.config['IS_API_COMPAT_APP'] = True
+
     return app
 
 

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -74,7 +74,7 @@ def init_error_handlers(app):
                 A Response which will be a json error if request was made to the LB api and an html page
                 otherwise
         """
-        if request.path.startswith(API_PREFIX):
+        if request.path.startswith(API_PREFIX) or app.config.get('IS_API_COMPAT_APP', False):
             return json_error_wrapper(error, code)
         else:
             return error_wrapper('errors/{code}.html'.format(code=code), error, code)


### PR DESCRIPTION
This allows us to do error handling correctly (the app tried to
render some templates which required views that weren't in
api_compate)

Fixes LB-209.