### PR TITLE
Style cleanup db

### DIFF
--- a/listenbrainz/db/exceptions.py
+++ b/listenbrainz/db/exceptions.py
@@ -2,9 +2,11 @@ class DatabaseException(Exception):
     """Base exception for this package."""
     pass
 
+
 class NoDataFoundException(DatabaseException):
     """Should be used when no data has been found."""
     pass
+
 
 class BadDataException(DatabaseException):
     """Should be used when incorrect data is being submitted."""

--- a/listenbrainz/db/lastfm_session.py
+++ b/listenbrainz/db/lastfm_session.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import os
 import binascii
-from listenbrainz import db
+import os
+
 from sqlalchemy import text
+
+from listenbrainz import db
 from listenbrainz.db.lastfm_user import User
 
 

--- a/listenbrainz/db/lastfm_token.py
+++ b/listenbrainz/db/lastfm_token.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import os
 import binascii
+import os
 from datetime import datetime, timedelta
-from listenbrainz import db
+
 from sqlalchemy import text
+
+from listenbrainz import db
 from listenbrainz.db.lastfm_user import User
 
 # Token expiration time in minutes

--- a/listenbrainz/db/lastfm_token.py
+++ b/listenbrainz/db/lastfm_token.py
@@ -26,7 +26,7 @@ class Token(object):
         """ Check if the api_key is valid or not, and return a boolean.
 
             Last.fm uses a (api_key, user) mapping to detect the app which is making
-            the rquest, but since this mapping is private we have no way to authenticate
+            the request, but since this mapping is private we have no way to authenticate
             the api_key.
 
             To prevent the abuse of the service, it falls back to ratelimiter.
@@ -69,7 +69,7 @@ class Token(object):
         """ Check if the token has expired.
             NOTE: Make sure you capture timezones to avoid issues.
         """
-        return (self.timestamp < datetime.now() - timedelta(minutes=TOKEN_EXPIRATION_TIME))
+        return self.timestamp < datetime.now() - timedelta(minutes=TOKEN_EXPIRATION_TIME)
 
     def approve(self, user):
         """ Authenticate the token. User has to be present.

--- a/listenbrainz/db/lastfm_user.py
+++ b/listenbrainz/db/lastfm_user.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from listenbrainz import db
 from sqlalchemy import text
+
+from listenbrainz import db
 
 
 class User(object):

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -1,8 +1,9 @@
 
-from listenbrainz import db
-import unittest
 import os
+import unittest
+
 from listenbrainz import config
+from listenbrainz import db
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..','admin', 'sql')
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_data')

--- a/listenbrainz/db/tests/test_lastfm_session.py
+++ b/listenbrainz/db/tests/test_lastfm_session.py
@@ -1,10 +1,11 @@
 
-from listenbrainz.db.testing import DatabaseTestCase
 import logging
+
 import listenbrainz.db.user as db_user
-from listenbrainz.db.lastfm_user import User
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.db.lastfm_token import Token
+from listenbrainz.db.lastfm_user import User
+from listenbrainz.db.testing import DatabaseTestCase
 
 
 class TestAPICompatSessionClass(DatabaseTestCase):

--- a/listenbrainz/db/tests/test_lastfm_token.py
+++ b/listenbrainz/db/tests/test_lastfm_token.py
@@ -1,13 +1,15 @@
 
-from listenbrainz.db.testing import DatabaseTestCase
 import logging
-from datetime import timedelta
-from listenbrainz import db
-import listenbrainz.db.user as db_user
-from listenbrainz.db.lastfm_user import User
-from listenbrainz.db.lastfm_token import Token, TOKEN_EXPIRATION_TIME
-from sqlalchemy import text
 import uuid
+from datetime import timedelta
+
+from sqlalchemy import text
+
+import listenbrainz.db.user as db_user
+from listenbrainz import db
+from listenbrainz.db.lastfm_token import Token, TOKEN_EXPIRATION_TIME
+from listenbrainz.db.lastfm_user import User
+from listenbrainz.db.testing import DatabaseTestCase
 
 
 class TestAPICompatTokenClass(DatabaseTestCase):

--- a/listenbrainz/db/tests/test_lastfm_token.py
+++ b/listenbrainz/db/tests/test_lastfm_token.py
@@ -37,7 +37,7 @@ class TestAPICompatTokenClass(DatabaseTestCase):
         self.assertIsInstance(token, Token)
         self.assertIsNone(token.user)
 
-        ##### Before approving
+        """ Before approving """
         # Load with token
         token1 = Token.load(token.token)
         self.assertIsNone(token1.user)
@@ -50,7 +50,7 @@ class TestAPICompatTokenClass(DatabaseTestCase):
 
         token.approve(self.user.name)
 
-        ##### After approving the token
+        """ After approving the token """
         # Load with token
         token1 = Token.load(token.token)
         self.assertIsInstance(token1.user, User)

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -1,14 +1,16 @@
 
-from listenbrainz.db.testing import DatabaseTestCase
 import logging
 from datetime import datetime
+
+from sqlalchemy import text
+
+import listenbrainz.db.user as db_user
+from listenbrainz import config
+from listenbrainz import db
+from listenbrainz.db.lastfm_user import User
+from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.tests.utils import generate_data
 from listenbrainz.webserver.influx_connection import init_influx_connection
-from listenbrainz import db
-import listenbrainz.db.user as db_user
-from listenbrainz.db.lastfm_user import User
-from sqlalchemy import text
-from listenbrainz import config
 
 
 class TestAPICompatUserClass(DatabaseTestCase):

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -32,7 +32,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
                 SELECT *
                   FROM "user"
                  WHERE id = :id
-            """),{
+            """), {
                 "id": uid,
             })
             row = result.fetchone()
@@ -47,12 +47,12 @@ class TestAPICompatUserClass(DatabaseTestCase):
 
     def test_user_load_by_name(self):
         user = User.load_by_name(self.user.name)
-        assert isinstance(user, User) == True
+        self.assertTrue(isinstance(user, User))
         self.assertDictEqual(user.__dict__, self.user.__dict__)
 
     def test_user_load_by_id(self):
         user = User.load_by_id(self.user.id)
-        assert isinstance(user, User) == True
+        self.assertTrue(isinstance(user, User))
         self.assertDictEqual(user.__dict__, self.user.__dict__)
 
     def test_user_get_play_count(self):

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-from listenbrainz.db.testing import DatabaseTestCase
+import time
+
+import sqlalchemy
+
 import listenbrainz.db.user as db_user
 from listenbrainz import db
-import time
-import sqlalchemy
+from listenbrainz.db.testing import DatabaseTestCase
 
 
 class UserTestCase(DatabaseTestCase):

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -1,10 +1,11 @@
 
-from listenbrainz import db
-import uuid
-import sqlalchemy
-from listenbrainz.db.exceptions import DatabaseException
 import logging
-import time
+import uuid
+
+import sqlalchemy
+
+from listenbrainz import db
+from listenbrainz.db.exceptions import DatabaseException
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -30,6 +30,7 @@ def create(musicbrainz_id):
         })
         return result.fetchone()["id"]
 
+
 def update_token(id):
     """Update a user's token to a new UUID
 
@@ -38,7 +39,7 @@ def update_token(id):
     """
     with db.engine.connect() as connection:
         try:
-            result = connection.execute(sqlalchemy.text("""
+            connection.execute(sqlalchemy.text("""
                 UPDATE "user"
                    SET auth_token = :token
                  WHERE id = :id
@@ -104,7 +105,6 @@ def get_by_mb_id(musicbrainz_id):
         return dict(row) if row else None
 
 
-
 def get_by_token(token):
     """Get user with a specified authentication token.
 
@@ -148,6 +148,7 @@ def get_user_count():
             logger.error(e)
             raise
 
+
 def get_or_create(musicbrainz_id):
     """Get user with a specified MusicBrainz ID, or create if there's no account.
 
@@ -169,6 +170,7 @@ def get_or_create(musicbrainz_id):
         user = get_by_mb_id(musicbrainz_id)
     return user
 
+
 def update_last_login(musicbrainz_id):
     """ Update the value of last_login field for user with specified MusicBrainz ID
 
@@ -178,7 +180,7 @@ def update_last_login(musicbrainz_id):
 
     with db.engine.connect() as connection:
         try:
-            result = connection.execute(sqlalchemy.text("""
+            connection.execute(sqlalchemy.text("""
                 UPDATE "user"
                    SET last_login = NOW()
                  WHERE musicbrainz_id = :musicbrainz_id
@@ -188,6 +190,7 @@ def update_last_login(musicbrainz_id):
         except sqlalchemy.exc.ProgrammingError as err:
             logger.error(err)
             raise DatabaseException("Couldn't update last_login: %s" % str(err))
+
 
 def update_latest_import(musicbrainz_id, ts):
     """ Update the value of latest_import field for user with specified MusicBrainz ID
@@ -202,7 +205,7 @@ def update_latest_import(musicbrainz_id, ts):
     if ts > int(user['latest_import'].strftime('%s')):
         with db.engine.connect() as connection:
             try:
-                result = connection.execute(sqlalchemy.text("""
+                connection.execute(sqlalchemy.text("""
                     UPDATE "user"
                        SET latest_import = to_timestamp(:ts)
                      WHERE musicbrainz_id = :musicbrainz_id


### PR DESCRIPTION
This PR cleans up formatting of the listenbrainz.db module according to pep8. I'm submitting each module as a separate PR as I don't want to submit a huge patch that would have to be reverted if we find an issue in the changes.
I used pycharm to rearrange the imports and to find items to change, but skipped a few that would require non-trivial changes.
I have tested unittests and everything still seems to work fine.