### PR TITLE
Style cleanup listenstore

### DIFF
--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -1,15 +1,15 @@
 # coding=utf-8
 
 
-from listenbrainz.listenstore import ListenStore
-import logging
-from listenbrainz.listen import Listen
-from influxdb import InfluxDBClient
-from redis import Redis
-from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
-import json
 from datetime import datetime
-from listenbrainz.listenstore import ORDER_DESC, ORDER_ASC, ORDER_TEXT, \
+
+from influxdb import InfluxDBClient
+from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
+from redis import Redis
+
+from listenbrainz.listen import Listen
+from listenbrainz.listenstore import ListenStore
+from listenbrainz.listenstore import ORDER_ASC, ORDER_TEXT, \
     USER_CACHE_TIME, REDIS_USER_TIMESTAMPS
 from listenbrainz.utils import quote, get_escaped_measurement_name, get_measurement_name, get_influx_query_timestamp, \
     convert_influx_nano_to_python_time, convert_python_time_to_nano_int, convert_to_unix_timestamp

--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 
-
+import calendar
 import logging
+import time
+
 from listenbrainz.listenstore import ORDER_ASC, ORDER_DESC, DEFAULT_LISTENS_PER_FETCH
 
 

--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -4,6 +4,7 @@
 import logging
 from listenbrainz.listenstore import ORDER_ASC, ORDER_DESC, DEFAULT_LISTENS_PER_FETCH
 
+
 class ListenStore(object):
     MAX_FETCH = 5000          # max batch size to fetch from the db
     MAX_FUTURE_SECONDS = 600  # 10 mins in future - max fwd clock skew
@@ -15,11 +16,11 @@ class ListenStore(object):
     def max_id(self):
         return int(self.MAX_FUTURE_SECONDS + calendar.timegm(time.gmtime()))
 
-    def fetch_listens_from_storage():
+    def fetch_listens_from_storage(self):
         """ Override this method in PostgresListenStore class """
         raise NotImplementedError()
 
-    def get_total_listen_count():
+    def get_total_listen_count(self):
         """ Return the total number of listens stored in the ListenStore """
         raise NotImplementedError()
 

--- a/listenbrainz/listenstore/postgres_listenstore.py
+++ b/listenbrainz/listenstore/postgres_listenstore.py
@@ -101,7 +101,7 @@ class PostgresListenStore(ListenStore):
                    AND "user".musicbrainz_id = :user_name
             """
 
-            if from_ts != None:
+            if from_ts is not None:
                 query += " AND ts AT TIME ZONE 'UTC' > :from_ts "
             else:
                 query += " AND ts AT TIME ZONE 'UTC' < :to_ts "
@@ -110,10 +110,10 @@ class PostgresListenStore(ListenStore):
               ORDER BY ts """ + ORDER_TEXT[order] + """
                  LIMIT :limit
             """
-            if from_ts != None:
+            if from_ts is not None:
                 args['from_ts'] = pytz.utc.localize(datetime.utcfromtimestamp(from_ts))
             else:
-                args['to_ts'] =  pytz.utc.localize(datetime.utcfromtimestamp(from_ts))
+                args['to_ts'] = pytz.utc.localize(datetime.utcfromtimestamp(from_ts))
 
             results = connection.execute(text(query), args)
             listens = []

--- a/listenbrainz/listenstore/postgres_listenstore.py
+++ b/listenbrainz/listenstore/postgres_listenstore.py
@@ -1,19 +1,16 @@
 # coding=utf-8
 
 
-from listenbrainz.listenstore import ListenStore, ORDER_TEXT
-import logging
 import ujson
-import time
 import uuid
+from datetime import datetime
+
 import pytz
-from datetime import date, datetime
-from listenbrainz.listen import Listen
-from dateutil.relativedelta import relativedelta
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
-import sqlalchemy.exc
-import json
+
+from listenbrainz.listen import Listen
+from listenbrainz.listenstore import ListenStore, ORDER_TEXT
 
 
 class PostgresListenStore(ListenStore):

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -1,14 +1,13 @@
 # coding=utf-8
 
 
-from listenbrainz.listenstore import ListenStore, MIN_ID
-import logging
 import ujson
-import uuid
-from listenbrainz.listen import Listen
-from redis import Redis
+
 import redis
-import json
+from redis import Redis
+
+from listenbrainz.listen import Listen
+from listenbrainz.listenstore import ListenStore, MIN_ID
 
 
 class RedisListenStore(ListenStore):

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -100,6 +100,7 @@ TEST_LISTEN_JSON = [
     """
 ]
 
+
 class TestInfluxListenStore(DatabaseTestCase):
 
     def setUp(self):
@@ -119,7 +120,6 @@ class TestInfluxListenStore(DatabaseTestCase):
             'INFLUX_DB_NAME': config.INFLUX_DB_NAME,
         })
         self.testuser_id = db_user.create("test")
-        user = db_user.get(self.testuser_id)
         self.testuser_name = db_user.get(self.testuser_id)['musicbrainz_id']
 
     def tearDown(self):
@@ -163,13 +163,13 @@ class TestInfluxListenStore(DatabaseTestCase):
         self.assertEqual(len(self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1399999999)), count)
 
     def test_fetch_listens_0(self):
-        count = self._create_test_data(self.testuser_name)
+        self._create_test_data(self.testuser_name)
         listens = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000000, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].ts_since_epoch, 1400000050)
 
     def test_fetch_listens_1(self):
-        count = self._create_test_data(self.testuser_name)
+        self._create_test_data(self.testuser_name)
         listens = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000000)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -178,14 +178,14 @@ class TestInfluxListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
 
     def test_fetch_listens_2(self):
-        count = self._create_test_data(self.testuser_name)
+        self._create_test_data(self.testuser_name)
         listens = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000100)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
 
     def test_fetch_listens_3(self):
-        count = self._create_test_data(self.testuser_name)
+        self._create_test_data(self.testuser_name)
         listens = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=1400000300)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -203,7 +203,7 @@ class TestInfluxListenStore(DatabaseTestCase):
     def test_fetch_listens_escaped(self):
         user = db_user.get_or_create('i have a\\weird\\user, name"\n')
         user_name = user['musicbrainz_id']
-        count = self._create_test_data(user_name)
+        self._create_test_data(user_name)
         listens = self.logstore.fetch_listens(user_name=user_name, from_ts=1400000100)
         self.assertEquals(len(listens), 2)
         self.assertEquals(listens[0].ts_since_epoch, 1400000200)

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -1,21 +1,16 @@
 # coding=utf-8
 
-from listenbrainz.db.testing import DatabaseTestCase
 import logging
-from datetime import datetime
-from listenbrainz.listenstore.tests.util import generate_data, to_epoch
-from listenbrainz.listen import Listen
-from listenbrainz.listenstore import InfluxListenStore
-from listenbrainz.webserver.influx_connection import init_influx_connection
-from influxdb import InfluxDBClient
-import random
-import uuid
-from collections import OrderedDict
-from sqlalchemy import text
 import ujson
+from time import sleep
+
+from influxdb import InfluxDBClient
+
 import listenbrainz.db.user as db_user
 from listenbrainz import config
-from time import sleep
+from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.listen import Listen
+from listenbrainz.webserver.influx_connection import init_influx_connection
 
 TEST_LISTEN_JSON = [
     """

--- a/listenbrainz/listenstore/tests/test_postgreslistenstore.py
+++ b/listenbrainz/listenstore/tests/test_postgreslistenstore.py
@@ -1,17 +1,18 @@
 # coding=utf-8
 
-from listenbrainz.db.testing import DatabaseTestCase
 import logging
-from datetime import datetime
-from listenbrainz.listenstore.tests.util import generate_data, to_epoch
-from listenbrainz.listen import Listen
-from listenbrainz.listenstore import PostgresListenStore, MIN_ID
-from listenbrainz.webserver.postgres_connection import init_postgres_connection
 import random
 import uuid
 from collections import OrderedDict
-from sqlalchemy import text
+from datetime import datetime
+
 import listenbrainz.db.user as db_user
+from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.listen import Listen
+from listenbrainz.listenstore import MIN_ID
+from listenbrainz.listenstore.tests.util import generate_data, to_epoch
+from listenbrainz.webserver.postgres_connection import init_postgres_connection
+
 
 class TestPostgresListenStore(DatabaseTestCase):
 

--- a/listenbrainz/listenstore/tests/test_postgreslistenstore.py
+++ b/listenbrainz/listenstore/tests/test_postgreslistenstore.py
@@ -20,7 +20,6 @@ class TestPostgresListenStore(DatabaseTestCase):
         self.log = logging.getLogger(__name__)
         self.logstore = init_postgres_connection(self.config.SQLALCHEMY_DATABASE_URI)
         self.testuser_id = db_user.create("test")
-        user = db_user.get(self.testuser_id)
         self.testuser_name = db_user.get(self.testuser_id)['musicbrainz_id']
 
     def tearDown(self):
@@ -47,7 +46,7 @@ class TestPostgresListenStore(DatabaseTestCase):
         now = datetime.utcnow()
         data = [('id', 1), ('user_id', self.testuser_id), ('user_name', self.testuser_name), ('timestamp', now),
                 ('artist_msid', str(uuid.uuid4())), ('release_msid', str(uuid.uuid4())), ('recording_msid', str(uuid.uuid4())),
-                ('data', "{'additional_info':{}}"), ('ts_since_epoch', to_epoch(now)) ]
+                ('data', "{'additional_info':{}}"), ('ts_since_epoch', to_epoch(now))]
         row = OrderedDict([(str(k), v) for (k, v) in data[1:]])
         listen = self.logstore.convert_row([1] + list(row.values()))
         self.assertIsInstance(listen, Listen)
@@ -56,4 +55,3 @@ class TestPostgresListenStore(DatabaseTestCase):
         self.assertEqual(listen.artist_msid, row['artist_msid'])
         self.assertEqual(listen.release_msid, row['release_msid'])
         self.assertEqual(listen.recording_msid, row['recording_msid'])
-

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -1,15 +1,15 @@
 # coding=utf-8
 
-from listenbrainz.db.testing import DatabaseTestCase
 import logging
-from datetime import datetime
-from listenbrainz.listenstore.tests.util import generate_data, to_epoch
-from listenbrainz.listenstore import MIN_ID, RedisListenStore
-from listenbrainz.webserver.redis_connection import init_redis_connection
-from redis.connection import Connection
-import random
 import ujson
+
+from redis.connection import Connection
+
 import listenbrainz.db.user as db_user
+from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.listenstore import MIN_ID
+from listenbrainz.listenstore.tests.util import generate_data
+from listenbrainz.webserver.redis_connection import init_redis_connection
 
 
 class TestRedisListenStore(DatabaseTestCase):

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -1,8 +1,9 @@
 # coding=utf-8
 
-from datetime import datetime, timedelta
-from listenbrainz.listen import Listen
 import uuid
+from datetime import datetime
+
+from listenbrainz.listen import Listen
 
 
 def generate_data(test_user_id, from_ts, num_records):


### PR DESCRIPTION
Continuation of #253
This PR cleans up formatting of the listenbrainz.listenstore module according to pep8. I'm submitting each module as a separate PR as I don't want to submit a huge patch that would have to be reverted if we find an issue in the changes.
I used pycharm to rearrange the imports and to find items to change, but skipped a few that would require non-trivial changes.
I have tested unittests and everything still seems to work fine.
