### PR TITLE
Improve development environment configuration, support SELinux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docker/data
 [Ll]ib
 [Ll]ib64
 [Ll]ocal
+[Mm]an
 [Ss]cripts
 pyvenv.cfg
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,19 @@ env
 bigquery-credentials.json
 *.bak
 
-# Application data
-/docker/data
+# ListenBrainz application data
+docker/data
+
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,19 +12,21 @@ services:
   db:
     image: postgres:9.5.3
     volumes:
-      - ./dbvolume:/var/lib/postgresql/data/
+      - ./dbvolume:/var/lib/postgresql/data:z
     ports:
       - "15432:5432"
 
   redis:
     image: redis:3.2.1
     volumes:
-      - ./docker/data/redis:/data
+      - ./data/redis:/data:z
+    ports:
+      - "6379:6379"
 
   influx:
     image: influxdb:1.2.4
     volumes:
-      - ./docker/data/influxdb:/var/lib/influxdb
+      - ./data/influxdb:/var/lib/influxdb:z
     environment:
       INFLUXDB_REPORTING_DISABLED: 'true'
       INFLUXDB_META_LOGGING_ENABLED: 'false'
@@ -41,7 +43,7 @@ services:
   rabbitmq:
     image: rabbitmq:3.6.5
     volumes:
-      - ./docker/data/rabbitmq:/var/lib/rabbitmq
+      - ./data/rabbitmq:/var/lib/rabbitmq:z
     ports:
       - "5672:5672"
 
@@ -52,12 +54,12 @@ services:
     command: python3 /code/listenbrainz/manage.py runserver -h 0.0.0.0 -p 80 -d
     image: web
     volumes:
-      - ..:/code/listenbrainz
-      - ../credentials:/code/credentials
+      - ..:/code/listenbrainz:z
+      - ../credentials:/code/credentials:z
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: '/code/credentials/bigquery-credentials.json'
     ports:
-      - "80:80"
+      - "8000:80"
     depends_on:
       - redis
       - db
@@ -79,7 +81,7 @@ services:
       context: ..
       dockerfile: Dockerfile
     volumes:
-      - ../credentials:/code/credentials
+      - ../credentials:/code/credentials:z
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: '/code/credentials/bigquery-credentials.json'
     command: python3 -m "listenbrainz.bigquery-writer.bigquery-writer"


### PR DESCRIPTION
This commit makes three changes:

* Supports enforcing SELinux on the host computer by adding the `:z` annotation to the volume mount
* Actually starts the local server on port 8000 on the host system (before, was running on port 80, contradicting the README)
* Create `docker/data` instead of `docker/docker/data`, fixes accidental recursion and plays nicely with the .gitignore

I also added some more paths to ignore in the .gitignore, for Python virtualenvs. Ideally, most people won't have to use them, but I had to when I was playing around to get things working, so I went ahead
and added them.

This should help make it easier for first-time contributors to get started. With the current changes, I'm able to successfully create a development environment on first clone, where I had not been able
to before. Whooo!

**Edit**: I wrote a draft blog post on how to set up a development environment – a temporary preview link is [here](https://blog.justinwflory.com/?p=758&preview=1&_ppp=727602ac6d "How to set up a ListenBrainz development environment")!