### PR TITLE
Apply reST style guide to JSON page, promote API from beta

### DIFF
--- a/docs/dev/api.rst
+++ b/docs/dev/api.rst
@@ -1,5 +1,5 @@
-ListenBrainz API for Beta
-=========================
+ListenBrainz API
+================
 
 The ListenBrainz server supports the following end-points for submitting and
 fetching listens.  All endpoints have this root URL for our current production
@@ -11,7 +11,7 @@ site [#]_.
 
 *Note*: All ListenBrainz services are only available on **HTTPS**!
 
-.. [#] The beta endpoints (i.e. ``beta.listenbrainz.org`` was deprecated in
+.. [#] The beta endpoints (i.e. ``beta.listenbrainz.org``) were deprecated in
    Fall 2017. If you were using this endpoint, please use the current,
    production endpoints instead.
 

--- a/docs/dev/json.rst
+++ b/docs/dev/json.rst
@@ -3,22 +3,36 @@
 JSON Documentation
 ==================
 
+.. note:: Do not submit copyrighted information in these fields!
+
 Submission JSON
 ---------------
 
-To submit a listen via our :doc:`api` you'll need to POST a JSON document to the ``submit-listens`` endpoint. You
-can submit one of three types JSON documents:
+To submit a listen via our API (see: :doc:`api`), ``POST`` a JSON document to
+the ``submit-listens`` endpoint. Submit one of three types JSON documents:
 
-* ``single`` - submit a single listen. This indicates that the user just finished listening to this track. Only
-  a single track may be specified in the ``payload``.
-* ``playing_now`` - submit a playing_now notification; This indicates that the user just began listening to this
-  track. The ``payload`` may contain only one track and submitting ``playing_now`` documents is optional.
-* ``import`` - submit previously saved listens; the ``payload`` may contain more than one listen, but the complete
-  document may not exceed :data:`~webserver.views.api.MAX_LISTEN_SIZE` bytes in size.
+- ``single``: Submit single listen
 
-These different types of submissions are defined by the ``listen_type`` element at the top-most level of the submitted
-JSON document. The only other element required at the top level is the payload element that provides an array of
-listens -- the payload may be one or more listens (as designated by the listen_type)::
+   - Indicates user just finished listening to track
+   - Only a single track may be specified in ``payload``
+
+- ``playing_now``: Submit ``playing_now`` notification
+  
+   - Indicates that user just began listening to track
+
+   - ``payload`` contains *only* one track
+
+   - Submitting ``playing_now`` documents is optional
+
+- ``import``: Submit previously saved listens
+
+  - ``payload`` may contain more than one listen, but complete document may not
+    exceed :data:`~webserver.views.api.MAX_LISTEN_SIZE` bytes in size
+
+The ``listen_type`` element defines different types of submissions. The element
+is placed at the top-most level of the JSON document. The only other required
+element is the ``payload`` element. This provides an array of listens – the
+payload may be one or mote listens (as designated by ``listen_type``)::
 
     {
       "listen_type": "single",
@@ -83,14 +97,16 @@ The JSON documents returned from our API look like the following::
       ]
     }
 
-The top level count element indicates how many listens are returned in this document. The other element is the payload element, which contains
-listen JSON elements as described above.
+The number of listens in the document are returned by the top-level ``count``
+element. The other element is the ``payload`` element. This contains the listen
+JSON elements (described above).
+
 
 Payload JSON details
 --------------------
 
-A minimal payload must include the ``listened_at``, ``track_metadata/artist_name`` and ``track_metadata/track_name``
-elements::
+A minimal payload must include the ``listened_at``,
+``track_metadata/artist_name`` and ``track_metadata/track_name`` elements::
 
     {
       "listened_at": 1443521965,
@@ -100,11 +116,13 @@ elements::
       }
     }
 
-The artist_name and track_name elements must be simple strings, while the listened_at element must be an integer.
+``artist_name`` and ``track_name`` elements must be simple strings, while the
+``listened_at`` element must be an integer.
 
-We strongly recommend to add whatever additional metadata you may have for a track to the ``additional_info`` element.
-Any additional information will allow us to better correlate your listen data to existing MusicBrainz based data. If you
-have MusicBrainz IDs availble, submit them!
+Add additional metadata you may have for a track to the ``additional_info``
+element. Any additional information allows us to better correlate your listen
+data to existing MusicBrainz-based data. If you have MusicBrainz IDs availble,
+submit them!
 
 The following optional elements may also be included in the ``track_metadata`` element:
 
@@ -132,8 +150,8 @@ element                 description
 ``tags``                A list of user defined tags to be associated with this recording. These tags are similar to last.fm tags. For example, you have apply tags such as ``punk``, ``see-live``, ``smelly``. You may submit up to :data:`~webserver.views.api.MAX_TAGS_PER_LISTEN` tags and each tag may be up to :data:`~webserver.views.api.MAX_TAG_SIZE` characters large.
 ======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
 
-At this point, we are not scrubbing any superflous elements that may be submitted via the ``additional_info`` element. We're
-open to see how people will make use of these unspecified fields and may decide to formally specify or scrub elements in
-the future.
+At this point, we are not scrubbing any superflous elements that may be
+submitted via the ``additional_info`` element. We're open to see how people
+will make use of these unspecified fields and may decide to formally specify or
+scrub elements in the future.
 
-**Please do not submit copyrighted information in these fields!!**


### PR DESCRIPTION
Per discussion with @mayhem in `#metabrainz`, this PR removes all mention of the beta from the API docs and it also applies the [reST style guide](https://documentation-style-guide-sphinx.readthedocs.io/en/latest/index.html) to the JSON page.