### PR TITLE
LB-124: Add messybrainz-server to requirements.txt (also fixes doc builds)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ requests == 2.13.0
 google-api-python-client==1.5.2
 pika == 0.10.0
 git+https://github.com/bninja/pika-pool.git@5b1d3b650395aed60d9995fbfd289de7e62fe8d5#egg=pika_pool
+git+https://github.com/metabrainz/messybrainz-server.git@production#egg=messybrainz


### PR DESCRIPTION
This PR addresses [LB-124](https://tickets.metabrainz.org/projects/LB/issues/LB-124 "Install messybrainz as a a python library from requirements"). It's fairly simple. I locked the version of messybrainz-server to what is in the `production` branch. Not sure if this is preferred or `master`.