### PR TITLE
LB-221: Only calculate stats of users who haven't been done recently

### DIFF
--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -236,13 +236,13 @@ def get_users_with_uncalculated_stats():
 
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-                SELECT public."user".musicbrainz_id
-                  FROM public."user"
-             LEFT JOIN statistics.user
-                    ON public."user".id = statistics.user.user_id
-                 WHERE public."user".last_login >= NOW() - INTERVAL ':x days'
-                   AND (statistics.user.last_updated IS NULL OR statistics.user.last_updated < NOW() - INTERVAL ':y days')
-                """.format(columns=','.join(USER_GET_COLUMNS))), {
+                SELECT pu.musicbrainz_id
+                  FROM public."user" pu
+             LEFT JOIN statistics.user su
+                    ON pu.id = su.user_id
+                 WHERE pu.last_login >= NOW() - INTERVAL ':x days'
+                   AND (su.last_updated IS NULL OR su.last_updated < NOW() - INTERVAL ':y days')
+                """), {
                     'x': config.STATS_CALCULATION_LOGIN_TIME,
                     'y': config.STATS_CALCULATION_INTERVAL,
                 })

--- a/listenbrainz/stats/calculate.py
+++ b/listenbrainz/stats/calculate.py
@@ -4,13 +4,16 @@ import listenbrainz.db.user as db_user
 import listenbrainz.stats.user as stats_user
 import time
 
-from listenbrainz import db
 from listenbrainz import config
+from listenbrainz import db
 from listenbrainz import stats
 
 
 def calculate_user_stats():
-    for user in db_user.get_recently_logged_in_users():
+    """Get the users we need to calculate our statistics for and calculate their stats.
+    """
+
+    for user in db_user.get_users_with_uncalculated_stats():
         recordings = stats_user.get_top_recordings(musicbrainz_id=user['musicbrainz_id'])
         artists = stats_user.get_top_artists(musicbrainz_id=user['musicbrainz_id'])
         releases = stats_user.get_top_releases(musicbrainz_id=user['musicbrainz_id'])
@@ -23,6 +26,7 @@ def calculate_user_stats():
             releases=releases,
             artist_count=artist_count
         )
+
 
 def calculate_stats():
     calculate_user_stats()


### PR DESCRIPTION
This means that if someone's stats get calculated then the script
needs to start up again, it won't calculate their stats again.

This is part of the better error handling for stats calculation I'm working on.