### PR TITLE
LB-224: Add support for dumping PostgreSQL tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
                        libpq-dev \
                        libffi-dev \
                        cron \
+                       pxz \
     && rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -1,0 +1,283 @@
+""" This module contains data dump creation and import functions.
+"""
+
+# listenbrainz-server - Server for the ListenBrainz project
+#
+# Copyright (C) 2017 MetaBrainz Foundation Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+import listenbrainz.config as config
+import listenbrainz.db as db
+import logging
+import os
+import shutil
+import sqlalchemy
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+from datetime import datetime
+from listenbrainz.utils import create_path
+
+
+DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                      "licenses", "COPYING-PublicDomain")
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+TABLES = {
+    '"user"': (
+        'id',
+        'created',
+        'musicbrainz_id',
+        'auth_token',
+        'last_login',
+        'latest_import',
+    ),
+    'api_compat.token': (
+        'id',
+        'user_id',
+        'token',
+        'api_key',
+        'ts',
+    ),
+    'api_compat.session': (
+        'id',
+        'user_id',
+        'sid',
+        'api_key',
+        'ts',
+    ),
+    'statistics.user': (
+        'user_id',
+        'artist',
+        'release',
+        'recording',
+        'last_updated',
+    ),
+    'statistics.artist': (
+        'id',
+        'msid',
+        'name',
+        'release',
+        'recording',
+        'listener',
+        'listen_count',
+        'last_updated',
+    ),
+    'statistics.release': (
+        'id',
+        'msid',
+        'name',
+        'recording',
+        'listener',
+        'listen_count',
+        'last_updated',
+    ),
+    'statistics.recording': (
+        'id',
+        'msid',
+        'name',
+        'listener',
+        'listen_count',
+        'last_updated',
+    ),
+    'data_dump': (
+        'id',
+        'created',
+    ),
+}
+
+
+PRIVATE_TABLES = [
+    '"user"',
+    'api_compat.session',
+    'api_compat.token',
+]
+
+STATS_TABLES = [
+    'statistics.user',
+    'statistics.release',
+    'statistics.artist',
+    'statistics.recording',
+]
+
+def dump_postgres_db(location, threads=None):
+    """ Create postgres database dump in the specified location
+
+        Arguments:
+            location: Directory where the final dump will be stored
+            threads: Maximal number of threads to run during compression
+
+        Returns:
+            Path to created dump.
+    """
+
+    logger.info('Beginning dump of PostgreSQL database...')
+    time_now = datetime.today()
+    dump_path = os.path.join(location, 'listenbrainz-dump-{time}'.format(time=time_now.strftime('%Y%m%d-%H%M%S')))
+    create_path(dump_path)
+    logger.info('dump path: %s', dump_path)
+
+
+    logger.info('Creating dump of private data...')
+    private_dump = create_private_dump(dump_path, time_now, threads)
+    logger.info('Dump of private data created at %s!', private_dump)
+
+    logger.info('Creating dump of stats data...')
+    stats_dump = create_stats_dump(dump_path, time_now, threads)
+    logger.info('Dump of stats data created at %s!', stats_dump)
+
+
+    logger.info('Creating a new entry in the data_dump table...')
+    dump_id = add_dump_entry()
+    logger.info('New entry with id %d added to data_dump table!', dump_id)
+
+    logger.info('ListenBrainz PostgreSQL data dump created at %s!', dump_path)
+    return dump_path
+
+
+def _create_dump(location, dump_type, tables, time_now, threads=None):
+    """ Creates a dump of the provided tables at the location passed
+
+        Arguments:
+            location: the path where the dump should be created
+            dump_type: the type of data dump being made - private or stats
+            tables: a list containing the names of the tables to be dumped
+            time_now: the time at which the dump process was started
+            threads: the maximum number of threads to use for compression
+
+        Returns:
+            the path to the archive file created
+    """
+
+    archive_name = 'listenbrainz-{dump_type}-dump-{time}'.format(
+        dump_type=dump_type,
+        time=time_now.strftime('%Y%m%d-%H%M%S')
+    )
+    archive_path = os.path.join(location, '{archive_name}.tar.xz'.format(
+        archive_name=archive_name,
+    ))
+
+    with open(archive_path, 'w') as archive:
+
+        pxz_command = ['pxz', '--compress']
+        if threads is not None:
+            pxz_command.append('-T {threads}'.format(threads=threads))
+
+        pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
+
+        with tarfile.open(fileobj=pxz.stdin, mode='w|') as tar:
+
+            temp_dir = tempfile.mkdtemp()
+
+            schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
+            with open(schema_seq_path, "w") as f:
+                f.write(str(db.SCHEMA_VERSION))
+            tar.add(schema_seq_path,
+                    arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
+            timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
+            with open(timestamp_path, "w") as f:
+                f.write(time_now.isoformat(" "))
+            tar.add(timestamp_path,
+                    arcname=os.path.join(archive_name, "TIMESTAMP"))
+            tar.add(DUMP_LICENSE_FILE_PATH,
+                    arcname=os.path.join(archive_name, "COPYING"))
+
+
+            archive_tables_dir = os.path.join(temp_dir, 'lb-{}-dump'.format(dump_type), 'lb{}dump'.format(dump_type))
+            create_path(archive_tables_dir)
+
+
+            for table in tables:
+                copy_table(archive_tables_dir, table)
+
+            tar.add(archive_tables_dir, arcname=os.path.join(archive_name, 'lb{}dump'.format(dump_type)))
+
+            shutil.rmtree(temp_dir)
+
+        pxz.stdin.close()
+
+    return location
+
+
+def create_private_dump(location, time_now, threads=None):
+    """ Create postgres database dump for private data in db.
+        This includes dumps of the following tables:
+            "user",
+            api_compat.token,
+            api_compat.session
+    """
+    return _create_dump(location, 'private', PRIVATE_TABLES, time_now, threads)
+
+
+def create_stats_dump(location, time_now, threads=None):
+    """ Create postgres database dump for private data in db.
+        This includes dumps of the following tables:
+            "user",
+            api_compat.token,
+            api_compat.session
+    """
+    return _create_dump(location, 'stats', STATS_TABLES, time_now, threads)
+
+
+def copy_table(location, table_name):
+    """ Copies a PostgreSQL table to a file
+
+        Arguments:
+            location: the directory where the table should be copied
+            table_name: the name of the table to be copied
+    """
+
+    connection = db.engine.raw_connection()
+    cursor = connection.cursor()
+
+    with open(os.path.join(location, table_name), 'w') as f:
+        cursor.copy_to(f, '(SELECT {columns} FROM {table})'.format(
+            columns=','.join(TABLES[table_name]),
+            table=table_name
+        ))
+
+    connection.close()
+
+
+def add_dump_entry():
+    """ Adds an entry to the data_dump table with current time.
+
+        Returns:
+            id (int): the id of the new entry added
+    """
+
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+                INSERT INTO data_dump (created)
+                     VALUES (NOW())
+                  RETURNING id
+            """))
+        return result.fetchone()['id']
+
+
+if __name__ == '__main__':
+    db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
+    dump_postgres_db('/dump/')

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -233,11 +233,12 @@ def create_private_dump(location, time_now, threads=None):
 
 
 def create_stats_dump(location, time_now, threads=None):
-    """ Create postgres database dump for private data in db.
-        This includes dumps of the following tables:
-            "user",
-            api_compat.token,
-            api_compat.session
+    """ Create postgres database dump for statistics in db.
+        This includes dumps of all tables in the statistics schema:
+            statistics.user
+            statistics.artist
+            statistics.release
+            statistics.recording
     """
     return _create_dump(location, 'stats', STATS_TABLES, time_now, threads)
 

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -173,11 +173,12 @@ def dump_postgres_db(location, threads=None):
 
 
     logger.info('Creating a new entry in the data_dump table...')
-    try:
-        dump_id = add_dump_entry()
-    except Exception as e:
-        logger.info('Error while adding dump entry: %s', str(e))
-        return
+    while True:
+        try:
+            dump_id = add_dump_entry()
+            break
+        except Exception as e:
+            logger.error('Error while adding dump entry: %s', str(e))
 
     logger.info('New entry with id %d added to data_dump table!', dump_id)
 

--- a/listenbrainz/db/licenses/COPYING-PublicDomain
+++ b/listenbrainz/db/licenses/COPYING-PublicDomain
@@ -1,0 +1,105 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work
+of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work
+for the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without
+fear of later claims of infringement build upon, modify, incorporate in
+other works, reuse and redistribute as freely as possible in any form
+whatsoever and for any purposes, including without limitation commercial
+purposes. These owners may contribute to the Commons to promote the
+ideal of a free culture and the further production of creative, cultural
+and scientific works, or to gain reputation or greater distribution for
+their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or
+she is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under
+its terms, with knowledge of his or her Copyright and Related Rights in
+the Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may
+be protected by copyright and related or neighboring rights ("Copyright
+and Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+the right to reproduce, adapt, distribute, perform, display, communicate,
+and translate a Work; moral rights retained by the original author(s)
+and/or performer(s); publicity and privacy rights pertaining to a person's
+image or likeness depicted in a Work; rights protecting against unfair
+competition in regards to a Work, subject to the limitations in paragraph
+4(a), below; rights protecting the extraction, dissemination, use and
+reuse of data in a Work; database rights (such as those arising under
+Directive 96/9/EC of the European Parliament and of the Council of 11
+March 1996 on the legal protection of databases, and under any national
+implementation thereof, including any amended or successor version of
+such directive); and other similar, equivalent or corresponding rights
+throughout the world based on applicable law or treaty, and any national
+implementations thereof.  2. Waiver. To the greatest extent permitted by,
+but not in contravention of, applicable law, Affirmer hereby overtly,
+fully, permanently, irrevocably and unconditionally waives, abandons,
+and surrenders all of Affirmer's Copyright and Related Rights and
+associated claims and causes of action, whether now known or unknown
+(including existing as well as future claims and causes of action), in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions),
+(iii) in any current or future medium and for any number of copies, and
+(iv) for any purpose whatsoever, including without limitation commercial,
+advertising or promotional purposes (the "Waiver"). Affirmer makes the
+Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such
+Waiver shall not be subject to revocation, rescission, cancellation,
+termination, or any other legal or equitable action to disrupt the quiet
+enjoyment of the Work by the public as contemplated by Affirmer's express
+Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright
+and Related Rights in the Work (i) in all territories worldwide, (ii)
+for the maximum duration provided by applicable law or treaty (including
+future time extensions), (iii) in any current or future medium and for
+any number of copies, and (iv) for any purpose whatsoever, including
+without limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law,
+such partial invalidity or ineffectiveness shall not invalidate the
+remainder of the License, and in such case Affirmer hereby affirms that
+he or she will not (i) exercise any of his or her remaining Copyright
+and Related Rights in the Work or (ii) assert any associated claims and
+causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+No trademark or patent rights held by Affirmer are waived, abandoned,
+surrendered, licensed or otherwise affected by this document.  Affirmer
+offers the Work as-is and makes no representations or warranties of any
+kind concerning the Work, express, implied, statutory or otherwise,
+including without limitation warranties of title, merchantability,
+fitness for a particular purpose, non infringement, or the absence of
+latent or other defects, accuracy, or the present or absence of errors,
+whether or not discoverable, all to the greatest extent permissible
+under applicable law.  Affirmer disclaims responsibility for clearing
+rights of other persons that may apply to the Work or any use thereof,
+including without limitation any person's Copyright and Related Rights
+in the Work. Further, Affirmer disclaims responsibility for obtaining
+any necessary consents, permissions or other rights required for any
+use of the Work.  Affirmer understands and acknowledges that Creative
+Commons is not a party to this document and has no duty or obligation
+with respect to this CC0 or use of the Work.

--- a/listenbrainz/db/licenses/README.md
+++ b/listenbrainz/db/licenses/README.md
@@ -1,0 +1,3 @@
+IMPORTANT: The license file in this directory is the text file that gets included into the data dumps.
+
+The CC0 license DOES NOT APPLY to the code in this repository.

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -1,12 +1,17 @@
+import errno
+import os
+
 from datetime import datetime
 
 INFLUX_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 INFLUX_TIME_FORMAT_NANO = "%Y-%m-%dT%H:%M:%S"
 
+
 def escape(value):
     """ Escapes backslashes, quotes and new lines present in the string value
     """
     return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
 
 def quote(user_name):
     # we have to always quote the user name to get the measurement name which we pass to
@@ -14,12 +19,14 @@ def quote(user_name):
     # errors are thrown if we don't.
     return "\"{0}\"".format(user_name.replace("\n", "\\n"))
 
+
 def get_measurement_name(user_name):
     """ Function to return the measurement name that influx has saved for given user name"""
 
     # Note: there are we have to replace each \ with two backslashes because influxdb-python
     # adds an extra backslash for each backslash in the measurement name itself
     return '"{}"'.format(user_name.replace('\\', '\\\\').replace('\n', '\\\\n'))
+
 
 def get_escaped_measurement_name(user_name):
     """ Function to return the string which can directly be passed into influx queries for a
@@ -36,13 +43,16 @@ def get_influx_query_timestamp(ts):
     """ Influx queries require timestamps in nanoseconds so convert ts into nanoseconds and return a string"""
     return "{}000000000".format(ts)
 
+
 def convert_to_unix_timestamp(influx_row_time):
     """ Converts time retreived from influxdb into unix timestamp """
     dt = datetime.strptime(influx_row_time, INFLUX_TIME_FORMAT)
     return int(dt.strftime('%s'))
 
+
 def convert_timestamp_to_influx_row_format(ts):
     return datetime.fromtimestamp(ts).strftime(INFLUX_TIME_FORMAT)
+
 
 def convert_influx_nano_to_python_time(influx_row_time):
     """ Converts time retreived from influxdb into python floating point time """
@@ -51,5 +61,16 @@ def convert_influx_nano_to_python_time(influx_row_time):
     fractional = int(date_bits[1][:-1])
     return float(dt.strftime('%s')) + (fractional / 100000000.0)
 
+
 def convert_python_time_to_nano_int(t):
     return int(t * 100000000)
+
+
+def create_path(path):
+    """Creates a directory structure if it doesn't exist yet."""
+    try:
+        os.makedirs(path)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise Exception("Failed to create directory structure %s. Error: %s" %
+                            (path, exception))

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -74,3 +74,11 @@ def create_path(path):
         if exception.errno != errno.EEXIST:
             raise Exception("Failed to create directory structure %s. Error: %s" %
                             (path, exception))
+
+
+def log_ioerrors(logger, e):
+    """ Logs IOErrors that occur in case we run out of disk space.
+        This is used in data dumps and is a placeholder while Sentry support
+        is added.
+    """
+    logger.error('IOError while creating dump: %s', str(e))


### PR DESCRIPTION
This commit adds support for dumping our postgres tables.
Dumps are of two types for now:

* private dumps: contains the user table, the api compat sessions
and tokens
* stat dumps: contains the stats tables

TODO: add tests, write code that imports data from dumps, add support for dumping listens from influx

This PR depends on #270, so will need to rebase after that gets merged.