### PR TITLE
LB-231: Add code volumes to web and scheduler containers

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       dockerfile: Dockerfile
     command: python3 /code/listenbrainz/manage.py runserver -h 0.0.0.0 -p 80 -d
     image: web
+    volumes:
+      - ..:/code/listenbrainz
     ports:
       - "80:80"
     depends_on:
@@ -109,6 +111,7 @@ services:
     command: cron && tail -f /var/log/cron.log
     volumes:
       - ../credentials:/code/credentials:z
+      - ..:/code/listenbrainz
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: '/code/credentials/bigquery-credentials.json'
     depends_on:


### PR DESCRIPTION
This seemed to have gotten removed somehow and it made development
a pain because to get changes into the docker container, you
have to run develop.sh from scratch.