### PR TITLE
LB-233: Refactor testcase classes to use single path_to_data_file

### DIFF
--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -6,7 +6,7 @@ from listenbrainz import config
 from listenbrainz import db
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..','admin', 'sql')
-TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_data')
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'testdata')
 
 
 class DatabaseTestCase(unittest.TestCase):
@@ -37,7 +37,10 @@ class DatabaseTestCase(unittest.TestCase):
     def drop_schema(self):
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'drop_schema.sql'))
 
-    def load_data_files(self):
-        """ Get the data files from the disk """
-        # return os.path.join(TEST_DATA_PATH, file_name)
-        return
+    def path_to_data_file(self, file_name):
+        """ Returns the path of the test data file relative to listenbrainz/db/testing.py.
+
+            Args:
+                file_name: the name of the data file
+        """
+        return os.path.join(TEST_DATA_PATH, file_name)

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -14,8 +14,6 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         DatabaseTestCase.setUp(self)
         self.user = db_user.get_or_create('stats_user')
 
-    def path_to_data_file(self, filename):
-       return os.path.join(StatsDatabaseTestCase.TEST_DATA_PATH, filename)
 
     def test_insert_user_stats(self):
 

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 import os
-import listenbrainz.db.user as db_user
 import listenbrainz.db.stats as db_stats
+import listenbrainz.db.user as db_user
+
 from listenbrainz.db.testing import DatabaseTestCase
 
 

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -8,7 +8,6 @@ from listenbrainz.db.testing import DatabaseTestCase
 
 class StatsDatabaseTestCase(DatabaseTestCase):
 
-    TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'testdata')
 
     def setUp(self):
         DatabaseTestCase.setUp(self)

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -7,7 +7,6 @@ from listenbrainz.db.testing import DatabaseTestCase
 
 class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
 
-    TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'testdata')
     def setUp(self):
         ServerTestCase.setUp(self)
         DatabaseTestCase.setUp(self)
@@ -16,18 +15,8 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
 
-    def path_to_data_file(self, fn):
-        """ Returns the path of the test data file relative to the test file.
-
-            Args:
-                fn: the name of the data file
-        """
-        return os.path.join(IntegrationTestCase.TEST_DATA_PATH, fn)
-
 
 class APICompatIntegrationTestCase(APICompatServerTestCase, DatabaseTestCase):
-
-    TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'testdata')
 
     def setUp(self):
         APICompatServerTestCase.setUp(self)
@@ -36,11 +25,3 @@ class APICompatIntegrationTestCase(APICompatServerTestCase, DatabaseTestCase):
     def tearDown(self):
         APICompatServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
-
-    def path_to_data_file(self, fn):
-        """ Returns the path of the test data file relative to the test file.
-
-            Args:
-                fn: the name of the data file
-        """
-        return os.path.join(APICompatIntegrationTestCase.TEST_DATA_PATH, fn)


### PR DESCRIPTION
I was working on creating a ListenBrainzTestCase class, but it seemed like too big of a refactor with problems like tests for server would require db setup and stuff. So this PR.