### PR TITLE
Use correct port number on final URL

### DIFF
--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -135,10 +135,11 @@ running, visit your new site from your browser!
 
 .. code-block:: none
 
-    http://localhost:8000/
+    http://localhost/
 
 
 Now, you are all set to begin making changes and testing them in your development environment!
 
 .. _MusicBrainz applications page: https://musicbrainz.org/account/applications
 .. _register: https://musicbrainz.org/account/applications/register
+


### PR DESCRIPTION
The development environment setup docs still refers to port 8000. This uses the correct default port, 80.

_Edit_: The Travis CI build failed because of `psycopg2`, but this was fixed in #289. Re-running the test will build it fine.