### PR TITLE
LB-239: Update psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pytest==2.9.1
 pytest-cov==2.2.1
 pytz==2016.6.1
 unittest2==1.1.0
-psycopg2 == 2.6.1
+psycopg2 == 2.7.3.2
 python-dateutil == 2.2
 ujson == 1.33
 redis == 2.10.3


### PR DESCRIPTION
LB's build is broken because of a bug in the version of psycopg2 we use (https://github.com/psycopg/psycopg2/issues/594). Upgrading fixes this.


