### PR TITLE
Fix SELinux context labels for web Docker image volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ install:
        python3 manage.py init_influx"
   - docker-compose -f docker/docker-compose.test.yml -p listenbrainz_test stop
 
-  # This file seemes to cause permission problems somehow, not sure how, leading to errors in building
-  # the other containers. So remove it.
-  - sudo rm docker/docker/data/rabbitmq/.erlang.cookie
+  # This file seemes to cause permission problems somehow, not sure how, leading
+  # to errors in building the other containers. So remove it.
+  - sudo rm docker/data/rabbitmq/.erlang.cookie
 
   # Build the integration test docker-compose project
   - docker-compose -f docker/docker-compose.integration.yml -p listenbrainz_int build

--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -1,4 +1,9 @@
 version: "2"
+
+# IMPORTANT NOTE: Volume paths mounted on containers are relative to the
+# directory that this file is in (`docker/`) and so probably need to start with
+# `../` to refer to a directory in the main code checkout
+
 services:
 
   db:
@@ -38,7 +43,7 @@ services:
   rabbitmq:
     image: rabbitmq:3.6.5
     volumes:
-      - ./docker/data/rabbitmq:/var/lib/rabbitmq
+      - ./data/rabbitmq:/var/lib/rabbitmq:z
     ports:
       - "5672:5672"
 

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,4 +1,9 @@
 version: "2"
+
+# IMPORTANT NOTE: Volume paths mounted on containers are relative to the
+# directory that this file is in (`docker/`) and so probably need to start with
+# `../` to refer to a directory in the main code checkout
+
 services:
 
   db:
@@ -21,7 +26,7 @@ services:
   rabbitmq:
     image: rabbitmq:3.6.5
     volumes:
-      - ./docker/data/rabbitmq:/var/lib/rabbitmq
+      - ./data/rabbitmq:/var/lib/rabbitmq:z
     ports:
       - "5672:5672"
 
@@ -33,7 +38,7 @@ services:
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: '/code/credentials/bigquery-credentials.json'
     volumes:
-      - ..:/code/listenbrainz
+      - ..:/code/listenbrainz:z
     depends_on:
       - redis
       - db

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "2"
 
-# IMPORTANT NOTE: Volume paths mounted on containers are relative to the directory that
-# this file is in (`docker/`) and so probably need to start with `../` to refer to a
-# directory in the main code checkout
+# IMPORTANT NOTE: Volume paths mounted on containers are relative to the
+# directory that this file is in (`docker/`) and so probably need to start with
+# `../` to refer to a directory in the main code checkout
 
 volumes:
   dbvolume:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     command: python3 /code/listenbrainz/manage.py runserver -h 0.0.0.0 -p 80 -d
     image: web
     volumes:
-      - ..:/code/listenbrainz
+      - ..:/code/listenbrainz:z
     ports:
       - "80:80"
     depends_on:
@@ -69,7 +69,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ..:/code/listenbrainz
+      - ..:/code/listenbrainz:z
     depends_on:
       - redis
       - db


### PR DESCRIPTION
After fixing my development environment (metabrainz/brainzutils-python#6), I was unable to create my development environment because of SELinux issues with starting the web Docker image. I missed the web Docker image volumes in #257. This PR adds them.