### PR TITLE
Put license path in listenbrainz/init for easy future imports

### DIFF
--- a/listenbrainz/__init__.py
+++ b/listenbrainz/__init__.py
@@ -1,1 +1,6 @@
+import os
+
 __version__ = '0.1'
+
+DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                      'db', 'licenses', 'COPYING-PublicDomain')

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -32,6 +32,7 @@ import tempfile
 import time
 
 from datetime import datetime
+from listenbrainz import DUMP_LICENSE_FILE_PATH
 from listenbrainz.utils import create_path, log_ioerrors
 
 from listenbrainz import default_config as config
@@ -39,9 +40,6 @@ try:
     from listenbrainz import custom_config as config
 except ImportError:
     pass
-
-DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                      "licenses", "COPYING-PublicDomain")
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -15,6 +15,7 @@ from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from redis import Redis
 
+from listenbrainz import DUMP_LICENSE_FILE_PATH
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore import ListenStore
 from listenbrainz.listenstore import ORDER_ASC, ORDER_TEXT, \
@@ -29,8 +30,6 @@ COUNT_MEASUREMENT_NAME = "listen_count"
 TEMP_COUNT_MEASUREMENT = COUNT_RETENTION_POLICY + "." + COUNT_MEASUREMENT_NAME
 TIMELINE_COUNT_MEASUREMENT = COUNT_MEASUREMENT_NAME
 
-DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                      '..', 'db', 'licenses', 'COPYING-PublicDomain')
 DUMP_CHUNK_SIZE = 100000
 
 


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Put license path in listenbrainz/init for easy future imports

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Have to import license path in InfluxListenStore for dumping
listens too. Keeping it in db.dump makes it hard to share this variable.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Putting the path in `listenbrainz/__init__.py` makes more sense and makes it easier to
import it in the future.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Just a merge.
