### PR TITLE
LB-229: Add support for importing listens from data dumps to Influx

### DIFF
--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -86,11 +86,13 @@ def import_dump(location):
 
 @cli.command()
 @click.option('--location', '-l')
-def import_listens_dump(location=None):
+@click.option('--threads', '-t', type=int)
+def import_listens_dump(location=None, threads=None):
     """ Import a ListenBrainz listen dump into the Influx database.
 
         Args:
             location (str): path to the listenbrainz listen .tar.xz archive
+            threads (int): the number of threads to use while decompressing, defaults to 1
     """
 
     if not location:
@@ -106,7 +108,7 @@ def import_listens_dump(location=None):
     })
 
     try:
-        ls.import_listens_dump(location)
+        ls.import_listens_dump(location, threads)
     except IOError as e:
         log.error('IOError while trying to import data into Influx: %s', str(e))
         raise

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -64,3 +64,21 @@ def create(location, threads):
 def import_dump(location):
     db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
     db_dump.import_postgres_dump(location)
+
+
+@cli.command()
+@click.option('--location', '-l')
+def import_listens_dump(location=None):
+
+    if not location:
+        print('No location given!')
+        return
+
+    ls = init_influx_connection(log,  {
+        'REDIS_HOST': config.REDIS_HOST,
+        'REDIS_PORT': config.REDIS_PORT,
+        'INFLUX_HOST': config.INFLUX_HOST,
+        'INFLUX_PORT': config.INFLUX_PORT,
+        'INFLUX_DB_NAME': config.INFLUX_DB_NAME,
+    })
+    ls.import_listens_dump(location)

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -70,7 +70,7 @@ def create(location, threads):
 
 @cli.command()
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'))
-def import_dump(location):
+def import_db(location):
     """ Import a ListenBrainz PostgreSQL dump into the PostgreSQL database.
 
         Note: This method tries to import the private dump first, followed by the statistics
@@ -87,7 +87,7 @@ def import_dump(location):
 @cli.command()
 @click.option('--location', '-l')
 @click.option('--threads', '-t', type=int)
-def import_listens_dump(location=None, threads=None):
+def import_listens(location=None, threads=None):
     """ Import a ListenBrainz listen dump into the Influx database.
 
         Args:

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -44,6 +44,13 @@ cli = click.Group()
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'))
 @click.option('--threads', '-t', type=int)
 def create(location, threads):
+    """ Create a ListenBrainz data dump which includes a private dump, a statistics dump
+        and a dump of the actual listens from InfluxDB
+
+        Args:
+            location (str): path to the directory where the dump should be made
+            threads (int): the number of threads to be used while compression
+    """
     db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
     ls = init_influx_connection(log,  {
         'REDIS_HOST': config.REDIS_HOST,
@@ -62,6 +69,15 @@ def create(location, threads):
 @cli.command()
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'))
 def import_dump(location):
+    """ Import a ListenBrainz PostgreSQL dump into the PostgreSQL database.
+
+        Note: This method tries to import the private dump first, followed by the statistics
+            dump. However, in absence of a private dump, it imports sanitized versions of the
+            user table in the statistics dump in order to satisfy foreign key constraints.
+
+        Args:
+            location (str): path to the directory which contains the private and the stats dump
+    """
     db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
     db_dump.import_postgres_dump(location)
 
@@ -69,6 +85,11 @@ def import_dump(location):
 @cli.command()
 @click.option('--location', '-l')
 def import_listens_dump(location=None):
+    """ Import a ListenBrainz listen dump into the Influx database.
+
+        Args:
+            location (str): path to the listenbrainz listen .tar.xz archive
+    """
 
     if not location:
         print('No location given!')

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -83,8 +83,8 @@ class Listen(object):
     def from_json(cls, j):
         """Factory to make Listen() objects from a dict"""
         return cls(
-            user_id=j['user_id'],
-            user_name=j.get('user_name', ""),
+            user_id=j.get('user_id'),
+            user_name=j.get('user_name', ''),
             timestamp=datetime.utcfromtimestamp(float(j['listened_at'])),
             artist_msid=j['track_metadata']['additional_info'].get('artist_msid'),
             release_msid=j['track_metadata']['additional_info'].get('release_msid'),

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -488,7 +488,8 @@ class InfluxListenStore(ListenStore):
                     schema_seq = int(tar.extractfile(member).read().strip())
                     if schema_seq != LISTENS_DUMP_SCHEMA_VERSION:
                         raise SchemaMismatchException('Incorrect schema version! Expected: %d, got: %d.'
-                                        'Please, get the latest version of the dump.'
+                                        'Please ensure that the data dump version matches the code version'
+                                        'in order to import the data.'
                                         % (LISTENS_DUMP_SCHEMA_VERSION, schema_seq))
 
                 elif file_name.endswith('.listens'):

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -512,8 +512,6 @@ class InfluxListenStore(ListenStore):
 
                     # if some listens are left, write them to db
                     if listen_count > 0:
-                        self.log.info('Inserting following: ')
-                        self.log.info(json.dumps(listens, indent=4))
                         self.write_points_to_db(listens)
 
         self.log.info('Import of listens from dump %s done!', archive_path)

--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -15,16 +15,20 @@ class ListenStore(object):
         self.log = logging.getLogger(__name__)
         self.log.setLevel(logging.INFO)
 
+
     def max_id(self):
         return int(self.MAX_FUTURE_SECONDS + calendar.timegm(time.gmtime()))
+
 
     def fetch_listens_from_storage(self):
         """ Override this method in PostgresListenStore class """
         raise NotImplementedError()
 
+
     def get_total_listen_count(self):
         """ Return the total number of listens stored in the ListenStore """
         raise NotImplementedError()
+
 
     def get_listen_count_for_user(self, user_name, need_exact):
         """ Override this method in ListenStore implementation class
@@ -35,6 +39,7 @@ class ListenStore(object):
                         otherwise, can get from a cache also
         """
         raise NotImplementedError()
+
 
     def dump_listens(self, location, dump_time, threads=None):
         """ Override this method in the implementation class.
@@ -48,6 +53,17 @@ class ListenStore(object):
             the path to the dump archive
         """
         raise NotImplementedError()
+
+
+    def import_listens_dump(self, archive_path, threads=None):
+        """ Override this method in the implementation class.
+
+        Args:
+            archive (str): the path to the listens dump .tar.xz archive to be imported
+            threads (int): the number of threads to be used for decompression (defaults to 1)
+        """
+        raise NotImplementedError()
+
 
     def fetch_listens(self, user_name, from_ts=None, to_ts=None, limit=DEFAULT_LISTENS_PER_FETCH):
         """ Check from_ts, to_ts, and limit for fetching listens

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -234,6 +234,7 @@ class TestInfluxListenStore(DatabaseTestCase):
 
     def test_import_listens(self):
         count = self._create_test_data(self.testuser_name)
+        sleep(1)
         temp_dir = tempfile.mkdtemp()
         dump_location = self.logstore.dump_listens(
             location=temp_dir,

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -234,7 +234,7 @@ class TestInfluxListenStore(DatabaseTestCase):
 
     def test_import_listens(self):
         count = self._create_test_data(self.testuser_name)
-        sleep(1)
+        sleep(2)
         temp_dir = tempfile.mkdtemp()
         dump_location = self.logstore.dump_listens(
             location=temp_dir,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Add a function to `InfluxListenStore` that imports listens from a listen data dump created by LB.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-229](https://tickets.metabrainz.org/browse/LB-229)

It wasn't possible to actually import back listens into master archive from a data dump.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Just wrote some code that opens the tar file, checks the schema version and imports
listens from each user's file into their measurement.

Also added a click command to `manage.py` to import: `python manage.py dump import_listens_dump -l <location>`

And added a test for the import method.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

This is based on #277, so it'll need to be rebased after that gets merged.

