### PR TITLE
LB-247: Paginate listens before sending them to BigQuery

### DIFF
--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -93,7 +93,7 @@ class BigQueryWriter(ListenWriter):
             except pika.exceptions.ConnectionClosed:
                 self.connect_to_rabbitmq()
 
-            sleep(ERROR_RETRY_DELAY)
+            sleep(self.ERROR_RETRY_DELAY)
 
         # collect and occasionally print some stats
         time_taken = time() - t0

--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -27,7 +27,8 @@ except ImportError:
 
 # the number of listens to send to BQ in one batch
 # NOTE: this MUST be greater than the maximum number of listens sent to us in one
-# RabbitMQ batch
+# RabbitMQ batch, otherwise BigQueryWriter will submit a partial batch and send an ack for
+# the batch.
 SUBMIT_CHUNK_SIZE = 1000
 
 PREFETCH_COUNT = 20    # the number of RabbitMQ batches to prefetch

--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -25,11 +25,12 @@ except ImportError:
     pass
 
 
-# the number of listens to send to BQ in one batch
-# NOTE: this MUST be greater than the maximum number of listens sent to us in one
+SUBMIT_CHUNK_SIZE = 1000 # the number of listens to send to BQ in one batch
+
+# NOTE: this MUST be greater than or equal to the maximum number of listens sent to us in one
 # RabbitMQ batch, otherwise BigQueryWriter will submit a partial batch and send an ack for
 # the batch.
-SUBMIT_CHUNK_SIZE = 1000
+assert(SUBMIT_CHUNK_SIZE >= 50)
 
 PREFETCH_COUNT = 20    # the number of RabbitMQ batches to prefetch
 FLUSH_LISTENS_TIME = 3 # the number of seconds to wait before flushing all listens in queue to BQ

--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -1,22 +1,36 @@
 #!/usr/bin/env python3
 
-import sys
-import os
-import ujson
 import json
-import logging
-import pika
-from time import time, sleep
-from redis import Redis
 import listenbrainz.utils as utils
+import logging
+import os
+import pika
+import sys
+import ujson
 
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
+from listenbrainz.listen_writer import ListenWriter
 from listenbrainz.bigquery import create_bigquery_object
 from listenbrainz.bigquery import NoCredentialsVariableException, NoCredentialsFileException
 from oauth2client.client import GoogleCredentials
+from redis import Redis
+from time import time, sleep
 
-from listenbrainz.listen_writer import ListenWriter
+
+from listenbrainz import default_config as config
+try:
+    from listenbrainz import custom_config as config
+except ImportError:
+    pass
+
+
+# the number of listens to send to BQ in one batch
+# NOTE: this MUST be greater than the maximum number of listens sent to us in one
+# RabbitMQ batch
+SUBMIT_CHUNK_SIZE = 200
+# the number of RabbitMQ batches to prefetch
+PREFETCH_COUNT = 20
 
 # TODO:
 #   Big query hardcoded data set ids
@@ -28,52 +42,36 @@ class BigQueryWriter(ListenWriter):
         self.channel = None
         self.DUMP_JSON_WITH_ERRORS = True
 
+        self.bq_data = []
+        self.delivery_tags = []
 
-    def callback(self, ch, method, properties, body):
 
-        listens = ujson.loads(body)
-        count = len(listens)
 
-        # We've collected listens to write, now write them
-        bq_data = []
+    def submit_data(self):
+        """ Submits the data in self.bq_data to Google BigQuery and
+            acknowledges the appropriate delivery tags.
+        """
 
-        for listen in listens:
-            meta = listen['track_metadata']
-            row = {
-                'user_name' : listen['user_name'],
-                'listened_at' : listen['listened_at'],
+        if len(self.bq_data) == 0:
+            return
 
-                'artist_msid' : meta['additional_info']['artist_msid'],
-                'artist_name' : meta['artist_name'],
-                'artist_mbids' : ",".join(meta['additional_info'].get('artist_mbids', [])),
+        assert(len(self.bq_data) > 0)
+        assert(len(self.delivery_tags) > 0)
 
-                'release_msid' : meta['additional_info'].get('release_msid', ''),
-                'release_name' : meta['additional_info'].get('release_name', ''),
-                'release_mbid' : meta['additional_info'].get('release_mbid', ''),
+        t0 = time()
 
-                'track_name' : meta['track_name'],
-                'recording_msid' : listen['recording_msid'],
-                'recording_mbid' : meta['additional_info'].get('recording_mbid', ''),
-
-                'tags' : ",".join(meta['additional_info'].get('tags', [])),
-            }
-            bq_data.append({
-                'json': row,
-                'insertId': "%s-%s-%s" % (listen['user_name'], listen['listened_at'], listen['recording_msid'])
-            })
-
-        body = { 'rows' : bq_data }
+        # convert the data to BQ format and send
+        body = {
+            'rows': self.bq_data,
+        }
         while True:
             try:
-                t0 = time()
                 ret = self.bigquery.tabledata().insertAll(
                     projectId=self.config.BIGQUERY_PROJECT_ID,
                     datasetId=self.config.BIGQUERY_DATASET_ID,
                     tableId=self.config.BIGQUERY_TABLE_ID,
                     body=body).execute(num_retries=5)
-                self.time += time() - t0
                 break
-
             except HttpError as e:
                 self.log.error("Submit to BigQuery failed: %s. Retrying in 3 seconds." % str(e))
             except Exception as e:
@@ -84,16 +82,75 @@ class BigQueryWriter(ListenWriter):
             sleep(self.ERROR_RETRY_DELAY)
 
 
+        # now that data has been sent, acknowledge all delivery tags for listens in
+        # the current batch
+        latest_delivery_tag = max(self.delivery_tags)
         while True:
             try:
-                self.channel.basic_ack(delivery_tag = method.delivery_tag)
+                self.channel.basic_ack(delivery_tag=latest_delivery_tag, multiple=True)
                 break
             except pika.exceptions.ConnectionClosed:
                 self.connect_to_rabbitmq()
 
-        self.log.info("inserted %d listens." % count)
+            sleep(ERROR_RETRY_DELAY)
 
-        self._collect_and_log_stats(count)
+        # collect and occasionally print some stats
+        time_taken = time() - t0
+        self.total_inserts += len(self.bq_data)
+        self.log.info(
+            'Inserted %d listens in %.1fs (%.2f listens/sec). Total %d rows.',
+            len(self.bq_data),
+            time_taken,
+            len(self.bq_data) / time_taken,
+            self.total_inserts
+        )
+
+        # reset back to normal
+        self.bq_data = []
+        self.delivery_tags = []
+
+
+    def callback(self, ch, method, body):
+
+        listens = ujson.loads(body)
+        count = len(listens)
+
+        # if adding this batch pushes us over the line, send this batch before
+        # adding new listens to queue
+        if len(self.bq_data) + count > SUBMIT_CHUNK_SIZE:
+            self.submit_data()
+
+        # now add current listens to the queue
+        for listen in listens:
+            meta = listen['track_metadata']
+            row = {
+                'user_name' : listen['user_name'],
+                'listened_at' : listen['listened_at'],
+
+                'artist_msid' : meta['additional_info']['artist_msid'],
+                'artist_name' : meta['artist_name'],
+                'artist_mbids' : ','.join(meta['additional_info'].get('artist_mbids', [])),
+
+                'release_msid' : meta['additional_info'].get('release_msid', ''),
+                'release_name' : meta['additional_info'].get('release_name', ''),
+                'release_mbid' : meta['additional_info'].get('release_mbid', ''),
+
+                'track_name' : meta['track_name'],
+                'recording_msid' : listen['recording_msid'],
+                'recording_mbid' : meta['additional_info'].get('recording_mbid', ''),
+
+                'tags' : ','.join(meta['additional_info'].get('tags', [])),
+            }
+            self.bq_data.append({
+                'json': row,
+                'insertId': '%s-%s-%s' % (listen['user_name'], listen['listened_at'], listen['recording_msid'])
+            })
+
+        self.delivery_tags.append(method.delivery_tag)
+
+        # if we won't get any new messages until we ack these, submit data
+        if len(self.delivery_tags) == PREFETCH_COUNT:
+            self.submit_data()
 
         return True
 
@@ -133,6 +190,7 @@ class BigQueryWriter(ListenWriter):
                 lambda ch, method, properties, body: self.static_callback(ch, method, properties, body, obj=self),
                 queue=self.config.UNIQUE_QUEUE,
             )
+            self.channel.basic_qos(prefetch_count=PREFETCH_COUNT)
 
             self.log.info("bigquery-writer started")
             try:

--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -111,7 +111,7 @@ class BigQueryWriter(ListenWriter):
         self.delivery_tags = []
 
 
-    def callback(self, ch, method, body):
+    def callback(self, ch, method, properties, body):
 
         # if some timeout exists, remove it as we'll add a new one
         # before this method exits

--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -28,7 +28,7 @@ except ImportError:
 # the number of listens to send to BQ in one batch
 # NOTE: this MUST be greater than the maximum number of listens sent to us in one
 # RabbitMQ batch
-SUBMIT_CHUNK_SIZE = 200
+SUBMIT_CHUNK_SIZE = 1000
 # the number of RabbitMQ batches to prefetch
 PREFETCH_COUNT = 20
 

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -150,14 +150,15 @@ class TestInfluxListenStore(DatabaseTestCase):
 
     def test_import_listens(self):
         count = self._create_test_data(self.testuser_name)
-        sleep(2)
+        sleep(1)
         temp_dir = tempfile.mkdtemp()
         dump_location = self.logstore.dump_listens(
             location=temp_dir,
         )
+        sleep(1)
         self.assertTrue(os.path.isfile(dump_location))
         self.reset_influx_db()
-
+        sleep(1)
         self.logstore.import_listens_dump(dump_location)
         listens = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=1400000300)
         self.assertEqual(len(listens), 5)


### PR DESCRIPTION
Keep track of listens and delivery tags in lists and
only ack after the messages have been sent.

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Paginate listens before sending them to BigQuery. 


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The bigquery writer is currently reading one "block" of listens from RabbitMQ and then sending it to BigQuery. This is currently 50 listens at a time, so updating a backlog takes a really long time. 

Ideally, the writer would read up to a max number of listens from RabbitMQ, submit a much larger batch, making things much faster. We'll need to take care that we can't possibly lose the listens until they are successfully submitted to BQ. I think this needs careful management of the RabbitMQ consumption acknowledgement.

* JIRA ticket (_optional_): [LB-247](https://tickets.metabrainz.org/browse/LB-247)




# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Increase prefetch count, keep track of listens in a list and only submit when 
the number of listens becomes greater than a certain value. Also, do 
multiple acknowledgements of all delivery tags for a batch.

