### PR TITLE
LB-250: Move test data to json file

### DIFF
--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -3,7 +3,7 @@
 from listenbrainz.db.testing import DatabaseTestCase
 import logging
 from datetime import datetime
-from listenbrainz.listenstore.tests.util import generate_data, to_epoch
+from listenbrainz.listenstore.tests.util import create_test_data_for_influxlistenstore
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore import InfluxListenStore
 from listenbrainz.webserver.influx_connection import init_influx_connection
@@ -17,88 +17,6 @@ import listenbrainz.db.user as db_user
 from listenbrainz import config
 from time import sleep
 
-TEST_LISTEN_JSON = [
-    """
-    {
-        "track_metadata": {
-           "track_name": "Immigrant Song 0",
-           "additional_info": {
-              "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-              "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-              "release_msid": null
-           },
-           "artist_name": "Led Zeppelin"
-        },
-        "user_id": 1,
-        "listened_at": "1400000000",
-        "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-    }
-    """,
-    """
-    {
-        "track_metadata": {
-           "track_name": "Immigrant Song 50",
-           "additional_info": {
-              "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-              "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-              "release_msid": null
-           },
-           "artist_name": "Led Zeppelin"
-        },
-        "user_id": 1,
-        "listened_at": "1400000050",
-        "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-    }
-    """,
-    """
-    {
-        "track_metadata": {
-           "track_name": "Immigrant Song 100",
-           "additional_info": {
-              "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-              "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-              "release_msid": null
-           },
-           "artist_name": "Led Zeppelin"
-        },
-        "user_id": 1,
-        "listened_at": "1400000100",
-        "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-    }
-    """,
-    """
-    {
-        "track_metadata": {
-           "track_name": "Immigrant Song 150",
-           "additional_info": {
-              "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-              "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-              "release_msid": null
-           },
-           "artist_name": "Led Zeppelin"
-        },
-        "user_id": 1,
-        "listened_at": "1400000150",
-        "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-    }
-    """,
-    """
-    {
-        "track_metadata": {
-           "track_name": "Immigrant Song 200",
-           "additional_info": {
-              "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-              "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-              "release_msid": null
-           },
-           "artist_name": "Led Zeppelin"
-        },
-        "user_id": 1,
-        "listened_at": "1400000200",
-        "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-    }
-    """
-]
 
 class TestInfluxListenStore(DatabaseTestCase):
 
@@ -127,11 +45,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         super(TestInfluxListenStore, self).tearDown()
 
     def _create_test_data(self, user_name):
-        test_data = []
-        for jdata in TEST_LISTEN_JSON:
-            x = ujson.loads(jdata)
-            x['user_name'] = user_name
-            test_data.append(Listen().from_json(x))
+        test_data = create_test_data_for_influxlistenstore(user_name)
         self.logstore.insert(test_data)
         return len(test_data)
 

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -3,6 +3,11 @@
 from datetime import datetime, timedelta
 from listenbrainz.listen import Listen
 import uuid
+import json
+import os
+
+
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'testdata')
 
 
 def generate_data(test_user_id, from_ts, num_records):
@@ -19,3 +24,27 @@ def generate_data(test_user_id, from_ts, num_records):
 
 def to_epoch(date):
     return int((date - datetime.utcfromtimestamp(0)).total_seconds())
+
+
+def create_test_data_for_influxlistenstore(user_name):
+    """Create listens for influxlistenstore tests.
+
+    From a json file 'influx_listenstore_test_listens.json' in testdata
+    it creates Listen objects with a specified user_name for tests.
+
+    Args:
+        user_name (str): MusicBrainz username of a user.
+
+    Returns:
+        A list of Listen objects.
+    """
+    test_data_file = os.path.join(TEST_DATA_PATH, 'influx_listenstore_test_listens.json')
+    with open(test_data_file, 'r') as f:
+        listens = json.load(f)
+
+    test_data = []
+    for listen in listens['payload']:
+        listen['user_name'] = user_name
+        test_data.append(Listen().from_json(listen))
+
+    return test_data

--- a/listenbrainz/testdata/influx_listenstore_test_listens.json
+++ b/listenbrainz/testdata/influx_listenstore_test_listens.json
@@ -1,0 +1,75 @@
+{
+    "listen_type": "single",
+    "payload":[
+	{
+            "track_metadata": {
+		"track_name": "Immigrant Song 0",
+		"additional_info": {
+		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+		    "release_msid": null
+		},
+		"artist_name": "Led Zeppelin"
+            },
+            "user_id": 1,
+            "listened_at": "1400000000",
+            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+	},
+	{
+            "track_metadata": {
+		"track_name": "Immigrant Song 50",
+		"additional_info": {
+		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+		    "release_msid": null
+		},
+		"artist_name": "Led Zeppelin"
+            },
+            "user_id": 1,
+            "listened_at": "1400000050",
+            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+	},
+	{
+            "track_metadata": {
+		"track_name": "Immigrant Song 100",
+		"additional_info": {
+		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+		    "release_msid": null
+		},
+		"artist_name": "Led Zeppelin"
+            },
+            "user_id": 1,
+            "listened_at": "1400000100",
+            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+	},
+	{
+            "track_metadata": {
+		"track_name": "Immigrant Song 150",
+		"additional_info": {
+		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+		    "release_msid": null
+		},
+		"artist_name": "Led Zeppelin"
+            },
+            "user_id": 1,
+            "listened_at": "1400000150",
+            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+	},
+	{
+            "track_metadata": {
+		"track_name": "Immigrant Song 200",
+		"additional_info": {
+		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+		    "release_msid": null
+		},
+		"artist_name": "Led Zeppelin"
+            },
+            "user_id": 1,
+            "listened_at": "1400000200",
+            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+	}
+    ]
+}


### PR DESCRIPTION
Test data should be present in testdata folder not in python files.
And data preprocessing should be done in util file so that data can
be used for other tests.

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other

# Problem
We have json data in the python file. but we already have testdata folder for json data.
And it's good to use util.py for generating test data.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

# Solution
Create listens.json in testdata folder and put the json data into it.
Add function into util.py for data processing.
Remove json data from python file and use the function created in util.py to get test data.
