### PR TITLE
LB-85:  Make username in the profile URL case insensitive 

### DIFF
--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -1,8 +1,13 @@
-from flask import url_for
+from flask import url_for, current_app
+from influxdb import InfluxDBClient
+
+from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.listenstore.tests.util import create_test_data_for_influxlistenstore
+from listenbrainz.webserver.influx_connection import init_influx_connection
+from listenbrainz.webserver.testing import ServerTestCase
 
 import listenbrainz.db.user as db_user
-from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.webserver.testing import ServerTestCase
+import logging
 
 
 class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
@@ -12,7 +17,27 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.user = db_user.get_or_create('iliekcomputers')
         self.weirduser = db_user.get_or_create('weird\\user name')
 
+        self.log = logging.getLogger(__name__)
+        self.influx = InfluxDBClient(
+            host=current_app.config['INFLUX_HOST'],
+            port=current_app.config['INFLUX_PORT'],
+            database=current_app.config['INFLUX_DB_NAME'],
+        )
+
+        self.influx.query('''create database %s''' % current_app.config['INFLUX_DB_NAME'])
+
+        self.logstore = init_influx_connection(self.log, {
+            'REDIS_HOST': current_app.config['REDIS_HOST'],
+            'REDIS_PORT': current_app.config['REDIS_PORT'],
+            'INFLUX_HOST': current_app.config['INFLUX_HOST'],
+            'INFLUX_PORT': current_app.config['INFLUX_PORT'],
+            'INFLUX_DB_NAME': current_app.config['INFLUX_DB_NAME'],
+        })
+
     def tearDown(self):
+        self.influx.query('''drop database %s''' % current_app.config['INFLUX_DB_NAME'])
+        self.logstore = None
+
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
 
@@ -41,3 +66,17 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         )
         self.assert200(response)
         self.assertIn('var user_name = "weird%5Cuser%20name";', response.data.decode('utf-8'))
+
+    def _create_test_data(self, user_name):
+        test_data = create_test_data_for_influxlistenstore(user_name)
+        self.logstore.insert(test_data)
+
+    def test_username_case(self):
+        """Tests that the username in URL is case insenstive"""
+        self._create_test_data('iliekcomputers')
+
+        response1 = self.client.get(url_for('user.profile', user_name='iliekcomputers'))
+        response2 = self.client.get(url_for('user.profile', user_name='IlieKcomPUteRs'))
+        self.assert200(response1)
+        self.assert200(response2)
+        self.assertEqual(response1.data.decode('utf-8'), response2.data.decode('utf-8'))

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -51,6 +51,8 @@ def profile(user_name):
     playing_now_conn = webserver.redis_connection._redis
 
     user = _get_user(user_name)
+    # User name used to get user may not have the same case as original user name.
+    user_name = user.musicbrainz_id
 
     try:
         have_listen_count = True


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other


# Problem
Username in the profile url is case senstive.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): https://tickets.metabrainz.org/projects/LB/issues/LB-85?filter=allopenissues


# Solution
After querying the user with given user name from the URL(which is case insensitive), we use the user name of the queried user instead of using the user name from the URL.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
1. use the user name of the queried user instead of using the user name from the URL.
2. write an unit test to check case insensitivity. 
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


