### PR TITLE
LB-213: Add API usage examples to docs

### DIFF
--- a/docs/dev/api-usage.rst
+++ b/docs/dev/api-usage.rst
@@ -1,0 +1,100 @@
+.. role:: json(code)
+   :language: json
+
+.. role:: py(code)
+   :language: python
+
+API Usage Examples
+==================
+
+.. note::
+
+   These examples are written in Python version **3.6.3** and use `requests
+   <http://docs.python-requests.org/en/master/>`_ version **2.18.4**.
+
+Prerequisites
+#############
+
+All the examples assume you have a development version of the ListenBrainz
+server set up on :code:`localhost`. Remember to set :code:`DEBUG` to :py:`True`
+in the config. When in production, you can replace :code:`localhost` with
+:code:`api.listenbrainz.org` to use the real API. In order to use either one,
+you'll need a token. You can find it under :code:`ROOT/profile/` when signed
+in, with :code:`ROOT` being either :code:`localhost` for the dev version or
+:code:`listenbrainz.org` for the real API.
+
+.. caution::
+
+   You should use the token from the API you're using. In production, change the
+   token to one from :code:`listenbrainz.org`.
+
+If you want to run the samples, you'll need to add the imports from this common
+file that are required by each sample:
+
+.. include:: ./api_usage_examples/common.py
+   :code: python
+
+Examples
+########
+
+Submitting Listens
+------------------
+
+See :ref:`json-doc` for details on the format of the Track dictionaries.
+
+If everything goes well, the json response should be :json:`{"status": "ok"}`,
+and you should see a recent listen of "Never Gonna Give You Up" when you visit
+:code:`ROOT/user/{your-user-name}`.
+
+.. include:: ./api_usage_examples/submit_listens.py
+   :code: python
+
+Getting Listen History
+----------------------
+
+See :ref:`json-doc` for details on the format of the Track dictionaries.
+
+If there's nothing in the listen history of your user, you can run
+:code:`submit_listens` before this.
+
+If there is some listen history, you should see a list
+of tracks like this:
+
+.. code::
+
+    Track: Never Gonna Give You Up, listened at 1512040365
+    Track: Never Gonna Give You Up, listened at 1511977429
+    Track: Never Gonna Give You Up, listened at 1511968583
+    Track: Never Gonna Give You Up, listened at 1443521965
+    Track: Never Gonna Give You Up, listened at 42042042
+
+.. include:: ./api_usage_examples/get_listens.py
+   :code: python
+
+Latest Import
+-------------
+
+Set and get the timestamp of the latest import into ListenBrainz.
+
+Setting
+^^^^^^^
+
+.. include:: ./api_usage_examples/set_latest_import.py
+   :code: python
+
+Getting
+^^^^^^^
+
+If your user has never imported before and the latest import has never been
+set by a script, then the server will return :code:`0` by default. Run
+:code:`set_latest_import` before this if you don't want to actually import any
+data.
+
+You should see output like this:
+
+.. code::
+
+   User naiveaiguy last imported on 30 11 2017 at 12:23
+
+.. include:: ./api_usage_examples/get_latest_import.py
+   :code: python

--- a/docs/dev/api_usage_examples/get_latest_import.py
+++ b/docs/dev/api_usage_examples/get_latest_import.py
@@ -1,0 +1,44 @@
+'''
+get_latest_import.py
+'''
+
+import requests
+
+ROOT = '127.0.0.1'
+TOKEN = 'YOUR_TOKEN_HERE'
+USERNAME = 'YOUR_USERNAME_HERE' # Replace with the username from which you got the token above.
+AUTH_HEADER = {
+    "Authorization": "Token {0}".format(TOKEN)
+}
+
+# The AUTH_HEADER token can be any valid token.
+def get_latest_import(username):
+    """Gets the latest import timestamp of a given user.
+
+    Args:
+        username: User to get latest import time of.
+
+    Returns:
+        A Unix timestamp if there's an OK status.
+
+    Raises:
+        An HTTPError if there's a failure.
+        A ValueError if the JSON in the response is invalid.
+        An IndexError if the JSON is not structured as expected.
+    """
+    response = requests.get(
+        url="http://{0}/1/latest-import".format(ROOT),
+        params={
+            "user_name": username
+        },
+        headers=AUTH_HEADER
+    )
+
+    response.raise_for_status()
+
+    return response.json()["latest_import"]
+
+if __name__ == "__main__":
+    timestamp = get_latest_import(USERNAME)
+
+    print("User {0} last imported on {1}".format(USERNAME, timestamp))

--- a/docs/dev/api_usage_examples/get_listens.py
+++ b/docs/dev/api_usage_examples/get_listens.py
@@ -1,0 +1,55 @@
+'''
+get_listens.py
+'''
+
+import requests
+
+ROOT = '127.0.0.1'
+TOKEN = 'YOUR_TOKEN_HERE'
+USERNAME = 'YOUR_USERNAME_HERE' # Replace with the username from which you got the token above.
+AUTH_HEADER = {
+    "Authorization": "Token {0}".format(TOKEN)
+}
+
+# The token in AUTH-HEADER must be valid, but it doesn't have to be the token of the user you're
+# trying to get the listen history of.
+def get_listens(username, min_ts=None, max_ts=None, count=None):
+    """Gets the listen history of a given user.
+
+    Args:
+        username: User to get listen history of.
+        min_ts: History before this timestamp will not be returned.
+                DO NOT USE WITH max_ts.
+        max_ts: History after this timestamp will not be returned.
+                DO NOT USE WITH min_ts.
+        count: How many listens to return. If not specified,
+               uses a default from the server.
+
+    Returns:
+        A list of listen info dictionaries if there's an OK status.
+
+    Raises:
+        An HTTPError if there's a failure.
+        A ValueError if the JSON in the response is invalid.
+        An IndexError if the JSON is not structured as expected.
+    """
+    response = requests.get(
+        url="http://{0}/1/user/{1}/listens".format(ROOT, username),
+        params={
+            "min_ts": min_ts,
+            "max_ts": max_ts,
+            "count": count
+        },
+        headers=AUTH_HEADER
+    )
+
+    response.raise_for_status()
+
+    return response.json()['payload']['listens']
+
+if __name__ == "__main__":
+    listens = get_listens(USERNAME)
+
+    for track in listens:
+        print("Track: {0}, listened at {1}".format(track["track_metadata"]["track_name"],
+                                                   track.get("listened_at", "unknown")))

--- a/docs/dev/api_usage_examples/set_latest_import.py
+++ b/docs/dev/api_usage_examples/set_latest_import.py
@@ -1,0 +1,45 @@
+'''
+set_latest_import.py
+'''
+
+from time import time
+import requests
+
+ROOT = '127.0.0.1'
+TOKEN = 'YOUR_TOKEN_HERE'
+AUTH_HEADER = {
+    "Authorization": "Token {0}".format(TOKEN)
+}
+
+# Token in AUTH_HEADER must be that of the user you're setting for.
+def set_latest_import(timestamp):
+    """Sets the time of the latest import.
+
+    Args:
+        timestamp: Unix epoch to set latest import to.
+
+    Returns:
+        The JSON response if there's an OK status.
+
+    Raises:
+        An HTTPError if there's a failure.
+        A ValueError if the JSON response is invalid.
+    """
+    response = requests.post(
+        url="http://{0}/1/latest-import".format(ROOT),
+        json={
+            "ts": timestamp
+        },
+        headers=AUTH_HEADER
+    )
+
+    response.raise_for_status()
+
+    return response.json()
+
+if __name__ == "__main__":
+    epoch = int(time())
+    json_response = set_latest_import(epoch)
+
+    print("Response was: {0}".format(json_response))
+    print("Set latest import time to {0}.".format(epoch))

--- a/docs/dev/api_usage_examples/submit_listens.py
+++ b/docs/dev/api_usage_examples/submit_listens.py
@@ -1,0 +1,73 @@
+'''
+submit_listens.py
+'''
+
+from time import time
+from enum import Enum
+import requests
+
+ROOT = '127.0.0.1'
+TOKEN = 'YOUR_TOKEN_HERE'
+AUTH_HEADER = {
+    "Authorization": "Token {0}".format(TOKEN)
+}
+
+# The token in AUTH-HEADER must be the token of the user you're submitting listens for.
+def submit_listen(listen_type, payload):
+    """Submits listens for the track(s) in payload.
+
+    Args:
+        listen_type: One type from the ListenType enum.
+        payload: A list of Track dictionaries.
+
+    Returns:
+         The json response if there's an OK status.
+
+    Raises:
+         An HTTPError if there's a failure.
+         A ValueError is the JSON in the response is invalid.
+    """
+
+    response = requests.post(
+        url="http://{0}/1/submit-listens".format(ROOT),
+        json={
+            "listen_type": listen_type.value,
+            "payload": payload
+        },
+        headers=AUTH_HEADER
+    )
+
+    response.raise_for_status()
+
+    return response.json()
+
+class ListenType(Enum):
+    Single = "single"
+    Playing = "playing_now"
+    Import = "import"
+
+if __name__ == "__main__":
+    EXAMPLE_PAYLOAD = [
+        {
+            # An example track.
+            "listened_at": int(time()),
+            "track_metadata": {
+                "additional_info": {
+                    "release_mbid": "bf9e91ea-8029-4a04-a26a-224e00a83266",
+                    "artist_mbids": [
+                        "db92a151-1ac2-438b-bc43-b82e149ddd50"
+                    ],
+                    "recording_mbid": "98255a8c-017a-4bc7-8dd6-1fa36124572b",
+                    "tags": ["you", "just", "got", "semi", "rick", "rolled"]
+                },
+                "artist_name": "Rick Astley",
+                "track_name": "Never Gonna Give You Up",
+                "release_name": "Whenever you need somebody"
+            }
+        }
+    ]
+
+    json_response = submit_listen(listen_type=ListenType.Single, payload=EXAMPLE_PAYLOAD)
+
+    print("Response was: {0}".format(json_response))
+    print("Check your listens - there should be a Never Gonna Give You Up track, played recently.")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:
This adds fully executable usage examples in Python 3 for the current API version. Current version includes examples for:

* [x] ~~`submit-listens`~~
* [x] ~~`get-listens`~~
* [x] ~~`set-latest-import`~~
* [x] ~~`get-latest-import`~~

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: https://tickets.metabrainz.org/projects/LB/issues/LB-213


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Each endpoint has an example file that's executable and demonstrates an example usecase for that particular endpoint.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Some aspects of how long the examples are, what additional details are needed, what parts are extraneous (for example, is the `verify_args` function useful for examples) etc.
