### PR TITLE
LB-252: Allow specifying threads when importing Postgres db dump

### DIFF
--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -70,7 +70,8 @@ def create(location, threads):
 
 @cli.command()
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'))
-def import_db(location):
+@click.option('--threads', '-t', type=int)
+def import_db(location, threads=None):
     """ Import a ListenBrainz PostgreSQL dump into the PostgreSQL database.
 
         Note: This method tries to import the private dump first, followed by the statistics
@@ -79,9 +80,10 @@ def import_db(location):
 
         Args:
             location (str): path to the directory which contains the private and the stats dump
+            threads (int): the number of threads to use during decompression, defaults to 1
     """
     db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
-    db_dump.import_postgres_dump(location)
+    db_dump.import_postgres_dump(location, threads)
 
 
 @cli.command()

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -62,6 +62,7 @@ class DumpTestCase(DatabaseTestCase):
         now_dumps = db_dump.get_dump_entries()
         self.assertEqual(len(now_dumps), len(prev_dumps) + 1)
 
+
     def test_copy_table(self):
         db_dump.add_dump_entry()
         with db.engine.connect() as connection:
@@ -75,6 +76,7 @@ class DumpTestCase(DatabaseTestCase):
         with open(os.path.join(self.tempdir, 'data_dump'), 'r') as f:
             file_contents = [line for line in f]
         self.assertEqual(len(dumps), len(file_contents))
+
 
     def test_import_postgres_db(self):
 
@@ -94,4 +96,11 @@ class DumpTestCase(DatabaseTestCase):
         user_count = db_user.get_user_count()
         self.assertEqual(user_count, 1)
 
+        # reset again, and use more threads to import
+        self.reset_db()
+        user_count = db_user.get_user_count()
+        self.assertEqual(user_count, 0)
 
+        db_dump.import_postgres_dump(location, threads=2)
+        user_count = db_user.get_user_count()
+        self.assertEqual(user_count, 1)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-252](https://tickets.metabrainz.org/browse/LB-252)

We weren't able to specify the number of threads we want dump_manager to use while importing 
the db dumps.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add options to the click command and functions and add a test.



