### PR TITLE
LB-256: Add logging of config values and git commit to LB webserver

### DIFF
--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import subprocess
 
 from datetime import datetime
 
@@ -82,3 +83,9 @@ def log_ioerrors(logger, e):
         is added.
     """
     logger.error('IOError while creating dump: %s', str(e))
+
+
+def get_git_commit():
+    """ Gets the SHA hash of the current git commit of the repository
+    """
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8')[:8]


### PR DESCRIPTION
Also, add importing config values from consul_config.py
as done in MeB.org

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): LB-256


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add logging and call `git rev-parse HEAD` to get the git commit on which we're running.

