### PR TITLE
LB-237: Add config values for Sentry to consul_config and custom_config

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -77,3 +77,11 @@ UPLOAD_FOLDER = '''{{template "KEY" "upload_folder"}}'''
 
 API_URL = '''{{template "KEY" "api_url"}}'''
 LASTFM_PROXY_URL = '''{{template "KEY" "lastfm_proxy_url"}}'''
+
+
+# Sentry config
+LOG_SENTRY = {
+    'dsn': '''{{template "KEY" "sentry/dsn_private"}}''',
+    'environment': '''{{template "KEY" "sentry/environment"}}''',
+}
+SENTRY_DSN_PUBLIC = '''{{template "KEY" "sentry/dsn_public"}}'''

--- a/listenbrainz/custom_config.py.sample
+++ b/listenbrainz/custom_config.py.sample
@@ -76,8 +76,10 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 #LOG_EMAIL_TOPIC = "ListenBrainz Webserver Failure"
 #LOG_EMAIL_RECIPIENTS = []  # List of email addresses (strings)
 
-#LOG_SENTRY_ENABLED = True
-#SENTRY_DSN = ""
+#LOG_SENTRY = {
+#    "dsn": "YOUR_SENTRY_DSN",
+#    "level": "WARNING",  # optional
+#}
 
 
 # MISCELLANEOUS

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ coverage == 3.7.1
 click == 4.1
 jsonschema == 2.5.1
 rauth == 0.7.1
-raven[flask] == 5.5.0
 setproctitle == 1.1.8
 markupsafe == 0.23
 blist == 1.3.6


### PR DESCRIPTION
This should allow for error reporting on Sentry for beta.

I'm making this PR on master, holding off on prod for now.

I've created projects on https://sentry.metabrainz.org so this should work once we get the config values into beta.