### PR TITLE
LB-261: Show total listen count on index page ala AB

### DIFF
--- a/listenbrainz/webserver/templates/index/index.html
+++ b/listenbrainz/webserver/templates/index/index.html
@@ -53,6 +53,34 @@
     </div>
 
     <div class="col-md-5 col-lg-4">
+
+      <div id="stats" class="panel panel-default">
+        <div class="panel-heading"><strong>Data Statistics</strong></div>
+        <div class="panel-body">
+
+          <table class="table table-collapsed">
+            <thead>
+              <tr>
+                <th>Description</th>
+                <th>Number</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% if listen_count %}
+              <tr>
+                <td>Number of Listens</td>
+                <td>{{ "{:,}".format(listen_count) }}</td>
+              </tr>
+            {% endif %}
+            </tbody>
+          </table>
+          <p style="text-align: center">
+            <small>updated every 5 minutes</small><br />
+            <small><a href="{{ url_for('index.current_status') }}">more on the current status page</a></small>
+          </p>
+        </div>
+      </div>
+
       <div id="twitter-block">
         <a class="twitter-timeline" data-dnt="true" data-lang="en" href="https://twitter.com/ListenBrainz" data-widget-id="640261552604643328">Tweets by @ListenBrainz</a>
         <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -23,7 +23,19 @@ CACHE_TIME = 10 * 60 # time in seconds we cache the stats
 
 @index_bp.route("/")
 def index():
-    return render_template("index/index.html")
+
+    # get total listen count
+    try:
+        listen_count = _influx.get_total_listen_count()
+    except Exception as e:
+        current_app.logger.error('Error while trying to get total listen count: %s', str(e))
+        listen_count = None
+
+
+    return render_template(
+        "index/index.html",
+        listen_count=listen_count,
+    )
 
 
 @index_bp.route("/import")


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-261](https://tickets.metabrainz.org/browse/LB-261)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add a table to which we can pass stats.

This table should also open the doors to showing
other stats such as artist count etc on the home
page.

