### PR TITLE
LB-268: Escape usernames before creating files in dumps

### DIFF
--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 import shutil
 import ujson
+import urllib.parse
 
 from datetime import datetime
 
@@ -394,14 +395,16 @@ class InfluxListenStore(ListenStore):
 
                 # get listens from all measurements and write them to files in
                 # a temporary dir before adding them to the archive
-                for user in users:
+                for index, user in enumerate(users):
                     username = user['musicbrainz_id']
+                    self.log.info('Dumping listens for user #%d: %s...', index + 1, username)
                     offset = 0
 
-                    user_listens_file = '{username}.listens'.format(username=username)
+                    user_listens_file = '{username}.listens'.format(username=urllib.parse.quote_plus(username))
                     user_listens_path = os.path.join(listens_path, user_listens_file)
 
                     with open(user_listens_path, 'w') as f:
+
                         # Get this user's listens in chunks
                         while True:
 
@@ -494,7 +497,7 @@ class InfluxListenStore(ListenStore):
                 elif file_name.endswith('.listens'):
 
                     # remove .listens from the filename to get the username
-                    user_name = file_name[:-8]
+                    user_name = urllib.parse.unquote_plus(file_name[:-8])
                     self.log.info('Importing user %s', user_name)
                     listens = []
                     listen_count = 0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-268](https://tickets.metabrainz.org/browse/LB-268)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

`urllib.quote` the filenames and then unquote when getting the username back.
Also, add a test for weird users. :D

And add a bit more logging while dumps are being created.
