### PR TITLE
LB-278: Ensure dump entry added to Postgres is consistent with time specified

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -177,7 +177,7 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
     logger.info('Creating a new entry in the data_dump table...')
     while True:
         try:
-            dump_id = add_dump_entry()
+            dump_id = add_dump_entry(dump_time.strftime('%s'))
             break
         except Exception as e:
             logger.error('Error while adding dump entry: %s', str(e))
@@ -329,8 +329,11 @@ def copy_table(cursor, location, columns, table_name):
         ))
 
 
-def add_dump_entry():
-    """ Adds an entry to the data_dump table with current time.
+def add_dump_entry(timestamp):
+    """ Adds an entry to the data_dump table with specified time.
+
+        Args:
+            timestamp: the unix timestamp to be added
 
         Returns:
             id (int): the id of the new entry added
@@ -339,9 +342,11 @@ def add_dump_entry():
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
                 INSERT INTO data_dump (created)
-                     VALUES (NOW())
+                     VALUES (TO_TIMESTAMP(:ts))
                   RETURNING id
-            """))
+            """), {
+                'ts': timestamp,
+            })
         return result.fetchone()['id']
 
 

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -58,13 +58,13 @@ class DumpTestCase(DatabaseTestCase):
 
     def test_add_dump_entry(self):
         prev_dumps = db_dump.get_dump_entries()
-        db_dump.add_dump_entry()
+        db_dump.add_dump_entry(datetime.today().strftime('%s'))
         now_dumps = db_dump.get_dump_entries()
         self.assertEqual(len(now_dumps), len(prev_dumps) + 1)
 
 
     def test_copy_table(self):
-        db_dump.add_dump_entry()
+        db_dump.add_dump_entry(datetime.today().strftime('%s'))
         with db.engine.connect() as connection:
             db_dump.copy_table(
                 cursor=connection.connection.cursor(),
@@ -104,3 +104,12 @@ class DumpTestCase(DatabaseTestCase):
         db_dump.import_postgres_dump(location, threads=2)
         user_count = db_user.get_user_count()
         self.assertEqual(user_count, 1)
+
+
+    def test_dump_postgres_db_table_entries(self):
+        db_user.create('test_user')
+        timestamp = datetime.today()
+        location = db_dump.dump_postgres_db(self.tempdir, dump_time=timestamp)
+        dump_entries = db_dump.get_dump_entries()
+        self.assertEqual(len(dump_entries), 1)
+        self.assertEqual(dump_entries[0]['created'].strftime('%s'), timestamp.strftime('%s'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-278](https://tickets.metabrainz.org/browse/LB-278)

The timestamp in the archives wouldn't be consistent with the timestamp added to the db.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Pass the time explicitly to the method that creates the dump entry and add a test.


