### PR TITLE
LB-198: Use brainzutils for caching instead of directly using redis

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -24,6 +24,7 @@ PG_ASYNC_LISTEN_COMMIT = False
 {{with index (service "listenbrainz-redis") 0}}
 REDIS_HOST = "{{.Address}}"
 REDIS_PORT = {{.Port}}
+REDIS_NAMESPACE = "listenbrainz"
 {{end}}
 {{end}}
 

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -59,6 +59,7 @@ def create(location, threads):
     ls = init_influx_connection(log,  {
         'REDIS_HOST': config.REDIS_HOST,
         'REDIS_PORT': config.REDIS_PORT,
+        'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
         'INFLUX_HOST': config.INFLUX_HOST,
         'INFLUX_PORT': config.INFLUX_PORT,
         'INFLUX_DB_NAME': config.INFLUX_DB_NAME,
@@ -100,6 +101,7 @@ def import_dump(private_archive, public_archive, listen_archive, threads):
     ls = init_influx_connection(log,  {
         'REDIS_HOST': config.REDIS_HOST,
         'REDIS_PORT': config.REDIS_PORT,
+        'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
         'INFLUX_HOST': config.INFLUX_HOST,
         'INFLUX_PORT': config.INFLUX_PORT,
         'INFLUX_DB_NAME': config.INFLUX_DB_NAME,

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -28,6 +28,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
             'INFLUX_DB_NAME': config.INFLUX_DB_NAME,
             'REDIS_HOST': config.REDIS_HOST,
             'REDIS_PORT': config.REDIS_PORT,
+            'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
         })
 
         # Create a user

--- a/listenbrainz/default_config.py
+++ b/listenbrainz/default_config.py
@@ -23,6 +23,7 @@ PG_ASYNC_LISTEN_COMMIT = False
 # Redis
 REDIS_HOST = "redis"
 REDIS_PORT = 6379
+REDIS_NAMESPACE = "listenbrainz"
 
 # Influx DB (main listen store)
 INFLUX_HOST    = "influx"

--- a/listenbrainz/influx_writer/count_flusher.py
+++ b/listenbrainz/influx_writer/count_flusher.py
@@ -10,9 +10,9 @@ except ImportError:
     pass
 from listenbrainz.listenstore import InfluxListenStore
 
-ls = InfluxListenStore({ 'REDIS_HOST' : config.REDIS_HOST,
-                         'REDIS_PORT' : config.REDIS_PORT,
-                         'REDIS_NAMESPACE' : config.REDIS_NAMESPACE,
+ls = InfluxListenStore({ 'REDIS_HOST': config.REDIS_HOST,
+                         'REDIS_PORT': config.REDIS_PORT,
+                         'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
                          'INFLUX_HOST': config.INFLUX_HOST,
                          'INFLUX_PORT': config.INFLUX_PORT,
                          'INFLUX_DB_NAME': config.INFLUX_DB_NAME})

--- a/listenbrainz/influx_writer/count_flusher.py
+++ b/listenbrainz/influx_writer/count_flusher.py
@@ -12,6 +12,7 @@ from listenbrainz.listenstore import InfluxListenStore
 
 ls = InfluxListenStore({ 'REDIS_HOST' : config.REDIS_HOST,
                          'REDIS_PORT' : config.REDIS_PORT,
+                         'REDIS_NAMESPACE' : config.REDIS_NAMESPACE,
                          'INFLUX_HOST': config.INFLUX_HOST,
                          'INFLUX_PORT': config.INFLUX_PORT,
                          'INFLUX_DB_NAME': config.INFLUX_DB_NAME})

--- a/listenbrainz/influx_writer/influx_writer.py
+++ b/listenbrainz/influx_writer/influx_writer.py
@@ -233,6 +233,7 @@ class InfluxWriterSubscriber(ListenWriter):
             try:
                 self.ls = InfluxListenStore({ 'REDIS_HOST' : self.config.REDIS_HOST,
                                               'REDIS_PORT' : self.config.REDIS_PORT,
+                                              'REDIS_NAMESPACE' : self.config.REDIS_NAMESPACE,
                                               'INFLUX_HOST': self.config.INFLUX_HOST,
                                               'INFLUX_PORT': self.config.INFLUX_PORT,
                                               'INFLUX_DB_NAME': self.config.INFLUX_DB_NAME})

--- a/listenbrainz/influx_writer/influx_writer.py
+++ b/listenbrainz/influx_writer/influx_writer.py
@@ -231,9 +231,9 @@ class InfluxWriterSubscriber(ListenWriter):
 
         while True:
             try:
-                self.ls = InfluxListenStore({ 'REDIS_HOST' : self.config.REDIS_HOST,
-                                              'REDIS_PORT' : self.config.REDIS_PORT,
-                                              'REDIS_NAMESPACE' : self.config.REDIS_NAMESPACE,
+                self.ls = InfluxListenStore({ 'REDIS_HOST': self.config.REDIS_HOST,
+                                              'REDIS_PORT': self.config.REDIS_PORT,
+                                              'REDIS_NAMESPACE': self.config.REDIS_NAMESPACE,
                                               'INFLUX_HOST': self.config.INFLUX_HOST,
                                               'INFLUX_PORT': self.config.INFLUX_PORT,
                                               'INFLUX_DB_NAME': self.config.INFLUX_DB_NAME})

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -49,7 +49,7 @@ class InfluxListenStore(ListenStore):
         ListenStore.__init__(self, conf)
         self.influx = InfluxDBClient(host=conf['INFLUX_HOST'], port=conf['INFLUX_PORT'], database=conf['INFLUX_DB_NAME'])
         # Initialize brainzutils cache
-        init_cache()
+        init_cache(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'], namespace=conf['REDIS_NAMESPACE'])
 
     def get_listen_count_for_user(self, user_name, need_exact=False):
         """Get the total number of listens for a user. The number of listens comes from

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -10,11 +10,11 @@ import shutil
 import ujson
 import uuid
 
+from brainzutils import cache
 from collections import defaultdict
 from datetime import datetime
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
-from redis import Redis
 
 from listenbrainz import DUMP_LICENSE_FILE_PATH
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
@@ -47,13 +47,11 @@ class InfluxListenStore(ListenStore):
 
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
-        self.redis = Redis(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'], decode_responses=True)
-        self.redis.ping()
         self.influx = InfluxDBClient(host=conf['INFLUX_HOST'], port=conf['INFLUX_PORT'], database=conf['INFLUX_DB_NAME'])
 
     def get_listen_count_for_user(self, user_name, need_exact=False):
         """Get the total number of listens for a user. The number of listens comes from
-           a redis cache unless an exact number is asked for.
+           brainzutils cache unless an exact number is asked for.
 
         Args:
             user_name: the user to get listens for
@@ -61,9 +59,12 @@ class InfluxListenStore(ListenStore):
         """
 
         if not need_exact:
-            # check if the user's listen count is already in redis
+            # check if the user's listen count is already in cache
             # if already present return it directly instead of calculating it again
-            count = self.redis.get(REDIS_INFLUX_USER_LISTEN_COUNT + user_name)
+            # decode is set to False as we have not encoded the value when we set it
+            # in brainzutils cache as we need to call increment operation which requires
+            # an integer value
+            count = cache.get(REDIS_INFLUX_USER_LISTEN_COUNT + user_name, decode=False)
             if count:
                 return int(count)
 
@@ -79,9 +80,9 @@ class InfluxListenStore(ListenStore):
         except (KeyError, StopIteration):
             count = 0
 
-        # put this value into redis with an expiry time
+        # put this value into brainzutils cache with an expiry time
         user_key = "{}{}".format(REDIS_INFLUX_USER_LISTEN_COUNT, user_name)
-        self.redis.setex(user_key, count, InfluxListenStore.USER_LISTEN_COUNT_CACHE_TIME)
+        cache.set(user_key, int(count), InfluxListenStore.USER_LISTEN_COUNT_CACHE_TIME, encode=False)
         return int(count)
 
     def reset_listen_count(self, user_name):
@@ -117,14 +118,14 @@ class InfluxListenStore(ListenStore):
 
         return None
 
-    def get_total_listen_count(self, cache=True):
+    def get_total_listen_count(self, cache_value=True):
         """ Returns the total number of listens stored in the ListenStore.
-            First checks the redis cache for the value, if not present there
-            makes a query to the db and caches it in redis.
+            First checks the brainzutils cache for the value, if not present there
+            makes a query to the db and caches it in brainzutils cache.
         """
 
-        if cache:
-            count = self.redis.get(InfluxListenStore.REDIS_INFLUX_TOTAL_LISTEN_COUNT)
+        if cache_value:
+            count = cache.get(InfluxListenStore.REDIS_INFLUX_TOTAL_LISTEN_COUNT, decode=False)
             if count:
                 return int(count)
 
@@ -160,15 +161,20 @@ class InfluxListenStore(ListenStore):
         except StopIteration:
             pass
 
-        if cache:
-            self.redis.setex(InfluxListenStore.REDIS_INFLUX_TOTAL_LISTEN_COUNT, count, InfluxListenStore.TOTAL_LISTEN_COUNT_CACHE_TIME)
+        if cache_value:
+            cache.set(
+                InfluxListenStore.REDIS_INFLUX_TOTAL_LISTEN_COUNT,
+                int(count),
+                InfluxListenStore.TOTAL_LISTEN_COUNT_CACHE_TIME,
+                encode=False,
+            )
         return count
 
     def get_timestamps_for_user(self, user_name):
-        """ Return the max_ts and min_ts for a given user and cache the result in redis
+        """ Return the max_ts and min_ts for a given user and cache the result in brainzutils cache
         """
 
-        tss = self.redis.get(REDIS_USER_TIMESTAMPS % user_name)
+        tss = cache.get(REDIS_USER_TIMESTAMPS % user_name)
         if tss:
             (min_ts, max_ts) = tss.split(",")
             min_ts = int(min_ts)
@@ -180,7 +186,7 @@ class InfluxListenStore(ListenStore):
             query = 'SELECT last(artist_msid) FROM ' + get_escaped_measurement_name(user_name)
             max_ts = self._select_single_timestamp(query, get_measurement_name(user_name))
 
-            self.redis.setex(REDIS_USER_TIMESTAMPS % user_name, "%d,%d" % (min_ts, max_ts), USER_CACHE_TIME)
+            cache.set(REDIS_USER_TIMESTAMPS % user_name, "%d,%d" % (min_ts, max_ts), USER_CACHE_TIME)
 
         return min_ts, max_ts
 
@@ -198,15 +204,16 @@ class InfluxListenStore(ListenStore):
             self.log.error("Cannot write data to influx. (write_points returned False)")
 
         # If we reach this point, we were able to write the listens to the InfluxListenStore.
-        # So update the listen counts of the users cached in redis.
+        # So update the listen counts of the users cached in brainzutils cache.
         for data in submit:
             user_key = "{}{}".format(REDIS_INFLUX_USER_LISTEN_COUNT, data['fields']['user_name'])
-            if self.redis.exists(user_key):
-                self.redis.incr(user_key)
+
+            if cache.get(user_key, decode=False):
+                cache.increment(user_key)
 
         # Invalidate cached data for user
         for user_name in user_names.keys():
-            self.redis.delete(REDIS_USER_TIMESTAMPS % user_name)
+            cache.delete(REDIS_USER_TIMESTAMPS % user_name)
 
         if len(listens):
             # Enter a measurement to count items inserted

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -25,7 +25,7 @@ from listenbrainz.listenstore import ORDER_ASC, ORDER_TEXT, \
     USER_CACHE_TIME, REDIS_USER_TIMESTAMPS, LISTENS_DUMP_SCHEMA_VERSION
 from listenbrainz.utils import quote, get_escaped_measurement_name, get_measurement_name, get_influx_query_timestamp, \
     convert_influx_nano_to_python_time, convert_python_time_to_nano_int, convert_to_unix_timestamp, \
-    create_path, log_ioerrors
+    create_path, log_ioerrors, init_cache
 
 REDIS_INFLUX_USER_LISTEN_COUNT = "ls.listencount."  # append username
 COUNT_RETENTION_POLICY = "one_week"
@@ -48,6 +48,8 @@ class InfluxListenStore(ListenStore):
     def __init__(self, conf):
         ListenStore.__init__(self, conf)
         self.influx = InfluxDBClient(host=conf['INFLUX_HOST'], port=conf['INFLUX_PORT'], database=conf['INFLUX_DB_NAME'])
+        # Initialize brainzutils cache
+        init_cache()
 
     def get_listen_count_for_user(self, user_name, need_exact=False):
         """Get the total number of listens for a user. The number of listens comes from

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -51,6 +51,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         self.logstore = init_influx_connection(self.log, {
             'REDIS_HOST': config.REDIS_HOST,
             'REDIS_PORT': config.REDIS_PORT,
+            'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
             'INFLUX_HOST': config.INFLUX_HOST,
             'INFLUX_PORT': config.INFLUX_PORT,
             'INFLUX_DB_NAME': config.INFLUX_DB_NAME,

--- a/listenbrainz/test_config.py
+++ b/listenbrainz/test_config.py
@@ -23,6 +23,7 @@ PG_ASYNC_LISTEN_COMMIT = False
 # Redis
 REDIS_HOST = "redis"
 REDIS_PORT = 6379
+REDIS_NAMESPACE = "listenbrainz"
 
 # Influx DB (main listen store)
 INFLUX_HOST    = "influx"

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -44,9 +44,9 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         super(APICompatDeprecatedTestCase, self).setUp()
         self.user = db_user.get_or_create('apicompatoldtestuser')
         self.ls = InfluxListenStore({
-            'REDIS_HOST' : config.REDIS_HOST,
-            'REDIS_PORT' : config.REDIS_PORT,
-            'REDIS_NAMESPACE' : config.REDIS_NAMESPACE,
+            'REDIS_HOST': config.REDIS_HOST,
+            'REDIS_PORT': config.REDIS_PORT,
+            'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
             'INFLUX_HOST': config.INFLUX_HOST,
             'INFLUX_PORT': config.INFLUX_PORT,
             'INFLUX_DB_NAME': config.INFLUX_DB_NAME,

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -46,6 +46,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.ls = InfluxListenStore({
             'REDIS_HOST' : config.REDIS_HOST,
             'REDIS_PORT' : config.REDIS_PORT,
+            'REDIS_NAMESPACE' : config.REDIS_NAMESPACE,
             'INFLUX_HOST': config.INFLUX_HOST,
             'INFLUX_PORT': config.INFLUX_PORT,
             'INFLUX_DB_NAME': config.INFLUX_DB_NAME,

--- a/listenbrainz/tests/integration/test_influx_writer.py
+++ b/listenbrainz/tests/integration/test_influx_writer.py
@@ -20,9 +20,9 @@ class InfluxWriterTestCase(IntegrationTestCase):
 
     def setUp(self):
         super(InfluxWriterTestCase, self).setUp()
-        self.ls = InfluxListenStore({ 'REDIS_HOST' : config.REDIS_HOST,
-                             'REDIS_PORT' : config.REDIS_PORT,
-                             'REDIS_NAMESPACE' : config.REDIS_NAMESPACE,
+        self.ls = InfluxListenStore({ 'REDIS_HOST': config.REDIS_HOST,
+                             'REDIS_PORT': config.REDIS_PORT,
+                             'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
                              'INFLUX_HOST': config.INFLUX_HOST,
                              'INFLUX_PORT': config.INFLUX_PORT,
                              'INFLUX_DB_NAME': config.INFLUX_DB_NAME})

--- a/listenbrainz/tests/integration/test_influx_writer.py
+++ b/listenbrainz/tests/integration/test_influx_writer.py
@@ -22,6 +22,7 @@ class InfluxWriterTestCase(IntegrationTestCase):
         super(InfluxWriterTestCase, self).setUp()
         self.ls = InfluxListenStore({ 'REDIS_HOST' : config.REDIS_HOST,
                              'REDIS_PORT' : config.REDIS_PORT,
+                             'REDIS_NAMESPACE' : config.REDIS_NAMESPACE,
                              'INFLUX_HOST': config.INFLUX_HOST,
                              'INFLUX_PORT': config.INFLUX_PORT,
                              'INFLUX_DB_NAME': config.INFLUX_DB_NAME})

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -118,3 +118,25 @@ def connect_to_rabbitmq(username, password,
             error_message = "Cannot connect to RabbitMQ: {error}, retrying in {delay} seconds."
             error_logger(error_message.format(error=str(err), delay=error_retry_delay))
             time.sleep(error_retry_delay)
+
+
+def init_cache():
+    """ Initializes brainzutils cache. """
+    from brainzutils import cache
+    from listenbrainz import default_config as config
+    try:
+        from listenbrainz import custom_config as config
+    except ImportError:
+        pass
+
+    import logging
+
+    try:
+        cache.init(
+            host=config.REDIS_HOST,
+            port=config.REDIS_PORT,
+            namespace=config.REDIS_NAMESPACE,
+        )
+    except KeyError as e:
+        logging.error("Redis is not defined in config file. Error: {}".format(e))
+        raise

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -120,23 +120,7 @@ def connect_to_rabbitmq(username, password,
             time.sleep(error_retry_delay)
 
 
-def init_cache():
+def init_cache(host, port, namespace):
     """ Initializes brainzutils cache. """
     from brainzutils import cache
-    from listenbrainz import default_config as config
-    try:
-        from listenbrainz import custom_config as config
-    except ImportError:
-        pass
-
-    import logging
-
-    try:
-        cache.init(
-            host=config.REDIS_HOST,
-            port=config.REDIS_PORT,
-            namespace=config.REDIS_NAMESPACE,
-        )
-    except KeyError as e:
-        logging.error("Redis is not defined in config file. Error: {}".format(e))
-        raise
+    cache.init(host=host, port=port, namespace=namespace)

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -5,6 +5,7 @@ from time import sleep
 from shutil import copyfile
 
 from brainzutils.flask import CustomFlask
+from listenbrainz.webserver.utils import init_cache
 
 API_PREFIX = '/1'
 
@@ -102,6 +103,9 @@ def gen_app(config_path=None, debug=None):
         email_config=app.config.get('LOG_EMAIL'),
         sentry_config=app.config.get('LOG_SENTRY')
     )
+
+    # Brainzutils cache
+    init_cache(app)
 
     # Redis connection
     create_redis(app)

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -5,7 +5,6 @@ from time import sleep
 from shutil import copyfile
 
 from brainzutils.flask import CustomFlask
-from listenbrainz.webserver.utils import init_cache
 
 API_PREFIX = '/1'
 
@@ -103,9 +102,6 @@ def gen_app(config_path=None, debug=None):
         email_config=app.config.get('LOG_EMAIL'),
         sentry_config=app.config.get('LOG_SENTRY')
     )
-
-    # Brainzutils cache
-    init_cache(app)
 
     # Redis connection
     create_redis(app)

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -23,6 +23,7 @@ def create_influx(app):
         'INFLUX_DB_NAME': app.config['INFLUX_DB_NAME'],
         'REDIS_HOST': app.config['REDIS_HOST'],
         'REDIS_PORT': app.config['REDIS_PORT'],
+        'REDIS_NAMESPACE': app.config['REDIS_NAMESPACE'],
     })
 
 

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -25,16 +25,3 @@ def reformat_date(value, fmt="%b %d, %Y"):
 
 def reformat_datetime(value, fmt="%b %d, %Y, %H:%M %Z"):
     return value.strftime(fmt)
-
-def init_cache(app):
-    from brainzutils import cache
-    import logging
-    try:
-        cache.init(
-            host=app.config['REDIS_HOST'],
-            port=app.config['REDIS_PORT'],
-            namespace=app.config['REDIS_NAMESPACE'],
-        )
-    except KeyError as e:
-        logging.error("Redis is not defined in config file. Error: {}".format(e))
-        raise

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -25,3 +25,16 @@ def reformat_date(value, fmt="%b %d, %Y"):
 
 def reformat_datetime(value, fmt="%b %d, %Y, %H:%M %Z"):
     return value.strftime(fmt)
+
+def init_cache(app):
+    from brainzutils import cache
+    import logging
+    try:
+        cache.init(
+            host=app.config['REDIS_HOST'],
+            port=app.config['REDIS_PORT'],
+            namespace=app.config['REDIS_NAMESPACE'],
+        )
+    except KeyError as e:
+        logging.error("Redis is not defined in config file. Error: {}".format(e))
+        raise

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -1,8 +1,8 @@
 
 #TODO(param): alphabetize these
+from brainzutils import cache
 from flask import Blueprint, render_template, current_app, redirect, url_for
 from flask_login import current_user
-from listenbrainz.webserver.redis_connection import _redis
 import os
 import subprocess
 import locale
@@ -121,18 +121,18 @@ def current_status():
 
 
 def _get_user_count():
-    """ Gets user count from either the redis cache or from the database.
+    """ Gets user count from either the brainzutils cache or from the database.
         If not present in the cache, it makes a query to the db and stores the
         result in the cache for 10 minutes.
     """
-    redis_connection = _redis.redis
     user_count_key = "{}.{}".format(STATS_PREFIX, 'user_count')
-    if redis_connection.exists(user_count_key):
-        return redis_connection.get(user_count_key)
+    user_count = cache.get(user_count_key, decode=False)
+    if user_count:
+        return user_count
     else:
         try:
             user_count = db_user.get_user_count()
         except DatabaseException as e:
             raise
-        redis_connection.setex(user_count_key, user_count, CACHE_TIME)
+        cache.set(user_count_key, int(user_count), CACHE_TIME, encode=False)
         return user_count

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -32,6 +32,7 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.logstore = init_influx_connection(self.log, {
             'REDIS_HOST': current_app.config['REDIS_HOST'],
             'REDIS_PORT': current_app.config['REDIS_PORT'],
+            'REDIS_NAMESPACE': current_app.config['REDIS_NAMESPACE'],
             'INFLUX_HOST': current_app.config['INFLUX_HOST'],
             'INFLUX_PORT': current_app.config['INFLUX_PORT'],
             'INFLUX_DB_NAME': current_app.config['INFLUX_DB_NAME'],

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -5,6 +5,7 @@ import ujson
 
 from flask import Blueprint, render_template, request, url_for, Response, redirect, flash, current_app, jsonify
 from flask_login import current_user, login_required
+from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from listenbrainz import webserver
 from listenbrainz.webserver import flash
 from listenbrainz.webserver.decorators import crossdomain


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem
brainzutils cache has code which can be used for caching instead of using redis directly.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-198](https://tickets.metabrainz.org/browse/LB-198)


# Solution
Start using brainzutils instead of redis
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->