### PR TITLE
Change Import dumps interface

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -365,24 +365,13 @@ def get_dump_entries():
         return [dict(row) for row in result]
 
 
-def import_postgres_dump(location, threads=None):
+def import_postgres_dump(private_dump_archive_path=None, public_dump_archive_path=None, threads=None):
     """ Imports postgres dump created by dump_postgres_db present at location.
 
         Arguments:
             location: the directory where the private and public archives are present
             threads: the number of threads to use while decompressing the archives, defaults to 1
     """
-
-    private_dump_archive_path = None
-    public_dump_archive_path = None
-
-    for archive in os.listdir(location):
-        if os.path.isfile(os.path.join(location, archive)):
-            if 'private' in archive:
-                private_dump_archive_path = os.path.join(location, archive)
-            else:
-                public_dump_archive_path = os.path.join(location, archive)
-
 
     if private_dump_archive_path:
         logger.info('Importing private dump %s...', private_dump_archive_path)
@@ -424,8 +413,6 @@ def import_postgres_dump(location, threads=None):
             logger.error('Error while importing public dump: %s', str(e))
             raise
         logger.info('Public dump %s imported!', public_dump_archive_path)
-
-    logger.info('PostgreSQL import of data dump at %s done!', location)
 
 
 

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -135,7 +135,7 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
             threads: Maximal number of threads to run during compression
 
         Returns:
-            Path to created dump.
+            a tuple: (path to private dump, path to public dump)
     """
 
     logger.info('Beginning dump of PostgreSQL database...')
@@ -186,7 +186,7 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
     logger.info('New entry with id %d added to data_dump table!', dump_id)
 
     logger.info('ListenBrainz PostgreSQL data dump created at %s!', location)
-    return location
+    return private_dump, public_dump
 
 
 def _create_dump(location, dump_type, tables, dump_time, threads=None):

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -86,13 +86,13 @@ class DumpTestCase(DatabaseTestCase):
         self.assertEqual(user_count, 1)
 
         # do a db dump and reset the db
-        location = db_dump.dump_postgres_db(self.tempdir)
+        private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir)
         self.reset_db()
         user_count = db_user.get_user_count()
         self.assertEqual(user_count, 0)
 
         # import the dump
-        db_dump.import_postgres_dump(location)
+        db_dump.import_postgres_dump(private_dump, public_dump)
         user_count = db_user.get_user_count()
         self.assertEqual(user_count, 1)
 
@@ -101,7 +101,7 @@ class DumpTestCase(DatabaseTestCase):
         user_count = db_user.get_user_count()
         self.assertEqual(user_count, 0)
 
-        db_dump.import_postgres_dump(location, threads=2)
+        db_dump.import_postgres_dump(private_dump, public_dump, threads=2)
         user_count = db_user.get_user_count()
         self.assertEqual(user_count, 1)
 


### PR DESCRIPTION
As discussed on IRC, I've changed the manage.py import command to take paths to the archives directly instead of taking a directory as input.

Based on #326, will rebase after that gets merged.