### PR TITLE
LB-292: Get release name from correct place in bigquery-writer

### DIFF
--- a/listenbrainz/bigquery-writer/bigquery-writer.py
+++ b/listenbrainz/bigquery-writer/bigquery-writer.py
@@ -141,7 +141,7 @@ class BigQueryWriter(ListenWriter):
                 'artist_mbids' : ','.join(meta['additional_info'].get('artist_mbids', [])),
 
                 'release_msid' : meta['additional_info'].get('release_msid', ''),
-                'release_name' : meta['additional_info'].get('release_name', ''),
+                'release_name' : meta.get('release_name', ''),
                 'release_mbid' : meta['additional_info'].get('release_mbid', ''),
 
                 'track_name' : meta['track_name'],


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-292](https://tickets.metabrainz.org/browse/LB-292) 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Release names are supposed to be in track_metadata and
not additional_info.

Tests in #331 