### PR TITLE
LB-291: Add stats config values to consul_config template

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -85,3 +85,9 @@ LOG_SENTRY = {
     'environment': '''{{template "KEY" "sentry/environment"}}''',
 }
 SENTRY_DSN_PUBLIC = '''{{template "KEY" "sentry/dsn_public"}}'''
+
+
+# Stats
+STATS_ENTITY_LIMIT = 100 # the number of entities to calculate at max with BQ
+STATS_CALCULATION_LOGIN_TIME = 30 # users must have logged in to LB in the past 30 days for stats to be calculated
+STATS_CALCULATION_INTERVAL = 7 # stats are calculated every 7 days


### PR DESCRIPTION
So the problem was that we create custom_config from consul_config.py.ctmpl (https://github.com/metabrainz/listenbrainz-server/blob/master/docker/consul-template.conf#L3) and the template didn't contain the stats config values.

This was made further confusing by the fact that the config values we print are the app config values loaded by `webserver/__init__.py` which are different from the values we get when directly importing. This is a problem that should be fixed by using config values from the flask app only (like we do in CB and AB now). I've opened a ticket for this: [LB-293](https://tickets.metabrainz.org/browse/LB-293).