### PR TITLE
LB-303: Add instruction to add last.fm api key to custom_config.py to developement environment setup guide

### DIFF
--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -111,7 +111,7 @@ Update the strings with your client ID and secret. After doing this, your
 ListenBrainz development environment is able to authenticate and log in from
 your MusicBrainz login.
 
-Also, in order for last.fm import to work, you should also update your last.fm api key in this file. Look for the following section in the file.
+Also, in order for Last.FM import to work, you should also update your Last.FM api key in this file. Look for the following section in the file.
 
 .. code-block:: yaml
 
@@ -119,8 +119,13 @@ Also, in order for last.fm import to work, you should also update your last.fm a
     LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/"
     LASTFM_API_KEY = "USE_LASTFM_API_KEY"
 
-Update the last.fm api key with your key. After doing this, your
-ListenBrainz development environment is able to import your listens from last.fm.
+Update the Last.FM api key with your key. After doing this, your
+ListenBrainz development environment is able to import your listens from Last.FM.
+
+In case you don't have a Last.FM API key, you can get it from `Last.FM API page`_.
+
+
+.. _Last.FM API page: https://last.fm/api
 
 
 Initialize ListenBrainz containers

--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -111,7 +111,8 @@ Update the strings with your client ID and secret. After doing this, your
 ListenBrainz development environment is able to authenticate and log in from
 your MusicBrainz login.
 
-Also, in order for Last.FM import to work, you should also update your Last.FM api key in this file. Look for the following section in the file.
+Also, in order for the Last.FM import to work, you should also update your
+Last.FM API key in this file. Look for the following section in the file.
 
 .. code-block:: yaml
 
@@ -119,7 +120,7 @@ Also, in order for Last.FM import to work, you should also update your Last.FM a
     LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/"
     LASTFM_API_KEY = "USE_LASTFM_API_KEY"
 
-Update the Last.FM api key with your key. After doing this, your
+Update the Last.FM API key with your key. After doing this, your
 ListenBrainz development environment is able to import your listens from Last.FM.
 
 In case you don't have a Last.FM API key, you can get it from `Last.FM API page`_.

--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -111,6 +111,17 @@ Update the strings with your client ID and secret. After doing this, your
 ListenBrainz development environment is able to authenticate and log in from
 your MusicBrainz login.
 
+Also, in order for last.fm import to work, you should also update your last.fm api key in this file. Look for the following section in the file.
+
+.. code-block:: yaml
+
+    # Lastfm API
+    LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/"
+    LASTFM_API_KEY = "USE_LASTFM_API_KEY"
+
+Update the last.fm api key with your key. After doing this, your
+ListenBrainz development environment is able to import your listens from last.fm.
+
 
 Initialize ListenBrainz containers
 ----------------------------------


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [X] Other

There was no instruction given for adding last.fm api to custom_config.py file in the development environment setup guide.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-303](https://tickets.metabrainz.org/browse/LB-303)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Added the instructions to the guide.