### PR TITLE
LB-308: API compat fails to record listens

### DIFF
--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -1,0 +1,71 @@
+""" This module tests Last.fm Scrobbling 2.0 compatibility features """
+
+# listenbrainz-server - Server for the ListenBrainz project.
+#
+# Copyright (C) 2018 Kartikeya Sharma <09kartikeya@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+
+import json
+import time
+import xmltodict
+
+import listenbrainz.db.user as db_user
+from flask import url_for, current_app
+from listenbrainz.db.lastfm_session import Session
+from listenbrainz.db.lastfm_token import Token
+from listenbrainz.db.lastfm_user import User
+from listenbrainz.tests.integration import APICompatIntegrationTestCase
+
+
+class APICompatTestCase(APICompatIntegrationTestCase):
+
+    def setUp(self):
+        super(APICompatTestCase, self).setUp()
+        self.lb_user = db_user.get_or_create('apicompattestuser')
+        self.lfm_user = User(
+            self.lb_user['id'],
+            self.lb_user['created'],
+            self.lb_user['musicbrainz_id'],
+            self.lb_user['auth_token'],
+        )
+
+    def test_record_listen_now_playing(self):
+        """ Tests if listen of type 'nowplaying' is recorded correctly
+            if valid information is provided.
+        """
+
+        token = Token.generate(self.lfm_user.api_key)
+        token.approve(self.lfm_user.name)
+        session = Session.create(token)
+
+        data = {
+            'method': 'track.updateNowPlaying',
+            'api_key': self.lfm_user.api_key,
+            'sk': session.sid,
+            'artist[0]': 'Kishore Kumar',
+            'track[0]': 'Saamne Ye Kaun Aya',
+            'album[0]': 'Jawani Diwani',
+            'duration[0]': 300,
+            'timestamp[0]': int(time.time()),
+        }
+
+        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        self.assert200(r)
+
+        response = xmltodict.parse(r.data)
+        self.assertEqual(response['lfm']['@status'], 'ok')
+        self.assertIsNotNone(response['lfm']['nowplaying'])

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -2,6 +2,7 @@
 import time
 import json
 import re
+import listenbrainz.db.user as db_user
 from collections import defaultdict
 from yattag import Doc
 import yattag
@@ -267,7 +268,9 @@ def record_listens(request, data):
     listen_type, native_payload = _to_native_api(lookup, data['method'], output_format)
     for listen in native_payload:
         validate_listen(listen, listen_type)
-    augmented_listens = insert_payload(native_payload, session.user, listen_type=listen_type)
+
+    user = db_user.get(session.user_id)
+    augmented_listens = insert_payload(native_payload, user, listen_type=listen_type)
 
     # With corrections than the original submitted listen.
     doc, tag, text = Doc().tagtext()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->
* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
At present api_compat is broken as it fails to record listens.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-308](https://tickets.metabrainz.org/browse/LB-308) -->

# Solution
In insert_payload the user argument should be of type LB user not a Last.FM user
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
# Action
Get the user using sessions userid and pass this user into insert_payload.
