### PR TITLE
LB-309: API compat record_listens response does not include accepted attribute

### DIFF
--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -47,6 +47,7 @@ class APICompatTestCase(APICompatIntegrationTestCase):
         self.ls = InfluxListenStore({
             'REDIS_HOST': current_app.config['REDIS_HOST'],
             'REDIS_PORT': current_app.config['REDIS_PORT'],
+            'REDIS_NAMESPACE': current_app.config['REDIS_NAMESPACE'],
             'INFLUX_HOST': current_app.config['INFLUX_HOST'],
             'INFLUX_PORT': current_app.config['INFLUX_PORT'],
             'INFLUX_DB_NAME': current_app.config['INFLUX_DB_NAME'],

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -279,7 +279,7 @@ def record_listens(request, data):
             doc.asis(create_response_for_single_listen(list(lookup.values())[0], augmented_listens[0], listen_type))
         else:
             accepted_listens = len(lookup.values())
-            # Currently LB acceptes all the listens and ignores none
+            # Currently LB accepts all the listens and ignores none
             with tag('scrobbles', accepted=accepted_listens, ignored='0'):
                 for original_listen, augmented_listen in zip(list(lookup.values()), augmented_listens):
                     doc.asis(create_response_for_single_listen(original_listen, augmented_listen, listen_type))
@@ -298,6 +298,10 @@ def create_response_for_single_listen(original_listen, augmented_listen, listen_
 
     Returns:
         XML response for a single listen.
+        If listen is of type 'playing_now' response is as described in following link
+        https://www.last.fm/api/show/track.updateNowPlaying
+        Otherwise response is as described in following link
+        https://www.last.fm/api/show/track.scrobble .
     """
     corrected = defaultdict(lambda: '0')
 

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -281,53 +281,53 @@ def record_listens(request, data):
             accepted_listens = len(lookup.values())
             # Currently LB acceptes all the listens and ignores none
             with tag('scrobbles', accepted=accepted_listens, ignored='0'):
-                for origL, augL in zip(list(lookup.values()), augmented_listens):
-                    doc.asis(create_response_for_single_listen(origL, augL, listen_type))
+                for original_listen, augmented_listen in zip(list(lookup.values()), augmented_listens):
+                    doc.asis(create_response_for_single_listen(original_listen, augmented_listen, listen_type))
 
     return format_response('<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue()),
                            output_format)
 
 
-def create_response_for_single_listen(origL, augL, listen_type):
+def create_response_for_single_listen(original_listen, augmented_listen, listen_type):
     """Create XML response for a single listen.
 
     Args:
-        origL (dict): Original submitted listen.
-        augL (dict): Augmented(corrected) listen.
+        original_listen (dict): Original submitted listen.
+        augmented_listen (dict): Augmented(corrected) listen.
         listen_type (string): Type of listen ('playing_now' or 'listens').
 
     Returns:
         XML response for a single listen.
     """
-    corr = defaultdict(lambda: '0')
+    corrected = defaultdict(lambda: '0')
 
-    track = augL['track_metadata']['track_name']
-    if origL['track'] != augL['track_metadata']['track_name']:
-        corr['track'] = '1'
+    track = augmented_listen['track_metadata']['track_name']
+    if original_listen['track'] != augmented_listen['track_metadata']['track_name']:
+        corrected['track'] = '1'
 
-    artist = augL['track_metadata']['artist_name']
-    if origL['artist'] != augL['track_metadata']['artist_name']:
-        corr['artist'] = '1'
+    artist = augmented_listen['track_metadata']['artist_name']
+    if original_listen['artist'] != augmented_listen['track_metadata']['artist_name']:
+        corrected['artist'] = '1'
 
-    ts = augL['listened_at']
+    ts = augmented_listen['listened_at']
 
     albumArtist = artist
-    if origL.get('albumArtist', origL['artist']) != artist:
-        corr['albumArtist'] = '1'
+    if original_listen.get('albumArtist', original_listen['artist']) != artist:
+        corrected['albumArtist'] = '1'
 
-    album = augL['track_metadata'].get('release_name', '')
-    if origL.get('album', '') != album:
-        corr['album'] = '1'
+    album = augmented_listen['track_metadata'].get('release_name', '')
+    if original_listen.get('album', '') != album:
+        corrected['album'] = '1'
 
     doc, tag, text = Doc().tagtext()
     with tag('nowplaying' if listen_type == 'playing_now' else 'scrobble'):
-        with tag('track', corrected=corr['track']):
+        with tag('track', corrected=corrected['track']):
             text(track)
-        with tag('artist', corrected=corr['artist']):
+        with tag('artist', corrected=corrected['artist']):
             text(artist)
-        with tag('album', corrected=corr['album']):
+        with tag('album', corrected=corrected['album']):
             text(album)
-        with tag('albumArtist', corrected=corr['albumArtist']):
+        with tag('albumArtist', corrected=corrected['albumArtist']):
             text(albumArtist)
         with tag('timestamp'):
             text(ts)

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -275,45 +275,66 @@ def record_listens(request, data):
     # With corrections than the original submitted listen.
     doc, tag, text = Doc().tagtext()
     with tag('lfm', status='ok'):
-        with tag('nowplaying' if listen_type == 'playing_now' else 'scrobbles'):
-
-            for origL, augL in zip(list(lookup.values()), augmented_listens):
-                corr = defaultdict(lambda: '0')
-
-                track = augL['track_metadata']['track_name']
-                if origL['track'] != augL['track_metadata']['track_name']:
-                    corr['track'] = '1'
-
-                artist = augL['track_metadata']['artist_name']
-                if origL['artist'] != augL['track_metadata']['artist_name']:
-                    corr['artist'] = '1'
-
-                ts = augL['listened_at']
-
-                albumArtist = artist
-                if origL.get('albumArtist', origL['artist']) != artist:
-                    corr['albumArtist'] = '1'
-
-                album = augL['track_metadata'].get('release_name', '')
-                if origL.get('album', '') != album:
-                    corr['album'] = '1'
-
-                with tag('scrobble'):
-                    with tag('track', corrected=corr['track']):
-                        text(track)
-                    with tag('artist', corrected=corr['artist']):
-                        text(artist)
-                    with tag('album', corrected=corr['album']):
-                        text(album)
-                    with tag('albumArtist', corrected=corr['albumArtist']):
-                        text(albumArtist)
-                    with tag('timestamp'):
-                        text(ts)
-                    with tag('ignoredMessage', code="0"):
-                        text('')
+        if listen_type == 'playing_now':
+            doc.asis(create_response_for_single_listen(list(lookup.values())[0], augmented_listens[0], listen_type))
+        else:
+            accepted_listens = len(lookup.values())
+            # Currently LB acceptes all the listens and ignores none
+            with tag('scrobbles', accepted=accepted_listens, ignored='0'):
+                for origL, augL in zip(list(lookup.values()), augmented_listens):
+                    doc.asis(create_response_for_single_listen(origL, augL, listen_type))
 
     return format_response('<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue()),
                            output_format)
+
+
+def create_response_for_single_listen(origL, augL, listen_type):
+    """Create XML response for a single listen.
+
+    Args:
+        origL (dict): Original submitted listen.
+        augL (dict): Augmented(corrected) listen.
+        listen_type (string): Type of listen ('playing_now' or 'listens').
+
+    Returns:
+        XML response for a single listen.
+    """
+    corr = defaultdict(lambda: '0')
+
+    track = augL['track_metadata']['track_name']
+    if origL['track'] != augL['track_metadata']['track_name']:
+        corr['track'] = '1'
+
+    artist = augL['track_metadata']['artist_name']
+    if origL['artist'] != augL['track_metadata']['artist_name']:
+        corr['artist'] = '1'
+
+    ts = augL['listened_at']
+
+    albumArtist = artist
+    if origL.get('albumArtist', origL['artist']) != artist:
+        corr['albumArtist'] = '1'
+
+    album = augL['track_metadata'].get('release_name', '')
+    if origL.get('album', '') != album:
+        corr['album'] = '1'
+
+    doc, tag, text = Doc().tagtext()
+    with tag('nowplaying' if listen_type == 'playing_now' else 'scrobble'):
+        with tag('track', corrected=corr['track']):
+            text(track)
+        with tag('artist', corrected=corr['artist']):
+            text(artist)
+        with tag('album', corrected=corr['album']):
+            text(album)
+        with tag('albumArtist', corrected=corr['albumArtist']):
+            text(albumArtist)
+        with tag('timestamp'):
+            text(ts)
+        with tag('ignoredMessage', code="0"):
+            text('')
+
+    return doc.getvalue()
 
 
 def format_response(data, format="xml"):


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary
In the XML response of record_listens the scrobbles tag should contain
number of accepted listens and number of ignored listens. As original
Last.FM API response for the same contains these fields.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Last.fm does not accept listens which have bad metadata e.g. artist = "unknown artist" and the method track.scrobble in its response sends the number of accepted listens and number of ignored listens.

<scrobbles accepted="1" ignored="0">

Whereas LB currently accepts all the listens provided to it (if mandatory fields are filled), so such fields are not really important for LB responses but as this API is to work with clients which anticipate that the response will be a Last.FM type of response. And in that case these fields may be used by clients to display number of accepted listens etc.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-309](https://tickets.metabrainz.org/browse/LB-309) -->


# Solution
Add accepted and ignored fields to the response.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->




