### PR TITLE
Add script to backup ListenBrainz dumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,14 +42,17 @@ RUN pip3 install -r requirements.txt
 # Now install our code, which may change frequently
 COPY . /code/listenbrainz/
 
+# create a user named listenbrainz for storing dump file backups
+RUN useradd --create-home --shell /bin/bash listenbrainz
+
 # setup a log dir
 RUN mkdir /logs
 RUN chown -R daemon:daemon /logs
 
 # Add cron jobs
 ADD docker/crontab /etc/cron.d/lb-crontab
-RUN chmod 0644 /etc/cron.d/lb-crontab && crontab -u nobody /etc/cron.d/lb-crontab
-RUN touch /var/log/stats.log /var/log/dump_create.log && chown nobody:nogroup /var/log/stats.log /var/log/dump_create.log
+RUN chmod 0644 /etc/cron.d/lb-crontab && crontab -u listenbrainz /etc/cron.d/lb-crontab
+RUN touch /var/log/stats.log /var/log/dump_create.log && chown listenbrainz:listenbrainz /var/log/stats.log /var/log/dump_create.log
 
 # Make sure the cron service doesn't start automagically
 # http://smarden.org/runit/runsv.8.html

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -49,10 +49,13 @@ WORKDIR /code/listenbrainz
 # Sometimes the local copy of config.py[c] gets in the way. Better nuke it to not conflict.
 RUN rm -f /code/listenbrainz/listenbrainz/config.py /code/listenbrainz/listenbrainz/config.pyc
 
+# create a user named listenbrainz for cron jobs and storing dump file backups
+RUN useradd --create-home --shell /bin/bash listenbrainz
+
 # Add cron jobs
 ADD docker/crontab /etc/cron.d/lb-crontab
-RUN chmod 0644 /etc/cron.d/lb-crontab && crontab -u nobody /etc/cron.d/lb-crontab
-RUN touch /var/log/stats.log /var/log/dump_create.log && chown nobody:nogroup /var/log/stats.log /var/log/dump_create.log
+RUN chmod 0644 /etc/cron.d/lb-crontab && crontab -u listenbrainz /etc/cron.d/lb-crontab
+RUN touch /var/log/stats.log /var/log/dump_create.log && chown listenbrainz:listenbrainz /var/log/stats.log /var/log/dump_create.log
 
 # Make sure the cron service doesn't start automagically
 # http://smarden.org/runit/runsv.8.html

--- a/admin/RunExport
+++ b/admin/RunExport
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# listenbrainz-server - Server for the ListenBrainz project.
+#
+# Copyright (C) 2018 MetaBrainz Foundation Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+echo "This script is being run by the following user: "; whoami
+
+# This is to help with disk space monitoring - run "df" before and after
+echo "Disk space when RunExport starts:" ; df -m
+trap 'echo "Disk space when RunExport ends:" ; df -m' 0
+
+
+LB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+cd "$LB_SERVER_ROOT"
+
+source admin/config.sh
+source admin/functions.sh
+
+TEMP_DIR="/home/listenbrainz/data/dumps"
+
+python manage.py dump create -l $TEMP_DIR -t $DUMP_THREADS
+
+DUMP_NAME=`ls $TEMP_DIR | sort -r | head -1`
+DUMP_DIR="$TEMP_DIR"/"$DUMP_NAME"
+
+echo "Creating Backup directories..."
+mkdir -m "$BACKUP_DIR_MODE" -p \
+         "$BACKUP_DIR"/fullexport/ \
+         "$BACKUP_DIR"/fullexport/"$DUMP_NAME"
+chown "$BACKUP_USER:$BACKUP_GROUP" \
+      "$BACKUP_DIR"/fullexport/ \
+      "$BACKUP_DIR"/fullexport/"$DUMP_NAME"
+echo "Backup directories created!"
+
+echo "Begin copying..."
+chown "$BACKUP_USER:$BACKUP_GROUP" "$DUMP_DIR"/*
+chmod "$BACKUP_FILE_MODE" "$DUMP_DIR"/*
+retry cp -a "$DUMP_DIR"/* "$BACKUP_DIR"/fullexport/"$DUMP_NAME"/
+echo "Dumps copied to backup directory!"

--- a/admin/config.sh
+++ b/admin/config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DUMP_THREADS=4
+
+# Where to back things up to, who should own the backup files, and what mode
+# those files should have.
+# The backups include a full database export, and all replication data.
+BACKUP_DIR=/home/listenbrainz/backup
+BACKUP_USER=listenbrainz
+BACKUP_GROUP=listenbrainz
+BACKUP_DIR_MODE=700
+BACKUP_FILE_MODE=600

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -21,8 +21,8 @@
 echo "This script is being run by the following user: "; whoami
 
 # This is to help with disk space monitoring - run "df" before and after
-echo "Disk space when RunExport starts:" ; df -m
-trap 'echo "Disk space when RunExport ends:" ; df -m' 0
+echo "Disk space when create-dumps starts:" ; df -m
+trap 'echo "Disk space when create-dumps ends:" ; df -m' 0
 
 
 LB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)

--- a/admin/functions.sh
+++ b/admin/functions.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+retry() {
+    local attempts_remaining=5
+    local delay=15
+    while true; do
+        "$@"
+        status=$?
+        if [[ $status -eq 0 ]]; then
+            break
+        fi
+        let 'attempts_remaining -= 1'
+        if [[ $attempts_remaining -gt 0 ]]; then
+            echo "Command failed with exit status $status; retrying in $delay seconds"
+            sleep $delay
+            let 'delay *= 2'
+        else
+            echo 'Failed to execute command after 5 attempts'
+            break
+        fi
+    done
+}

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,4 +1,4 @@
-PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/code/listenbrainz/admin
 PYTHONPATH=/usr/local/lib/python36.zip:/usr/local/lib/python3.6:/usr/local/lib/python3.6/lib-dynload:/usr/local/lib/python3.6/site-packages:/usr/local/lib/python3.6/site-packages/messybrainz-99.0.0.dev0-py3.6.egg
 GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentials.json
 
@@ -6,4 +6,4 @@ GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentia
 0 0 * * 0 /usr/local/bin/python /code/listenbrainz/manage.py stats calculate >> /var/log/stats.log 2>&1
 
 # Data dumps creation for backup and public use
-15 0 1 * * /usr/local/bin/python /code/listenbrainz/manage.py dump create >> /var/log/dump_create.log 2>&1
+15 0 1 * * RunExport >> /var/log/dump_create.log 2>&1

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,4 +1,4 @@
-PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/code/listenbrainz/admin
+PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
 PYTHONPATH=/usr/local/lib/python36.zip:/usr/local/lib/python3.6:/usr/local/lib/python3.6/lib-dynload:/usr/local/lib/python3.6/site-packages:/usr/local/lib/python3.6/site-packages/messybrainz-99.0.0.dev0-py3.6.egg
 GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentials.json
 
@@ -6,4 +6,4 @@ GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentia
 0 0 * * 0 /usr/local/bin/python /code/listenbrainz/manage.py stats calculate >> /var/log/stats.log 2>&1
 
 # Data dumps creation for backup and public use
-15 0 1 * * RunExport >> /var/log/dump_create.log 2>&1
+* * * * * /code/listenbrainz/admin/create-dumps.sh >> /var/log/dump_create.log 2>&1

--- a/docker/crontab
+++ b/docker/crontab
@@ -6,4 +6,4 @@ GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentia
 0 0 * * 0 /usr/local/bin/python /code/listenbrainz/manage.py stats calculate >> /var/log/stats.log 2>&1
 
 # Data dumps creation for backup and public use
-* * * * * /code/listenbrainz/admin/create-dumps.sh >> /var/log/dump_create.log 2>&1
+15 0 1 * * /code/listenbrainz/admin/create-dumps.sh >> /var/log/dump_create.log 2>&1


### PR DESCRIPTION
Also create a listenbrainz user (similar to MusicBrainz)
which will be needed later as we add ssh keys to rsync
the public dump into the FTP server.

We should now create a volume in prod to copy the dumps into
the host outside the container
