### PR TITLE
LB-294: user.py now returns artist_count as None if not calculated

### DIFF
--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -123,7 +123,7 @@ def profile(user_name):
     try:
         artist_count = int(user_stats['artist']['count'])
     except (KeyError, TypeError):
-        artist_count = 0
+        artist_count = None
 
     return render_template(
         "user/profile.html",
@@ -134,7 +134,7 @@ def profile(user_name):
         spotify_uri=_get_spotify_uri_for_listens(listens),
         have_listen_count=have_listen_count,
         listen_count=format(int(listen_count), ",d"),
-        artist_count=format(artist_count, ",d")
+        artist_count=format(artist_count, ",d") if artist_count else None
     )
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

If a user's artist count hasn't been calculated, we shouldn't show anything. 
Right now, we display artist count = 0 instead.

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-294](https://tickets.metabrainz.org/browse/LB-294)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add an if condition to ``user.py`` to return ``None`` if ``artist_count`` isn't calculated.
