### PR TITLE
LB:316: replace ERROR_RETRY_DELAY with self.ERROR_RETRY_DELAY in influx_writer.py

### DIFF
--- a/listenbrainz/influx_writer/influx_writer.py
+++ b/listenbrainz/influx_writer/influx_writer.py
@@ -75,10 +75,10 @@ class InfluxWriterSubscriber(ListenWriter):
                 failure_count += 1
                 if failure_count >= retries:
                     break
-                sleep(ERROR_RETRY_DELAY)
+                sleep(self.ERROR_RETRY_DELAY)
             except ConnectionError as e:
                 self.log.error("Cannot write data to listenstore: %s. Sleep." % str(e))
-                sleep(ERROR_RETRY_DELAY)
+                sleep(self.ERROR_RETRY_DELAY)
 
         # if we get here, we failed on trying to write the data
         if len(data) == 1:
@@ -235,7 +235,7 @@ class InfluxWriterSubscriber(ListenWriter):
                 break
             except Exception as err:
                 self.log.error("Cannot connect to influx: %s. Retrying in 2 seconds and trying again." % str(err))
-                sleep(ERROR_RETRY_DELAY)
+                sleep(self.ERROR_RETRY_DELAY)
 
         while True:
             try:
@@ -244,7 +244,7 @@ class InfluxWriterSubscriber(ListenWriter):
                 break
             except Exception as err:
                 self.log.error("Cannot connect to redis: %s. Retrying in 2 seconds and trying again." % str(err))
-                sleep(ERROR_RETRY_DELAY)
+                sleep(self.ERROR_RETRY_DELAY)
 
         while True:
             self.connect_to_rabbitmq()

--- a/listenbrainz/influx_writer/influx_writer.py
+++ b/listenbrainz/influx_writer/influx_writer.py
@@ -89,7 +89,7 @@ class InfluxWriterSubscriber(ListenWriter):
                 return 1
             except (InfluxDBServerError, InfluxDBClientError, ValueError, ConnectionError) as e:
                 self.log.error("Unable to insert bad listen to listenstore: %s" % str(e))
-                if DUMP_JSON_WITH_ERRORS:
+                if self.DUMP_JSON_WITH_ERRORS:
                     self.log.error("Was writing the following data:")
                     influx_dict = data[0].to_influx(get_measurement_name(data[0].user_name))
                     self.log.error(ujson.dumps(influx_dict))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
influx_writer.py checks in a number of places for configuration items, and if they don't exist it tries to sleep and then try again, however it sometime tries to sleep for ERROR_RETRY_DELAY seconds instead of self.ERROR_RETRY_DELAY

* JIRA ticket (_optional_): [LB-316](https://tickets.metabrainz.org/browse/LB-316)