### PR TITLE
Tune crontab to be easy to grasp for humans

### DIFF
--- a/docker/crontab
+++ b/docker/crontab
@@ -3,7 +3,7 @@ PYTHONPATH=/usr/local/lib/python36.zip:/usr/local/lib/python3.6:/usr/local/lib/p
 GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentials.json
 
 # Statistics calculation via Google BigQuery
-0 0 * * 0 /usr/local/bin/python /code/listenbrainz/manage.py stats calculate >> /var/log/stats.log 2>&1
+0 0 * * 1 /usr/local/bin/python /code/listenbrainz/manage.py stats calculate >> /var/log/stats.log 2>&1
 
 # Data dumps creation for backup and public use
-15 0 1 * * /code/listenbrainz/admin/create-dumps.sh >> /var/log/dump_create.log 2>&1
+4 0 1,15 * * /code/listenbrainz/admin/create-dumps.sh >> /var/log/dump_create.log 2>&1


### PR DESCRIPTION
Run stats every monday at midnight and run dumps every 1st and 15th of the month at 4am. I'm picking monday over sunday, since sunday is a high traffic time and monday is low.

The midnight/4am staggering should hopefully prevent both of these tasks from running at the same time.

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

We hadn't yet really thought about when to run the cron jobs. I think this makes sense.

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


