### PR TITLE
Remove port forwards for supporting services in the docker-compose file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,15 +13,11 @@ services:
     image: postgres:9.5.3
     volumes:
       - ./dbvolume:/var/lib/postgresql/data:z
-    ports:
-      - "15432:5432"
 
   redis:
     image: redis:3.2.1
     volumes:
       - ./data/redis:/data:z
-    ports:
-      - "6379:6379"
 
   influx:
     image: influxdb:1.2.4
@@ -36,16 +32,10 @@ services:
       INFLUXDB_HTTP_LOG_ENABLED: 'true'
       INFLUXDB_CONTINUOUS_QUERIES_LOG_ENABLED: 'false'
 
-    ports:
-      - "8086:8086"
-      - "8083:8083"
-
   rabbitmq:
     image: rabbitmq:3.6.5
     volumes:
       - ./data/rabbitmq:/var/lib/rabbitmq:z
-    ports:
-      - "5672:5672"
 
   web:
     build:


### PR DESCRIPTION
# Summary

* This is a…
    *  Refactoring

* **Describe this change in 1-2 sentences**:

Port forwards are not needed for running the services in docker-compose - they only serve to give access to services inside the container from a client on the host.
Services can still be accessed by running the client inside a container with `docker-compose run`

# Action

I'm opening this so that we can have a discussion about the best way to deal with these port forwards.
I specifically ran into a problem because I already have redis running on my host, and so it was unable to bind to the same port number. If we want to delete the port forwards, then we should still have an easy way to run a client and connect to these servers. As an example, you can do this with postgres by running something like

    docker-compose run --rm db psql -h db -U listenbrainz

We could adapt some ideas in [LB-326](https://tickets.metabrainz.org/projects/LB/issues/LB-326) to provide an easy way to run these clients from the develop.sh script.

Alternatively, we can keep the port forwards, but I'd recommend that we prefix port numbers on the host like we had with postgres:

```
    ports:
      - "15432:5432"
```

