### PR TITLE
Use absolute path to ssh key for rsync auth

### DIFF
--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -26,4 +26,4 @@ FTP_FILE_MODE=644
 RSYNC_FULLEXPORT_HOST="{{template "KEY" "rsync_fullexport_host"}}"
 RSYNC_FULLEXPORT_PORT="{{template "KEY" "rsync_fullexport_port"}}"
 RSYNC_FULLEXPORT_DIR="$FTP_DIR/fullexport"
-RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-listenbrainz-dumps-full'
+RSYNC_FULLEXPORT_KEY='/home/listenbrainz/.ssh/rsync-listenbrainz-dumps-full'

--- a/admin/config.sh.sample
+++ b/admin/config.sh.sample
@@ -24,4 +24,4 @@ FTP_FILE_MODE=644
 RSYNC_FULLEXPORT_HOST='10.2.2.28'
 RSYNC_FULLEXPORT_PORT='65415'
 RSYNC_FULLEXPORT_DIR="$FTP_DIR/fullexport"
-RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-listenbrainz-dumps-full'
+RSYNC_FULLEXPORT_KEY='/home/listenbrainz/.ssh/rsync-listenbrainz-dumps-full'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * Bug fix
  
* **Describe this change in 1-2 sentences**: Use absolute path to ssh key.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

LB data dumps weren't being synced to williams, because of invalid auth. It was looking for the key in `/root/.ssh` instead of `/home/listenbrainz/.ssh`


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Use absolute path to the ssh key to fix this.

