### PR TITLE
Use docker volume instead of local dbvolume

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   db:
     image: postgres:9.5.3
     volumes:
-      - ./dbvolume:/var/lib/postgresql/data:z
+      - dbvolume:/var/lib/postgresql/data:z
 
   redis:
     image: redis:3.2.1


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

docker-compose.yml set up a named volume for the DB but falsely continued to use a local one. Now the named volume is used instead.

This previously caused ./develop.sh to fail for me with a "Permission Denied" error after the DB had been set up ([log](https://gist.github.com/LeoVerto/c5b88ce6965bff63dd467cb98b5f56d8)) but that has also been fixed as a side effect of this PR.

@mayhem [came up with this fix](https://chatlogs.metabrainz.org/brainzbot/metabrainz/2018-03-13/?msg=4138493&page=3).