### PR TITLE
Fix missing query string format in error message

### DIFF
--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -1,6 +1,7 @@
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 import ujson
+from unittest import mock
 
 from flask import url_for, current_app
 from influxdb import InfluxDBClient
@@ -69,7 +70,6 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assertTemplateUsed('user/profile.html')
         self.assertContext('artist_count', '2')
 
-
     def test_scraper_username(self):
         """ Tests that the username is correctly rendered in the last.fm importer """
         response = self.client.get(
@@ -119,11 +119,9 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assert200(r)
         self.assertContext('section', 'artists')
 
-
     def _create_test_data(self, user_name):
         test_data = create_test_data_for_influxlistenstore(user_name)
         self.logstore.insert(test_data)
-
 
     def test_username_case(self):
         """Tests that the username in URL is case insensitive"""
@@ -134,3 +132,45 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assert200(response1)
         self.assert200(response2)
         self.assertEqual(response1.data.decode('utf-8'), response2.data.decode('utf-8'))
+
+    @mock.patch('listenbrainz.webserver.views.user.time')
+    @mock.patch('listenbrainz.webserver.influx_connection._influx.fetch_listens')
+    def test_ts_filters(self, influx, m_time):
+        """Check that max_ts and min_ts are passed to the influx """
+
+        # If no parameter is given, use current time as the to_ts
+        m_time.time.return_value = 1520946608
+        self.client.get(url_for('user.profile', user_name='iliekcomputers'))
+        influx.assert_called_with('iliekcomputers', limit=25, to_ts=1520946608)
+        influx.reset_mock()
+
+        # max_ts query param -> to_ts influx param
+        self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'max_ts': 1520946000})
+        influx.assert_called_with('iliekcomputers', limit=25, to_ts=1520946000)
+        influx.reset_mock()
+
+        # min_ts query param -> from_ts influx param
+        self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'min_ts': 1520941000})
+        influx.assert_called_with('iliekcomputers', limit=25, from_ts=1520941000)
+        influx.reset_mock()
+
+        # If max_ts and min_ts set, only max_ts is used
+        self.client.get(url_for('user.profile', user_name='iliekcomputers'),
+                        query_string={'min_ts': 1520941000, 'max_ts': 1520946000})
+        influx.assert_called_with('iliekcomputers', limit=25, to_ts=1520946000)
+
+    @mock.patch('listenbrainz.webserver.influx_connection._influx.fetch_listens')
+    def test_ts_filters_errors(self, influx):
+        """If max_ts and min_ts are not integers, show an error page"""
+        self._create_test_data('iliekcomputers')
+        response = self.client.get(url_for('user.profile', user_name='iliekcomputers'),
+                                   query_string={'max_ts': 'a'})
+        self.assert400(response)
+        self.assertIn(b'Incorrect timestamp argument max_ts: a', response.data)
+
+        response = self.client.get(url_for('user.profile', user_name='iliekcomputers'),
+                                   query_string={'min_ts': 'b'})
+        self.assert400(response)
+        self.assertIn(b'Incorrect timestamp argument min_ts: b', response.data)
+
+        influx.assert_not_called()

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -11,7 +11,7 @@ from listenbrainz.webserver import flash
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.login import User
 from listenbrainz.webserver.redis_connection import _redis
-from time import time
+import time
 from werkzeug.exceptions import NotFound, BadRequest, RequestEntityTooLarge, InternalServerError
 
 LISTENS_PER_PAGE = 25
@@ -67,17 +67,17 @@ def profile(user_name):
         try:
             max_ts = int(max_ts)
         except ValueError:
-            raise BadRequest("Incorrect timestamp argument max_ts:" % request.args.get("max_ts"))
+            raise BadRequest("Incorrect timestamp argument max_ts: %s" % request.args.get("max_ts"))
 
     min_ts = request.args.get("min_ts")
     if min_ts is not None:
         try:
             min_ts = int(min_ts)
         except ValueError:
-            raise BadRequest("Incorrect timestamp argument min_ts:" % request.args.get("min_ts"))
+            raise BadRequest("Incorrect timestamp argument min_ts: %s" % request.args.get("min_ts"))
 
-    if max_ts == None and min_ts == None:
-        max_ts = int(time())
+    if max_ts is None and min_ts is None:
+        max_ts = int(time.time())
 
     args = {}
     if max_ts:


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * Bug fix

* **Describe this change in 1-2 sentences**:

Some error strings were missing their format parameters

# Solution
Add format parameters to strings and add tests


