### PR TITLE
LB-329: Add supported keys to Influx rows explicitly

### DIFF
--- a/listenbrainz/testdata/additional_info.json
+++ b/listenbrainz/testdata/additional_info.json
@@ -19,10 +19,10 @@
                         "REMIX"
                     ],
                     "spotify_id": "http://open.spotify.com/track/1rrgWMXGCGHru5bIRxGFV0",
-                    "artist_mbids": ["abaa7001-0d80-4e58-be5d-d2d246fd9d87"],
+                    "artist_mbids": ["abaa7001-0d80-4e58-be5d-d2d246fd9d87", "7babc9be-ca2b-4544-b932-7c9ab38770d6"],
                     "release_group_mbid": "c2f7be65-056f-4589-ba84-3ad8cb674628",
                     "track_mbid": "3ad754b9-1af2-4743-8ee5-d91ba4c82f0f",
-                    "work_mbids": ["ac4f356f-23e5-40ab-990e-da7e34b65d6e"],
+                    "work_mbids": ["ac4f356f-23e5-40ab-990e-da7e34b65d6e", "ac3a827c-ad58-4624-9aa4-ecfffc56d8fe"],
                     "tracknumber": "7",
                     "isrc": "isrc"
                 }

--- a/listenbrainz/testdata/additional_info.json
+++ b/listenbrainz/testdata/additional_info.json
@@ -17,7 +17,14 @@
                     "release_type": [
                         "ALBUM",
                         "REMIX"
-                    ]
+                    ],
+                    "spotify_id": "http://open.spotify.com/track/1rrgWMXGCGHru5bIRxGFV0",
+                    "artist_mbids": ["abaa7001-0d80-4e58-be5d-d2d246fd9d87"],
+                    "release_group_mbid": "c2f7be65-056f-4589-ba84-3ad8cb674628",
+                    "track_mbid": "3ad754b9-1af2-4743-8ee5-d91ba4c82f0f",
+                    "work_mbids": ["ac4f356f-23e5-40ab-990e-da7e34b65d6e"],
+                    "tracknumber": "7",
+                    "isrc": "isrc"
                 }
             }
         }

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -235,6 +235,12 @@ class APITestCase(IntegrationTestCase):
         self.assertEqual(sent_additional_info['other_stuff'], received_additional_info['other_stuff'])
         self.assertEqual(sent_additional_info['nested']['info'], received_additional_info['nested.info'])
         self.assertEqual(str(sent_additional_info['release_type']), received_additional_info['release_type'])
+        self.assertEqual(sent_additional_info['spotify_id'], received_additional_info['spotify_id'])
+        self.assertEqual(sent_additional_info['isrc'], received_additional_info['isrc'])
+        self.assertEqual(sent_additional_info['tracknumber'], received_additional_info['tracknumber'])
+        self.assertEqual(sent_additional_info['release_group_mbid'], received_additional_info['release_group_mbid'])
+        self.assertListEqual(sent_additional_info['work_mbids'], received_additional_info['work_mbids'])
+        self.assertListEqual(sent_additional_info['artist_mbids'], received_additional_info['artist_mbids'])
 
 
     def test_latest_import(self):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -189,7 +189,7 @@ def _get_spotify_uri_for_listens(listens):
 
     def get_track_id_from_listen(listen):
         additional_info = listen["track_metadata"]["additional_info"]
-        if "spotify_id" in additional_info:
+        if "spotify_id" in additional_info and additional_info["spotify_id"] is not None:
             return additional_info["spotify_id"].rsplit('/', 1)[-1]
         else:
             return None


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a bug fix

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-329](https://tickets.metabrainz.org/browse/LB-329)

Spotify ID's weren't being returned by the API when listens were requested. This was due to the fact that we didn't add them explicitly into the influx db.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add all supported keys explicitly and add a test for this.


