### PR TITLE
Add copy button for user token

### DIFF
--- a/listenbrainz/webserver/static/js/info.js
+++ b/listenbrainz/webserver/static/js/info.js
@@ -1,0 +1,4 @@
+document.getElementById("copy-token").addEventListener("click", function() {
+    document.getElementById("auth-token").select();
+    document.execCommand("copy");
+});

--- a/listenbrainz/webserver/templates/profile/info.html
+++ b/listenbrainz/webserver/templates/profile/info.html
@@ -23,8 +23,9 @@
       user token:
     </p>
 
-    <div class="well">
-      {{ user.auth_token }}
+    <div class="form-inline form-group">
+      <input class="form-control" id="auth-token" type="text" size="36" value="{{ user.auth_token }}" readonly>
+      <button class="btn btn-info btn-sm glyphicon glyphicon-copy" id="copy-token" title="Copy token to clipboard"></button>
     </div>
 
     <p>If you want to reset your token, click below</p>
@@ -56,4 +57,9 @@
 
   </div>
 
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/info.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
# Summary

Replace the user token well with a text input and add a "copy to clipboard" button.

* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Previously a couple of users (including myself) had problems copying the user token from the well as they ended up with an additional space at the end which made the token incompatible in many clients ( especially ones where the token was ********).

# Solution

There now is a button to copy the token to the user's clipboard, additionally the well containing the token has been replaced by a readonly input that can be easily selected and copied from should the user have JS disabled.

# Screenshot
![screenshot-2018-3-15 user leo verto - listenbrainz](https://user-images.githubusercontent.com/912984/37496581-3c32383c-28ab-11e8-9796-373d56acf0c5.png)



