### PR TITLE
Make some testing processes faster

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -8,6 +8,7 @@ services:
 
   db:
     image: postgres:9.5.3
+    command: postgres -F
 
   redis:
     image: redis:3.2.1

--- a/test.sh
+++ b/test.sh
@@ -121,11 +121,11 @@ if [ $DB_EXISTS -eq 1 -a $DB_RUNNING -eq 1 ]; then
     setup
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                   run --rm listenbrainz py.test
+                   run --rm listenbrainz py.test "$@"
     dcdown
 else
     # Else, we have containers, just run tests
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                   run --rm listenbrainz py.test
+                   run --rm listenbrainz py.test "$@"
 fi


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    *  Feature addition

* **Describe this change in 1-2 sentences**:

Unit tests take some time to run when using `test.sh`


# Solution

* Add the ability to pass a single file to test.sh to run unit tests in just that file
* disable fsync on postgres in test so that disk operations happen faster

Normally disabling fsync is a bad idea (can cause data corruption if the machine unexpectedly turns off), but during test we're always destroying and recreating the database anyway, so it seems overkill to have the protection turned on. In informal testing tests became almost twice as fast.


