### PR TITLE
 LB-332: Remove redundant information from Listen additional info 

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -30,7 +30,7 @@ class Listen(object):
     """ Represents a listen object """
 
     # keys in additional_info that we support explicitly and are not superfluous
-    SUPPORTED_KEYS = [
+    SUPPORTED_KEYS = (
         'artist_mbids',
         'release_group_mbid',
         'release_mbid',
@@ -44,7 +44,15 @@ class Listen(object):
         'artist_msid',
         'release_msid',
         'recording_msid',
-    ]
+    )
+
+    TOP_LEVEL_KEYS = (
+        'time',
+        'user_name',
+        'artist_name',
+        'track_name',
+        'release_name',
+    )
 
     def __init__(self, user_id=None, user_name=None, timestamp=None, artist_msid=None, release_msid=None,
                  recording_msid=None, dedup_tag=0, data=None):
@@ -108,7 +116,6 @@ class Listen(object):
         data = {
             'release_msid': row.get('release_msid'),
             'release_mbid': row.get('release_mbid'),
-            'release_name': row.get('release_name'),
             'recording_mbid': row.get('recording_mbid'),
             'release_group_mbid': row.get('release_group_mbid'),
             'artist_mbids': convert_comma_seperated_string_to_list(row.get('artist_mbids', '')),
@@ -125,9 +132,7 @@ class Listen(object):
         # Also, we need to make sure that we don't add fields like time, user_name etc. into
         # the additional_info.
         for key, value in row.items():
-            if key not in data and \
-               key not in ['time', 'user_name', 'recording_msid', 'artist_mbids', 'tags'] and \
-               value is not None:
+            if key not in data and key not in Listen.TOP_LEVEL_KEYS and value is not None:
                 data[key] = value
 
         return cls(

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -242,6 +242,10 @@ class APITestCase(IntegrationTestCase):
         self.assertListEqual(sent_additional_info['work_mbids'], received_additional_info['work_mbids'])
         self.assertListEqual(sent_additional_info['artist_mbids'], received_additional_info['artist_mbids'])
 
+        self.assertNotIn('track_name', sent_additional_info)
+        self.assertNotIn('artist_name', sent_additional_info)
+        self.assertNotIn('release_name', sent_additional_info)
+
 
     def test_latest_import(self):
         """ Test for api.latest_import """

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -60,6 +60,12 @@ class ListenTestCase(unittest.TestCase):
         self.assertEqual(listen.release_msid, influx_row['release_msid'])
         self.assertEqual(listen.recording_msid, influx_row['recording_msid'])
 
+        # make sure additional info does not contain stuff like artist names, track names
+        self.assertNotIn('track_name', listen.data['additional_info'])
+        self.assertNotIn('artist_name', listen.data['additional_info'])
+        self.assertNotIn('release_name', listen.data['additional_info'])
+
+
     def test_to_influx(self):
         listen = Listen(
             timestamp=int(time.time()),


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Additional info contained duplicated fields `track_name`, `release_name`, `artist_name`

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-332](https://tickets.metabrainz.org/browse/LB-332)

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Make sure they aren't added with unsupported keys and add test.

