### PR TITLE
Improved Spotify Integration

### DIFF
--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -98,7 +98,7 @@
 
         {% if spotify_uri %}
           <div class="col-md-4 text-right">
-            <iframe id="player" frameborder="0" allowtransparency="true"
+            <iframe id="player" frameborder="0" allowtransparency="true" allow="encrypted-media"
                     src="https://embed.spotify.com/?uri={{ spotify_uri }}&theme=white"></iframe>
           </div>
         {% endif %}

--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -68,6 +68,9 @@
                       {% endif %}
                   </td>
                   <td>
+                      {% if spotify_uri %}
+                        <span class="fab fa-spotify"></span>
+                      {% endif %}
                       {% if listen.track_metadata.additional_info.recording_mbid %}
                         <a href="http://musicbrainz.org/recording/{{ listen.track_metadata.additional_info.recording_mbid }}">
                       {% endif %}
@@ -103,4 +106,9 @@
 
     {% endif %}
 
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
 {% endblock %}

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -194,11 +194,10 @@ def _get_spotify_uri_for_listens(listens):
         else:
             return None
 
-    track_ids = [get_track_id_from_listen(l) for l in listens]
-    track_ids = [t_id for t_id in track_ids if t_id]
+    track_id = get_track_id_from_listen(listens[0])
 
-    if track_ids:
-        return "spotify:trackset:Recent listens:" + ",".join(track_ids)
+    if track_id:
+        return "spotify:track:" + track_id
     else:
         return None
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -194,7 +194,9 @@ def _get_spotify_uri_for_listens(listens):
         else:
             return None
 
-    track_id = get_track_id_from_listen(listens[0])
+    track_id = None
+    if len(listens):
+        track_id = get_track_id_from_listen(listens[0])
 
     if track_id:
         return "spotify:track:" + track_id


### PR DESCRIPTION
# Summary

This PR does a couple things at once:

It provides a temporary fix for [LB-338](https://tickets.metabrainz.org/browse/LB-338).
Unfortunately with the current state of the Spotify play button widget we can only play one song at a time although I'd like to implement a fully-featured player in the future, so the big embedded player space feels kind of wasted right now.

It adds Spotify icons to listens with associated Spotify IDs
![screenshot-2018-3-27 user leo verto - listenbrainz](https://user-images.githubusercontent.com/912984/37979763-f3f958c0-31d8-11e8-810b-eeef2077346f.png)
