### PR TITLE
Don't let Flask-Debug intercept redirects by default

### DIFF
--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -99,3 +99,7 @@ UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 
 API_URL = 'https://api.listenbrainz.org'
 LASTFM_PROXY_URL = 'http://0.0.0.0:8080/'
+
+# Flask Debug redirect
+# Set to True if you want Flask-Debug to intercept redirects
+DEBUG_TB_INTERCEPT_REDIRECTS = False


### PR DESCRIPTION
We don't seem to need the redirect interception.