### PR TITLE
Make bigquery-writer send listens to yearly tables.

### DIFF
--- a/listenbrainz/__init__.py
+++ b/listenbrainz/__init__.py
@@ -4,3 +4,7 @@ __version__ = '0.1'
 
 DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                       'db', 'licenses', 'COPYING-PublicDomain')
+
+
+LAST_FM_FOUNDING_YEAR = 2002
+INVALID_LISTENS_BIGQUERY_TABLE_NAME = 'before_2002'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: We're doing new tables in BQ, so bqwriter needs to stream listens to these new tables.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

BigQueryWriter currently streams listens to a single table which is getting out of hand really quickly.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Make bigquerywriter stream listens to yearwise tables.




