### PR TITLE
Create md5sums of dump files during dump creation

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -89,8 +89,12 @@ retry cp -a "$DUMP_DIR"/* "$FTP_CURRENT_DUMP_DIR"
 touch "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
 PUBLIC_DUMP_RULE=`printf "include listenbrainz-public-dump-%s.tar.xz" $DUMP_TIMESTAMP`
 echo "$PUBLIC_DUMP_RULE" >> "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
+PUBLIC_DUMP_MD5_RULE=`printf "include listenbrainz-public-dump-%s.tar.xz.md5" $DUMP_TIMESTAMP`
+echo "$PUBLIC_DUMP_MD5_RULE" >> "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
 LISTENS_DUMP_RULE=`printf "include listenbrainz-listens-dump-%s.tar.xz" $DUMP_TIMESTAMP`
 echo "$LISTENS_DUMP_RULE" >> "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
+LISTENS_DUMP_MD5_RULE=`printf "include listenbrainz-listens-dump-%s.tar.xz.md5" $DUMP_TIMESTAMP`
+echo "$LISTENS_DUMP_MD5_RULE" >> "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
 EXCLUDE_RULE="exclude *"
 echo "$EXCLUDE_RULE" >> "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
 

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -269,6 +269,7 @@ def _create_dump(location, dump_type, tables, dump_time, threads=DUMP_DEFAULT_TH
 
         pxz.stdin.close()
 
+    pxz.wait()
     return archive_path
 
 

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import sys
 
 from datetime import datetime
@@ -70,6 +71,7 @@ def create(location, threads):
     create_path(dump_path)
     db_dump.dump_postgres_db(dump_path, time_now, threads)
     ls.dump_listens(dump_path, time_now, threads)
+    write_hashes(dump_path)
 
 
 @cli.command()
@@ -160,3 +162,15 @@ def _cleanup_dumps(location):
 
     print('Deleted %d old exports, kept %d exports!' % (remove_count, keep_count))
     return keep_count, remove_count
+
+
+def write_hashes(location):
+    """ Create MD5 hash files for each file in the given dump location
+
+    Args:
+        location (str): the path in which the dump archive files are present
+    """
+    for file in os.listdir(location):
+        with open(os.path.join(location, '{}.md5'.format(file)), 'w') as f:
+            md5sum = subprocess.check_output(['md5sum', os.path.join(location, file)]).decode('utf-8').split()[0]
+            f.write(md5sum)

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -534,6 +534,7 @@ class InfluxListenStore(ListenStore):
 
             pxz.stdin.close()
 
+        pxz.wait()
         self.log.info('ListenBrainz listen dump done!')
         self.log.info('Dump present at %s!', archive_path)
         return archive_path


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

The dumps created did not have any md5sums created.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Create md5s and send them to the FTP server as well.


