### PR TITLE
Keep track of when a listen was inserted into influx.

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -1,7 +1,8 @@
 # coding=utf-8
+import calendar
+import time
 
 from datetime import datetime
-import calendar
 from listenbrainz.utils import escape, convert_to_unix_timestamp
 
 def flatten_dict(d, seperator='', parent_key=''):
@@ -206,6 +207,7 @@ class Listen(object):
                 'tracknumber': self.data['additional_info'].get('tracknumber', ''),
                 'isrc': self.data['additional_info'].get('isrc', ''),
                 'spotify_id': self.data['additional_info'].get('spotify_id', ''),
+                'inserted_timestamp': int(time.time()),
             }
         }
 

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -30,6 +30,11 @@ def flatten_dict(d, seperator='', parent_key=''):
 class Listen(object):
     """ Represents a listen object """
 
+    # keys that we use ourselves for private usage
+    PRIVATE_KEYS = (
+        'inserted_timestamp',
+    )
+
     # keys in additional_info that we support explicitly and are not superfluous
     SUPPORTED_KEYS = (
         'artist_mbids',
@@ -56,7 +61,7 @@ class Listen(object):
     )
 
     def __init__(self, user_id=None, user_name=None, timestamp=None, artist_msid=None, release_msid=None,
-                 recording_msid=None, dedup_tag=0, data=None):
+                 recording_msid=None, dedup_tag=0, inserted_timestamp=None, data=None):
         self.user_id = user_id
         self.user_name = user_name
 
@@ -76,6 +81,7 @@ class Listen(object):
         self.release_msid = release_msid
         self.recording_msid = recording_msid
         self.dedup_tag = dedup_tag
+        self.inserted_timestamp = inserted_timestamp
         if data is None:
             self.data = {'additional_info': {}}
         else:
@@ -133,7 +139,7 @@ class Listen(object):
         # Also, we need to make sure that we don't add fields like time, user_name etc. into
         # the additional_info.
         for key, value in row.items():
-            if key not in data and key not in Listen.TOP_LEVEL_KEYS and value is not None:
+            if key not in data and key not in Listen.TOP_LEVEL_KEYS + Listen.PRIVATE_KEYS and value is not None:
                 data[key] = value
 
         return cls(
@@ -142,6 +148,7 @@ class Listen(object):
             artist_msid=row.get('artist_msid'),
             recording_msid=row.get('recording_msid'),
             release_msid=row.get('release_msid'),
+            inserted_timestamp=row.get('inserted_timestamp'),
             data={
                 'additional_info': data,
                 'artist_name': row.get('artist_name'),
@@ -218,6 +225,8 @@ class Listen(object):
 
         # add the user generated keys present in additional info to fields
         for key, value in self.data['additional_info'].items():
+            if key in Listen.PRIVATE_KEYS:
+                continue
             if key not in Listen.SUPPORTED_KEYS:
                 data['fields'][key] = escape(str(value))
 

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -28,7 +28,8 @@ class ListenTestCase(unittest.TestCase):
             "user_name": "iliekcomputers",
             "we_dict_now.hello": "afb",
             "we_dict_now.we_nested_now.hi": "312",
-            "tags": "sing, song"
+            "tags": "sing, song",
+            "inserted_timestamp": 1525557084,
         }
 
         listen = Listen.from_influx(influx_row)
@@ -65,6 +66,9 @@ class ListenTestCase(unittest.TestCase):
         self.assertNotIn('artist_name', listen.data['additional_info'])
         self.assertNotIn('release_name', listen.data['additional_info'])
 
+        self.assertEqual(listen.inserted_timestamp, influx_row['inserted_timestamp'])
+        self.assertNotIn('inserted_timestamp', listen.data)
+
 
     def test_to_influx(self):
         listen = Listen(
@@ -86,7 +90,7 @@ class ListenTestCase(unittest.TestCase):
 
         # Make sure every value that we don't explicitly support is a string
         for key in data['fields']:
-            if key not in Listen.SUPPORTED_KEYS:
+            if key not in Listen.SUPPORTED_KEYS and key not in Listen.PRIVATE_KEYS:
                 self.assertIsInstance(data['fields'][key], str)
 
         # Check values
@@ -98,3 +102,5 @@ class ListenTestCase(unittest.TestCase):
         self.assertEqual(data['fields']['recording_msid'], listen.recording_msid)
         self.assertEqual(data['fields']['track_name'], listen.data['track_name'])
         self.assertEqual(data['fields']['artist_name'], listen.data['artist_name'])
+
+        self.assertIn('inserted_timestamp', data['fields'])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->
Keep track of when a listen was inserted in an extra field `inserted_timestamp` in influx

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

It is hard to restream listens from influx into BQ without duplication, without row ids, as the influx db is dynamic and listens keep getting inserted.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
With this change, we could keep track of when we start a restream and only restream
those listens that were inserted before a particular timestamp, while the rest of the listens
get streamed to BQ by the bigquery-writer.
