### PR TITLE
LB-354: Musicbrainz delete endpoint

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -91,6 +91,7 @@ UPLOAD_FOLDER = '''{{template "KEY" "upload_folder"}}'''
 
 API_URL = '''{{template "KEY" "api_url"}}'''
 LASTFM_PROXY_URL = '''{{template "KEY" "lastfm_proxy_url"}}'''
+MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'
 
 
 # Sentry config

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -99,6 +99,7 @@ UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 
 API_URL = 'https://api.listenbrainz.org'
 LASTFM_PROXY_URL = 'http://0.0.0.0:8080/'
+MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'
 
 # Flask Debug redirect
 # Set to True if you want Flask-Debug to intercept redirects

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -684,4 +684,8 @@ class InfluxListenStore(ListenStore):
                 self.log.error('Error while trying to drop user %s: %s', musicbrainz_id, str(e))
                 time.sleep(3)
         else:
-            raise Exception("Couldn't delete user with MusicBrainz ID: %s" % musicbrainz_id)
+            raise InfluxListenStoreException("Couldn't delete user with MusicBrainz ID: %s" % musicbrainz_id)
+
+
+class InfluxListenStoreException(Exception):
+    pass

--- a/listenbrainz/rtd_config.py
+++ b/listenbrainz/rtd_config.py
@@ -98,3 +98,4 @@ UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 
 API_URL = 'https://api.listenbrainz.org'
 LASTFM_PROXY_URL = 'http://0.0.0.0:8080/'
+MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'

--- a/listenbrainz/test_config.py
+++ b/listenbrainz/test_config.py
@@ -97,3 +97,4 @@ UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 API_URL = 'https://api.listenbrainz.org'
 
 LASTFM_PROXY_URL = 'http://0.0.0.0:8080/'
+MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -170,9 +170,8 @@ def mb_user_deleter(musicbrainz_row_id):
 
 
 def _authorize_mb_user_deleter(auth_token):
-    query_url = 'https://musicbrainz.org/oauth2/userinfo'
     headers = {'Authorization': 'Bearer {}'.format(auth_token)}
-    r = requests.get(query_url, headers=headers)
+    r = requests.get(current_app.config['MUSICBRAINZ_OAUTH_URL'], headers=headers)
     try:
         r.raise_for_status()
     except HTTPError:
@@ -185,6 +184,8 @@ def _authorize_mb_user_deleter(auth_token):
         raise Unauthorized('Not authorized to use this view')
 
     try:
+        # 2007538 is the row ID of the `UserDeleter` account that is
+        # authorized to access the `delete-user` endpoint
         if data['sub'] != 'UserDeleter' or data['metabrainz_user_id'] != 2007538:
             raise Unauthorized('Not authorized to use this view')
     except KeyError:

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -148,6 +148,19 @@ def gdpr_notice():
 
 @index_bp.route('/delete-user/<int:musicbrainz_row_id>')
 def mb_user_deleter(musicbrainz_row_id):
+    """ This endpoint is used by MusicBrainz to delete accounts once they
+    are deleted on MusicBrainz too.
+
+    See https://tickets.metabrainz.org/browse/MBS-9680 for details.
+
+    Args: musicbrainz_row_id (int): the MusicBrainz row ID of the user to be deleted.
+
+    Returns: 200 if the user has been successfully found and deleted from LB
+
+    Raises:
+        NotFound if the user is not found in the LB database
+        Unauthorized if the MusicBrainz access token provided with the query is invalid
+    """
     _authorize_mb_user_deleter(request.args.get('access_token', ''))
     user = db_user.get_by_mb_row_id(musicbrainz_row_id)
     if user is None:

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -12,6 +12,7 @@ from flask import Blueprint, render_template, request, url_for, redirect, curren
 from flask_login import current_user, login_required
 from listenbrainz import webserver
 from listenbrainz.db.exceptions import DatabaseException
+from listenbrainz.listenstore.influx_listenstore import InfluxListenStoreException
 from listenbrainz.stats.utils import construct_stats_queue_key
 from listenbrainz.webserver import flash
 from listenbrainz.webserver.redis_connection import _redis

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -222,6 +222,10 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         user1 = db_user.create(1, 'iliekcomputers')
         r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assert200(r)
+        mock_requests_get.assert_called_with(
+            'https://musicbrainz.org/oauth2/userinfo',
+            headers={'Authorization': 'Bearer 132'},
+        )
         mock_delete_user.assert_called_with('iliekcomputers')
 
     @mock.patch('listenbrainz.webserver.views.index.requests.get')

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -192,10 +192,14 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assertIsInstance(self.get_context_variable('current_user'), listenbrainz.webserver.login.User)
 
     @mock.patch('listenbrainz.webserver.views.index._authorize_mb_user_deleter')
-    def test_mb_user_deleter(self, mock_authorize):
+    @mock.patch('listenbrainz.webserver.views.index.delete_user')
+    def test_mb_user_deleter(self, mock_delete_user, mock_authorize_mb_user_deleter):
         user1 = db_user.create(1, 'iliekcomputers')
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_id='iliekcomputers'))
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assert200(r)
+        mock_authorize_mb_user_deleter.assert_called_with('132')
 
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_id='thisuserdoesnotexist'))
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=2, access_token='312421'))
         self.assert404(r)
+        mock_authorize_mb_user_deleter.assert_called_with('312421')
+        mock_delete_user.assert_called_once_with('iliekcomputers')

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -11,6 +11,7 @@ from listenbrainz.webserver import create_app
 from listenbrainz.webserver.testing import ServerTestCase
 
 
+
 class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
 
     def setUp(self):
@@ -190,3 +191,11 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         mock_user_get.assert_called_once()
         self.assertIsInstance(self.get_context_variable('current_user'), listenbrainz.webserver.login.User)
 
+    @mock.patch('listenbrainz.webserver.views.index._authorize_mb_user_deleter')
+    def test_mb_user_deleter(self, mock_authorize):
+        user1 = db_user.create(1, 'iliekcomputers')
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_id='iliekcomputers'))
+        self.assert200(r)
+
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_id='thisuserdoesnotexist'))
+        self.assert404(r)

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -1,7 +1,9 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
 from flask import url_for
 from flask_login import login_required, AnonymousUserMixin
+from requests.exceptions import HTTPError
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import listenbrainz.db.user as db_user
@@ -193,13 +195,84 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
 
     @mock.patch('listenbrainz.webserver.views.index._authorize_mb_user_deleter')
     @mock.patch('listenbrainz.webserver.views.index.delete_user')
-    def test_mb_user_deleter(self, mock_delete_user, mock_authorize_mb_user_deleter):
+    def test_mb_user_deleter_valid_account(self, mock_delete_user, mock_authorize_mb_user_deleter):
         user1 = db_user.create(1, 'iliekcomputers')
         r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assert200(r)
-        mock_authorize_mb_user_deleter.assert_called_with('132')
+        mock_authorize_mb_user_deleter.assert_called_once_with('132')
+        mock_delete_user.assert_called_once_with('iliekcomputers')
 
+    @mock.patch('listenbrainz.webserver.views.index._authorize_mb_user_deleter')
+    @mock.patch('listenbrainz.webserver.views.index.delete_user')
+    def test_mb_user_deleter_not_found(self, mock_delete_user, mock_authorize_mb_user_deleter):
+        # no user in the db with musicbrainz_row_id = 2
         r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=2, access_token='312421'))
         self.assert404(r)
         mock_authorize_mb_user_deleter.assert_called_with('312421')
-        mock_delete_user.assert_called_once_with('iliekcomputers')
+        mock_delete_user.assert_not_called()
+
+    @mock.patch('listenbrainz.webserver.views.index.requests.get')
+    @mock.patch('listenbrainz.webserver.views.index.delete_user')
+    def test_mb_user_deleter_valid_access_token(self, mock_delete_user, mock_requests_get):
+        mock_requests_get.return_value = MagicMock()
+        mock_requests_get.return_value.json.return_value = {
+            'sub': 'UserDeleter',
+            'metabrainz_user_id': 2007538,
+        }
+        user1 = db_user.create(1, 'iliekcomputers')
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        self.assert200(r)
+        mock_delete_user.assert_called_with('iliekcomputers')
+
+    @mock.patch('listenbrainz.webserver.views.index.requests.get')
+    @mock.patch('listenbrainz.webserver.views.index.delete_user')
+    def test_mb_user_deleter_invalid_access_tokens(self, mock_delete_user, mock_requests_get):
+        mock_requests_get.return_value = MagicMock()
+        mock_requests_get.return_value.json.return_value = {
+            'sub': 'UserDeleter',
+            'metabrainz_user_id': 2007531, # incorrect musicbrainz row id for UserDeleter
+        }
+        user1 = db_user.create(1, 'iliekcomputers')
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        self.assertStatus(r, 401)
+        mock_delete_user.assert_not_called()
+
+        # no sub value
+        mock_requests_get.return_value.json.return_value = {
+            'metabrainz_user_id': 2007538,
+        }
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        self.assertStatus(r, 401)
+        mock_delete_user.assert_not_called()
+
+        # no row id
+        mock_requests_get.return_value.json.return_value = {
+            'sub': 'UserDeleter',
+        }
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        self.assertStatus(r, 401)
+        mock_delete_user.assert_not_called()
+
+        # incorrect username
+        mock_requests_get.return_value.json.return_value = {
+            'sub': 'iliekcomputers',
+            'metabrainz_user_id': 2007538
+        }
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        self.assertStatus(r, 401)
+        mock_delete_user.assert_not_called()
+
+        # everything incorrect
+        mock_requests_get.return_value.json.return_value = {
+            'sub': 'iliekcomputers',
+            'metabrainz_user_id': 1,
+        }
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        self.assertStatus(r, 401)
+        mock_delete_user.assert_not_called()
+
+        # HTTPError while getting userinfo from MusicBrainz
+        mock_requests_get.return_value.raise_for_status.side_effect = HTTPError
+        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        self.assertStatus(r, 401)
+        mock_delete_user.assert_not_called()


### PR DESCRIPTION
This PR adds the MusicBrainz `delete-user` endpoint as specified by https://tickets.metabrainz.org/browse/MBS-9680.