### PR TITLE
Reload the Agree-to-terms page if the user doesn't make a choice

### DIFF
--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -137,6 +137,9 @@ def gdpr_notice():
             return redirect(url_for('index.index'))
         elif request.form.get('gdpr-options') == 'disagree':
             return redirect(url_for('profile.delete'))
+        else:
+            flash.error('You must agree to or decline our terms')
+            return render_template('index/gdpr.html', next=request.args.get('next'))
 
 
 def _get_user_count():


### PR DESCRIPTION
Older browsers don't understand the 'required' attribute of form
elements and so will happily submit the form without requiring
the user to make a choice. In this case, show an error message
and display the form again

