### PR TITLE
Upgrade brainzutils to fix listen count problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-WTF == 0.12
 Flask-SQLAlchemy == 2.0
 Jinja2 == 2.8
 Werkzeug == 0.10.4
-SQLAlchemy == 1.0.8
+SQLAlchemy == 1.2.5
 nose == 1.3.7
 coverage == 3.7.1
 click == 4.1
@@ -30,4 +30,4 @@ google-api-python-client==1.5.2
 pika == 0.11.0
 git+https://github.com/bninja/pika-pool.git@5b1d3b650395aed60d9995fbfd289de7e62fe8d5#egg=pika_pool
 git+https://github.com/metabrainz/messybrainz-server.git@production#egg=messybrainz
-git+https://github.com/metabrainz/brainzutils-python.git@v1.4.2
+git+https://github.com/metabrainz/brainzutils-python.git@v1.5.0


### PR DESCRIPTION
The last time we upgraded brainzutils, I forgot to update
`__version__` in `__init__.py` which meant that the new changes
fixing cache expiration didn't get installed in the container.
This new release should fix that.

Also, brainzutils uses a new version of SQLAlchemy, so upgrade
SQLAlchemy too. Testing doesn't show any problems.


