### PR TITLE
Get MusicBrainz row ids for exceptions by hand.

### DIFF
--- a/import_musicbrainz_row_ids.py
+++ b/import_musicbrainz_row_ids.py
@@ -22,20 +22,39 @@ influx = init_influx_connection(logging, {
 
 
 def fix_username_for_exceptions():
-    with db.engine.connect() as connection:
-        # 2106 - Fée Deuspi
-        connection.execute(sqlalchemy.text("""
-            UPDATE "user"
-               SET musicbrainz_id = 'Fée Deuspi'
-             WHERE id = 2106
-            """))
+    with brainzutils.musicbrainz_db.connect() as mb_connection:
+        with db.engine.connect() as connection:
+            # 2106 - Fée Deuspi
+            result = mb_connection.execute(sqlalchemy.text("""
+                SELECT id
+                  FROM editor
+                 WHERE name = 'Fée Deuspi'
+                """))
 
-        # 243 - ClæpsHydra
-        connection.execute(sqlalchemy.text("""
-            UPDATE "user"
-               SET musicbrainz_id = 'ClæpsHydra'
-             WHERE id = 243
-            """))
+            mb_row_id = result.fetchone()['id']
+            connection.execute(sqlalchemy.text("""
+                UPDATE "user"
+                   SET musicbrainz_row_id = :mb_row_id
+                 WHERE id = 2106
+                """), {
+                    'mb_row_id': mb_row_id,
+                })
+
+            # 243 - ClæpsHydra
+            result = mb_connection.execute(sqlalchemy.text("""
+                SELECT id
+                  FROM editor
+                 WHERE name = 'ClæpsHydra'
+                """))
+
+            mb_row_id = result.fetchone()['id']
+            connection.execute(sqlalchemy.text("""
+                UPDATE "user"
+                   SET musicbrainz_row_id = :mb_row_id
+                 WHERE id = 243
+                """), {
+                    'mb_row_id': mb_row_id,
+                })
 
 
 def delete_user(user):

--- a/import_musicbrainz_row_ids.py
+++ b/import_musicbrainz_row_ids.py
@@ -21,7 +21,7 @@ influx = init_influx_connection(logging, {
         })
 
 
-def fix_username_for_exceptions():
+def update_row_ids_for_exceptions():
     with brainzutils.musicbrainz_db.connect() as mb_connection:
         with db.engine.connect() as connection:
             # 2106 - Fée Deuspi
@@ -81,7 +81,7 @@ def import_musicbrainz_rows(musicbrainz_db_uri, dry_run=True):
     deleted = 0
 
     if not dry_run:
-        fix_username_for_exceptions()
+        update_row_ids_for_exceptions()
     with musicbrainz_db.engine.connect() as mb_connection:
         with db.engine.connect() as connection:
             for user in users:

--- a/import_musicbrainz_row_ids.py
+++ b/import_musicbrainz_row_ids.py
@@ -79,7 +79,9 @@ def import_musicbrainz_rows(musicbrainz_db_uri, dry_run=True):
     already_imported = 0
     not_found = 0
     deleted = 0
-    fix_username_for_exceptions()
+
+    if not dry_run:
+        fix_username_for_exceptions()
     with musicbrainz_db.engine.connect() as mb_connection:
         with db.engine.connect() as connection:
             for user in users:


### PR DESCRIPTION
Just realized that we can't willy nilly rename users in postgres, we would need to fix the influx measurement name for these users too. :/

Influx doesn't have an easy way to rename measurements (and there's around 200k listens for one of the users)

https://listenbrainz.org/user/Cl%EF%BF%BDpsHydra
https://listenbrainz.org/user/F%EF%BF%BDe%20Deuspi

I decided to just write the musicbrainz row id's of these two users by hand...
Then, once we allow renaming user accounts, their names would get fixed automatically.