### PR TITLE
Add NOT NULL constraint to musicbrainz_row_id column.

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -8,7 +8,7 @@ CREATE TABLE "user" (
   last_login     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   latest_import  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch',
   gdpr_agreed    TIMESTAMP WITH TIME ZONE,
-  musicbrainz_row_id INTEGER
+  musicbrainz_row_id INTEGER NOT NULL
 );
 ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_id_key UNIQUE (musicbrainz_id);
 ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_row_id_key UNIQUE (musicbrainz_row_id);

--- a/admin/sql/updates/2018-06-21-make-musicbrainz-row-id-not-null.sql
+++ b/admin/sql/updates/2018-06-21-make-musicbrainz-row-id-not-null.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE "user" ALTER COLUMN musicbrainz_row_id SET NOT NULL;
+
+COMMIT;

--- a/listenbrainz/db/__init__.py
+++ b/listenbrainz/db/__init__.py
@@ -6,7 +6,7 @@ import time
 import psycopg2
 
 # This value must be incremented after schema changes on replicated tables!
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 engine = None
 

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -53,6 +53,7 @@ PUBLIC_TABLES = {
         'id',
         'created',
         'musicbrainz_id',
+        'musicbrainz_row_id',
         # the following are dummy values for columns that we do not want to
         # dump in the public dump
         '\'\'', # auth token
@@ -105,6 +106,8 @@ PRIVATE_TABLES = {
         'auth_token',
         'last_login',
         'latest_import',
+        'musicbrainz_row_id',
+        'gdpr_agreed',
     ),
     'api_compat.token': (
         'id',

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -22,17 +22,6 @@ class UserTestCase(DatabaseTestCase):
         self.assertEqual(user['id'], user_id)
         user = db_user.get_by_mb_row_id(0, musicbrainz_id='frank')
         self.assertEqual(user['id'], user_id)
-        with db.engine.connect() as connection:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET musicbrainz_row_id = NULL
-                 WHERE id = :user_id
-                 """), {
-                     'user_id': user_id,
-                })
-        user = db_user.get_by_mb_row_id(0, musicbrainz_id='frank')
-        self.assertIsNotNone(user)
-        self.assertEqual(user['id'], user_id)
 
     def test_update_token(self):
         user = db_user.get_or_create(1, 'testuserplsignore')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Now that all users in LB have a musicbrainz row id, we should add a constraint for this.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

The newly added musicbrainz_row_id column does not have a not null constraint because we needed to import user musicbrainz ids first. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add a constraint for this. 

Also, needed to update the schema version and dump new columns to maintain consistency in dumps and backups.



