### PR TITLE
Improve error reports to the user for spotify imports

### DIFF
--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -8,7 +8,7 @@ import datetime
 
 class Spotify:
     def __init__(self, user_id, musicbrainz_id, user_token, token_expires, refresh_token,
-                 last_updated, active, error_message):
+                 last_updated, active, error_message, latest_listened_at):
         self.user_id = user_id
         self.user_token = user_token
         self.token_expires = token_expires
@@ -17,6 +17,7 @@ class Spotify:
         self.active = active
         self.error_message = error_message
         self.musicbrainz_id = musicbrainz_id
+        self.latest_listened_at = latest_listened_at
 
     def get_spotipy_client(self):
         return spotipy.Spotify(auth=self.user_token)
@@ -43,6 +44,7 @@ class Spotify:
            active=row['active'],
            error_message=row['error_message'],
            musicbrainz_id=row['musicbrainz_id'],
+           latest_listened_at=row['latest_listened_at'],
         )
 
     def __str__(self):

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -22,10 +22,13 @@ class Spotify:
     def get_spotipy_client(self):
         return spotipy.Spotify(auth=self.user_token)
 
-    def nice_last_updated(self):
-        if not self.last_updated:
-            return 'never'
-        return self.last_updated
+    @property
+    def last_updated_iso(self):
+        return self.last_updated.isoformat() + "Z"
+
+    @property
+    def latest_listened_at_iso(self):
+        return self.latest_listened_at.isoformat() + "Z"
 
     @property
     def token_expired(self):

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -20,6 +20,7 @@ class SpotifyDomainTestCase(ServerTestCase):
                 last_updated=None,
                 active=True,
                 error_message=None,
+                latest_listened_at=None,
             )
 
     @mock.patch('listenbrainz.domain.spotify.db_spotify.get_user')
@@ -61,6 +62,7 @@ class SpotifyDomainTestCase(ServerTestCase):
             'last_updated': None,
             'active': True,
             'error_message': 'oops',
+            'latest_listened_at': None,
         }
 
         user = spotify.get_user(1)
@@ -100,6 +102,7 @@ class SpotifyDomainTestCase(ServerTestCase):
                 'last_updated': None,
                 'active': True,
                 'error_message': 'oops',
+                'latest_listened_at': None,
             },
             {
                 'user_id': 2,
@@ -110,6 +113,7 @@ class SpotifyDomainTestCase(ServerTestCase):
                 'last_updated': None,
                 'active': True,
                 'error_message': 'oops2',
+                'latest_listened_at': None,
             },
         ]
 

--- a/listenbrainz/webserver/templates/user/spotify.html
+++ b/listenbrainz/webserver/templates/user/spotify.html
@@ -13,14 +13,45 @@
     </p>
 
     {% if account %}
-       <p>Your account is linked. Click the button below to unlink it</p>
-       <form method="POST">
-         <input type="hidden" name="delete" value="yes" />
-         <input class="btn btn-primary btn-lg" type="submit" value="Unlink" />
-       </form>
+      <p>Your account is linked. Click the button below to unlink it</p>
+      <form method="POST">
+        <input type="hidden" name="delete" value="yes" />
+        <input class="btn btn-primary btn-lg" type="submit" value="Unlink" />
+      </form>
+
+      {% if account.error_message %}
+        <h3>Import Errors</h3>
+        <p>There was an error while importing listens from your Spotify account.</p>
+        <div class="alert alert-danger">
+          <p> {{account.error_message}} </p>
+        </div>
+      {% endif %}
+
+      <h3>Activity Status</h3>
+      {% if not account.active %}
+        <p>ListenBrainz is currently not importing your Spotify listens due to errors,
+        please unlink and link your Spotify account to try again.</p>
+      {% endif %}
+
+      {% if not account.last_updated %}
+        <p>We haven't gotten around to importing your listens yet, please come back later!</p>
+      {% else %}
+      <p>We imported your listens <abbr class="timeago" title="{{last_updated}}">{{last_updated}}</abbr> and the last song we imported was listened to <abbr class="timeago" title="{{latest_listened_at}}">{{latest_listened_at}}</abbr>.</p>
+      {% endif %}
+
     {% else %}
       <p><a href="{{ spotify_login_url }}">Log in with Spotify.</a></p>
     {% endif %}
 
   </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/lib/jquery.timeago.js') }}"></script>
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $("abbr.timeago").timeago();
+    });
+  </script>
 {% endblock %}

--- a/listenbrainz/webserver/templates/user/spotify.html
+++ b/listenbrainz/webserver/templates/user/spotify.html
@@ -34,7 +34,7 @@
       {% endif %}
 
       {% if not account.last_updated %}
-        <p>We haven't gotten around to importing your listens yet, please come back later!</p>
+        <p>We haven't gotten around to importing your listens yet, please check back later!</p>
       {% else %}
       <p>We imported your listens <abbr class="timeago" title="{{last_updated}}">{{last_updated}}</abbr> and the last song we imported was listened to <abbr class="timeago" title="{{latest_listened_at}}">{{latest_listened_at}}</abbr>.</p>
       {% endif %}

--- a/listenbrainz/webserver/templates/user/spotify.html
+++ b/listenbrainz/webserver/templates/user/spotify.html
@@ -21,7 +21,7 @@
 
       {% if account.error_message %}
         <h3>Import Errors</h3>
-        <p>There was an error while importing listens from your Spotify account.</p>
+        <p>There was an error while importing listens from your Spotify account:</p>
         <div class="alert alert-danger">
           <p> {{account.error_message}} </p>
         </div>

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -298,6 +298,8 @@ def connect_spotify():
     return render_template(
         'user/spotify.html',
         account=user,
+        last_updated=user.last_updated_iso,
+        latest_listened_at=user.latest_listened_at_iso,
         spotify_login_url=spotify_url
     )
 

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -298,8 +298,8 @@ def connect_spotify():
     return render_template(
         'user/spotify.html',
         account=user,
-        last_updated=user.last_updated_iso,
-        latest_listened_at=user.latest_listened_at_iso,
+        last_updated=user.last_updated_iso if user else None,
+        latest_listened_at=user.latest_listened_at_iso if user else None,
         spotify_login_url=spotify_url
     )
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is an **Improvement**.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

We saved error messages for users in the db but didn't display them.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Improve error reporting and information given to user.

* Tell the user if their account is inactive i.e we aren't
importing their listens.
* Show errors that occured during their imports.
* Show times when listens were imported last.



