### PR TITLE
Make sure that old lists in the database are parsed correctly too

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ git+https://github.com/bninja/pika-pool.git@5b1d3b650395aed60d9995fbfd289de7e62f
 git+https://github.com/metabrainz/messybrainz-server.git@production#egg=messybrainz
 git+https://github.com/metabrainz/brainzutils-python.git@v1.5.0
 spotipy == 2.4.4
+pyyaml == 3.13


### PR DESCRIPTION
there are some lists in the database that were converted to  via str(list) so they can't be loaded via json.

Example: "['Blank & Jones']"

However, yaml parses them safely and correctly