### PR TITLE
Make spotify callback url a config value

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -122,6 +122,7 @@ ADMINS = [
 # SPOTIFY
 SPOTIFY_CLIENT_ID = '''{{template "KEY" "spotify/client_id"}}'''
 SPOTIFY_CLIENT_SECRET = '''{{template "KEY" "spotify/client_secret"}}'''
+SPOTIFY_CALLBACK_URL = '''{{template "KEY" "spotify/callback"}}'''
 
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -110,6 +110,7 @@ ADMINS = []
 # SPOTIFY
 SPOTIFY_CLIENT_ID = ''
 SPOTIFY_CLIENT_SECRET = ''
+SPOTIFY_CALLBACK_URL = 'http://0.0.0.0/profile/connect-spotify/callback'
 
 # This is set to False to stop a warning from flask_sqlalchemy.
 # We do not use this feature at all, so it is safe to set to False.

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -1,5 +1,5 @@
 import pytz
-from flask import current_app, url_for
+from flask import current_app
 import spotipy.oauth2
 
 from listenbrainz.db import spotify as db_spotify
@@ -82,9 +82,7 @@ def get_spotify_oauth():
     client_id = current_app.config['SPOTIFY_CLIENT_ID']
     client_secret = current_app.config['SPOTIFY_CLIENT_SECRET']
     scope = 'user-read-recently-played'
-    redirect_url = url_for(
-            'profile.connect_spotify_callback',
-            _external=True)
+    redirect_url = current_app.config['SPOTIFY_CALLBACK_URL']
     return spotipy.oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri=redirect_url, scope=scope)
 
 

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -51,7 +51,7 @@ class SpotifyDomainTestCase(ServerTestCase):
         func_oauth = spotify.get_spotify_oauth()
         self.assertEqual(func_oauth.client_id, current_app.config['SPOTIFY_CLIENT_ID'])
         self.assertEqual(func_oauth.client_secret, current_app.config['SPOTIFY_CLIENT_SECRET'])
-        self.assertEqual(func_oauth.redirect_uri, 'http://localhost/profile/connect-spotify/callback')
+        self.assertEqual(func_oauth.redirect_uri, 'http://0.0.0.0/profile/connect-spotify/callback')
         self.assertEqual(func_oauth.scope, 'user-read-recently-played')
 
     @mock.patch('listenbrainz.domain.spotify.db_spotify.get_user')

--- a/listenbrainz/test_config.py
+++ b/listenbrainz/test_config.py
@@ -103,5 +103,10 @@ UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 
 API_URL = 'https://api.listenbrainz.org'
 
+# SPOTIFY
+SPOTIFY_CLIENT_ID = ''
+SPOTIFY_CLIENT_SECRET = ''
+SPOTIFY_CALLBACK_URL = 'http://0.0.0.0/profile/connect-spotify/callback'
+
 LASTFM_PROXY_URL = 'http://0.0.0.0:8080/'
 MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'


### PR DESCRIPTION
Creating the callback URL using url_for needs a SERVER_NAME set which causes problems with our production setup. It would be better if we just used it as a callback value.