### PR TITLE
Remove import LAST.FM backup files feature

### DIFF
--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -47,18 +47,7 @@
     <p>
       <a href={{ url_for('profile.connect_spotify') }}>Connect your Spotify account to ListenBrainz.</a>
     </p>
-
-    <h3>Import a Last.fm backup file</h3>
-
-    <p>Import your listens from a Last.fm backup file (.zip)</p>
-    <div class="well">
-      <form action="upload" method="POST" enctype=multipart/form-data>
-        <input type="file" name="file">
-        </br>
-        <input type="submit" value="Upload">
-      </form>
-    </div>
-
+    
   {% endif %}
 {% endblock %}
 

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -252,34 +252,6 @@ def _messybrainz_lookup(listens):
     return augmented_listens
 
 
-def convert_backup_to_native_format(data):
-    """
-    Converts the imported listen-payload from the lastfm backup file
-    to the native payload format.
-    """
-    payload = []
-    for native_lis in data:
-        listen = {}
-        listen['track_metadata'] = {}
-        listen['track_metadata']['additional_info'] = {}
-
-        if 'timestamp' in native_lis and 'unixtimestamp' in native_lis['timestamp']:
-            listen['listened_at'] = native_lis['timestamp']['unixtimestamp']
-
-        if 'track' in native_lis:
-            if 'name' in native_lis['track']:
-                listen['track_metadata']['track_name'] = native_lis['track']['name']
-            if 'mbid' in native_lis['track']:
-                listen['track_metadata']['additional_info']['recording_mbid'] = native_lis['track']['mbid']
-            if 'artist' in native_lis['track']:
-                if 'name' in native_lis['track']['artist']:
-                    listen['track_metadata']['artist_name'] = native_lis['track']['artist']['name']
-                if 'mbid' in native_lis['track']['artist']:
-                    listen['track_metadata']['additional_info']['artist_mbids'] = [native_lis['track']['artist']['mbid']]
-        payload.append(listen)
-    return payload
-
-
 def log_raise_400(msg, data=""):
     """ Helper function for logging issues with request data and showing error page.
         Logs the message and data, raises BadRequest exception which shows 400 Bad

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -23,7 +23,7 @@ from listenbrainz.webserver.redis_connection import _redis
 from listenbrainz.webserver.influx_connection import _influx
 from listenbrainz.webserver.utils import sizeof_readable
 from listenbrainz.webserver.views.user import delete_user, _get_user
-from listenbrainz.webserver.views.api_tools import convert_backup_to_native_format, insert_payload, validate_listen, \
+from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, \
     LISTEN_TYPE_IMPORT, publish_data_to_queue
 from os import path, makedirs
 from time import time


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary
Since Last.FM removed their download scrobbles data, the function to import backup data in listenbrainz is pretty useless. So, it's better to remove this in order to not confuse people.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:
Deleted the function about import last.fm backup files
# Problem
The deletion of the feature from last.fm make this functions pretty much useless.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-379](https://tickets.metabrainz.org/browse/LB-379)


# Solution
Delete the functions
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
Delete the functions
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


