### PR TITLE
Print message after init_db command finishes

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -97,6 +97,8 @@ def init_db(force, create_db):
         print('Creating indexes...')
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_indexes.sql'))
 
+        print("Done!")
+
 
 @cli.command()
 @click.option("--force", "-f", is_flag=True, help="Drop existing database and user.")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
The ```docker-compose -f docker/docker-compose.yml -p listenbrainz run --rm web python3 manage.py init_db --create-db``` command in the end doesn't print a "Done" message and prints "Creating indexes..." as the last message which might confuse someone to think that it aborted before completion. And we do print a "Done" message for other init_db commands. So, it makes sense to do that here.

```
Starting listenbrainz_rabbitmq_1 ... 
Starting listenbrainz_redis_1 ... 
Starting listenbrainz_rabbitmq_1
Starting listenbrainz_redis_1
Starting listenbrainz_db_1 ... 
Starting listenbrainz_influx_1 ... 
Starting listenbrainz_db_1
Starting listenbrainz_redis_1 ... done
Connection to db established!
Creating user and a database...
Creating database extensions...
Starting metabrainz service with  environment.
Configuration values are as follows: 
{   'API_URL': 'https://api.listenbrainz.org',
    'APPLICATION_ROOT': None,
    'BIGQUERY_DATASET_ID': 'listenbrainz_test',
    'BIGQUERY_PROJECT_ID': 'listenbrainz',
    'BIGQUERY_TABLE_ID': 'listen',
    'COMPILE_LESS': True,
    'DEBUG': True,
    'DEBUG_TB_ENABLED': True,
    'DEBUG_TB_HOSTS': (),
    'DEBUG_TB_INTERCEPT_REDIRECTS': True,
    'DEBUG_TB_PANELS': (   'flask_debugtoolbar.panels.versions.VersionDebugPanel',
                           'flask_debugtoolbar.panels.timer.TimerDebugPanel',
                           'flask_debugtoolbar.panels.headers.HeaderDebugPanel',
                           'flask_debugtoolbar.panels.request_vars.RequestVarsDebugPanel',
                           'flask_debugtoolbar.panels.config_vars.ConfigVarsDebugPanel',
                           'flask_debugtoolbar.panels.template.TemplateDebugPanel',
                           'flask_debugtoolbar.panels.sqlalchemy.SQLAlchemyDebugPanel',
                           'flask_debugtoolbar.panels.logger.LoggingPanel',
                           'flask_debugtoolbar.panels.route_list.RouteListDebugPanel',
                           'flask_debugtoolbar.panels.profiler.ProfilerDebugPanel'),
    'EXPLAIN_TEMPLATE_LOADING': False,
    'INFLUX_DB_NAME': 'listenbrainz',
    'INFLUX_HOST': 'influx',
    'INFLUX_PORT': 8086,
    'JSONIFY_MIMETYPE': 'application/json',
    'JSONIFY_PRETTYPRINT_REGULAR': True,
    'JSON_AS_ASCII': True,
    'JSON_SORT_KEYS': True,
    'LASTFM_API_KEY': 'e5b650429d485857e68e0c5bf2874525',
    'LASTFM_API_URL': 'https://ws.audioscrobbler.com/2.0/',
    'LASTFM_PROXY_URL': 'http://0.0.0.0:8080/',
    'LOGGER_HANDLER_POLICY': 'always',
    'LOGGER_NAME': 'listenbrainz.webserver',
    'MAX_CONTENT_LENGTH': 16777216,
    'MAX_POSTGRES_LISTEN_HISTORY': '-1',
    'MESSYBRAINZ_SQLALCHEMY_DATABASE_URI': 'postgresql://messybrainz:messybrainz@db:5432/messybrainz',
    'MUSICBRAINZ_CLIENT_ID': '2LXvDjyab0KGaZ9HHH4eJw',
    'MUSICBRAINZ_CLIENT_SECRET': '0yqMqBYQZKG20FblBpvBJQ',
    'PERMANENT_SESSION_LIFETIME': datetime.timedelta(31),
    'PG_ASYNC_LISTEN_COMMIT': False,
    'PG_QUERY_TIMEOUT': '3000',
    'PLAYING_NOW_MAX_DURATION': 600,
    'POSTGRES_ADMIN_URI': 'postgresql://postgres@db/template1',
    'PREFERRED_URL_SCHEME': 'http',
    'PRESERVE_CONTEXT_ON_EXCEPTION': None,
    'PROPAGATE_EXCEPTIONS': None,
    'RABBITMQ_HOST': 'rabbitmq',
    'RABBITMQ_PASSWORD': 'guest',
    'RABBITMQ_PORT': 5672,
    'RABBITMQ_USERNAME': 'guest',
    'RABBITMQ_VHOST': '/',
    'REDIS_HOST': 'redis',
    'REDIS_NAMESPACE': 'listenbrainz',
    'REDIS_PORT': 6379,
    'SECRET_KEY': 'CHANGE_ME',
    'SEND_FILE_MAX_AGE_DEFAULT': datetime.timedelta(0, 43200),
    'SERVER_NAME': None,
    'SESSION_COOKIE_DOMAIN': None,
    'SESSION_COOKIE_HTTPONLY': True,
    'SESSION_COOKIE_NAME': 'session',
    'SESSION_COOKIE_PATH': None,
    'SESSION_COOKIE_SECURE': False,
    'SESSION_REFRESH_EACH_REQUEST': True,
    'SQLALCHEMY_DATABASE_URI': 'postgresql://listenbrainz:listenbrainz@db:5432/listenbrainz',
    'STATS_CALCULATION_INTERVAL': 7,
    'STATS_CALCULATION_LOGIN_TIME': 30,
    'STATS_ENTITY_LIMIT': 100,
    'TEMPLATES_AUTO_RELOAD': None,
    'TESTING': False,
    'TRAP_BAD_REQUEST_ERRORS': False,
    'TRAP_HTTP_EXCEPTIONS': False,
    'UPLOAD_FOLDER': '/tmp/lastfm-backup-upload',
    'USE_X_SENDFILE': False,
    'WRITE_TO_BIGQUERY': False}
Unable to retrieve git commit. Error: %s [Errno 2] No such file or directory: '.git-version'
--------------------------------------------------------------------------------
INFO in redis_connection [/code/listenbrainz/listenbrainz/webserver/redis_connection.py:15]:
Connecting to redis redis:6379
--------------------------------------------------------------------------------
2018-10-27 11:27:09,123 INFO Connecting to redis: redis:6379
--------------------------------------------------------------------------------
INFO in influx_connection [/code/listenbrainz/listenbrainz/webserver/influx_connection.py:17]:
Successfully created InfluxListenStore instance!
--------------------------------------------------------------------------------
Connection to db established!
Connection to db established
/usr/local/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py:778: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
  'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
Creating schema...
Creating tables...
Creating primary and foreign keys...
Creating indexes...
```
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->