### PR TITLE
LB-377 - Add user token query

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -318,8 +318,10 @@ class APITestCase(IntegrationTestCase):
         """Sends an invalid token to api.validate_token"""
         url = url_for('api_v1.validate_token')
         response = self.client.get(url, query_string = {"token":"invalidtoken"})
-        self.assert401(response)
-        self.assertEqual(response.json['code'], 401)
+        self.assert200(response)
+        self.assertEqual(response.json['code'], 200)
+        self.assertEqual('Token invalid.', response.json['message'])
+
 
     def test_valid_token_validation(self):
         """Sends a valid token to api.validate_token"""
@@ -327,4 +329,4 @@ class APITestCase(IntegrationTestCase):
         response = self.client.get(url, query_string = {"token":self.user['auth_token']})
         self.assert200(response)
         self.assertEqual(response.json['code'], 200)
-        self.assertEqual('Token exists in database.', response.json['message'])
+        self.assertEqual('Token valid.', response.json['message'])

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -313,3 +313,18 @@ class APITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
         self.assertEqual('Value for key listened_at is too high.', response.json['error'])
+
+    def test_invalid_token_validation(self):
+        """Sends an invalid token to api.validate_token"""
+        url = url_for('api_v1.validate_token')
+        response = self.client.get(url, query_string = {"token":"invalidtoken"})
+        self.assert401(response)
+        self.assertEqual(response.json['code'], 401)
+
+    def test_valid_token_validation(self):
+        """Sends a valid token to api.validate_token"""
+        url = url_for('api_v1.validate_token')
+        response = self.client.get(url, query_string = {"token":self.user['auth_token']})
+        self.assert200(response)
+        self.assertEqual(response.json['code'], 200)
+        self.assertEqual('Token exists in database.', response.json['message'])

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -190,7 +190,7 @@ def validate_token():
     In order to query this endpoint, send a GET request.
     A JSON response will be returned, with one of three codes.
 
-    :statuscode 200: The user token is (in)valid.
+    :statuscode 200: The user token is valid/invalid.
     :statuscode 400: No token was sent to the endpoint.
     """
     auth_token = request.args.get('token', '')

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -181,6 +181,31 @@ def latest_import():
         return jsonify({'status': 'ok'})
 
 
+@api_bp.route('/validate-token', methods=['GET'])
+@ratelimit()
+def validate_token():
+    """
+    Check whether a User Token is a valid entry in the database.
+
+    In order to query this endpoint, send make a GET request to this endpoint.
+    A JSON response will be returned, with one of three codes.
+
+    :statuscode 200: The user token is valid.
+    :statuscode 400: No token was sent to the endpoint.
+    :statuscode 401: The user token is invalid (does not exist).
+    """
+    auth_token = request.args.get('token', '')
+    if not auth_token:
+        raise BadRequest("You need to provide an Authorization token.")
+    user = db_user.get_by_token(auth_token)
+    if user is None:
+        raise Unauthorized("Token does not exist in database.")
+    return jsonify({
+        'code': 200,
+        'message': 'Token exists in database.'
+    })
+
+
 def _parse_int_arg(name, default=None):
     value = request.args.get(name)
     if value:

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -187,7 +187,7 @@ def validate_token():
     """
     Check whether a User Token is a valid entry in the database.
 
-    In order to query this endpoint, send make a GET request to this endpoint.
+    In order to query this endpoint, send a GET request.
     A JSON response will be returned, with one of three codes.
 
     :statuscode 200: The user token is valid.

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -190,9 +190,8 @@ def validate_token():
     In order to query this endpoint, send a GET request.
     A JSON response will be returned, with one of three codes.
 
-    :statuscode 200: The user token is valid.
+    :statuscode 200: The user token is (in)valid.
     :statuscode 400: No token was sent to the endpoint.
-    :statuscode 401: The user token is invalid (does not exist).
     """
     auth_token = request.args.get('token', '')
     if not auth_token:

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -199,12 +199,15 @@ def validate_token():
         raise BadRequest("You need to provide an Authorization token.")
     user = db_user.get_by_token(auth_token)
     if user is None:
-        raise Unauthorized("Token does not exist in database.")
-    return jsonify({
-        'code': 200,
-        'message': 'Token exists in database.'
-    })
-
+        return jsonify({
+            'code': 200,
+            'message': 'Token invalid.'
+        })
+    else:
+        return jsonify({
+            'code': 200,
+            'message': 'Token valid.'
+        })
 
 def _parse_int_arg(name, default=None):
     value = request.args.get(name)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
This is a new API endpoint for querying whether user tokens exist or not, in response to ticket [LB-377](https://tickets.metabrainz.org/browse/LB-377). I have also included two test cases for the endpoint, for both a successful and unsuccessful token.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

JIRA ticket: [LB-377](https://tickets.metabrainz.org/browse/LB-377):

> Add an endpoint to query if a user token is correct. Currently you have to send a request with an authentication header and check if there is any authentication errors. It would be nice to be able to query the token to warn the user in advance.




# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The endpoint itself is queried with a GET request, and queries the database for a user with this token. If no such user exists, an invalid response is returned.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
I noticed that some endpoints only had _one_ test case (to check an invalid response), so I just wanted to make sure that both of these two endpoints are needed?

