### PR TITLE
Retry some times while trying to refresh user tokens

### DIFF
--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -5,6 +5,8 @@ import spotipy.oauth2
 from listenbrainz.db import spotify as db_spotify
 import datetime
 
+SPOTIFY_API_RETRIES = 5
+
 
 class Spotify:
     def __init__(self, user_id, musicbrainz_id, user_token, token_expires, refresh_token,
@@ -69,11 +71,11 @@ def refresh_user_token(spotify_user):
     """
     auth = get_spotify_oauth()
 
-    retries = 5
+    retries = SPOTIFY_API_RETRIES
     new_token = None
     while retries > 0:
         new_token = auth.refresh_access_token(spotify_user.refresh_token)
-        if new_token is not None:
+        if new_token:
             break
         retries -= 1
     if new_token is None:

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -68,7 +68,17 @@ def refresh_user_token(spotify_user):
         user (domain.spotify.Spotify): the same user with updated tokens
     """
     auth = get_spotify_oauth()
-    new_token = auth.refresh_access_token(spotify_user.refresh_token)
+
+    retries = 5
+    new_token = None
+    while retries > 0:
+        new_token = auth.refresh_access_token(spotify_user.refresh_token)
+        if new_token is not None:
+            break
+        retries -= 1
+    if new_token is None:
+        raise SpotifyAPIError('Could not refresh API Token for Spotify user')
+
     access_token = new_token['access_token']
     refresh_token = new_token['refresh_token']
     expires_at = new_token['expires_at']

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -5,6 +5,7 @@ from flask import current_app
 from listenbrainz.domain import spotify
 from listenbrainz.webserver.testing import ServerTestCase
 from unittest import mock
+from unittest.mock import MagicMock
 
 
 class SpotifyDomainTestCase(ServerTestCase):
@@ -134,3 +135,12 @@ class SpotifyDomainTestCase(ServerTestCase):
         t = int(time.time())
         spotify.update_latest_listened_at(1, t)
         mock_update_listened_at.assert_called_once_with(1, t)
+
+    @mock.patch('listenbrainz.domain.spotify.get_spotify_oauth')
+    def test_refresh_user_token_bad(self, mock_get_spotify_oauth):
+        mock_oauth = MagicMock()
+        mock_oauth.refresh_access_token.return_value = None
+        mock_get_spotify_oauth.return_value = mock_oauth
+
+        with self.assertRaises(spotify.SpotifyAPIError):
+            spotify.refresh_user_token(self.spotify_user)

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -152,7 +152,11 @@ def process_one_user(user):
 
     """
     if user.token_expired:
-        user = spotify.refresh_user_token(user)
+        try:
+            user = spotify.refresh_user_token(user)
+        except spotify.SpotifyAPIError:
+            current_app.logger.error('Could not refresh user token from spotify', exc_info=True)
+            raise
 
     listenbrainz_user = db_user.get(user.user_id)
     try:


### PR DESCRIPTION
There was a sentry error for this in the Spotify importer.