### PR TITLE
Use new rabbitmq connection pooler in the current-status view

### DIFF
--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -91,32 +91,32 @@ def current_status():
 
     load = "%.2f %.2f %.2f" % os.getloadavg()
 
-    incoming_len = -1
-    unique_len = -1
     try:
-        with rabbitmq_connection._rabbitmq.acquire() as connection:
-            queue = connection.channel.queue_declare(current_app.config['INCOMING_QUEUE'], durable=True)
-            incoming_len = queue.method.message_count
+        with rabbitmq_connection._rabbitmq.get() as connection:
+            queue = connection.channel.queue_declare(current_app.config['INCOMING_QUEUE'], passive=True, durable=True)
+            incoming_len_msg = format(int(queue.method.message_count), ',d')
 
-            queue = connection.channel.queue_declare(current_app.config['UNIQUE_QUEUE'], durable=True)
-            unique_len = queue.method.message_count
+            queue = connection.channel.queue_declare(current_app.config['UNIQUE_QUEUE'], passive=True, durable=True)
+            unique_len_msg = format(int(queue.method.message_count), ',d')
 
-    except (pika.exceptions.ConnectionClosed, AttributeError):
-        pass
+    except (pika.exceptions.ConnectionClosed, pika.exceptions.ChannelClosed):
+        current_app.logger.error('Unable to get the length of queues', exc_info=True)
+        incoming_len_msg = 'Unknown'
+        unique_len_msg = 'Unknown'
 
     listen_count = _influx.get_total_listen_count()
     try:
-        user_count = _get_user_count()
+        user_count = format(int(_get_user_count()), ',d')
     except DatabaseException as e:
-        user_count = None
+        user_count = 'Unknown'
 
     return render_template(
         "index/current-status.html",
         load=load,
         listen_count=format(int(listen_count), ",d"),
-        incoming_len=format(int(incoming_len), ",d"),
-        unique_len=format(int(unique_len), ",d"),
-        user_count=format(int(user_count), ",d"),
+        incoming_len=incoming_len_msg,
+        unique_len=unique_len_msg,
+        user_count=user_count,
     )
 
 

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -3,6 +3,7 @@ from unittest import mock
 from flask import url_for
 from flask_login import login_required, AnonymousUserMixin
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
+from pika.exceptions import ConnectionClosed, ChannelClosed
 
 import listenbrainz.db.user as db_user
 import listenbrainz.webserver.login
@@ -73,6 +74,20 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
     def test_current_status(self):
         resp = self.client.get(url_for('index.current_status'))
         self.assert200(resp)
+
+    @mock.patch('listenbrainz.webserver.views.index.rabbitmq_connection')
+    def test_current_status_ise(self, mock_rabbitmq_connection_module):
+        mock_rabbitmq_connection_module._rabbitmq.get.side_effect = InternalServerError
+        r = self.client.get(url_for('index.current_status'))
+        self.assert500(r)
+
+        mock_rabbitmq_connection_module._rabbitmq.get.side_effect = ConnectionClosed
+        r = self.client.get(url_for('index.current_status'))
+        self.assert200(r)
+
+        mock_rabbitmq_connection_module._rabbitmq.get.side_effect = ConnectionClosed
+        r = self.client.get(url_for('index.current_status'))
+        self.assert200(r)
 
     @mock.patch('listenbrainz.db.user.get')
     def test_menu_not_logged_in(self, mock_user_get):


### PR DESCRIPTION
Then add more descriptive error messages if channel or
connection is closed.

Also, add a test.

