### PR TITLE
Retry RabbitMQ connection establishment instead of giving up after one failure

### DIFF
--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -6,6 +6,9 @@ import listenbrainz.utils as utils
 
 _rabbitmq = None
 
+CONNECTION_RETRIES = 10
+TIME_BEFORE_RETRIES = 2
+
 def init_rabbitmq_connection(app):
     """Initialize the webserver rabbitmq connection.
 
@@ -28,7 +31,7 @@ def init_rabbitmq_connection(app):
 
     _rabbitmq = RabbitMQConnectionPool(app.logger, connection_parameters, app.config['MAXIMUM_RABBITMQ_CONNECTIONS'])
     _rabbitmq.add()
-    app.logger.error('Connection to RabbitMQ established!')
+    app.logger.info('Connection to RabbitMQ established!')
 
 
 class RabbitMQConnectionPool:
@@ -62,9 +65,16 @@ class RabbitMQConnectionPool:
             connection.close()
 
     def create(self):
-        connection = pika.BlockingConnection(self.connection_parameters)
-        channel = connection.channel()
-        return RabbitMQConnection(connection, channel, self)
+        for attempt in range(CONNECTION_RETRIES):
+            try:
+                connection = pika.BlockingConnection(self.connection_parameters)
+                channel = connection.channel()
+                return RabbitMQConnection(connection, channel, self)
+            except (pika.exceptions.ConnectionClosed, pika.exceptions.ChannelClosed) as e:
+                sleep(TIME_BEFORE_RETRIES)
+                if attempt == CONNECTION_RETRIES - 1: # if this is the last attempt
+                    self.log.critical('Unable to create a RabbitMQ connection: %s', str(e), exc_info=True)
+                    raise
 
 
 class RabbitMQConnection:

--- a/listenbrainz/webserver/test_rabbitmq_connection.py
+++ b/listenbrainz/webserver/test_rabbitmq_connection.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from pika.exceptions import ConnectionClosed
+
+
+from listenbrainz.webserver.rabbitmq_connection import RabbitMQConnectionPool, CONNECTION_RETRIES
+
+
+class RabbitMQConnectionPoolTestCase(TestCase):
+
+    def setUp(self):
+        self.pool = RabbitMQConnectionPool(MagicMock(), MagicMock(), 10)
+
+    @patch('listenbrainz.webserver.rabbitmq_connection.pika.BlockingConnection')
+    @patch('listenbrainz.webserver.rabbitmq_connection.sleep')
+    def test_connection_closed_while_creating(self, mock_sleep, mock_blocking_connection):
+        mock_blocking_connection.side_effect = ConnectionClosed
+        with self.assertRaises(ConnectionClosed):
+            connection = self.pool.create()
+            self.pool.log.critical.assert_called_once()
+            self.assertEqual(self.mock_sleep.call_count, CONNECTION_RETRIES - 1)


### PR DESCRIPTION
The flask app wasn't created in `listenbrainz-api-compat` due to timeout errors during startup leading to 500s.

This should fix that.