### PR TITLE
Make sure the webserver stays up even if RabbitMQ is down.

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -99,7 +99,11 @@ def gen_app(config_path=None, debug=None):
     create_influx(app)
 
     # RabbitMQ connection
-    create_rabbitmq(app)
+    try:
+        create_rabbitmq(app)
+    except ConnectionError:
+        app.logger.critical("RabbitMQ service is not up!", exc_info=True)
+
 
     # Database connection
     from listenbrainz import db

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -19,12 +19,14 @@ def init_rabbitmq_connection(app):
     # if RabbitMQ config values are not in the config file, the app should
     # wait for them to come back. Consul will bring the values back into
     # config once the RabbitMQ service comes up.
-    while True:
+    for _ in range(CONNECTION_RETRIES):
         if "RABBITMQ_HOST" not in app.config:
             app.logger.critical("RabbitMQ host:port not defined. Sleeping 2 seconds and trying again...")
             sleep(2)
         else:
             break
+    else:
+        raise ConnectionError("RabbitMQ service is not up!")
 
     connection_parameters = pika.ConnectionParameters(
         host=app.config['RABBITMQ_HOST'],

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -1,4 +1,3 @@
-import sys
 import queue
 from time import sleep
 import pika
@@ -17,10 +16,15 @@ def init_rabbitmq_connection(app):
     """
     global _rabbitmq
 
-    if "RABBITMQ_HOST" not in app.config:
-        app.logger.error("RabbitMQ host:port not defined. Sleeping 2 seconds, and exiting.")
-        sleep(2)
-        sys.exit(-1)
+    # if RabbitMQ config values are not in the config file, the app should
+    # wait for them to come back. Consul will bring the values back into
+    # config once the RabbitMQ service comes up.
+    while True:
+        if "RABBITMQ_HOST" not in app.config:
+            app.logger.critical("RabbitMQ host:port not defined. Sleeping 2 seconds and trying again...")
+            sleep(2)
+        else:
+            break
 
     connection_parameters = pika.ConnectionParameters(
         host=app.config['RABBITMQ_HOST'],

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -20,7 +20,7 @@ def init_rabbitmq_connection(app):
     # raise an error. This is caught in create_app, so the app will continue running.
     # Consul will bring the values back into config once the RabbitMQ service comes up.
     if "RABBITMQ_HOST" not in app.config:
-        app.logger.critical("RabbitMQ host:port not defined. Sleeping 2 seconds and trying again...")
+        app.logger.critical("RabbitMQ host:port not defined, cannot create RabbitMQ connection...")
         raise ConnectionError("RabbitMQ service is not up!")
 
     connection_parameters = pika.ConnectionParameters(

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -16,16 +16,11 @@ def init_rabbitmq_connection(app):
     """
     global _rabbitmq
 
-    # if RabbitMQ config values are not in the config file, the app should
+    # if RabbitMQ config values are not in the config filed
     # wait for them to come back. Consul will bring the values back into
     # config once the RabbitMQ service comes up.
-    for _ in range(CONNECTION_RETRIES):
-        if "RABBITMQ_HOST" not in app.config:
-            app.logger.critical("RabbitMQ host:port not defined. Sleeping 2 seconds and trying again...")
-            sleep(2)
-        else:
-            break
-    else:
+    if "RABBITMQ_HOST" not in app.config:
+        app.logger.critical("RabbitMQ host:port not defined. Sleeping 2 seconds and trying again...")
         raise ConnectionError("RabbitMQ service is not up!")
 
     connection_parameters = pika.ConnectionParameters(

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -16,9 +16,9 @@ def init_rabbitmq_connection(app):
     """
     global _rabbitmq
 
-    # if RabbitMQ config values are not in the config filed
-    # wait for them to come back. Consul will bring the values back into
-    # config once the RabbitMQ service comes up.
+    # if RabbitMQ config values are not in the config file
+    # raise an error. This is caught in create_app, so the app will continue running.
+    # Consul will bring the values back into config once the RabbitMQ service comes up.
     if "RABBITMQ_HOST" not in app.config:
         app.logger.critical("RabbitMQ host:port not defined. Sleeping 2 seconds and trying again...")
         raise ConnectionError("RabbitMQ service is not up!")

--- a/listenbrainz/webserver/test_rabbitmq_connection.py
+++ b/listenbrainz/webserver/test_rabbitmq_connection.py
@@ -21,12 +21,10 @@ class RabbitMQConnectionPoolTestCase(TestCase):
             self.pool.log.critical.assert_called_once()
             self.assertEqual(self.mock_sleep.call_count, CONNECTION_RETRIES - 1)
 
-    @patch('listenbrainz.webserver.rabbitmq_connection.sleep')
-    def test_connection_error_when_rabbitmq_down(self, mock_sleep):
+    def test_connection_error_when_rabbitmq_down(self):
         # create an app with no RabbitMQ config
         # as will be the case when RabbitMQ is down in production
         app = Flask(__name__)
 
         with self.assertRaises(ConnectionError):
             init_rabbitmq_connection(app)
-            self.assertEqual(self.mock_sleep.call_count, CONNECTION_RETRIES - 1)

--- a/listenbrainz/webserver/test_rabbitmq_connection.py
+++ b/listenbrainz/webserver/test_rabbitmq_connection.py
@@ -1,9 +1,10 @@
+from flask import Flask
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from pika.exceptions import ConnectionClosed
 
 
-from listenbrainz.webserver.rabbitmq_connection import RabbitMQConnectionPool, CONNECTION_RETRIES
+from listenbrainz.webserver.rabbitmq_connection import RabbitMQConnectionPool, CONNECTION_RETRIES, init_rabbitmq_connection
 
 
 class RabbitMQConnectionPoolTestCase(TestCase):
@@ -18,4 +19,14 @@ class RabbitMQConnectionPoolTestCase(TestCase):
         with self.assertRaises(ConnectionClosed):
             connection = self.pool.create()
             self.pool.log.critical.assert_called_once()
+            self.assertEqual(self.mock_sleep.call_count, CONNECTION_RETRIES - 1)
+
+    @patch('listenbrainz.webserver.rabbitmq_connection.sleep')
+    def test_connection_error_when_rabbitmq_down(self, mock_sleep):
+        # create an app with no RabbitMQ config
+        # as will be the case when RabbitMQ is down in production
+        app = Flask(__name__)
+
+        with self.assertRaises(ConnectionError):
+            init_rabbitmq_connection(app)
             self.assertEqual(self.mock_sleep.call_count, CONNECTION_RETRIES - 1)


### PR DESCRIPTION
Trille went down today, which led to the ListenBrainz app not being created and listenbrainz.org erroring out.

These changes should make it so that the webserver still works but the rabbitmq thing is logged to sentry and 503s are returned until RabbitMQ comes back.