### PR TITLE
Allow deletion of users who have activated the spotify import

### DIFF
--- a/admin/sql/create_foreign_keys.sql
+++ b/admin/sql/create_foreign_keys.sql
@@ -18,6 +18,10 @@ ALTER TABLE statistics.user
     REFERENCES "user" (id)
     ON DELETE CASCADE;
 
-ALTER TABLE spotify_auth ADD CONSTRAINT spotify_auth_user_id_foreign_key FOREIGN KEY (user_id) REFERENCES "user" (id);
+ALTER TABLE spotify_auth
+    ADD CONSTRAINT spotify_auth_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
 
 COMMIT;

--- a/admin/sql/updates/2018-11-17-add-on-delete-cascade-to-spotify-fk.sql
+++ b/admin/sql/updates/2018-11-17-add-on-delete-cascade-to-spotify-fk.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE spotify_auth
+    DROP CONSTRAINT spotify_auth_user_id_foreign_key;
+
+ALTER TABLE spotify_auth
+    ADD CONSTRAINT spotify_auth_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
+
+COMMIT;

--- a/listenbrainz/db/__init__.py
+++ b/listenbrainz/db/__init__.py
@@ -6,7 +6,7 @@ import time
 import psycopg2
 
 # This value must be incremented after schema changes on replicated tables!
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 engine = None
 

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import listenbrainz.db.user as db_user
+import listenbrainz.db.spotify as db_spotify
 import listenbrainz.db.stats as db_stats
 import sqlalchemy
 import time
@@ -191,3 +192,15 @@ class UserTestCase(DatabaseTestCase):
         self.assertIsNone(user)
         user_stats = db_stats.get_all_user_stats(user_id)
         self.assertIsNone(user_stats)
+
+    def test_delete_when_spotify_import_activated(self):
+        user_id = db_user.create(11, 'kishore')
+        user = db_user.get(user_id)
+        self.assertIsNotNone(user)
+        db_spotify.create_spotify(user_id, 'user token', 'refresh token', 0)
+
+        db_user.delete(user_id)
+        user = db_user.get(user_id)
+        self.assertIsNone(user)
+        token = db_spotify.get_token_for_user(user_id)
+        self.assertIsNone(token)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: You can't delete your account if spotify import is activated. I've added an `ON DELETE CASCADE` to the fk constraint to fix this.


