### PR TITLE
Fix the is_open property for RabbitMQ connections

### DIFF
--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -92,7 +92,11 @@ class RabbitMQConnection:
 
     @property
     def is_open(self):
-        return self.connection.is_open
+        try:
+            self.connection.process_data_events()
+            return True
+        except pika.exceptions.ConnectionClosed as e:
+            return False
 
     def close(self):
         self.connection.close()


### PR DESCRIPTION
We cannot directly use the `is_open` property that pika's
BlockingConnection provides because the heartbeat mechanism
does not detect closed connections itself.

See: https://github.com/pika/pika/issues/877

This lead to a lot of ConnectionClosed errors in the API which
was the main cause of almost all the Sentry errors.

