### PR TITLE
Also catch FileNotFound and OSErrors in is_open property

### DIFF
--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -95,8 +95,9 @@ class RabbitMQConnection:
         try:
             self.connection.process_data_events()
             return True
-        except pika.exceptions.ConnectionClosed as e:
+        except (pika.exceptions.ConnectionClosed, FileNotFoundError, OSError) as e:
             return False
 
     def close(self):
-        self.connection.close()
+        if self.connection.is_open:
+            self.connection.close()


### PR DESCRIPTION
Also, check if the connection is open before closing it in
close().

This should fix https://sentry.metabrainz.org/share/issue/a1f67af826cb4e178f91caf8c954ac82/,
https://sentry.metabrainz.org/share/issue/f93198de54004fd8bb26e284851c5984/ and put to rest https://sentry.metabrainz.org/share/issue/89abfd06eafd4e87a174dde91114bef4/.

Pika seems to be looking for some file which I assume goes away when the connection closes, leading to the error...