### PR TITLE
Fix bug in the UUID validation function

### DIFF
--- a/listenbrainz/tests/unit/test_utils.py
+++ b/listenbrainz/tests/unit/test_utils.py
@@ -20,9 +20,11 @@ import listenbrainz.utils as utils
 import pika
 import time
 import unittest
+import uuid
 
 from datetime import datetime
 from listenbrainz.webserver import create_app
+from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
 class ListenBrainzUtilsTestCase(unittest.TestCase):
 
@@ -53,3 +55,8 @@ class ListenBrainzUtilsTestCase(unittest.TestCase):
         x = utils.unix_timestamp_to_datetime(t)
         self.assertIsInstance(x, datetime)
         self.assertEqual(int(x.strftime('%s')), t)
+
+    def test_valid_uuid(self):
+        self.assertTrue(is_valid_uuid(str(uuid.uuid4())))
+        self.assertFalse(is_valid_uuid('hjjkghjk'))
+        self.assertFalse(is_valid_uuid(123))

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -155,7 +155,7 @@ def is_valid_uuid(u):
     try:
         u = uuid.UUID(u)
         return True
-    except ValueError:
+    except (AttributeError, ValueError):
         return False
 
 


### PR DESCRIPTION
uuid.UUID can raise attribute errors if passed an integer

https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/7140/