### PR TITLE
use --no-cache-dir in pip install during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,19 +25,19 @@ RUN apt-get update \
 RUN mkdir /code
 WORKDIR /code
 
-RUN pip3 install setuptools==36.0.1
+RUN pip3 install --no-cache-dir setuptools==36.0.1
 
 # MessyBrainz
 RUN git clone https://github.com/metabrainz/messybrainz-server.git messybrainz
 WORKDIR /code/messybrainz
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 RUN python3 setup.py install
 
 RUN mkdir /code/listenbrainz
 WORKDIR /code/listenbrainz
 
 COPY requirements.txt /code/listenbrainz/
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Now install our code, which may change frequently
 COPY . /code/listenbrainz/


### PR DESCRIPTION
In Docker the pip cache uses space and doesn't make anything faster, so don't use it

