### PR TITLE
LB-401: Fix logging config format

### DIFF
--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -94,6 +94,7 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 # LOG_SENTRY = {
 #    'dsn':'',
 #    'environment': 'development',
+#    'level': 'ERROR',
 # }
 
 

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -73,6 +73,9 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 
 # LOGGING
 
+# Uncomment any of the following logging stubs if you want to enable logging
+# during development. In general you shouldn't need to do this
+
 # LOG_FILE = {
 #    'filename': './logs/listenbrainz.txt',
 #    'max_bytes': 512 * 1024, # optional

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -98,7 +98,6 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 #    'dsn':'',
 #    'environment': 'development',
 # }
-# SENTRY_DSN_PUBLIC = ''
 
 
 # MISCELLANEOUS

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -73,15 +73,29 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 
 # LOGGING
 
-#LOG_FILE_ENABLED = True
-#LOG_FILE = "./listenbrainz.log"
+# LOG_FILE = {
+#    'filename': './logs/listenbrainz.txt',
+#    'max_bytes': 512 * 1024, # optional
+#    'backup_count': 100, # optional
+# }
 
-#LOG_EMAIL_ENABLED = True
-#LOG_EMAIL_TOPIC = "ListenBrainz Webserver Failure"
-#LOG_EMAIL_RECIPIENTS = []  # List of email addresses (strings)
+# LOG_EMAIL = {
+#    'mail_server': 'localhost',
+#    'mail_port': 25,
+#    'mail_from_host': 'example.org',
+#    'log_email_recipients': [
+#        'user1@example.org',
+#        'user2@example.org',
+#    ],
+#    'log_email_topic': 'ListenBrainz Error',
+#    'level': 'ERROR',
+# }
 
-#LOG_SENTRY_ENABLED = True
-#SENTRY_DSN = ""
+# LOG_SENTRY = {
+#    'dsn':'',
+#    'environment': 'development',
+# }
+# SENTRY_DSN_PUBLIC = ''
 
 
 # MISCELLANEOUS

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -85,11 +85,8 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 # LOG_EMAIL = {
 #    'mail_server': 'localhost',
 #    'mail_port': 25,
-#    'mail_from_host': 'example.org',
-#    'log_email_recipients': [
-#        'user1@example.org',
-#        'user2@example.org',
-#    ],
+#    'mail_from_host': 'listenbrainz.org',
+#    'log_email_recipients': [],
 #    'log_email_topic': 'ListenBrainz Error',
 #    'level': 'ERROR',
 # }


### PR DESCRIPTION
The logging config values needed has changed with us starting to use brainzutils loggers. This PR changes the config.py.sample to reflect this change, so that users have the correct format to fill.