### PR TITLE
LB-403: Add an endpoint for getting `playing_now` listens

### DIFF
--- a/docs/dev/json.rst
+++ b/docs/dev/json.rst
@@ -107,27 +107,35 @@ element. The ``user_id`` element contains the MusicBrainz ID of the user whose l
 being returned. The other element is the ``listens`` element. This is a list which contains
 the listen JSON elements (described above).
 
+The JSON document returned by the API endpoint for getting tracks being played right now
+is the same as above, except that it also contains the ``payload/playing_now`` element as a
+boolean set to True.
+
 
 Payload JSON details
 --------------------
 
-A minimal payload must include the ``listened_at``,
+A minimal payload must include
 ``track_metadata/artist_name`` and ``track_metadata/track_name`` elements::
 
     {
-      "listened_at": 1443521965,
       "track_metadata": {
         "artist_name": "Rick Astley",
         "track_name": "Never Gonna Give You Up",
       }
     }
 
-``artist_name`` and ``track_name`` elements must be simple strings, while the
-``listened_at`` element must be an integer.
+``artist_name`` and ``track_name`` elements must be simple strings.
+
+The payload will also include the ``listened_at`` element which must be an integer
+representing the Unix time when the track was listened to. The only exception to this
+rule is when the listen is being played right now and has been retrieved from the
+endpoint to get listens being played right now. The ``listened_at`` element will be
+absent for such listens.
 
 Add additional metadata you may have for a track to the ``additional_info``
 element. Any additional information allows us to better correlate your listen
-data to existing MusicBrainz-based data. If you have MusicBrainz IDs availble,
+data to existing MusicBrainz-based data. If you have MusicBrainz IDs available,
 submit them!
 
 The following optional elements may also be included in the ``track_metadata`` element:

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -1,9 +1,8 @@
 # coding=utf-8
 
-
 import ujson
-
 import redis
+import time
 from redis import Redis
 
 from listenbrainz.listen import Listen
@@ -31,6 +30,20 @@ class RedisListenStore(ListenStore):
         data = ujson.loads(data)
         data.update({'playing_now': True})
         return Listen.from_json(data)
+
+    def put_playing_now(self, user_id, listen, expire_time):
+        """ Save a listen as `playing_now` for a particular time in Redis.
+
+        Args:
+            user_id (int): the row ID of the user
+            listen (dict): the listen data
+            expire_time (int): the time in seconds in which the `playing_now` listen should expire
+        """
+        self.redis.setex(
+            'playing_now:{}'.format(user_id),
+            ujson.dumps(listen).encode('utf-8'),
+            expire_time,
+        )
 
     def check_connection(self):
         """ Pings the redis server to check if the connection works or not """

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -1,38 +1,50 @@
 # coding=utf-8
 
 import logging
+import time
 import ujson
 
 from redis.connection import Connection
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.listen import Listen
 from listenbrainz.listenstore.tests.util import generate_data
 from listenbrainz.webserver.redis_connection import init_redis_connection
 
 
-class TestRedisListenStore(DatabaseTestCase):
+class RedisListenStoreTestCase(DatabaseTestCase):
 
     def setUp(self):
-        super(TestRedisListenStore, self).setUp()
-        self.log = logging.getLogger(__name__)
+        super(RedisListenStoreTestCase, self).setUp()
+        self.log = logging.getLogger()
         self._redis = init_redis_connection(self.log, self.config.REDIS_HOST, self.config.REDIS_PORT)
-        self.testuser_id = db_user.create(1, "test")
-        self._create_test_data()
+        self.testuser = db_user.get_or_create(1, "test")
 
     def tearDown(self):
         self._redis.redis.flushdb()
         Connection(self._redis.redis).disconnect()
-        super(TestRedisListenStore, self).tearDown()
-
-    def _create_test_data(self):
-        self.log.info("Inserting test data...")
-        self.listen = generate_data(self.testuser_id,'test', None , 1)[0]
-        listen = self.listen.to_json()
-        self._redis.redis.setex('playing_now' + ':' + str(listen['user_id']),
-                                ujson.dumps(listen).encode('utf-8'), self.config.PLAYING_NOW_MAX_DURATION)
-        self.log.info("Test data inserted")
+        super(RedisListenStoreTestCase, self).tearDown()
 
     def test_get_playing_now(self):
         playing_now = self._redis.get_playing_now(self.listen.user_id)
         assert playing_now is not None
+
+    def test_get_and_put_playing_now(self):
+        listen = {
+            'user_id': self.testuser['id'],
+            'user_name': self.testuser['musicbrainz_id'],
+            'listened_at': int(time.time()),
+            'track_metadata': {
+                'artist_name': 'The Strokes',
+                'track_name': 'Call It Fate, Call It Karma',
+                'additional_info': {},
+            },
+        }
+        self._redis.put_playing_now(listen['user_id'], listen, self.config.PLAYING_NOW_MAX_DURATION)
+
+        playing_now = self._redis.get_playing_now(listen['user_id'])
+        self.assertIsNotNone(playing_now)
+        self.assertIsInstance(playing_now, Listen)
+        self.assertEqual(playing_now.data['artist_name'], 'The Strokes')
+        self.assertEqual(playing_now.data['track_name'], 'Call It Fate, Call It Karma')

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -26,10 +26,6 @@ class RedisListenStoreTestCase(DatabaseTestCase):
         Connection(self._redis.redis).disconnect()
         super(RedisListenStoreTestCase, self).tearDown()
 
-    def test_get_playing_now(self):
-        playing_now = self._redis.get_playing_now(self.listen.user_id)
-        assert playing_now is not None
-
     def test_get_and_put_playing_now(self):
         listen = {
             'user_id': self.testuser['id'],

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -7,6 +7,7 @@ from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz import webserver
 import listenbrainz.db.user as db_user
 from listenbrainz.webserver.rate_limiter import ratelimit
+import listenbrainz.webserver.redis_connection as redis_connection
 from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400, validate_listen, MAX_LISTEN_SIZE, MAX_ITEMS_PER_GET,\
     DEFAULT_ITEMS_PER_GET, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
 import time
@@ -123,6 +124,44 @@ def get_listens(user_name):
         'count': len(listen_data),
         'listens': listen_data,
     }})
+
+
+@api_bp.route("/user/<user_name>/playing-now")
+@ratelimit()
+def get_playing_now(user_name):
+    """
+    Get the listen being played right now for user ``user_name``.
+
+    This endpoint returns a JSON document with a single listen in the same format as the ``/user/<user_name>/listens`` endpoint,
+    with one key difference, there will only be one listen returned at maximum and the listen will not contain a ``listened_at`` element.
+
+    The format for the JSON returned is defined in our :ref:`json-doc`.
+
+    :statuscode 200: Yay, you have data!
+    :resheader Content-Type: *application/json*
+    """
+
+    user = db_user.get_by_mb_id(user_name)
+    if user is None:
+        raise NotFound("Cannot find user: %s" % user_name)
+
+    playing_now_listen = redis_connection._redis.get_playing_now(user['id'])
+    listen_data = []
+    count = 0
+    if playing_now_listen:
+        count += 1
+        listen_data = [{
+            'track_metadata': playing_now_listen.data,
+        }]
+
+    return jsonify({
+        'payload': {
+            'count': count,
+            'user_id': user_name,
+            'playing_now': True,
+            'listens': listen_data,
+        },
+    })
 
 
 @api_bp.route('/latest-import', methods=['GET', 'POST', 'OPTIONS'])

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -57,11 +57,7 @@ def _send_listens_to_queue(listen_type, listens):
             try:
                 expire_time = listen["track_metadata"]["additional_info"].get("duration",
                                     current_app.config['PLAYING_NOW_MAX_DURATION'])
-                redis_connection._redis.redis.setex(
-                    'playing_now:{}'.format(listen['user_id']),
-                    ujson.dumps(listen).encode('utf-8'),
-                    expire_time
-                )
+                redis_connection._redis.put_playing_now(listen['user_id'], listen, expire_time)
             except Exception as e:
                 current_app.logger.error("Redis rpush playing_now write error: " + str(e))
                 raise ServiceUnavailable("Cannot record playing_now at this time.")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-403](https://tickets.metabrainz.org/browse/LB-403)

There was no way to retrieve what was being played right now by a user.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
--> 
Add a new endpoint and tests, update documentation, do some refactoring of
old code.



