### PR TITLE
Only create extension uuid-ossp if it doesn't exist

### DIFF
--- a/admin/sql/create_extensions.sql
+++ b/admin/sql/create_extensions.sql
@@ -1,1 +1,1 @@
-CREATE EXTENSION "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";


### PR DESCRIPTION
* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem
Error: (psycopg2.ProgrammingError) extension "uuid-ossp" already exists

# Solution
Changing "create extension" to "create extension if not exists" would create extension only if does not exists during the creation of database.

