### PR TITLE
make timestamp optional for playing now listens in RedisListenStore

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -6,7 +6,6 @@ import yaml
 
 from datetime import datetime
 from listenbrainz.utils import escape, convert_to_unix_timestamp
-from flask import current_app
 
 def flatten_dict(d, seperator='', parent_key=''):
     """
@@ -77,8 +76,8 @@ class Listen(object):
                 self.timestamp = timestamp
                 self.ts_since_epoch = calendar.timegm(self.timestamp.utctimetuple())
             else:
-                self.timestamp = 0
-                self.ts_since_epoch = 0
+                self.timestamp = None
+                self.ts_since_epoch = None
 
         self.artist_msid = artist_msid
         self.release_msid = release_msid

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -6,6 +6,7 @@ import yaml
 
 from datetime import datetime
 from listenbrainz.utils import escape, convert_to_unix_timestamp
+from flask import current_app
 
 def flatten_dict(d, seperator='', parent_key=''):
     """
@@ -99,7 +100,10 @@ class Listen(object):
     @classmethod
     def from_json(cls, j):
         """Factory to make Listen() objects from a dict"""
-        if j['listened_at']:
+
+        if 'playing_now' in j:
+            j.update({'listened_at': None})
+        else:
             j['listened_at']=datetime.utcfromtimestamp(float(j['listened_at']))
         return cls(
             user_id=j.get('user_id'),

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -99,10 +99,12 @@ class Listen(object):
     @classmethod
     def from_json(cls, j):
         """Factory to make Listen() objects from a dict"""
+        if j['listened_at']:
+            j['listened_at']=datetime.utcfromtimestamp(float(j['listened_at']))
         return cls(
             user_id=j.get('user_id'),
             user_name=j.get('user_name', ''),
-            timestamp=datetime.utcfromtimestamp(float(j['listened_at'])),
+            timestamp=j['listened_at'],
             artist_msid=j['track_metadata']['additional_info'].get('artist_msid'),
             release_msid=j['track_metadata']['additional_info'].get('release_msid'),
             recording_msid=j.get('recording_msid'),

--- a/listenbrainz/listenstore/__init__.py
+++ b/listenbrainz/listenstore/__init__.py
@@ -1,6 +1,5 @@
 import logging
 
-MIN_ID = 1033430400     # approx when audioscrobbler was created
 ORDER_DESC = 0
 ORDER_ASC = 1
 ORDER_TEXT = [ "DESC", "ASC" ]

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -7,8 +7,7 @@ import redis
 from redis import Redis
 
 from listenbrainz.listen import Listen
-from listenbrainz.listenstore import ListenStore, MIN_ID
-
+from listenbrainz.listenstore import ListenStore
 
 class RedisListenStore(ListenStore):
     def __init__(self, log, conf):
@@ -30,7 +29,7 @@ class RedisListenStore(ListenStore):
         if not data:
             return None
         data = ujson.loads(data)
-        data.update({'listened_at': None})
+        data.update({'playing_now': True})
         return Listen.from_json(data)
 
     def check_connection(self):

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -30,7 +30,7 @@ class RedisListenStore(ListenStore):
         if not data:
             return None
         data = ujson.loads(data)
-        data.update({'listened_at': MIN_ID+1})
+        data.update({'listened_at': None})
         return Listen.from_json(data)
 
     def check_connection(self):

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -7,7 +7,6 @@ from redis.connection import Connection
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.listenstore import MIN_ID
 from listenbrainz.listenstore.tests.util import generate_data
 from listenbrainz.webserver.redis_connection import init_redis_connection
 
@@ -28,7 +27,7 @@ class TestRedisListenStore(DatabaseTestCase):
 
     def _create_test_data(self):
         self.log.info("Inserting test data...")
-        self.listen = generate_data(self.testuser_id,'test', MIN_ID + 1, 1)[0]
+        self.listen = generate_data(self.testuser_id,'test', None , 1)[0]
         listen = self.listen.to_json()
         self._redis.redis.setex('playing_now' + ':' + str(listen['user_id']),
                                 ujson.dumps(listen).encode('utf-8'), self.config.PLAYING_NOW_MAX_DURATION)

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -15,7 +15,7 @@ def generate_data(test_user_id, user_name, from_ts, num_records):
     test_data = []
     artist_msid = str(uuid.uuid4())
 
-    if (from_ts == None):  #check for playing now listens
+    if from_ts == None:  #check for playing now listens
         timestamp = None
     else:
         from_ts += 1   # Add one second
@@ -25,7 +25,7 @@ def generate_data(test_user_id, user_name, from_ts, num_records):
         item = Listen(
             user_name=user_name,
             user_id=test_user_id,
-            timestamp= timestamp,
+            timestamp=timestamp,
             artist_msid=artist_msid,
             recording_msid=str(uuid.uuid4()),
             data={

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -15,12 +15,17 @@ def generate_data(test_user_id, user_name, from_ts, num_records):
     test_data = []
     artist_msid = str(uuid.uuid4())
 
-    for i in range(num_records):
+    if (from_ts == None):  #check for playing now listens
+        timestamp = None
+    else:
         from_ts += 1   # Add one second
+        timestamp = datetime.utcfromtimestamp(from_ts)
+
+    for i in range(num_records):
         item = Listen(
             user_name=user_name,
             user_id=test_user_id,
-            timestamp=datetime.utcfromtimestamp(from_ts),
+            timestamp= timestamp,
             artist_msid=artist_msid,
             recording_msid=str(uuid.uuid4()),
             data={

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -100,3 +100,37 @@ class ListenTestCase(unittest.TestCase):
         self.assertEqual(data['fields']['artist_name'], listen.data['artist_name'])
 
         self.assertIn('inserted_timestamp', data['fields'])
+
+
+    def test_from_json(self):
+        json_row = {
+                    "track_metadata": {
+                      "additional_info": {
+                        "release_mbid": "bf9e91ea-8029-4a04-a26a-224e00a83266",
+                        'release_msid': '4a3c7b15-323a-4e27-9801-0be47517ab85',
+                        'artist_msid': 'b2e47f94-c2e6-4a66-83f7-1eaf5949f049',
+                        "artist_mbids": [
+                          "db92a151-1ac2-438b-bc43-b82e149ddd50"
+                        ],
+                        "recording_mbid": "98255a8c-017a-4bc7-8dd6-1fa36124572b",
+                        "tags": [ "you", "just", "got", "rick rolled!"]
+                       },
+                       "artist_name": "Rick Astley",
+                       "track_name": "Never Gonna Give You Up",
+                       "release_name": "Whenever you need somebody"
+                      },
+                      'recording_msid': '1bf647b3-c8ba-487c-ae91-993de9ea944c',
+                      'user_id': 3,
+                      'user_name': 'Vansika Pareek'
+                    }
+
+        json_row.update({'listened_at': 123456})
+        listen = Listen.from_json(json_row) 
+
+        self.assertEqual(listen.timestamp, json_row['listened_at'])
+
+        del json_row['listened_at']
+        json_row.update({'playing_now': True})
+        listen = Listen.from_json(json_row)
+
+        self.assertEqual(listen.timestamp, 0)

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -105,23 +105,8 @@ class ListenTestCase(unittest.TestCase):
     def test_from_json(self):
         json_row = {
                     "track_metadata": {
-                      "additional_info": {
-                        "release_mbid": "bf9e91ea-8029-4a04-a26a-224e00a83266",
-                        'release_msid': '4a3c7b15-323a-4e27-9801-0be47517ab85',
-                        'artist_msid': 'b2e47f94-c2e6-4a66-83f7-1eaf5949f049',
-                        "artist_mbids": [
-                          "db92a151-1ac2-438b-bc43-b82e149ddd50"
-                        ],
-                        "recording_mbid": "98255a8c-017a-4bc7-8dd6-1fa36124572b",
-                        "tags": [ "you", "just", "got", "rick rolled!"]
-                       },
-                       "artist_name": "Rick Astley",
-                       "track_name": "Never Gonna Give You Up",
-                       "release_name": "Whenever you need somebody"
-                      },
-                      'recording_msid': '1bf647b3-c8ba-487c-ae91-993de9ea944c',
-                      'user_id': 3,
-                      'user_name': 'Vansika Pareek'
+                      "additional_info": {}
+                      }
                     }
 
         json_row.update({'listened_at': 123456})
@@ -133,4 +118,4 @@ class ListenTestCase(unittest.TestCase):
         json_row.update({'playing_now': True})
         listen = Listen.from_json(json_row)
 
-        self.assertEqual(listen.timestamp, 0)
+        self.assertEqual(listen.timestamp, None)


### PR DESCRIPTION
* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

A random value is used as timestamp for 'playing now' listens. 

* JIRA ticket (_optional_): [LB-404](https://tickets.metabrainz.org/browse/LB-404)

# Solution

Timestamp value in Listen object is assigned after checking the 'Listened_at' value which would be None in case of 'playing_now' listens.