### PR TITLE
LB-414: Spotify now playing

### DIFF
--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -95,7 +95,7 @@ def get_spotify_oauth():
     """
     client_id = current_app.config['SPOTIFY_CLIENT_ID']
     client_secret = current_app.config['SPOTIFY_CLIENT_SECRET']
-    scope = 'user-read-recently-played'
+    scope = 'user-read-recently-played user-read-currently-playing'
     redirect_url = current_app.config['SPOTIFY_CALLBACK_URL']
     return spotipy.oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri=redirect_url, scope=scope)
 

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -7,6 +7,8 @@ import datetime
 
 SPOTIFY_API_RETRIES = 5
 
+SPOTIFY_PERMISSIONS_SCOPE = 'user-read-currently-playing user-read-recently-played'
+
 
 class Spotify:
     def __init__(self, user_id, musicbrainz_id, musicbrainz_row_id, user_token, token_expires,
@@ -95,7 +97,7 @@ def get_spotify_oauth():
     """
     client_id = current_app.config['SPOTIFY_CLIENT_ID']
     client_secret = current_app.config['SPOTIFY_CLIENT_SECRET']
-    scope = 'user-read-recently-played user-read-currently-playing'
+    scope = SPOTIFY_PERMISSIONS_SCOPE
     redirect_url = current_app.config['SPOTIFY_CALLBACK_URL']
     return spotipy.oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri=redirect_url, scope=scope)
 

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -54,7 +54,7 @@ class SpotifyDomainTestCase(ServerTestCase):
         self.assertEqual(func_oauth.client_id, current_app.config['SPOTIFY_CLIENT_ID'])
         self.assertEqual(func_oauth.client_secret, current_app.config['SPOTIFY_CLIENT_SECRET'])
         self.assertEqual(func_oauth.redirect_uri, 'http://localhost/profile/connect-spotify/callback')
-        self.assertEqual(func_oauth.scope, 'user-read-currently-playing user-read-recently-played')
+        self.assertEqual(func_oauth.scope, spotify.SPOTIFY_PERMISSIONS_SCOPE)
 
     @mock.patch('listenbrainz.domain.spotify.db_spotify.get_user')
     def test_get_user(self, mock_db_get_user):

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -54,7 +54,7 @@ class SpotifyDomainTestCase(ServerTestCase):
         self.assertEqual(func_oauth.client_id, current_app.config['SPOTIFY_CLIENT_ID'])
         self.assertEqual(func_oauth.client_secret, current_app.config['SPOTIFY_CLIENT_SECRET'])
         self.assertEqual(func_oauth.redirect_uri, 'http://localhost/profile/connect-spotify/callback')
-        self.assertEqual(func_oauth.scope, 'user-read-recently-played')
+        self.assertEqual(func_oauth.scope, 'user-read-currently-playing user-read-recently-played')
 
     @mock.patch('listenbrainz.domain.spotify.db_spotify.get_user')
     def test_get_user(self, mock_db_get_user):

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -6,6 +6,7 @@ import time
 
 from listenbrainz.domain.spotify import Spotify, SpotifyAPIError, SpotifyListenBrainzError
 from listenbrainz.spotify_updater import spotify_read_listens
+from listenbrainz.webserver.views.api_tools import LISTEN_TYPE_IMPORT
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -17,7 +18,7 @@ class ConvertListensTestCase(TestCase):
     def test_parse_play_to_listen_no_isrc(self):
         data = json.load(open(os.path.join(self.DATA_DIR, 'spotify_play_no_isrc.json')))
 
-        listen = spotify_read_listens._convert_spotify_play_to_listen(data)
+        listen = spotify_read_listens._convert_spotify_play_to_listen(data, LISTEN_TYPE_IMPORT)
 
         expected_listen = {
             'listened_at': 1519241031,
@@ -49,7 +50,7 @@ class ConvertListensTestCase(TestCase):
         # If a spotify play record has many artists, make sure they are appended
         data = json.load(open(os.path.join(self.DATA_DIR, 'spotify_play_two_artists.json')))
 
-        listen = spotify_read_listens._convert_spotify_play_to_listen(data)
+        listen = spotify_read_listens._convert_spotify_play_to_listen(data, LISTEN_TYPE_IMPORT)
 
         expected_listen = {
             'listened_at': 1519240503,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a Feature Addtion

* **Describe this change in 1-2 sentences**: Make the spotify importer send now playing listens 

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-414](https://tickets.metabrainz.org/browse/LB-414)

the importer did not notify listenbrainz about the user's currently playing tracks.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Make requests to the currently-playing endpoint and submit that data as well.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
This increases the scope of the permissions we need. So people will have to unlink
and link their accounts. I'm not sure if there is a way around this.

