### PR TITLE
Get duration from `duration_ms` for playing_now listens

### DIFF
--- a/listenbrainz/testdata/playing_now_with_duration.json
+++ b/listenbrainz/testdata/playing_now_with_duration.json
@@ -1,0 +1,15 @@
+{
+    "listen_type": "playing_now",
+    "payload": [
+        {
+            "track_metadata": {
+                "artist_name": "Kanye West",
+                "release_name": "The Life of Pablo",
+                "track_name": "Fade",
+                "additional_info": {
+                    "duration": 1
+                }
+            }
+        }
+    ]
+}

--- a/listenbrainz/testdata/playing_now_with_duration_ms.json
+++ b/listenbrainz/testdata/playing_now_with_duration_ms.json
@@ -1,0 +1,15 @@
+{
+    "listen_type": "playing_now",
+    "payload": [
+        {
+            "track_metadata": {
+                "artist_name": "Kanye West",
+                "release_name": "The Life of Pablo",
+                "track_name": "Fade",
+                "additional_info": {
+                    "duration_ms": 1001
+                }
+            }
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -127,6 +127,44 @@ class APITestCase(IntegrationTestCase):
         r = self.client.get(url_for('user.profile', user_name=self.user['musicbrainz_id']))
         self.assertIn('Playing now', r.data.decode('utf-8'))
 
+    def test_playing_now_with_duration(self):
+        """ Test that playing now listens with durations expire
+        """
+        with open(self.path_to_data_file('playing_now_with_duration.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
+
+        r = self.client.get(url_for('api_v1.get_playing_now', user_name=self.user['musicbrainz_id']))
+        self.assertEqual(r.json['payload']['count'], 1)
+        self.assertEqual(r.json['payload']['listens'][0]['track_metadata']['track_name'], 'Fade')
+
+        time.sleep(1.1)
+
+        # should have expired by now
+        r = self.client.get(url_for('api_v1.get_playing_now', user_name=self.user['musicbrainz_id']))
+        self.assertEqual(r.json['payload']['count'], 0)
+
+    def test_playing_now_with_duration_ms(self):
+        """ Test that playing now submissions with duration_ms also expire
+        """
+        with open(self.path_to_data_file('playing_now_with_duration_ms.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
+
+        r = self.client.get(url_for('api_v1.get_playing_now', user_name=self.user['musicbrainz_id']))
+        self.assertEqual(r.json['payload']['count'], 1)
+        self.assertEqual(r.json['payload']['listens'][0]['track_metadata']['track_name'], 'Fade')
+
+        time.sleep(1.1)
+
+        # should have expired by now
+        r = self.client.get(url_for('api_v1.get_playing_now', user_name=self.user['musicbrainz_id']))
+        self.assertEqual(r.json['payload']['count'], 0)
+
     def test_playing_now_with_ts(self):
         """ Test for invalid submission of listen_type 'playing_now' which contains
             timestamp 'listened_at'

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -56,12 +56,12 @@ def _send_listens_to_queue(listen_type, listens):
         if listen_type == LISTEN_TYPE_PLAYING_NOW:
             try:
                 if 'duration' in listen['track_metadata']['additional_info']:
-                    expire_time = listen['track_metadata']['additional_info']['duration']
+                    listen_timeout = listen['track_metadata']['additional_info']['duration']
                 elif 'duration_ms' in listen['track_metadata']['additional_info']:
-                    expire_time = listen['track_metadata']['additional_info']['duration_ms'] // 1000
+                    listen_timeout = listen['track_metadata']['additional_info']['duration_ms'] // 1000
                 else:
-                    expire_time = current_app.config['PLAYING_NOW_MAX_DURATION']
-                redis_connection._redis.put_playing_now(listen['user_id'], listen, expire_time)
+                    listen_timeout = current_app.config['PLAYING_NOW_MAX_DURATION']
+                redis_connection._redis.put_playing_now(listen['user_id'], listen, listen_timeout)
             except Exception as e:
                 current_app.logger.error("Redis rpush playing_now write error: " + str(e))
                 raise ServiceUnavailable("Cannot record playing_now at this time.")

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -55,8 +55,12 @@ def _send_listens_to_queue(listen_type, listens):
     for listen in listens:
         if listen_type == LISTEN_TYPE_PLAYING_NOW:
             try:
-                expire_time = listen["track_metadata"]["additional_info"].get("duration",
-                                    current_app.config['PLAYING_NOW_MAX_DURATION'])
+                if 'duration' in listen['track_metadata']['additional_info']:
+                    expire_time = listen['track_metadata']['additional_info']['duration']
+                elif 'duration_ms' in listen['track_metadata']['additional_info']:
+                    expire_time = listen['track_metadata']['additional_info']['duration_ms'] // 1000
+                else:
+                    expire_time = current_app.config['PLAYING_NOW_MAX_DURATION']
                 redis_connection._redis.put_playing_now(listen['user_id'], listen, expire_time)
             except Exception as e:
                 current_app.logger.error("Redis rpush playing_now write error: " + str(e))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a Feature Addition

* **Describe this change in 1-2 sentences**: The Spotify API sends us the durations in ms, so if we get a listen with the key `duration_ms` we should use it to calculate the expiration time of currently playing tracks.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

We were ignoring the `duration_ms` key.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Use the `duration_ms` key and add tests for expiration.
