### PR TITLE
Only display spotify logo for listens with spotify IDs

### DIFF
--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -68,7 +68,7 @@
                       {% endif %}
                   </td>
                   <td>
-                      {% if spotify_uri %}
+                      {% if listen.track_metadata.additional_info.spotify_id %}
                         <span class="fab fa-spotify"></span>
                       {% endif %}
                       {% if listen.track_metadata.additional_info.recording_mbid %}
@@ -96,10 +96,10 @@
           </ul>
         </div>
 
-        {% if spotify_uri %}
+        {% if latest_spotify_uri %}
           <div class="col-md-4 text-right">
             <iframe id="player" frameborder="0" allowtransparency="true" allow="encrypted-media"
-                    src="https://embed.spotify.com/?uri={{ spotify_uri }}&theme=white"></iframe>
+                    src="https://embed.spotify.com/?uri={{ latest_spotify_uri }}&theme=white"></iframe>
           </div>
         {% endif %}
       </div>

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -134,7 +134,7 @@ def profile(user_name):
         listens=listens,
         previous_listen_ts=previous_listen_ts,
         next_listen_ts=next_listen_ts,
-        spotify_uri=_get_spotify_uri_for_listens(listens),
+        latest_spotify_uri=_get_spotify_uri_for_listens(listens),
         have_listen_count=have_listen_count,
         listen_count=format(int(listen_count), ",d"),
         artist_count=format(artist_count, ",d") if artist_count else None,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
    
    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a Bug fix
* **Describe this change in 1-2 sentences**: We were checking the first track for spotify ids for each track.

# Problem

<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Tracks which did not have Spotify IDs also displayed the Spotify Logo.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Check the correct place for Spotify IDs in each track.



