### PR TITLE
LB-416: Change data type of auth_token from string to UUID

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -4,7 +4,7 @@ CREATE TABLE "user" (
   id             SERIAL,
   created        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   musicbrainz_id VARCHAR NOT NULL,
-  auth_token     VARCHAR,
+  auth_token     UUID NOT NULL DEFAULT uuid_generate_v4(),
   last_login     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   latest_import  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch',
   gdpr_agreed    TIMESTAMP WITH TIME ZONE,

--- a/admin/sql/updates/2019-01-20-alter-auth-token.sql
+++ b/admin/sql/updates/2019-01-20-alter-auth-token.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE "user" ALTER COLUMN auth_token TYPE UUID USING auth_token::UUID,
+ALTER COLUMN auth_token SET NOT NULL;
+
+ALTER TABLE "user" ALTER COLUMN auth_token SET DEFAULT uuid_generate_v4();
+
+COMMIT;

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -26,12 +26,11 @@ def create(musicbrainz_row_id, musicbrainz_id):
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            INSERT INTO "user" (musicbrainz_id, musicbrainz_row_id, auth_token)
-                 VALUES (:mb_id, :mb_row_id, :token)
+            INSERT INTO "user" (musicbrainz_id, musicbrainz_row_id)
+                 VALUES (:mb_id, :mb_row_id)
               RETURNING id
         """), {
             "mb_id": musicbrainz_id,
-            "token": str(uuid.uuid4()),
             "mb_row_id": musicbrainz_row_id,
         })
         return result.fetchone()["id"]
@@ -50,7 +49,7 @@ def update_token(id):
                    SET auth_token = :token
                  WHERE id = :id
             """), {
-                "token": str(uuid.uuid4()),
+                "token": uuid.uuid4(),
                 "id": id
             })
         except DatabaseException as e:

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -94,7 +94,7 @@ class APICompatTestCase(APICompatIntegrationTestCase):
         response = xmltodict.parse(r.data)
         self.assertEqual(response['lfm']['@status'], 'ok')
 
-        token = Token.load(response['lfm']['token'], api_key=self.lfm_user.api_key)
+        token = Token.load(response['lfm']['token'], api_key=str(self.lfm_user.api_key))
         self.assertIsNotNone(token)
 
     def test_get_session(self):

--- a/listenbrainz/webserver/rate_limiter.py
+++ b/listenbrainz/webserver/rate_limiter.py
@@ -10,6 +10,7 @@ from flask import request, g
 from listenbrainz.webserver.redis_connection import _redis
 import listenbrainz.db.user as db_user
 from listenbrainz.redis_keys import RATELIMIT_PER_TOKEN_KEY, RATELIMIT_PER_IP_KEY, RATELIMIT_WINDOW_KEY
+from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
 # Defaults
 RATELIMIT_PER_TOKEN_DEFAULT = 50
@@ -115,7 +116,10 @@ def get_rate_limit_data(request):
     auth_header = request.headers.get('Authorization')
     if auth_header:
         auth_token = auth_header[6:]
-        user = db_user.get_by_token(auth_token)
+        if is_valid_uuid(auth_token):
+            user = db_user.get_by_token(auth_token)
+        else:
+            user = None
         if user:
             values = get_per_token_limits()
             values['key'] = auth_token

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -214,7 +214,5 @@ def _get_audioscrobbler_auth_token(lb_auth_token, timestamp):
         We use auth_token as password here, so users can just put their LB auth tokens
         as passwords in clients and it should work.
     """
-
-    token_md5 = md5(lb_auth_token.encode('utf-8')).hexdigest()
-    concatenated = '{}{}'.format(token_md5, timestamp)
+    concatenated = '{}{}'.format(lb_auth_token, timestamp)
     return md5(concatenated.encode('utf-8')).hexdigest()

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -5,6 +5,7 @@ import os
 import re
 import ujson
 import zipfile
+import uuid
 
 
 from datetime import datetime
@@ -39,7 +40,7 @@ EXPORT_FETCH_COUNT = 5000
 @login_required
 def reset_token():
     if request.method == "POST":
-        token = request.form.get("token")
+        token = uuid.UUID(request.form.get("token"))
         if token != current_user.auth_token:
             raise BadRequest("Can only reset token of currently logged in user")
         reset = request.form.get("reset")
@@ -62,7 +63,7 @@ def reset_token():
 @login_required
 def reset_latest_import_timestamp():
     if request.method == "POST":
-        token = request.form.get("token")
+        token = uuid.UUID(request.form.get("token"))
         if token != current_user.auth_token:
             raise BadRequest("Can only reset latest import timestamp of currently logged in user")
         reset = request.form.get("reset")
@@ -201,7 +202,7 @@ def delete():
     that they wish to delete their ListenBrainz account.
     """
     if request.method == 'POST':
-        if request.form.get('token') == current_user.auth_token:
+        if uuid.UUID(request.form.get("token")) == current_user.auth_token:
             try:
                 delete_user(current_user.musicbrainz_id)
             except Exception as e:

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -33,7 +33,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
         response = self.client.get(url_for('profile.info', user_name=self.user['musicbrainz_id']))
         self.assertTemplateUsed('profile/info.html')
         self.assert200(response)
-        self.assertIn(self.user['auth_token'], response.data.decode('utf-8'))
+        self.assertIn(str(self.user['auth_token']), response.data.decode('utf-8'))
 
     def test_reset_import_timestamp(self):
         self.temporary_login(self.user['id'])


### PR DESCRIPTION
* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

Datatype of auth_token is string when it actually stores UUID. 

* JIRA ticket (_optional_): [LB-416](https://tickets.metabrainz.org/browse/LB-416) 

# Solution

Changing datatype from string/varchar to UUID. Since request headers return auth_token as string, it should be explicitely converted to UUID.

