### PR TITLE
Fix Werkzeug TypeError: '<' not supported between instances of 'str' and 'int

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Login == 0.4.1
 Flask-WTF == 0.14
 Flask-SQLAlchemy == 2.3
 Jinja2 == 2.10
-Werkzeug == 0.14
+Werkzeug == 0.14.1
 SQLAlchemy == 1.2.5
 nose == 1.3.7
 coverage == 4.5.1


### PR DESCRIPTION
* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
TypeError: ('<' not supported between instances of 'str' and 'int ) on every request.

# Solution

Upgrade Werkzeug version 

