### PR TITLE
Improve Spotify player style and UX

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -6,11 +6,8 @@
 @dark: #053b47;
 @controlsHeight: 60px;
 
-@import url('https://fonts.googleapis.com/css?family=Questrial');
-@font: 'Questrial', sans-serif;
-
 #music-player {
-  background: @white;
+  background: @primary;
   position: relative;
   margin: auto;
   width: 100%;
@@ -35,6 +32,9 @@
   .noAlbumArt{
     min-height: 180px;
     margin: 0;
+    color: white;
+    text-align: center;
+    padding-top: 30px;
   }
   
   .currently-playing {
@@ -92,3 +92,26 @@
   
 }
 
+
+#listens {
+  
+  td {
+    vertical-align: middle;
+  }
+  .playing_now {
+    background-color: #fffcca ;
+  }
+  .playButton {
+    padding: 0;
+    & > * {
+      font-size: 1.2em;
+      padding-top: 0;
+      padding-bottom: 0;
+      opacity: 0;
+      transition: opacity .3s ease-in-out;
+    }
+  }
+  tr:hover > .playButton > *{
+    opacity: 1;
+  }
+}

--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -39,28 +39,38 @@
   
   .currently-playing {
     text-align: center;
-    padding: 10px;
+    padding-top: 10px;
     background: fadeout(@white, 15%);
+    .song-name, .artist-name {
+      text-transform: uppercase;
+      font-weight: 400;
+      margin: 0;
+    }
+    
+    .song-name {
+      font-size: 1.2em;
+      letter-spacing: 2px;
+      color: @dark;
+    }
+    
+    .artist-name {
+      font-size: .8em;
+      letter-spacing: 1.5px;
+      color: lighten(@dark, 15%);
+      margin: 5px 0;
+    }
+    /** Progress **/
+    .progress {
+      height: 0.35em;
+      background-color: fadeout(@white,80%);
+    }
+
+    .progress-bar {
+      height: 100%;
+      background-color: @primary;
+    }
   }
   
-  .song-name, .artist-name {
-    text-transform: uppercase;
-    font-weight: 400;
-    margin: 0;
-  }
-  
-  .song-name {
-    font-size: 1.2em;
-    letter-spacing: 2px;
-    color: @dark;
-  }
-  
-  .artist-name {
-    font-size: .8em;
-    letter-spacing: 1.5px;
-    color: lighten(@dark, 15%);
-    margin-top: 5px;
-  }
   
   .controls {
     background: fadeout(@white, 40%);

--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -107,25 +107,28 @@
 }
 
 
-#listens, .listens-table {
+.listens-table > tbody {
   
-  td {
-    vertical-align: middle;
-  }
-  .playing_now {
-    background-color: #fffcca ;
-  }
-  .playButton {
-    padding: 0;
-    & > * {
-      font-size: 1.2em;
-      padding-top: 0;
-      padding-bottom: 0;
-      opacity: 0;
-      transition: opacity .3s ease-in-out;
+  > tr {
+    &.playing_now {
+      background-color: #fffcca ;
     }
-  }
-  tr:hover > .playButton > *{
-    opacity: 1;
+    & > td {
+      vertical-align: middle;
+      &.playButton {
+        padding: 0;
+        & > * {
+          font-size: 1.2em;
+          padding-top: 0;
+          padding-bottom: 0;
+          opacity: 0;
+          transition: opacity .3s ease-in-out;
+        }
+      }
+    }
+
+    &:hover > td.playButton > *{
+      opacity: 1;
+    }
   }
 }

--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -88,6 +88,10 @@
       position: absolute;
       right: 10px;
     }
+    .left{
+      position: absolute;
+      left: 10px;
+    }
   }
   
 }

--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -107,7 +107,7 @@
 }
 
 
-#listens {
+#listens, .listens-table {
   
   td {
     vertical-align: middle;

--- a/listenbrainz/webserver/static/css/main.less
+++ b/listenbrainz/webserver/static/css/main.less
@@ -1,4 +1,5 @@
 @import "theme/theme.less";
+@import "music-player.less";
 
 @import "highlight.css"; // Styles for highlight.js
 

--- a/listenbrainz/webserver/static/css/main.less
+++ b/listenbrainz/webserver/static/css/main.less
@@ -1,5 +1,5 @@
 @import "theme/theme.less";
-@import "music-player.less";
+@import "listens-page.less";
 
 @import "highlight.css"; // Styles for highlight.js
 
@@ -96,9 +96,4 @@ h2.page-title { @media (max-width: @grid-float-breakpoint) { margin-top: 0px; } 
     fill: #EB743B;
     stroke: black;
   }
-}
-
-// Playing_now
-#playing_now {
-  background-color: #fffcca ;
 }

--- a/listenbrainz/webserver/static/css/music-player.less
+++ b/listenbrainz/webserver/static/css/music-player.less
@@ -1,0 +1,89 @@
+
+@primary: #08949b;
+@secondary: #0d696e;
+@white: #FFFFFF;
+@light: #C0CFB2;
+@dark: #053b47;
+@controlsHeight: 60px;
+
+@import url('https://fonts.googleapis.com/css?family=Questrial');
+@font: 'Questrial', sans-serif;
+
+#music-player {
+  background: @white;
+  position: relative;
+  margin: auto;
+  width: 100%;
+  // min-height: 180px;
+  border-radius: 5px;
+  overflow: hidden;
+  box-shadow: 5px 5px 15px fadeout(@dark, 60%);
+  
+  .info {
+    width: 100%;
+    position: absolute;
+    transition: all .5s ease;
+  }
+  .info:not(.showControls){
+    bottom: -@controlsHeight;
+  }
+  &:hover .info, .info.showControls{
+    bottom:0;
+  }
+  
+  .noAlbumArt{
+    min-height: 180px;
+    margin: 0;
+  }
+  
+  .currently-playing {
+    text-align: center;
+    padding: 10px;
+    background: fadeout(@white, 15%);
+  }
+  
+  .song-name, .artist-name {
+    text-transform: uppercase;
+    font-weight: 400;
+    margin: 0;
+  }
+  
+  .song-name {
+    font-size: 1.2em;
+    letter-spacing: 2px;
+    color: @dark;
+  }
+  
+  .artist-name {
+    font-size: .8em;
+    letter-spacing: 1.5px;
+    color: lighten(@dark, 15%);
+    margin-top: 5px;
+  }
+  
+  .controls {
+    background: fadeout(@white, 40%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: @secondary;
+    font-size: 1.5em;
+    height: @controlsHeight;
+    .play {
+      color: darken(@secondary, 10%);
+      font-size: 1em;
+    }
+    .next, .previous{
+      font-size: .8em;
+    }
+    .play, .next, .previous {
+      transition: all .5s ease;
+      background: none;
+      &:hover {
+        color: lighten(@dark, 15%);
+      }
+    }
+  }
+  
+}
+

--- a/listenbrainz/webserver/static/css/music-player.less
+++ b/listenbrainz/webserver/static/css/music-player.less
@@ -14,6 +14,7 @@
   position: relative;
   margin: auto;
   width: 100%;
+  max-width: 500px;
   // min-height: 180px;
   border-radius: 5px;
   overflow: hidden;
@@ -73,15 +74,19 @@
       color: darken(@secondary, 10%);
       font-size: 1em;
     }
-    .next, .previous{
+    > *:not(.play){
       font-size: .8em;
     }
-    .play, .next, .previous {
+    > * {
       transition: all .5s ease;
       background: none;
       &:hover {
         color: lighten(@dark, 15%);
       }
+    }
+    .right{
+      position: absolute;
+      right: 10px;
     }
   }
   

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -91,6 +91,9 @@ class PlaybackControls extends React.Component {
 					<div className="currently-playing">
 						<h2 className="song-name">{this.props.trackName || '—'}</h2>
 						<h3 className="artist-name">{this.props.artistName}</h3>
+						<div class="progress">
+							<div class="progress-bar" style={{width: `${this.props.progress_ms * 100 / this.props.duration_ms}%`}}></div>
+						</div>
 					</div>
 					<div className="controls">
 						<div className="left btn btn-xs"
@@ -145,8 +148,10 @@ class SpotifyPlayer extends React.Component {
 		this.state = { 
 			listens: props.listens,
 			currentSpotifyTrack: null,
-			playerPaused:true,
-			errorMessage:null,
+			playerPaused: true,
+			errorMessage: null,
+			progressMs: 0,
+			durationMs: 0,
 			direction: props.direction || "down"
 		};
 		this._accessToken = props.spotify_access_token;
@@ -329,6 +334,8 @@ connectSpotifyPlayer() {
 			return;
 		}
 		this.setState({
+			progressMs:position,
+			durationMs: duration,
 			currentSpotifyTrack: current_track,
 			playerPaused: paused,
 			errorMessage: null
@@ -361,6 +368,8 @@ connectSpotifyPlayer() {
 					artistName={this.state.currentSpotifyTrack && 
 						this.state.currentSpotifyTrack.artists.map(artist => artist.name).join(', ')
 					}
+					progress_ms={this.state.progressMs}
+					duration_ms={this.state.durationMs}
 				>
 					{this.getAlbumArt()}
 				</PlaybackControls>

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -83,7 +83,7 @@ class PlaybackControls extends React.Component {
 					{this.props.children ? this.props.children : 
 					<div className="noAlbumArt well text-center">No album art</div>}
 				</div>
-				<div className={`info ${(!this.props.children || this.props.playerPaused) && 'showControls'}`}>
+				<div className={`info ${(!this.props.children || this.props.playerPaused) ? 'showControls' : ''}`}>
 					<div className="currently-playing">
 						<h2 className="song-name">{this.props.trackName || '—'}</h2>
 						<h3 className="artist-name">{this.props.artistName}</h3>

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -1,749 +1,817 @@
 'use strict';
 
-function getSpotifyEmbedUriFromListen(listen){
-	
-	if(!listen || !listen.track_metadata || !listen.track_metadata.additional_info ||
-		typeof listen.track_metadata.additional_info.spotify_id !== "string"){
-		return null;
-	}
-	const spotifyId = listen.track_metadata.additional_info.spotify_id;
-	const spotify_track = spotifyId.split('https://open.spotify.com/')[1];
-	if(typeof spotify_track !== "string"){
-		return null;
-	}
-	return  spotifyId.replace("https://open.spotify.com/","https://open.spotify.com/embed/");
+function getSpotifyEmbedUriFromListen(listen) {
+
+  if (!listen || !listen.track_metadata || !listen.track_metadata.additional_info ||
+    typeof listen.track_metadata.additional_info.spotify_id !== "string")
+  {
+    return null;
+  }
+  const spotifyId = listen.track_metadata.additional_info.spotify_id;
+  const spotify_track = spotifyId.split('https://open.spotify.com/')[1];
+  if (typeof spotify_track !== "string")
+  {
+    return null;
+  }
+  return spotifyId.replace("https://open.spotify.com/", "https://open.spotify.com/embed/");
 }
 
-function getSpotifyUriFromListen(listen){
-	
-	if(!listen || !listen.track_metadata || !listen.track_metadata.additional_info ||
-		typeof listen.track_metadata.additional_info.spotify_id !== "string"){
-		return null;
-	}
-	const spotifyId = listen.track_metadata.additional_info.spotify_id;
-	const spotify_track = spotifyId.split('https://open.spotify.com/')[1];
-	if(typeof spotify_track !== "string"){
-		return null;
-	}
-	return "spotify:" + spotify_track.replace("/",":");
-}
-function millisecondsToHumanReadable(milliseconds)
-{
-	var seconds = milliseconds/1000;
-	var numyears = Math.floor(seconds / 31536000);
-	var numdays = Math.floor((seconds % 31536000) / 86400); 
-	var numhours = Math.floor(((seconds % 31536000) % 86400) / 3600);
-	var numminutes = Math.floor((((seconds % 31536000) % 86400) % 3600) / 60);
-	var numseconds = Math.floor((((seconds % 31536000) % 86400) % 3600) % 60);
-	var string="";
-	if(numyears) string += numyears + " y ";
-	if(numdays) string += numdays + " d ";
-	if(numhours) string += numhours + " h ";
-	if(numminutes) string += numminutes + " m ";
-	if(numseconds) string += numseconds + " s";
+function getSpotifyUriFromListen(listen) {
 
-	return string;
+  if (!listen || !listen.track_metadata || !listen.track_metadata.additional_info ||
+    typeof listen.track_metadata.additional_info.spotify_id !== "string")
+  {
+    return null;
+  }
+  const spotifyId = listen.track_metadata.additional_info.spotify_id;
+  const spotify_track = spotifyId.split('https://open.spotify.com/')[1];
+  if (typeof spotify_track !== "string")
+  {
+    return null;
+  }
+  return "spotify:" + spotify_track.replace("/", ":");
+}
+function millisecondsToHumanReadable(milliseconds) {
+  var seconds = milliseconds / 1000;
+  var numyears = Math.floor(seconds / 31536000);
+  var numdays = Math.floor((seconds % 31536000) / 86400);
+  var numhours = Math.floor(((seconds % 31536000) % 86400) / 3600);
+  var numminutes = Math.floor((((seconds % 31536000) % 86400) % 3600) / 60);
+  var numseconds = Math.floor((((seconds % 31536000) % 86400) % 3600) % 60);
+  var string = "";
+  if (numyears) string += numyears + " y ";
+  if (numdays) string += numdays + " d ";
+  if (numhours) string += numhours + " h ";
+  if (numminutes) string += numminutes + " m ";
+  if (numseconds) string += numseconds + " s";
+
+  return string;
 }
 
 function getArtistLink(listen) {
-	if(listen.track_metadata.additional_info.artist_mbids && listen.track_metadata.additional_info.artist_mbids.length){
-		return (<a href={`http://musicbrainz.org/artist/${listen.track_metadata.additional_info.artist_mbids[0]}`}>
-		{listen.track_metadata.artist_name}
-		</a>);
-	}
-	return listen.track_metadata.artist_name
+  if (listen.track_metadata.additional_info.artist_mbids && listen.track_metadata.additional_info.artist_mbids.length)
+  {
+    return (<a href={`http://musicbrainz.org/artist/${listen.track_metadata.additional_info.artist_mbids[0]}`}>
+      {listen.track_metadata.artist_name}
+    </a>);
+  }
+  return listen.track_metadata.artist_name
 }
 
 function getTrackLink(listen) {
-	if(listen.track_metadata.additional_info.recording_mbid) {
-		return (<a href={`http://musicbrainz.org/recording/${listen.track_metadata.additional_info.recording_mbid}`}>
-		{ listen.track_metadata.track_name }
-		</a>);
-	}
-	return listen.track_metadata.track_name;
+  if (listen.track_metadata.additional_info.recording_mbid)
+  {
+    return (<a href={`http://musicbrainz.org/recording/${listen.track_metadata.additional_info.recording_mbid}`}>
+      {listen.track_metadata.track_name}
+    </a>);
+  }
+  return listen.track_metadata.track_name;
 }
 
 function getPlayButton(listen, onClickFunction) {
-	if(listen.track_metadata.additional_info.spotify_id) {
-		return (
-			<button title="Play" className="btn btn-link" onClick={onClickFunction.bind(listen)}>
-				<i className="fas fa-play-circle fa-2x"></i>
-			</button>
-		)
-	}
-	return null;
+  if (listen.track_metadata.additional_info.spotify_id)
+  {
+    return (
+      <button title="Play" className="btn btn-link" onClick={onClickFunction.bind(listen)}>
+        <i className="fas fa-play-circle fa-2x"></i>
+      </button>
+    )
+  }
+  return null;
 }
 
 class PlaybackControls extends React.Component {
 
-	state = {
-		autoHideControls: true
-	}
-	
-	render(){
-		return (
-			<div id="music-player" aria-label="Playback control">
-				<div className="album">
-					{this.props.children ? this.props.children : 
-					<div className="noAlbumArt">No album art</div>}
-				</div>
-				<div className={`info ${!this.state.autoHideControls || !this.props.children || this.props.playerPaused ? 'showControls' : ''}`}>
-					<div className="currently-playing">
-						<h2 className="song-name">{this.props.trackName || '—'}</h2>
-						<h3 className="artist-name">{this.props.artistName}</h3>
-						<div class="progress">
-							<div class="progress-bar" style={{width: `${this.props.progress_ms * 100 / this.props.duration_ms}%`}}></div>
-						</div>
-					</div>
-					<div className="controls">
-						<div className="left btn btn-xs"
-							title={`${this.state.autoHideControls ? 'Always show' : 'Autohide'} controls`}
-							onClick={()=>this.setState(state => ({autoHideControls: !state.autoHideControls}))}>
-							<span className={`${this.state.autoHideControls? 'hidden' : ''}`}>
-								<i className="fas fa-eye"></i>
-							</span>
-							<span className={`${!this.state.autoHideControls? 'hidden' : ''}`}>
-								<i className="fas fa-eye-slash"></i>
-							</span>
-						</div>
-						<div className="previous btn btn-xs" onClick={this.props.playPreviousTrack} title="Previous">
-							<i className="fas fa-fast-backward"></i>
-						</div>
-						<div className="play btn" onClick={this.props.togglePlay} title={`${this.props.playerPaused ? 'Play' : 'Pause'}`} >
-							<span className={`${this.props.playerPaused ? 'hidden' : ''}`}>
-								<i className="fa fa-2x fa-pause-circle"></i>
-							</span>
-							<span className={`${!this.props.playerPaused ? 'hidden' : ''}`}>
-								<i className="fa fa-2x fa-play-circle"></i>
-							</span>
-						</div>
-						<div className="next btn btn-xs" onClick={this.props.playNextTrack} title="Next">
-							<i className="fas fa-fast-forward"></i>
-						</div>
-						{this.props.direction !== "hidden" &&
-							<div className="right btn btn-xs" onClick={this.props.toggleDirection} title={`Play ${this.props.direction === 'up'? 'down' : 'up'}`}>
-								<span className={`${this.props.direction === 'up'? 'hidden' : ''}`}>
-									<i className="fa fa-sort-amount-down"></i>
-								</span>
-								<span className={`${this.props.direction === 'down' ? 'hidden' : ''}`}>
-									<i className="fa fa-sort-amount-up"></i>
-								</span>
-							</div>
-						}
-		 			</div>
-		 		</div>
-		 	</div>
-		);
-	}
+  state = {
+    autoHideControls: true
+  }
+
+  render() {
+    return (
+      <div id="music-player" aria-label="Playback control">
+        <div className="album">
+          {this.props.children ? this.props.children :
+            <div className="noAlbumArt">No album art</div>}
+        </div>
+        <div className={`info ${!this.state.autoHideControls || !this.props.children || this.props.playerPaused ? 'showControls' : ''}`}>
+          <div className="currently-playing">
+            <h2 className="song-name">{this.props.trackName || '—'}</h2>
+            <h3 className="artist-name">{this.props.artistName}</h3>
+            <div class="progress">
+              <div class="progress-bar" style={{ width: `${this.props.progress_ms * 100 / this.props.duration_ms}%` }}></div>
+            </div>
+          </div>
+          <div className="controls">
+            <div className="left btn btn-xs"
+              title={`${this.state.autoHideControls ? 'Always show' : 'Autohide'} controls`}
+              onClick={() => this.setState(state => ({ autoHideControls: !state.autoHideControls }))}>
+              <span className={`${this.state.autoHideControls ? 'hidden' : ''}`}>
+                <i className="fas fa-eye"></i>
+              </span>
+              <span className={`${!this.state.autoHideControls ? 'hidden' : ''}`}>
+                <i className="fas fa-eye-slash"></i>
+              </span>
+            </div>
+            <div className="previous btn btn-xs" onClick={this.props.playPreviousTrack} title="Previous">
+              <i className="fas fa-fast-backward"></i>
+            </div>
+            <div className="play btn" onClick={this.props.togglePlay} title={`${this.props.playerPaused ? 'Play' : 'Pause'}`} >
+              <span className={`${this.props.playerPaused ? 'hidden' : ''}`}>
+                <i className="fa fa-2x fa-pause-circle"></i>
+              </span>
+              <span className={`${!this.props.playerPaused ? 'hidden' : ''}`}>
+                <i className="fa fa-2x fa-play-circle"></i>
+              </span>
+            </div>
+            <div className="next btn btn-xs" onClick={this.props.playNextTrack} title="Next">
+              <i className="fas fa-fast-forward"></i>
+            </div>
+            {this.props.direction !== "hidden" &&
+              <div className="right btn btn-xs" onClick={this.props.toggleDirection} title={`Play ${this.props.direction === 'up' ? 'down' : 'up'}`}>
+                <span className={`${this.props.direction === 'up' ? 'hidden' : ''}`}>
+                  <i className="fa fa-sort-amount-down"></i>
+                </span>
+                <span className={`${this.props.direction === 'down' ? 'hidden' : ''}`}>
+                  <i className="fa fa-sort-amount-up"></i>
+                </span>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 
 class SpotifyPlayer extends React.Component {
 
-	_spotifyPlayer;
-	_accessToken;
-	_firstRun = true;
+  _spotifyPlayer;
+  _accessToken;
+  _firstRun = true;
 
-	constructor(props) {
-		super(props);
-		this.state = { 
-			listens: props.listens,
-			currentSpotifyTrack: null,
-			playerPaused: true,
-			errorMessage: null,
-			progressMs: 0,
-			durationMs: 0,
-			direction: props.direction || "down"
-		};
-		this._accessToken = props.spotify_access_token;
-		this.playNextTrack = this.playNextTrack.bind(this);
-		this.playPreviousTrack = this.playPreviousTrack.bind(this);
-		this.togglePlay = this.togglePlay.bind(this);
-		this.toggleDirection = this.toggleDirection.bind(this);
-		this.handlePlayerStateChanged = this.handlePlayerStateChanged.bind(this);
-		this.handleError = this.handleError.bind(this);
-		this.isCurrentListen = this.isCurrentListen.bind(this);
-		this.getAlbumArt = this.getAlbumArt.bind(this);
-		this.playListen = this.playListen.bind(this);
-		this.disconnectSpotifyPlayer = this.disconnectSpotifyPlayer.bind(this);
-		this.connectSpotifyPlayer = this.connectSpotifyPlayer.bind(this);
-		window.onSpotifyWebPlaybackSDKReady = this.connectSpotifyPlayer;
-	}
-	
-	play_spotify_uri(spotify_uri){
-		if(!this._spotifyPlayer) {
-			const error ="Spotify player not initialized. Please refresh the page";
-			this.setState({errorMessage:error});
-			return;
-		}
-		fetch(`https://api.spotify.com/v1/me/player/play?device_id=${this._spotifyPlayer._options.id}`, {
-		method: 'PUT',
-		body: JSON.stringify({ uris: [spotify_uri] }),
-		headers: {
-			'Content-Type': 'application/json',
-			'Authorization': `Bearer ${this._accessToken}`
-		},
-	});
-};
+  constructor(props) {
+    super(props);
+    this.state = {
+      listens: props.listens,
+      currentSpotifyTrack: null,
+      playerPaused: true,
+      errorMessage: null,
+      warningMessage: null,
+      progressMs: 0,
+      durationMs: 0,
+      direction: props.direction || "down"
+    };
+    this._accessToken = props.spotify_access_token;
+    this.playNextTrack = this.playNextTrack.bind(this);
+    this.playPreviousTrack = this.playPreviousTrack.bind(this);
+    this.togglePlay = this.togglePlay.bind(this);
+    this.toggleDirection = this.toggleDirection.bind(this);
+    this.handlePlayerStateChanged = this.handlePlayerStateChanged.bind(this);
+    this.handleSpotifyAPICurrentlyPlaying = this.handleSpotifyAPICurrentlyPlaying.bind(this);
+    this.handleError = this.handleError.bind(this);
+    this.isCurrentListen = this.isCurrentListen.bind(this);
+    this.getAlbumArt = this.getAlbumArt.bind(this);
+    this.playListen = this.playListen.bind(this);
+    this.disconnectSpotifyPlayer = this.disconnectSpotifyPlayer.bind(this);
+    this.connectSpotifyPlayer = this.connectSpotifyPlayer.bind(this);
+    window.onSpotifyWebPlaybackSDKReady = this.connectSpotifyPlayer;
+  }
 
-playListen(listen){
-	if(listen.track_metadata.additional_info.spotify_id){
-		this.play_spotify_uri(getSpotifyUriFromListen(listen));
-		this.props.onCurrentListenChange(listen);
-	} else {
-		console.error("No Spotify ID for this listen :/");
-		this.handleError("Cannot play this song on Spotify");
-	}
-};
-isCurrentListen(element) {
-	return this.props.currentListen
-		&& element.listened_at
-		&& element.listened_at === this.props.currentListen.listened_at;
+  play_spotify_uri(spotify_uri) {
+    if (!this._spotifyPlayer)
+    {
+      const error = "Spotify player not initialized. Please refresh the page";
+      this.setState({ errorMessage: error });
+      return;
+    }
+    fetch(`https://api.spotify.com/v1/me/player/play?device_id=${this._spotifyPlayer._options.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({ uris: [spotify_uri] }),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this._accessToken}`
+      },
+    })
+    .catch(this.handleError);
+  };
+
+  playListen(listen) {
+    if (listen.track_metadata.additional_info.spotify_id)
+    {
+      this.play_spotify_uri(getSpotifyUriFromListen(listen));
+      this.props.onCurrentListenChange(listen);
+    } else
+    {
+      console.error("No Spotify ID for this listen :/");
+      this.handleError("Cannot play this song on Spotify");
+    }
+  };
+  isCurrentListen(element) {
+    return this.props.currentListen
+      && element.listened_at
+      && element.listened_at === this.props.currentListen.listened_at;
+  }
+  playPreviousTrack() {
+    this.playNextTrack(true);
+  }
+  playNextTrack(invert) {
+    if (this.state.listens.length === 0)
+    {
+      const error = "No Spotify listens to play. Maybe refresh the page?";
+      console.error(error);
+      this.setState({ errorMessage: error });
+      return;
+    }
+
+    const currentListenIndex = this.state.listens.findIndex(this.isCurrentListen);
+    let nextListen;
+    if (currentListenIndex === -1)
+    {
+      nextListen = this.state.direction === "up" ? this.state.listens[this.state.listens.length - 1] : this.state.listens[0];
+    }
+    else if ((this.state.direction === "up" && invert !== true) || invert === true)
+    {
+      nextListen = this.state.listens[currentListenIndex - 1];
+    } else
+    {
+      nextListen = this.state.listens[currentListenIndex + 1];
+    }
+
+    if (!nextListen)
+    {
+      const error = "No more listens, maybe wait some?";
+      console.error(error);
+      this.setState({ errorMessage: error });
+      return;
+    }
+
+    this.playListen(nextListen);
+    this.handleError(null);
+  }
+  handleError(error) {
+    if (!error)
+    {
+      this.setState({ errorMessage: null });
+      return;
+    }
+    console.error(error);
+    error = error.message ? error.message : error;
+    this.setState({ errorMessage: error });
+  }
+
+  async togglePlay() {
+    try
+    {
+      await this._spotifyPlayer.togglePlay();
+    } catch (error)
+    {
+      this.handleError(error);
+    }
+  }
+
+  toggleDirection() {
+    this.setState(prevState => {
+      const direction = prevState.direction === "down" ? "up" : "down";
+      return { direction: direction }
+    });
+  }
+  disconnectSpotifyPlayer() {
+    if (!this._spotifyPlayer)
+    {
+      return;
+    }
+    if (typeof this._spotifyPlayer.disconnect === "function")
+    {
+      this._spotifyPlayer.disconnect();
+      this._spotifyPlayer.removeListener('initialization_error');
+      this._spotifyPlayer.removeListener('authentication_error');
+      this._spotifyPlayer.removeListener('account_error');
+      this._spotifyPlayer.removeListener('playback_error');
+      this._spotifyPlayer.removeListener('ready');
+      this._spotifyPlayer.removeListener('player_state_changed');
+    }
+    this._spotifyPlayer = null;
+    this.handleError(null);
+    this._firstRun = true;
+  }
+
+  connectSpotifyPlayer() {
+    this.disconnectSpotifyPlayer();
+    if (!this._accessToken)
+    {
+      console.error("No spotify acces_token");
+      const noTokenErrorMessage = <span>No Spotify access token. Please try to <a href="/profile/connect-spotify">link your account</a> and refresh this page</span>;
+      this.handleError(noTokenErrorMessage);
+      return;
+    }
+
+    this._spotifyPlayer = new window.Spotify.Player({
+      name: 'ListenBrainz Player',
+      getOAuthToken: callback => {
+        callback(this._accessToken);
+      },
+      volume: 0.7 // Careful with this, now…
+    });
+
+    // Error handling
+    const authErrorMessage = <span>Spotify authentication error. <br /><button onClick={this.connectSpotifyPlayer} className="btn btn-primary">Reconnect</button> or <a href="/profile/connect-spotify">relink your Spotify account</a></span>
+    this._spotifyPlayer.on('initialization_error', this.handleError);
+    this._spotifyPlayer.on('authentication_error', error => this.handleError(authErrorMessage));
+    this._spotifyPlayer.on('account_error', this.handleError);
+    this._spotifyPlayer.on('playback_error', this.handleError);
+
+    this._spotifyPlayer.addListener('ready', ({ device_id }) => {
+      console.log('Spotify player connected with Device ID', device_id);
+      this.handleError(null);
+    });
+
+    this._spotifyPlayer.addListener('player_state_changed', this.handlePlayerStateChanged);
+
+    this._spotifyPlayer.connect().then(success => {
+      if (success)
+      {
+        console.log('The Web Playback SDK successfully connected to Spotify!');
+        this.handleError(null);
+        fetch('https://api.spotify.com/v1/me/player/currently-playing', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${this._accessToken}`
+          },
+        })
+        .then(response => response.json())
+        .then(this.handleSpotifyAPICurrentlyPlaying)
+        .catch(this.handleError);
+      }
+      else
+      {
+        this.handleError('Could not connect Web Playback SDK');
+      }
+    });
+  }
+
+  handleSpotifyAPICurrentlyPlaying(currentlyPlaying) {
+    this.setState({
+      progressMs: currentlyPlaying.progress_ms,
+      durationMs: currentlyPlaying.item && currentlyPlaying.item.duration_ms,
+      currentSpotifyTrack: currentlyPlaying.item,
+      errorMessage: null,
+      warningMessage: currentlyPlaying.is_playing ? 'Using Spotify on this page will interrupt your current playback' : ''
+    });
+  }
+
+  handlePlayerStateChanged({
+    paused,
+    position,
+    duration,
+    track_window: { current_track }
+  }) {
+    console.debug('Currently Playing', current_track);
+    console.debug('Position in Song', position);
+    console.debug('Duration of Song', duration);
+    console.debug('Player paused?', paused);
+
+    // How do we accurately detect the end of a song?
+    if (position === 0 && paused === true)
+    {
+      // Track finished, play next track
+      console.debug("Detected Spotify end of track, playing next track")
+      this.playNextTrack();
+      return;
+    }
+    this.setState({
+      progressMs: position,
+      durationMs: duration,
+      currentSpotifyTrack: current_track,
+      playerPaused: paused,
+      errorMessage: null
+    });
+    if (this._firstRun)
+    {
+      this._firstRun = false;
+    }
+  }
+
+  getAlbumArt() {
+    const track = this.state.currentSpotifyTrack;
+    if (!track || !track.album || !Array.isArray(track.album.images))
+    {
+      return null
+    }
+    const sortedImages = track.album.images.sort((a, b) => a.height > b.height ? -1 : 1);
+    return sortedImages[0] && <img className="img-responsive" src={sortedImages[0].url} />;
+  }
+
+  render() {
+    return (
+      <div>
+        <PlaybackControls
+          playPreviousTrack={this.playPreviousTrack}
+          playNextTrack={this.playNextTrack}
+          togglePlay={this._firstRun ? this.playNextTrack : this.togglePlay}
+          playerPaused={this.state.playerPaused}
+          toggleDirection={this.toggleDirection}
+          direction={this.state.direction}
+          trackName={this.state.currentSpotifyTrack && this.state.currentSpotifyTrack.name}
+          artistName={this.state.currentSpotifyTrack &&
+            this.state.currentSpotifyTrack.artists.map(artist => artist.name).join(', ')
+          }
+          progress_ms={this.state.progressMs}
+          duration_ms={this.state.durationMs}
+        >
+          {this.getAlbumArt()}
+        </PlaybackControls>
+
+        {this.state.errorMessage &&
+          <div className="alert alert-danger" role="alert">
+            {this.state.errorMessage}
+          </div>
+        }
+        {this.state.warningMessage &&
+          <div className="alert alert-warning" role="alert">
+            {this.state.warningMessage}
+          </div>
+        }
+      </div>
+    );
+  }
 }
-playPreviousTrack(){
-	this.playNextTrack(true);
-}
-playNextTrack(invert){
-	if(this.state.listens.length === 0){
-		const error = "No Spotify listens to play. Maybe refresh the page?";
-		console.error(error);
-		this.setState({errorMessage:error});
-		return;
-	}
-	
-	const currentListenIndex = this.state.listens.findIndex(this.isCurrentListen);
-	let nextListen;
-	if(currentListenIndex === -1){
-		nextListen = this.state.direction === "up" ? this.state.listens[this.state.listens.length-1] : this.state.listens[0];
-	}
-	else if((this.state.direction === "up" && invert !== true) || invert === true){
-		nextListen = this.state.listens[currentListenIndex-1];
-	} else {
-		nextListen = this.state.listens[currentListenIndex+1];
-	}
 
-	if(!nextListen){
-		const error = "No more listens, maybe wait some?";
-		console.error(error);
-		this.setState({errorMessage:error});
-		return;
-	}
 
-	this.playListen(nextListen);
-	this.handleError(null);
-}
-handleError(error){
-	if(!error){
-		this.setState({errorMessage: null});
-		return;
-	}
-	console.error(error);
-	error = error.message ? error.message : error;
-	this.setState({errorMessage: error});
-}
 
-async togglePlay(){
-	try {
-		await this._spotifyPlayer.togglePlay();
-	} catch (error) {
-		this.handleError(error);
-	}
-}
+class RecentListens extends React.Component {
 
-toggleDirection(){
-	this.setState(prevState =>{
-		const direction = prevState.direction === "down"? "up" : "down";
-		return {direction: direction }
-	});
-}
-disconnectSpotifyPlayer(){
-	if(!this._spotifyPlayer){
-		return;
-	}
-	if(typeof this._spotifyPlayer.disconnect === "function"){
-		this._spotifyPlayer.disconnect();
-		this._spotifyPlayer.removeListener('initialization_error');
-		this._spotifyPlayer.removeListener('authentication_error');
-		this._spotifyPlayer.removeListener('account_error');
-		this._spotifyPlayer.removeListener('playback_error');
-		this._spotifyPlayer.removeListener('ready');
-		this._spotifyPlayer.removeListener('player_state_changed');
-	}
-	this._spotifyPlayer = null;
-	this.handleError(null);
-	this._firstRun = true;
-}
+  spotifyListens = [];
+  constructor(props) {
+    super(props);
+    this.state = {
+      listens: props.listens || [],
+      currentListen: null,
+      mode: props.mode === "follow" ? "follow" : "listens",
+      playingNowByUser: {}
+    };
+    this.isCurrentListen = this.isCurrentListen.bind(this);
+    this.handleCurrentListenChange = this.handleCurrentListenChange.bind(this);
+    this.playListen = this.playListen.bind(this);
+    this.spotifyPlayer = React.createRef();
+    window.handleIncomingListen = this.receiveNewListen.bind(this);
+    window.handleIncomingPlayingNow = this.receiveNewPlayingNow.bind(this);
+  }
 
-connectSpotifyPlayer() {
-	this.disconnectSpotifyPlayer();
-	if(!this._accessToken){
-		console.error("No spotify acces_token");
-		const noTokenErrorMessage = <span>No Spotify access token. Please try to <a href="/profile/connect-spotify">link your account</a> and refresh this page</span>;
-		this.handleError(noTokenErrorMessage);
-		return;
-	}
-	
-	this._spotifyPlayer = new window.Spotify.Player({
-		name: 'ListenBrainz Player',
-		getOAuthToken: callback => {
-			callback(this._accessToken);
-		},
-		volume: 0.7 // Careful with this, now…
-	});
+  playListen(listen) {
+    if (this.spotifyPlayer.current)
+    {
+      this.spotifyPlayer.current.playListen(listen);
+      return;
+    } else
+    {
+      // For fallback embedded player
+      this.setState({ currentListen: listen });
+      return;
+    }
+  }
 
-	// Error handling
-	const authErrorMessage = <span>Spotify authentication error. <br/><button onClick={this.connectSpotifyPlayer} className="btn btn-primary">Reconnect</button> or <a href="/profile/connect-spotify">relink your Spotify account</a></span>
-	this._spotifyPlayer.on('initialization_error', this.handleError);
-	this._spotifyPlayer.on('authentication_error', error => this.handleError(authErrorMessage));
-	this._spotifyPlayer.on('account_error', this.handleError);
-	this._spotifyPlayer.on('playback_error', this.handleError);
-	
-	this._spotifyPlayer.addListener('ready', ({ device_id }) => {
-		console.log('Spotify player connected with Device ID', device_id);
-		this.handleError(null);
-	});
-	
-	this._spotifyPlayer.addListener('player_state_changed', this.handlePlayerStateChanged);
-	
-	this._spotifyPlayer.connect().then(success => {
-		if (success) {
-				console.log('The Web Playback SDK successfully connected to Spotify!');
-				this.handleError(null);
-			}
-			else {
-				this.handleError('Could not connect Web Playback SDK');
-			}
-		});
-	}
+  receiveNewListen(newListen) {
+    try
+    {
+      newListen = JSON.parse(newListen);
+    } catch (error)
+    {
+      console.error(error);
+    }
+    console.debug(typeof newListen, newListen);
+    this.setState(prevState => {
+      return { listens: [newListen].concat(prevState.listens) }
+    })
+  }
+  receiveNewPlayingNow(newPlayingNow) {
+    try
+    {
+      newPlayingNow = JSON.parse(newPlayingNow);
+    } catch (error)
+    {
+      console.error(error);
+    }
+    newPlayingNow.playing_now = true;
 
-	handlePlayerStateChanged({
-		paused,
-		position,
-		duration,
-		track_window: { current_track }
-	}) {
-		console.debug('Currently Playing', current_track);
-		console.debug('Position in Song', position);
-		console.debug('Duration of Song', duration);
-		console.debug('Player paused?', paused);
-		
-		// How do we accurately detect the end of a song?
-		if(position === 0 && paused === true) {
-			// Track finished, play next track
-			console.debug("Detected Spotify end of track, playing next track")
-			this.playNextTrack();
-			return;
-		}
-		this.setState({
-			progressMs:position,
-			durationMs: duration,
-			currentSpotifyTrack: current_track,
-			playerPaused: paused,
-			errorMessage: null
-		});
-		if(this._firstRun){
-			this._firstRun = false;
-		}
-	}
-		
-	getAlbumArt(){
-		const track = this.state.currentSpotifyTrack;
-		if (!track || !track.album || !Array.isArray(track.album.images)){
-			return null
-		}
-		const sortedImages = track.album.images.sort((a,b)=>a.height > b.height ? -1 :1);
-		return sortedImages[0] && <img className="img-responsive" src={sortedImages[0].url}/>;
-	}
-	
-	render(){
-		return (
-			<div>
-				<PlaybackControls
-					playPreviousTrack={this.playPreviousTrack}
-					playNextTrack={this.playNextTrack}
-					togglePlay={this._firstRun ? this.playNextTrack : this.togglePlay}
-					playerPaused={this.state.playerPaused}
-					toggleDirection={this.toggleDirection}
-					direction={this.state.direction}
-					trackName={this.state.currentSpotifyTrack && this.state.currentSpotifyTrack.name}
-					artistName={this.state.currentSpotifyTrack && 
-						this.state.currentSpotifyTrack.artists.map(artist => artist.name).join(', ')
-					}
-					progress_ms={this.state.progressMs}
-					duration_ms={this.state.durationMs}
-				>
-					{this.getAlbumArt()}
-				</PlaybackControls>
-				
-				{this.state.errorMessage && 
-					<div className="alert alert-danger" role="alert">
-						{this.state.errorMessage}
-					</div>
-				}
-			</div>
-			);
-		}
-	}
-	
-	
-	
-	class RecentListens extends React.Component {
-		
-		spotifyListens = [];
-		constructor(props) {
-			super(props);
-			this.state = {
-				listens: props.listens || [],
-				currentListen : null,
-				mode: props.mode === "follow" ? "follow" : "listens",
-				playingNowByUser: {}
-			};
-			this.isCurrentListen = this.isCurrentListen.bind(this);
-			this.handleCurrentListenChange = this.handleCurrentListenChange.bind(this);
-			this.playListen = this.playListen.bind(this);
-			this.spotifyPlayer = React.createRef();
-			window.handleIncomingListen = this.receiveNewListen.bind(this);
-			window.handleIncomingPlayingNow = this.receiveNewPlayingNow.bind(this);
-		}
-		
-		playListen(listen){
-			if(this.spotifyPlayer.current){
-				this.spotifyPlayer.current.playListen(listen);
-				return;
-			} else {
-				// For fallback embedded player
-				this.setState({currentListen:listen});
-				return;
-			}
-		}
+    this.setState(prevState => {
+      if (prevState.mode === "follow")
+      {
+        const userName = newPlayingNow.user_name;
+        return {
+          playingNowByUser: Object.assign(
+            {},
+            prevState.playingNowByUser,
+            { [userName]: newPlayingNow }
+          )
+        }
+      }
+      const indexOfPreviousPlayingNow = prevState.listens.findIndex(listen => listen.playing_now);
+      prevState.listens.splice(indexOfPreviousPlayingNow, 1);
+      return { listens: [newPlayingNow].concat(prevState.listens) }
+    })
+  }
 
-		receiveNewListen(newListen){
-			try {
-				newListen = JSON.parse(newListen);
-			} catch (error) {
-				console.error(error);
-			}
-			console.debug(typeof newListen, newListen);
-			this.setState(prevState =>{
-				return { listens: [newListen].concat(prevState.listens)}
-			})
-		}
-		receiveNewPlayingNow(newPlayingNow){
-			try {
-				newPlayingNow = JSON.parse(newPlayingNow);
-			} catch (error) {
-				console.error(error);
-			}
-			newPlayingNow.playing_now = true;
+  handleCurrentListenChange(listen) {
+    this.setState({ currentListen: listen });
+  }
+  isCurrentListen(listen) {
+    return this.state.currentListen && this.state.currentListen.listened_at === listen.listened_at;
+  }
+  handleFollowUserListChange(users) {
+    if (!Array.isArray(users))
+    {
+      console.error("Expected array in handleFollowUserListChange, got", typeof users);
+      return;
+    }
+    if (typeof window.emitFollowUsersList !== "function")
+    {
+      console.error("window.emitFollowUsersList is not a function, can't emit follow users list");
+      return;
+    }
+    window.emitFollowUsersList(users);
+  }
 
-			this.setState(prevState =>{
-				if(prevState.mode === "follow"){
-					const userName = newPlayingNow.user_name;
-					return {playingNowByUser: Object.assign(
-						{},
-						prevState.playingNowByUser,
-						{[userName]:newPlayingNow}
-						)
-					}
-				}
-				const indexOfPreviousPlayingNow = prevState.listens.findIndex(listen => listen.playing_now);
-				prevState.listens.splice(indexOfPreviousPlayingNow, 1);
-				return { listens: [newPlayingNow].concat(prevState.listens)}
-			})
-		}
-		
-		handleCurrentListenChange(listen){
-			this.setState({currentListen:listen});
-		}
-		isCurrentListen(listen){
-			return this.state.currentListen && this.state.currentListen.listened_at === listen.listened_at;
-		}
-		handleFollowUserListChange(users){
-			if(!Array.isArray(users)){
-				console.error("Expected array in handleFollowUserListChange, got", typeof users);
-				return;
-			}
-			if(typeof window.emitFollowUsersList !== "function"){
-				console.error("window.emitFollowUsersList is not a function, can't emit follow users list");
-				return;
-			}
-			window.emitFollowUsersList(users);
-		}
-		
-		render() {
-			
-			const spotifyListens = this.state.listens.filter(listen => listen.track_metadata
-					&& listen.track_metadata.additional_info
-					&& listen.track_metadata.additional_info.listening_from === "spotify"
-			);
+  render() {
 
-			const getSpotifyEmbedSrc = () => {
-				if(this.state.currentListen) {
-					return getSpotifyEmbedUriFromListen(this.state.currentListen);
-				} else if(spotifyListens.length){
-					
-					return getSpotifyEmbedUriFromListen(spotifyListens[0]);
-				}
-				return null
-			};
+    const spotifyListens = this.state.listens.filter(listen => listen.track_metadata
+      && listen.track_metadata.additional_info
+      && listen.track_metadata.additional_info.listening_from === "spotify"
+    );
 
-			return (
-				<div>
-					{this.state.mode === "listens" && <div className="row">
-						<div className="col-md-8">
-							<h3> Statistics </h3>
-							<table className="table table-border table-condensed table-striped">
-							<tbody>
-							{this.props.listen_count && 
-								<tr>
-								<td>Listen count</td>
-								<td>{ this.props.listen_count }</td>
-								</tr>
-							}
-							{ this.props.artist_count &&
-								<tr>
-								<td>Artist count</td>
-								<td>{ this.props.artist_count }</td>
-								</tr>
-							}
-							</tbody>
-							</table>
-						</div>
-					</div>
-					}
-					{this.state.mode === "follow" &&
-						<FollowUsers onUserListChange={this.handleFollowUserListChange}
-						initialList={this.props.follow_list} playListen={this.playListen.bind(this)}
-						playingNow={this.state.playingNowByUser}/>
-					}
-					<div className="row">
-					<div className="col-md-8">
-					<h3>{this.state.mode === "listens" ? "Recent listens" : "Playlist"}</h3>
-					
-					{ !this.state.listens.length ?
-						<p className="lead" className="text-center">No listens :/</p> :
-						<div>
-							<table className="table table-condensed table-striped listens-table" id="listens">
-							<thead>
-							<tr>
-							<th>Track</th>
-							<th>Artist</th>
-							<th>Time</th>
-							{this.state.mode === "follow" && <th>User</th>}
-							<th></th>
-							</tr>
-							</thead>
-							<tbody>
-							{this.state.listens
-								.sort((a,b)=> a.playing_now ? -1 : b.playing_now ? 1 : 0) 
-								.map((listen,index) => {
-									return (
-										<tr key={index} className={`listen ${this.isCurrentListen(listen) ? 'info' : ''} ${listen.playing_now ? 'playing_now' : ''}`}  >
-											<td>{getTrackLink(listen)}</td>
-											<td>{getArtistLink(listen)}</td>
-											{listen.playing_now ?
-												<td><span className="fab fa-spotify" aria-hidden="true"></span> Playing now</td>
-												:
-												<td>
-													<abbr className="timeago" title={listen.listened_at_iso}>
-													{listen.listened_at_iso ? $.timeago(listen.listened_at_iso) : $.timeago(listen.listened_at*1000) }
-													</abbr>
-												</td>
-											}
-											{this.state.mode === "follow" && <td>{listen.user_name}</td>}
-											<td className="playButton">{getPlayButton(listen,this.playListen.bind(this,listen))}</td>
-										</tr>
-										)
-									})
-								}
-								
-								</tbody>
-								</table>
-							
-								{this.state.mode === "listens" &&
-									<ul className="pager">
-										<li className="previous" className={!this.props.previous_listen_ts ? 'hidden' :''}>
-										<a href={`${this.props.profile_url}?min_ts=${this.props.previous_listen_ts}`}>&larr; Previous</a>
-										</li>
-										<li className="next" disabled={!this.props.next_listen_ts ? 'hidden' : ''}>
-										<a href={`${this.props.profile_url}?max_ts=${this.props.next_listen_ts}`}>Next &rarr;</a>
-										</li>
-									</ul>
-								}
-						</div>
-							
-							
-						}
-					</div>
-					<div className="col-md-4" style={{position: "-webkit-sticky",position: "sticky",top: 20}}>
-						{ this.props.spotify_access_token ?
-							<SpotifyPlayer
-								ref={this.spotifyPlayer}
-								listens={spotifyListens}
-								direction={this.state.mode === "follow" ? "up" : "down"}
-								spotify_access_token= {this.props.spotify_access_token}
-								onCurrentListenChange={this.handleCurrentListenChange}
-								currentListen={this.state.currentListen}
-							/> :
-							// Fallback embedded player
-							<div className="col-md-4 text-right">
-								<iframe src={getSpotifyEmbedSrc()} 
-									width="300" height="380" frameBorder="0" allowtransparency="true" allow="encrypted-media">
-								</iframe>
-							</div>
-						}
-					</div>
-				</div>
-			</div>);
-		}
+    const getSpotifyEmbedSrc = () => {
+      if (this.state.currentListen)
+      {
+        return getSpotifyEmbedUriFromListen(this.state.currentListen);
+      } else if (spotifyListens.length)
+      {
+
+        return getSpotifyEmbedUriFromListen(spotifyListens[0]);
+      }
+      return null
+    };
+
+    return (
+      <div>
+        {this.state.mode === "listens" && <div className="row">
+          <div className="col-md-8">
+            <h3> Statistics </h3>
+            <table className="table table-border table-condensed table-striped">
+              <tbody>
+                {this.props.listen_count &&
+                  <tr>
+                    <td>Listen count</td>
+                    <td>{this.props.listen_count}</td>
+                  </tr>
+                }
+                {this.props.artist_count &&
+                  <tr>
+                    <td>Artist count</td>
+                    <td>{this.props.artist_count}</td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+        }
+        {this.state.mode === "follow" &&
+          <FollowUsers onUserListChange={this.handleFollowUserListChange}
+            initialList={this.props.follow_list} playListen={this.playListen.bind(this)}
+            playingNow={this.state.playingNowByUser} />
+        }
+        <div className="row">
+          <div className="col-md-8">
+            <h3>{this.state.mode === "listens" ? "Recent listens" : "Playlist"}</h3>
+
+            {!this.state.listens.length ?
+              <p className="lead" className="text-center">No listens :/</p> :
+              <div>
+                <table className="table table-condensed table-striped listens-table" id="listens">
+                  <thead>
+                    <tr>
+                      <th>Track</th>
+                      <th>Artist</th>
+                      <th>Time</th>
+                      {this.state.mode === "follow" && <th>User</th>}
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {this.state.listens
+                      .sort((a, b) => a.playing_now ? -1 : b.playing_now ? 1 : 0)
+                      .map((listen, index) => {
+                        return (
+                          <tr key={index} className={`listen ${this.isCurrentListen(listen) ? 'info' : ''} ${listen.playing_now ? 'playing_now' : ''}`}  >
+                            <td>{getTrackLink(listen)}</td>
+                            <td>{getArtistLink(listen)}</td>
+                            {listen.playing_now ?
+                              <td><span className="fab fa-spotify" aria-hidden="true"></span> Playing now</td>
+                              :
+                              <td>
+                                <abbr className="timeago" title={listen.listened_at_iso}>
+                                  {listen.listened_at_iso ? $.timeago(listen.listened_at_iso) : $.timeago(listen.listened_at * 1000)}
+                                </abbr>
+                              </td>
+                            }
+                            {this.state.mode === "follow" && <td>{listen.user_name}</td>}
+                            <td className="playButton">{getPlayButton(listen, this.playListen.bind(this, listen))}</td>
+                          </tr>
+                        )
+                      })
+                    }
+
+                  </tbody>
+                </table>
+
+                {this.state.mode === "listens" &&
+                  <ul className="pager">
+                    <li className="previous" className={!this.props.previous_listen_ts ? 'hidden' : ''}>
+                      <a href={`${this.props.profile_url}?min_ts=${this.props.previous_listen_ts}`}>&larr; Previous</a>
+                    </li>
+                    <li className="next" disabled={!this.props.next_listen_ts ? 'hidden' : ''}>
+                      <a href={`${this.props.profile_url}?max_ts=${this.props.next_listen_ts}`}>Next &rarr;</a>
+                    </li>
+                  </ul>
+                }
+              </div>
+
+
+            }
+          </div>
+          <div className="col-md-4" style={{ position: "-webkit-sticky", position: "sticky", top: 20 }}>
+            {this.props.spotify_access_token ?
+              <SpotifyPlayer
+                ref={this.spotifyPlayer}
+                listens={spotifyListens}
+                direction={this.state.mode === "follow" ? "up" : "down"}
+                spotify_access_token={this.props.spotify_access_token}
+                onCurrentListenChange={this.handleCurrentListenChange}
+                currentListen={this.state.currentListen}
+              /> :
+              // Fallback embedded player
+              <div className="col-md-4 text-right">
+                <iframe src={getSpotifyEmbedSrc()}
+                  width="300" height="380" frameBorder="0" allowtransparency="true" allow="encrypted-media">
+                </iframe>
+              </div>
+            }
+          </div>
+        </div>
+      </div>);
+  }
 }
 
 class FollowUsers extends React.Component {
-	constructor(props){
-		super(props);
-		this.state = {
-			users: props.initialList || []
-		}
-		this.addUserToList = this.addUserToList.bind(this);
-		this.reorderUser = this.reorderUser.bind(this);
-	}
+  constructor(props) {
+    super(props);
+    this.state = {
+      users: props.initialList || []
+    }
+    this.addUserToList = this.addUserToList.bind(this);
+    this.reorderUser = this.reorderUser.bind(this);
+  }
 
-	addUserToList(event){
-		event.preventDefault();
-		if(this.textInput.value === "" ||
-			this.state.users.find(user => user === this.textInput.value)){
-			return;
-		}
-		this.setState(prevState=>{
-			return {users: prevState.users.concat([this.textInput.value])}
-		},()=>{
-			this.textInput.value = "";
-			this.props.onUserListChange(this.state.users);
-		});
-	}
-	removeUserFromList(index){
-		this.setState(prevState=>{
-			prevState.users.splice(index,1);
-			return {users: prevState.users}
-		},() => {this.props.onUserListChange(this.state.users)});
-	}
+  addUserToList(event) {
+    event.preventDefault();
+    if (this.textInput.value === "" ||
+      this.state.users.find(user => user === this.textInput.value))
+    {
+      return;
+    }
+    this.setState(prevState => {
+      return { users: prevState.users.concat([this.textInput.value]) }
+    }, () => {
+      this.textInput.value = "";
+      this.props.onUserListChange(this.state.users);
+    });
+  }
+  removeUserFromList(index) {
+    this.setState(prevState => {
+      prevState.users.splice(index, 1);
+      return { users: prevState.users }
+    }, () => { this.props.onUserListChange(this.state.users) });
+  }
 
-	reorderUser(currentIndex, targetIndex){
-		this.setState(prevState=>{
-			var element = prevState.users[currentIndex];
-			prevState.users.splice(currentIndex, 1);
-			prevState.users.splice(targetIndex, 0, element);
-			return {users: prevState.users}
-		});
-	}
+  reorderUser(currentIndex, targetIndex) {
+    this.setState(prevState => {
+      var element = prevState.users[currentIndex];
+      prevState.users.splice(currentIndex, 1);
+      prevState.users.splice(targetIndex, 0, element);
+      return { users: prevState.users }
+    });
+  }
 
-	render(){
-		const noTopBottomPadding = {
-			paddingTop: 0,
-			paddingBottom: 0
-		};
-		return (
-			<div className="panel panel-primary">
-				<div className="panel-heading">
-					<i class="fas fa-sitemap fa-2x fa-flip-vertical"></i>
-					<span style={{fontSize: "x-large", marginLeft: "0.55em", verticalAign: "middle"}}>
-						Follow users
-					</span>
-				</div>
-				<div className="panel-body">
-					<div className="text-muted">
-					Add a user to discover what they are listening to:
-					</div>
-					<hr/>
-					<div className="input-group">
-						<input type="text" className="form-control" placeholder="Username…"
-							ref={(input) => this.textInput = input}
-						/>
-						<span className="input-group-btn btn-primary">
-							<button className="btn btn-primary" type="button" onClick={this.addUserToList}>
-								<span className="fa fa-plus-circle" aria-hidden="true"></span> Add
-							</button>
-						</span>
-					</div>
-					<table className="table table-condensed table-striped listens-table">
-					<thead>
-						<tr>
-							<th colSpan="2" width="50px">Order</th>
-							<th>User</th>
-							<th width="50%">Listening now</th>
-							<th width="25px"></th>
-							<th width="85px"></th>
-						</tr>
-					</thead>
-					<tbody>
-						{this.state.users.map((user,index) => {
-							return (
-							<tr key={user} className={this.props.playingNow[user] && "playing_now"}>
-								<td>
-									{index + 1}
-								</td>
-								<td>
-									<span className="btn-group btn-group-xs" role="group" aria-label="Reorder">
-										{index > 0 && 
-											<button className="btn btn-info"
-												onClick={this.reorderUser.bind(this,index,index-1)}>
-												<span className="fa fa-chevron-up"></span>
-											</button>
-										}
-										{index < this.state.users.length-1 && 
-											<button className="btn btn-info"
-												onClick={this.reorderUser.bind(this,index,index+1)}>
-												<span className="fa fa-chevron-down"></span>
-											</button>
-										}
-									</span>
-								</td>
-								<td>
-									{user}
-								</td>
-								<td>
-								{this.props.playingNow[user] &&
-									<React.Fragment>
-										{getTrackLink(this.props.playingNow[user])}
-										 <span className="small"> — {getArtistLink(this.props.playingNow[user])}</span>
-									</React.Fragment>
-								}
-								</td>
-								<td style={noTopBottomPadding}>
-									<button className="btn btn-danger" type="button" aria-label="Remove"
-										onClick={this.removeUserFromList.bind(this,index)}>
-										<span className="fa fa-trash-alt"></span>
-									</button>
-								</td>
-								<td className="playButton">
-								{this.props.playingNow[user] &&
-									getPlayButton(this.props.playingNow[user],this.props.playListen.bind(this,this.props.playingNow[user]))
-								}
-								</td>
-							</tr>
-							);
-						})}
-					</tbody>
-					</table>
-				</div>
-			</div>
-		);
-	}
+  render() {
+    const noTopBottomPadding = {
+      paddingTop: 0,
+      paddingBottom: 0
+    };
+    return (
+      <div className="panel panel-primary">
+        <div className="panel-heading">
+          <i class="fas fa-sitemap fa-2x fa-flip-vertical"></i>
+          <span style={{ fontSize: "x-large", marginLeft: "0.55em", verticalAign: "middle" }}>
+            Follow users
+              </span>
+        </div>
+        <div className="panel-body">
+          <div className="text-muted">
+            Add a user to discover what they are listening to:
+              </div>
+          <hr />
+          <div className="input-group">
+            <input type="text" className="form-control" placeholder="Username…"
+              ref={(input) => this.textInput = input}
+            />
+            <span className="input-group-btn btn-primary">
+              <button className="btn btn-primary" type="button" onClick={this.addUserToList}>
+                <span className="fa fa-plus-circle" aria-hidden="true"></span> Add
+              </button>
+            </span>
+          </div>
+          <table className="table table-condensed table-striped listens-table">
+            <thead>
+              <tr>
+                <th colSpan="2" width="50px">Order</th>
+                <th>User</th>
+                <th width="50%">Listening now</th>
+                <th width="25px"></th>
+                <th width="85px"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.state.users.map((user, index) => {
+                return (
+                  <tr key={user} className={this.props.playingNow[user] && "playing_now"}>
+                    <td>
+                      {index + 1}
+                    </td>
+                    <td>
+                      <span className="btn-group btn-group-xs" role="group" aria-label="Reorder">
+                        {index > 0 &&
+                          <button className="btn btn-info"
+                            onClick={this.reorderUser.bind(this, index, index - 1)}>
+                            <span className="fa fa-chevron-up"></span>
+                          </button>
+                        }
+                        {index < this.state.users.length - 1 &&
+                          <button className="btn btn-info"
+                            onClick={this.reorderUser.bind(this, index, index + 1)}>
+                            <span className="fa fa-chevron-down"></span>
+                          </button>
+                        }
+                      </span>
+                    </td>
+                    <td>
+                      {user}
+                    </td>
+                    <td>
+                      {this.props.playingNow[user] &&
+                        <React.Fragment>
+                          {getTrackLink(this.props.playingNow[user])}
+                          <span className="small"> — {getArtistLink(this.props.playingNow[user])}</span>
+                        </React.Fragment>
+                      }
+                    </td>
+                    <td style={noTopBottomPadding}>
+                      <button className="btn btn-danger" type="button" aria-label="Remove"
+                        onClick={this.removeUserFromList.bind(this, index)}>
+                        <span className="fa fa-trash-alt"></span>
+                      </button>
+                    </td>
+                    <td className="playButton">
+                      {this.props.playingNow[user] &&
+                        getPlayButton(this.props.playingNow[user], this.props.playListen.bind(this, this.props.playingNow[user]))
+                      }
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
 
 }
 
-			
+
 let domContainer = document.querySelector('#react-listens');
 let propsElement = document.getElementById('react-props');
 let reactProps;
-try{
-reactProps = JSON.parse(propsElement.innerHTML);
-// console.log("props",reactProps);
+try
+{
+  reactProps = JSON.parse(propsElement.innerHTML);
+  // console.log("props",reactProps);
 }
-catch(err){
-console.error("Error parsing props:", err);
+catch (err)
+{
+  console.error("Error parsing props:", err);
 }
-ReactDOM.render(<RecentListens {...reactProps}/>, domContainer);
-			
-window.onSpotifyWebPlaybackSDKReady = window.onSpotifyWebPlaybackSDKReady || console.log; 
+ReactDOM.render(<RecentListens {...reactProps} />, domContainer);
+
+window.onSpotifyWebPlaybackSDKReady = window.onSpotifyWebPlaybackSDKReady || console.log;
 
 

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -66,7 +66,7 @@ function getTrackLink(listen) {
 function getPlayButton(listen, onClickFunction) {
 	if(listen.track_metadata.additional_info.spotify_id) {
 		return (
-			<button className="btn btn-link" onClick={onClickFunction.bind(listen)}>
+			<button title="Play" className="btn btn-link" onClick={onClickFunction.bind(listen)}>
 				<i className="fas fa-play-circle fa-2x"></i>
 			</button>
 		)
@@ -76,6 +76,10 @@ function getPlayButton(listen, onClickFunction) {
 
 class PlaybackControls extends React.Component {
 
+	state = {
+		autoHideControls: true
+	}
+	
 	render(){
 		return (
 			<div id="music-player" aria-label="Playback control">
@@ -83,16 +87,26 @@ class PlaybackControls extends React.Component {
 					{this.props.children ? this.props.children : 
 					<div className="noAlbumArt">No album art</div>}
 				</div>
-				<div className={`info ${(!this.props.children || this.props.playerPaused) ? 'showControls' : ''}`}>
+				<div className={`info ${!this.state.autoHideControls || !this.props.children || this.props.playerPaused ? 'showControls' : ''}`}>
 					<div className="currently-playing">
 						<h2 className="song-name">{this.props.trackName || '—'}</h2>
 						<h3 className="artist-name">{this.props.artistName}</h3>
 					</div>
 					<div className="controls">
-						<div className="previous btn btn-xs" onClick={this.props.playPreviousTrack}>
+						<div className="left btn btn-xs"
+							title={`${this.state.autoHideControls ? 'Always show' : 'Autohide'} controls`}
+							onClick={()=>this.setState(state => ({autoHideControls: !state.autoHideControls}))}>
+							<span className={`${this.state.autoHideControls? 'hidden' : ''}`}>
+								<i className="fas fa-eye"></i>
+							</span>
+							<span className={`${!this.state.autoHideControls? 'hidden' : ''}`}>
+								<i className="fas fa-eye-slash"></i>
+							</span>
+						</div>
+						<div className="previous btn btn-xs" onClick={this.props.playPreviousTrack} title="Previous">
 							<i className="fas fa-fast-backward"></i>
 						</div>
-						<div className="play btn" onClick={this.props.togglePlay}>
+						<div className="play btn" onClick={this.props.togglePlay} title={`${this.props.playerPaused ? 'Play' : 'Pause'}`} >
 							<span className={`${this.props.playerPaused ? 'hidden' : ''}`}>
 								<i className="fa fa-2x fa-pause-circle"></i>
 							</span>
@@ -100,15 +114,15 @@ class PlaybackControls extends React.Component {
 								<i className="fa fa-2x fa-play-circle"></i>
 							</span>
 						</div>
-						<div className="next btn btn-xs" onClick={this.props.playNextTrack}>
+						<div className="next btn btn-xs" onClick={this.props.playNextTrack} title="Next">
 							<i className="fas fa-fast-forward"></i>
 						</div>
 						{this.props.direction !== "hidden" &&
-							<div className="right btn btn-xs" onClick={this.props.toggleDirection}>
-								<span className={`${this.props.direction === "up"? 'hidden' : ''}`}>
+							<div className="right btn btn-xs" onClick={this.props.toggleDirection} title={`Play ${this.props.direction === 'up'? 'down' : 'up'}`}>
+								<span className={`${this.props.direction === 'up'? 'hidden' : ''}`}>
 									<i className="fa fa-sort-amount-down"></i>
 								</span>
-								<span className={`${this.props.direction === "down" ? 'hidden' : ''}`}>
+								<span className={`${this.props.direction === 'down' ? 'hidden' : ''}`}>
 									<i className="fa fa-sort-amount-up"></i>
 								</span>
 							</div>

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -123,7 +123,8 @@ class PlaybackControls extends React.Component {
 class SpotifyPlayer extends React.Component {
 
 	_spotifyPlayer;
-	_accessToken; 
+	_accessToken;
+	_firstRun = true;
 
 	constructor(props) {
 		super(props);
@@ -192,7 +193,10 @@ playNextTrack(invert){
 	
 	const currentListenIndex = this.state.listens.findIndex(this.isCurrentListen);
 	let nextListen;
-	if((this.state.direction === "up" && invert !== true) || invert === true){
+	if(currentListenIndex === -1){
+		nextListen = this.state.direction === "up" ? this.state.listens[this.state.listens.length-1] : this.state.listens[0];
+	}
+	else if((this.state.direction === "up" && invert !== true) || invert === true){
 		nextListen = this.state.listens[currentListenIndex-1];
 	} else {
 		nextListen = this.state.listens[currentListenIndex+1];
@@ -315,6 +319,9 @@ connectSpotifyPlayer() {
 			playerPaused: paused,
 			errorMessage: null
 		});
+		if(this._firstRun){
+			this._firstRun = false;
+		}
 	}
 		
 	getAlbumArt(){
@@ -332,7 +339,7 @@ connectSpotifyPlayer() {
 				<PlaybackControls
 					playPreviousTrack={this.playPreviousTrack}
 					playNextTrack={this.playNextTrack}
-					togglePlay={this.togglePlay}
+					togglePlay={this._firstRun ? this.playNextTrack : this.togglePlay}
 					playerPaused={this.state.playerPaused}
 					toggleDirection={this.toggleDirection}
 					direction={this.state.direction}

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -522,7 +522,7 @@ connectSpotifyPlayer() {
 					{ !this.state.listens.length ?
 						<p className="lead" className="text-center">No listens :/</p> :
 						<div>
-							<table className="table table-condensed table-striped" id="listens">
+							<table className="table table-condensed table-striped listens-table" id="listens">
 							<thead>
 							<tr>
 							<th>Track</th>
@@ -644,7 +644,10 @@ class FollowUsers extends React.Component {
 		return (
 			<div className="panel panel-primary">
 				<div className="panel-heading">
-					<span style={{fontSize: "x-large"}}>Follow users</span>
+					<i class="fas fa-sitemap fa-2x fa-flip-vertical"></i>
+					<span style={{fontSize: "x-large", marginLeft: "0.55em", verticalAign: "middle"}}>
+						Follow users
+					</span>
 				</div>
 				<div className="panel-body">
 					<div className="text-muted">
@@ -661,7 +664,7 @@ class FollowUsers extends React.Component {
 							</button>
 						</span>
 					</div>
-					<table className="table table-condensed table-striped">
+					<table className="table table-condensed table-striped listens-table">
 					<thead>
 						<tr>
 							<th colSpan="2" width="50px">Order</th>
@@ -711,7 +714,7 @@ class FollowUsers extends React.Component {
 										<span className="fa fa-trash-alt"></span>
 									</button>
 								</td>
-								<td style={noTopBottomPadding}>
+								<td style={noTopBottomPadding} className="playButton">
 								{this.props.playingNow[user] &&
 									getPlayButton(this.props.playingNow[user],this.props.playListen.bind(this,this.props.playingNow[user]))
 								}

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -63,11 +63,11 @@ function getTrackLink(listen) {
 	return listen.track_metadata.track_name;
 }
 
-function getSpotifyPlayButton(listen, onClickFunction) {
+function getPlayButton(listen, onClickFunction) {
 	if(listen.track_metadata.additional_info.spotify_id) {
 		return (
-			<button className="btn btn-info btn-sm" onClick={onClickFunction.bind(listen)}>
-				<span className="fab fa-spotify"></span> Play
+			<button className="btn btn-link" onClick={onClickFunction.bind(listen)}>
+				<i className="fas fa-play-circle fa-2x"></i>
 			</button>
 		)
 	}
@@ -81,7 +81,7 @@ class PlaybackControls extends React.Component {
 			<div id="music-player" aria-label="Playback control">
 				<div className="album">
 					{this.props.children ? this.props.children : 
-					<div className="noAlbumArt well text-center">No album art</div>}
+					<div className="noAlbumArt">No album art</div>}
 				</div>
 				<div className={`info ${(!this.props.children || this.props.playerPaused) ? 'showControls' : ''}`}>
 					<div className="currently-playing">
@@ -499,42 +499,38 @@ connectSpotifyPlayer() {
 					{ !this.state.listens.length ?
 						<p className="lead" className="text-center">No listens :/</p> :
 						<div>
-							<table className="table table-condensed table-striped">
+							<table className="table table-condensed table-striped" id="listens">
 							<thead>
 							<tr>
-							<th>Artist</th>
 							<th>Track</th>
+							<th>Artist</th>
 							<th>Time</th>
 							{this.state.mode === "follow" && <th>User</th>}
-							<th>Play</th>
+							<th></th>
 							</tr>
 							</thead>
 							<tbody>
 							{this.state.listens
 								.sort((a,b)=> a.playing_now ? -1 : b.playing_now ? 1 : 0) 
 								.map((listen,index) => {
-									if (listen.playing_now) {
-										return (
-											<tr id="playing_now" key='playing_now'>
-											<td>{getArtistLink(listen)}</td>
+									return (
+										<tr key={index} className={`listen ${this.isCurrentListen(listen) ? 'info' : ''} ${listen.playing_now ? 'playing_now' : ''}`}  >
 											<td>{getTrackLink(listen)}</td>
-											<td><span className="fab fa-spotify" aria-hidden="true"></span> Playing now</td>
-											{this.state.mode === "follow" && <td>{listen.user_name}</td>}
-											<td>{getSpotifyPlayButton(listen,this.playListen.bind(this,listen))}</td>
-											</tr>
-											)
-										} else {
-											return (
-												<tr key={index} className={this.isCurrentListen(listen) ? 'info' : ''}>
-												<td>{getArtistLink(listen)}</td>
-												<td>{getTrackLink(listen)}</td>
-												<td><abbr className="timeago" title={listen.listened_at_iso}>{ listen.listened_at_iso ? $.timeago(listen.listened_at_iso) : $.timeago(listen.listened_at*1000) }</abbr></td>
-												{this.state.mode === "follow" && <td>{listen.user_name}</td>}
-												<td>{getSpotifyPlayButton(listen,this.playListen.bind(this,listen))}</td>
-												</tr>
-												)
+											<td>{getArtistLink(listen)}</td>
+											{listen.playing_now ?
+												<td><span className="fab fa-spotify" aria-hidden="true"></span> Playing now</td>
+												:
+												<td>
+													<abbr className="timeago" title={listen.listened_at_iso}>
+													{listen.listened_at_iso ? $.timeago(listen.listened_at_iso) : $.timeago(listen.listened_at*1000) }
+													</abbr>
+												</td>
 											}
-										})
+											{this.state.mode === "follow" && <td>{listen.user_name}</td>}
+											<td className="playButton">{getPlayButton(listen,this.playListen.bind(this,listen))}</td>
+										</tr>
+										)
+									})
 								}
 								
 								</tbody>
@@ -694,7 +690,7 @@ class FollowUsers extends React.Component {
 								</td>
 								<td style={noTopBottomPadding}>
 								{this.props.playingNow[user] &&
-									getSpotifyPlayButton(this.props.playingNow[user],this.props.playListen.bind(this,this.props.playingNow[user]))
+									getPlayButton(this.props.playingNow[user],this.props.playListen.bind(this,this.props.playingNow[user]))
 								}
 								</td>
 							</tr>

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -677,7 +677,7 @@ class FollowUsers extends React.Component {
 					<tbody>
 						{this.state.users.map((user,index) => {
 							return (
-							<tr key={user} valign="middle">
+							<tr key={user} className={this.props.playingNow[user] && "playing_now"}>
 								<td>
 									{index + 1}
 								</td>
@@ -714,7 +714,7 @@ class FollowUsers extends React.Component {
 										<span className="fa fa-trash-alt"></span>
 									</button>
 								</td>
-								<td style={noTopBottomPadding} className="playButton">
+								<td className="playButton">
 								{this.props.playingNow[user] &&
 									getPlayButton(this.props.playingNow[user],this.props.playListen.bind(this,this.props.playingNow[user]))
 								}

--- a/listenbrainz/webserver/static/js/profile.jsx
+++ b/listenbrainz/webserver/static/js/profile.jsx
@@ -79,7 +79,7 @@ class PlaybackControls extends React.Component {
 	render(){
 		return (
 			<div id="music-player" aria-label="Playback control">
-				<div className="album img-responsive">
+				<div className="album">
 					{this.props.children ? this.props.children : 
 					<div className="noAlbumArt well text-center">No album art</div>}
 				</div>
@@ -103,6 +103,16 @@ class PlaybackControls extends React.Component {
 						<div className="next btn btn-xs" onClick={this.props.playNextTrack}>
 							<i className="fas fa-fast-forward"></i>
 						</div>
+						{this.props.direction !== "hidden" &&
+							<div className="right btn btn-xs" onClick={this.props.toggleDirection}>
+								<span className={`${this.props.direction === "up"? 'hidden' : ''}`}>
+									<i className="fa fa-sort-amount-down"></i>
+								</span>
+								<span className={`${this.props.direction === "down" ? 'hidden' : ''}`}>
+									<i className="fa fa-sort-amount-up"></i>
+								</span>
+							</div>
+						}
 		 			</div>
 		 		</div>
 		 	</div>


### PR DESCRIPTION
# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * (x) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

# Solution

Improved the player UI and UX
Better error management and recovery
Added initial fetch of current paying track in Spotify, and a warning about possible playback interruption
Touched up the table of listens in user's listens/follow pages


Sorry about the diff on profile.jsx, my text editor had originally used tabs for indentation. That's corrected, but the diff is not particularly useful.
