### PR TITLE
Do not send follow list on startup if list is empty

### DIFF
--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -31,8 +31,14 @@
       var socket = io.connect("{{ web_sockets_server_url }}");
       socket.on('connect', function() {
           console.log("Connected to websocket!");
-          var followList = {{ follow_list|default("")|tojson }} || ['{{ user.musicbrainz_id }}'];
-          window.emitFollowUsersList(followList)
+          let initialList = ['{{ user.musicbrainz_id }}'];
+          if ("{{ mode }}" === "follow"){
+              initialList = {{ follow_list|default("")|tojson }} || [];
+              if(!initialList.length){
+                return;
+              }
+          }
+          window.emitFollowUsersList(initialList);
           console.log("Emitted!");
       });
       socket.on('listen', function(data) {

--- a/listenbrainz/webserver/views/follow.py
+++ b/listenbrainz/webserver/views/follow.py
@@ -48,7 +48,8 @@ def follow(user_list):
     }
 
     return render_template("user/profile.html", 
-        props=ujson.dumps(props), 
+        props=ujson.dumps(props),
+        mode='follow',
         web_sockets_server_url=current_app.config['WEBSOCKETS_SERVER_URL'],
         user=current_user, 
         follow_list=follow_list,

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -150,7 +150,8 @@ def profile(user_name):
     }
 
     return render_template("user/profile.html", 
-        props=ujson.dumps(props), 
+        props=ujson.dumps(props),
+        mode='listens',
         web_sockets_server_url=current_app.config['WEBSOCKETS_SERVER_URL'],
         user=user, 
         active_section='listens')


### PR DESCRIPTION
# Summary

* This is a…
    * (x) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

On loading the `/follow` route with no usernames, prevent sending an empty list through websockets.

This is a temporary fix, I'll be moving the front-end websockets stuff into proper js files and dealing with it better