### PR TITLE
Change login id column type to string

### DIFF
--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -2,6 +2,7 @@ BEGIN;
 
 CREATE UNIQUE INDEX auth_token_ndx_user ON "user" (auth_token);
 CREATE UNIQUE INDEX lower_musicbrainz_id_ndx_user ON "user" (lower(musicbrainz_id));
+CREATE UNIQUE INDEX login_id_ndx_user ON "user" (login_id);
 
 CREATE UNIQUE INDEX token_ndx_token ON api_compat.token (token);
 CREATE UNIQUE INDEX token_api_key_ndx_token ON api_compat.token (token, api_key);

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -1,18 +1,19 @@
 BEGIN;
 
 CREATE TABLE "user" (
-  id             SERIAL,
-  created        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  musicbrainz_id VARCHAR NOT NULL,
-  auth_token     VARCHAR,
-  last_login     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-  latest_import  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch',
-  gdpr_agreed    TIMESTAMP WITH TIME ZONE,
-  musicbrainz_row_id INTEGER NOT NULL,
-  user_login_id  UUID NOT NULL DEFAULT uuid_generate_v4()
+  id                    SERIAL,
+  created               TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  musicbrainz_id        VARCHAR NOT NULL,
+  auth_token            VARCHAR,
+  last_login            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  latest_import         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch',
+  gdpr_agreed           TIMESTAMP WITH TIME ZONE,
+  musicbrainz_row_id    INTEGER NOT NULL,
+  login_id              TEXT NOT NULL DEFAULT uuid_generate_v4()::text
 );
 ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_id_key UNIQUE (musicbrainz_id);
 ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_row_id_key UNIQUE (musicbrainz_row_id);
+ALTER TABLE "user" ADD CONSTRAINT user_login_id_key UNIQUE (login_id);
 
 CREATE TABLE spotify_auth (
   user_id                   INTEGER NOT NULL, -- PK and FK to user.id

--- a/admin/sql/updates/2019-02-13-change-login-id-type.sql
+++ b/admin/sql/updates/2019-02-13-change-login-id-type.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE "user" DROP COLUMN user_login_id;
+ALTER TABLE "user" ADD COLUMN login_id TEXT NOT NULL DEFAULT uuid_generate_v4()::text;
+
+UPDATE "user"
+   SET login_id = id::text;
+
+ALTER TABLE "user" user_login_id_key UNIQUE (login_id);
+CREATE UNIQUE INDEX login_id_ndx_user ON "user" (login_id);
+
+COMMIT;
+

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -85,7 +85,8 @@ def get(id):
         row = result.fetchone()
         return dict(row) if row else None
 
-def get_by_user_login_id(login_id):
+
+def get_by_login_id(login_id):
     """Get user with a specified login ID.
 
     Args:

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -58,7 +58,7 @@ def update_token(id):
             raise
 
 
-USER_GET_COLUMNS = ['id', 'created', 'musicbrainz_id', 'auth_token', 'last_login', 'latest_import', 'gdpr_agreed', 'musicbrainz_row_id', 'user_login_id']
+USER_GET_COLUMNS = ['id', 'created', 'musicbrainz_id', 'auth_token', 'last_login', 'latest_import', 'gdpr_agreed', 'musicbrainz_row_id', 'login_id']
 
 
 def get(id):
@@ -104,7 +104,7 @@ def get_by_user_login_id(login_id):
         result = connection.execute(sqlalchemy.text("""
             SELECT {columns}
               FROM "user"
-             WHERE user_login_id = :user_login_id
+             WHERE login_id = :user_login_id
         """.format(columns=','.join(USER_GET_COLUMNS))), {"user_login_id": login_id})
         row = result.fetchone()
         return dict(row) if row else None

--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -14,7 +14,7 @@ class User(db.Model):
     latest_import = db.Column(db.DateTime(timezone=True), default=lambda: datetime.fromutctimestamp(0))
     gdpr_agreed = db.Column(db.DateTime(timezone=True))
     musicbrainz_row_id = db.Column(db.Integer, nullable=False)
-    user_login_id = db.Column(db.String)
+    login_id = db.Column(db.String)
 
 class UserAdminView(AdminModelView):
     form_columns = [
@@ -30,7 +30,7 @@ class UserAdminView(AdminModelView):
         'gdpr_agreed',
         'last_login',
         'latest_import',
-        'user_login_id',
+        'login_id',
     ]
     column_searchable_list = [
         'id',

--- a/listenbrainz/tests/integration/test_profile_views.py
+++ b/listenbrainz/tests/integration/test_profile_views.py
@@ -28,7 +28,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         Test for the user export of ListenBrainz data.
         """
         # test get requests to export view first
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         resp = self.client.get(url_for('profile.export_data'))
         self.assert200(resp)
 

--- a/listenbrainz/webserver/admin/test_admin.py
+++ b/listenbrainz/webserver/admin/test_admin.py
@@ -21,7 +21,7 @@ class AdminTestCase(ServerTestCase, DatabaseTestCase):
 
     def test_admin_views_when_authorized_logged_in(self):
         self.app.config['ADMINS'] = [self.authorized_user['musicbrainz_id']]
-        self.temporary_login(self.authorized_user['user_login_id'])
+        self.temporary_login(self.authorized_user['login_id'])
         # flask-admin seems to do a few redirects before going to the actual
         # final web page, so we have to follow redirects
         r = self.client.get('/admin', follow_redirects=True)
@@ -30,7 +30,7 @@ class AdminTestCase(ServerTestCase, DatabaseTestCase):
 
     def test_admin_views_when_unauthorized_logged_in(self):
         self.app.config['ADMINS'] = [self.authorized_user['musicbrainz_id']]
-        self.temporary_login(self.unauthorized_user['user_login_id'])
+        self.temporary_login(self.unauthorized_user['login_id'])
         r = self.client.get('/admin', follow_redirects=True)
         self.assert200(r)
         self.assertNotIn('BDFL Zone', r.data.decode('utf-8'))

--- a/listenbrainz/webserver/login/__init__.py
+++ b/listenbrainz/webserver/login/__init__.py
@@ -33,7 +33,7 @@ class User(UserMixin):
 @login_manager.user_loader
 def load_user(user_login_id):
     try:
-        user = db_user.get_by_user_login_id(user_login_id)
+        user = db_user.get_by_login_id(user_login_id)
     except Exception as e:
         current_app.logger.error("Error while getting user by login ID: %s", str(e), exc_info=True)
         return None

--- a/listenbrainz/webserver/login/__init__.py
+++ b/listenbrainz/webserver/login/__init__.py
@@ -8,16 +8,16 @@ login_manager.login_view = 'login.index'
 
 
 class User(UserMixin):
-    def __init__(self, id, created, musicbrainz_id, auth_token, gdpr_agreed, user_login_id):
+    def __init__(self, id, created, musicbrainz_id, auth_token, gdpr_agreed, login_id):
         self.id = id
         self.created = created
         self.musicbrainz_id = musicbrainz_id
         self.auth_token = auth_token
         self.gdpr_agreed = gdpr_agreed
-        self.user_login_id = user_login_id
+        self.login_id = login_id
 
     def get_id(self):
-        return self.user_login_id
+        return self.login_id
 
     @classmethod
     def from_dbrow(cls, user):
@@ -27,7 +27,7 @@ class User(UserMixin):
             musicbrainz_id=user['musicbrainz_id'],
             auth_token=user['auth_token'],
             gdpr_agreed=user['gdpr_agreed'],
-            user_login_id=user['user_login_id'],
+            login_id=user['login_id'],
         )
 
 @login_manager.user_loader

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -102,7 +102,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assertNotIn('My Listens', data)
         mock_user_get.assert_not_called()
 
-    @mock.patch('listenbrainz.db.user.get_by_user_login_id')
+    @mock.patch('listenbrainz.db.user.get_by_login_id')
     def test_menu_logged_in(self, mock_user_get):
         """ If the user is logged in, check that we perform a database query to get user data """
         user = db_user.get_or_create(1, 'iliekcomputers')
@@ -122,7 +122,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assertIn('My Listens', data)
         mock_user_get.assert_called_with(user['login_id'])
 
-    @mock.patch('listenbrainz.db.user.get_by_user_login_id')
+    @mock.patch('listenbrainz.db.user.get_by_login_id')
     def test_menu_logged_in_error_show(self, mock_user_get):
         """ If the user is logged in, if we show a 400 or 404 error, show the user menu"""
         @self.app.route('/page_that_returns_400')
@@ -181,7 +181,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assertNotIn('Sign in', data)
         self.assertIn('Import', data)
 
-    @mock.patch('listenbrainz.db.user.get_by_user_login_id')
+    @mock.patch('listenbrainz.db.user.get_by_login_id')
     def test_menu_logged_in_error_dont_show_user_loaded(self, mock_user_get):
         """ If the user is logged in, if we show a 500 error, do not show the user menu
         If the user has previously been loaded in the view, check that it's not

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -110,7 +110,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         user = db_user.get_or_create(1, 'iliekcomputers')
 
         mock_user_get.return_value = user
-        self.temporary_login(user['user_login_id'])
+        self.temporary_login(user['login_id'])
         resp = self.client.get(url_for('index.index'))
         data = resp.data.decode('utf-8')
 
@@ -120,7 +120,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         # item in user menu
 
         self.assertIn('My Listens', data)
-        mock_user_get.assert_called_with(user['user_login_id'])
+        mock_user_get.assert_called_with(user['login_id'])
 
     @mock.patch('listenbrainz.db.user.get_by_user_login_id')
     def test_menu_logged_in_error_show(self, mock_user_get):
@@ -137,7 +137,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         db_user.agree_to_gdpr(user['musicbrainz_id'])
         user = db_user.get_or_create(1, 'iliekcomputers')
         mock_user_get.return_value = user
-        self.temporary_login(user['user_login_id'])
+        self.temporary_login(user['login_id'])
         resp = self.client.get('/page_that_returns_400')
         data = resp.data.decode('utf-8')
         self.assert400(resp)
@@ -148,7 +148,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         # item in user menu
 
         self.assertIn('My Listens', data)
-        mock_user_get.assert_called_with(user['user_login_id'])
+        mock_user_get.assert_called_with(user['login_id'])
 
         resp = self.client.get('/page_that_returns_404')
         data = resp.data.decode('utf-8')
@@ -159,7 +159,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         # item in user menu
 
         self.assertIn('My Listens', data)
-        mock_user_get.assert_called_with(user['user_login_id'])
+        mock_user_get.assert_called_with(user['login_id'])
 
     @mock.patch('listenbrainz.db.user.get')
     def test_menu_logged_in_error_dont_show_no_user(self, mock_user_get):
@@ -173,7 +173,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         db_user.agree_to_gdpr(user['musicbrainz_id'])
         user = db_user.get_or_create(1, 'iliekcomputers')
         mock_user_get.return_value = user
-        self.temporary_login(user['user_login_id'])
+        self.temporary_login(user['login_id'])
         resp = self.client.get('/page_that_returns_500')
         data = resp.data.decode('utf-8')
         # item not in user menu
@@ -197,10 +197,10 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         @login_required
         def view500():
             # flask-login user is loaded during @login_required, so check that the db has been queried
-            mock_user_get.assert_called_with(user['user_login_id'])
+            mock_user_get.assert_called_with(user['login_id'])
             raise InternalServerError('error')
 
-        self.temporary_login(user['user_login_id'])
+        self.temporary_login(user['login_id'])
         resp = self.client.get('/page_that_returns_500')
         data = resp.data.decode('utf-8')
         self.assertIn('Import', data)

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -22,21 +22,21 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
         DatabaseTestCase.tearDown(self)
 
     def test_reset_import_timestamp_get(self):
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         response = self.client.get(url_for('profile.reset_latest_import_timestamp'))
         self.assertTemplateUsed('profile/resetlatestimportts.html')
         self.assert200(response)
 
     def test_profile_view(self):
         """Tests the user info view and makes sure auth token is present there"""
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         response = self.client.get(url_for('profile.info', user_name=self.user['musicbrainz_id']))
         self.assertTemplateUsed('profile/info.html')
         self.assert200(response)
         self.assertIn(self.user['auth_token'], response.data.decode('utf-8'))
 
     def test_reset_import_timestamp(self):
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         val = int(time.time())
         db_user.update_latest_import(self.user['musicbrainz_id'], val)
 
@@ -53,7 +53,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assertEqual(int(ts), 0)
 
     def test_reset_import_timestamp_post(self):
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         val = int(time.time())
         db_user.update_latest_import(self.user['musicbrainz_id'], val)
 
@@ -78,7 +78,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
 
     @patch('listenbrainz.webserver.views.user.publish_data_to_queue')
     def test_delete(self, mock_publish_data_to_queue):
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         r = self.client.get(url_for('profile.delete'))
         self.assert200(r)
 
@@ -93,7 +93,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
     @patch('listenbrainz.webserver.views.profile.spotify.get_spotify_oauth')
     def test_connect_spotify(self, mock_get_spotify_oauth, mock_remove_user):
         mock_get_spotify_oauth.return_value.get_authorize_url.return_value = 'someurl'
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         r = self.client.get(url_for('profile.connect_spotify'))
         self.assert200(r)
 
@@ -110,7 +110,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
             'refresh_token': 'refresh',
             'expires_in': 3600,
         }
-        self.temporary_login(self.user['user_login_id'])
+        self.temporary_login(self.user['login_id'])
         r = self.client.get(url_for('profile.connect_spotify_callback', code='code'))
         self.assertStatus(r, 302)
         mock_get_access_token.assert_called_once_with('code')

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -87,7 +87,7 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         props = ujson.loads(self.get_context_variable('props'))
         self.assertEqual(props['spotify_access_token'], '')
 
-        self.temporary_login(self.user.user_login_id)
+        self.temporary_login(self.user.login_id)
         mock_db_spotify.get_token_for_user.return_value = None
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)


### PR DESCRIPTION
Changed the type to string as discussed on IRC with default values as uuids. The migration script puts the default values for existing users as their user IDs which should make sure that they do not get logged out.

Also create index and add a constraint and rename to column to login_id from user_login_id.