### PR TITLE
Add recent listens page, now with tests

### DIFF
--- a/listenbrainz/influx_writer/influx_writer.py
+++ b/listenbrainz/influx_writer/influx_writer.py
@@ -8,11 +8,11 @@ from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 import ujson
 import logging
-import time
 
 from listenbrainz.listen import Listen
 from time import time, sleep
 from listenbrainz.listenstore import InfluxListenStore
+from listenbrainz.listenstore import RedisListenStore
 from listenbrainz.utils import escape, get_measurement_name, get_escaped_measurement_name, \
                                get_influx_query_timestamp, convert_to_unix_timestamp, \
                                convert_timestamp_to_influx_row_format
@@ -27,6 +27,7 @@ from collections import defaultdict
 from listenbrainz.listen_writer import ListenWriter
 
 class InfluxWriterSubscriber(ListenWriter):
+
     def __init__(self):
         super().__init__()
 
@@ -34,6 +35,7 @@ class InfluxWriterSubscriber(ListenWriter):
         self.influx = None
         self.incoming_ch = None
         self.unique_ch = None
+        self.redis_listenstore = None
 
 
     def callback(self, ch, method, properties, body):
@@ -108,6 +110,7 @@ class InfluxWriterSubscriber(ListenWriter):
 
     def write(self, listen_dicts):
         submit = []
+        unique = []
         unique = []
         duplicate_count = 0
         unique_count = 0
@@ -219,6 +222,9 @@ class InfluxWriterSubscriber(ListenWriter):
             except pika.exceptions.ConnectionClosed:
                 self.connect_to_rabbitmq()
 
+
+        self.redis_listenstore.update_recent_listens(unique)
+
         return True
 
 
@@ -257,6 +263,7 @@ class InfluxWriterSubscriber(ListenWriter):
                 try:
                     self.redis = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'], decode_responses=True)
                     self.redis.ping()
+                    self.redis_listenstore = RedisListenStore(current_app.logger, current_app.config)
                     break
                 except Exception as err:
                     current_app.logger.error("Cannot connect to redis: %s. Retrying in 2 seconds and trying again." % str(err), exc_info=True)

--- a/listenbrainz/influx_writer/influx_writer.py
+++ b/listenbrainz/influx_writer/influx_writer.py
@@ -111,7 +111,6 @@ class InfluxWriterSubscriber(ListenWriter):
     def write(self, listen_dicts):
         submit = []
         unique = []
-        unique = []
         duplicate_count = 0
         unique_count = 0
 

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -73,7 +73,7 @@ class RedisListenStore(ListenStore):
 
         # Don't take this very seriously -- if it fails, really no big deal. Let is go.
         if recent:
-            self.redis.rpush(self.RECENT_LISTENS_KEY, *recent)
+            self.redis.lpush(self.RECENT_LISTENS_KEY, *recent)
             self.redis.ltrim(self.RECENT_LISTENS_KEY, -self.RECENT_LISTENS_MAX, -1)
 
 
@@ -82,7 +82,7 @@ class RedisListenStore(ListenStore):
             Get the max number of most recent listens
         """
         recent = []
-        for listen in self.redis.lrange(self.RECENT_LISTENS_KEY, 0, max):
+        for listen in self.redis.lrange(self.RECENT_LISTENS_KEY, 0, max - 1):
             recent.append(Listen.from_json(ujson.loads(listen)))
 
         return recent

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import datetime
 import logging
 import time
 import ujson
@@ -44,3 +45,44 @@ class RedisListenStoreTestCase(DatabaseTestCase):
         self.assertIsInstance(playing_now, Listen)
         self.assertEqual(playing_now.data['artist_name'], 'The Strokes')
         self.assertEqual(playing_now.data['track_name'], 'Call It Fate, Call It Karma')
+
+
+    def test_update_and_get_recent_listens(self):
+
+        dt0 = datetime.datetime.now()
+        dt1 = dt0.replace(second=dt0.second + 1)
+
+        recent = self._redis.get_recent_listens()
+        self.assertEqual(recent, [])
+
+        listens = []
+        listens.append({
+            'user_id': self.testuser['id'],
+            'user_name': self.testuser['musicbrainz_id'],
+            'listened_at': dt0,
+            'track_metadata': {
+                'artist_name': 'The Dimwitted Hillbillies',
+                'track_name': 'Ice cream, guns and bling!',
+                'additional_info': {},
+            },
+        })
+        listens.append({
+            'user_id': self.testuser['id'],
+            'user_name': self.testuser['musicbrainz_id'],
+            'listened_at': dt1,
+            'track_metadata': {
+                'artist_name': 'The Dimwitted Hillbillies',
+                'track_name': 'White gas and sparklers are a great combo for toddlers!',
+                'additional_info': {},
+            },
+        })
+        self._redis.update_recent_listens(listens)
+
+        recent = self._redis.get_recent_listens()
+        self.assertEqual(len(recent), 2)
+        self.assertIsInstance(recent[0], Listen)
+        self.assertEqual(recent[0].timestamp, dt1)
+        self.assertEqual(recent[1].timestamp, dt0)
+
+        recent = self._redis.get_recent_listens(1)
+        self.assertEqual(len(recent), 1)

--- a/listenbrainz/tests/integration/test_influx_writer.py
+++ b/listenbrainz/tests/integration/test_influx_writer.py
@@ -3,7 +3,9 @@ import sys
 import os
 import uuid
 from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.listen import Listen
 from listenbrainz.listenstore import InfluxListenStore
+from listenbrainz.listenstore import RedisListenStore
 from flask import url_for
 import listenbrainz.db.user as db_user
 import time
@@ -22,6 +24,12 @@ class InfluxWriterTestCase(IntegrationTestCase):
                              'INFLUX_HOST': config.INFLUX_HOST,
                              'INFLUX_PORT': config.INFLUX_PORT,
                              'INFLUX_DB_NAME': config.INFLUX_DB_NAME}, self.app.logger)
+        self.rs = RedisListenStore(self.app.logger, { 'REDIS_HOST': config.REDIS_HOST,
+                             'REDIS_PORT': config.REDIS_PORT,
+                             'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
+                             'INFLUX_HOST': config.INFLUX_HOST,
+                             'INFLUX_PORT': config.INFLUX_PORT,
+                             'INFLUX_DB_NAME': config.INFLUX_DB_NAME})
 
     def send_listen(self, user, filename):
         with open(self.path_to_data_file(filename)) as f:
@@ -49,6 +57,11 @@ class InfluxWriterTestCase(IntegrationTestCase):
         listens = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
+        recent = self.rs.get_recent_listens()
+        self.assertEqual(len(recent), 5)
+        self.assertIsInstance(recent[0], Listen)
+
+
     def test_dedup_user_special_characters(self):
 
         user = db_user.get_or_create(2, 'i have a\\weird\\user, name"\n')
@@ -64,6 +77,7 @@ class InfluxWriterTestCase(IntegrationTestCase):
         to_ts = int(time.time())
         listens = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
+
 
     def test_dedup_same_batch(self):
 
@@ -99,6 +113,7 @@ class InfluxWriterTestCase(IntegrationTestCase):
 
         listens = self.ls.fetch_listens(user2['musicbrainz_id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
+
 
     def test_dedup_same_timestamp_different_tracks(self):
         """ Test to check that if there are two tracks w/ the same timestamp,

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -21,7 +21,7 @@ class RecentListens extends React.Component {
 		this.state = {
 			listens: props.listens || [],
 			currentListen : null,
-      mode: props.mode === "follow" ? "follow" : "listens",
+      mode: props.mode,
       followList: props.follow_list || [],
 			playingNowByUser: {}
 		};
@@ -181,7 +181,7 @@ class RecentListens extends React.Component {
         }
         <div className="row">
           <div className="col-md-8">
-            <h3>{this.state.mode === "listens" ? "Recent listens" : "Playlist"}</h3>
+            <h3>{(this.state.mode === "listens" || this.state.mode === "recent" )? "Recent listens" : "Playlist"}</h3>
 
             {!this.state.listens.length ?
               <p className="lead" className="text-center">No listens :/</p> :
@@ -192,7 +192,7 @@ class RecentListens extends React.Component {
                       <th>Track</th>
                       <th>Artist</th>
                       <th>Time</th>
-                      {this.state.mode === "follow" && <th>User</th>}
+                      {this.state.mode === "follow" || this.state.mode === "recent" && <th>User</th>}
                       <th></th>
                     </tr>
                   </thead>
@@ -215,7 +215,7 @@ class RecentListens extends React.Component {
                                 </abbr>
                               </td>
                             }
-                            {this.state.mode === "follow" && <td>{listen.user_name}</td>}
+                            {this.state.mode === "follow" || this.state.mode === "recent" && <td>{listen.user_name}</td>}
                             <td className="playButton">{getPlayButton(listen, this.playListen.bind(this, listen))}</td>
                           </tr>
                         )

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -215,7 +215,7 @@ class RecentListens extends React.Component {
                                 </abbr>
                               </td>
                             }
-                            {this.state.mode === "follow" || this.state.mode === "recent" && <td>{listen.user_name}</td>}
+                            {this.state.mode === "follow" || this.state.mode === "recent" && <td><a href={`/user/${listen.user_name}`}>{listen.user_name}</a></td>}
                             <td className="playButton">{getPlayButton(listen, this.playListen.bind(this, listen))}</td>
                           </tr>
                         )

--- a/listenbrainz/webserver/templates/index/recent.html
+++ b/listenbrainz/webserver/templates/index/recent.html
@@ -26,6 +26,7 @@
           <td></td>
           <td>No recent listens. :(</td>
           <td></td>
+          <td></td>
        </tr>
     {% endfor %}
     </tbody>

--- a/listenbrainz/webserver/templates/index/recent.html
+++ b/listenbrainz/webserver/templates/index/recent.html
@@ -18,7 +18,7 @@
       <tr>
         <td>{{ listen.track_metadata.track_name }}</td>
         <td>{{ listen.track_metadata.artist_name }}</td>
-        <td><abbr class="timeago" title="{{ listen.listened_at_iso }}">{{ listen.listened_at_iso }}</td>
+        <td>{{ listen.listened_at_iso }}</td>
         <td>{{ listen.user_name }}</td>
       </tr>
     {% else %}

--- a/listenbrainz/webserver/templates/index/recent.html
+++ b/listenbrainz/webserver/templates/index/recent.html
@@ -1,0 +1,34 @@
+{%- extends 'base.html' -%}
+{%- block title -%}Recent listens - ListenBrainz{%- endblock -%}
+{%- block content -%}
+
+  <h2 class="page-title">Recent listens</h2>
+
+  <table class="table table-border table-condensed table-striped">
+    <thead>
+      <tr>
+        <th>Track</th>
+        <th>Artist</th>
+        <th>Time</th>
+        <th>User</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for listen in recent %}
+      <tr>
+        <td>{{ listen.track_metadata.track_name }}</td>
+        <td>{{ listen.track_metadata.artist_name }}</td>
+        <td><abbr class="timeago" title="{{ listen.listened_at_iso }}">{{ listen.listened_at_iso }}</td>
+        <td>{{ listen.user_name }}</td>
+      </tr>
+    {% else %}
+       <tr>
+          <td></td>
+          <td>No recent listens. :(</td>
+          <td></td>
+       </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+{%- endblock -%}

--- a/listenbrainz/webserver/templates/index/recent.html
+++ b/listenbrainz/webserver/templates/index/recent.html
@@ -2,34 +2,14 @@
 {%- block title -%}Recent listens - ListenBrainz{%- endblock -%}
 {%- block content -%}
 
-  <h2 class="page-title">Recent listens</h2>
-
-  <table class="table table-border table-condensed table-striped">
-    <thead>
-      <tr>
-        <th>Track</th>
-        <th>Artist</th>
-        <th>Time</th>
-        <th>User</th>
-      </tr>
-    </thead>
-    <tbody>
-    {% for listen in recent %}
-      <tr>
-        <td>{{ listen.track_metadata.track_name }}</td>
-        <td>{{ listen.track_metadata.artist_name }}</td>
-        <td>{{ listen.listened_at_iso }}</td>
-        <td>{{ listen.user_name }}</td>
-      </tr>
-    {% else %}
-       <tr>
-          <td></td>
-          <td>No recent listens. :(</td>
-          <td></td>
-          <td></td>
-       </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  <div id="react-listens">
+  </div>
 
 {%- endblock -%}
+
+{% block scripts %}
+  {{ super() }}
+  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
+  <script id="react-props" type="application/json">{{ props|safe }}</script>
+  <script src="{{ get_static_path('main.js') }}" type="text/javascript"></script>
+{% endblock %}

--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -23,6 +23,7 @@
             <li><a href="{{ url_for('follow.follow') }}">Follow</a></li>
           {% endif %}
         {%- endif -%}
+        <li><a href="{{ url_for('index.recent_listens') }}">Recent</a></li>
         <li><a href="{{ url_for('profile.import_data') }}">Import</a></li>
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -298,3 +298,10 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
+
+
+    def test_recent_listens_page(self):
+
+        # This test is very rudimentary -- improve this once the improved react template is done
+        response = self.client.get(url_for('index.recent_listens'))
+        self.assert200(response)

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -1,3 +1,4 @@
+import ujson
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -302,6 +303,9 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
 
     def test_recent_listens_page(self):
 
-        # This test is very rudimentary -- improve this once the improved react template is done
         response = self.client.get(url_for('index.recent_listens'))
         self.assert200(response)
+        self.assertTemplateUsed('index/recent.html')
+        props = ujson.loads(self.get_context_variable('props'))
+        self.assertEqual(props['mode'], 'recent')
+        self.assertEqual(props['spotify_access_token'], '')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

This adds a page that displays recent listens. The view still needs to be reactified and improved tests for the view written.

# Problem

It was hard to find other people who are listening right now in order to play with the follow feature.


# Solution

Store recent listens in a redis and then add a view to show them.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


