### PR TITLE
Create separate follow page template

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -266,7 +266,7 @@ class RecentListens extends React.Component {
 }
 
 
-let domContainer = document.querySelector('#react-listens');
+let domContainer = document.querySelector('#react-container');
 let propsElement = document.getElementById('react-props');
 let reactProps;
 try

--- a/listenbrainz/webserver/templates/base-react.html
+++ b/listenbrainz/webserver/templates/base-react.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <div id="react-container">
+    </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
+  <script id="react-props" type="application/json">{{ props|safe }}</script>
+{% endblock %}

--- a/listenbrainz/webserver/templates/index/follow.html
+++ b/listenbrainz/webserver/templates/index/follow.html
@@ -1,17 +1,8 @@
-{% extends 'base.html' %}
+{%- extends 'base-react.html' -%}
 
 {% block title %}Follow users {{ follow_list|join(', ') }} - ListenBrainz{% endblock %}
 
-{% block content %}
-
-    <div id="react-listens">
-    </div>
-
-{% endblock %}
-
 {% block scripts %}
   {{ super() }}
-  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
-  <script id="react-props" type="application/json">{{ props|safe }}</script>
   <script src="{{ get_static_path('main.js') }}" type="text/javascript"></script>
 {% endblock %}

--- a/listenbrainz/webserver/templates/index/follow.html
+++ b/listenbrainz/webserver/templates/index/follow.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block title %}Follow users {{ follow_list|join(', ') }} - ListenBrainz{% endblock %}
+
+{% block content %}
+
+    <div id="react-listens">
+    </div>
+
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
+  <script id="react-props" type="application/json">{{ props|safe }}</script>
+  <script src="{{ get_static_path('main.js') }}" type="text/javascript"></script>
+{% endblock %}

--- a/listenbrainz/webserver/templates/index/recent.html
+++ b/listenbrainz/webserver/templates/index/recent.html
@@ -1,15 +1,8 @@
-{%- extends 'base.html' -%}
+{%- extends 'base-react.html' -%}
+
 {%- block title -%}Recent listens - ListenBrainz{%- endblock -%}
-{%- block content -%}
-
-  <div id="react-listens">
-  </div>
-
-{%- endblock -%}
 
 {% block scripts %}
   {{ super() }}
-  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
-  <script id="react-props" type="application/json">{{ props|safe }}</script>
   <script src="{{ get_static_path('main.js') }}" type="text/javascript"></script>
 {% endblock %}

--- a/listenbrainz/webserver/templates/user/base.html
+++ b/listenbrainz/webserver/templates/user/base.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'base-react.html' %}
 
 {% block title %}User "{{ user.musicbrainz_id }}" - ListenBrainz{% endblock %}
 
@@ -14,14 +14,6 @@
     {% block profile_content %} {% endblock %}
 
   </div>
-{% endblock %}
 
-{% block scripts %}
   {{ super() }}
-  <script src="{{ url_for('static', filename='js/lib/jquery.timeago.js') }}"></script>
-  <script type="text/javascript">
-    $(document).ready(function() {
-      $("abbr.timeago").timeago();
-    });
-  </script>
 {% endblock %}

--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -1,8 +1,5 @@
 {% extends 'user/base.html' %}
-<!-- 
-     this template now supports a mode argument that is either "listens" or "follow", since Mr_Monkey says that the
-     two pages will share a lot in common and that will make supporting these two pages easier. 
--->
+
 {% block profile_content %}
 
     <div style="margin-top:20px">
@@ -10,15 +7,9 @@
     	<b><a href="https://musicbrainz.org/user/{{ user.musicbrainz_id }}">See profile on MusicBrainz</a></b>
     </div>
 
-
-    <div id="react-listens">
-    </div>
-
 {% endblock %}
 
 {% block scripts %}
   {{ super() }}
-  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
-  <script id="react-props" type="application/json">{{ props|safe }}</script>
   <script src="{{ get_static_path('main.js') }}" type="text/javascript"></script>
 {% endblock %}

--- a/listenbrainz/webserver/views/follow.py
+++ b/listenbrainz/webserver/views/follow.py
@@ -48,7 +48,7 @@ def follow(user_list):
         "web_sockets_server_url": current_app.config['WEBSOCKETS_SERVER_URL'],
     }
 
-    return render_template("user/profile.html", 
+    return render_template("index/follow.html", 
         props=ujson.dumps(props),
         mode='follow',
         user=current_user, 


### PR DESCRIPTION
# Summary

* This is a…
    * (x) Refactoring

Sure enough, it came quick. I got annoyed at seeing the user name and stats block on the follow page, so here's a fix.

Considering the similarities between user/profile and index/follow templates, it may be worth refactoring further to have for example the  scripts block in common.
This could turn out to be a hindrance later, so I abstained for now (*insert premature optimization comic strip reference*)