### PR TITLE
Log out users from listenbrainz account.

### DIFF
--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -42,6 +42,6 @@ def musicbrainz_post():
 @login_bp.route('/logout/')
 @login_required
 def logout():
-    logout_user()
     session.clear()
+    logout_user()
     return redirect(url_for('index.index'))


### PR DESCRIPTION
* This is a…
    * (x) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

Users are not able to log out from their listenbrainz account. Session variables must be cleared before attempting log out.