### PR TITLE
Make the follow page require logged in users

### DIFF
--- a/listenbrainz/webserver/views/test/test_follow.py
+++ b/listenbrainz/webserver/views/test/test_follow.py
@@ -1,13 +1,5 @@
-import listenbrainz.db.user as db_user
-import ujson
-from unittest import mock
-
-from flask import url_for, current_app
-from influxdb import InfluxDBClient
+from flask import url_for
 from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.listenstore.tests.util import create_test_data_for_influxlistenstore
-from listenbrainz.webserver.influx_connection import init_influx_connection
-from listenbrainz.webserver.login import User
 from listenbrainz.webserver.testing import ServerTestCase
 
 import listenbrainz.db.user as db_user
@@ -17,23 +9,20 @@ class FollowViewsTestCase(ServerTestCase, DatabaseTestCase):
     def setUp(self):
         ServerTestCase.setUp(self)
         DatabaseTestCase.setUp(self)
-
-        user = db_user.get_or_create(1, 'iliekcomputers')
-        self.user = User.from_dbrow(user)
-
+        self.user = db_user.get_or_create(1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.user['musicbrainz_id'])
 
     def tearDown(self):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
 
-
     def test_follow_page(self):
-        response = self.client.get(url_for('follow.follow', user_name=self.user.musicbrainz_id))
+        self.temporary_login(self.user['login_id'])
+        response = self.client.get(url_for('follow.follow'))
         self.assert200(response)
         self.assertContext('active_section', 'listens')
-
 
     def test_user_info_not_logged_in(self):
         """Tests user follow view when not logged in"""
         response = self.client.get(url_for('follow.follow'))
-        self.assertStatus(response, 200)
+        self.assertStatus(response, 302)


### PR DESCRIPTION
We already didn't have functionality to allow for playing songs for non-logged in users. Should just make the page only available to logged-in users.