### PR TITLE
Sort listens by user rank in follow page

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/follow-users.jsx
+++ b/listenbrainz/webserver/static/js/jsx/follow-users.jsx
@@ -39,7 +39,7 @@ export class FollowUsers extends React.Component {
       prevState.users.splice(currentIndex, 1);
       prevState.users.splice(targetIndex, 0, element);
       return { users: prevState.users }
-    });
+    }, () => { this.props.onUserListChange(this.state.users, true) });
   }
 
   render() {

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -65,13 +65,16 @@ class RecentListens extends React.Component {
   }
 
   sortListensByFollowUserRank(listens, userList){
+    if(userList.length <= 1){
+      return listens;
+    }
     const currentListenIndex = listens.indexOf(this.state.currentListen);
-    let notGonnaSort = [];
+    let ignoredPastListens = [];
     if(currentListenIndex !== -1){
-      notGonnaSort = listens.splice(currentListenIndex);
+      ignoredPastListens = listens.splice(currentListenIndex);
     }
     const sortFunction = (a, b) => userList.indexOf(b.user_name) - userList.indexOf(a.user_name)
-    return listens.sort(sortFunction).concat(notGonnaSort);
+    return listens.sort(sortFunction).concat(ignoredPastListens);
   }
 
   handleFollowUserListChange(userList, dontSendUpdate){


### PR DESCRIPTION

# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

# Solution

Basic sorting based on follow users rank (order in the list).
Ignore past listens (all listens before currently playing listens, if any), and reorder upcoming listens (both up in the playlist and future incoming WS listens)

It's not very convenient to test locally, but with some trickery in the browser I was able to.
It for sure needs another round of testing on beta, where following multiple users is easier.