### PR TITLE
fix LB-426: Fallback to embedded player for non-premium spotify users

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -30,15 +30,16 @@ class RecentListens extends React.Component {
     };
 
     this.connectWebsockets = this.connectWebsockets.bind(this);
+    this.getRecentListensForFollowList = this.getRecentListensForFollowList.bind(this);
+    this.handleCurrentListenChange = this.handleCurrentListenChange.bind(this);
+    this.handleFollowUserListChange = this.handleFollowUserListChange.bind(this);
+    this.handleSpotifyAccountError = this.handleSpotifyAccountError.bind(this);
+    this.isCurrentListen = this.isCurrentListen.bind(this);
     this.playListen = this.playListen.bind(this);
     this.receiveNewListen = this.receiveNewListen.bind(this);
     this.receiveNewPlayingNow = this.receiveNewPlayingNow.bind(this);
     this.sortListensByFollowUserRank = this.sortListensByFollowUserRank.bind(this);
     this.spotifyPlayer = React.createRef();
-    this.getRecentListensForFollowList = this.getRecentListensForFollowList.bind(this);
-    this.handleCurrentListenChange = this.handleCurrentListenChange.bind(this);
-    this.handleFollowUserListChange = this.handleFollowUserListChange.bind(this);
-    this.isCurrentListen = this.isCurrentListen.bind(this);
 
     this.APIService = new APIService(props.api_url || `${window.location.origin}/1`);
   }
@@ -115,6 +116,9 @@ class RecentListens extends React.Component {
         this.getRecentListensForFollowList();
       }
     })
+  }
+  handleSpotifyAccountError(error){
+    this.setState({isSpotifyPremium: false})
   }
 
   playListen(listen){
@@ -304,13 +308,14 @@ class RecentListens extends React.Component {
             }
           </div>
           <div className="col-md-4" style={{ position: "-webkit-sticky", position: "sticky", top: 20 }}>
-            {this.props.spotify_access_token ?
+            {this.props.spotify_access_token && this.state.isSpotifyPremium !== false ?
               <SpotifyPlayer
                 ref={this.spotifyPlayer}
                 listens={spotifyListens}
                 direction={this.state.mode === "follow" ? "up" : "down"}
                 spotify_access_token={this.props.spotify_access_token}
                 onCurrentListenChange={this.handleCurrentListenChange}
+                onAccountError={this.handleSpotifyAccountError}
                 currentListen={this.state.currentListen}
               /> :
               // Fallback embedded player

--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -20,12 +20,12 @@ function getSpotifyUriFromListen(listen) {
 export class SpotifyPlayer extends React.Component {
 
   _spotifyPlayer;
-  _accessToken;
   _firstRun = true;
 
   constructor(props) {
     super(props);
     this.state = {
+      accessToken: props.spotify_access_token,
       currentSpotifyTrack: null,
       playerPaused: true,
       errorMessage: null,
@@ -34,7 +34,6 @@ export class SpotifyPlayer extends React.Component {
       durationMs: 0,
       direction: props.direction || "down"
     };
-    this._accessToken = props.spotify_access_token;
     this.playNextTrack = this.playNextTrack.bind(this);
     this.playPreviousTrack = this.playPreviousTrack.bind(this);
     this.togglePlay = this.togglePlay.bind(this);
@@ -63,8 +62,17 @@ export class SpotifyPlayer extends React.Component {
       body: JSON.stringify({ uris: [spotify_uri] }),
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this._accessToken}`
+        'Authorization': `Bearer ${this.state.accessToken}`
       },
+    })
+    .then(response =>{
+      if(response.status === 403){
+        return this.handleAccountError(response.statusText);
+      }
+      if(!response.ok){
+        return this.handleError(response.statusText);
+      }
+      return;
     })
     .catch(this.handleError);
   };
@@ -141,6 +149,12 @@ export class SpotifyPlayer extends React.Component {
     this.setState({ errorMessage: error });
   }
 
+  handleAccountError(error) {
+    const errorMessage = 'Failed to validate Spotify premium account';
+    console.error(errorMessage, error);
+    this.setState({ accessToken: null, errorMessage });
+  }
+
   async togglePlay() {
     try
     {
@@ -179,7 +193,7 @@ export class SpotifyPlayer extends React.Component {
 
   connectSpotifyPlayer() {
     this.disconnectSpotifyPlayer();
-    if (!this._accessToken)
+    if (!this.state.accessToken)
     {
       console.error("No spotify acces_token");
       const noTokenErrorMessage = <span>No Spotify access token. Please try to <a href="/profile/connect-spotify">link your account</a> and refresh this page</span>;
@@ -190,7 +204,7 @@ export class SpotifyPlayer extends React.Component {
     this._spotifyPlayer = new window.Spotify.Player({
       name: 'ListenBrainz Player',
       getOAuthToken: callback => {
-        callback(this._accessToken);
+        callback(this.state.accessToken);
       },
       volume: 0.7 // Careful with this, now…
     });
@@ -199,7 +213,7 @@ export class SpotifyPlayer extends React.Component {
     const authErrorMessage = <span>Spotify authentication error. <br /><button onClick={this.connectSpotifyPlayer} className="btn btn-primary">Reconnect</button> or <a href="/profile/connect-spotify">relink your Spotify account</a></span>
     this._spotifyPlayer.on('initialization_error', this.handleError);
     this._spotifyPlayer.on('authentication_error', error => this.handleError(authErrorMessage));
-    this._spotifyPlayer.on('account_error', this.handleError);
+    this._spotifyPlayer.on('account_error', this.handleAccountError);
     this._spotifyPlayer.on('playback_error', this.handleError);
 
     this._spotifyPlayer.addListener('ready', ({ device_id }) => {
@@ -218,7 +232,7 @@ export class SpotifyPlayer extends React.Component {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${this._accessToken}`
+            'Authorization': `Bearer ${this.state.accessToken}`
           },
         });
       }

--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -150,11 +150,11 @@ export class SpotifyPlayer extends React.Component {
   }
 
   handleAccountError(error) {
-    const errorMessage = 'Failed to validate Spotify premium account';
+    const errorMessage = 'Failed to validate Spotify account';
     console.error(errorMessage, error);
     this.setState({ accessToken: null, errorMessage });
     if(typeof this.props.onAccountError === "function") {
-      this.props.onAccountError(error);
+      this.props.onAccountError(`${errorMessage} ${error}`);
     }
   }
 

--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -66,7 +66,7 @@ export class SpotifyPlayer extends React.Component {
       },
     })
     .then(response =>{
-      if(response.status === 403){
+      if(response.status === 403 || response.status === 401){
         return this.handleAccountError(response.statusText);
       }
       if(!response.ok){
@@ -153,6 +153,9 @@ export class SpotifyPlayer extends React.Component {
     const errorMessage = 'Failed to validate Spotify premium account';
     console.error(errorMessage, error);
     this.setState({ accessToken: null, errorMessage });
+    if(typeof this.props.onAccountError === "function") {
+      this.props.onAccountError(error);
+    }
   }
 
   async togglePlay() {

--- a/listenbrainz/webserver/templates/user/spotify.html
+++ b/listenbrainz/webserver/templates/user/spotify.html
@@ -38,7 +38,7 @@
       {% endif %}
 
     {% else %}
-      <p><a href="{{ only_listen_url }}">Log in with Spotify (only listen to music).</a></p>
+      <p><a href="{{ only_listen_url }}">Log in with Spotify (only listen to music, <i>requires a premium account</i>).</a></p>
       <p><a href="{{ only_import_url }}">Log in with Spotify (import listens).</a></p>
       <p><a href="{{ both_url }}">Log in with Spotify (both).</a></p>
     {% endif %}


### PR DESCRIPTION
# Summary

* This is a…
    * (x) Bug fix

# Problem

I misunderstood the Spotify docs: non-premium users can't use the Web Playback SDK (the new player in the react pages).

# Solution

Thankfully it's easy to check if a user is premium, and we can fall back to the embedded iframe player if it's not the case.
Non-premium users should be able to play the full tracks in the embedded player. Unfortunately, they'll need to press 'play' every new song.