### PR TITLE
Listens table sorting

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/follow-users.jsx
+++ b/listenbrainz/webserver/static/js/jsx/follow-users.jsx
@@ -1,5 +1,7 @@
+import { faChevronDown, faChevronUp, faPlusCircle, faSave, faSitemap, faTimes, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import {getArtistLink, getPlayButton, getTrackLink} from './utils.jsx';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import {isNil as _isNil} from 'lodash';
 
@@ -114,7 +116,7 @@ export class FollowUsers extends React.Component {
     return (
       <div className="panel panel-primary">
         <div className="panel-heading">
-          <i className="fas fa-sitemap fa-2x fa-flip-vertical"></i>
+          <FontAwesomeIcon icon={faSitemap} size="2x" flip="vertical"/>
           <span style={{fontSize: "x-large", marginLeft: "0.55em", verticalAign: "middle" }}>
             Follow users
           </span>
@@ -134,7 +136,7 @@ export class FollowUsers extends React.Component {
                   />
                   <span className="input-group-btn">
                     <button className="btn btn-primary" type="button" onClick={this.addUserToList} style={{lineHeight: "2em", marginTop: 0, marginBottom: 0}}>
-                      <span className="fa fa-plus-circle" aria-hidden="true"></span> Add
+                      <FontAwesomeIcon icon={faPlusCircle}/> Add
                     </button>
                   </span>
                 </div>
@@ -147,10 +149,10 @@ export class FollowUsers extends React.Component {
                   />
                   <div className="input-group-btn">
                     <button className="btn btn-primary" type="button" onClick={this.saveFollowList.bind(this)} style={{lineHeight: "2em", marginTop: 0, marginBottom: 0}}>
-                        <span className="fa fa-save" aria-hidden="true"></span> Save
+                        <FontAwesomeIcon icon={faSave}/> Save
                       </button>
                     <button className="btn btn-danger" type="button" onClick={this.newFollowList.bind(this)} style={{lineHeight: "2em", marginTop: 0, marginBottom: 0}}>
-                      <span className="fa fa-times" aria-hidden="true"></span> Clear
+                      <FontAwesomeIcon icon={faTimes}/> Clear
                     </button>
                   </div>
                 </div>
@@ -178,13 +180,13 @@ export class FollowUsers extends React.Component {
                           {index > 0 &&
                             <button className="btn btn-info"
                               onClick={this.reorderUser.bind(this, index, index - 1)}>
-                              <span className="fa fa-chevron-up"></span>
+                              <FontAwesomeIcon icon={faChevronUp}/>
                             </button>
                           }
                           {index < this.state.users.length - 1 &&
                             <button className="btn btn-info"
                               onClick={this.reorderUser.bind(this, index, index + 1)}>
-                              <span className="fa fa-chevron-down"></span>
+                              <FontAwesomeIcon icon={faChevronDown}/>
                             </button>
                           }
                         </span>
@@ -208,7 +210,7 @@ export class FollowUsers extends React.Component {
                       <td style={noTopBottomPadding}>
                         <button className="btn btn-danger" type="button" aria-label="Remove"
                           onClick={this.removeUserFromList.bind(this, index)}>
-                          <span className="fa fa-trash-alt"></span>
+                          <FontAwesomeIcon icon={faTrashAlt}/>
                         </button>
                       </td>
                     </tr>

--- a/listenbrainz/webserver/static/js/jsx/playback-controls.jsx
+++ b/listenbrainz/webserver/static/js/jsx/playback-controls.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import { faEye, faEyeSlash, faFastBackward, faFastForward, faPauseCircle, faPlayCircle, faSortAmountDown, faSortAmountUp } from '@fortawesome/free-solid-svg-icons'
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
 function millisecondsToHumanReadable(milliseconds) {
   var seconds = milliseconds / 1000;
   var numyears = Math.floor(seconds / 31536000);
@@ -42,35 +44,20 @@ export class PlaybackControls extends React.Component {
             <div className="left btn btn-xs"
               title={`${this.state.autoHideControls ? 'Always show' : 'Autohide'} controls`}
               onClick={() => this.setState(state => ({ autoHideControls: !state.autoHideControls }))}>
-              <span className={`${this.state.autoHideControls ? 'hidden' : ''}`}>
-                <i className="fas fa-eye"></i>
-              </span>
-              <span className={`${!this.state.autoHideControls ? 'hidden' : ''}`}>
-                <i className="fas fa-eye-slash"></i>
-              </span>
+                <FontAwesomeIcon icon={this.state.autoHideControls ? faEyeSlash : faEye}/>
             </div>
             <div className="previous btn btn-xs" onClick={this.props.playPreviousTrack} title="Previous">
-              <i className="fas fa-fast-backward"></i>
+              <FontAwesomeIcon icon={faFastBackward}/>
             </div>
             <div className="play btn" onClick={this.props.togglePlay} title={`${this.props.playerPaused ? 'Play' : 'Pause'}`} >
-              <span className={`${this.props.playerPaused ? 'hidden' : ''}`}>
-                <i className="fa fa-2x fa-pause-circle"></i>
-              </span>
-              <span className={`${!this.props.playerPaused ? 'hidden' : ''}`}>
-                <i className="fa fa-2x fa-play-circle"></i>
-              </span>
+              <FontAwesomeIcon icon={this.props.playerPaused ? faPlayCircle : faPauseCircle} size="2x"/>
             </div>
             <div className="next btn btn-xs" onClick={this.props.playNextTrack} title="Next">
-              <i className="fas fa-fast-forward"></i>
+              <FontAwesomeIcon icon={faFastForward}/>
             </div>
             {this.props.direction !== "hidden" &&
               <div className="right btn btn-xs" onClick={this.props.toggleDirection} title={`Play ${this.props.direction === 'up' ? 'down' : 'up'}`}>
-                <span className={`${this.props.direction === 'up' ? 'hidden' : ''}`}>
-                  <i className="fa fa-sort-amount-down"></i>
-                </span>
-                <span className={`${this.props.direction === 'down' ? 'hidden' : ''}`}>
-                  <i className="fa fa-sort-amount-up"></i>
-                </span>
+                <FontAwesomeIcon icon={this.state.direction === 'up' ? faSortAmountUp : faSortAmountDown}/>
               </div>
             }
           </div>

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -2,14 +2,17 @@
 
 import * as timeago from 'time-ago';
 
+import { faListUl, faSort } from '@fortawesome/free-solid-svg-icons'
 import {getArtistLink, getPlayButton, getSpotifyEmbedUriFromListen, getTrackLink} from './utils.jsx';
 
 import APIService from './api-service';
 import {FollowUsers} from './follow-users.jsx';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {SpotifyPlayer} from './spotify-player.jsx';
 import {isEqual as _isEqual} from 'lodash';
+import { faSpotify } from '@fortawesome/free-brands-svg-icons'
 import io from 'socket.io-client';
 
 class RecentListens extends React.Component {
@@ -301,7 +304,7 @@ class RecentListens extends React.Component {
                 <p>No listens yet</p>
                 {this.state.mode === "follow" &&
                   <div title="Load recent listens" className="btn btn-primary" onClick={this.getRecentListensForFollowList}>
-                    <i className="fas fa-list-ul"></i>&nbsp;&nbsp;Load recent listens
+                    <FontAwesomeIcon icon={faListUl}/>&nbsp;&nbsp;Load recent listens
                   </div>
                 }
               </div>
@@ -313,8 +316,8 @@ class RecentListens extends React.Component {
                     <tr>
                       <th>Track</th>
                       <th>Artist</th>
-                      <th>Time</th>
-                      {(this.state.mode === "follow" || this.state.mode === "recent") && <th>User</th>}
+                      <th>Time {this.state.sortBy === "time" && <FontAwesomeIcon icon={faSort}/>}</th>
+                      {(this.state.mode === "follow" || this.state.mode === "recent") && <th>User {(this.state.sortBy === "username" || this.state.sortBy === "followList") && <FontAwesomeIcon icon={faSort}/>}</th>}
                       <th width="50px"></th>
                     </tr>
                   </thead>
@@ -329,7 +332,7 @@ class RecentListens extends React.Component {
                             <td>{getTrackLink(listen)}</td>
                             <td>{getArtistLink(listen)}</td>
                             {listen.playing_now ?
-                              <td><span className="fab fa-spotify" aria-hidden="true"></span> Playing now</td>
+                              <td><FontAwesomeIcon icon={faSpotify}/> Playing now</td>
                               :
                               <td>
                                 <abbr title={listen.listened_at_iso}>

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -83,11 +83,12 @@ class RecentListens extends React.Component {
   }
 
   setSortMethod(method){
+    let safeMethod = method;
     if (["time","username","followList"].indexOf(method) === -1){
       console.error("Trying to set sort method to unrecognized:",method);
-      return;
+      safeMethod = "time";
     }
-    this.setState({sortBy: method},()=>{
+    this.setState({sortBy: safeMethod},()=>{
       //Sort listens after changing sortBy
       this.setState(prevState => {
         return {listens: this.sortListens(prevState.listens, prevState)}
@@ -124,10 +125,6 @@ class RecentListens extends React.Component {
           sortFunction = (a, b) => state.followList.indexOf(b.user_name) - state.followList.indexOf(a.user_name)
         }
         sortedListens = listensToSort.sort(sortFunction);
-      }
-      else {
-        console.error("Cannot sort with unrecognized method",state.sortBy);
-        return listens;
       }
 
       let reassembledListens;

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -27,6 +27,8 @@ class RecentListens extends React.Component {
       saveUrl: props.save_url || '',
       listName: props.follow_list_name,
       listId: props.follow_list_id,
+      direction: "down",
+      sortBy: props.mode === "follow" ? "followList" : "time"
     };
     this.handleSpotifyAccountError = this.handleSpotifyAccountError.bind(this);
     this.connectWebsockets = this.connectWebsockets.bind(this);
@@ -38,7 +40,7 @@ class RecentListens extends React.Component {
     this.playListen = this.playListen.bind(this);
     this.receiveNewListen = this.receiveNewListen.bind(this);
     this.receiveNewPlayingNow = this.receiveNewPlayingNow.bind(this);
-    this.sortListensByFollowUserRank = this.sortListensByFollowUserRank.bind(this);
+    this.sortListens = this.sortListens.bind(this);
     this.spotifyPlayer = React.createRef();
 
     this.APIService = new APIService(props.api_url || `${window.location.origin}/1`);
@@ -77,17 +79,57 @@ class RecentListens extends React.Component {
     });
   }
 
-  sortListensByFollowUserRank(listens, userList){
-    if(userList.length <= 1){
-      return listens;
+  setSortMethod(method){
+    if (["time","username","followList"].indexOf(method) === -1){
+      console.error("Trying to set sort method to unrecognized:",method);
+      return;
     }
-    const currentListenIndex = listens.indexOf(this.state.currentListen);
-    let ignoredPastListens = [];
-    if(currentListenIndex !== -1){
-      ignoredPastListens = listens.splice(currentListenIndex);
-    }
-    const sortFunction = (a, b) => userList.indexOf(b.user_name) - userList.indexOf(a.user_name)
-    return listens.sort(sortFunction).concat(ignoredPastListens);
+    this.setState({sortBy: method});
+  }
+
+  sortListens(listens, state){
+      const currentListenIndex = listens.indexOf(state.currentListen);
+      let listensToSort, sortedListens;
+      let pastListens = [];
+
+      if(currentListenIndex === -1){
+        listensToSort = listens;
+      } else if (state.direction === "down"){
+        listensToSort = listens.splice(currentListenIndex);
+        pastListens = listens;
+      }  else {
+        pastListens = listens.splice(currentListenIndex);
+        listensToSort = listens;
+      }
+
+      if (state.mode === "listens" || state.sortBy === "time") {
+        sortedListens = _.orderBy(listensToSort, "listened_at", "desc");
+      }
+      else if (state.sortBy === "username"){
+        sortedListens = _.sortBy(listensToSort, "user_name");
+      }
+      else if (state.sortBy === "followList") {
+        let sortFunction;
+        if (state.direction === "down"){
+          sortFunction = (a, b) => state.followList.indexOf(a.user_name) - state.followList.indexOf(b.user_name)
+        } else {
+          sortFunction = (a, b) => state.followList.indexOf(b.user_name) - state.followList.indexOf(a.user_name)
+        }
+        sortedListens = listensToSort.sort(sortFunction);
+      }
+      else {
+        console.error("Cannot sort with unrecognized method",state.sortBy);
+        return listens;
+      }
+
+      let reassembledListens;
+      if (state.direction === "down"){
+        reassembledListens = pastListens.concat(sortedListens);
+      } else {
+        reassembledListens = sortedListens.concat(pastListens);
+      }
+
+      return reassembledListens
   }
 
   handleFollowUserListChange(userList, dontSendUpdate){
@@ -100,7 +142,7 @@ class RecentListens extends React.Component {
       previousFollowList = prevState.followList;
       return {
         followList: userList,
-        listens: this.sortListensByFollowUserRank(prevState.listens, userList)
+        listens: this.sortListens(prevState.listens, prevState)
       }
     }, ()=>{
       if(dontSendUpdate){
@@ -140,7 +182,8 @@ class RecentListens extends React.Component {
     }
     console.debug(typeof newListen, newListen);
     this.setState(prevState =>{
-      return { listens: this.sortListensByFollowUserRank([newListen].concat(prevState.listens), prevState.followList) }
+      prevState.listens.push(newListen);
+      return { listens: this.sortListens(prevState.listens, prevState) }
     })
   }
 
@@ -182,7 +225,7 @@ class RecentListens extends React.Component {
     this.APIService.getRecentListensForUsers(this.state.followList)
       .then(listens => 
         this.setState(prevState =>{
-          return { listens: this.sortListensByFollowUserRank(listens, prevState.followList) }
+          return { listens: this.sortListens(listens, prevState) }
         })
       )
       .catch(console.error)
@@ -240,6 +283,18 @@ class RecentListens extends React.Component {
         <div className="row">
           <div className="col-md-8">
             <h3>{(this.state.mode === "listens" || this.state.mode === "recent" )? "Recent listens" : "Playlist"}</h3>
+
+            <div className="dropdown pull-right">
+              <button className="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                Sort by
+                <span className="caret"></span>
+              </button>
+              <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
+                <li><a onClick={this.setSortMethod.bind(this, "time")}>Time</a></li>
+                {(this.state.mode === "follow" || this.state.mode === "recent" ) && <li><a onClick={this.setSortMethod.bind(this, "username")}>Username</a></li>}
+                {this.state.mode === "follow" && <li><a onClick={this.setSortMethod.bind(this, "followList")}>Follow list</a></li>}
+              </ul>
+            </div>
 
             {!this.state.listens.length &&
               <div className="lead text-center">
@@ -314,7 +369,7 @@ class RecentListens extends React.Component {
               <SpotifyPlayer
                 ref={this.spotifyPlayer}
                 listens={spotifyListens}
-                direction={this.state.mode === "follow" ? "up" : "down"}
+                direction={this.state.direction}
                 spotify_access_token={this.props.spotify_access_token}
                 onCurrentListenChange={this.handleCurrentListenChange}
                 onAccountError={this.handleSpotifyAccountError}

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -2,7 +2,6 @@
 
 import * as timeago from 'time-ago';
 
-import { faListUl, faSort } from '@fortawesome/free-solid-svg-icons'
 import {getArtistLink, getPlayButton, getSpotifyEmbedUriFromListen, getTrackLink} from './utils.jsx';
 
 import APIService from './api-service';
@@ -12,6 +11,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {SpotifyPlayer} from './spotify-player.jsx';
 import {isEqual as _isEqual} from 'lodash';
+import { faListUl } from '@fortawesome/free-solid-svg-icons'
 import { faSpotify } from '@fortawesome/free-brands-svg-icons'
 import io from 'socket.io-client';
 
@@ -325,8 +325,10 @@ class RecentListens extends React.Component {
                     <tr>
                       <th>Track</th>
                       <th>Artist</th>
-                      <th>Time {this.state.sortBy === "time" && <FontAwesomeIcon icon={faSort}/>}</th>
-                      {(this.state.mode === "follow" || this.state.mode === "recent") && <th>User {(this.state.sortBy === "username" || this.state.sortBy === "followList") && <FontAwesomeIcon icon={faSort}/>}</th>}
+                      <th>Time</th>
+                      {(this.state.mode === "follow" || this.state.mode === "recent") &&
+                        <th>User</th>
+                      }
                       <th width="50px"></th>
                     </tr>
                   </thead>

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -87,7 +87,12 @@ class RecentListens extends React.Component {
       console.error("Trying to set sort method to unrecognized:",method);
       return;
     }
-    this.setState({sortBy: method});
+    this.setState({sortBy: method},()=>{
+      //Sort listens after changing sortBy
+      this.setState(prevState => {
+        return {listens: this.sortListens(prevState.listens, prevState)}
+      })
+    });
   }
 
   sortListens(listens, state){
@@ -285,19 +290,23 @@ class RecentListens extends React.Component {
         }
         <div className="row">
           <div className="col-md-8">
-            <h3>{(this.state.mode === "listens" || this.state.mode === "recent" )? "Recent listens" : "Playlist"}</h3>
+            {this.state.mode !== "listens" && 
+              <div className="dropdown pull-right">
+                <button className="btn btn-info dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                  Sort by {_.startCase(this.state.sortBy)}
+                  &nbsp;<span className="caret"></span>
+                </button>
+                <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
+                  <li><a onClick={this.setSortMethod.bind(this, "time")}>Time</a></li>
+                  <li><a onClick={this.setSortMethod.bind(this, "username")}>Username</a></li>
+                  {this.state.mode === "follow" &&
+                    <li><a onClick={this.setSortMethod.bind(this, "followList")}>Follow list</a></li>
+                  }
+                </ul>
+              </div>
+            }
 
-            <div className="dropdown pull-right">
-              <button className="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                Sort by
-                <span className="caret"></span>
-              </button>
-              <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
-                <li><a onClick={this.setSortMethod.bind(this, "time")}>Time</a></li>
-                {(this.state.mode === "follow" || this.state.mode === "recent" ) && <li><a onClick={this.setSortMethod.bind(this, "username")}>Username</a></li>}
-                {this.state.mode === "follow" && <li><a onClick={this.setSortMethod.bind(this, "followList")}>Follow list</a></li>}
-              </ul>
-            </div>
+            <h3>{(this.state.mode === "listens" || this.state.mode === "recent" )? "Recent listens" : "Playlist"}</h3>
 
             {!this.state.listens.length &&
               <div className="lead text-center">

--- a/listenbrainz/webserver/templates/base-react.html
+++ b/listenbrainz/webserver/templates/base-react.html
@@ -7,6 +7,5 @@
 
 {% block scripts %}
   {{ super() }}
-  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
   <script id="react-props" type="application/json">{{ props|safe }}</script>
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -839,6 +839,52 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.15.tgz",
+      "integrity": "sha512-ATBRyKJw1d2ko+0DWN9+BXau0EK3I/Q6pPzPv3LhJD7r052YFAkAdfb1Bd7ZqhBsJrdse/S7jKxWUOZ61qBD4g=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.15.tgz",
+      "integrity": "sha512-M/sHyl4g2VBtKYkay1Z+XImMyTVcaBPmehYtPw4HKD9zg2E7eovB7Yx98aUfZjPbroGqa+IL4/+KhWBMOGlHIQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.15"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.7.2.tgz",
+      "integrity": "sha512-91rIjo00vy7PNrXg5auDsPOSTjmgzc+UUqMyUZHmIrXG5OXMHgjAYMTgEIgs91Lm5XcJtggFZCQz1u5fGFnj2A==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.15"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.7.2.tgz",
+      "integrity": "sha512-ZO+zQcncfT7omTsTIjBkugj/dFXiSnoK44I5p0/WAoNX8aX2Au7j+uxq1qFX4bevkfGFGsPeJUYU1+Q1PB/5pQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.15"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.7.2.tgz",
+      "integrity": "sha512-iujcXMyAvIbWM8W3jkOLpvJbR+rPpdN1QyqhZeJaLRdHPH4JmuovIAYP4vx5Sa1csZVXfRD1eDWqVZ/jGM620A==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.15"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz",
+      "integrity": "sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==",
+      "requires": {
+        "humps": "^2.0.1",
+        "prop-types": "^15.5.10"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -3382,6 +3428,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "ieee754": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
   "homepage": "https://listenbrainz.org",
   "dependencies": {
     "@babel/runtime": "^7.3.1",
+    "@fortawesome/fontawesome-svg-core": "^1.2.15",
+    "@fortawesome/free-brands-svg-icons": "^5.7.2",
+    "@fortawesome/free-regular-svg-icons": "^5.7.2",
+    "@fortawesome/free-solid-svg-icons": "^5.7.2",
+    "@fortawesome/react-fontawesome": "^0.1.4",
     "less": "^2.7.2",
     "less-plugin-clean-css": "^1.5.1",
     "lodash": "^4.17.11",


### PR DESCRIPTION

# Summary

* This is a…
    * (x) Feature addition

# Problem

Different playing direction on the follow page was confusing, and made sorting the listens table even more confusing.

# Solution


Improve the sorting, and offer the choice between three sorting modes: time, username, follow list.

I ran into a small issue (not for the first time) with FontAwesome (the icon collection) that doesn't play well with React, so I moved from importing FA from a CDN to using the official react library.