### PR TITLE
Add a new endpoint to refresh spotify tokens

### DIFF
--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -48,6 +48,11 @@ class APIServiceUnavailable(APIError):
         super(APIServiceUnavailable, self).__init__(message, 503, payload)
 
 
+class APIForbidden(APIError):
+    def __init__(self, message, payload=None):
+        super(APIForbidden, self).__init__(message, 403, payload)
+
+
 # List of errors compatible with LastFM messages for API_compat.
 class CompatError(object):
     DOES_NOT_EXIST           = LastFMError(code = 1, message = "This error does not exist")

--- a/listenbrainz/webserver/login/__init__.py
+++ b/listenbrainz/webserver/login/__init__.py
@@ -3,6 +3,7 @@ from flask_login import LoginManager, UserMixin, current_user
 from functools import wraps
 import listenbrainz.db.user as db_user
 from werkzeug.exceptions import Unauthorized
+from listenbrainz.webserver.errors import APIUnauthorized
 
 login_manager = LoginManager()
 login_manager.login_view = 'login.index'
@@ -49,6 +50,16 @@ def login_forbidden(f):
     def decorated(*args, **kwargs):
         if not current_user.is_anonymous:
             return redirect(url_for('index.index'))
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def api_login_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not current_user.is_authenticated:
+            raise APIUnauthorized("You must be logged in to access this endpoint")
         return f(*args, **kwargs)
 
     return decorated

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -196,7 +196,7 @@ def _get_session(session_id):
 
     session = Session.load(session_id)
     if session is None:
-        raise BadRequest
+        raise BadRequest("Session not found")
     return session
 
 

--- a/listenbrainz/webserver/views/follow_api.py
+++ b/listenbrainz/webserver/views/follow_api.py
@@ -7,7 +7,7 @@ from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.rate_limiter import ratelimit
 from listenbrainz.webserver.views.api import _validate_auth_header
 from listenbrainz.webserver.views.api_tools import log_raise_400
-from werkzeug.exceptions import NotFound, Forbidden, Unauthorized
+from listenbrainz.webserver.errors import APINotFound, APIForbidden, APIUnauthorized
 from listenbrainz.db.exceptions import DatabaseException
 
 follow_api_bp = Blueprint('follow_api_v1', __name__)
@@ -40,15 +40,15 @@ def save_list():
                 members=[member['id'] for member in members],
             )
         except DatabaseException as e:
-            raise Forbidden("List with same name already exists.")
+            raise APIForbidden("List with same name already exists.")
     else:
 
         # do some validation
         current_list = db_follow_list.get(list_id)
         if current_list is None:
-            raise NotFound("List not found: %d" % list_id)
+            raise APINotFound("List not found: %d" % list_id)
         if current_list['creator'] != creator['id']:
-            raise Unauthorized("You can only edit your own lists.")
+            raise APIUnauthorized("You can only edit your own lists.")
 
         # update the old list
         db_follow_list.update(

--- a/listenbrainz/webserver/views/test/test_follow.py
+++ b/listenbrainz/webserver/views/test/test_follow.py
@@ -108,13 +108,13 @@ class FollowViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assertListEqual(props['follow_list'], [])
 
     def test_save_endpoint_bad_data(self):
-        self.temporary_login(self.user['login_id'])
         r = self.client.post(
             '/1/follow/save',
             data=json.dumps({}),
             headers={"Authorization": "Token {token}".format(token=self.user['auth_token'])},
         )
         self.assert400(r)
+        self.assertEqual(r.json['code'], 400)
 
         r = self.client.post(
             '/1/follow/save',
@@ -122,6 +122,7 @@ class FollowViewsTestCase(ServerTestCase, DatabaseTestCase):
             headers={"Authorization": "Token {token}".format(token=self.user['auth_token'])},
         )
         self.assert400(r)
+        self.assertEqual(r.json['code'], 400)
 
         r = self.client.post(
             '/1/follow/save',
@@ -129,6 +130,7 @@ class FollowViewsTestCase(ServerTestCase, DatabaseTestCase):
             headers={"Authorization": "Token {token}".format(token=self.user['auth_token'])},
         )
         self.assert400(r)
+        self.assertEqual(r.json['code'], 400)
 
         r = self.client.post(
             '/1/follow/save',
@@ -136,3 +138,4 @@ class FollowViewsTestCase(ServerTestCase, DatabaseTestCase):
             headers={"Authorization": "Token {token}".format(token=self.user['auth_token'])},
         )
         self.assert400(r)
+        self.assertEqual(r.json['code'], 400)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

Tokens expired, leading to errors in the frontend.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

I added an endpoint to which you can send GET requests to get a new token if needed.

Also, I improved the error handling to raise API specific errors which return json instead of html.

