### PR TITLE
Refresh the Spotify token for the front-end player

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/api-service.js
+++ b/listenbrainz/webserver/static/js/jsx/api-service.js
@@ -76,6 +76,13 @@ export default class APIService {
     
     return result.payload.listens
   }
+
+  async refreshSpotifyToken(){
+    const response = await fetch("/profile/refresh-spotify-token",{method:"POST"})
+    this.checkStatus(response);
+    const result = await response.json();
+    return result.user_token;
+  }
   
   checkStatus(response) {
     if (response.status >= 200 && response.status < 300) {

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -415,6 +415,7 @@ class RecentListens extends React.Component {
           <div className="col-md-4" style={{ position: "-webkit-sticky", position: "sticky", top: 20 }}>
             {this.props.spotify_access_token && this.state.isSpotifyPremium !== false ?
               <SpotifyPlayer
+                APIService={this.APIService}
                 ref={this.spotifyPlayer}
                 listens={spotifyListens}
                 direction={this.state.direction}

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -263,7 +263,7 @@ def connect_spotify_callback():
     return redirect(url_for('profile.connect_spotify'))
 
 
-@profile_bp.route('/refresh-spotify-token', methods=['GET'])
+@profile_bp.route('/refresh-spotify-token', methods=['POST'])
 @crossdomain()
 @api_login_required
 def refresh_spotify_token():
@@ -274,7 +274,7 @@ def refresh_spotify_token():
         try:
             spotify_user = spotify.refresh_user_token(spotify_user)
         except spotify.SpotifyAPIError:
-            raise APIServiceUnvailable("Cannot refresh Spotify token right now")
+            raise APIServiceUnavailable("Cannot refresh Spotify token right now")
 
     return jsonify({
         'id': current_user.id,

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -128,12 +128,12 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assert400(r)
 
     def test_spotify_refresh_token_logged_out(self):
-        r = self.client.get(url_for('profile.refresh_spotify_token'))
+        r = self.client.post(url_for('profile.refresh_spotify_token'))
         self.assert401(r)
 
     def test_spotify_refresh_token_no_token(self):
         self.temporary_login(self.user['login_id'])
-        r = self.client.get(url_for('profile.refresh_spotify_token'))
+        r = self.client.post(url_for('profile.refresh_spotify_token'))
         self.assert404(r)
 
     @patch('listenbrainz.webserver.views.profile.spotify.get_user')
@@ -155,7 +155,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
             latest_listened_at=None,
             permission='user-read-recently-played',
         )
-        r = self.client.get(url_for('profile.refresh_spotify_token'))
+        r = self.client.post(url_for('profile.refresh_spotify_token'))
         self.assert200(r)
         mock_refresh_user_token.assert_not_called()
         self.assertDictEqual(r.json, {
@@ -187,7 +187,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
         mock_get_user.return_value = spotify_user
         spotify_user.user_token = 'new-token'
         mock_refresh_user_token.return_value = spotify_user
-        r = self.client.get(url_for('profile.refresh_spotify_token'))
+        r = self.client.post(url_for('profile.refresh_spotify_token'))
         self.assert200(r)
         mock_refresh_user_token.assert_called_once()
         self.assertDictEqual(r.json, {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * (x) Feature addition

# Problem

The Spotify player's token expires after an hour. That obviously sucks.

# Solution

After merging PR #540, use the new endpoint to get a refreshed token (or the existing one if still valid) from the server.


