### PR TITLE
Follow page playlist improvements

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -132,3 +132,29 @@
     }
   }
 }
+
+.input-group-flex {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  width: 100%;
+  > *:not(.form-control) {
+    width: auto;
+    line-height: 1.4;
+  }
+  > .form-control {
+    flex: 1 1 120px;
+  }
+  > .input-group-btn {
+    flex: 1;
+    display: flex;
+    > .btn {
+      flex: 1 1 auto
+    }
+  }
+}
+
+.input-group > .input-group-btn > .btn {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}

--- a/listenbrainz/webserver/static/js/jsx/follow-users.jsx
+++ b/listenbrainz/webserver/static/js/jsx/follow-users.jsx
@@ -131,30 +131,30 @@ export class FollowUsers extends React.Component {
             <hr />
             <div>
               <div className="col-sm-6">
-                <div className="input-group">
+                <div className="input-group input-group-flex">
                   <span className="input-group-addon">Follow user</span>
                   <input type="text" className="form-control" placeholder="Username…"
                     ref={(input) => this.textInput = input}
                     onKeyPress={this.addFollowerOnEnter}
                   />
                   <span className="input-group-btn">
-                    <button className="btn btn-primary" type="button" onClick={this.addUserToList} style={{lineHeight: "2em", marginTop: 0, marginBottom: 0}}>
+                    <button className="btn btn-primary" type="button" onClick={this.addUserToList}>
                       <FontAwesomeIcon icon={faPlusCircle}/> Add
                     </button>
                   </span>
                 </div>
               </div>
               <div className="col-sm-6">
-                <div className="input-group">
+                <div className="input-group input-group-flex">
                   <span className="input-group-addon">Save list</span>
                   <input type="text" className="form-control" defaultValue={this.state.listName} placeholder="New list name" ref={(input) => this.nameInput = input} 
                     onKeyPress={this.saveListOnEnter}
                   />
                   <div className="input-group-btn">
-                    <button className="btn btn-primary" type="button" onClick={this.saveFollowList.bind(this)} style={{lineHeight: "2em", marginTop: 0, marginBottom: 0}}>
+                    <button className="btn btn-primary" type="button" onClick={this.saveFollowList.bind(this)}>
                         <FontAwesomeIcon icon={faSave}/> Save
                       </button>
-                    <button className="btn btn-danger" type="button" onClick={this.newFollowList.bind(this)} style={{lineHeight: "2em", marginTop: 0, marginBottom: 0}}>
+                    <button className="btn btn-danger" type="button" onClick={this.newFollowList.bind(this)}>
                       <FontAwesomeIcon icon={faTimes}/> Clear
                     </button>
                   </div>

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -115,7 +115,10 @@ class RecentListens extends React.Component {
         listensToSort = listens;
       }
 
-      if (state.mode === "listens" || state.sortBy === "time") {
+      if (state.mode === "follow" && state.sortBy === "time") {
+        sortedListens = _.orderBy(listensToSort, "listened_at", "asc");
+      }
+      else if (state.mode === "listens" || state.sortBy === "time") {
         sortedListens = _.orderBy(listensToSort, "listened_at", "desc");
       }
       else if (state.sortBy === "username"){


### PR DESCRIPTION
# Summary

* This is a…
    * (x) Bug fix

# Problem
- Sorting tracks by time on the follow page should have newest at the bottom (ascending, got it wrong in the commit message)
- Tracks were being skipped when detecting the end of the previous track: we receive multiple events in a short burst at the end of a track