### PR TITLE
Remove listens sorting

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/follow-users.jsx
+++ b/listenbrainz/webserver/static/js/jsx/follow-users.jsx
@@ -15,7 +15,6 @@ export class FollowUsers extends React.Component {
       listName: props.listName,
     }
     this.addUserToList = this.addUserToList.bind(this);
-    this.reorderUser = this.reorderUser.bind(this);
     this.addFollowerOnEnter = this.addFollowerOnEnter.bind(this);
     this.saveListOnEnter = this.saveListOnEnter.bind(this);
   }
@@ -40,15 +39,6 @@ export class FollowUsers extends React.Component {
       prevState.users.splice(index, 1);
       return { users: prevState.users }
     }, () => { this.props.onUserListChange(this.state.users) });
-  }
-
-  reorderUser(currentIndex, targetIndex) {
-    this.setState(prevState => {
-      var element = prevState.users[currentIndex];
-      prevState.users.splice(currentIndex, 1);
-      prevState.users.splice(targetIndex, 0, element);
-      return { users: prevState.users }
-    }, () => { this.props.onUserListChange(this.state.users, true) });
   }
 
   saveFollowList(event) {
@@ -164,7 +154,6 @@ export class FollowUsers extends React.Component {
             <table className="table table-condensed table-striped listens-table" style={{marginTop: "5em"}}>
               <thead>
                 <tr>
-                  <th colSpan="2" width="50px">Order</th>
                   <th>User</th>
                   <th>Listening now</th>
                   <th width="50px"></th>
@@ -175,25 +164,6 @@ export class FollowUsers extends React.Component {
                 {this.state.users.map((user, index) => {
                   return (
                     <tr key={user} className={this.props.playingNow[user] && "playing_now"} onDoubleClick={this.props.playListen.bind(this, this.props.playingNow[user])}>
-                      <td>
-                        {index + 1}
-                      </td>
-                      <td>
-                        <span className="btn-group btn-group-xs" role="group" aria-label="Reorder">
-                          {index > 0 &&
-                            <button className="btn btn-info"
-                              onClick={this.reorderUser.bind(this, index, index - 1)}>
-                              <FontAwesomeIcon icon={faChevronUp}/>
-                            </button>
-                          }
-                          {index < this.state.users.length - 1 &&
-                            <button className="btn btn-info"
-                              onClick={this.reorderUser.bind(this, index, index + 1)}>
-                              <FontAwesomeIcon icon={faChevronDown}/>
-                            </button>
-                          }
-                        </span>
-                      </td>
                       <td>
                         {user}
                       </td>

--- a/listenbrainz/webserver/static/js/jsx/follow-users.jsx
+++ b/listenbrainz/webserver/static/js/jsx/follow-users.jsx
@@ -109,17 +109,16 @@ export class FollowUsers extends React.Component {
     return (
       <div className="panel panel-primary">
         <div className="panel-heading">
-          <FontAwesomeIcon icon={faSitemap} size="2x" flip="vertical"/>
+          <FontAwesomeIcon icon={faSitemap} flip="vertical"/>
           <span style={{fontSize: "x-large", marginLeft: "0.55em", verticalAign: "middle" }}>
             Follow users
           </span>
         </div>
         <div className="panel-body">
-            <span className="text-muted">
-                Add a user to discover what they are listening to:
-              </span>
-            <hr />
-            <div>
+            <p className="text-muted">
+              Add a user to discover what they are listening to:
+            </p>
+            <div className="row">
               <div className="col-sm-6">
                 <div className="input-group input-group-flex">
                   <span className="input-group-addon">Follow user</span>
@@ -151,7 +150,8 @@ export class FollowUsers extends React.Component {
                 </div>
               </div>
             </div>
-            <table className="table table-condensed table-striped listens-table" style={{marginTop: "5em"}}>
+            <hr/>
+            <table className="table table-condensed table-striped listens-table">
               <thead>
                 <tr>
                   <th>User</th>

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -135,6 +135,15 @@ class RecentListens extends React.Component {
     console.debug(typeof newListen, newListen);
     this.setState(prevState =>{
       const listens = prevState.listens;
+      // Crop listens array to 100 max
+      if(listens.length >= 100) {
+        if (prevState.mode === "follow"){
+          listens.shift();
+        } else {
+          listens.pop()
+        }
+      }
+
       if (prevState.mode === "follow"){
         listens.push(newListen);
       } else {

--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -269,13 +269,6 @@ class RecentListens extends React.Component {
           </div>
         </div>
         }
-        {this.state.mode === "follow" &&
-          <FollowUsers onUserListChange={this.handleFollowUserListChange}
-            followList={this.state.followList} playListen={this.playListen.bind(this)}
-            playingNow={this.state.playingNowByUser} saveUrl={this.state.saveUrl}
-            listName={this.state.listName} listId={this.state.listId} creator={this.props.user}
-            newAlert={this.newAlert}/>
-        }
         <div className="row">
           <div className="col-md-8">
 
@@ -349,6 +342,14 @@ class RecentListens extends React.Component {
               </div>
 
 
+            }
+            <br/>
+            {this.state.mode === "follow" &&
+              <FollowUsers onUserListChange={this.handleFollowUserListChange}
+                followList={this.state.followList} playListen={this.playListen.bind(this)}
+                playingNow={this.state.playingNowByUser} saveUrl={this.state.saveUrl}
+                listName={this.state.listName} listId={this.state.listId} creator={this.props.user}
+                newAlert={this.newAlert}/>
             }
           </div>
           <div className="col-md-4" style={{ position: "-webkit-sticky", position: "sticky", top: 20 }}>

--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -48,6 +48,8 @@ export class SpotifyPlayer extends React.Component {
     this.toggleDirection = this.toggleDirection.bind(this);
     window.onSpotifyWebPlaybackSDKReady = this.connectSpotifyPlayer;
     const spotifyPlayerSDKLib = require('../lib/spotify-player-sdk-1.6.0');
+    // ONLY FOR TESTING PURPOSES
+    window.disconnectSpotifyPlayer = this.disconnectSpotifyPlayer;
   }
 
   play_spotify_uri(spotify_uri) {
@@ -348,7 +350,6 @@ export class SpotifyPlayer extends React.Component {
         >
           {this.getAlbumArt()}
         </PlaybackControls>
-        <div className='btn' onClick={this.disconnectSpotifyPlayer}>Sneaky disconnect for testing</div>
       </div>
     );
   }


### PR DESCRIPTION
# Summary

* This is a…
    * (x) Bug fix
    * (x) Feature addition
    * (x) Minor / simple change (like a typo)



# Problem
This PR is a mish-mash of different improvements:

- A retry mechanism for playing songs so that if a token expires, or other errors, the player reconnects and then continues whatever it was doing (presumably playing)
- Removed the sorting functionnality on the follows page until we figure out the UX for it
- Moved the "Follow users" block down the page
- Crop the listens list after 100 listens