### PR TITLE
Reinstate an initial sort by time

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -21,10 +21,10 @@ class RecentListens extends React.Component {
   spotifyListens = [];
   constructor(props) {
     super(props);
-
+    const sortedListens = _.orderBy(props.listens || [], "listened_at", props.mode === "follow" ? "asc" : "desc");
     this.state = {
       alerts: [],
-      listens: props.listens || [],
+      listens: sortedListens || [],
       currentListen : null,
       mode: props.mode,
       followList: props.follow_list || [],


### PR DESCRIPTION
# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other


Like it says on the tin.
The list of listens sent by the server when visiting the follow page is sorted by time but clumped by user.
An initial sort by time should do it.