### PR TITLE
Add a max_age to the get recent listens call and set default of an hour

### DIFF
--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -354,7 +354,7 @@ class InfluxListenStore(ListenStore):
 
             user_list: A list containing the users for which you'd like to retrieve recent listens.
             limit: the maximum number of listens for each user to fetch.
-            max_age: Only return listens if the are no more than max_age seconds old. Default 3600 seconds
+            max_age: Only return listens if they are no more than max_age seconds old. Default 3600 seconds
         """
 
         escaped_user_list = []

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -348,19 +348,22 @@ class InfluxListenStore(ListenStore):
         return listens
 
 
-    def fetch_recent_listens_for_users(self, user_list, limit = 2):
+    def fetch_recent_listens_for_users(self, user_list, limit = 2, max_age = 3600):
         """ Fetch recent listens for a list of users, given a limit which applies per user. If you 
             have a limit of 3 and 3 users you should get 9 listens if they are available.
 
             user_list: A list containing the users for which you'd like to retrieve recent listens.
             limit: the maximum number of listens for each user to fetch.
+            max_age: Only return listens if the are no more than max_age seconds old. Default 3600 seconds
         """
 
         escaped_user_list = []
         for user_name in user_list:
            escaped_user_list.append(get_escaped_measurement_name(user_name))
 
-        query = 'SELECT username, * FROM ' + ",".join(escaped_user_list) + " ORDER BY time DESC LIMIT " + str(limit)
+        query = "SELECT username, * FROM " + ",".join(escaped_user_list) 
+        query += " WHERE time > " + get_influx_query_timestamp(int(time.time()) - max_age)
+        query += " ORDER BY time DESC LIMIT " + str(limit)
         try:
             results = self.influx.query(query)
         except Exception as err:

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -149,11 +149,16 @@ class TestInfluxListenStore(DatabaseTestCase):
         user_name2 = user['musicbrainz_id']
         self._create_test_data(user_name2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], limit=1) 
+        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], limit=1, max_age=10000000000) 
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2]) 
+        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], max_age=10000000000) 
         self.assertEqual(len(recent), 4)
+
+        recent = self.logstore.fetch_recent_listens_for_users([user_name], max_age = int(time.time()) - recent[0].ts_since_epoch + 1) 
+        self.assertEqual(len(recent), 1)
+        self.assertEqual(recent[0].ts_since_epoch, 1400000200)
+
 
     def test_dump_listens(self):
         self._create_test_data(self.testuser_name)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

Ancient listens were being loaded when loading the follow page, which ended up in me repeatedly listening to these tracks. This doesn't return anything older than max_age, which has a default of 3600 seconds.
