### PR TITLE
Correctly update state for current playing track

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -327,7 +327,7 @@ export class SpotifyPlayer extends React.Component {
     this.setState({
       progressMs: position,
       durationMs: duration,
-      currentSpotifyTrack: current_track,
+      currentSpotifyTrack: current_track || {},
       playerPaused: paused
     });
     if (this._firstRun)


### PR DESCRIPTION
A friend of mine created a new account and was getting `TypeError: "this.state.currentSpotifyTrack is null"` 

I'm not sure if this fixes it, because the bug seems to be gone, but still this looks like it might be needed?