### PR TITLE
Fix LB-432: Check spotify token scopes and fallback graciously

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -33,6 +33,7 @@ export class SpotifyPlayer extends React.Component {
       durationMs: 0,
       direction: props.direction || "down"
     };
+
     this.connectSpotifyPlayer = this.connectSpotifyPlayer.bind(this);
     this.disconnectSpotifyPlayer = this.disconnectSpotifyPlayer.bind(this);
     this.getAlbumArt = this.getAlbumArt.bind(this);
@@ -49,10 +50,19 @@ export class SpotifyPlayer extends React.Component {
     this.stopPlayerStateTimer = this.stopPlayerStateTimer.bind(this);
     this.togglePlay = this.togglePlay.bind(this);
     this.toggleDirection = this.toggleDirection.bind(this);
-    window.onSpotifyWebPlaybackSDKReady = this.connectSpotifyPlayer;
-    const spotifyPlayerSDKLib = require('../lib/spotify-player-sdk-1.6.0');
+    // Do an initial check of the spotify token permissions (scopes) before loading the SDK library
+    this.checkSpotifyToken(props.spotify_access_token).then(success =>{
+      if(success){
+        window.onSpotifyWebPlaybackSDKReady = this.connectSpotifyPlayer;
+        const spotifyPlayerSDKLib = require('../lib/spotify-player-sdk-1.6.0');
+      }
+    })
     // ONLY FOR TESTING PURPOSES
     window.disconnectSpotifyPlayer = this.disconnectSpotifyPlayer;
+  }
+
+  componentWillUnmount() {
+    this.disconnectSpotifyPlayer();
   }
 
   play_spotify_uri(spotify_uri) {
@@ -86,6 +96,40 @@ export class SpotifyPlayer extends React.Component {
     })
     .catch(this.handleError);
   };
+
+  async checkSpotifyToken(accessToken){
+    if(!accessToken){
+      {
+        this.handleAccountError(noTokenErrorMessage);
+        return false;
+      }
+    }
+    try {
+      const response = await fetch("https://api.spotify.com/v1/melody/v1/check_scope?scope=web-playback", {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': `Bearer ${accessToken}`
+        },
+      });
+      if(response.ok){
+        return true
+      }
+      const body = await response.json();
+      
+      if(response.status === 401){
+        this.handleTokenError(body.error || response.statusText);
+      }
+      if(response.status === 403){
+        this.handleAccountError(body.error || response.statusText);
+      }
+      return false;
+    } catch (error) {
+        this.handleError(error);
+        return false;
+    }
+    
+  }
 
   playListen(listen) {
     if (listen.track_metadata.additional_info.spotify_id)
@@ -157,6 +201,9 @@ export class SpotifyPlayer extends React.Component {
 
   async handleTokenError(error, callbackFunction) {
     console.error(error);
+    if(error && error.message === "Invalid token scopes.") {
+      this.handleAccountError(error.message)
+    }
     try {
       const userToken = await this.props.APIService.refreshSpotifyToken();
       this.setState({accessToken: userToken},()=>{
@@ -169,10 +216,10 @@ export class SpotifyPlayer extends React.Component {
   }
 
   handleAccountError(error) {
-    const errorMessage = 'Failed to validate Spotify account: ';
-    console.error(errorMessage, error);
+    const errorMessage = <p>This functionnality requires you to link your Spotify Premium account.<br/>Please try to <a href="/profile/connect-spotify" target="_blank">link for "playing music" feature</a> and refresh this page</p>;
+    console.error('Failed to validate Spotify account', error);
     if(typeof this.props.onAccountError === "function") {
-      this.props.onAccountError(`${errorMessage} ${error}`);
+      this.props.onAccountError(errorMessage);
     }
   }
 
@@ -200,13 +247,13 @@ export class SpotifyPlayer extends React.Component {
     }
     if (typeof this._spotifyPlayer.disconnect === "function")
     {
-      this._spotifyPlayer.disconnect();
       this._spotifyPlayer.removeListener('initialization_error');
       this._spotifyPlayer.removeListener('authentication_error');
       this._spotifyPlayer.removeListener('account_error');
       this._spotifyPlayer.removeListener('playback_error');
       this._spotifyPlayer.removeListener('ready');
       this._spotifyPlayer.removeListener('player_state_changed');
+      this._spotifyPlayer.disconnect();
     }
     this._spotifyPlayer = null;
     this._firstRun = true;
@@ -214,12 +261,7 @@ export class SpotifyPlayer extends React.Component {
 
   connectSpotifyPlayer(callbackFunction) {
     this.disconnectSpotifyPlayer();
-    if (!this.state.accessToken)
-    {
-      const noTokenErrorMessage = <span> Please try to <a href="/profile/connect-spotify" target="_blank">link your account</a> and refresh this page</span>;
-      this.handleError(noTokenErrorMessage, "No Spotify access token");
-      return;
-    }
+
     this._spotifyPlayer = new window.Spotify.Player({
       name: 'ListenBrainz Player',
       getOAuthToken: authCallback => {


### PR DESCRIPTION
# Summary

* This is a…
    * (x) Bug fix


# Problem
https://tickets.metabrainz.org/projects/LB/issues/LB-432
With a spotify account linked for only recording listens, the resulting scope error was not recognised as such, and the player entered a loop of reconnection/retry until Spotify complained about too many attempts.

I implemented an initial check of the token scopes to save some other error being thrown (and caught adequately) by the Spotify web player.

While I was at it I improved the component unmounting in case of fallback to embedded player.