### PR TITLE
Fix player icon for direction

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/playback-controls.jsx
+++ b/listenbrainz/webserver/static/js/jsx/playback-controls.jsx
@@ -57,7 +57,7 @@ export class PlaybackControls extends React.Component {
             </div>
             {this.props.direction !== "hidden" &&
               <div className="right btn btn-xs" onClick={this.props.toggleDirection} title={`Play ${this.props.direction === 'up' ? 'down' : 'up'}`}>
-                <FontAwesomeIcon icon={this.state.direction === 'up' ? faSortAmountUp : faSortAmountDown}/>
+                <FontAwesomeIcon icon={this.props.direction === 'up' ? faSortAmountUp : faSortAmountDown}/>
               </div>
             }
           </div>


### PR DESCRIPTION
* This is a…
    * (x) Bug fix

# Problem

In the playback controls, the icon for playing up or down the list was stuck showing "playing down"  position, even though the rest of the mechanism was working fine.
