### PR TITLE
Make spotify reader parse listens in a less restrictive way

### DIFF
--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -59,26 +59,32 @@ def _convert_spotify_play_to_listen(play, listen_type):
             'listened_at': int(parser.parse(play['played_at']).timestamp()),
         }
 
+    if track is None:
+        return None
 
-    album = track['album']
-    artists = track['artists']
-    album_artists = album['artists']
-    artist_name = ', '.join([a['name'] for a in artists])
-    album_artist_name = ', '.join([a['name'] for a in album_artists])
+    album = track.get('album', {})
+    artists = track.get('artists', [])
+    album_artists = album.get('artists', [])
+    artist_name = ', '.join([a.get('name') for a in artists if a.get('name')])
+    album_artist_name = ', '.join([a.get('name') for a in album_artists if a.get('name')])
 
     additional = {
-        'tracknumber': track['track_number'],
-        'spotify_artist_ids': [a['external_urls']['spotify'] for a in artists],
-        'artist_names': [a['name'] for a in artists],
+        'tracknumber': track.get('track_number'),
+        'spotify_artist_ids': [
+            a.get('external_urls', {}).get('spotify') for a in artists if a.get('external_urls', {}).get('spotify')
+        ],
+        'artist_names': [a.get('name') for a in artists if a.get('name')],
         'listening_from': 'spotify',
-        'discnumber': track['disc_number'],
-        'duration_ms': track['duration_ms'],
-        'spotify_album_id': track['album']['external_urls']['spotify'],
+        'discnumber': track.get('disc_number'),
+        'duration_ms': track.get('duration_ms'),
+        'spotify_album_id': album.get('external_urls', {}).get('spotify'),
         # Named 'release_*' because 'release_name' is an official name in the docs
         'release_artist_name': album_artist_name,
-        'release_artist_names': [a['name'] for a in album_artists],
+        'release_artist_names': [a.get('name') for a in album_artists if a.get('name')],
         # Named 'album_*' because Spotify calls it album and this is spotify-specific
-        'spotify_album_artist_ids': [a['external_urls']['spotify'] for a in album_artists],
+        'spotify_album_artist_ids': [
+            a.get('external_urls', {}).get('spotify') for a in album_artists if a.get('external_urls', {}).get('spotify')
+        ],
     }
     isrc = track.get('external_ids', {}).get('isrc')
     spotify_url = track.get('external_urls', {}).get('spotify')

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -64,9 +64,19 @@ def _convert_spotify_play_to_listen(play, listen_type):
 
     album = track.get('album', {})
     artists = track.get('artists', [])
-    album_artists = album.get('artists', [])
     artist_name = ', '.join([a.get('name') for a in artists if a.get('name')])
-    album_artist_name = ', '.join([a.get('name') for a in album_artists if a.get('name')])
+
+    album_artists = album.get('artists', [])
+    release_artist_names = []
+    spotify_album_artist_ids = []
+    for a in album_artists:
+        name = a.get('name')
+        if name is not None:
+            release_artist_names.append(name)
+        spotify_id = a.get('external_urls', {}).get('spotify')
+        if spotify_id is not None:
+            spotify_album_artist_ids.append(spotify_id)
+    album_artist_name = ', '.join(release_artist_names)
 
     additional = {
         'tracknumber': track.get('track_number'),
@@ -80,11 +90,9 @@ def _convert_spotify_play_to_listen(play, listen_type):
         'spotify_album_id': album.get('external_urls', {}).get('spotify'),
         # Named 'release_*' because 'release_name' is an official name in the docs
         'release_artist_name': album_artist_name,
-        'release_artist_names': [a.get('name') for a in album_artists if a.get('name')],
+        'release_artist_names': release_artist_names,
         # Named 'album_*' because Spotify calls it album and this is spotify-specific
-        'spotify_album_artist_ids': [
-            a.get('external_urls', {}).get('spotify') for a in album_artists if a.get('external_urls', {}).get('spotify')
-        ],
+        'spotify_album_artist_ids': spotify_album_artist_ids,
     }
     isrc = track.get('external_ids', {}).get('isrc')
     spotify_url = track.get('external_urls', {}).get('spotify')

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -62,10 +62,19 @@ def _convert_spotify_play_to_listen(play, listen_type):
     if track is None:
         return None
 
-    album = track.get('album', {})
     artists = track.get('artists', [])
-    artist_name = ', '.join([a.get('name') for a in artists if a.get('name')])
+    artist_names = []
+    spotify_artist_ids = []
+    for a in artists:
+        name = a.get('name')
+        if name is not None:
+            artist_names.append(name)
+        spotify_id = a.get('external_urls', {}).get('spotify')
+        if spotify_id is not None:
+            spotify_artist_ids.append(spotify_id)
+    artist_name = ', '.join(artist_names)
 
+    album = track.get('album', {})
     album_artists = album.get('artists', [])
     release_artist_names = []
     spotify_album_artist_ids = []
@@ -80,10 +89,8 @@ def _convert_spotify_play_to_listen(play, listen_type):
 
     additional = {
         'tracknumber': track.get('track_number'),
-        'spotify_artist_ids': [
-            a.get('external_urls', {}).get('spotify') for a in artists if a.get('external_urls', {}).get('spotify')
-        ],
-        'artist_names': [a.get('name') for a in artists if a.get('name')],
+        'spotify_artist_ids': spotify_artist_ids,
+        'artist_names': artist_names,
         'listening_from': 'spotify',
         'discnumber': track.get('disc_number'),
         'duration_ms': track.get('duration_ms'),


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * (x) Bug fix
    * () Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other



# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

There were errors in JIRA because we expected some keys from spotify that didn't exist. 
# Solution
This PR makes spotify reader more resistant to missing keys.

