### PR TITLE
Spotify player state silent

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -350,8 +350,7 @@ export class SpotifyPlayer extends React.Component {
     }
     // How do we accurately detect the end of a song?
     // From https://github.com/spotify/web-playback-sdk/issues/35#issuecomment-469834686
-    if (position === 0 && paused === true &&
-      _.has(state, "restrictions.disallow_resuming_reasons") && state.restrictions.disallow_resuming_reasons[0] === "not_paused")
+    if (position === 0 && paused === true)
     {
       // Track finished, play next track
       console.debug("Detected Spotify end of track, playing next track");

--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -326,7 +326,7 @@ export class SpotifyPlayer extends React.Component {
   startPlayerStateTimer() {
     this._playerStateTimerID = setInterval(()=>{
       this._spotifyPlayer.getCurrentState().then(this.handlePlayerStateChanged)
-    }, 200);
+    }, 500);
   }
   stopPlayerStateTimer() {
     clearInterval(this._playerStateTimerID);
@@ -336,7 +336,6 @@ export class SpotifyPlayer extends React.Component {
     if(!state) {
       return;
     }
-    console.debug('Spotify player state', state);
     const {
       paused,
       position,
@@ -355,7 +354,8 @@ export class SpotifyPlayer extends React.Component {
       _.has(state, "restrictions.disallow_resuming_reasons") && state.restrictions.disallow_resuming_reasons[0] === "not_paused")
     {
       // Track finished, play next track
-      console.debug("Detected Spotify end of track, playing next track")
+      console.debug("Detected Spotify end of track, playing next track");
+      console.debug('Spotify player state', state);
       this.debouncedPlayNextTrack();
       return;
     }


### PR DESCRIPTION
# Summary

* This is a…
    * ( ) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * (x) Minor / simple change (like a typo)
    * ( ) Other


Player state check is called too often (I don't see a need for more than twice a second), and each time logging its output while playing music.
That's a lot of console output.

I was also previously able to skip songs using my keyboard media keys. The song end detection method was too restrictive to allow that, so I changed it back. Song detection functionality remains otherwise unchanged.

