### PR TITLE
LB-439: Allow cross-origin requests for playing now and listens api endpoints

### DIFF
--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -77,6 +77,7 @@ def submit_listen():
 
 
 @api_bp.route("/user/<user_name>/listens")
+@crossdomain()
 @ratelimit()
 def get_listens(user_name):
     """
@@ -136,6 +137,7 @@ def get_listens(user_name):
 
 
 @api_bp.route("/user/<user_name>/playing-now")
+@crossdomain()
 @ratelimit()
 def get_playing_now(user_name):
     """


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * ( ) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * (x) Other

* **Describe this change in 1-2 sentences**: Enables cross-origin requests for two API endpoints so requests can be made to retrieve basic user activity like recent listen info via the browser / javascript.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

It's currently not possible for a website to make a request to any of the endpoints that get data about a users current or recent listens, as a cross-origin request error is thrown in the console (even though it's possible in other non-browser based applications).

* JIRA ticket: [LB-439](https://tickets.metabrainz.org/browse/LB-439)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

As the GET endpoints don't use any authorisation, this change adds `@crossdomain()` (used in a few other places already) to `listens` and `playing-now`, allowing cross-origin requests from all domains.