### PR TITLE
Quickfix for LB-447: spotify iframe styling issue = no sound on chrome

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -274,7 +274,10 @@ export class SpotifyPlayer extends React.Component {
       if(callbackFunction){
         callbackFunction();
       }
-      this.startPlayerStateTimer()
+      this.startPlayerStateTimer();
+      if(window.fixSpotifyPlayerStyleIssue) {
+        window.fixSpotifyPlayerStyleIssue();
+      }
     });
 
     this._spotifyPlayer.addListener('player_state_changed', this.handlePlayerStateChanged);
@@ -401,5 +404,17 @@ export class SpotifyPlayer extends React.Component {
         </PlaybackControls>
       </div>
     );
+  }
+}
+
+// Fix for LB-447 (Player does not play any sound)
+// https://github.com/spotify/web-playback-sdk/issues/75#issuecomment-487325589
+window.fixSpotifyPlayerStyleIssue = function(){
+  const iframe = document.querySelector('iframe[src="https://sdk.scdn.co/embedded/index.html"]');
+  if (iframe) {
+    iframe.style.display = 'block';
+    iframe.style.position = 'absolute';
+    iframe.style.top = '-1000px';
+    iframe.style.left = '-1000px';
   }
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * (X) Bug fix
# Problem
[LB-447](https://tickets.metabrainz.org/browse/LB-447)

Recently the ListenBrainz player has stopped working on Chrome, not playing any sound.
This is due to, believe it or not, the css style applied to the iframe the Spotify player injects into the dom. Unbelievable.
https://github.com/spotify/web-playback-sdk/issues/75

# Solution

Added a temporary fix: when the player is ready, call a globally defined function that can access the DOM and correct the style on it.
Because the style is added inline by the Spotify player with `!important`, it can't be overridden with CSS, hence the use of this JS trickery.

# Actions
I'll keep updated with the Spotify github issue and will hopefully be able to remove this once  Spotify fixes their player.