### PR TITLE
Search on Spotify for songs listened to elsewhere

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/profile.jsx
+++ b/listenbrainz/webserver/static/js/jsx/profile.jsx
@@ -225,22 +225,19 @@ class RecentListens extends React.Component {
 
   render() {
 
-    const spotifyListens = this.state.listens.filter(listen => listen.track_metadata
-      && listen.track_metadata.additional_info
-      && listen.track_metadata.additional_info.listening_from === "spotify"
-    );
-
     const getSpotifyEmbedSrc = () => {
       if (this.state.currentListen)
       {
         return getSpotifyEmbedUriFromListen(this.state.currentListen);
-      } else if (spotifyListens.length)
-      {
-
+      }
+      const spotifyListens = this.state.listens.filter(listen =>
+        _.get(listen, "listen.track_metadata.additional_info.listening_from") === "spotify"
+      );
+      if (spotifyListens.length){
         return getSpotifyEmbedUriFromListen(spotifyListens[0]);
       }
-      return null
-    };
+      return null;
+    }
 
     return (
       <div>
@@ -361,7 +358,7 @@ class RecentListens extends React.Component {
               <SpotifyPlayer
                 APIService={this.APIService}
                 ref={this.spotifyPlayer}
-                listens={spotifyListens}
+                listens={this.state.listens}
                 direction={this.state.direction}
                 spotify_user={this.props.spotify}
                 onCurrentListenChange={this.handleCurrentListenChange}

--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -125,7 +125,7 @@ export class SpotifyPlayer extends React.Component {
   }
 
   playListen(listen) {
-    if (listen.track_metadata.additional_info.spotify_id)
+    if (_.get(listen,"track_metadata.additional_info.spotify_id"))
     {
       this.play_spotify_uri(getSpotifyUriFromListen(listen));
       this.props.onCurrentListenChange(listen);

--- a/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
+++ b/listenbrainz/webserver/static/js/jsx/spotify-player.jsx
@@ -71,12 +71,13 @@ export class SpotifyPlayer extends React.Component {
   search_and_play_track(listen) {
     const trackName = _.get(listen,"track_metadata.track_name");
     const artistName = _.get(listen,"track_metadata.artist_name");
-    if (!trackName || !artistName)
+    const releaseName = _.get(listen,"track_metadata.release_name");
+    if (!trackName)
     {
       return this.handleWarning("Not enough info to search on Spotify");
     }
     
-    searchForSpotifyTrack(this.state.accessToken, trackName, artistName)
+    searchForSpotifyTrack(this.state.accessToken, trackName, artistName, releaseName)
     .then(track => {
       // Track should be a Spotify track object:
       // https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full

--- a/listenbrainz/webserver/static/js/jsx/utils.jsx
+++ b/listenbrainz/webserver/static/js/jsx/utils.jsx
@@ -1,11 +1,10 @@
-import { faPlayCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react'; // jsx compiled to React.createElement
+import { faPlayCircle } from '@fortawesome/free-solid-svg-icons'
 
 export function getSpotifyEmbedUriFromListen(listen){
 	
-	if(!listen || !listen.track_metadata || !listen.track_metadata.additional_info ||
-		typeof listen.track_metadata.additional_info.spotify_id !== "string"){
+	if( typeof _.get(listen,"track_metadata.additional_info.spotify_id") !== "string"){
 		return null;
 	}
 	const spotifyId = listen.track_metadata.additional_info.spotify_id;
@@ -17,29 +16,32 @@ export function getSpotifyEmbedUriFromListen(listen){
 }
 
 export function getArtistLink(listen) {
-  if (listen.track_metadata.additional_info.artist_mbids && listen.track_metadata.additional_info.artist_mbids.length)
+  const artistName = _.get(listen,"track_metadata.artist_name");
+  const firstArtist = _.first(_.get(listen,"track_metadata.additional_info.artist_mbids"));
+  if (firstArtist)
   {
-    return (<a href={`http://musicbrainz.org/artist/${listen.track_metadata.additional_info.artist_mbids[0]}`}
+    return (<a href={`http://musicbrainz.org/artist/${firstArtist}`}
       target="_blank">
-      {listen.track_metadata.artist_name}
+      {artistName}
     </a>);
   }
-  return listen.track_metadata.artist_name
+  return artistName;
 }
 
 export function getTrackLink(listen) {
-  if (listen.track_metadata.additional_info.recording_mbid)
+  const trackName = _.get(listen,"track_metadata.track_name");
+  if (_.get(listen,"track_metadata.additional_info.recording_mbid"))
   {
     return (<a href={`http://musicbrainz.org/recording/${listen.track_metadata.additional_info.recording_mbid}`}
       target="_blank">
-      {listen.track_metadata.track_name}
+      {trackName}
     </a>);
   }
-  return listen.track_metadata.track_name;
+  return trackName;
 }
 
 export function getPlayButton(listen, onClickFunction) {
-  if (listen.track_metadata.additional_info.spotify_id)
+  if (_.get(listen,"track_metadata.additional_info.spotify_id"))
   {
     return (
       <button title="Play" className="btn-link" onClick={onClickFunction.bind(listen)}>

--- a/listenbrainz/webserver/static/js/jsx/utils.jsx
+++ b/listenbrainz/webserver/static/js/jsx/utils.jsx
@@ -14,7 +14,7 @@ export function getSpotifyEmbedUriFromListen(listen){
 	return  spotifyId.replace("https://open.spotify.com/","https://open.spotify.com/embed/");
 }
 
-export async function searchForSpotifyTrack(spotifyToken, trackName, artistName) {
+export async function searchForSpotifyTrack(spotifyToken, trackName, artistName, releaseName) {
   if(!spotifyToken) {
     throw new Error({status:403,message: "You need to connect to your Spotify account"});
   }
@@ -22,7 +22,11 @@ export async function searchForSpotifyTrack(spotifyToken, trackName, artistName)
     console.error("searchForSpotifyTrack was not passed a trackName, cannot proceed");
     return null;
   }
-  const queryString = `q="${trackName}" artist:${artistName}&type=track`;
+  const queryString = `q="${trackName}"
+    ${artistName &&  " artist:"+artistName}
+    ${releaseName &&  " album:"+releaseName}
+    &type=track`;
+    
   const response = await fetch(`https://api.spotify.com/v1/search?${encodeURI(queryString)}`, {
     method: 'GET',
     headers: {


### PR DESCRIPTION

# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other


So far we've only been able to play songs that have been listened to through Spotify.
This PR aims to implement a first attempt at searching for a matching track and artist on Spotify, and playing that.

Caveats:
• Currently we play the first result returned by the Spotify search API. However that first result might not be the correct version (for example it might return a live version of the song as first result, and a second result with an exact matching name.
Passing an album title as well helps but all in all it is not fully reliable.
• Using the Spotify search API requires a Spotify user token. Spotify free users should be able to get an embedded player with the full song.
However, that requires fetching aynchronously the result on the Spotify API, and async functions in a react component rendre method is a no-no. I'll have to think about how to implement it best. In the meantime we only offer embedded iframe players for songs listened to on Spotify, same as before.