### PR TITLE
Skip listens which cause client errors in influx

### DIFF
--- a/listenbrainz/influx_writer/influx_writer.py
+++ b/listenbrainz/influx_writer/influx_writer.py
@@ -78,11 +78,14 @@ class InfluxWriterSubscriber(ListenWriter):
             try:
                 self.ls.insert(data)
                 return len(data)
-            except (InfluxDBServerError, InfluxDBClientError, ValueError) as e:
+            except (InfluxDBServerError, ValueError) as e:
                 failure_count += 1
                 if failure_count >= retries:
                     break
                 sleep(self.ERROR_RETRY_DELAY)
+            except InfluxDBClientError as e:
+                current_app.logger.error("Cannot write data because of ClientError, data = %s" % json.dumps(data, indent=4), exc_info=True)
+                return 0
             except ConnectionError as e:
                 current_app.logger.error("Cannot write data to listenstore: %s. Sleep." % str(e), exc_info=True)
                 sleep(self.ERROR_RETRY_DELAY)


### PR DESCRIPTION
This is a temporary fix to get the pipeline moving,
while we look into better solutions to the type mismatch problem.

