### PR TITLE
Incremental data dumps

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -33,7 +33,15 @@ source admin/functions.sh
 
 TEMP_DIR="/home/listenbrainz/data/dumps"
 
-/usr/local/bin/python manage.py dump create -l $TEMP_DIR -t $DUMP_THREADS
+DUMP_TYPE=${1:-full}
+if [ $DUMP_TYPE == "full" ]; then
+    /usr/local/bin/python manage.py dump create_full -l $TEMP_DIR -t $DUMP_THREADS --last-dump-id
+elif [ $DUMP_TYPE == "incremental"] then
+    /usr/local/bin/python manage.py dump create_incremental -l $TEMP_DIR -t $DUMP_THREADS
+else
+    echo "Not sure what type of dump to create, exiting!"
+    exit 1
+fi
 
 DUMP_NAME=`ls $TEMP_DIR | sort -r | head -1`
 DUMP_TIMESTAMP=`echo $DUMP_NAME | awk -F '-' '{ printf "%s-%s", $3, $4 }'`

--- a/docker/beta/uwsgi/uwsgi.service
+++ b/docker/beta/uwsgi/uwsgi.service
@@ -2,6 +2,9 @@
 
 if [ "${CONTAINER_NAME}" = "listenbrainz-web-beta" ]
 then
+    rm -f /etc/service/cron/down
+    sv restart cron
+
     exec uwsgi /etc/uwsgi/uwsgi.ini
 fi
 

--- a/docker/crontab
+++ b/docker/crontab
@@ -5,5 +5,8 @@ GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentia
 # Statistics calculation via Google BigQuery
 0 0 * * 1 /usr/local/bin/python /code/listenbrainz/manage.py stats populate_queue>> /var/log/stats.log 2>&1
 
-# Data dumps creation for backup and public use
-4 0 1,15 * * /code/listenbrainz/admin/create-dumps.sh >> /var/log/dump_create.log 2>&1
+# Full Data dumps creation for backup and public use
+00 12 1,15 * * /code/listenbrainz/admin/create-dumps.sh full >> /var/log/dump_create.log 2>&1
+
+# Incremental listen data dumps at 00:00 every Sunday
+00 00 * * 0 /code/listenbrainz/admin/create-dumps.sh incrementeal >> /var/log/dump_create.log 2>&1

--- a/docker/crontab
+++ b/docker/crontab
@@ -9,4 +9,4 @@ GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentia
 00 12 1,15 * * /code/listenbrainz/admin/create-dumps.sh full >> /var/log/dump_create.log 2>&1
 
 # Incremental listen data dumps at 00:00 every Sunday
-00 00 * * 0 /code/listenbrainz/admin/create-dumps.sh incrementeal >> /var/log/dump_create.log 2>&1
+00 00 * * 0 /code/listenbrainz/admin/create-dumps.sh incremental >> /var/log/dump_create.log 2>&1

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -343,6 +343,7 @@ def get_dump_entries():
 
         return [dict(row) for row in result]
 
+
 def get_dump_entry(dump_id):
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
@@ -355,6 +356,7 @@ def get_dump_entry(dump_id):
         if result.rowcount > 0:
             return dict(result.fetchone())
         return None
+
 
 def import_postgres_dump(private_dump_archive_path=None, public_dump_archive_path=None, threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Imports postgres dump created by dump_postgres_db present at location.

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -166,18 +166,6 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
 
     current_app.logger.info('Dump of public data created at %s!', public_dump)
 
-
-    current_app.logger.info('Creating a new entry in the data_dump table...')
-    while True:
-        try:
-            dump_id = add_dump_entry(dump_time.strftime('%s'))
-            break
-        except Exception as e:
-            current_app.logger.warn('Error while adding dump entry: %s, trying again...', str(e), exc_info=True)
-            time.sleep(3)
-
-    current_app.logger.info('New entry with id %d added to data_dump table!', dump_id)
-
     current_app.logger.info('ListenBrainz PostgreSQL data dump created at %s!', location)
     return private_dump, public_dump
 

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -355,6 +355,18 @@ def get_dump_entries():
 
         return [dict(row) for row in result]
 
+def get_dump_entry(dump_id):
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT id, created
+              FROM data_dump
+             WHERE id = :dump_id
+        """), {
+            'dump_id': dump_id,
+        })
+        if result.rowcount > 0:
+            return dict(result.fetchone())
+        return None
 
 def import_postgres_dump(private_dump_archive_path=None, public_dump_archive_path=None, threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Imports postgres dump created by dump_postgres_db present at location.

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -109,13 +109,3 @@ class DumpTestCase(DatabaseTestCase):
             self.assertEqual(user_count, 1)
             two_id = db_user.create(2, 'vnskprk')
             self.assertGreater(two_id, one_id)
-
-
-    def test_dump_postgres_db_table_entries(self):
-        with self.app.app_context():
-            db_user.create(1, 'test_user')
-            timestamp = datetime.today()
-            location = db_dump.dump_postgres_db(self.tempdir, dump_time=timestamp)
-            dump_entries = db_dump.get_dump_entries()
-            self.assertEqual(len(dump_entries), 1)
-            self.assertEqual(dump_entries[0]['created'].strftime('%s'), timestamp.strftime('%s'))

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -33,17 +33,37 @@ class DumpManagerTestCase(unittest.TestCase):
 
 
     def test_cleanup_dumps(self):
-        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-20180312-000001'))
-        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-20180312-000002'))
-        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-20180312-000003'))
-        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-20180312-000004'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-1-20180312-000001-full'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-2-20180312-000002-full'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-3-20180312-000003-full'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-4-20180312-000004-full'))
+
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-1-20180312-000001-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-2-20180312-000002-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-3-20180312-000003-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-4-20180312-000004-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-5-20180312-000005-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-6-20180312-000006-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-7-20180312-000007-incremental'))
+
         create_path(os.path.join(self.tempdir, 'not-a-dump'))
 
         dump_manager._cleanup_dumps(self.tempdir)
 
         newdirs = os.listdir(self.tempdir)
-        self.assertNotIn('listenbrainz-dump-20180312-000001', newdirs)
-        self.assertNotIn('listenbrainz-dump-20180312-000002', newdirs)
-        self.assertIn('listenbrainz-dump-20180312-000003', newdirs)
-        self.assertIn('listenbrainz-dump-20180312-000003', newdirs)
+        self.assertNotIn('listenbrainz-dump-1-20180312-000001-full', newdirs)
+        self.assertNotIn('listenbrainz-dump-2-20180312-000002-full', newdirs)
+
+        self.assertIn('listenbrainz-dump-3-20180312-000003-full', newdirs)
+        self.assertIn('listenbrainz-dump-4-20180312-000004-full', newdirs)
+
+        self.assertNotIn('listenbrainz-dump-1-20180312-000001-incremental', newdirs)
+
+        self.assertIn('listenbrainz-dump-2-20180312-000002-incremental', newdirs)
+        self.assertIn('listenbrainz-dump-3-20180312-000003-incremental', newdirs)
+        self.assertIn('listenbrainz-dump-4-20180312-000004-incremental', newdirs)
+        self.assertIn('listenbrainz-dump-5-20180312-000005-incremental', newdirs)
+        self.assertIn('listenbrainz-dump-6-20180312-000006-incremental', newdirs)
+        self.assertIn('listenbrainz-dump-7-20180312-000007-incremental', newdirs)
+
         self.assertIn('not-a-dump', newdirs)

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -653,8 +653,9 @@ class InfluxListenStore(ListenStore):
             users (List[dict]): A list of all users
             start_time and end_time: the range of time for which listens are to be dumped
         """
-        for user in users:
+        for i, user in enumerate(users):
             self.dump_user_for_spark(user['musicbrainz_id'], start_time, end_time, listens_path)
+            self.log.info("%d users done. Total: %d", i + 1, len(users))
 
 
     def write_dump_index_file(self, index, temp_dir, tar, archive_name):

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -15,13 +15,8 @@ def generate_data(test_user_id, user_name, from_ts, num_records):
     test_data = []
     artist_msid = str(uuid.uuid4())
 
-    if from_ts == None:  #check for playing now listens
-        timestamp = None
-    else:
-        from_ts += 1   # Add one second
-        timestamp = datetime.utcfromtimestamp(from_ts)
-
     for i in range(num_records):
+        timestamp = datetime.utcfromtimestamp(from_ts)
         item = Listen(
             user_name=user_name,
             user_id=test_user_id,
@@ -35,6 +30,8 @@ def generate_data(test_user_id, user_name, from_ts, num_records):
             },
         )
         test_data.append(item)
+        from_ts += 1   # Add one second
+
     return test_data
 
 


### PR DESCRIPTION
Currently this only supports incremental data dumps for listens (which is really the only important data we have right now, so shouldn't be a problem). 

I added commands to create incremental dumps. You can also pass IDs to recreate dumps if needed.

TODO:

- [x] Fix tests
- [x] Add documentation
- [x] Add tests
- [x] Change cronjobs to create both
- [x] See if the data dump scripts which sync to FTP need changes as well