### PR TITLE
LB-438 / LB-444: Return username in validate-token endpoint and improve documentation

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -394,6 +394,8 @@ class APITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json['code'], 200)
         self.assertEqual('Token invalid.', response.json['message'])
+        self.assertFalse(response.json['valid'])
+        self.assertNotIn('user_name', response.json)
 
 
     def test_valid_token_validation(self):
@@ -403,6 +405,9 @@ class APITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json['code'], 200)
         self.assertEqual('Token valid.', response.json['message'])
+        self.assertTrue(response.json['valid'])
+        self.assertEqual(response.json['user_name'], self.user['musicbrainz_id'])
+
 
     def test_get_playing_now(self):
         """ Test for valid submission and retrieval of listen_type 'playing_now'

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -272,8 +272,10 @@ def validate_token():
     """
     Check whether a User Token is a valid entry in the database.
 
-    In order to query this endpoint, send a GET request.
-    A JSON response will be returned, with one of three codes.
+    In order to query this endpoint, send a GET request with the token to check
+    as the `token` argument (example: /validate-token?token=token-to-check)
+
+    A JSON response will be returned, with one of two codes.
 
     :statuscode 200: The user token is valid/invalid.
     :statuscode 400: No token was sent to the endpoint.

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -287,12 +287,14 @@ def validate_token():
     if user is None:
         return jsonify({
             'code': 200,
-            'message': 'Token invalid.'
+            'message': 'Token invalid.',
+            'valid': False,
         })
     else:
         return jsonify({
             'code': 200,
-            'message': 'Token valid.'
+            'message': 'Token valid.',
+            'valid': True,
         })
 
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -295,6 +295,7 @@ def validate_token():
             'code': 200,
             'message': 'Token valid.',
             'valid': True,
+            'user_name': user['musicbrainz_id'],
         })
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * ( ) Bug fix
    * (x) Feature addition
    * ( ) Refactoring
    * (x) Minor / simple change (like a typo)
    * ( ) Other



# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->



A user was confused by the documentation into incorrect usage of the validate-token endpoint.

Also, there was a feature request to return usernames as well with valid tokens.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Improve documentation and the data returned by the endpoint.



