### PR TITLE
Fix name of variable in spark listens dump

### DIFF
--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -440,8 +440,8 @@ class InfluxListenStore(ListenStore):
             listens : the listens to be written into the disk
             temp_dir: the dir into which listens should be written
         """
-        for year in unwritten_listens:
-            for month in unwritten_listens[year]:
+        for year in listens:
+            for month in listens[year]:
                 if year < 2002:
                     directory = temp_dir
                     filename = os.path.join(directory, 'invalid.json')
@@ -450,7 +450,7 @@ class InfluxListenStore(ListenStore):
                     filename = os.path.join(directory, '{}.json'.format(str(month)))
                 create_path(directory)
                 with open(filename, 'a') as f:
-                    f.write('\n'.join([ujson.dumps(listen) for listen in unwritten_listens[year][month]]))
+                    f.write('\n'.join([ujson.dumps(listen) for listen in listens[year][month]]))
                     f.write('\n')
 
 

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -169,6 +169,16 @@ class TestInfluxListenStore(DatabaseTestCase):
         )
         self.assertTrue(os.path.isfile(dump))
 
+    def test_dump_listens_spark_format(self):
+        self._create_test_data(self.testuser_name)
+        temp_dir = tempfile.mkdtemp()
+        dump = self.logstore.dump_listens(
+            location=temp_dir,
+            dump_id=1,
+            spark_format=True
+        )
+        self.assertTrue(os.path.isfile(dump))
+
     def test_incremental_dump(self):
         """ Dump and import listens
         """


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * (x) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

* **Describe this change in 1-2 sentences**: Fix name of variable in spark listens dump

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

There was a bug added during the recent incremental dumps PR, due to change of names.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Fix the name and add a test to make sure it doesn't happen again.



