### PR TITLE
Change the schedule of incremental data dumps and other general improvements

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -66,7 +66,7 @@ else
 fi
 
 
-DUMP_NAME=`ls $TEMP_DIR/$SUB_DIR | sort -r | head -1`
+DUMP_NAME=`ls -t $TEMP_DIR/$SUB_DIR | head -1`
 DUMP_TIMESTAMP=`echo $DUMP_NAME | awk -F '-' '{ printf "%s-%s", $4, $5 }'`
 DUMP_ID=`echo $DUMP_NAME | awk -F '-' '{ printf "%s", $3}'`
 echo "Dump created with timestamp $DUMP_TIMESTAMP"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -130,6 +130,7 @@ cat $FTP_CURRENT_DUMP_DIR/.rsync-filter
 
 
 /usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR"/$SUB_DIR
+/usr/local/bin/python manage.py dump delete_old_dumps $BACKUP_DIR/$SUB_DIR
 
 # rsync to ftp folder taking care of the rules
 ./admin/rsync-dump-files.sh $DUMP_TYPE

--- a/docker/crontab
+++ b/docker/crontab
@@ -8,5 +8,5 @@ GOOGLE_APPLICATION_CREDENTIALS=/code/listenbrainz/credentials/bigquery-credentia
 # Full Data dumps creation for backup and public use
 00 12 1,15 * * /code/listenbrainz/admin/create-dumps.sh full >> /var/log/dump_create.log 2>&1
 
-# Incremental listen data dumps at 00:00 every Sunday
-00 00 * * 0 /code/listenbrainz/admin/create-dumps.sh incremental >> /var/log/dump_create.log 2>&1
+# Incremental listen data dumps at 00:00 every Monday and Thursday
+00 00 * * 1,4 /code/listenbrainz/admin/create-dumps.sh incremental >> /var/log/dump_create.log 2>&1


### PR DESCRIPTION
* Sort the output of ls by modified date to make sure the `create-dumps.sh` script gets the correct name
* Delete old dumps from the backup directory 

# Schedule

4 incremental dumps are up on [FTP](http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/incremental/).

| Dump ID | Time interval | Size  |
|---------|---------------|-------|
| 56      | 48 hours      | 20 MB |
| 57      | ~40 hours     | 1 MB  |
| 58      | 24 hours      | 1 MB  |

Seems to me like doing it twice or thrice a week should be okay.
