### PR TITLE
Make sure dumps include consistent user lists

### DIFF
--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -164,7 +164,7 @@ class UserTestCase(DatabaseTestCase):
                 self.assertIn(column, user)
 
         # check that only id is present if columns = ['id']
-        users = db_user.get_all_users(['id'])
+        users = db_user.get_all_users(columns=['id'])
         for user in users:
             self.assertIn('id', user)
             for column in db_user.USER_GET_COLUMNS:

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -294,6 +294,7 @@ def get_all_users(created_before=None, columns=None):
 
         Args:
             columns: a list of columns to be returned for each user
+            created_before (datetime): only return users who were created before this timestamp, defaults to now
 
         Returns: if columns is None, A list of dicts of the following format for each user
             {

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -1,10 +1,9 @@
-
 import logging
-
+import sqlalchemy
 import uuid
 
-import sqlalchemy
 
+from datetime import datetime
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz import config
@@ -290,7 +289,7 @@ def get_users_with_uncalculated_stats():
         return [dict(row) for row in result]
 
 
-def get_all_users(columns=None):
+def get_all_users(created_before=None, columns=None):
     """ Returns a list of all users in the database
 
         Args:
@@ -312,12 +311,18 @@ def get_all_users(columns=None):
     if columns is None:
         columns = USER_GET_COLUMNS
 
+    if created_before is None:
+        created_before = datetime.now()
+
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
                 SELECT {columns}
                   FROM "user"
+                 WHERE created <= :created
               ORDER BY id
-            """.format(columns=', '.join(columns))))
+            """.format(columns=', '.join(columns))),{
+                "created": created_before,
+            })
 
         return [dict(row) for row in result]
 

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -716,7 +716,7 @@ class InfluxListenStore(ListenStore):
         self.log.info('Beginning dump of listens from InfluxDB...')
 
         self.log.info('Getting list of users whose listens are to be dumped...')
-        users = db_user.get_all_users(columns=['id', 'musicbrainz_id'])
+        users = db_user.get_all_users(columns=['id', 'musicbrainz_id'], created_before=end_time)
         self.log.info('Total number of users: %d', len(users))
 
         if start_time == datetime.utcfromtimestamp(0):

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -691,7 +691,7 @@ class InfluxListenStore(ListenStore):
             raise
 
 
-    def dump_listens(self, location, dump_id, start_time=datetime.utcfromtimestamp(0), end_time=datetime.now(),
+    def dump_listens(self, location, dump_id, start_time=datetime.utcfromtimestamp(0), end_time=None,
             threads=DUMP_DEFAULT_THREAD_COUNT, spark_format=False):
         """ Dumps all listens in the ListenStore into a .tar.xz archive.
 
@@ -712,6 +712,9 @@ class InfluxListenStore(ListenStore):
         Returns:
             the path to the dump archive
         """
+
+        if end_time is None:
+            end_time = datetime.now()
 
         self.log.info('Beginning dump of listens from InfluxDB...')
 


### PR DESCRIPTION
Only dump those users who had been created in the range of the dump. This is more important when we're recreating old dumps.