### PR TITLE
Fix bug where listens weren't added to spark dump archive

### DIFF
--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -746,6 +746,7 @@ class InfluxListenStore(ListenStore):
                 listens_path = os.path.join(temp_dir, 'listens')
                 if spark_format:
                     self.write_listens_for_spark(listens_path, users, start_time, end_time)
+                    tar.add(listens_path, arcname=os.path.join(archive_name, 'listens'))
                 else:
                     index = self.write_listens_to_dump(listens_path, users, tar, archive_name, start_time, end_time)
                     self.write_dump_index_file(index, temp_dir, tar, archive_name)

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -349,7 +349,7 @@ class InfluxListenStore(ListenStore):
 
 
     def fetch_recent_listens_for_users(self, user_list, limit = 2, max_age = 3600):
-        """ Fetch recent listens for a list of users, given a limit which applies per user. If you 
+        """ Fetch recent listens for a list of users, given a limit which applies per user. If you
             have a limit of 3 and 3 users you should get 9 listens if they are available.
 
             user_list: A list containing the users for which you'd like to retrieve recent listens.
@@ -361,7 +361,7 @@ class InfluxListenStore(ListenStore):
         for user_name in user_list:
            escaped_user_list.append(get_escaped_measurement_name(user_name))
 
-        query = "SELECT username, * FROM " + ",".join(escaped_user_list) 
+        query = "SELECT username, * FROM " + ",".join(escaped_user_list)
         query += " WHERE time > " + get_influx_query_timestamp(int(time.time()) - max_age)
         query += " ORDER BY time DESC LIMIT " + str(limit)
         try:

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -150,13 +150,13 @@ class TestInfluxListenStore(DatabaseTestCase):
         user_name2 = user['musicbrainz_id']
         self._create_test_data(user_name2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], limit=1, max_age=10000000000) 
+        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], limit=1, max_age=10000000000)
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], max_age=10000000000) 
+        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], max_age=10000000000)
         self.assertEqual(len(recent), 4)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name], max_age = int(time.time()) - recent[0].ts_since_epoch + 1) 
+        recent = self.logstore.fetch_recent_listens_for_users([user_name], max_age = int(time.time()) - recent[0].ts_since_epoch + 1)
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)
 


### PR DESCRIPTION
This was caused by the recent refactor to add files to normal
dumps one by one. To do something similar for spark dumps would
require a relatively big refactor, so we just add all the files
at once for the spark dumps for now.

Added a more comprehensive test for spark dumps to make sure
this doesn't happen again.