### PR TITLE
Skip listens with inserted_timestamps not in time range

### DIFF
--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -475,6 +475,14 @@ class InfluxListenStore(ListenStore):
                 result = self.get_incremental_listens_batch(username, start_time, end_time, offset)
             rows_added = 0
             for row in result.get_points(get_measurement_name(username)):
+
+                # make sure that listen was inserted in current dump's time range
+                # need to do this check in python, because influx doesn't
+                # do "IS NULL" operations and we have null inserted_timestamps from
+                # old data
+                if datetime.utcfromtimestamp(row.get('inserted_timestamp', 0)) > end_time:
+                    continue
+
                 listen = convert_influx_row_to_spark_row(row)
                 timestamp = convert_influx_to_datetime(row['time'])
 
@@ -521,6 +529,14 @@ class InfluxListenStore(ListenStore):
 
             rows_added = 0
             for row in result.get_points(get_measurement_name(username)):
+
+                # make sure that listen was inserted in current dump's time range
+                # need to do this check in python, because influx doesn't
+                # do "IS NULL" operations and we have null inserted_timestamps from
+                # old data
+                if datetime.utcfromtimestamp(row.get('inserted_timestamp', 0)) > end_time:
+                    continue
+
                 listen = Listen.from_influx(row).to_api()
                 listen['user_name'] = username
                 try:

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -453,7 +453,7 @@ class InfluxListenStore(ListenStore):
                     f.write('\n'.join([ujson.dumps(listen) for listen in listens[year][month]]))
                     f.write('\n')
 
-    def row_inserted_before(self, row, timestamp):
+    def row_inserted_before_or_equal(self, row, timestamp):
         """ Check that the influx row passed was inserted to influx before the specified timestamp
 
         Args:
@@ -496,7 +496,7 @@ class InfluxListenStore(ListenStore):
                 # need to do this check in python, because influx doesn't
                 # do "IS NULL" operations and we have null inserted_timestamps from
                 # old data
-                if not self.row_inserted_before(row, end_time):
+                if not self.row_inserted_before_or_equal(row, end_time):
                     continue
 
                 listen = convert_influx_row_to_spark_row(row)
@@ -550,7 +550,7 @@ class InfluxListenStore(ListenStore):
                 # need to do this check in python, because influx doesn't
                 # do "IS NULL" operations and we have null inserted_timestamps from
                 # old data
-                if not self.row_inserted_before(row, end_time):
+                if not self.row_inserted_before_or_equal(row, end_time):
                     continue
 
                 listen = Listen.from_influx(row).to_api()

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -453,6 +453,22 @@ class InfluxListenStore(ListenStore):
                     f.write('\n'.join([ujson.dumps(listen) for listen in listens[year][month]]))
                     f.write('\n')
 
+    def row_inserted_before(self, row, timestamp):
+        """ Check that the influx row passed was inserted to influx before the specified timestamp
+
+        Args:
+            row (dict): the influx row representing the listen
+            timestamp (datetime): the datetime against which the row is to be checked
+
+        Returns:
+            bool: True if row was inserted before timestamp, false otherwise
+                   (also True for all listens with no inserted_timestamp)
+        """
+        inserted_timestamp = row.get('inserted_timestamp')
+        if not inserted_timestamp:
+            inserted_timestamp = 0
+        return datetime.utcfromtimestamp(inserted_timestamp) <= timestamp
+
 
     def dump_user_for_spark(self, username, start_time, end_time, temp_dir):
         """ Dump listens for a particular user in the format for the ListenBrainz spark dump.
@@ -480,7 +496,7 @@ class InfluxListenStore(ListenStore):
                 # need to do this check in python, because influx doesn't
                 # do "IS NULL" operations and we have null inserted_timestamps from
                 # old data
-                if datetime.utcfromtimestamp(row.get('inserted_timestamp', 0)) > end_time:
+                if not self.row_inserted_before(row, end_time):
                     continue
 
                 listen = convert_influx_row_to_spark_row(row)
@@ -534,7 +550,7 @@ class InfluxListenStore(ListenStore):
                 # need to do this check in python, because influx doesn't
                 # do "IS NULL" operations and we have null inserted_timestamps from
                 # old data
-                if datetime.utcfromtimestamp(row.get('inserted_timestamp', 0)) > end_time:
+                if not self.row_inserted_before(row, end_time):
                     continue
 
                 listen = Listen.from_influx(row).to_api()

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -256,6 +256,13 @@ class TestInfluxListenStore(DatabaseTestCase):
             dump_id=1,
             end_time=between_time,
         )
+        spark_dump_location = self.logstore.dump_listens(
+            location=temp_dir,
+            dump_id=1,
+            end_time=between_time,
+            spark_format=True,
+        )
+
         sleep(1)
         self.assertTrue(os.path.isfile(dump_location))
         self.reset_influx_db()
@@ -269,6 +276,8 @@ class TestInfluxListenStore(DatabaseTestCase):
         self.assertEqual(listens[2].ts_since_epoch, 3)
         self.assertEqual(listens[3].ts_since_epoch, 2)
         self.assertEqual(listens[4].ts_since_epoch, 1)
+
+        self.assert_spark_dump_contains_listens(spark_dump_location, 5)
         shutil.rmtree(temp_dir)
 
     def test_full_dump_listen_with_no_insert_timestamp(self):
@@ -296,6 +305,12 @@ class TestInfluxListenStore(DatabaseTestCase):
             dump_id=1,
             end_time=datetime.now(),
         )
+        spark_dump_location = self.logstore.dump_listens(
+            location=temp_dir,
+            dump_id=1,
+            end_time=datetime.now(),
+            spark_format=True,
+        )
         self.assertTrue(os.path.isfile(dump_location))
         self.reset_influx_db()
         sleep(1)
@@ -303,6 +318,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         sleep(1)
         listens_from_influx = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=11)
         self.assertEqual(len(listens_from_influx), 5)
+        self.assert_spark_dump_contains_listens(spark_dump_location, 5)
         shutil.rmtree(temp_dir)
 
     def test_incremental_dumps_listen_with_no_insert_timestamp(self):
@@ -331,6 +347,13 @@ class TestInfluxListenStore(DatabaseTestCase):
             start_time=t,
             end_time=datetime.now(),
         )
+        spark_dump_location = self.logstore.dump_listens(
+            location=temp_dir,
+            dump_id=1,
+            start_time=t,
+            end_time=datetime.now(),
+            spark_format=True,
+        )
         self.assertTrue(os.path.isfile(dump_location))
         self.reset_influx_db()
         sleep(1)
@@ -338,6 +361,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         sleep(1)
         listens_from_influx = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=11)
         self.assertEqual(len(listens_from_influx), 1)
+        self.assert_spark_dump_contains_listens(spark_dump_location, 1)
         shutil.rmtree(temp_dir)
 
     def test_import_listens(self):

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -167,6 +167,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         dump = self.logstore.dump_listens(
             location=temp_dir,
             dump_id=1,
+            end_time=datetime.now(),
         )
         self.assertTrue(os.path.isfile(dump))
         shutil.rmtree(temp_dir)
@@ -177,7 +178,8 @@ class TestInfluxListenStore(DatabaseTestCase):
         dump = self.logstore.dump_listens(
             location=temp_dir,
             dump_id=1,
-            spark_format=True
+            spark_format=True,
+            end_time=datetime.now(),
         )
         self.assertTrue(os.path.isfile(dump))
         self.assert_spark_dump_contains_listens(dump, expected_count)
@@ -246,6 +248,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         dump_location = self.logstore.dump_listens(
             location=temp_dir,
             dump_id=1,
+            end_time=datetime.now(),
         )
         sleep(1)
         self.assertTrue(os.path.isfile(dump_location))
@@ -274,6 +277,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         dump_location = self.logstore.dump_listens(
             location=temp_dir,
             dump_id=1,
+            end_time=datetime.now(),
         )
         sleep(1)
         self.assertTrue(os.path.isfile(dump_location))
@@ -309,6 +313,7 @@ class TestInfluxListenStore(DatabaseTestCase):
         dump_location = self.logstore.dump_listens(
             location=temp_dir,
             dump_id=1,
+            end_time=datetime.now(),
         )
         sleep(1)
         self.assertTrue(os.path.isfile(dump_location))

--- a/listenbrainz/listenstore/tests/test_influxlistenstore.py
+++ b/listenbrainz/listenstore/tests/test_influxlistenstore.py
@@ -240,6 +240,35 @@ class TestInfluxListenStore(DatabaseTestCase):
         self.assert_spark_dump_contains_listens(spark_dump_location, 5)
         shutil.rmtree(temp_dir)
 
+    def test_time_range_full_dumps(self):
+        listens = generate_data(1, self.testuser_name, 1, 5) # generate 5 listens with ts 1-5
+        self.logstore.insert(listens)
+        sleep(1)
+        between_time = datetime.now()
+        sleep(1)
+        listens = generate_data(1, self.testuser_name, 6, 5) # generate 5 listens with ts 6-10
+        self.logstore.insert(listens)
+        sleep(1)
+        temp_dir = tempfile.mkdtemp()
+        dump_location = self.logstore.dump_listens(
+            location=temp_dir,
+            dump_id=1,
+            end_time=between_time,
+        )
+        sleep(1)
+        self.assertTrue(os.path.isfile(dump_location))
+        self.reset_influx_db()
+        sleep(1)
+        self.logstore.import_listens_dump(dump_location)
+        sleep(1)
+        listens = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=11)
+        self.assertEqual(len(listens), 5)
+        self.assertEqual(listens[0].ts_since_epoch, 5)
+        self.assertEqual(listens[1].ts_since_epoch, 4)
+        self.assertEqual(listens[2].ts_since_epoch, 3)
+        self.assertEqual(listens[3].ts_since_epoch, 2)
+        self.assertEqual(listens[4].ts_since_epoch, 1)
+        shutil.rmtree(temp_dir)
 
     def test_import_listens(self):
         count = self._create_test_data(self.testuser_name)


### PR DESCRIPTION
Theoretically, without this check we'd get listens that weren't inserted in the time range of the dump, leading to inconsistencies. We also can't do this in queries because influx is weird with fields with null values being queried, it doesn't return those listens with null `inserted_timestamp`. 

So we do the check in python.