### PR TITLE
Use specific dir to save temp files during listens dump

### DIFF
--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -4,6 +4,7 @@
 #!/bin/bash
 
 DUMP_THREADS="{{template "KEY" "dump_threads"}}"
+TEMP_DIR="{{template "KEY" "temp_dir"}}"
 
 # Where to back things up to, who should own the backup files, and what mode
 # those files should have.

--- a/admin/config.sh.sample
+++ b/admin/config.sh.sample
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DUMP_THREADS=4
+TEMP_DIR='/home/listenbrainz/data/dumps'
 
 # Where to back things up to, who should own the backup files, and what mode
 # those files should have.

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -46,8 +46,6 @@ cd "$LB_SERVER_ROOT"
 source admin/config.sh
 source admin/functions.sh
 
-TEMP_DIR="/home/listenbrainz/data/dumps"
-
 DUMP_TYPE=${1:-full}
 
 if [ $DUMP_TYPE == "full" ]; then

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -8,6 +8,8 @@
     {{- end -}}
 {{- end -}}
 
+import os
+
 DEBUG = False
 
 SECRET_KEY = '''{{template "KEY" "secret_key"}}'''
@@ -146,3 +148,5 @@ MAIL_FROM_DOMAIN = '''{{template "KEY" "mail_from_domain"}}'''
 WEBSOCKETS_SERVER_URL = '''{{template "KEY" "websockets_server_url"}}'''
 
 SESSION_REMEMBER_ME_DURATION = 365
+
+LISTEN_DUMP_TEMP_DIR_ROOT = '''{{template "KEY" "listen_dump_temp_dir"}}'''

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -8,8 +8,6 @@
     {{- end -}}
 {{- end -}}
 
-import os
-
 DEBUG = False
 
 SECRET_KEY = '''{{template "KEY" "secret_key"}}'''

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -152,4 +152,4 @@ MAIL_FROM_DOMAIN = 'listenbrainz.org'
 SESSION_REMEMBER_ME_DURATION = 365
 
 # listen dumps creation dir
-LISTEN_DUMP_TEMP_DIR_ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__), '..', 'tmp'))
+LISTEN_DUMP_TEMP_DIR_ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'tmp')

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -1,3 +1,5 @@
+import os
+
 DEBUG = True # set to False in production mode
 
 SECRET_KEY = "CHANGE_ME"
@@ -149,3 +151,5 @@ MAIL_FROM_DOMAIN = 'listenbrainz.org'
 # expiration of 'Remember me' cookie
 SESSION_REMEMBER_ME_DURATION = 365
 
+# listen dumps creation dir
+LISTEN_DUMP_TEMP_DIR_ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__), '..', 'tmp'))

--- a/listenbrainz/listenstore/influx_listenstore.py
+++ b/listenbrainz/listenstore/influx_listenstore.py
@@ -51,6 +51,7 @@ class InfluxListenStore(ListenStore):
         self.influx = InfluxDBClient(host=conf['INFLUX_HOST'], port=conf['INFLUX_PORT'], database=conf['INFLUX_DB_NAME'])
         # Initialize brainzutils cache
         init_cache(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'], namespace=conf['REDIS_NAMESPACE'])
+        self.dump_temp_dir_root = conf.get('LISTEN_DUMP_TEMP_DIR_ROOT', tempfile.mkdtemp())
 
     def get_listen_count_for_user(self, user_name, need_exact=False):
         """Get the total number of listens for a user. The number of listens comes from
@@ -775,7 +776,8 @@ class InfluxListenStore(ListenStore):
 
             with tarfile.open(fileobj=pxz.stdin, mode='w|') as tar:
 
-                temp_dir = tempfile.mkdtemp()
+                temp_dir = os.path.join(self.dump_temp_dir_root, str(uuid.uuid4()))
+                create_path(temp_dir)
                 self.write_dump_metadata(archive_name, start_time, end_time, temp_dir, tar, full_dump)
 
                 listens_path = os.path.join(temp_dir, 'listens')

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -26,6 +26,7 @@ def create_influx(app):
         'REDIS_HOST': app.config['REDIS_HOST'],
         'REDIS_PORT': app.config['REDIS_PORT'],
         'REDIS_NAMESPACE': app.config['REDIS_NAMESPACE'],
+        'LISTEN_DUMP_TEMP_DIR_ROOT': app.config['LISTEN_DUMP_TEMP_DIR_ROOT'],
     })
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * ( ) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * (x) Other

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

We kept running out of space on lemmy while creating full dumps.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Change the code to use a configurable directory to save temp files instead of using `/tmp`
by default.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Merge, merge https://github.com/metabrainz/docker-server-configs/pull/80 and then deploy.
