### PR TITLE
Update the musicbrainz ID of users if it has changed

### DIFF
--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -246,6 +246,24 @@ def update_latest_import(musicbrainz_id, ts):
             raise DatabaseException
 
 
+def update_musicbrainz_id(id, musicbrainz_id):
+    """ Update the username (musicbrainz_id) of the user with specified row ID
+    """
+    with db.engine.connect() as connection:
+        try:
+            connection.execute(sqlalchemy.text("""
+                UPDATE "user"
+                   SET musicbrainz_id = :musicbrainz_id
+                 WHERE id = :id
+                """), {
+                'id': id,
+                'musicbrainz_id': musicbrainz_id,
+            })
+        except sqlalchemy.exc.ProgrammingError as e:
+            logger.error(e)
+            raise DatabaseException
+
+
 def increase_latest_import(musicbrainz_id, ts):
     """Increases the latest_import field for user with specified MusicBrainz ID"""
     user = get_by_mb_id(musicbrainz_id)

--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -36,6 +36,12 @@ def get_user():
     if user:
         if not user['musicbrainz_row_id']:
             db_user.update_musicbrainz_row_id(musicbrainz_id, data['metabrainz_user_id'])
+
+        # if the musicbrainz_id of the user from MusicBrainz is different, we need
+        # to update it here too
+        if user['musicbrainz_id'] != musicbrainz_id:
+            db_user.update_musicbrainz_id(user['id'], musicbrainz_id)
+
         return User.from_dbrow(user)
     else:
         return None


### PR DESCRIPTION
This means that once users log into LB after renaming
their accounts, their LB account will get automatically
renamed.

cc @reosarevok , is this similar to what you wanted?