### PR TITLE
Set up spark_reader config and uwsgi stuff

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -73,6 +73,8 @@ BIGQUERY_EXCHANGE = '''{{template "KEY" "bigquery_exchange"}}'''
 BIGQUERY_QUEUE = '''{{template "KEY" "bigquery_queue"}}'''
 PLAYING_NOW_EXCHANGE = '''{{template "KEY" "playing_now_exchange"}}'''
 PLAYING_NOW_QUEUE = '''{{template "KEY" "playing_now_queue"}}'''
+SPARK_EXCHANGE = '''{{template "KEY" "spark_exchange"}}'''
+SPARK_QUEUE = '''{{template "KEY" "spark_queue"}}'''
 
 
 MUSICBRAINZ_CLIENT_ID = '''{{template "KEY" "musicbrainz/client_id"}}'''

--- a/docker/beta/uwsgi/uwsgi.service
+++ b/docker/beta/uwsgi/uwsgi.service
@@ -43,5 +43,10 @@ then
     exec python3 manage.py run_follow_server -h 0.0.0.0 -p 3031
 fi
 
+if [ "${CONTAINER_NAME}" = "listenbrainz-stats-consumer-beta" ]
+then
+    cd /code/listenbrainz
+    exec python3 -m listenbrainz.spark.spark_reader
+fi
 
 echo "init script has no clue which service to start. Set env var CONTAINER_NAME!"

--- a/docker/beta/uwsgi/uwsgi.service
+++ b/docker/beta/uwsgi/uwsgi.service
@@ -43,7 +43,7 @@ then
     exec python3 manage.py run_follow_server -h 0.0.0.0 -p 3031
 fi
 
-if [ "${CONTAINER_NAME}" = "listenbrainz-stats-consumer-beta" ]
+if [ "${CONTAINER_NAME}" = "listenbrainz-spark-reader-beta" ]
 then
     cd /code/listenbrainz
     exec python3 -m listenbrainz.spark.spark_reader

--- a/docker/prod/uwsgi/uwsgi.service
+++ b/docker/prod/uwsgi/uwsgi.service
@@ -40,5 +40,10 @@ then
     exec python3 -m listenbrainz.spotify_updater.spotify_read_listens
 fi
 
+if [ "${CONTAINER_NAME}" = "listenbrainz-spark-reader-prod" ]
+then
+    cd /code/listenbrainz
+    exec python3 -m listenbrainz.spark.spark_reader
+fi
 
 echo "init script has no clue which service to start. Set env var CONTAINER_NAME!"


### PR DESCRIPTION
This is to start a consumer that processes statistics.

## Open Questions

* Do we just want an independent container for stats? Or maybe we want to merge it with a generic `listenbrainz-jobs` container? For example: [LB-465](https://tickets.metabrainz.org/projects/LB/issues/LB-465?filter=allopenissues) shows that user export dump creation should also probably be done as a rabbitmq job instead of being done inside the request right now. Do we want to start a new container for that?

* Do we want a container running cron jobs to push statistics into the queue on the cluster now? Because that is something we can do just now to get stats back.