### PR TITLE
Remove py.test *command* from docker compose for test.

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -34,7 +34,6 @@ services:
       context: ..
       dockerfile: Dockerfile
       target: listenbrainz-dev
-    command: py.test
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: '/code/credentials/bigquery-credentials.json'
     volumes:


### PR DESCRIPTION
Since py.test is already invoked from test.sh we may consider removing it from docker.compose.test.yml
https://github.com/metabrainz/listenbrainz-server/blob/master/test.sh#L125

