### PR TITLE
Improve the messages of the spotify recorder

### DIFF
--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -271,6 +271,8 @@ def process_one_user(user):
     spotify.update_latest_listened_at(user.user_id, latest_listened_at)
     spotify.update_last_updated(user.user_id)
 
+    current_app.logger.info('imported %d listens for %s' % (len(listens), str(user)))
+
 
 def process_all_spotify_users():
     """ Get a batch of users to be processed and import their Spotify plays.
@@ -294,7 +296,6 @@ def process_all_spotify_users():
     failure = 0
     for u in users:
         t = time.time()
-        current_app.logger.info('Importing spotify listens for user %s', str(u))
         try:
             process_one_user(u)
             success += 1
@@ -314,8 +315,6 @@ def process_all_spotify_users():
         except Exception as e:
             current_app.logger.critical('spotify_reader could not import listens: %s', str(e), exc_info=True)
             failure += 1
-
-        current_app.logger.info('Took a total of %.2f seconds to process user %s', time.time() - t, str(u))
 
     current_app.logger.info('Processed %d users successfully!', success)
     current_app.logger.info('Encountered errors while processing %d users.', failure)


### PR DESCRIPTION
Improve the status messages of the reader to print how many listens were imported, but only if some listens were imported. This should improve the ability to check the reader's health.