### PR TITLE
Fixed npm install in develop.sh

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -24,7 +24,7 @@ function open_psql_shell {
 }
 
 function npm_install {
-	invoke_docker_compose run --rm --user `id -u`:`id -g` -e \
+	invoke_docker_compose run --rm -e \
 				HOME=/tmp static_builder npm install
 }
 # Arguments following "manage" are as it is passed to function "invoke_manage" and executed.


### PR DESCRIPTION

# Summary

* This is a…
    * ( ) Bug fix

# Problem

While setting up the environment for LB-server, the `./develop.sh npm` script didn't work for installing the node dependencies.


