### PR TITLE
LB-179: Show error message if Last.fm import fails

### DIFF
--- a/listenbrainz/webserver/templates/user/scraper.js
+++ b/listenbrainz/webserver/templates/user/scraper.js
@@ -500,12 +500,17 @@ function getTotalNumberOfScrobbles() {
     xhr.timeout = 10 * 1000; // 10 seconds
     xhr.open('GET', encodeURI(url));
     xhr.onload = function () {
-        var data = JSON.parse(this.response)['user'];
-        if ('playcount' in data) {
-            playCount = parseInt(data['playcount']);
+        if (/^2/.test(this.status)) {
+            var data = JSON.parse(this.response)['user'];
+            if ('playcount' in data) {
+                playCount = parseInt(data['playcount']);
+            }
+            else {
+                playCount = -1;
+            }
         }
         else {
-            playCount = -1;
+            updateMessage("An error occurred, please try again. :(");
         }
     };
     xhr.ontimeout = function () {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Summary

* This is a…
    * (X ) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

# Problem
Last.fm importer doesn't indicate if it receives a error from Last.fm.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: [LB-179](https://tickets.metabrainz.org/browse/LB-179)


# Solution
If a non OK response code is received from the AJAX request in the function getTotalNumberOfScrobbles(), then an error message is shown.

