### PR TITLE
Fix data dumps by making sure that we remove the oldest dump by ID

### DIFF
--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -198,6 +198,10 @@ def delete_old_dumps(location):
     _cleanup_dumps(location)
 
 
+def get_dump_id(dump_name):
+    return int(dump_name.split('-')[2])
+
+
 def _cleanup_dumps(location):
     """ Delete old dumps while keeping the latest two dumps in the specified directory
 
@@ -208,14 +212,16 @@ def _cleanup_dumps(location):
         (int, int): the number of dumps remaining, the number of dumps deleted
     """
     full_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-full')
-    full_dumps = [x for x in sorted(os.listdir(location), reverse=True) if full_dump_re.match(x)]
+    dump_files = [x for x in os.listdir(location) if full_dump_re.match(x)]
+    full_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
     if not full_dumps:
         print('No full dumps present in specified directory!')
     else:
         remove_dumps(location, full_dumps, NUMBER_OF_FULL_DUMPS_TO_KEEP)
 
     incremental_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-incremental')
-    incremental_dumps = [x for x in sorted(os.listdir(location), reverse=True) if incremental_dump_re.match(x)]
+    dump_files = [x for x in os.listdir(location) if incremental_dump_re.match(x)]
+    incremental_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
     if not incremental_dumps:
         print('No full dumps present in specified directory!')
     else:

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -72,6 +72,8 @@ class DumpManagerTestCase(DatabaseTestCase):
         create_path(os.path.join(self.tempdir, 'listenbrainz-dump-5-20180312-000005-incremental'))
         create_path(os.path.join(self.tempdir, 'listenbrainz-dump-6-20180312-000006-incremental'))
         create_path(os.path.join(self.tempdir, 'listenbrainz-dump-7-20180312-000007-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-99-20200124-000007-incremental'))
+        create_path(os.path.join(self.tempdir, 'listenbrainz-dump-100-20200124-000008-incremental'))
 
         create_path(os.path.join(self.tempdir, 'not-a-dump'))
 
@@ -86,12 +88,12 @@ class DumpManagerTestCase(DatabaseTestCase):
 
         self.assertNotIn('listenbrainz-dump-1-20180312-000001-incremental', newdirs)
 
-        self.assertIn('listenbrainz-dump-2-20180312-000002-incremental', newdirs)
-        self.assertIn('listenbrainz-dump-3-20180312-000003-incremental', newdirs)
         self.assertIn('listenbrainz-dump-4-20180312-000004-incremental', newdirs)
         self.assertIn('listenbrainz-dump-5-20180312-000005-incremental', newdirs)
         self.assertIn('listenbrainz-dump-6-20180312-000006-incremental', newdirs)
         self.assertIn('listenbrainz-dump-7-20180312-000007-incremental', newdirs)
+        self.assertIn('listenbrainz-dump-99-20200124-000007-incremental', newdirs)
+        self.assertIn('listenbrainz-dump-100-20200124-000008-incremental', newdirs)
 
         self.assertIn('not-a-dump', newdirs)
 

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -87,6 +87,8 @@ class DumpManagerTestCase(DatabaseTestCase):
         self.assertIn('listenbrainz-dump-4-20180312-000004-full', newdirs)
 
         self.assertNotIn('listenbrainz-dump-1-20180312-000001-incremental', newdirs)
+        self.assertNotIn('listenbrainz-dump-2-20180312-000002-incremental', newdirs)
+        self.assertNotIn('listenbrainz-dump-3-20180312-000003-incremental', newdirs)
 
         self.assertIn('listenbrainz-dump-4-20180312-000004-incremental', newdirs)
         self.assertIn('listenbrainz-dump-5-20180312-000005-incremental', newdirs)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
<!--
 A one line description of what this change does
-->


* This is a bugfix.

* **Describe this change in 1-2 sentences**: Fix ListenBrainz data dump sync to FTP.

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->

New dumps were not getting uploaded to FTP. This was because our sorting logic sorted dumps by their name, not by their ID. So as soon as we crossed 100, the logic that was supposed to remove OLD data dumps started removing new data dumps.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Sort by ID instead of filename and add tests.


