### PR TITLE
Make stats rabbitmq messages smaller 

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -13,10 +13,3 @@ def handle_user_artist(data):
     artist_count = data['artist_count']
     db_stats.insert_user_stats(user['id'], artists, {}, {}, artist_count)
     current_app.logger.info('Processed artist data for %s', musicbrainz_id)
-
-
-def handle_user_release(data):
-    pass #TODO: add releases
-
-def handle_user_track(data):
-    pass #TODO: add track

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -1,0 +1,22 @@
+import listenbrainz.db.user as db_user
+import listenbrainz.db.stats as db_stats
+
+from flask import current_app
+
+
+def handle_user_artist(data):
+    musicbrainz_id = data['musicbrainz_id']
+    user = db_user.get_by_mb_id(musicbrainz_id)
+    if not user:
+        return
+    artists = data['artist_stats']
+    artist_count = data['artist_count']
+    db_stats.insert_user_stats(user['id'], artists, {}, {}, artist_count)
+    current_app.logger.info('Processed artist data for %s', musicbrainz_id)
+
+
+def handle_user_release(data):
+    pass #TODO: add releases
+
+def handle_user_track(data):
+    pass #TODO: add track

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -1,3 +1,6 @@
+""" This file contains handler functions for rabbitmq messages we
+receive from the Spark cluster.
+"""
 import listenbrainz.db.user as db_user
 import listenbrainz.db.stats as db_stats
 
@@ -5,6 +8,8 @@ from flask import current_app
 
 
 def handle_user_artist(data):
+    """ Take artist stats for a user and save it in the database.
+    """
     musicbrainz_id = data['musicbrainz_id']
     user = db_user.get_by_mb_id(musicbrainz_id)
     if not user:
@@ -12,4 +17,3 @@ def handle_user_artist(data):
     artists = data['artist_stats']
     artist_count = data['artist_count']
     db_stats.insert_user_stats(user['id'], artists, {}, {}, artist_count)
-    current_app.logger.info('Processed artist data for %s', musicbrainz_id)

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -50,7 +50,7 @@ class SparkReader:
             return
 
         try:
-            response_handler = get_response_handler(response_type)
+            response_handler = self.get_response_handler(response_type)
         except Exception:
             current_app.logger.error('Unknown response type: %s, doing nothing.', response_type, exc_info=True)
             return

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -10,7 +10,7 @@ from listenbrainz import utils
 from listenbrainz.db import user as db_user, stats as db_stats
 from listenbrainz.webserver import create_app
 from listenbrainz.db.exceptions import DatabaseException
-from listenbrainz.spark.handlers import handle_user_artist, handle_user_release, handle_user_track
+from listenbrainz.spark.handlers import handle_user_artist
 import sqlalchemy
 
 class SparkReader:
@@ -20,8 +20,6 @@ class SparkReader:
     def get_response_handler(self, response_type):
         response_handler_map = {
             'user_artist': handle_user_artist,
-            'user_release': handle_user_release,
-            'user_track': handle_user_track,
         }
         return response_handler_map[response_type]
 

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -44,9 +44,8 @@ class SparkReader:
     def process_response(self, response):
         try:
             response_type = response['type']
-            data = response.get('data', {})
         except KeyError:
-            current_app.logger.error('Bad response sent to spark_reader: %s', json.dumps(response), exc_info=True)
+            current_app.logger.error('Bad response sent to spark_reader: %s', json.dumps(response, indent=4), exc_info=True)
             return
 
         try:
@@ -56,9 +55,9 @@ class SparkReader:
             return
 
         try:
-            response_handler(data)
+            response_handler(response)
         except Exception as e:
-            current_app.logger.error('Error in the response handler: %s', str(e), exc_info=True)
+            current_app.logger.error('Error in the response handler: %s, data: %s', str(e), json.dumps(response, indent=4), exc_info=True)
             return
 
 

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -46,7 +46,7 @@ class SparkReader:
             response_type = response['type']
             data = response.get('data', {})
         except KeyError:
-            current_app.logger.error('Bad response sent to spark_reader: %s', json.dumps(request), exc_info=True)
+            current_app.logger.error('Bad response sent to spark_reader: %s', json.dumps(response), exc_info=True)
             return
 
         try:

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -13,14 +13,14 @@ from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.spark.handlers import handle_user_artist
 import sqlalchemy
 
+response_handler_map = {
+    'user_artist': handle_user_artist,
+}
 class SparkReader:
     def __init__(self):
         self.app = create_app() # creating a flask app for config values and logging to Sentry
 
     def get_response_handler(self, response_type):
-        response_handler_map = {
-            'user_artist': handle_user_artist,
-        }
         return response_handler_map[response_type]
 
 

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -1,0 +1,21 @@
+import unittest
+from listenbrainz.spark.handlers import handle_user_artist
+
+class HandlersTestCase(unittest.TestCase):
+
+    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_stats')
+    @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
+    @mock.patch('listenbrainz.spark.handlers.current_app')
+    def test_handle_user_artist(self, mock_app, mock_get_by_mb_id, mock_db_insert):
+        data = {
+            'musicbrainz_id': 'iliekcomputers',
+            'type': 'user_artist',
+            'artist_stats': [{'artist_name': 'Kanye West', 'count': 200}],
+            'artist_count': 1,
+        }
+        mock_get_by_mb_id.return_value = {'id': 1, 'musicbrainz_id': 'iliekcomputers'}
+
+        handle_user_artist(data)
+        mock_db_insert.assert_called_with(1, data['artist_stats'], {}, {}, data['artist_count'])
+
+

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -1,4 +1,6 @@
 import unittest
+
+from unittest import mock
 from listenbrainz.spark.handlers import handle_user_artist
 
 class HandlersTestCase(unittest.TestCase):

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -17,5 +17,3 @@ class HandlersTestCase(unittest.TestCase):
 
         handle_user_artist(data)
         mock_db_insert.assert_called_with(1, data['artist_stats'], {}, {}, data['artist_count'])
-
-

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -60,7 +60,7 @@ class RequestConsumer:
             return None
 
 
-    def push_to_result_queue(self, result):
+    def push_to_result_queue(self, messages):
         for message in messages:
             while True:
                 try:

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -86,7 +86,7 @@ class RequestConsumer:
         current_app.logger.info("Calculating result...")
         messages = self.get_result(request)
         current_app.logger.info("Done!")
-        if result:
+        if messages:
             current_app.logger.info("Pushing to result queue...")
             self.push_to_result_queue(messages)
             current_app.logger.info("Done!")

--- a/listenbrainz_spark/stats/user/all.py
+++ b/listenbrainz_spark/stats/user/all.py
@@ -21,7 +21,7 @@ def calculate():
     for user_name, user_artists in artist_data.items():
         messages.append({
             'musicbrainz_id': user_name,
-            'response_type': 'user_artist',
+            'type': 'user_artist',
             'artist_stats': user_artists,
             'artist_count': len(user_artists ),
         })

--- a/listenbrainz_spark/stats/user/all.py
+++ b/listenbrainz_spark/stats/user/all.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from datetime import datetime
 from listenbrainz_spark.utils import get_listens
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
@@ -7,7 +8,7 @@ from collections import defaultdict
 
 def calculate():
     now = datetime.utcnow()
-    listens_df = get_listens(from_date=datetime(LAST_FM_FOUNDING_YEAR, 1, 1), to_date=now, dest_path=path.LISTENBRAINZ_DATA_DIRECTORY)
+    listens_df = get_listens(from_date=datetime(LAST_FM_FOUNDING_YEAR, 1, 1), to_date=now, dest_path=current_app.config['HDFS_CLUSTER_URI']+path.LISTENBRAINZ_DATA_DIRECTORY)
     table_name = 'stats_user_all'
     listens_df.createOrReplaceTempView(table_name)
 
@@ -15,10 +16,14 @@ def calculate():
 
     # calculate and put artist stats into the result
     artist_data = get_artists(table_name)
+    messages = []
+
     for user_name, user_artists in artist_data.items():
-        data[user_name]['artists'] = {
+        messages.append({
+            'musicbrainz_id': user_name,
+            'response_type': 'user_artist',
             'artist_stats': user_artists,
             'artist_count': len(user_artists ),
-        }
+        })
 
-    return data
+    return messages


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
<!--
 A one line description of what this change does
-->


* This is an improvement.

Make the rabbitmq messages being transmitted around for stats smaller, so that the pipeline doesn't error so much.

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->

We were sending one message as result per query to the spark cluster. This meant that we sent all stats of all users in a single json document. This document was generally gigabytes in size. This isn't something rabbitmq handles well and json parsing is slow anyways.
 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

This pull request changes the code so that we send one user's statistics in one json document.
I've tested this on the cluster.


<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

