### PR TITLE
Fix build and run spark containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ ENV/
 
 config.py
 docker/tunnel/keys
+
+# temporary files
+tmp/

--- a/develop.sh
+++ b/develop.sh
@@ -13,6 +13,7 @@ function invoke_docker_compose_spark {
 
 function invoke_docker_compose {
 	docker-compose -f docker/docker-compose.yml \
+	 			-f docker/docker-compose.spark.yml \
 				-p listenbrainz \
 				"$@"
 }

--- a/docker/docker-compose.spark.yml
+++ b/docker/docker-compose.spark.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - ..:/rec:z
 
-networks:
-  default:
-    external:
-      name: listenbrainz_default
+# networks:
+#   default:
+#     external:
+#       name: listenbrainz_default


### PR DESCRIPTION
#11 Description
Fix Spark containers not being build and run in develop.sh (In continuation to PR #703 ).

* This is a…
    * (x) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

# Problem
Even after combining the code to create Spark containers in PR #703 the function `invoke_docker_compose_spark` was not being called. Hence the Spark containers were not run using develop.sh.

# Solution

* Running both `docker-compose.yml` and `docker-compose.spark.yml` using a single `docker-compose` command
* Remove the `network` configured in `docker-compose.spark.yml` as now `listenbrainz-default` is in the same network.