### PR TITLE
LB-484: Stream response from /profile/export endpoint

### DIFF
--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -139,16 +139,6 @@ def fetch_listens(musicbrainz_id, to_ts):
         to_ts = batch[-1].ts_since_epoch  # new to_ts will be the the timestamp of the last listen fetched
 
 
-def map_listen_for_export(obj):
-    """ Convert a listen fetched from listenstore into a dict to export. """
-    dic = obj.data
-    dic['timestamp'] = obj.ts_since_epoch
-    dic['release_msid'] = None if obj.release_msid is None else str(obj.release_msid)
-    dic['artist_msid'] = None if obj.artist_msid is None else str(obj.artist_msid)
-    dic['recording_msid'] = None if obj.recording_msid is None else str(obj.recording_msid)
-    return dic
-
-
 def stream_json_array(elements):
     """ Return a generator of string fragments of the elements encoded as array. """
     for i, element in enumerate(elements):
@@ -170,7 +160,7 @@ def export_data():
         # immediately.
         to_ts = int(time())
         listens = fetch_listens(current_user.musicbrainz_id, to_ts)
-        output = stream_json_array(map_listen_for_export(obj) for obj in listens)
+        output = stream_json_array(listen.to_api() for listen in listens)
 
         response = Response(stream_with_context(output))
         response.headers["Content-Disposition"] = "attachment; filename=" + filename

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -3,11 +3,13 @@ import listenbrainz.db.user as db_user
 import listenbrainz.db.spotify as db_spotify
 import pytz
 import time
+import ujson
 
 from datetime import datetime
 from flask import url_for
 from listenbrainz.domain import spotify
 from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.listen import Listen
 from listenbrainz.webserver.testing import ServerTestCase
 from unittest.mock import patch
 
@@ -196,4 +198,82 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
             'musicbrainz_id': self.user['musicbrainz_id'],
             'user_token': 'new-token',
             'permission': 'user-read-recently-played',
+        })
+
+    @patch('listenbrainz.listenstore.influx_listenstore.InfluxListenStore.fetch_listens')
+    def test_export_streaming(self, mock_fetch_listens):
+        self.temporary_login(self.user['login_id'])
+
+        # Three example listens, with only basic data for the purpose of this test.
+        # In each listen, one of {release_artist, release_msid, recording_msid}
+        # is missing.
+        listens = [
+            Listen(
+                timestamp=1539509881,
+                artist_msid='61746abb-76a5-465d-aee7-c4c42d61b7c4',
+                recording_msid='6c617681-281e-4dae-af59-8e00f93c4376',
+                data={
+                    'artist_name': 'Massive Attack',
+                    'track_name': 'The Spoils',
+                    'additional_info': {},
+                },
+            ),
+            Listen(
+                timestamp=1539441702,
+                release_msid='0c1d2dc3-3704-4e75-92f9-940801a1eebd',
+                recording_msid='7ad53fd7-5b40-4e13-b680-52716fb86d5f',
+                data={
+                    'artist_name': 'Snow Patrol',
+                    'track_name': 'Lifening',
+                    'additional_info': {},
+                },
+            ),
+            Listen(
+                timestamp=1539441531,
+                release_msid='7816411a-2cc6-4e43-b7a1-60ad093c2c31',
+                artist_msid='7e2c6fe4-3e3f-496e-961d-dce04a44f01b',
+                data={
+                    'artist_name': 'Muse',
+                    'track_name': 'Drones',
+                    'additional_info': {},
+                },
+            ),
+        ]
+
+        # We expect three calls to fetch_listens, and we return two, one, and
+        # zero listens in the batch. This tests that we fetch all batches.
+        mock_fetch_listens.side_effect = [listens[0:2], listens[2:3], []]
+
+        r = self.client.post(url_for('profile.export_data'))
+        self.assert200(r)
+
+        # r.json returns None, so we decode the response manually.
+        results = ujson.loads(r.data.decode('utf-8'))
+
+        self.assertDictEqual(results[0], {
+            'artist_name': 'Massive Attack',
+            'track_name': 'The Spoils',
+            'timestamp': 1539509881,
+            'release_msid': None,
+            'artist_msid': '61746abb-76a5-465d-aee7-c4c42d61b7c4',
+            'recording_msid': '6c617681-281e-4dae-af59-8e00f93c4376',
+            'additional_info': {},
+        })
+        self.assertDictEqual(results[1], {
+            'artist_name': 'Snow Patrol',
+            'track_name': 'Lifening',
+            'timestamp': 1539441702,
+            'release_msid': '0c1d2dc3-3704-4e75-92f9-940801a1eebd',
+            'artist_msid': None,
+            'recording_msid': '7ad53fd7-5b40-4e13-b680-52716fb86d5f',
+            'additional_info': {},
+        })
+        self.assertDictEqual(results[2], {
+            'artist_name': 'Muse',
+            'track_name': 'Drones',
+            'timestamp': 1539441531,
+            'release_msid': '7816411a-2cc6-4e43-b7a1-60ad093c2c31',
+            'artist_msid': '7e2c6fe4-3e3f-496e-961d-dce04a44f01b',
+            'recording_msid': None,
+            'additional_info': {},
         })

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -251,29 +251,41 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
         results = ujson.loads(r.data.decode('utf-8'))
 
         self.assertDictEqual(results[0], {
-            'artist_name': 'Massive Attack',
-            'track_name': 'The Spoils',
-            'timestamp': 1539509881,
-            'release_msid': None,
-            'artist_msid': '61746abb-76a5-465d-aee7-c4c42d61b7c4',
+            'listened_at': 1539509881,
             'recording_msid': '6c617681-281e-4dae-af59-8e00f93c4376',
-            'additional_info': {},
+            'user_name': None,
+            'track_metadata': {
+                'artist_name': 'Massive Attack',
+                'track_name': 'The Spoils',
+                'additional_info': {
+                    'artist_msid': '61746abb-76a5-465d-aee7-c4c42d61b7c4',
+                    'release_msid': None,
+                },
+            },
         })
         self.assertDictEqual(results[1], {
-            'artist_name': 'Snow Patrol',
-            'track_name': 'Lifening',
-            'timestamp': 1539441702,
-            'release_msid': '0c1d2dc3-3704-4e75-92f9-940801a1eebd',
-            'artist_msid': None,
+            'listened_at': 1539441702,
             'recording_msid': '7ad53fd7-5b40-4e13-b680-52716fb86d5f',
-            'additional_info': {},
+            'user_name': None,
+            'track_metadata': {
+                'artist_name': 'Snow Patrol',
+                'track_name': 'Lifening',
+                'additional_info': {
+                    'artist_msid': None,
+                    'release_msid': '0c1d2dc3-3704-4e75-92f9-940801a1eebd',
+                },
+            },
         })
         self.assertDictEqual(results[2], {
-            'artist_name': 'Muse',
-            'track_name': 'Drones',
-            'timestamp': 1539441531,
-            'release_msid': '7816411a-2cc6-4e43-b7a1-60ad093c2c31',
-            'artist_msid': '7e2c6fe4-3e3f-496e-961d-dce04a44f01b',
+            'listened_at': 1539441531,
             'recording_msid': None,
-            'additional_info': {},
+            'user_name': None,
+            'track_metadata': {
+                'artist_name': 'Muse',
+                'track_name': 'Drones',
+                'additional_info': {
+                    'artist_msid': '7e2c6fe4-3e3f-496e-961d-dce04a44f01b',
+                    'release_msid': '7816411a-2cc6-4e43-b7a1-60ad093c2c31',
+                },
+            },
         })


### PR DESCRIPTION
# Description

Do not materialize all listens in memory when exporting them, stream them instead.


* This is a…
    * (x) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * ( ) Minor / simple change (like a typo)
    * ( ) Other

* **Describe this change in 1-2 sentences**: Previously, the export endpoint would fetch all listens from the listenstore into a list in memory, then build a second list in memory, then serialize that as json, and only then the response could be served. This pull request replaces the lists with generators, so serving the response and fetching from the database can be interleaved, for faster time-to-first-byte and lower memory consumption.

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->

* JIRA ticket: [LB-484](https://tickets.metabrainz.org/browse/LB-484)

When I try to export the listens for my profile, I consistently get a gateway timeout after 60 seconds. I suspect that this is because fetching my almost 150k listens into a list in memory takes more than 60 seconds, and the response cannot be served until all listens have been fetched.

Building that list also consumes memory proportional to the amount of listens, but I don't know if that has been a problem for you.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Rather than fetching all listens into memory first, we can stream them. If we move the loops into a function and replace `append` with `yield`, then we get a generator that produces the listens on demand. Instead of building a second list of result dicts, we can map a function over the listens to produce the dicts. And instead of building a list and serializing the entire thing in one go, add a generator that streams a json array. Flask supports generators that produce the response body. This way, the response can be served immediately after fetching the first batch of listens.

I hope that starting the response earlier will avoid the gateway timeout, but I have not been able to verify this.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

I have not been able to set up a local development environment for this yet, but Travis does run the test suite, and there was already a test covering export, which still passes. I also added an extra test in `test_profile.py` that tests the structure of the response and calls to `fetch_listens`.

I tried to keep the style consistent with the code that was already there, but please let me know if anything can be improved.
