### PR TITLE
fix sentry config for spark

### DIFF
--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -43,8 +43,8 @@ SIMILAR_ARTISTS_LIMIT = 10
 LOG_SENTRY = {
     'dsn':'',
     'environment': 'development',
-    'level': 'ERROR',
 }
+SENTRY_DSN_PUBLIC = ''
 
 # Model id is made up of two parts.
 # String + UUID


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
<!--
 A one line description of what this change does
-->


* This is a bugfix

* **Describe this change in 1-2 sentences**: The config file didn't have a variable for the public DSN.

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->

The Sentry config in lsitenbrainz_spark didn't have a variable for the public DSN.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
I've added a seperate DSN variable as is required by brainzutils. Ideally it should be a part of the dict, but that would require changing the brainzutils library which I don't think is worth the effort right now.


