### PR TITLE
Add clarification about Last.fm privacy settings to import page.

### DIFF
--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -17,10 +17,13 @@
         process. Running the import process multiple times <strong>does not</strong> create duplicates in your
         ListenBrainz listen history.
       </p>
+      <p>In order for this to work, you must disable the &#34;Hide recent listening information&#34;
+        setting in your Last.fm <a href="https://www.last.fm/settings/privacy">Privacy Settings</a>.
+      </p>
       <p>
         Clicking the "Import now!" button will import your profile now without the need to open lastfm.<br/>
         You need to keep this page open for the tool to work, it might take a while to complete. Though, you can continue doing your work. :)
-      <br/>
+      </p>
       We need to know your Last.fm username:
       <div class="well">
         <form onsubmit="return lastfm_import();">


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description

Adds a clarification to the import page notifying the user that import will not work without disabling the "Hide recent listening information" privacy setting.


* This is a…
    * ( ) Bug fix
    * ( ) Feature addition
    * ( ) Refactoring
    * (x) Minor / simple change (like a typo)
    * ( ) Other

* **Describe this change in 1-2 sentences**:

# Problem

Last.fm import doesn't work when the user has "Hide recent listening information" enabled in Last.fm.  The import page doesn't specify this.

# Solution

Specify to disable "Hide recent listening information" in Last.fm settings.


