### PR TITLE
Send a mail when new user stats start getting written into the db from spark

### DIFF
--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -26,6 +26,19 @@ import ujson
 
 from listenbrainz import db
 
+def get_timestamp_for_last_user_stats_update():
+    """ Get the time when the user stats table was last updated
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT MAX(last_updated) as last_update_ts
+              FROM statistics.user
+            """
+        ))
+        row = result.fetchone()
+        return row['last_update_ts'] if row else None
+
+
 def insert_user_stats(user_id, artists, recordings, releases, artist_count):
     """Inserts user stats calculated from Spark into the database.
 

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -4,6 +4,7 @@ import os
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 
+from datetime import datetime, timezone
 from listenbrainz.db.testing import DatabaseTestCase
 
 class StatsDatabaseTestCase(DatabaseTestCase):
@@ -61,6 +62,12 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             'user_releases': releases,
             'user_recordings': recordings,
         }
+
+    def test_get_timestamp_for_last_user_stats_update(self):
+        ts = datetime.now(timezone.utc)
+        self.insert_test_data()
+        received_ts = db_stats.get_timestamp_for_last_user_stats_update()
+        self.assertGreaterEqual(received_ts, ts)
 
     def test_get_user_stats(self):
         data_inserted = self.insert_test_data()

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -10,7 +10,13 @@ from datetime import datetime, timezone, timedelta
 
 TIME_TO_CONSIDER_STATS_AS_OLD = 12 # hours
 
-def new_user_stats():
+def is_new_user_stats_batch():
+    """ Returns True if this batch of user stats is new, False otherwise
+
+    User stats come in as multiple rabbitmq messages. We only wish to send an email once per batch.
+    So, we check the database and see if the difference between the last time stats were updated
+    and right now is greater than 12 hours.
+    """
     return datetime.now(timezone.utc) - db_stats.get_timestamp_for_last_user_stats_update() > timedelta(hours=TIME_TO_CONSIDER_STATS_AS_OLD)
 
 
@@ -34,7 +40,7 @@ def handle_user_artist(data):
         return
 
     # send a notification if this is a new batch of stats
-    if new_user_stats():
+    if is_new_user_stats_batch():
         notify_user_stats_update()
     artists = data['artist_stats']
     artist_count = data['artist_count']

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -1,14 +1,21 @@
 import unittest
 
+from datetime import datetime, timezone, timedelta
+from flask import current_app
+from listenbrainz.spark.handlers import handle_user_artist, new_user_stats
+from listenbrainz.webserver import create_app
 from unittest import mock
-from listenbrainz.spark.handlers import handle_user_artist
 
 class HandlersTestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.app = create_app()
+
     @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_stats')
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
-    @mock.patch('listenbrainz.spark.handlers.current_app')
-    def test_handle_user_artist(self, mock_app, mock_get_by_mb_id, mock_db_insert):
+    @mock.patch('listenbrainz.spark.handlers.new_user_stats')
+    @mock.patch('listenbrainz.spark.handlers.send_mail')
+    def test_handle_user_artist(self, mock_send_mail, mock_new_user_stats, mock_get_by_mb_id, mock_db_insert):
         data = {
             'musicbrainz_id': 'iliekcomputers',
             'type': 'user_artist',
@@ -16,6 +23,18 @@ class HandlersTestCase(unittest.TestCase):
             'artist_count': 1,
         }
         mock_get_by_mb_id.return_value = {'id': 1, 'musicbrainz_id': 'iliekcomputers'}
+        mock_new_user_stats.return_value = True
 
-        handle_user_artist(data)
+        with self.app.app_context():
+            current_app.config['TESTING'] = False # set testing to false to check the notifications
+            handle_user_artist(data)
+
         mock_db_insert.assert_called_with(1, data['artist_stats'], {}, {}, data['artist_count'])
+        mock_send_mail.assert_called_once()
+
+    @mock.patch('listenbrainz.spark.handlers.db_stats.get_timestamp_for_last_user_stats_update')
+    def test_new_user_stats(self, mock_db_get_timestamp):
+        mock_db_get_timestamp.return_value = datetime.now(timezone.utc)
+        self.assertFalse(new_user_stats())
+        mock_db_get_timestamp.return_value = datetime.now(timezone.utc) - timedelta(hours=13)
+        self.assertTrue(new_user_stats())

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -2,7 +2,7 @@ import unittest
 
 from datetime import datetime, timezone, timedelta
 from flask import current_app
-from listenbrainz.spark.handlers import handle_user_artist, new_user_stats
+from listenbrainz.spark.handlers import handle_user_artist, is_new_user_stats_batch
 from listenbrainz.webserver import create_app
 from unittest import mock
 
@@ -13,7 +13,7 @@ class HandlersTestCase(unittest.TestCase):
 
     @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_stats')
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
-    @mock.patch('listenbrainz.spark.handlers.new_user_stats')
+    @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_handle_user_artist(self, mock_send_mail, mock_new_user_stats, mock_get_by_mb_id, mock_db_insert):
         data = {
@@ -33,8 +33,8 @@ class HandlersTestCase(unittest.TestCase):
         mock_send_mail.assert_called_once()
 
     @mock.patch('listenbrainz.spark.handlers.db_stats.get_timestamp_for_last_user_stats_update')
-    def test_new_user_stats(self, mock_db_get_timestamp):
+    def test_is_new_user_stats_batch(self, mock_db_get_timestamp):
         mock_db_get_timestamp.return_value = datetime.now(timezone.utc)
-        self.assertFalse(new_user_stats())
+        self.assertFalse(is_new_user_stats_batch())
         mock_db_get_timestamp.return_value = datetime.now(timezone.utc) - timedelta(hours=13)
-        self.assertTrue(new_user_stats())
+        self.assertTrue(is_new_user_stats_batch())

--- a/listenbrainz/webserver/templates/emails/user_stats_notification.txt
+++ b/listenbrainz/webserver/templates/emails/user_stats_notification.txt
@@ -1,0 +1,8 @@
+Hi! 👋
+
+New user stats were received by the spark consumer
+and are being written into the database.
+
+The first stat came in at {{ now }} UTC.
+
+Your Friendly Neighbourhood Brainzbot 🤖


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
<!--
 A one line description of what this change does.
-->
This PR sends an email when new user statistics start coming in. If the user stats table was last updated 12 hours ago, we send a mail.

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

Observability on listenbrainz stats generation is non-existent.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Start sending emails so that we know that stuff is up and working.



