### PR TITLE
Fix all.py path bug

### DIFF
--- a/listenbrainz_spark/stats/user/all.py
+++ b/listenbrainz_spark/stats/user/all.py
@@ -1,3 +1,5 @@
+""" Calculate and return ALL user stats in rabbitmq compatible format
+"""
 from flask import current_app
 from datetime import datetime
 from listenbrainz_spark.utils import get_listens
@@ -8,16 +10,13 @@ from collections import defaultdict
 
 def calculate():
     now = datetime.utcnow()
-    listens_df = get_listens(from_date=datetime(LAST_FM_FOUNDING_YEAR, 1, 1), to_date=now, dest_path=current_app.config['HDFS_CLUSTER_URI']+path.LISTENBRAINZ_DATA_DIRECTORY)
+    listens_df = get_listens(from_date=datetime(LAST_FM_FOUNDING_YEAR, 1, 1), to_date=now, dest_path=path.LISTENBRAINZ_DATA_DIRECTORY)
     table_name = 'stats_user_all'
     listens_df.createOrReplaceTempView(table_name)
-
-    data = defaultdict(dict)
 
     # calculate and put artist stats into the result
     artist_data = get_artists(table_name)
     messages = []
-
     for user_name, user_artists in artist_data.items():
         messages.append({
             'musicbrainz_id': user_name,

--- a/listenbrainz_spark/stats/user/tests/test_all.py
+++ b/listenbrainz_spark/stats/user/tests/test_all.py
@@ -1,0 +1,55 @@
+from pyspark.sql import Row
+
+from listenbrainz_spark.tests import SparkTestCase
+from listenbrainz_spark.stats.user.all import calculate
+from listenbrainz_spark import utils
+
+class UserStatsAllTestCase(SparkTestCase):
+
+    def save_dataframe(self):
+        df = utils.create_dataframe(Row(user_name='user2', artist_name='artist1', artist_msid='1',artist_mbids='1',
+            track_name='test', recording_msid='1', recording_mbid='1', release_name='test',release_msid='1',
+            release_mbid='1'), schema=None)
+        df1 = utils.create_dataframe(Row(user_name='user1',artist_name='artist1', artist_msid='1',artist_mbids='1',
+            track_name='test', recording_msid='1', recording_mbid='1', release_name='test',release_msid='1',
+             release_mbid='1'), schema=None)
+        df2 = utils.create_dataframe(Row(user_name='user1',artist_name='artist1', artist_msid='1',artist_mbids='1',
+            track_name='test', recording_msid='1', recording_mbid='1', release_name='test',release_msid='1',
+            release_mbid='1'), schema=None)
+        df = df.union(df1).union(df2)
+        utils.save_parquet(df, '/data/listenbrainz/2019/12.parquet')
+
+    def test_all(self):
+        self.save_dataframe()
+        data = calculate()
+        expected_result = [
+            {
+                "musicbrainz_id": "user1",
+                "type": "user_artist",
+                "artist_stats": [
+                    {
+                        "artist_name": "artist1",
+                        "artist_msid": "1",
+                        "artist_mbids": "1",
+                        "listen_count": 2
+                    }
+                ],
+                "artist_count": 1
+            },
+            {
+                "musicbrainz_id": "user2",
+                "type": "user_artist",
+                "artist_stats": [
+                    {
+                        "artist_name": "artist1",
+                        "artist_msid": "1",
+                        "artist_mbids": "1",
+                        "listen_count": 1
+                    }
+                ],
+                "artist_count": 1
+            }
+        ]
+        self.assertListEqual(expected_result, data)
+        self.assertDictEqual(expected_result[0], data[0])
+        self.assertDictEqual(expected_result[1], data[1])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
<!--
 A one line description of what this change does.
-->
Fix the regression in stats calculation.

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

There was a bug in our user stats calculation. Essentially we were passing the HDFS_CLUSTER_URI to the path twice.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Remove the extra path param added and add a test.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Merge and deploy.

