### PR TITLE
[LB-494] Make LastFM Importer modal responsive

### DIFF
--- a/listenbrainz/webserver/static/js/jsx/lastFmImporter.jsx
+++ b/listenbrainz/webserver/static/js/jsx/lastFmImporter.jsx
@@ -53,7 +53,7 @@ export default class LastFmImporter extends React.Component {
           <input type="submit" value="Import Now!" disabled={!this.state.lastfmUsername} />
         </form>
         <Modal show={this.state.show} onClose={this.toggleModal} disable={!this.state.canClose}>
-          <img src='/static/img/listenbrainz-logo.svg' height='75' class='img-responsive'/>
+          <img src='/static/img/listenbrainz-logo.svg' height='75' className='img-responsive'/>
           <br /><br />
           <div>{this.state.msg}</div>
           <br />

--- a/listenbrainz/webserver/static/js/jsx/lastFmImporterModal.jsx
+++ b/listenbrainz/webserver/static/js/jsx/lastFmImporterModal.jsx
@@ -9,12 +9,14 @@ export default class Modal extends React.Component {
     }
     const divStyle = {
       position: 'fixed',
-      top: '200px',
+      height: '90%',
+      maxHeight: '300px',
+      top: '50%',
       zIndex: '200000000000000',
       width: '90%',
       maxWidth: '500px',
-      transform: 'translateX(-50%)',
       left: '50%',
+      transform: 'translate(-50%, -50%)',
       backgroundColor: '#fff',
       boxShadow: '0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22)',
       textAlign: 'center',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
Make the Last FM importer modal aware of height and width of the browser window.

This is a continuation of [https://github.com/metabrainz/listenbrainz-server/pull/738](url)
<!--
 A one line description of what this change does.
-->


# Problem
The modal doesn't consider the the height of the window, forcing the user to resize the window.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Making the of the modal relative to the browser height fixes the problem.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

# Screenshots
![2020-03-01-205324_1366x746_scrot](https://user-images.githubusercontent.com/25200200/75628459-2abc6800-5bff-11ea-8f75-7187de16daaa.png)
![2020-03-01-205441_504x456_scrot](https://user-images.githubusercontent.com/25200200/75628462-2ee88580-5bff-11ea-9e6c-bcb9baf30fea.png)


