### PR TITLE
added vlc-listenbrainz-plugin to https://listenbrainz.org/api-docs

### DIFF
--- a/listenbrainz/webserver/templates/index/api-docs.html
+++ b/listenbrainz/webserver/templates/index/api-docs.html
@@ -23,6 +23,7 @@
     <li><em><a href="https://github.com/InputUsername/rescrobbled">Rescrobbled</a></em>, a universal Linux scrobbler for MPRIS enabled players</li>
     <li><em><a href="https://add0n.com/lastfm-scrobbler.html">Last.fm Scrobbler</a></em>, an extension for Firefox and Chrome</li>
     <li><em><a href="https://github.com/tgwizard/sls">Simple Last.fm Scrobbler</a></em>, for Android devices</li>
+    <li><em><a href="https://github.com/amCap1712/vlc-listenbrainz-plugin">VLC Listenbrainz plugin</a></em>, cross-platform plugin for VLC player</li>
   </ul>
 
 {%- endblock -%}


### PR DESCRIPTION
Added https://github.com/amCap1712/vlc-listenbrainz-plugin plugin to the list of the options to scrobble to the web page: https://listenbrainz.org/api-docs