### PR TITLE
[wip] LB-500: Fix DB setup scripts in manage.py

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -101,7 +101,7 @@ def gen_app(config_path=None, debug=None):
     create_redis(app)
 
     # Influx connection
-    create_influx(app)
+    # create_influx(app)
 
     # RabbitMQ connection
     try:

--- a/manage.py
+++ b/manage.py
@@ -185,7 +185,7 @@ def init_db(force, create_db):
         if not res:
             raise Exception('Failed to drop existing database and user! Exit code: %i' % res)
 
-    if create_db:
+    if create_db or force:
         print('Creating user and a database...')
         res = ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_db.sql'))
         if not res:


### PR DESCRIPTION
# Description
The command `./develop.sh manage init_ts_db -f` raises psycopg2 authentication error [(JIRA ticket)](https://tickets.metabrainz.org/projects/LB/issues/LB-500).

# Problem
The command `./develop.sh manage init_ts_db -f` throws an error 
`sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) FATAL: password authentication failed for user "timescale_lb"`

This might be due to the reason that on running the above command it runs the queries in *admin.timescale.drop_db.sql* which also drops the timescale_lb user. Although the timescale_lb  user gets created during execution of the following code and queries but no password is associated with it.

Also, the `listenbrainz_web` docker container crashes as the webserver tries to create connection to Influx.

# Solution

- Run the queries in *admin.timescale.create_db.sql* to create the timescale_lb user and associate password with it

- Remove the function call `create_influx(app)` in *listenbrainz.webserver.__init__.py*