### PR TITLE
LB-501: Fix DB setup scripts in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -85,7 +85,7 @@ def init_db(force, create_db):
         if not res:
             raise Exception('Failed to drop existing database and user! Exit code: %i' % res)
 
-    if create_db:
+    if create_db or force:
         print('Creating user and a database...')
         res = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'create_db.sql'))
         if not res:
@@ -134,7 +134,7 @@ def init_msb_db(force, create_db):
         if not res:
             raise Exception('Failed to drop existing database and user! Exit code: %s' % res)
 
-    if create_db:
+    if create_db or force:
         print('Creating user and a database...')
         res = db.run_sql_script_without_transaction(os.path.join(MSB_ADMIN_SQL_DIR, 'create_db.sql'))
         if not res:


### PR DESCRIPTION
# Description

This PR is in continuation to #761 

The commands `./develop.sh manage init_db -f` and `./develop.sh manage init_msb_db -f` raise psycopg2 errors [(JIRA ticket)](https://tickets.metabrainz.org/browse/LB-501).

# Problem

The command `./develop.sh manage init_db` -f throws an error
`sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) FATAL:  role "listenbrainz" does not exist`

A similar error is thrown on running `./develop.sh manage init_msb_db`.

# Solution
Running the queries in *create_db.sql* files for the associated DB creates the user and fixes this error.