### PR TITLE
LB-503: Add command to connect to Timescale DB via develop.sh

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -23,6 +23,12 @@ function open_psql_shell {
             -h db listenbrainz
 }
 
+function open_timescale_shell {
+    invoke_docker_compose run --rm web psql \
+            -U timescale_lb  \
+            -h timescale timescale_lb
+}
+
 function npm_install {
     invoke_docker_compose run --rm -e \
                 HOME=/tmp static_builder npm install
@@ -39,6 +45,11 @@ if [ "$1" == "manage" ]; then shift
 elif [ "$1" == "psql" ]; then
     echo "Entering into PSQL shell to query DB..."
     open_psql_shell
+    exit
+
+elif [ "$1" == "timescale" ]; then
+    echo "Entering into PSQL shell to query Timescale DB..."
+    open_timescale_shell
     exit
 
 elif [ "$1" == "npm" ]; then

--- a/develop.sh
+++ b/develop.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+POSTGRES_ADMIN_LB_URI="postgresql://postgres@db/listenbrainz"
+SQLALCHEMY_TIMESCALE_URI="postgresql://timescale_lb:timescale_lb@timescale/timescale_lb"
 
 if [[ ! -d "docker" ]]; then
     echo "This script must be run from the top level directory of the listenbrainz-server source."
@@ -19,14 +21,12 @@ function invoke_manage {
 
 function open_psql_shell {
     invoke_docker_compose run --rm web psql \
-            -U listenbrainz  \
-            -h db listenbrainz
+            $POSTGRES_ADMIN_LB_URI
 }
 
 function open_timescale_shell {
     invoke_docker_compose run --rm web psql \
-            -U timescale_lb  \
-            -h timescale timescale_lb
+            $SQLALCHEMY_TIMESCALE_URI
 }
 
 function npm_install {

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -101,7 +101,7 @@ def gen_app(config_path=None, debug=None):
     create_redis(app)
 
     # Influx connection
-    create_influx(app)
+    # create_influx(app)
 
     # RabbitMQ connection
     try:

--- a/manage.py
+++ b/manage.py
@@ -185,7 +185,7 @@ def init_db(force, create_db):
         if not res:
             raise Exception('Failed to drop existing database and user! Exit code: %i' % res)
 
-    if create_db:
+    if create_db or force:
         print('Creating user and a database...')
         res = ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_db.sql'))
         if not res:


### PR DESCRIPTION
# Description

Just like `./develop.sh psql` we can have a command to connect to Timmescale DB directly.

# Problem

There didn't exist any command to directly enter into PSQL shell and connect to timescale DB.

# Solution

- Add  `timescale` option to `./develop.sh` to enter into PSQL shell and connect to timescale DB automatically.
- Use URLs to connect to the PSQL dbs.

# Action

- Enter the `./develop.sh timescale` command in the 
Done. You can now query the Timescale Db directly.