### PR TITLE
Reset latest import when the user deletes their listens as well

### DIFF
--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -253,7 +253,6 @@ def increase_latest_import(musicbrainz_id, ts):
 
 def reset_latest_import(musicbrainz_id):
     """Resets the latest_import field for user with specified MusicBrainz ID to 0"""
-    user = get_by_mb_id(musicbrainz_id)
     update_latest_import(musicbrainz_id, 0)
 
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -268,3 +268,4 @@ def delete_listens_history(musicbrainz_id):
     user = _get_user(musicbrainz_id)
     _influx.delete(user.musicbrainz_id)
     _influx.reset_listen_count(user.musicbrainz_id)
+    db_user.reset_latest_import(user.musicbrainz_id)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
<!--
 A one line description of what this change does.
-->
Reset the latest_import timestamp for a user to when they delete their listens.


# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
If a user deleted their listens and tried to re-import from last.fm, it would only import a subset of listens because the latest_import timestamp had not been reset. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Set it back to 0 and add a test.


