### PR TITLE
Add Artist MBID and Release MBID fields for lastFM imports

### DIFF
--- a/docs/dev/json.rst
+++ b/docs/dev/json.rst
@@ -71,6 +71,7 @@ A complete submit listen JSON document may look like::
           "listened_at": 1443521965,
           "track_metadata": {
             "additional_info": {
+              "listened_from": "spotify",
               "release_mbid": "bf9e91ea-8029-4a04-a26a-224e00a83266",
               "artist_mbids": [
                 "db92a151-1ac2-438b-bc43-b82e149ddd50"
@@ -162,6 +163,7 @@ element                 description
 ``isrc``                The ISRC code associated with the recording.
 ``spotify_id``          The Spotify track URL associated with this recording.  e.g.: http://open.spotify.com/track/1rrgWMXGCGHru5bIRxGFV0
 ``tags``                A list of user defined tags to be associated with this recording. These tags are similar to last.fm tags. For example, you have apply tags such as ``punk``, ``see-live``, ``smelly``. You may submit up to :data:`~webserver.views.api.MAX_TAGS_PER_LISTEN` tags and each tag may be up to :data:`~webserver.views.api.MAX_TAG_SIZE` characters large.
+``listened_from``       The source of the listen, i.e the name of the client or service which submits the listen.
 ======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
 
 At this point, we are not scrubbing any superflous elements that may be

--- a/listenbrainz/testdata/valid_single.json
+++ b/listenbrainz/testdata/valid_single.json
@@ -6,7 +6,10 @@
             "track_metadata": {
                 "artist_name": "Kanye West",
                 "track_name": "Fade",
-                "release_name": "The Life of Pablo"
+                "release_name": "The Life of Pablo",
+                "additional_info": {
+                    "listened_from": "spotify"
+                }
             }
         }
     ]

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -70,6 +70,7 @@ class APITestCase(IntegrationTestCase):
         self.assertEqual(data['listens'][0]['track_metadata']['track_name'], 'Fade')
         self.assertEqual(data['listens'][0]['track_metadata']['artist_name'], 'Kanye West')
         self.assertEqual(data['listens'][0]['track_metadata']['release_name'], 'The Life of Pablo')
+        self.assertEqual(data['listens'][0]['track_metadata']['additional_info']['listened_from'], 'spotify');
 
         # make sure that artist msid, release msid and recording msid are present in data
         self.assertTrue(is_valid_uuid(data['listens'][0]['recording_msid']))

--- a/listenbrainz/webserver/static/js/jsx/__mocks__/encodeScrobble_output.json
+++ b/listenbrainz/webserver/static/js/jsx/__mocks__/encodeScrobble_output.json
@@ -5,7 +5,9 @@
       "artist_name": "Coldplay",
       "release_name": "A Head Full Of Dreams",
       "additional_info": {
-        "recording_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b"
+        "recording_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
+        "release_mbid": "002183a5-c087-4c0a-9c47-65ef79261dd2",
+        "artist_mbids": ["cc197bad-dc9c-440d-a5b5-d52ba2e14234"]
       }
     },
     "listened_at": "1583223398"
@@ -16,7 +18,21 @@
       "artist_name": "Imagine Dragons",
       "release_name": "Evolve",
       "additional_info": {
-        "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9"
+        "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9",
+        "release_mbid": "25c11880-bc5e-43db-927b-522eb871dc9e",
+        "artist_mbids": ["012151a8-0f9a-44c9-997f-ebd68b5389f9"]
+      }
+    },
+    "listened_at": "1583222465"
+  },
+  {
+    "track_metadata": {
+      "track_name": "Believer",
+      "artist_name": "Imagine Dragons",
+      "release_name": "Evolve",
+      "additional_info": {
+        "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9",
+        "artist_mbids": []
       }
     },
     "listened_at": "1583222465"

--- a/listenbrainz/webserver/static/js/jsx/__mocks__/encodeScrobble_output.json
+++ b/listenbrainz/webserver/static/js/jsx/__mocks__/encodeScrobble_output.json
@@ -5,9 +5,10 @@
       "artist_name": "Coldplay",
       "release_name": "A Head Full Of Dreams",
       "additional_info": {
+        "listening_from": "lastfm",
         "recording_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
-        "release_mbid": "002183a5-c087-4c0a-9c47-65ef79261dd2",
-        "artist_mbids": ["cc197bad-dc9c-440d-a5b5-d52ba2e14234"]
+        "lastfm_release_mbid": "002183a5-c087-4c0a-9c47-65ef79261dd2",
+        "lastfm_artist_mbid": "cc197bad-dc9c-440d-a5b5-d52ba2e14234"
       }
     },
     "listened_at": "1583223398"
@@ -18,9 +19,10 @@
       "artist_name": "Imagine Dragons",
       "release_name": "Evolve",
       "additional_info": {
+        "listening_from": "lastfm",
         "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9",
-        "release_mbid": "25c11880-bc5e-43db-927b-522eb871dc9e",
-        "artist_mbids": ["012151a8-0f9a-44c9-997f-ebd68b5389f9"]
+        "lastfm_release_mbid": "25c11880-bc5e-43db-927b-522eb871dc9e",
+        "lastfm_artist_mbid": "012151a8-0f9a-44c9-997f-ebd68b5389f9"
       }
     },
     "listened_at": "1583222465"
@@ -31,8 +33,8 @@
       "artist_name": "Imagine Dragons",
       "release_name": "Evolve",
       "additional_info": {
-        "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9",
-        "artist_mbids": []
+        "listening_from": "lastfm",
+        "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9"
       }
     },
     "listened_at": "1583222465"

--- a/listenbrainz/webserver/static/js/jsx/__mocks__/page.json
+++ b/listenbrainz/webserver/static/js/jsx/__mocks__/page.json
@@ -79,6 +79,40 @@
         "url": "https://www.last.fm/music/Imagine+Dragons/_/Believer",
         "name": "Believer",
         "mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9"
+      },
+      {
+        "artist": {
+          "#text": "Imagine Dragons"
+        },
+        "album": {
+          "#text": "Evolve"
+        },
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/8c77e9f509c4dd3bca8d3ac6b5344ce5.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/8c77e9f509c4dd3bca8d3ac6b5344ce5.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/8c77e9f509c4dd3bca8d3ac6b5344ce5.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/8c77e9f509c4dd3bca8d3ac6b5344ce5.png"
+          }
+        ],
+        "streamable": "0",
+        "date": {
+          "uts": "1583222465",
+          "#text": "03 Mar 2020, 08:01"
+        },
+        "url": "https://www.last.fm/music/Imagine+Dragons/_/Believer",
+        "name": "Believer",
+        "mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9"
       }
     ]
   }

--- a/listenbrainz/webserver/static/js/jsx/api-service.js
+++ b/listenbrainz/webserver/static/js/jsx/api-service.js
@@ -15,6 +15,7 @@ export default class APIService {
       APIBaseURI += '/1';
     }
     this.APIBaseURI = APIBaseURI;
+    this.MAX_LISTEN_SIZE = 10000; // Maximum size of listens that can be sent
   }
 
   async getRecentListensForUsers(userNames, limit) {
@@ -86,7 +87,7 @@ export default class APIService {
 
   async submitListens(userToken, listenType, payload) {
     /*
-    *  Send a POST request to the ListenBrainz server to submit a listen
+      Send a POST request to the ListenBrainz server to submit a listen
     */
 
     if (!isString(userToken)) {
@@ -96,27 +97,42 @@ export default class APIService {
       throw new SyntaxError(`listenType can be "single", "playingNow" or "import", got ${listenType} instead`);
     }
 
-    let struct = {
-      "listen_type": listenType,
-      "payload": payload,
-    }
+    if (JSON.stringify(payload).length <= this.MAX_LISTEN_SIZE) {
+      // Payload is within submission limit, submit directly
+      let struct = {
+        "listen_type": listenType,
+        "payload": payload,
+      }
 
-    let url = `${this.APIBaseURI}/submit-listens`;
+      let url = `${this.APIBaseURI}/submit-listens`;
 
-    try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Token ${userToken}`,
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        body: JSON.stringify(struct),
-      })
-      return response; // Return status so that caller can handle appropriately
-    } catch {
-      // Retry if there is an network error
-      console.warn("Error, retrying in 3 sec");
-      setTimeout(() => this.submitListens(userToken, listenType, payload), 3000)
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Token ${userToken}`,
+            'Content-Type': 'application/json;charset=UTF-8',
+          },
+          body: JSON.stringify(struct),
+        })
+
+        if (response.status == 429) {
+          // This should never happen, but if it does, try again.
+          console.warn("Error, retrying in 3 sec");
+          setTimeout(() => this.submitListens(userToken, listenType, payload), 3000)
+        } else {
+          console.warn(`Got ${response.status} error, skipping`);
+        }
+        return response; // Return response so that caller can handle appropriately
+      } catch {
+        // Retry if there is an network error
+        console.warn("Error, retrying in 3 sec");
+        setTimeout(() => this.submitListens(userToken, listenType, payload), 3000)
+      }
+    } else {
+      // Payload is not within submission limit, split and submit
+      this.submitListens(userToken, listenType, payload.slice(0, payload.length/2));
+      return this.submitListens(userToken, listenType, payload.slice(payload.length/2, payload.length));
     }
   }
 

--- a/listenbrainz/webserver/static/js/jsx/api-service.js
+++ b/listenbrainz/webserver/static/js/jsx/api-service.js
@@ -120,7 +120,7 @@ export default class APIService {
           // This should never happen, but if it does, try again.
           console.warn("Error, retrying in 3 sec");
           setTimeout(() => this.submitListens(userToken, listenType, payload), 3000)
-        } else {
+        } else if (!(response.status >= 200 && response.status < 300)){
           console.warn(`Got ${response.status} error, skipping`);
         }
         return response; // Return response so that caller can handle appropriately
@@ -131,8 +131,8 @@ export default class APIService {
       }
     } else {
       // Payload is not within submission limit, split and submit
-      this.submitListens(userToken, listenType, payload.slice(0, payload.length/2));
-      return this.submitListens(userToken, listenType, payload.slice(payload.length/2, payload.length));
+      await this.submitListens(userToken, listenType, payload.slice(0, payload.length/2));
+      return await this.submitListens(userToken, listenType, payload.slice(payload.length/2, payload.length));
     }
   }
 

--- a/listenbrainz/webserver/static/js/jsx/importer.js
+++ b/listenbrainz/webserver/static/js/jsx/importer.js
@@ -225,7 +225,7 @@ export default class Importer {
     if (this.rl_reset < 0 || current > this.rl_origin + this.rl_reset) {
       delay = 0;
     } else if (this.rl_remain > 0) {
-      delay = Math.max(0, Math.ceil((this.rl_reset * 1000) / rl_remain));
+      delay = Math.max(0, Math.ceil((this.rl_reset * 1000) / this.rl_remain));
     } else {
       delay = Math.max(0, Math.ceil(this.rl_reset * 1000));
     }
@@ -234,8 +234,8 @@ export default class Importer {
 
   updateRateLimitParameters(response) {
     /* Update the variables we use to honor LB's rate limits */
-    this.rl_remain = parseInt(response.headers['X-RateLimit-Remaining']);
-    this.rl_reset = parseInt(response.headers['X-RateLimit-Reset-In']);
+    this.rl_remain = parseInt(response.headers.get('X-RateLimit-Remaining'));
+    this.rl_reset = parseInt(response.headers.get('X-RateLimit-Reset-In'));
     this.rl_origin = new Date().getTime() / 1000;
   }
 }

--- a/listenbrainz/webserver/static/js/jsx/importer.js
+++ b/listenbrainz/webserver/static/js/jsx/importer.js
@@ -25,7 +25,6 @@ export default class Importer {
     this.incrementalImport = false;
 
     this.numCompleted = 0; // number of pages completed till now
-    this.numSuccesful = 0; // number of pages succesfully submitted
 
     this.props = props;
 
@@ -183,34 +182,14 @@ export default class Importer {
   }
 
   async submitPage(payload) {
-    try {
-      let delay = this.getRateLimitDelay();
-      // Halt execution for some time
-      await new Promise((resolve) => {
-        setTimeout(resolve, delay);
-      })
+    let delay = this.getRateLimitDelay();
+    // Halt execution for some time
+    await new Promise((resolve) => {
+      setTimeout(resolve, delay);
+    })
 
-      let response = await this.APIService.submitListens(this.userToken, "import", payload);
-      if (response.status >= 200 && response.status < 300) {
-        this.numSuccesful++;
-      } else if (response.status == 429) {
-        // This should never happen, but if it does, toss it back in and try again.
-        setTimeout(() => this.submitPage(payload), 3000);
-      } else if (response.status >= 400 && response.status < 500) {
-        // We mark 4xx errors as completed because we don't
-        // retry them
-        console.warn("4xx error, skipping");
-      } else if (response.status >= 500) {
-        console.warn("received http error " + response.status + " req'ing");
-        // If something causes a 500 error, better not repeat it and just skip it.
-      } else {
-        console.warn("received http status " + response.status + ", skipping");
-      }
-      this.updateRateLimitParameters(response);
-    } catch {
-      console.warn("Error, retrying in 3s");
-      setTimeout(() => this.submitPage(payload), 3000);
-    }
+    let response = await this.APIService.submitListens(this.userToken, "import", payload);
+    this.updateRateLimitParameters(response);
   }
 
   encodeScrobbles(scrobbles) {

--- a/listenbrainz/webserver/static/js/jsx/lastFmImporter.jsx
+++ b/listenbrainz/webserver/static/js/jsx/lastFmImporter.jsx
@@ -54,7 +54,7 @@ export default class LastFmImporter extends React.Component {
         </form>
         {this.state.show &&
           <Modal onClose={this.toggleModal} disable={!this.state.canClose}>
-            <img src='/static/img/listenbrainz-logo.svg' height='75' class='img-responsive'/>
+            <img src='/static/img/listenbrainz-logo.svg' height='75' className='img-responsive'/>
             <br /><br />
             <div>{this.state.msg}</div>
             <br />

--- a/listenbrainz/webserver/static/js/jsx/scrobble.js
+++ b/listenbrainz/webserver/static/js/jsx/scrobble.js
@@ -91,9 +91,10 @@ export default class Scrobble {
         "artist_name": this.artistName(),
         "release_name": this.releaseName(),
         "additional_info": {
+          "listening_from": "lastfm",
           "recording_mbid": this.trackMBID(),
-          "release_mbid": this.releaseMBID(),
-          "artist_mbids": [this.artistMBID()]
+          "lastfm_release_mbid": this.releaseMBID(),
+          "lastfm_artist_mbid": this.artistMBID()
         }
       },
       "listened_at": this.scrobbledAt(),

--- a/listenbrainz/webserver/static/js/jsx/scrobble.js
+++ b/listenbrainz/webserver/static/js/jsx/scrobble.js
@@ -4,7 +4,7 @@ export default class Scrobble {
   }
 
   lastfmID() {
-    // Returns url of type "http://www.last.fm/music/Mot%C3%B6rhead"
+    /* Returns url of type "http://www.last.fm/music/Mot%C3%B6rhead" */
     if ('url' in this.rootScrobbleElement && this.rootScrobbleElement['url'] !== "" ) {
       let url = this.rootScrobbleElement['url'];
       url = url.split("/");
@@ -15,6 +15,7 @@ export default class Scrobble {
   }
 
   artistName() {
+    /* Returns artistName if present, else returns an empty string */
     if ('artist' in this.rootScrobbleElement && '#text' in this.rootScrobbleElement['artist']) {
       return this.rootScrobbleElement['artist']['#text'];
     } else {
@@ -22,7 +23,17 @@ export default class Scrobble {
     }
   }
 
+  artistMBID() {
+    /* Returns artistName if present, else returns an empty string */
+    if ('artist' in this.rootScrobbleElement && 'mbid' in this.rootScrobbleElement['artist']) {
+      return this.rootScrobbleElement['artist']['mbid'];
+    } else {
+      return "";
+    }
+  }
+
   trackName() {
+    /* Returns trackName if present, else returns an empty string */
     if ('name' in this.rootScrobbleElement) {
       return this.rootScrobbleElement['name'];
     } else {
@@ -31,6 +42,7 @@ export default class Scrobble {
   }
 
   releaseName() {
+    /* Returns releaseName if present, else returns an empty string */
     if ('album' in this.rootScrobbleElement && '#text' in this.rootScrobbleElement['album']) {
       return this.rootScrobbleElement['album']['#text'];
     } else {
@@ -38,7 +50,17 @@ export default class Scrobble {
     }
   };
 
+  releaseMBID() {
+    /* Returns releaseMBID if present, else returns an empty string */
+    if ('album' in this.rootScrobbleElement && 'mbid' in this.rootScrobbleElement['album']) {
+      return this.rootScrobbleElement['album']['mbid'];
+    } else {
+      return "";
+    }
+  };
+
   scrobbledAt() {
+    /* Returns scrobbledAt if present, else returns an empty string */
     if ('date' in this.rootScrobbleElement && 'uts' in this.rootScrobbleElement['date']) {
       return this.rootScrobbleElement['date']['uts'];
     } else {
@@ -54,6 +76,7 @@ export default class Scrobble {
   };
 
   trackMBID() {
+    /* Returns trackMBID if present, else returns an empty string */
     if ('mbid' in this.rootScrobbleElement) {
       return this.rootScrobbleElement['mbid'];
     } else {
@@ -68,7 +91,9 @@ export default class Scrobble {
         "artist_name": this.artistName(),
         "release_name": this.releaseName(),
         "additional_info": {
-          "recording_mbid": this.trackMBID()
+          "recording_mbid": this.trackMBID(),
+          "release_mbid": this.releaseMBID(),
+          "artist_mbids": [this.artistMBID()]
         }
       },
       "listened_at": this.scrobbledAt(),
@@ -83,6 +108,8 @@ export default class Scrobble {
         } else if (Object.prototype.toString.call(value) === '[object Object]') {
           filter(value);
         } else if (Array.isArray(value)) {
+          value = value.filter(Boolean);
+          obj[key] = value;
           value.forEach(function (el) { filter(el); });
         }
       });


### PR DESCRIPTION
# Description
Add Artist MBID and Release MBID fields for lastFM imports.

# Problem
LastFM API provides Artist MBID as well as Release MBID. However this information was not incorporated into the database.

# Solution
The issue can be solved by embedding the information in the `additional_metadata` field. After embedding the information, the payload size exceed `MAX_LISTEN_SIZE` specified in the documentation. To fix this some changes had to be made to the `submitListens` function.