### PR TITLE
Add ability to update snapshots to frontend-test.sh

### DIFF
--- a/frontend-test.sh
+++ b/frontend-test.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
+# ./frontend-test.sh                    Run tests
+# ./frontend-test.sh -u                 Run tests, update snapshots
+# ./frontend-test.sh -b                 Build containers
+
+if [ "$1" == "-u" ]; then
+    docker-compose -f docker/docker-compose.test.yml \
+       -p listenbrainz_test \
+       run --rm frontend_tester npm run test:update-snapshots
+    exit 0
+fi
+
+if [ "$1" == "-b" ]; then
+    docker-compose -f docker/docker-compose.test.yml -p listenbrainz_test build
+    exit 0
+fi
+
 docker-compose -f docker/docker-compose.test.yml \
                -p listenbrainz_test \
                run --rm frontend_tester npm test
-docker-compose -f docker/docker-compose.test.yml \
-               -p listenbrainz_test \
-               run --rm frontend_tester npm run type-check
-docker-compose -f docker/docker-compose.test.yml \
-               -p listenbrainz_test \
-               run --rm frontend_tester npm run format

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "eslint ./static/js/src --ignore-path .gitignore --ext .js,jsx,ts,tsx --fix",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:update-snapshots": "jest -u",
     "test:coverage": "jest --coverage --colors",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description
<!--
 A one line description of what this change does.
-->

* Remove the automatic linting and typechecks from frontend-test.sh
* Add `./frontend-test.sh -u` which updates failing snapshots
* Add `./frontend-test.sh -b` which builds the test containers

# Problem
 
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
There was no easy way to update snapshots for frontend tests.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add new commands.

Removing the type check and linting from running in this command is ok to me because
* The type-check is automatically a part of the ./develop.sh process
* The linting is specifically called out in the docs and can be done using ./lint.sh


