### PR TITLE
Add definition to remaining types

### DIFF
--- a/frontend-test.sh
+++ b/frontend-test.sh
@@ -2,6 +2,7 @@
 
 # ./frontend-test.sh                    Run tests
 # ./frontend-test.sh -u                 Run tests, update snapshots
+# ./frontend-test.sh -t                 Run type-checker
 # ./frontend-test.sh -b                 Build containers
 
 if [ "$1" == "-u" ]; then
@@ -13,6 +14,13 @@ fi
 
 if [ "$1" == "-b" ]; then
     docker-compose -f docker/docker-compose.test.yml -p listenbrainz_test build
+    exit 0
+fi
+
+if [ "$1" == "-t" ]; then
+    docker-compose -f docker/docker-compose.test.yml \
+                   -p listenbrainz_test \
+                   run --rm frontend_tester npm run type-check
     exit 0
 fi
 

--- a/listenbrainz/webserver/static/js/src/APIService.test.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.test.ts
@@ -16,7 +16,15 @@ describe("submitListens", () => {
   });
 
   it("calls fetch with correct parameters", async () => {
-    await apiService.submitListens("foobar", "import", "foobar");
+    await apiService.submitListens("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
     expect(window.fetch).toHaveBeenCalledWith("foobar/1/submit-listens", {
       method: "POST",
       headers: {
@@ -25,7 +33,15 @@ describe("submitListens", () => {
       },
       body: JSON.stringify({
         listen_type: "import",
-        payload: "foobar",
+        payload: [
+          {
+            listened_at: 1000,
+            track_metadata: {
+              artist_name: "foobar",
+              track_name: "bazfoo",
+            },
+          },
+        ],
       }),
     });
   });
@@ -44,7 +60,15 @@ describe("submitListens", () => {
         });
       });
 
-    await apiService.submitListens("foobar", "import", "foobar");
+    await apiService.submitListens("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
     expect(setTimeout).toHaveBeenCalledTimes(1);
   });
 
@@ -57,7 +81,15 @@ describe("submitListens", () => {
       });
     });
 
-    await apiService.submitListens("foobar", "import", "foobar");
+    await apiService.submitListens("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
     expect(setTimeout).toHaveBeenCalledTimes(1);
   });
 
@@ -70,13 +102,29 @@ describe("submitListens", () => {
       });
     });
 
-    await apiService.submitListens("foobar", "import", "foobar");
+    await apiService.submitListens("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
     expect(setTimeout).not.toHaveBeenCalled(); // no setTimeout calls for future retries
   });
 
   it("returns the response if successful", async () => {
     await expect(
-      apiService.submitListens("foobar", "import", "foobar")
+      apiService.submitListens("foobar", "import", [
+        {
+          listened_at: 1000,
+          track_metadata: {
+            artist_name: "foobar",
+            track_name: "bazfoo",
+          },
+        },
+      ])
     ).resolves.toEqual({
       ok: true,
       status: 200,
@@ -84,15 +132,60 @@ describe("submitListens", () => {
   });
 
   it("calls itself recursively if size of payload exceeds MAX_LISTEN_SIZE", async () => {
-    // Change MAX_LISTEN_SIZE to 0
-    apiService.MAX_LISTEN_SIZE = 9;
+    apiService.MAX_LISTEN_SIZE = 100;
 
     const spy = jest.spyOn(apiService, "submitListens");
-    await apiService.submitListens("foobar", "import", ["foo", "bar"]);
+    await apiService.submitListens("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "bazfoo",
+          track_name: "foobar",
+        },
+      },
+    ]);
     expect(spy).toHaveBeenCalledTimes(3);
-    expect(spy).toHaveBeenCalledWith("foobar", "import", ["foo", "bar"]);
-    expect(spy).toHaveBeenCalledWith("foobar", "import", ["foo"]);
-    expect(spy).toHaveBeenCalledWith("foobar", "import", ["bar"]);
+    expect(spy).toHaveBeenCalledWith("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "bazfoo",
+          track_name: "foobar",
+        },
+      },
+    ]);
+    expect(spy).toHaveBeenCalledWith("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
+    expect(spy).toHaveBeenCalledWith("foobar", "import", [
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "bazfoo",
+          track_name: "foobar",
+        },
+      },
+    ]);
   });
 });
 

--- a/listenbrainz/webserver/static/js/src/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.ts
@@ -89,14 +89,14 @@ export default class APIService {
   submitListens = async (
     userToken: string,
     listenType: ListenType,
-    payload: SubmitListensPayload
+    payload: Array<Listen>
   ): Promise<Response> => {
     if (JSON.stringify(payload).length <= this.MAX_LISTEN_SIZE) {
       // Payload is within submission limit, submit directly
       const struct = {
         listen_type: listenType,
         payload,
-      };
+      } as SubmitListensPayload;
 
       const url = `${this.APIBaseURI}/submit-listens`;
 

--- a/listenbrainz/webserver/static/js/src/Importer.test.ts
+++ b/listenbrainz/webserver/static/js/src/Importer.test.ts
@@ -196,7 +196,15 @@ describe("submitPage", () => {
     importer.APIService.submitListens = jest.fn().mockImplementation(() => {
       return Promise.resolve({ status: 200 });
     });
-    importer.submitPage(["listen"]);
+    importer.submitPage([
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
 
     jest.runAllTimers();
 
@@ -211,7 +219,15 @@ describe("submitPage", () => {
     importer.APIService.submitListens = jest.fn().mockImplementation(() => {
       return Promise.resolve({ status: 200 });
     });
-    importer.submitPage(["listen"]);
+    importer.submitPage([
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
 
     jest.runAllTimers();
 
@@ -226,7 +242,15 @@ describe("submitPage", () => {
   });
 
   it("calls getRateLimitDelay once", async () => {
-    importer.submitPage(["listen"]);
+    importer.submitPage([
+      {
+        listened_at: 1000,
+        track_metadata: {
+          artist_name: "foobar",
+          track_name: "bazfoo",
+        },
+      },
+    ]);
     expect(importer.getRateLimitDelay).toHaveBeenCalledTimes(1);
   });
 });

--- a/listenbrainz/webserver/static/js/src/Importer.tsx
+++ b/listenbrainz/webserver/static/js/src/Importer.tsx
@@ -243,8 +243,7 @@ export default class Importer {
     return null;
   }
 
-  // TODO: Replace with array of Listens
-  async submitPage(payload: any) {
+  async submitPage(payload: Array<Listen>) {
     const delay = this.getRateLimitDelay();
     // Halt execution for some time
     await new Promise((resolve) => {
@@ -259,7 +258,6 @@ export default class Importer {
     this.updateRateLimitParameters(response);
   }
 
-  // TODO: Replace return type with array of Listens
   static encodeScrobbles(scrobbles: LastFmScrobblePage): any {
     const rawScrobbles = scrobbles.recenttracks.track;
     const parsedScrobbles = Importer.map((rawScrobble: any) => {
@@ -269,12 +267,12 @@ export default class Importer {
     return parsedScrobbles;
   }
 
-  static map(applicable: Function, collection: any) {
+  static map(applicable: (collection: any) => Listen, collection: any) {
     const newCollection = [];
     for (let i = 0; i < collection.length; i += 1) {
       const result = applicable(collection[i]);
-      if ("listened_at" in result) {
-        // Add If there is no 'listened_at' attribute then either the listen is invalid or the
+      if (result.listened_at > 0) {
+        // If the 'listened_at' attribute is -1 then either the listen is invalid or the
         // listen is currently playing. In both cases we need to skip the submission.
         newCollection.push(result);
       }

--- a/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
@@ -35,7 +35,7 @@ const props = {
   nextListenTs,
   previousListenTs,
   profileUrl,
-  spotify,
+  spotify: spotify as SpotifyUser,
   user,
   webSocketsServerUrl,
 };

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -72,7 +72,13 @@ export default class RecentListens extends React.Component<
     this.state = {
       alerts: [],
       listens: props.listens || [],
-      currentListen: null,
+      currentListen: {
+        listened_at: 0,
+        track_metadata: {
+          artist_name: "",
+          track_name: "",
+        },
+      },
       mode: props.mode,
       followList: props.followList || [],
       playingNowByUser: {},
@@ -206,6 +212,7 @@ export default class RecentListens extends React.Component<
         return {
           playingNowByUser: {
             ...prevState.playingNowByUser,
+            // @ts-ignore
             [userName]: playingNow,
           },
           listens: prevState.listens,
@@ -410,7 +417,7 @@ export default class RecentListens extends React.Component<
                       .map((listen) => {
                         return (
                           <tr
-                            key={listen}
+                            key={listen.listened_at}
                             onDoubleClick={this.playListen.bind(this, listen)}
                             className={`listen ${
                               this.isCurrentListen(listen) ? "info" : ""
@@ -425,7 +432,9 @@ export default class RecentListens extends React.Component<
                               </td>
                             ) : (
                               <td>
-                                <abbr title={listen.listened_at_iso}>
+                                <abbr
+                                  title={listen.listened_at_iso?.toString()}
+                                >
                                   {listen.listened_at_iso
                                     ? timeago.ago(listen.listened_at_iso)
                                     : timeago.ago(listen.listened_at * 1000)}

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -72,13 +72,7 @@ export default class RecentListens extends React.Component<
     this.state = {
       alerts: [],
       listens: props.listens || [],
-      currentListen: {
-        listened_at: 0,
-        track_metadata: {
-          artist_name: "",
-          track_name: "",
-        },
-      },
+      currentListen: {} as Listen,
       mode: props.mode,
       followList: props.followList || [],
       playingNowByUser: {},
@@ -208,11 +202,10 @@ export default class RecentListens extends React.Component<
 
     this.setState((prevState) => {
       if (prevState.mode === "follow") {
-        const userName = playingNow.user_name;
+        const userName = playingNow.user_name as string;
         return {
           playingNowByUser: {
             ...prevState.playingNowByUser,
-            // @ts-ignore
             [userName]: playingNow,
           },
           listens: prevState.listens,
@@ -417,7 +410,7 @@ export default class RecentListens extends React.Component<
                       .map((listen) => {
                         return (
                           <tr
-                            key={listen.listened_at}
+                            key={`${listen.listened_at}-${listen.track_metadata.additional_info?.recording_msid}-${listen.user_name}`}
                             onDoubleClick={this.playListen.bind(this, listen)}
                             className={`listen ${
                               this.isCurrentListen(listen) ? "info" : ""

--- a/listenbrainz/webserver/static/js/src/Scrobble.ts
+++ b/listenbrainz/webserver/static/js/src/Scrobble.ts
@@ -58,7 +58,7 @@ export default class Scrobble {
   }
 
   scrobbledAt(): number {
-    /* Returns scrobbledAt if present, else returns an empty string */
+    /* Returns scrobbledAt if present, else returns -1 */
     if (
       "date" in this.rootScrobbleElement &&
       "uts" in this.rootScrobbleElement.date

--- a/listenbrainz/webserver/static/js/src/Scrobble.ts
+++ b/listenbrainz/webserver/static/js/src/Scrobble.ts
@@ -57,7 +57,7 @@ export default class Scrobble {
     return "";
   }
 
-  scrobbledAt(): string {
+  scrobbledAt(): number {
     /* Returns scrobbledAt if present, else returns an empty string */
     if (
       "date" in this.rootScrobbleElement &&
@@ -72,7 +72,7 @@ export default class Scrobble {
       attribute as {"date": {"utc":"12345756", "#text":"21 Jul 2016, 10:22"}}
       We need to only submit listens which were played in the past.
       */
-    return "";
+    return -1;
   }
 
   trackMBID(): string {
@@ -83,8 +83,7 @@ export default class Scrobble {
     return "";
   }
 
-  // TODO: Make this type as Listen
-  asJSONSerializable(): any {
+  asJSONSerializable(): Listen {
     const trackjson = {
       track_metadata: {
         track_name: this.trackName(),
@@ -102,7 +101,7 @@ export default class Scrobble {
 
     // Remove keys with blank values
     (function filter(obj: any) {
-      Object.keys(obj).forEach(function (key) {
+      Object.keys(obj).forEach((key) => {
         let value = obj[key];
         if (value === "" || value === null) {
           delete obj[key]; // eslint-disable-line no-param-reassign
@@ -113,7 +112,7 @@ export default class Scrobble {
         } else if (Array.isArray(value)) {
           value = value.filter(Boolean);
           obj[key] = value; // eslint-disable-line no-param-reassign
-          value.forEach(function (el: any) {
+          value.forEach((el: any) => {
             filter(el);
           });
         }

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
@@ -7,7 +7,7 @@ import APIService from "./APIService";
 const props = {
   spotifyUser: {
     access_token: "heyo",
-    permission: "read",
+    permission: "read" as SpotifyPermission,
   },
   direction: "up" as SpotifyPlayDirection,
   onPermissionError: (message: string) => {},

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -24,7 +24,7 @@ const getSpotifyUriFromListen = (listen: Listen): string => {
 
 // Fix for LB-447 (Player does not play any sound)
 // https://github.com/spotify/web-playback-sdk/issues/75#issuecomment-487325589
-const fixSpotifyPlayerStyleIssue = function () {
+const fixSpotifyPlayerStyleIssue = () => {
   const iframe = document.querySelector(
     'iframe[src="https://sdk.scdn.co/embedded/index.html"]'
   ) as any; // TODO: this is hacky, but this whole function seems hacky tbh
@@ -234,7 +234,7 @@ export default class SpotifyPlayer extends React.Component<
     }
   };
 
-  playListen = (listen?: Listen): void => {
+  playListen = (listen: Listen): void => {
     const { onCurrentListenChange } = this.props;
     onCurrentListenChange(listen);
     if (_.get(listen, "track_metadata.additional_info.spotify_id")) {
@@ -246,7 +246,7 @@ export default class SpotifyPlayer extends React.Component<
 
   isCurrentListen = (element: Listen): boolean => {
     const { currentListen } = this.props;
-    return currentListen && _isEqual(element, currentListen);
+    return (currentListen && _isEqual(element, currentListen)) as boolean;
   };
 
   playPreviousTrack = (): void => {

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -82,8 +82,7 @@ export default class SpotifyPlayer extends React.Component<
     this.state = {
       accessToken: props.spotifyUser.access_token,
       permission: props.spotifyUser.permission,
-      // @ts-ignore
-      currentSpotifyTrack: {},
+      currentSpotifyTrack: {} as SpotifyTrack,
       playerPaused: true,
       progressMs: 0,
       durationMs: 0,

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -82,6 +82,7 @@ export default class SpotifyPlayer extends React.Component<
     this.state = {
       accessToken: props.spotifyUser.access_token,
       permission: props.spotifyUser.permission,
+      // @ts-ignore
       currentSpotifyTrack: {},
       playerPaused: true,
       progressMs: 0,
@@ -409,18 +410,15 @@ export default class SpotifyPlayer extends React.Component<
     this.spotifyPlayer.on("account_error", this.handleAccountError);
     this.spotifyPlayer.on("playback_error", this.handleError);
 
-    this.spotifyPlayer.addListener(
-      "ready",
-      ({ deviceID }: { deviceID: SpotifyDeviceID }) => {
-        if (callbackFunction) {
-          callbackFunction();
-        }
-        this.startPlayerStateTimer();
-        if (fixSpotifyPlayerStyleIssue) {
-          fixSpotifyPlayerStyleIssue();
-        }
+    this.spotifyPlayer.addListener("ready", () => {
+      if (callbackFunction) {
+        callbackFunction();
       }
-    );
+      this.startPlayerStateTimer();
+      if (fixSpotifyPlayerStyleIssue) {
+        fixSpotifyPlayerStyleIssue();
+      }
+    });
 
     this.spotifyPlayer.addListener(
       "player_state_changed",

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -113,7 +113,9 @@ declare type Alert = {
   message: string | JSX.Element;
 };
 
-declare type FollowUsersPlayingNow = any;
+declare type FollowUsersPlayingNow = {
+  [user: string]: Listen;
+};
 
 declare type LastFmScrobblePage = {
   recenttracks: {

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -2,8 +2,43 @@ declare module "spotify-web-playback-sdk";
 declare module "react-bs-notifier";
 declare module "time-ago";
 
-// TODO: make this type specific
-declare type Listen = any;
+// TODO: Remove "| null" when backend stops sending fields with null
+declare type Listen = {
+  listened_at: number;
+  listened_at_iso?: string | null;
+  playing_now?: boolean | null;
+  user_name?: string | null;
+  track_metadata: {
+    artist_name: string;
+    release_name?: string | null;
+    track_name: string;
+    additional_info?: {
+      artist_mbids?: Array<string> | null;
+      artist_msid?: string | null;
+      discnumber?: number | null;
+      duration_ms?: number | null;
+      isrc?: string | null;
+      listening_from?: string | null;
+      recording_mbid?: string | null;
+      recording_msid?: string | null;
+      release_artist_name?: string | null;
+      release_artist_names?: Array<string> | null;
+      release_group_mbid?: string | null;
+      release_mbid?: string | null;
+      release_msid?: string | null;
+      spotify_album_artist_ids?: Array<string> | null;
+      spotify_album_id?: string | null;
+      spotify_artist_ids?: Array<string> | null;
+      spotify_id?: string | null;
+      tags?: Array<string> | null;
+      track_mbid?: string | null;
+      tracknumber?: number | null;
+      work_mbids?: Array<string> | null;
+      [key: string]: any;
+    };
+  };
+};
+
 declare type ListenBrainzUser = {
   id?: number;
   name: string;
@@ -13,8 +48,11 @@ declare type ListenBrainzUser = {
 declare type ListenType = "single" | "playingNow" | "import";
 
 declare type SpotifyPlayDirection = "up" | "down" | "hidden";
-// TODO: make this type specific
-declare type SubmitListensPayload = any;
+
+declare type SubmitListensPayload = {
+  listen_type: "single" | "playing_now" | "import";
+  payload: Array<Listen>;
+};
 
 declare type SpotifyUser = {
   access_token: string;

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -59,15 +59,45 @@ declare type SpotifyUser = {
   permission: string;
 };
 
-declare type SpotifyPermission = any; // TODO
-declare type SpotifyTrack = any; // TODO
-declare type SpotifyArtist = any; // TODO
-declare type SpotifyDeviceID = any; // TODO
-declare interface SpotifyImage {
+declare type SpotifyPermission = string;
+
+declare type SpotifyImage = {
   height: number;
-}
-declare type SpotifyPlayerTrackWindow = any; // TODO
-declare type SpotifyPlayerSDKState = any;
+  url: string;
+};
+
+declare type SpotifyArtist = {
+  uri: string;
+  name: string;
+};
+
+declare type SpotifyTrack = {
+  album: {
+    uri: string;
+    name: string;
+    images: Array<SpotifyImage>;
+  };
+  artists: Array<SpotifyTrack>;
+  id: string | null;
+  is_playable: boolean;
+  media_type: "audio" | "video";
+  name: string;
+  type: "track" | "episode" | "ad";
+  uri: string;
+};
+
+declare type SpotifyPlayerTrackWindow = {
+  device_id: string;
+};
+
+declare type SpotifyPlayerSDKState = {
+  paused: boolean;
+  position: number;
+  duration: number;
+  track_window: {
+    current_track: SpotifyTrack;
+  };
+};
 
 // the spotify-web-playback-sdk types are a bit messy
 // Adding an any here for now.
@@ -75,6 +105,7 @@ declare type SpotifyPlayerSDKState = any;
 declare type SpotifyPlayerType = any | Spotify.SpotifyPlayer;
 
 declare type AlertType = "danger" | "warning" | "success";
+
 declare type Alert = {
   id: number;
   type: AlertType;
@@ -83,6 +114,7 @@ declare type Alert = {
 };
 
 declare type FollowUsersPlayingNow = any;
+
 declare type LastFmScrobblePage = {
   recenttracks: {
     track: any;

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -3,6 +3,30 @@ declare module "react-bs-notifier";
 declare module "time-ago";
 
 // TODO: Remove "| null" when backend stops sending fields with null
+interface AdditionalInfo {
+  artist_mbids?: Array<string> | null;
+  artist_msid?: string | null;
+  discnumber?: number | null;
+  duration_ms?: number | null;
+  isrc?: string | null;
+  listening_from?: string | null;
+  recording_mbid?: string | null;
+  recording_msid?: string | null;
+  release_artist_name?: string | null;
+  release_artist_names?: Array<string> | null;
+  release_group_mbid?: string | null;
+  release_mbid?: string | null;
+  release_msid?: string | null;
+  spotify_album_artist_ids?: Array<string> | null;
+  spotify_album_id?: string | null;
+  spotify_artist_ids?: Array<string> | null;
+  spotify_id?: string | null;
+  tags?: Array<string> | null;
+  track_mbid?: string | null;
+  tracknumber?: number | null;
+  work_mbids?: Array<string> | null;
+}
+
 declare type Listen = {
   listened_at: number;
   listened_at_iso?: string | null;
@@ -12,30 +36,7 @@ declare type Listen = {
     artist_name: string;
     release_name?: string | null;
     track_name: string;
-    additional_info?: {
-      artist_mbids?: Array<string> | null;
-      artist_msid?: string | null;
-      discnumber?: number | null;
-      duration_ms?: number | null;
-      isrc?: string | null;
-      listening_from?: string | null;
-      recording_mbid?: string | null;
-      recording_msid?: string | null;
-      release_artist_name?: string | null;
-      release_artist_names?: Array<string> | null;
-      release_group_mbid?: string | null;
-      release_mbid?: string | null;
-      release_msid?: string | null;
-      spotify_album_artist_ids?: Array<string> | null;
-      spotify_album_id?: string | null;
-      spotify_artist_ids?: Array<string> | null;
-      spotify_id?: string | null;
-      tags?: Array<string> | null;
-      track_mbid?: string | null;
-      tracknumber?: number | null;
-      work_mbids?: Array<string> | null;
-      [key: string]: any;
-    };
+    additional_info?: AdditionalInfo;
   };
 };
 
@@ -56,10 +57,16 @@ declare type SubmitListensPayload = {
 
 declare type SpotifyUser = {
   access_token: string;
-  permission: string;
+  permission: SpotifyPermission;
 };
 
-declare type SpotifyPermission = string;
+declare type SpotifyPermission =
+  | "user-read-currently-playing"
+  | "user-read-recently-played"
+  | "streaming"
+  | "user-read-birthdate"
+  | "user-read-email"
+  | "user-read-private";
 
 declare type SpotifyImage = {
   height: number;
@@ -77,7 +84,7 @@ declare type SpotifyTrack = {
     name: string;
     images: Array<SpotifyImage>;
   };
-  artists: Array<SpotifyTrack>;
+  artists: Array<SpotifyArtist>;
   id: string | null;
   is_playable: boolean;
   media_type: "audio" | "video";


### PR DESCRIPTION
# Description
Adds definition to remaining types.

# Problem
Some types were defined as `any`, which doesn't help in development or to catch errors.

# Solution
Adding correct definitions to these types fixes the problem