### PR TITLE
Add support for seperate cron production container

### DIFF
--- a/docker/beta/uwsgi/uwsgi.service
+++ b/docker/beta/uwsgi/uwsgi.service
@@ -2,9 +2,6 @@
 
 if [ "${CONTAINER_NAME}" = "listenbrainz-web-beta" ]
 then
-    rm -f /etc/service/cron/down
-    sv restart cron
-
     exec uwsgi /etc/uwsgi/uwsgi.ini
 fi
 

--- a/docker/prod/uwsgi/uwsgi.service
+++ b/docker/prod/uwsgi/uwsgi.service
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ "${CONTAINER_NAME}" = "listenbrainz-cron-prod" ]
+then
+    rm -f /etc/service/cron/down
+    sv restart cron
+    exit 0
+fi
+
 if [ "${CONTAINER_NAME}" = "listenbrainz-web-prod" ]
 then
     exec uwsgi /etc/uwsgi/uwsgi.ini


### PR DESCRIPTION
Add support for a seperate cron container for production.

Now that we've started releasing the webserver more frequently, the dumps process (specially the full dumps) has gotten interrupted the last 3 times, meaning that there haven't been any new dumps since March.

This pull request adds a seperate cron container, which should only be deployed when we make changes to our cron jobs. This doesn't totally solve the problem of dumps getting interrupted, but is a first step.