### PR TITLE
Fix last_update_ts for user stats

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -17,7 +17,11 @@ def is_new_user_stats_batch():
     So, we check the database and see if the difference between the last time stats were updated
     and right now is greater than 12 hours.
     """
-    return datetime.now(timezone.utc) - db_stats.get_timestamp_for_last_user_stats_update() > timedelta(hours=TIME_TO_CONSIDER_STATS_AS_OLD)
+    last_update_ts = db_stats.get_timestamp_for_last_user_stats_update()
+    if(last_update_ts is None):
+        last_update_ts = datetime.min.replace(tzinfo=timezone.utc) # use min datetime value if last_update_ts is None
+
+    return datetime.now(timezone.utc) - last_update_ts > timedelta(hours=TIME_TO_CONSIDER_STATS_AS_OLD)
 
 
 def notify_user_stats_update():

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -18,8 +18,8 @@ def is_new_user_stats_batch():
     and right now is greater than 12 hours.
     """
     last_update_ts = db_stats.get_timestamp_for_last_user_stats_update()
-    if(last_update_ts is None):
-        last_update_ts = datetime.min.replace(tzinfo=timezone.utc) # use min datetime value if last_update_ts is None
+    if last_update_ts is None:
+        last_update_ts = datetime.min.replace(tzinfo=timezone.utc)  # use min datetime value if last_update_ts is None
 
     return datetime.now(timezone.utc) - last_update_ts > timedelta(hours=TIME_TO_CONSIDER_STATS_AS_OLD)
 


### PR DESCRIPTION
# Problem

The spark reader raised an error when the user stats are calculated for the first time as `last_update_ts` is None and hence can't be used in datetime operations.

# Solution

Using a default min value for datetime (in UTC timezone) for last_update_ts if its None fixes the issue.