### PR TITLE
Add option to download a specific dump

### DIFF
--- a/docker/docker-compose.spark.yml
+++ b/docker/docker-compose.spark.yml
@@ -40,7 +40,7 @@ services:
       context: ..
       dockerfile: Dockerfile.spark
       target: metabrainz-spark-dev
-    command: bash -c "zip -r listenbrainz_spark.zip listenbrainz_spark/ ; python spark_manage.py request_consumer"
+    command: bash -c "zip -r /rec/listenbrainz_spark.zip listenbrainz_spark/ ; python spark_manage.py request_consumer"
     volumes:
       - ..:/rec:z
 

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -25,13 +25,14 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
                 req_dump (str): Name of the dump to be downloaded.
         """
         if dump_id:
+            req_dump = None
             for dump_name in dump:
-                if int(dump_name.split('-')[dump_id_pos] == dump_id):
+                if int(dump_name.split('-')[dump_id_pos]) == dump_id:
                     req_dump = dump_name
                     break
-                else:
-                    err_msg = "Could not find dump with ID: {}. Aborting...".format(dump_id)
-                    raise DumpNotFoundException(err_msg)
+            if not req_dump:
+                err_msg = "Could not find dump with ID: {}. Aborting...".format(dump_id)
+                raise DumpNotFoundException(err_msg)
         else:
             req_dump = dump[-1]
         return req_dump

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -30,7 +30,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
                 if int(dump_name.split('-')[dump_id_pos]) == dump_id:
                     req_dump = dump_name
                     break
-            if not req_dump:
+            if req_dump is None:
                 err_msg = "Could not find dump with ID: {}. Aborting...".format(dump_id)
                 raise DumpNotFoundException(err_msg)
         else:

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -23,14 +23,14 @@ class FTPDownloaderTestCase(unittest.TestCase):
     @patch('ftplib.FTP')
     def test_get_dump_name_to_download(self, mock_ftp_cons):
         dump = ['listenbrainz-01-00000', 'listenbrainz-02-00000']
-        req_dump = ListenbrainzDataDownloader().get_dump_name_to_download(dump, '01', 1)
+        req_dump = ListenbrainzDataDownloader().get_dump_name_to_download(dump, 1, 1)
         self.assertEqual(req_dump, 'listenbrainz-01-00000')
 
         req_dump = ListenbrainzDataDownloader().get_dump_name_to_download(dump, None, 1)
         self.assertEqual(req_dump, 'listenbrainz-02-00000')
 
         with self.assertRaises(DumpNotFoundException):
-            ListenbrainzDataDownloader().get_dump_name_to_download(dump, '03', 1)
+            ListenbrainzDataDownloader().get_dump_name_to_download(dump, 3, 1)
 
     @patch('ftplib.FTP')
     def test_get_dump_archive_name(self, mock_ftp_cons):

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -6,7 +6,8 @@ import listenbrainz_spark
 from listenbrainz_spark import config, utils
 from listenbrainz_spark.exceptions import DumpNotFoundException
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader, MAPPING_DUMP_ID_POS, \
-        ARTIST_RELATION_DUMP_ID_POS
+    ARTIST_RELATION_DUMP_ID_POS
+
 
 class FTPDownloaderTestCase(unittest.TestCase):
 
@@ -52,9 +53,9 @@ class FTPDownloaderTestCase(unittest.TestCase):
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir')
     @patch('ftplib.FTP')
     def download_spark_dump_and_get_path(
-            self, mock_ftp_cons, mock_list_dir,
-            mock_req_dir, mock_get_f_name, mock_download_dump
-        ):
+        self, mock_ftp_cons, mock_list_dir,
+        mock_req_dir, mock_get_f_name, mock_download_dump
+    ):
         mock_ftp = mock_ftp_cons.return_value
         dest_path = ListenbrainzDataDownloader().download_spark_dump_and_get_path('fakedir', None, 'fakeftpdir', 4)
         mock_list_dir.assert_called_once()
@@ -82,7 +83,8 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-123-20190101-000000-spark-full.tar.xz'
         dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='full')
         mock_list_dir.assert_called_once()
-        mock_ftp.return_value.cwd.assert_has_calls([call(config.FTP_LISTENS_DIR + 'fullexport/'), call('listenbrainz-dump-123-20190101-000000/')])
+        mock_ftp.return_value.cwd.assert_has_calls(
+            [call(config.FTP_LISTENS_DIR + 'fullexport/'), call('listenbrainz-dump-123-20190101-000000/')])
         self.assertEqual('listenbrainz-listens-dump-123-20190101-000000-spark-full.tar.xz', filename)
 
         mock_get_f_name.assert_called_once()
@@ -99,9 +101,9 @@ class FTPDownloaderTestCase(unittest.TestCase):
         dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45, dump_type='full')
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls([
-                call(config.FTP_LISTENS_DIR + 'fullexport/'),
-                call('listenbrainz-dump-45-20190201-000000')
-            ])
+            call(config.FTP_LISTENS_DIR + 'fullexport/'),
+            call('listenbrainz-dump-45-20190201-000000')
+        ])
         self.assertEqual('listenbrainz-listens-dump-45-20190201-000000-spark-full.tar.xz', filename)
 
         mock_get_f_name.assert_called_once()
@@ -117,7 +119,8 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-123-20190101-000000-spark-incremental.tar.xz'
         dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='incremental')
         mock_list_dir.assert_called_once()
-        mock_ftp.return_value.cwd.assert_has_calls([call(config.FTP_LISTENS_DIR + 'incremental/'), call('listenbrainz-dump-123-20190101-000000/')])
+        mock_ftp.return_value.cwd.assert_has_calls(
+            [call(config.FTP_LISTENS_DIR + 'incremental/'), call('listenbrainz-dump-123-20190101-000000/')])
         self.assertEqual('listenbrainz-listens-dump-123-20190101-000000-spark-incremental.tar.xz', filename)
 
         mock_get_f_name.assert_called_once()
@@ -131,13 +134,13 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_incremental_dump_by_id(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-45-20190201-000000-spark-incremental.tar.xz'
-        dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45, 
-                dump_type='incremental')
+        dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45,
+                                                                            dump_type='incremental')
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls([
-                call(config.FTP_LISTENS_DIR + 'incremental/'),
-                call('listenbrainz-dump-45-20190201-000000')
-            ])
+            call(config.FTP_LISTENS_DIR + 'incremental/'),
+            call('listenbrainz-dump-45-20190201-000000')
+        ])
         self.assertEqual('listenbrainz-listens-dump-45-20190201-000000-spark-incremental.tar.xz', filename)
 
         mock_get_f_name.assert_called_once()
@@ -149,5 +152,5 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_artist_relation(self, mock_ftp_cons, mock_spark_dump):
         dest_path = ListenbrainzDataDownloader().download_artist_relation('/fakedir', 1)
         mock_spark_dump.assert_called_once_with(
-                '/fakedir', 1, config.FTP_ARTIST_RELATION_DIR, ARTIST_RELATION_DUMP_ID_POS)
+            '/fakedir', 1, config.FTP_ARTIST_RELATION_DIR, ARTIST_RELATION_DUMP_ID_POS)
         self.assertEqual(dest_path, mock_spark_dump.return_value)

--- a/spark_manage.py
+++ b/spark_manage.py
@@ -90,7 +90,8 @@ def upload_mapping(force):
 @cli.command(name='upload_listens')
 @click.option('--incremental', '-i', is_flag=True, default=False, help="Use a smaller dump (more for testing purposes)")
 @click.option("--force", "-f", is_flag=True, help="Deletes existing listens.")
-def upload_listens(force, incremental):
+@click.option("--idx", default=None, type=int, help="Get a specific dump based on index")
+def upload_listens(force, incremental, idx):
     """ Invoke script to upload listens to HDFS.
     """
     from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
@@ -98,7 +99,7 @@ def upload_listens(force, incremental):
     with app.app_context():
         downloader_obj = ListenbrainzDataDownloader()
         dump_type = 'incremental' if incremental else 'full'
-        src, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, dump_type=dump_type)
+        src, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, listens_dump_id=idx, dump_type=dump_type)
         uploader_obj = ListenbrainzDataUploader()
         uploader_obj.upload_listens(src, force=force)
 

--- a/spark_manage.py
+++ b/spark_manage.py
@@ -90,7 +90,7 @@ def upload_mapping(force):
 @cli.command(name='upload_listens')
 @click.option('--incremental', '-i', is_flag=True, default=False, help="Use a smaller dump (more for testing purposes)")
 @click.option("--force", "-f", is_flag=True, help="Deletes existing listens.")
-@click.option("--idx", default=None, type=int, help="Get a specific dump based on index")
+@click.option("--id", default=None, type=int, help="Get a specific dump based on index")
 def upload_listens(force, incremental, idx):
     """ Invoke script to upload listens to HDFS.
     """
@@ -99,7 +99,7 @@ def upload_listens(force, incremental, idx):
     with app.app_context():
         downloader_obj = ListenbrainzDataDownloader()
         dump_type = 'incremental' if incremental else 'full'
-        src, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, listens_dump_id=idx, dump_type=dump_type)
+        src, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, listens_dump_id=id, dump_type=dump_type)
         uploader_obj = ListenbrainzDataUploader()
         uploader_obj.upload_listens(src, force=force)
 

--- a/spark_manage.py
+++ b/spark_manage.py
@@ -91,7 +91,7 @@ def upload_mapping(force):
 @click.option('--incremental', '-i', is_flag=True, default=False, help="Use a smaller dump (more for testing purposes)")
 @click.option("--force", "-f", is_flag=True, help="Deletes existing listens.")
 @click.option("--id", default=None, type=int, help="Get a specific dump based on index")
-def upload_listens(force, incremental, idx):
+def upload_listens(force, incremental, id):
     """ Invoke script to upload listens to HDFS.
     """
     from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->
Adds option to download a specific dump using `spark_manage`. Fixes some bugs and adds tests.
# Problem
Currently the `spark_manage` script allows to download the latest dump only. However this is inconvenient if a developer wants to use a older dump.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

# Solution
The `download_listens` function has an option to download a dump by index. Exposing this option in the `spark_manage` script fixes the issue.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

