### PR TITLE
LB-511: Raise 400 if the payload doesn't contain any listens

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -110,6 +110,18 @@ class APITestCase(IntegrationTestCase):
             content_type = 'application/json'
         )
 
+    def test_zero_listens_payload(self):
+        """ Test that API returns 400 for payloads with no listens
+        """
+
+        for listen_type in ('single', 'playing_now', 'import'):
+            payload = {
+                'listen_type': listen_type,
+                'payload': [],
+            }
+            response = self.send_data(payload)
+            self.assert400(response)
+
     def test_unauthorized_submission(self):
         """ Test for checking that unauthorized submissions return 401
         """

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -21,7 +21,8 @@ api_bp = Blueprint('api_v1', __name__)
 def submit_listen():
     """
     Submit listens to the server. A user token (found on  https://listenbrainz.org/profile/ ) must
-    be provided in the Authorization header!
+    be provided in the Authorization header! Each request should also contain at least one listen
+    in the payload.
 
     Listens should be submitted for tracks when the user has listened to half the track or 4 minutes of
     the track, whichever is lower. If the user hasn't listened to 4 minutes or half the track, it doesn't 
@@ -46,7 +47,7 @@ def submit_listen():
     try:
         payload = data['payload']
         if len(payload) == 0:
-            return "success"
+            log_raise_400("JSON document does not contain any listens", payload)
 
         if len(raw_data) > len(payload) * MAX_LISTEN_SIZE:
             log_raise_400("JSON document is too large. In aggregate, listens may not "


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
LB-511

We returned a inconsistent "success" string if the payload to `submit-listens` contained no listens.



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Raise a 400 with an appropriate message and improve documentation.




