### PR TITLE
LB-495 - Document JSON response format for "/1/validate-token"

### DIFF
--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -275,7 +275,7 @@ def validate_token():
     In order to query this endpoint, send a GET request with the token to check
     as the `token` argument (example: /validate-token?token=token-to-check)
 
-    A JSON response will the following format be returned,
+    A JSON response, with the following format, will be returned. 
 
     - If the given token is valid::
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -275,7 +275,24 @@ def validate_token():
     In order to query this endpoint, send a GET request with the token to check
     as the `token` argument (example: /validate-token?token=token-to-check)
 
-    A JSON response will be returned, with one of two codes.
+    A JSON response will the following format be returned,
+
+    - If the given token is valid::
+
+        {
+            "code": 200,
+            "message": "Token valid.",
+            "valid": True,
+            "user": "MusicBrainz ID of the user with the passed token"
+        }
+
+    - If the given token is invalid::
+
+        {
+            "code": 200,
+            "message": "Token invalid.",
+            "valid": False,
+        }
 
     :statuscode 200: The user token is valid/invalid.
     :statuscode 400: No token was sent to the endpoint.

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -275,7 +275,7 @@ def validate_token():
     In order to query this endpoint, send a GET request with the token to check
     as the `token` argument (example: /validate-token?token=token-to-check)
 
-    A JSON response, with the following format, will be returned. 
+    A JSON response, with the following format, will be returned.
 
     - If the given token is valid::
 


### PR DESCRIPTION
Adds documentation for the JSON response format for `/1/validate-token` route.

# Problem
The documentation does not provide the format of the JSON response received on querying the above endpoint.

# Solution
Adding the response format solves the problem
