### PR TITLE
use mapping matchable to generate recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ ENV/
 
 config.py
 docker/tunnel/keys
+
+# recommendation engine HTMl files
+listenbrainz_spark/recommendations/html_files*

--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -52,6 +52,6 @@ SENTRY_DSN_PUBLIC = ''
 MODEL_ID_PREFIX = 'listenbrainz-recommendation-model'
 
 FTP_SERVER_URI = 'ftp.eu.metabrainz.org'
-FTP_MSID_MBID_DIR = '/pub/musicbrainz/listenbrainz/labs/mappings/msid-mbid-mapping/'
+FTP_MSID_MBID_DIR = '/pub/musicbrainz/listenbrainz/labs/mappings/msid-mbid-mapping-with-matchable/'
 FTP_ARTIST_RELATION_DIR = '/pub/musicbrainz/listenbrainz/labs/artist-credit-artist-credit-relations/'
 FTP_LISTENS_DIR = '/pub/musicbrainz/listenbrainz/'

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -5,7 +5,9 @@ from listenbrainz_spark.exceptions import DumpNotFoundException
 
 from flask import current_app
 
-MAPPING_DUMP_ID_POS = 3
+# mbid_msid_mapping_with_matchable is used.
+# refer to: http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/labs/mappings/
+MAPPING_DUMP_ID_POS = 5
 ARTIST_RELATION_DUMP_ID_POS = 5
 
 FULL = 'full'
@@ -108,12 +110,6 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
                         MAPPING_DUMP_ID_POS
                     )
         return dest_path
-
-    def download_msid_mbid_mapping_with_text(self):
-        pass
-
-    def download_msid_mbid_mapping_with_matchable(self):
-        pass
 
     def download_listens(self, directory, listens_dump_id=None, dump_type=FULL):
         """ Download listens to dir passed as an argument.

--- a/listenbrainz_spark/recommendations/candidate_sets.py
+++ b/listenbrainz_spark/recommendations/candidate_sets.py
@@ -48,12 +48,11 @@ def get_top_artists(df, user_name):
                     'mb_artist_credit_id', 'artist_name'
                 ]
     """
-    top_artists_df = df.select('mb_artist_credit_id', 'artist_name') \
+    top_artists_df = df.select('mb_artist_credit_id', 'msb_artist_credit_name_matchable') \
         .where(col('user_name') == user_name) \
-        .groupBy('mb_artist_credit_id', 'artist_name') \
+        .groupBy('mb_artist_credit_id', 'msb_artist_credit_name_matchable') \
         .agg(func.count('mb_artist_credit_id').alias('count')) \
         .orderBy('count', ascending=False).limit(config.TOP_ARTISTS_LIMIT)
-
     return top_artists_df
 
 def get_similar_artists(top_artists_df, artists_relation_df, user_name):
@@ -93,6 +92,7 @@ def get_similar_artists(top_artists_df, artists_relation_df, user_name):
     top_similar_artists_df = similar_artists_df.withColumn('rank', row_number().over(window)) \
         .where(col('rank') <= config.SIMILAR_ARTISTS_LIMIT) \
         .select('top_artist_credit_id', 'similar_artist_credit_id', 'similar_artist_name', 'top_artist_name')
+
     # Remove artists from similar artists that already occurred in top artists.
     distinct_similar_artists_df = top_similar_artists_df[top_similar_artists_df \
         .similar_artist_credit_id.isin(top_artists) == False]

--- a/listenbrainz_spark/recommendations/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/create_dataframes.py
@@ -135,12 +135,15 @@ def get_mapped_artist_and_recording_mbids(partial_listens_df, recording_artist_m
         Returns:
             mapped_df (dataframe): Dataframe with all the columns/fields that a typical listen has.
     """
-    mapped_df = partial_listens_df.join(
-        recording_artist_mapping_df,
+    df = partial_listens_df.join(recording_artist_mapping_df,
             (partial_listens_df.recording_msid == recording_artist_mapping_df.msb_recording_msid) &
             (partial_listens_df.artist_msid == recording_artist_mapping_df.msb_artist_msid),
         'inner'
     )
+    # msb_release_name_matchable is skipped till the bug in mapping is resolved.
+    # bug : release_name in listens and msb_release_name in mapping is different.
+    mapped_df = df.select('listened_at', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
+        'mb_release_mbid', 'msb_artist_credit_name_matchable', 'track_name', 'user_name')
     save_dataframe(mapped_df, path.MAPPED_LISTENS)
     return mapped_df
 
@@ -249,7 +252,7 @@ def main():
     # Dataframe containing recording msid->mbid and artist msid->mbid mapping.
     recording_artist_mapping_df = utils.read_files_from_HDFS(path.MBID_MSID_MAPPING)
 
-    # Dataframe containing all fields that a listen should have including artist_mbids and recording_msid.
+    # Dataframe containing all fields that a listen should have including artist_mbids and recording_mbid.
     complete_listens_df = get_mapped_artist_and_recording_mbids(partial_listens_df, recording_artist_mapping_df)
 
     current_app.logger.info('Preparing users data and saving to HDFS...')

--- a/listenbrainz_spark/recommendations/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/create_dataframes.py
@@ -142,8 +142,10 @@ def get_mapped_artist_and_recording_mbids(partial_listens_df, recording_artist_m
     )
     # msb_release_name_matchable is skipped till the bug in mapping is resolved.
     # bug : release_name in listens and msb_release_name in mapping is different.
-    mapped_df = df.select('listened_at', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
-        'mb_release_mbid', 'msb_artist_credit_name_matchable', 'track_name', 'user_name')
+    mapped_df = df.select(
+        'listened_at', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
+        'mb_release_mbid', 'msb_artist_credit_name_matchable', 'track_name', 'user_name'
+    )
     save_dataframe(mapped_df, path.MAPPED_LISTENS)
     return mapped_df
 

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -64,13 +64,13 @@ def get_recommended_recordings(candidate_set, limit, recordings_df, model, mappe
     # get the track_name and artist_name to make the HTML redable. This step will not be required when sending recommendations
     # to lemmy since gids are enough to recognize the track.
     recommendations_df = df.join(mapped_listens, ['mb_artist_credit_id', 'mb_recording_mbid']) \
-        .select('artist_name', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid', \
-            'mb_release_mbid', 'release_name', 'track_name').distinct()
+        .select('msb_artist_credit_name_matchable', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid', \
+            'mb_release_mbid', 'track_name').distinct()
 
     recommended_recordings = []
     for row in recommendations_df.collect():
-        rec = (row.artist_name, row.mb_artist_credit_id, row.mb_artist_credit_mbids, row.mb_recording_mbid,
-            row.mb_release_mbid, row.release_name, row.track_name)
+        rec = (row.msb_artist_credit_name_matchable, row.mb_artist_credit_id, row.mb_artist_credit_mbids, row.mb_recording_mbid,
+            row.mb_release_mbid, row.track_name)
         recommended_recordings.append(rec)
     return recommended_recordings
 
@@ -202,8 +202,8 @@ def get_recommendation_html(recommendations, time_, best_model_id, ti):
     """
     date = datetime.utcnow().strftime('%Y-%m-%d')
     recommendation_html = 'Recommendation-{}-{}.html'.format(uuid.uuid4(), date)
-    column = ('ARTIST_NAME', 'MB_ARTIST_CREDIT_ID', 'MB_ARTIST_CREDIT_MBIDS', 'MB_RECORDING_MBID',
-        'MB_RELEASE_MBID', 'RELEASE_NAME', 'TRACK_NAME')
+    column = ('MSB_ARTIST_CREDIT_NAME_MATCHABLE', 'MB_ARTIST_CREDIT_ID', 'MB_ARTIST_CREDIT_MBIDS', 'MB_RECORDING_MBID',
+        'MB_RELEASE_MBID', 'TRACK_NAME')
     context = {
         'recommendations' : recommendations,
         'column' : column,

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -64,13 +64,13 @@ def get_recommended_recordings(candidate_set, limit, recordings_df, model, mappe
     # get the track_name and artist_name to make the HTML redable. This step will not be required when sending recommendations
     # to lemmy since gids are enough to recognize the track.
     recommendations_df = df.join(mapped_listens, ['mb_artist_credit_id', 'mb_recording_mbid']) \
-        .select('msb_artist_credit_name_matchable', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid', \
-            'mb_release_mbid', 'track_name').distinct()
+        .select('msb_artist_credit_name_matchable', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
+                'mb_release_mbid', 'track_name').distinct()
 
     recommended_recordings = []
     for row in recommendations_df.collect():
         rec = (row.msb_artist_credit_name_matchable, row.mb_artist_credit_id, row.mb_artist_credit_mbids, row.mb_recording_mbid,
-            row.mb_release_mbid, row.track_name)
+               row.mb_release_mbid, row.track_name)
         recommended_recordings.append(rec)
     return recommended_recordings
 
@@ -203,7 +203,7 @@ def get_recommendation_html(recommendations, time_, best_model_id, ti):
     date = datetime.utcnow().strftime('%Y-%m-%d')
     recommendation_html = 'Recommendation-{}-{}.html'.format(uuid.uuid4(), date)
     column = ('MSB_ARTIST_CREDIT_NAME_MATCHABLE', 'MB_ARTIST_CREDIT_ID', 'MB_ARTIST_CREDIT_MBIDS', 'MB_RECORDING_MBID',
-        'MB_RELEASE_MBID', 'TRACK_NAME')
+              'MB_RELEASE_MBID', 'TRACK_NAME')
     context = {
         'recommendations' : recommendations,
         'column' : column,

--- a/listenbrainz_spark/recommendations/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/tests/test_candidate.py
@@ -23,12 +23,9 @@ class CandidateSetsTestClass(SparkTestCase):
     @classmethod
     def get_listen_row(cls, date, user_name, credit_id):
         test_mapped_listens = Row(
-            user_name=user_name, artist_msid="a36d6fc9-49d0-4789-a7dd-a2b72369ca45", release_msid="xxxxxx",
-            release_name="xxxxxx", artist_name="Less Than Jake", release_mbid="xxxxxx", track_name="Al's War",
-            recording_msid="cb6985cd-cc71-4d59-b4fb-2e72796af741", tags=['xxxx'], listened_at=date,
-            msb_recording_msid="cb6985cd-cc71-4d59-b4fb-2e72796af741", mb_recording_gid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
-            msb_artist_msid="a36d6fc9-49d0-4789-a7dd-a2b72369ca45", mb_artist_gids=["181c4177-f33a-441d-b15d-910acaf18b07"],
-            mb_artist_credit_id=credit_id
+            user_name=user_name, msb_artist_credit_name_matchable="lessthanjake", mb_release_mbid="xxxxxx",
+            track_name="Al's War", listened_at=date, mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
+            mb_artist_credit_mbids=["181c4177-f33a-441d-b15d-910acaf18b07"], mb_artist_credit_id=credit_id
         )
         return test_mapped_listens
 
@@ -56,7 +53,7 @@ class CandidateSetsTestClass(SparkTestCase):
     def test_get_top_artists(self):
         mapped_df = self.get_mapped_listens()
         test_top_artist_df = candidate_sets.get_top_artists(mapped_df, 'vansika')
-        self.assertListEqual(['mb_artist_credit_id', 'artist_name', 'count'], test_top_artist_df.columns)
+        self.assertListEqual(['mb_artist_credit_id', 'msb_artist_credit_name_matchable', 'count'], test_top_artist_df.columns)
         self.assertEqual(test_top_artist_df.count(), 1)
         row = test_top_artist_df.collect()[0]
         self.assertEqual(row.mb_artist_credit_id, 1)

--- a/listenbrainz_spark/recommendations/tests/test_dataframe.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe.py
@@ -47,7 +47,10 @@ class CreateDataframeTestCase(SparkTestCase):
         test_mapping = {"msb_recording_msid":"cb6985cd-cc71-4d59-b4fb-2e72796af741",
             "mb_recording_mbid":"3acb406f-c716-45f8-a8bd-96ca3939c2e5","msb_artist_msid":"a36d6fc9-49d0-4789-a7dd-a2b72369ca45",
             "mb_artist_credit_mbids":["181c4177-f33a-441d-b15d-910acaf18b07"],"mb_artist_credit_id":2157963,
-            "mb_release_mbid": "xxxxx", "msb_release_msid": "xxxxx"}
+            "mb_release_mbid": "xxxxx", "msb_release_msid": "xxxxx", "msb_artist_credit_name": "Less Than Jake",
+            "msb_artist_credit_name_matchable": 'lessthanjake', "msb_recording_name": "Al's War", "msb_recording_name_matchable": "alswar",
+            "msb_release_name": "Easier", "msb_release_name_matchable": "easier",
+        }
 
         test_mapping_df = utils.create_dataframe(schema.convert_mapping_to_row(test_mapping), schema.msid_mbid_mapping_schema)
         utils.save_parquet(test_mapping_df, MAPPING_PATH)
@@ -88,9 +91,8 @@ class CreateDataframeTestCase(SparkTestCase):
 
         mapped_df = create_dataframes.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df)
         self.assertEqual(mapped_df.count(), 1)
-        complete_listen_col = ['artist_msid', 'artist_name', 'listened_at', 'recording_msid', 'release_mbid', 'release_msid',
-            'release_name', 'tags', 'track_name', 'user_name', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
-            'mb_release_mbid', 'msb_artist_msid', 'msb_recording_msid', 'msb_release_msid']
+        complete_listen_col = ['listened_at', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
+        'mb_release_mbid', 'msb_artist_credit_name_matchable', 'track_name', 'user_name']
         self.assertListEqual(complete_listen_col, mapped_df.columns)
         status = utils.path_exists(path.MAPPED_LISTENS)
         self.assertTrue(status)

--- a/listenbrainz_spark/recommendations/tests/test_dataframe.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe.py
@@ -44,12 +44,13 @@ class CreateDataframeTestCase(SparkTestCase):
 
     @classmethod
     def upload_test_mapping_to_HDFS(cls):
-        test_mapping = {"msb_recording_msid":"cb6985cd-cc71-4d59-b4fb-2e72796af741",
+        test_mapping = {
+            "msb_recording_msid":"cb6985cd-cc71-4d59-b4fb-2e72796af741",
             "mb_recording_mbid":"3acb406f-c716-45f8-a8bd-96ca3939c2e5","msb_artist_msid":"a36d6fc9-49d0-4789-a7dd-a2b72369ca45",
             "mb_artist_credit_mbids":["181c4177-f33a-441d-b15d-910acaf18b07"],"mb_artist_credit_id":2157963,
             "mb_release_mbid": "xxxxx", "msb_release_msid": "xxxxx", "msb_artist_credit_name": "Less Than Jake",
-            "msb_artist_credit_name_matchable": 'lessthanjake', "msb_recording_name": "Al's War", "msb_recording_name_matchable": "alswar",
-            "msb_release_name": "Easier", "msb_release_name_matchable": "easier",
+            "msb_artist_credit_name_matchable": 'lessthanjake', "msb_recording_name": "Al's War",
+            "msb_recording_name_matchable": "alswar", "msb_release_name": "Easier", "msb_release_name_matchable": "easier",
         }
 
         test_mapping_df = utils.create_dataframe(schema.convert_mapping_to_row(test_mapping), schema.msid_mbid_mapping_schema)
@@ -91,8 +92,10 @@ class CreateDataframeTestCase(SparkTestCase):
 
         mapped_df = create_dataframes.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df)
         self.assertEqual(mapped_df.count(), 1)
-        complete_listen_col = ['listened_at', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
-        'mb_release_mbid', 'msb_artist_credit_name_matchable', 'track_name', 'user_name']
+        complete_listen_col = [
+            'listened_at', 'mb_artist_credit_id', 'mb_artist_credit_mbids', 'mb_recording_mbid',
+            'mb_release_mbid', 'msb_artist_credit_name_matchable', 'track_name', 'user_name'
+        ]
         self.assertListEqual(complete_listen_col, mapped_df.columns)
         status = utils.path_exists(path.MAPPED_LISTENS)
         self.assertTrue(status)

--- a/listenbrainz_spark/recommendations/tests/test_dataframe.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe.py
@@ -45,12 +45,19 @@ class CreateDataframeTestCase(SparkTestCase):
     @classmethod
     def upload_test_mapping_to_HDFS(cls):
         test_mapping = {
-            "msb_recording_msid":"cb6985cd-cc71-4d59-b4fb-2e72796af741",
-            "mb_recording_mbid":"3acb406f-c716-45f8-a8bd-96ca3939c2e5","msb_artist_msid":"a36d6fc9-49d0-4789-a7dd-a2b72369ca45",
-            "mb_artist_credit_mbids":["181c4177-f33a-441d-b15d-910acaf18b07"],"mb_artist_credit_id":2157963,
-            "mb_release_mbid": "xxxxx", "msb_release_msid": "xxxxx", "msb_artist_credit_name": "Less Than Jake",
-            "msb_artist_credit_name_matchable": 'lessthanjake', "msb_recording_name": "Al's War",
-            "msb_recording_name_matchable": "alswar", "msb_release_name": "Easier", "msb_release_name_matchable": "easier",
+            "msb_recording_msid": "cb6985cd-cc71-4d59-b4fb-2e72796af741",
+            "mb_recording_mbid": "3acb406f-c716-45f8-a8bd-96ca3939c2e5",
+            "msb_artist_msid": "a36d6fc9-49d0-4789-a7dd-a2b72369ca45",
+            "mb_artist_credit_mbids": ["181c4177-f33a-441d-b15d-910acaf18b07"],
+            "mb_artist_credit_id": 2157963,
+            "mb_release_mbid": "xxxxx",
+            "msb_release_msid": "xxxxx",
+            "msb_artist_credit_name": "Less Than Jake",
+            "msb_artist_credit_name_matchable": "lessthanjake",
+            "msb_recording_name": "Al's War",
+            "msb_recording_name_matchable": "alswar",
+            "msb_release_name": "Easier",
+            "msb_release_name_matchable": "easier",
         }
 
         test_mapping_df = utils.create_dataframe(schema.convert_mapping_to_row(test_mapping), schema.msid_mbid_mapping_schema)

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -50,14 +50,14 @@ class RecommendTestClass(SparkTestCase):
         candidate_set_user_rdd = candidate_set_user.rdd.map(lambda r: (r['user_id'], r['recording_id']))
         recommended_rec = recommend.get_recommended_recordings(candidate_set_user_rdd, limit, recordings_df, model,
             mapped_listens)
+        print(recommended_rec)
         self.assertEqual(len(recommended_rec), limit)
-        self.assertEqual(recommended_rec[0][0], 'Less Than Jake')
+        self.assertEqual(recommended_rec[0][0], 'lessthanjake')
         self.assertEqual(recommended_rec[0][1], 1)
         self.assertEqual(recommended_rec[0][2], ['181c4177-f33a-441d-b15d-910acaf18b07'])
         self.assertEqual(recommended_rec[0][3], '3acb406f-c716-45f8-a8bd-96ca3939c2e5')
         self.assertEqual(recommended_rec[0][4], 'xxxxxx')
-        self.assertEqual(recommended_rec[0][5], 'xxxxxx')
-        self.assertEqual(recommended_rec[0][6], "Al's War")
+        self.assertEqual(recommended_rec[0][5], "Al's War")
 
     def test_recommend_user(self):
         model = recommend.load_model(config.HDFS_CLUSTER_URI + self.model_save_path)
@@ -85,16 +85,16 @@ class RecommendTestClass(SparkTestCase):
         user_recommendations = recommend.get_recommendations(user_names, recordings_df, model, users_df,
             top_artist_candidate_set, similar_artist_candidate_set, mapped_listens)
         self.assertListEqual(user_recommendations['vansika'].get('top_artists_recordings'),
-            [('Less Than Jake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'xxxxxx', "Al's War")])
+            [('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', "Al's War")])
         self.assertListEqual(user_recommendations['vansika'].get('similar_artists_recordings'),
-            [('Less Than Jake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'xxxxxx', "Al's War")])
+            [('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', "Al's War")])
         self.assertTrue(user_recommendations['vansika'].get('time'))
         self.assertListEqual(user_recommendations['rob'].get('top_artists_recordings'),
-            [('Kishore Kumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'xxxxxx', 'Mere Sapno ki Rani')])
+            [('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', 'Mere Sapno ki Rani')])
         self.assertListEqual(user_recommendations['rob'].get('similar_artists_recordings'),
-            [('Kishore Kumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'xxxxxx', 'Mere Sapno ki Rani')])
+            [('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', 'Mere Sapno ki Rani')])
         self.assertTrue(user_recommendations['rob'].get('time'))

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -88,14 +88,14 @@ class RecommendTestClass(SparkTestCase):
             user_recommendations['vansika'].get('top_artists_recordings'),
             [
                 ('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', "Al's War")
+                 'xxxxxx', "Al's War")
             ]
         )
         self.assertListEqual(
             user_recommendations['vansika'].get('similar_artists_recordings'),
             [
                 ('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', "Al's War")
+                 'xxxxxx', "Al's War")
             ]
         )
         self.assertTrue(user_recommendations['vansika'].get('time'))
@@ -103,14 +103,14 @@ class RecommendTestClass(SparkTestCase):
             user_recommendations['rob'].get('top_artists_recordings'),
             [
                 ('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'Mere Sapno ki Rani')
+                 'xxxxxx', 'Mere Sapno ki Rani')
             ]
         )
         self.assertListEqual(
             user_recommendations['rob'].get('similar_artists_recordings'),
             [
                 ('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'Mere Sapno ki Rani')
+                 'xxxxxx', 'Mere Sapno ki Rani')
             ]
         )
         self.assertTrue(user_recommendations['rob'].get('time'))

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -84,17 +84,33 @@ class RecommendTestClass(SparkTestCase):
 
         user_recommendations = recommend.get_recommendations(user_names, recordings_df, model, users_df,
             top_artist_candidate_set, similar_artist_candidate_set, mapped_listens)
-        self.assertListEqual(user_recommendations['vansika'].get('top_artists_recordings'),
-            [('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', "Al's War")])
-        self.assertListEqual(user_recommendations['vansika'].get('similar_artists_recordings'),
-            [('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', "Al's War")])
+        self.assertListEqual(
+            user_recommendations['vansika'].get('top_artists_recordings'),
+            [
+                ('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', "Al's War")
+            ]
+        )
+        self.assertListEqual(
+            user_recommendations['vansika'].get('similar_artists_recordings'),
+            [
+                ('lessthanjake', 1, ['181c4177-f33a-441d-b15d-910acaf18b07'], '3acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', "Al's War")
+            ]
+        )
         self.assertTrue(user_recommendations['vansika'].get('time'))
-        self.assertListEqual(user_recommendations['rob'].get('top_artists_recordings'),
-            [('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'Mere Sapno ki Rani')])
-        self.assertListEqual(user_recommendations['rob'].get('similar_artists_recordings'),
-            [('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
-                'xxxxxx', 'Mere Sapno ki Rani')])
+        self.assertListEqual(
+            user_recommendations['rob'].get('top_artists_recordings'),
+            [
+                ('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', 'Mere Sapno ki Rani')
+            ]
+        )
+        self.assertListEqual(
+            user_recommendations['rob'].get('similar_artists_recordings'),
+            [
+                ('kishorekumar', 2, ['281c4177-f33a-441d-b15d-910acaf18b07'], '2acb406f-c716-45f8-a8bd-96ca3939c2e5',
+                'xxxxxx', 'Mere Sapno ki Rani')
+            ]
+        )
         self.assertTrue(user_recommendations['rob'].get('time'))

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -58,9 +58,15 @@ msid_mbid_mapping_schema = [
     StructField('mb_artist_credit_mbids', ArrayType(StringType()), nullable=False),
     StructField('mb_recording_mbid', StringType(), nullable=False),
     StructField('mb_release_mbid', StringType(), nullable=False),
+    StructField('msb_artist_credit_name', StringType(), nullable=False),
+    StructField('msb_artist_credit_name_matchable', StringType(), nullable=False),
     StructField('msb_artist_msid', StringType(), nullable=False),
     StructField('msb_recording_msid', StringType(), nullable=False),
     StructField('msb_release_msid', StringType(), nullable=False),
+    StructField('msb_recording_name', StringType(), nullable=False),
+    StructField('msb_recording_name_matchable', StringType(), nullable=False),
+    StructField('msb_release_name', StringType(), nullable=False),
+    StructField('msb_release_name_matchable', StringType(), nullable=False),
 ]
 
 artist_relation_schema =[
@@ -170,7 +176,13 @@ def convert_mapping_to_row(mapping):
         mb_artist_credit_mbids=mapping.get('mb_artist_credit_mbids'),
         mb_recording_mbid=mapping.get('mb_recording_mbid'),
         mb_release_mbid=mapping.get('mb_release_mbid'),
+        msb_artist_credit_name=mapping.get('msb_artist_credit_name'),
+        msb_artist_credit_name_matchable=mapping.get('msb_artist_credit_name_matchable'),
         msb_artist_msid=mapping.get('msb_artist_msid'),
         msb_recording_msid=mapping.get('msb_recording_msid'),
         msb_release_msid=mapping.get('msb_release_msid'),
+        msb_recording_name=mapping.get('msb_recording_name'),
+        msb_recording_name_matchable=mapping.get('msb_recording_name_matchable'),
+        msb_release_name=mapping.get('msb_release_name'),
+        msb_release_name_matchable=mapping.get('msb_release_name_matchable'),
     )

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -87,22 +87,16 @@ class SparkTestCase(unittest.TestCase):
     @classmethod
     def get_mapped_listens(cls):
         mapped_listens_row_1 = Row(
-            user_name='vansika', artist_msid="a36d6fc9-49d0-4789-a7dd-a2b72369ca45", release_msid="xxxxxx",
-            release_name="xxxxxx", artist_name="Less Than Jake", release_mbid="xxxxxx", track_name="Al's War",
-            recording_msid="cb6985cd-cc71-4d59-b4fb-2e72796af741", tags=['xxxx'], listened_at=datetime.utcnow(),
-            msb_recording_msid="cb6985cd-cc71-4d59-b4fb-2e72796af741", mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
-            msb_artist_msid="a36d6fc9-49d0-4789-a7dd-a2b72369ca45", mb_artist_credit_mbids=["181c4177-f33a-441d-b15d-910acaf18b07"],
-            mb_artist_credit_id=1, mb_release_mbid="xxxxxx", msb_release_msid='xxxxxx',
+            user_name='vansika', msb_artist_credit_name_matchable="lessthanjake", track_name="Al's War",
+            listened_at=datetime.utcnow(), mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
+            mb_artist_credit_mbids=["181c4177-f33a-441d-b15d-910acaf18b07"], mb_artist_credit_id=1, mb_release_mbid="xxxxxx",
         )
         df = utils.create_dataframe(mapped_listens_row_1, schema=None)
 
         mapped_listens_row_2 = Row(
-            user_name='rob', artist_msid="b36d6fc9-49d0-4789-a7dd-a2b72369ca45", release_msid="xxxxxx",
-            release_name="xxxxxx", artist_name="Kishore Kumar", release_mbid="xxxxxx", track_name="Mere Sapno ki Rani",
-            recording_msid="bb6985cd-cc71-4d59-b4fb-2e72796af741", tags=['xxxx'], listened_at=datetime.utcnow(),
-            msb_recording_msid="bb6985cd-cc71-4d59-b4fb-2e72796af741", mb_recording_gid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
-            msb_artist_msid="b36d6fc9-49d0-4789-a7dd-a2b72369ca45", mb_artist_gids=["281c4177-f33a-441d-b15d-910acaf18b07"],
-            mb_artist_credit_id=2, mb_release_mbid="xxxxxx", msb_release_msid='xxxxxx',
+            user_name='rob', msb_artist_credit_name_matchable="kishorekumar", track_name="Mere Sapno ki Rani",
+            listened_at=datetime.utcnow(), mb_recording_mbid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
+            mb_artist_mbids=["281c4177-f33a-441d-b15d-910acaf18b07"], mb_artist_credit_id=2, mb_release_mbid="xxxxxx",
         )
         mapped_listens_df = df.union(utils.create_dataframe(mapped_listens_row_2, schema=None))
         return mapped_listens_df


### PR DESCRIPTION
With this PR, rec engine switches to [msid_mbid_mapping_with_matchable](http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/labs/mappings/msid-mbid-mapping-with-matchable/) from [msib_mbid_mapping](http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/labs/mappings/msid-mbid-mapping/)
