### PR TITLE
Improve spotify track search

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -38,7 +38,7 @@ const searchForSpotifyTrack = async (
     // search for track was not provided a track name, cannot proceed
     return null;
   }
-  let queryString = `q="${trackName}"`;
+  let queryString = `q=track:${trackName}`;
   if (artistName) {
     queryString += ` artist:${artistName}`;
   }


### PR DESCRIPTION
# Problem

Fix issue where a track with the same name as album might not appear first in results. Spotify is likely to return the most popular song of the album first instead.

# Solution

Specify `track:` in front of the trackname

I also remove the quotes around the trackname that have no effect I could measure, while possibly preventing to find the song with a slightly different name (I'm thinking "feat.. XYZ", "- Radio Edit" etc.)
