### PR TITLE
LB-586: Fix bad font of the "Copy token" button

### DIFF
--- a/listenbrainz/webserver/static/js/info.js
+++ b/listenbrainz/webserver/static/js/info.js
@@ -27,5 +27,5 @@ document.getElementById("copy-token").addEventListener("click", function() {
     }
     copy(token);
     var copyButton = document.getElementById("copy-token");
-    copyButton.value = "Copied!"
+    copyButton.textContent = "Copied!"
 });

--- a/listenbrainz/webserver/templates/profile/info.html
+++ b/listenbrainz/webserver/templates/profile/info.html
@@ -41,8 +41,8 @@
     <p>
       <form class="form-inline">
         <input type="password" class="form-control" id="auth-token" style="width: 400px; height:30px;" value="{{ user.auth_token }}" readonly />
-        <button type="button" class="btn btn-info glyphicon glyphicon-eye-open" id="show-hide-token" style="width: 50px; height:30px;" title="Show user token"></button>
-        <input type="button" class="btn btn-info btn-med glyphicon glyphicon-copy" id="copy-token" style="height:30px;" value="Copy" />
+        <button type="button" class="btn btn-info glyphicon glyphicon-eye-open" id="show-hide-token" style="width: 50px; height:30px; top: 0px;" title="Show user token"></button>
+        <button type="button" class="btn btn-info" id="copy-token" style="width: 90px; height:30px;" title="Copy user token">Copy</button>
       </form>
     </p>
 


### PR DESCRIPTION
# Problem

The unnecessary glyphicon class makes the "Copy" button text look bad.

![image](https://user-images.githubusercontent.com/33172244/81855351-ddecfa00-957c-11ea-884d-dc3e1020fd8b.png)

# Solution

Removing the class fixes the issue.

![image](https://user-images.githubusercontent.com/33172244/81855720-56ec5180-957d-11ea-8909-dad568e424a2.png)