### PR TITLE
Add artist/artist_credit relations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-norecursedirs=listenbrainz/tests/integration listenbrainz_spark
+norecursedirs=listenbrainz/tests/integration listenbrainz_spark relations
 addopts = --cov=listenbrainz

--- a/relations/README.md
+++ b/relations/README.md
@@ -1,0 +1,24 @@
+Introduction
+============
+
+How artists and artist_credits relate to each other can be derived by loading various
+artist albums in MusicBrainz and using the fact that two artists(_credits) appear on 
+the same album as a fact that they are somewhat related. 
+
+Given this principle, these scripts require a MusicBrainz replicated slave instance
+and will create a new schema "relations" inside the MusicBrainz database. The create
+scripts will calculate the relationships, create new tables and then build indexes
+on those tables.
+
+Installation
+------------
+
+To build the artist-artist and artist_credit-artist_credit relations, you'll need to:
+
+1. Install and setup musicbrainz-docker ( https://github.com/metabrainz/musicbrainz-docker ). No need for search indexes.
+2. Expose the postgres port to the host machine.
+3. Copy config.py.sample to config.py and set your DB connect string, based on your setup of musicbrainz-docker.
+4. Create a python virtual env (e.g. virtualenv -p python3 .ve) and activate it.
+5. Install requirements with `pip install -r requirements.txt`
+6. run create_artist_relations.py and.or create_artist_credit_relations.py to actually create the relationships.
+7. run write_artist_relations.py to save the relation to a dump file.

--- a/relations/config.py.sample
+++ b/relations/config.py.sample
@@ -1,0 +1,7 @@
+#
+# Database connection.
+
+# If you are connecting to a musicbrainz-docker instance for MusicBrainz data, this string should work:
+# DB_CONNECT = "dbname=musicbrainz_db user=musicbrainz host=localhost port=5432 password=musicbrainz"
+
+DB_CONNECT = ""

--- a/relations/create_artist_credit_relations.py
+++ b/relations/create_artist_credit_relations.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import sys
+import pprint
+import psycopg2
+from time import asctime
+from psycopg2.errors import OperationalError, DuplicateTable, UndefinedObject
+
+import config
+from utils import create_schema, dump_similarities, insert_artist_pairs
+
+ARTIST_CREDIT_IDS_TO_EXCLUDE = [
+    15071, # anonymous
+    97546, # unknown
+]
+
+def create_or_truncate_table(conn):
+    '''
+        Create the artist_credit_relations table if it doesn't exist, otherwise truncate it.
+    '''
+
+    print(asctime(),"drop old indexes, truncate table or create new table")
+    try:
+        with conn.cursor() as curs:
+            print(asctime(), "create table")
+            curs.execute("""CREATE TABLE relations.artist_credit_artist_credit_relations (
+                                         count integer, 
+                                         artist_credit_0 integer, 
+                                         artist_credit_1 integer)""")
+
+    except DuplicateTable as err:
+        conn.rollback() 
+        try:
+            with conn.cursor() as curs:
+                try:
+                    curs.execute("TRUNCATE relations.artist_credit_artist_credit_relations")
+                    conn.commit()
+                except UndefinedObject as err:
+                    conn.rollback()
+
+                try:
+                    curs.execute("DROP INDEX relations.artist_credit_artist_credit_relations_artist_0_ndx")
+                    curs.execute("DROP INDEX relations.artist_credit_artist_credit_relations_artist_1_ndx")
+                    conn.commit()
+                except UndefinedObject as err:
+                    conn.rollback()
+
+        except OperationalError as err:
+            print(asctime(),"failed to truncate existing table")
+            conn.rollback()
+
+
+def create_indexes(conn):
+    '''
+        Create the indexes for the completed relations tables
+    '''
+
+    print(asctime(),"creating indexes")
+    try:
+        with conn.cursor() as curs:
+            curs.execute('''CREATE INDEX artist_credit_artist_credit_relations_artist_0_ndx 
+                                      ON relations.artist_credit_artist_credit_relations (artist_credit_0)''')
+            curs.execute('''CREATE INDEX artist_credit_artist_credit_relations_artist_1_ndx 
+                                      ON relations.artist_credit_artist_credit_relations (artist_credit_1)''')
+            conn.commit()
+    except OperationalError as err:
+        conn.rollback()
+        print(asctime(),"creating indexes failed.")
+
+            
+def calculate_artist_credit_similarities():
+    '''
+        Calculate artist credit relations by fetching recordings for various artist albums and then
+        using the fact that two artists are on teh same album as a vote that they are related.
+    '''
+
+    relations = {}
+    release_id = 0
+    artist_credits = []
+
+    with psycopg2.connect(config.DB_CONNECT) as conn:
+        create_schema(conn)
+        with conn.cursor() as curs:
+            count = 0
+            print(asctime(), "query for various artist recordings")
+            curs.execute("""SELECT DISTINCT r.id as release_id, ac.id as artist_id
+                                       FROM release r
+                                       JOIN medium m ON m.release = r.id AND r.artist_credit = 1
+                                       JOIN track t ON t.medium = m.id
+                                       JOIN artist_credit ac ON t.artist_credit = ac.id
+                                       JOIN artist_credit_name acm ON acm.artist_credit = ac.id
+                                       JOIN artist a ON acm.artist = a.id""")
+            print(asctime(), "load various artist recordings")
+            while True:
+                row = curs.fetchone()
+                if not row:
+                    break
+
+                if row[1] in ARTIST_CREDIT_IDS_TO_EXCLUDE:
+                    continue
+
+                if release_id != row[0] and artist_credits:
+                    insert_artist_pairs(artist_credits, relations)
+                    artist_credits = []
+
+                artist_credits.append(row[1])
+                release_id = row[0]
+                count += 1
+
+        print(asctime(), "save relations to new table")
+        create_or_truncate_table(conn)
+        dump_similarities(conn, "relations.artist_credit_artist_credit_relations", relations)
+        print(asctime(), "create indexes")
+        create_indexes(conn)
+        print(asctime(), "done!")
+
+
+if __name__ == "__main__":
+    calculate_artist_credit_similarities()

--- a/relations/create_artist_credit_relations.py
+++ b/relations/create_artist_credit_relations.py
@@ -8,9 +8,10 @@ import config
 from utils import create_schema, dump_similarities, insert_artist_pairs
 
 ARTIST_CREDIT_IDS_TO_EXCLUDE = [
-    15071, # anonymous
-    97546, # unknown
+    15071,  # anonymous
+    97546,  # unknown
 ]
+
 
 def create_or_truncate_table(conn):
     '''

--- a/relations/create_artist_credit_relations.py
+++ b/relations/create_artist_credit_relations.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
-import sys
-import pprint
-import psycopg2
 from time import asctime
+import psycopg2
 from psycopg2.errors import OperationalError, DuplicateTable, UndefinedObject
 
 import config
@@ -19,34 +17,34 @@ def create_or_truncate_table(conn):
         Create the artist_credit_relations table if it doesn't exist, otherwise truncate it.
     '''
 
-    print(asctime(),"drop old indexes, truncate table or create new table")
+    print(asctime(), "drop old indexes, truncate table or create new table")
     try:
         with conn.cursor() as curs:
             print(asctime(), "create table")
             curs.execute("""CREATE TABLE relations.artist_credit_artist_credit_relations (
-                                         count integer, 
-                                         artist_credit_0 integer, 
+                                         count integer,
+                                         artist_credit_0 integer,
                                          artist_credit_1 integer)""")
 
-    except DuplicateTable as err:
-        conn.rollback() 
+    except DuplicateTable:
+        conn.rollback()
         try:
             with conn.cursor() as curs:
                 try:
                     curs.execute("TRUNCATE relations.artist_credit_artist_credit_relations")
                     conn.commit()
-                except UndefinedObject as err:
+                except UndefinedObject:
                     conn.rollback()
 
                 try:
                     curs.execute("DROP INDEX relations.artist_credit_artist_credit_relations_artist_0_ndx")
                     curs.execute("DROP INDEX relations.artist_credit_artist_credit_relations_artist_1_ndx")
                     conn.commit()
-                except UndefinedObject as err:
+                except UndefinedObject:
                     conn.rollback()
 
-        except OperationalError as err:
-            print(asctime(),"failed to truncate existing table")
+        except OperationalError:
+            print(asctime(), "failed to truncate existing table")
             conn.rollback()
 
 
@@ -55,19 +53,19 @@ def create_indexes(conn):
         Create the indexes for the completed relations tables
     '''
 
-    print(asctime(),"creating indexes")
+    print(asctime(), "creating indexes")
     try:
         with conn.cursor() as curs:
-            curs.execute('''CREATE INDEX artist_credit_artist_credit_relations_artist_0_ndx 
+            curs.execute('''CREATE INDEX artist_credit_artist_credit_relations_artist_0_ndx
                                       ON relations.artist_credit_artist_credit_relations (artist_credit_0)''')
-            curs.execute('''CREATE INDEX artist_credit_artist_credit_relations_artist_1_ndx 
+            curs.execute('''CREATE INDEX artist_credit_artist_credit_relations_artist_1_ndx
                                       ON relations.artist_credit_artist_credit_relations (artist_credit_1)''')
             conn.commit()
-    except OperationalError as err:
+    except OperationalError:
         conn.rollback()
-        print(asctime(),"creating indexes failed.")
+        print(asctime(), "creating indexes failed.")
 
-            
+
 def calculate_artist_credit_similarities():
     '''
         Calculate artist credit relations by fetching recordings for various artist albums and then

--- a/relations/create_artist_relations.py
+++ b/relations/create_artist_relations.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
-import sys
-import pprint
-import psycopg2
 from time import asctime
+import psycopg2
 from psycopg2.errors import OperationalError, DuplicateTable, UndefinedObject
 
 import config
@@ -19,33 +17,33 @@ def create_or_truncate_table(conn):
     Create the artist_credit_relations table if it doesn't exist, otherwise truncate it.
     '''
 
-    print(asctime(),"drop old indexes, truncate table or create new table")
+    print(asctime(), "drop old indexes, truncate table or create new table")
     try:
         with conn.cursor() as curs:
             print(asctime(), "create table")
             curs.execute("""CREATE TABLE relations.artist_artist_relations (
-                                         count integer, 
-                                         artist_0 integer, 
+                                         count integer,
+                                         artist_0 integer,
                                          artist_1 integer)""")
 
-    except DuplicateTable as err:
-        conn.rollback() 
+    except DuplicateTable:
+        conn.rollback()
         try:
             with conn.cursor() as curs:
                 try:
                     curs.execute("TRUNCATE relations.artist_artist_relations")
                     conn.commit()
-                except UndefinedObject as err:
+                except UndefinedObject:
                     conn.rollback()
 
                 try:
                     curs.execute("DROP INDEX relations.artist_artist_relations_artist_0_ndx")
                     curs.execute("DROP INDEX relations.artist_artist_relations_artist_1_ndx")
                     conn.commit()
-                except UndefinedObject as err:
+                except UndefinedObject:
                     conn.rollback()
 
-        except OperationalError as err:
+        except OperationalError:
             print(asctime(), "failed to truncate existing table")
             conn.rollback()
 
@@ -55,15 +53,15 @@ def create_indexes(conn):
         Create the indexes for the completed relations tables
     '''
 
-    print(asctime(),"creating indexes")
+    print(asctime(), "creating indexes")
     try:
         with conn.cursor() as curs:
-            curs.execute('''CREATE INDEX artist_artist_relations_artist_0_ndx 
+            curs.execute('''CREATE INDEX artist_artist_relations_artist_0_ndx
                                       ON relations.artist_artist_relations (artist_0)''')
-            curs.execute('''CREATE INDEX artist_artist_relations_artist_1_ndx 
+            curs.execute('''CREATE INDEX artist_artist_relations_artist_1_ndx
                                       ON relations.artist_artist_relations (artist_1)''')
             conn.commit()
-    except OperationalError as err:
+    except OperationalError:
         conn.rollback()
         print(asctime(), "creating indexes failed.")
 

--- a/relations/create_artist_relations.py
+++ b/relations/create_artist_relations.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import sys
+import pprint
+import psycopg2
+from time import asctime
+from psycopg2.errors import OperationalError, DuplicateTable, UndefinedObject
+
+import config
+from utils import create_schema, dump_similarities, insert_artist_pairs
+
+ARTIST_MBIDS_TO_EXCLUDE = [
+    'f731ccc4-e22a-43af-a747-64213329e088', # anonymous
+    '125ec42a-7229-4250-afc5-e057484327fe', # unknown
+]
+
+def create_or_truncate_table(conn):
+    '''
+    Create the artist_credit_relations table if it doesn't exist, otherwise truncate it.
+    '''
+
+    print(asctime(),"drop old indexes, truncate table or create new table")
+    try:
+        with conn.cursor() as curs:
+            print(asctime(), "create table")
+            curs.execute("""CREATE TABLE relations.artist_artist_relations (
+                                         count integer, 
+                                         artist_0 integer, 
+                                         artist_1 integer)""")
+
+    except DuplicateTable as err:
+        conn.rollback() 
+        try:
+            with conn.cursor() as curs:
+                try:
+                    curs.execute("TRUNCATE relations.artist_artist_relations")
+                    conn.commit()
+                except UndefinedObject as err:
+                    conn.rollback()
+
+                try:
+                    curs.execute("DROP INDEX relations.artist_artist_relations_artist_0_ndx")
+                    curs.execute("DROP INDEX relations.artist_artist_relations_artist_1_ndx")
+                    conn.commit()
+                except UndefinedObject as err:
+                    conn.rollback()
+
+        except OperationalError as err:
+            print(asctime(), "failed to truncate existing table")
+            conn.rollback()
+
+
+def create_indexes(conn):
+    '''
+        Create the indexes for the completed relations tables
+    '''
+
+    print(asctime(),"creating indexes")
+    try:
+        with conn.cursor() as curs:
+            curs.execute('''CREATE INDEX artist_artist_relations_artist_0_ndx 
+                                      ON relations.artist_artist_relations (artist_0)''')
+            curs.execute('''CREATE INDEX artist_artist_relations_artist_1_ndx 
+                                      ON relations.artist_artist_relations (artist_1)''')
+            conn.commit()
+    except OperationalError as err:
+        conn.rollback()
+        print(asctime(), "creating indexes failed.")
+
+
+def calculate_artist_similarities():
+
+    relations = {}
+    release_id = 0
+    artists = []
+
+    with psycopg2.connect(config.DB_CONNECT) as conn:
+        create_schema(conn)
+        with conn.cursor() as curs:
+            count = 0
+            print(asctime(), "query for various artist recordings")
+            curs.execute("""SELECT DISTINCT r.id as release_id, a.id as artist_id, a.gid as artist_mbid
+                                       FROM release r
+                                       JOIN medium m ON m.release = r.id AND r.artist_credit = 1
+                                       JOIN track t ON t.medium = m.id
+                                       JOIN artist_credit ac ON t.artist_credit = ac.id
+                                       JOIN artist_credit_name acm ON acm.artist_credit = ac.id
+                                       JOIN artist a ON acm.artist = a.id""")
+            print(asctime(), "load various artist recordings")
+            while True:
+                row = curs.fetchone()
+                if not row:
+                    break
+
+                if row[2] in ARTIST_MBIDS_TO_EXCLUDE:
+                    continue
+
+                if release_id != row[0] and artists:
+                    insert_artist_pairs(artists, relations)
+                    artists = []
+
+                artists.append(row[1])
+                release_id = row[0]
+                count += 1
+
+        print(asctime(), "save relations to new table")
+        create_or_truncate_table(conn)
+        dump_similarities(conn, "relations.artist_artist_relations", relations)
+        print(asctime(), "create indexes")
+        create_indexes(conn)
+        print(asctime(), "done!")
+
+
+if __name__ == "__main__":
+    calculate_artist_similarities()

--- a/relations/create_artist_relations.py
+++ b/relations/create_artist_relations.py
@@ -8,9 +8,10 @@ import config
 from utils import create_schema, dump_similarities, insert_artist_pairs
 
 ARTIST_MBIDS_TO_EXCLUDE = [
-    'f731ccc4-e22a-43af-a747-64213329e088', # anonymous
-    '125ec42a-7229-4250-afc5-e057484327fe', # unknown
+    'f731ccc4-e22a-43af-a747-64213329e088',  # anonymous
+    '125ec42a-7229-4250-afc5-e057484327fe',  # unknown
 ]
+
 
 def create_or_truncate_table(conn):
     '''

--- a/relations/data_dump_files/README
+++ b/relations/data_dump_files/README
@@ -1,0 +1,46 @@
+MusicBrainz Artist-Artist and Artist_Credit-Artist_Credit relations
+===================================================================
+
+This data dump contains artist to artist or artist_credit to artist_credit
+relations that indicate how strongly (or not) an artist is related to 
+another artist.
+
+Each of the two tables contain a score (from 0.0 to 1.0) of the
+relationship between the two entities and the ids and names of 
+the entities. Each relation is written to a line of text as a JSON
+document.
+
+
+artist-artist
+-------------
+
+This dump contain the score, mbids (mbid_0 and mbid_1) and the names of the artists (name_0 and name_1):
+
+{
+    "score" :1.0,
+    "mbid_0":"1f9df192-a621-4f54-8850-2c5373b7eac9",
+    "name_0":"Ludwig van Beethoven",
+    "mbid_1":"b972f589-fb0e-474e-b64a-803b0364fa75",
+    "name_1":"Wolfgang Amadeus Mozart"
+}
+
+This document expresses that Ludwig van Beethoven and Wolfgang Amadeus Mozart are very strongly (the strongest, in fact!) 
+related to each other.
+
+
+artist_credit-artist_credit
+---------------------------
+
+This dump contain the score, artist_credit_ids (id_0 and id_1) and the names of the artist_credits (name_0 and name_1):
+
+{
+    "score" :1.0,
+    "id_0"  :1021,
+    "name_0":"Ludwig van Beethoven",
+    "id_1"  :11285,
+    "name_1":"Wolfgang Amadeus Mozart"
+}
+
+This document expresses that the artist credit Ludwig van Beethoven and artist credit Wolfgang Amadeus Mozart are very 
+strongly related to each other.
+

--- a/relations/data_dump_files/README_data_dump_files.md
+++ b/relations/data_dump_files/README_data_dump_files.md
@@ -1,0 +1,1 @@
+Please note -- the files in this directory are here for inclusion in data dump files. They do not apply to the code in this repository!

--- a/relations/get_relations.py
+++ b/relations/get_relations.py
@@ -7,7 +7,7 @@ import config
 
 
 SELECT_ARTIST_RELATIONS_QUERY = '''
-    SELECT count, arr.artist_0, a0.name AS artist_name_0, arr.artist_1, a1.name AS artist_name_1 
+    SELECT count, arr.artist_0, a0.name AS artist_name_0, arr.artist_1, a1.name AS artist_name_1
       FROM relations.artist_artist_relations arr
       JOIN artist a0 ON arr.artist_0 = a0.id
       JOIN artist a1 ON arr.artist_1 = a1.id
@@ -16,13 +16,14 @@ SELECT_ARTIST_RELATIONS_QUERY = '''
 '''
 
 SELECT_ARTIST_CREDIT_RELATIONS_QUERY = '''
-    SELECT count, arr.artist_credit_0, a0.name AS artist_name_0, arr.artist_credit_1, a1.name AS artist_name_1 
+    SELECT count, arr.artist_credit_0, a0.name AS artist_name_0, arr.artist_credit_1, a1.name AS artist_name_1
       FROM relations.artist_credit_artist_credit_relations arr
       JOIN artist a0 ON arr.artist_credit_0 = a0.id
       JOIN artist a1 ON arr.artist_credit_1 = a1.id
      WHERE (arr.artist_credit_0 = %s OR arr.artist_credit_1 = %s)
   ORDER BY count desc
 '''
+
 
 def get_artist_credit_similarities(artist_credit_id):
     '''
@@ -54,17 +55,17 @@ def _get_similarities(query, id):
                 if not row:
                     break
 
-                if id == row[1]: 
+                if id == row[1]:
                     relations.append({
-                        'count' : row[0],
-                        'id' : row[3],
-                        'artist_name' : row[4]
+                        'count': row[0],
+                        'id': row[3],
+                        'artist_name': row[4]
                     })
                 else:
                     relations.append({
-                        'count' : row[0],
-                        'id' : row[1],
-                        'artist_name' : row[2]
+                        'count': row[0],
+                        'id': row[1],
+                        'artist_name': row[2]
                     })
 
-            return relations 
+            return relations

--- a/relations/get_relations.py
+++ b/relations/get_relations.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import sys
+import psycopg2
+
+import config
+
+
+SELECT_ARTIST_RELATIONS_QUERY = '''
+    SELECT count, arr.artist_0, a0.name AS artist_name_0, arr.artist_1, a1.name AS artist_name_1 
+      FROM relations.artist_artist_relations arr
+      JOIN artist a0 ON arr.artist_0 = a0.id
+      JOIN artist a1 ON arr.artist_1 = a1.id
+     WHERE (arr.artist_0 = %s OR arr.artist_1 = %s)
+  ORDER BY count desc
+'''
+
+SELECT_ARTIST_CREDIT_RELATIONS_QUERY = '''
+    SELECT count, arr.artist_credit_0, a0.name AS artist_name_0, arr.artist_credit_1, a1.name AS artist_name_1 
+      FROM relations.artist_credit_artist_credit_relations arr
+      JOIN artist a0 ON arr.artist_credit_0 = a0.id
+      JOIN artist a1 ON arr.artist_credit_1 = a1.id
+     WHERE (arr.artist_credit_0 = %s OR arr.artist_credit_1 = %s)
+  ORDER BY count desc
+'''
+
+def get_artist_credit_similarities(artist_credit_id):
+    '''
+        Fetch artist credit relations for the given artist_credit_id.
+    '''
+
+    return _get_similarities(SELECT_ARTIST_CREDIT_RELATIONS_QUERY, artist_credit_id)
+
+
+def get_artist_similarities(artist_id):
+    '''
+        Fetch artist relations for the given artist_mbid.
+    '''
+
+    return _get_similarities(SELECT_ARTIST_RELATIONS_QUERY, artist_id)
+
+
+def _get_similarities(query, id):
+    '''
+        The actual function that does the real work.
+    '''
+
+    with psycopg2.connect(config.DB_CONNECT) as conn:
+        with conn.cursor() as curs:
+            curs.execute(query, (id, id))
+            relations = []
+            while True:
+                row = curs.fetchone()
+                if not row:
+                    break
+
+                if id == row[1]: 
+                    relations.append({
+                        'count' : row[0],
+                        'id' : row[3],
+                        'artist_name' : row[4]
+                    })
+                else:
+                    relations.append({
+                        'count' : row[0],
+                        'id' : row[1],
+                        'artist_name' : row[2]
+                    })
+
+            return relations 

--- a/relations/requirements.txt
+++ b/relations/requirements.txt
@@ -1,3 +1,4 @@
 click==7.1.2
 psycopg2-binary==2.8.5
 ujson==2.0.3
+nose==1.3.7

--- a/relations/requirements.txt
+++ b/relations/requirements.txt
@@ -1,0 +1,3 @@
+click==7.1.2
+psycopg2-binary==2.8.5
+ujson==2.0.3

--- a/relations/test.sh
+++ b/relations/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+nosetests tests/test_artist_relations.py

--- a/relations/tests/test_artist_relations.py
+++ b/relations/tests/test_artist_relations.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import psycopg2
+
+from get_relations import get_artist_credit_similarities, get_artist_similarities
+import config
+
+def test_artist_credits():
+
+    relations = get_artist_credit_similarities(65)
+    assert relations
+
+    id_list = [ rel['id'] for rel in relations ]
+    assert 963 in id_list
+    assert 650 in id_list
+
+
+def test_artists():
+
+    relations = get_artist_similarities(65)
+    assert relations
+
+    id_list = [ rel['id'] for rel in relations ]
+    assert 963 in id_list
+    assert 650 in id_list

--- a/relations/tests/test_artist_relations.py
+++ b/relations/tests/test_artist_relations.py
@@ -5,12 +5,13 @@ import psycopg2
 from get_relations import get_artist_credit_similarities, get_artist_similarities
 import config
 
+
 def test_artist_credits():
 
     relations = get_artist_credit_similarities(65)
     assert relations
 
-    id_list = [ rel['id'] for rel in relations ]
+    id_list = [rel['id'] for rel in relations]
     assert 963 in id_list
     assert 650 in id_list
 
@@ -20,6 +21,6 @@ def test_artists():
     relations = get_artist_similarities(65)
     assert relations
 
-    id_list = [ rel['id'] for rel in relations ]
+    id_list = [rel['id'] for rel in relations]
     assert 963 in id_list
     assert 650 in id_list

--- a/relations/utils.py
+++ b/relations/utils.py
@@ -1,0 +1,80 @@
+import psycopg2
+from time import asctime
+
+def create_schema(conn):
+    '''
+        Create the relations schema if it doesn't already exist
+    '''
+
+    try:
+        with conn.cursor() as curs:
+            print(asctime(), "create schema")
+            curs.execute("CREATE SCHEMA IF NOT EXISTS relations")
+            conn.commit()
+    except OperationalError as err:
+        print(asctime(),"failed to create schema 'relations'")
+        conn.rollback()
+
+
+        print(asctime(),"creating indexes failed.")
+
+
+def insert_artist_pairs(artist_pairs, relations):
+    '''
+        After the artist(_credit) pairs have been collected, create the list of relations for this artist.
+    '''
+
+    for a0 in artist_pairs:
+        for a1 in artist_pairs:
+            if a0 == 1 or a1 == 1:
+                continue 
+
+            if a0 == a1:
+                continue
+
+            if a0 < a1:
+                k = "%d=%d" % (a0, a1)
+            else:
+                k = "%d=%d" % (a1, a0)
+
+            try:
+                relations[k][0] += 1
+            except KeyError:
+                relations[k] = [ 1, a0, a1 ]
+
+
+def insert_rows(curs, table, values):
+    '''
+        Use the bulk insert function to insert rows into the relations table.
+    '''
+
+    query = ("INSERT INTO %s VALUES " % table) + ",".join(values)
+    try:
+        curs.execute(query)
+    except psycopg2.OperationalError as err:
+        print(asctime(), "failed to insert rows")
+
+            
+def dump_similarities(conn, table, relations):
+    '''
+        After all the similarities have been collected, write then to the DB in batches.
+    '''
+
+    print(asctime(), "write relations to table")
+
+    values = []
+    with conn.cursor() as curs:
+
+        for k in relations:
+            r = relations[k]
+            if r[0] > 2:
+                values.append("(%d, %d, %d)" % (r[0], r[1], r[2]))
+
+            if len(values) > 1000:
+                insert_rows(curs, table, values)
+                conn.commit()
+                values = []
+
+        if len(values):
+            insert_rows(curs, table, values)
+            conn.commit()

--- a/relations/utils.py
+++ b/relations/utils.py
@@ -1,6 +1,7 @@
 from time import asctime
 import psycopg2
 
+
 def create_schema(conn):
     '''
         Create the relations schema if it doesn't already exist
@@ -14,7 +15,6 @@ def create_schema(conn):
     except OperationalError:
         print(asctime(), "failed to create schema 'relations'")
         conn.rollback()
-
 
         print(asctime(), "creating indexes failed.")
 

--- a/relations/utils.py
+++ b/relations/utils.py
@@ -1,5 +1,5 @@
-import psycopg2
 from time import asctime
+import psycopg2
 
 def create_schema(conn):
     '''
@@ -11,12 +11,12 @@ def create_schema(conn):
             print(asctime(), "create schema")
             curs.execute("CREATE SCHEMA IF NOT EXISTS relations")
             conn.commit()
-    except OperationalError as err:
-        print(asctime(),"failed to create schema 'relations'")
+    except OperationalError:
+        print(asctime(), "failed to create schema 'relations'")
         conn.rollback()
 
 
-        print(asctime(),"creating indexes failed.")
+        print(asctime(), "creating indexes failed.")
 
 
 def insert_artist_pairs(artist_pairs, relations):
@@ -27,7 +27,7 @@ def insert_artist_pairs(artist_pairs, relations):
     for a0 in artist_pairs:
         for a1 in artist_pairs:
             if a0 == 1 or a1 == 1:
-                continue 
+                continue
 
             if a0 == a1:
                 continue
@@ -40,7 +40,7 @@ def insert_artist_pairs(artist_pairs, relations):
             try:
                 relations[k][0] += 1
             except KeyError:
-                relations[k] = [ 1, a0, a1 ]
+                relations[k] = [1, a0, a1]
 
 
 def insert_rows(curs, table, values):
@@ -51,10 +51,10 @@ def insert_rows(curs, table, values):
     query = ("INSERT INTO %s VALUES " % table) + ",".join(values)
     try:
         curs.execute(query)
-    except psycopg2.OperationalError as err:
+    except psycopg2.OperationalError:
         print(asctime(), "failed to insert rows")
 
-            
+
 def dump_similarities(conn, table, relations):
     '''
         After all the similarities have been collected, write then to the DB in batches.
@@ -75,6 +75,6 @@ def dump_similarities(conn, table, relations):
                 conn.commit()
                 values = []
 
-        if len(values):
+        if len(values) > 0:
             insert_rows(curs, table, values)
             conn.commit()

--- a/relations/write_artist_relations.py
+++ b/relations/write_artist_relations.py
@@ -12,6 +12,7 @@ import psycopg2
 import ujson
 import config
 
+
 DUMP_QUERY = '''SELECT CAST(count AS float) / (select max(count) from relations.artist_artist_relations) as score,
                        a0.gid, a0.name, a1.gid, a1.name
                   FROM relations.artist_artist_relations arr
@@ -51,7 +52,7 @@ def write_table(use_ac):
         tarname = "artist-artist-relations.%s.tar.bz2" % date_string
 
     fh, temp_file = mkstemp()
-    os.close(fh) # pesky!
+    os.close(fh)  # pesky!
 
     print(asctime(), "writing relations to %s" % temp_file)
     with open(temp_file, "wt") as f:
@@ -68,21 +69,20 @@ def write_table(use_ac):
 
                     if use_ac:
                         f.write(ujson.dumps({
-                            'score' : row[0],
-                            'id_0' : row[1],
-                            'name_0' : row[2],
-                            'id_1' : row[3],
-                            'name_1' : row[4]
+                            'score': row[0],
+                            'id_0': row[1],
+                            'name_0': row[2],
+                            'id_1': row[3],
+                            'name_1': row[4]
                         }) + "\n")
                     else:
                         f.write(ujson.dumps({
-                            'score' : row[0],
-                            'mbid_0' : row[1],
-                            'name_0' : row[2],
-                            'mbid_1' : row[3],
-                            'name_1' : row[4]
+                            'score': row[0],
+                            'mbid_0': row[1],
+                            'name_0': row[2],
+                            'mbid_1': row[3],
+                            'name_1': row[4]
                         }) + "\n")
-
 
     print(asctime(), "create tar file...")
     with tarfile.open(tarname, "w:bz2") as tf:

--- a/relations/write_artist_relations.py
+++ b/relations/write_artist_relations.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import psycopg2
+import ujson
+import tarfile
+import datetime, time
+from time import asctime
+import click
+from tempfile import mkstemp
+import config
+
+DUMP_QUERY = '''SELECT CAST(count AS float) / (select max(count) from relations.artist_artist_relations) as score,
+                       a0.gid, a0.name, a1.gid, a1.name
+                  FROM relations.artist_artist_relations arr
+                  JOIN artist a0 ON arr.artist_0 = a0.id
+                  JOIN artist a1 ON arr.artist_1 = a1.id
+                 WHERE count > 3
+              ORDER BY score DESC
+             '''
+
+DUMP_QUERY_AC = '''SELECT CAST(count AS float) / (select max(count) from relations.artist_credit_artist_credit_relations) as score,
+                          ac0.id, string_agg(concat(acn0.name, acn0.join_phrase), ''),
+                          ac1.id, string_agg(concat(acn1.name, acn1.join_phrase), '')
+                     FROM relations.artist_credit_artist_credit_relations arr
+                     JOIN artist_credit ac0 ON arr.artist_credit_0 = ac0.id
+                     JOIN artist_credit_name acn0 ON arr.artist_credit_0 = acn0.artist_credit
+                     JOIN artist_credit ac1 ON arr.artist_credit_1 = ac1.id
+                     JOIN artist_credit_name acn1 ON arr.artist_credit_1 = acn1.artist_credit
+                    WHERE count > 3
+                 GROUP BY ac0.id, acn0.position, ac1.id, acn1.position, arr.count
+                 ORDER BY score DESC
+                '''
+
+def write_table(use_ac):
+    '''
+        Write the relations from the table to a temp file. Is use_ac is True, dump the artist_credit_relations table,
+        not the artist_relations_table.
+    '''
+
+    if use_ac:
+        filename = "artist-credit-artist-credit-relations.json"
+        tarname = "artist-credit-artist-credit-relations.tar.bz2"
+    else:
+        filename = "artist-artist-relations.json"
+        tarname = "artist-artist-relations.tar.bz2"
+
+    count = 0
+    fh, temp_file = mkstemp()
+    os.close(fh) # pesky!
+
+    print(asctime(), "writing relations to %s" % temp_file)
+    with open(temp_file, "wt") as f:
+        with psycopg2.connect(config.DB_CONNECT) as conn:
+            with conn.cursor() as curs:
+                if use_ac:
+                    curs.execute(DUMP_QUERY_AC)
+                else:
+                    curs.execute(DUMP_QUERY)
+                while True:
+                    row = curs.fetchone()
+                    if not row:
+                        break
+
+                    if use_ac:
+                        f.write(ujson.dumps({
+                            'score' : row[0],
+                            'id_0' : row[1],
+                            'name_0' : row[2],
+                            'id_1' : row[3],
+                            'name_1' : row[4]
+                        }) + "\n")
+                    else:
+                        f.write(ujson.dumps({
+                            'score' : row[0],
+                            'mbid_0' : row[1],
+                            'name_0' : row[2],
+                            'mbid_1' : row[3],
+                            'name_1' : row[4]
+                        }) + "\n")
+
+
+    print(asctime(), "create tar file...")
+    with tarfile.open(tarname, "w:bz2") as tf:
+        tf.add(temp_file, os.path.join('mbdump', filename))
+        tf.add('../listenbrainz/db/licenses/COPYING-PublicDomain', 'COPYING')
+        tf.add('data_dump_files/README', 'README')
+
+        os.unlink(temp_file)
+
+        with open(temp_file, "wt") as f:
+            utc_offset_sec = time.altzone if time.localtime().tm_isdst else time.timezone
+            utc_offset = datetime.timedelta(seconds=-utc_offset_sec)
+            f.write(datetime.datetime.now().replace(tzinfo=datetime.timezone(offset=utc_offset)).isoformat())
+            f.write("\n")
+
+        tf.add(temp_file, 'TIMESTAMP')
+        os.unlink(temp_file)
+
+    print(asctime(), "done!")
+
+
+@click.command()
+@click.option('--use-ac', '-a', is_flag=True, default=False)
+def write(**opts):
+    write_table(opts['use_ac'])
+
+
+if __name__ == "__main__":
+    write()


### PR DESCRIPTION
This is the first step in adding support for artist-artist and artist_credit-artist_credit relations support for our recommendation efforts.

This PR aims to get the tables generated in a new schema inside a (replicated) MB database. It also has support for making file dumps that can be used as part of the spark CF tools. The get_relations.py is mostly there as an example and a base for a very rudimentary test.

This PR has nothing to do with deploying this in any way -- that will be left for a future PR.

