### PR TITLE
LB-588: Remove old dumps from the /mnt/dumps as well

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -127,6 +127,7 @@ cat $FTP_CURRENT_DUMP_DIR/.rsync-filter
 
 /usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR"/$SUB_DIR
 /usr/local/bin/python manage.py dump delete_old_dumps $BACKUP_DIR/$SUB_DIR
+/usr/local/bin/python manage.py dump delete_old_dumps  $TEMP_DIR/$SUB_DIR
 
 # rsync to ftp folder taking care of the rules
 ./admin/rsync-dump-files.sh $DUMP_TYPE


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

`/mnt/dumps` on lemmy is filled with very old dumps.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
This PR removes old dumps from there as well.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Need to merge and deploy this by tomorrow. A full dump is scheduled on Sunday. I don't want to restart the cron container after that.

