### PR TITLE
LB-591: Upgrade postgresql-client to 12 from 9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 
 # PostgreSQL client
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-ENV PG_MAJOR 9.5
+ENV PG_MAJOR 12
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \

--- a/develop.sh
+++ b/develop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+POSTGRES_ADMIN_LB_URI="postgresql://postgres:postgres@db/listenbrainz"
+
 if [[ ! -d "docker" ]]; then
     echo "This script must be run from the top level directory of the listenbrainz-server source."
     exit -1
@@ -19,8 +21,7 @@ function invoke_manage {
 
 function open_psql_shell {
     invoke_docker_compose run --rm web psql \
-            -U listenbrainz  \
-            -h db listenbrainz
+        $POSTGRES_ADMIN_LB_URI
 }
 
 function npm_install {

--- a/develop.sh
+++ b/develop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-POSTGRES_ADMIN_LB_URI="postgresql://postgres:postgres@db/listenbrainz"
+POSTGRES_ADMIN_LB_URI="postgresql://listenbrainz:listenbrainz@db/listenbrainz"
 
 if [[ ! -d "docker" ]]; then
     echo "This script must be run from the top level directory of the listenbrainz-server source."

--- a/develop.sh
+++ b/develop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-POSTGRES_ADMIN_LB_URI="postgresql://listenbrainz:listenbrainz@db/listenbrainz"
+POSTGRES_LB_URI="postgresql://listenbrainz:listenbrainz@db/listenbrainz"
 
 if [[ ! -d "docker" ]]; then
     echo "This script must be run from the top level directory of the listenbrainz-server source."
@@ -21,7 +21,7 @@ function invoke_manage {
 
 function open_psql_shell {
     invoke_docker_compose run --rm web psql \
-        $POSTGRES_ADMIN_LB_URI
+        $POSTGRES_LB_URI
 }
 
 function npm_install {

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 # PostgreSQL client
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
-ENV PG_MAJOR 9.5
+ENV PG_MAJOR 12
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \


### PR DESCRIPTION
# Problem

After the lastest upgrade to postgresql 12, the postgresql-client was left for upgrade.

# Solution

- Update the _Dockerfile_ and _Dockerfile.test_ files
- Update _develop.sh_ to use URL to log into psql.

# Action

The steps I followed are
1. Copy configs
2. Update dockerfile
3. `./develop.sh build`
4. Remove old image 
5. `./develop.sh psql`
