### PR TITLE
Schema-qualify a reference to public.array_sort

### DIFF
--- a/admin/messybrainz/sql/create_functions.sql
+++ b/admin/messybrainz/sql/create_functions.sql
@@ -17,7 +17,7 @@ RETURNS uuid[] AS $converted_array$
 DECLARE
     converted_array uuid[];
 BEGIN
-    SELECT array_sort(array_agg(elements)::uuid[]) || ARRAY[]::uuid[] INTO converted_array
+    SELECT public.array_sort(array_agg(elements)::uuid[]) || ARRAY[]::uuid[] INTO converted_array
     FROM jsonb_array_elements_text($1) elements;
     RETURN converted_array;
 END


### PR DESCRIPTION
# Problem

Since PG v10.3, pg_dump, pg_upgrade, vacuumdb, and autovacuum worker processes only include `pg_catalog` in the `search_path`. So naked references to `array_sort` will error if any of these processes indirectly execute this function. This particular instance prevented a `vacuumdb` run from completing.

# Solution

Replace the reference to `array_sort` with `public.array_sort`.

# Action

We'll have to run the updated `CREATE OR REPLACE FUNCTION` statement on the prod messybrainz DB before the upgrade tomorrow.