### PR TITLE
Change lovehate to feedback

### DIFF
--- a/admin/sql/create_foreign_keys.sql
+++ b/admin/sql/create_foreign_keys.sql
@@ -54,8 +54,8 @@ ALTER TABLE recommendation.recommender_session
     REFERENCES recommendation.recommender (id)
     ON DELETE CASCADE;
 
-ALTER TABLE recording_lovehate
-    ADD CONSTRAINT recording_lovehate_user_id_foreign_key
+ALTER TABLE recording_feedback
+    ADD CONSTRAINT recording_feedback_user_id_foreign_key
     FOREIGN KEY (user_id)
     REFERENCES "user" (id)
     ON DELETE CASCADE;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -20,4 +20,6 @@ CREATE INDEX latest_listened_at_spotify_auth ON spotify_auth (latest_listened_at
 CREATE INDEX creator_ndx_follow_list ON follow_list (creator);
 CREATE INDEX last_saved_ndx_follow_list ON follow_list (last_saved DESC);
 
+CREATE UNIQUE INDEX user_id_rec_msid_ndx_feedback ON recording_feedback (user_id, recording_msid);
+
 COMMIT;

--- a/admin/sql/create_primary_keys.sql
+++ b/admin/sql/create_primary_keys.sql
@@ -14,6 +14,6 @@ ALTER TABLE recommendation.cf_recording ADD CONSTRAINT rec_cf_recording_pkey PRI
 ALTER TABLE recommendation.recommender ADD CONSTRAINT rec_recommender_pkey PRIMARY KEY (id);
 ALTER TABLE recommendation.recommender_session ADD CONSTRAINT rec_recommender_session_pkey PRIMARY KEY (id);
 
-ALTER TABLE recording_lovehate ADD CONSTRAINT recording_lovehate_pkey PRIMARY KEY (id);
+ALTER TABLE recording_feedback ADD CONSTRAINT recording_feedback_pkey PRIMARY KEY (id);
 
 COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -134,7 +134,7 @@ CREATE TABLE statistics.user (
     last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE recording_lovehate (
+CREATE TABLE recording_feedback (
     id                      SERIAL, -- PK
     user_id                 INTEGER NOT NULL, -- FK to "user".id
     recording_msid          UUID NOT NULL,

--- a/admin/sql/drop_tables.sql
+++ b/admin/sql/drop_tables.sql
@@ -4,6 +4,6 @@ DROP TABLE IF EXISTS "user"               CASCADE;
 DROP TABLE IF EXISTS data_dump            CASCADE;
 DROP TABLE IF EXISTS spotify_auth         CASCADE;
 DROP TABLE IF EXISTS follow_list          CASCADE;
-DROP TABLE IF EXISTS recording_lovehate   CASCADE;
+DROP TABLE IF EXISTS recording_feedback   CASCADE;
 
 COMMIT;

--- a/admin/sql/updates/2020-05-19-add-lovehate-table.sql
+++ b/admin/sql/updates/2020-05-19-add-lovehate-table.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 -- Create new table
-CREATE TABLE recording_feedback (
+CREATE TABLE recording_lovehate (
     user_id                 INTEGER NOT NULL, -- FK to "user".id
     recording_msid          UUID NOT NULL,
     score                   SMALLINT NOT NULL,
@@ -9,9 +9,9 @@ CREATE TABLE recording_feedback (
 );
 
 -- Create primary key
-ALTER TABLE recording_feedback ADD CONSTRAINT recording_feedback_pkey PRIMARY KEY (id);
+ALTER TABLE recording_lovehate ADD CONSTRAINT recording_lovehate_pkey PRIMARY KEY (id);
 
 -- Create foreign key
-ALTER TABLE recording_feedback ADD CONSTRAINT recording_feedback_user_id_foreign_key FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+ALTER TABLE recording_lovehate ADD CONSTRAINT recording_lovehate_user_id_foreign_key FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
 
 COMMIT;

--- a/admin/sql/updates/2020-05-19-add-lovehate-table.sql
+++ b/admin/sql/updates/2020-05-19-add-lovehate-table.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 -- Create new table
-CREATE TABLE recording_lovehate (
+CREATE TABLE recording_feedback (
     user_id                 INTEGER NOT NULL, -- FK to "user".id
     recording_msid          UUID NOT NULL,
     score                   SMALLINT NOT NULL,
@@ -9,9 +9,9 @@ CREATE TABLE recording_lovehate (
 );
 
 -- Create primary key
-ALTER TABLE recording_lovehate ADD CONSTRAINT recording_lovehate_pkey PRIMARY KEY (id);
+ALTER TABLE recording_feedback ADD CONSTRAINT recording_feedback_pkey PRIMARY KEY (id);
 
 -- Create foreign key
-ALTER TABLE recording_lovehate ADD CONSTRAINT recording_lovehate_user_id_foreign_key FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+ALTER TABLE recording_feedback ADD CONSTRAINT recording_feedback_user_id_foreign_key FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
 
 COMMIT;

--- a/admin/sql/updates/2020-05-20-change-lovehate-to-feedback.sql
+++ b/admin/sql/updates/2020-05-20-change-lovehate-to-feedback.sql
@@ -5,6 +5,7 @@ DROP TABLE IF EXISTS recording_lovehate CASCADE;
 
 -- Create new table
 CREATE TABLE recording_feedback (
+    id                      SERIAL, -- PK
     user_id                 INTEGER NOT NULL, -- FK to "user".id
     recording_msid          UUID NOT NULL,
     score                   SMALLINT NOT NULL,

--- a/admin/sql/updates/2020-05-20-change-lovehate-to-feedback.sql
+++ b/admin/sql/updates/2020-05-20-change-lovehate-to-feedback.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+-- Drop old table
+DROP TABLE IF EXISTS recording_lovehate CASCADE;
+
+-- Create new table
+CREATE TABLE recording_feedback (
+    user_id                 INTEGER NOT NULL, -- FK to "user".id
+    recording_msid          UUID NOT NULL,
+    score                   SMALLINT NOT NULL,
+    created                 TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Create primary key
+ALTER TABLE recording_feedback ADD CONSTRAINT recording_feedback_pkey PRIMARY KEY (id);
+
+-- Create foreign key
+ALTER TABLE recording_feedback ADD CONSTRAINT recording_feedback_user_id_foreign_key FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+
+-- Create unique index
+CREATE UNIQUE INDEX user_id_rec_msid_ndx_feedback ON recording_feedback (user_id, recording_msid);
+
+COMMIT;


### PR DESCRIPTION
# Problem

- The name `recording_lovehate` is not so user friendly.
- A unique index on `(user_id, recording_msid)` for the table was missing.

# Solution

# Problem

- Change the name `recording_lovehate` to `recording_feedback`.
- Add a Unique index on `(user_id, recording_msid)`
