### PR TITLE
Add new cron jobs for weekly, monthly and yearly artist stats

### DIFF
--- a/docker/stats-crontab
+++ b/docker/stats-crontab
@@ -1,5 +1,14 @@
-# Request user stats every day at 12:00
-00 12 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_all_user_stats 
+# Request user all_time artists every day at 12:00
+00 12 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --all-time
+
+# Request user weekly artists every day at 13:00
+00 13 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --week
+
+# Request user monthly artists every day at 14:00
+00 14 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --month
+
+# Request user yearly artists every day at 15:00
+00 15 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --year
 
 # Request full data dump import into spark cluster, every Wednesday
 00 00 * * 3 /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -36,7 +36,7 @@ class HandlersTestCase(unittest.TestCase):
     def test_is_new_user_stats_batch(self, mock_db_get_timestamp):
         mock_db_get_timestamp.return_value = datetime.now(timezone.utc)
         self.assertFalse(is_new_user_stats_batch())
-        mock_db_get_timestamp.return_value = datetime.now(timezone.utc) - timedelta(hours=13)
+        mock_db_get_timestamp.return_value = datetime.now(timezone.utc) - timedelta(minutes=21)
         self.assertTrue(is_new_user_stats_batch())
 
     @mock.patch('listenbrainz.spark.handlers.send_mail')

--- a/listenbrainz/webserver/templates/emails/user_stats_notification.txt
+++ b/listenbrainz/webserver/templates/emails/user_stats_notification.txt
@@ -3,6 +3,8 @@ Hi! 👋
 New user stats were received by the spark consumer
 and are being written into the database.
 
+Stat type: {{ stat_type }}
+
 The first stat came in at {{ now }} UTC.
 
 Your Friendly Neighbourhood Brainzbot 🤖


### PR DESCRIPTION
Also, fix up the observability email thingy, and add the
type of stat to the email.

The cron job schedule isn't that important right now, we're just trying to make sure this stuff is stable, we can fix the timelines later.