### PR TITLE
Send params with spark request 

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -145,10 +145,14 @@ def request_model():
 
 
 @cli.command(name='request_candidate_sets')
-def request_candidate_sets():
+@click.option("--days", type=int, default=7, help="Request recommendations to be generated on history of given number of days")
+def request_candidate_sets(days):
     """ Send the cluster a request to generate candidate sets.
     """
-    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.candidate_sets'))
+    params = {
+        'recommendation_generation_window': days,
+    }
+    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.candidate_sets', params))
 
 
 @cli.command(name='request_recommendations')

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -134,7 +134,7 @@ def request_dataframes(days):
     params = {
         'train_model_window': days,
     }
-    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.create_dataframes', params))
+    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.create_dataframes', params=params))
 
 
 @cli.command(name='request_model')
@@ -146,17 +146,27 @@ def request_model():
 
 @cli.command(name='request_candidate_sets')
 @click.option("--days", type=int, default=7, help="Request recommendations to be generated on history of given number of days")
-def request_candidate_sets(days):
+@click.option("--top", type=int, default=20, help="Calculate given number of top artist.")
+@click.option("--similar", type=int, default=20, help="Calculate given number of similar artist.")
+def request_candidate_sets(days, top, similar):
     """ Send the cluster a request to generate candidate sets.
     """
     params = {
         'recommendation_generation_window': days,
+        "top_artist_limit": top,
+        "similar_artist_limit": similar,
     }
-    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.candidate_sets', params))
+    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.candidate_sets', params=params))
 
 
 @cli.command(name='request_recommendations')
-def request_recommendations():
+@click.option("--top", type=int, default=200, help="Generate given number of top artist recommendations")
+@click.option("--similar", type=int, default=200, help="Generate given number of similar artist recommendations")
+def request_recommendations(top, similar):
     """ Send the cluster a request to generate recommendations.
     """
-    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.recommend'))
+    params = {
+        'recommendation_top_artist_limit': top,
+        'recommendation_similar_artist_limit': similar,
+    }
+    send_request_to_spark_cluster(_prepare_query_message('cf_recording.recommendations.recommend', params=params))

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -42,11 +42,11 @@
   "cf_recording.recommendations.candidate_sets": {
     "name": "cf_recording.recommendations.candidate_sets",
     "description": "Create candidate sets to generate recommendations",
-    "params": ["recommendation_generation_window"]
+    "params": ["recommendation_generation_window", "top_artist_limit", "similar_artist_limit"]
   },
   "cf_recording.recommendations.recommend": {
     "name": "cf_recording.recommendations.recommend",
     "description": "Generate recommendations for all active ListenBrainz users.",
-    "params": []
+    "params": ["recommendation_top_artist_limit", "recommendation_similar_artist_limit"]
   }
 }

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -42,7 +42,7 @@
   "cf_recording.recommendations.candidate_sets": {
     "name": "cf_recording.recommendations.candidate_sets",
     "description": "Create candidate sets to generate recommendations",
-    "params": []
+    "params": ["recommendation_generation_window"]
   },
   "cf_recording.recommendations.recommend": {
     "name": "cf_recording.recommendations.recommend",

--- a/listenbrainz/spark/test_request_manage.py
+++ b/listenbrainz/spark/test_request_manage.py
@@ -96,8 +96,15 @@ class RequestManageTestCase(unittest.TestCase):
         received_message = request_manage._prepare_query_message('cf_recording.recommendations.train_model')
         self.assertEqual(expected_message, received_message)
 
-        expected_message = ujson.dumps({'query': 'cf_recording.recommendations.candidate_sets'})
-        received_message = request_manage._prepare_query_message('cf_recording.recommendations.candidate_sets')
+        message = {
+            'query': 'cf_recording.recommendations.candidate_sets',
+            'params': {
+                'recommendation_generation_window': 20,
+            }
+        }
+        expected_message = ujson.dumps(message)
+        received_message = request_manage._prepare_query_message('cf_recording.recommendations.candidate_sets',
+                                                                 message['params'])
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'cf_recording.recommendations.recommend'})

--- a/listenbrainz/spark/test_request_manage.py
+++ b/listenbrainz/spark/test_request_manage.py
@@ -109,7 +109,6 @@ class RequestManageTestCase(unittest.TestCase):
                                                                  message['params'])
         self.assertEqual(expected_message, received_message)
 
-
         message = {
             'query': 'cf_recording.recommendations.recommend',
             'params': {

--- a/listenbrainz/spark/test_request_manage.py
+++ b/listenbrainz/spark/test_request_manage.py
@@ -99,7 +99,9 @@ class RequestManageTestCase(unittest.TestCase):
         message = {
             'query': 'cf_recording.recommendations.candidate_sets',
             'params': {
-                'recommendation_generation_window': 20,
+                'recommendation_generation_window': 7,
+                'top_artist_limit': 10,
+                'similar_artist_limit': 10,
             }
         }
         expected_message = ujson.dumps(message)
@@ -107,6 +109,15 @@ class RequestManageTestCase(unittest.TestCase):
                                                                  message['params'])
         self.assertEqual(expected_message, received_message)
 
-        expected_message = ujson.dumps({'query': 'cf_recording.recommendations.recommend'})
-        received_message = request_manage._prepare_query_message('cf_recording.recommendations.recommend')
+
+        message = {
+            'query': 'cf_recording.recommendations.recommend',
+            'params': {
+                'recommendation_top_artist_limit': 7,
+                'recommendation_similar_artist_limit': 7,
+            }
+        }
+        expected_message = ujson.dumps(message)
+        received_message = request_manage._prepare_query_message('cf_recording.recommendations.recommend',
+                                                                 message['params'])
         self.assertEqual(expected_message, received_message)

--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -21,14 +21,8 @@ RANKS = [8, 12]
 LAMBDAS = [0.1, 10.0]
 ITERATIONS = [5, 10]
 
-# train model on X days data
-TRAIN_MODEL_WINDOW = 180
-
 # calculate stats on X months data
 STATS_CALCULATION_WINDOW = 1
-
-# generate recommendations after every X days
-RECOMMENDATION_GENERATION_WINDOW = 7
 
 STEPS_TO_REACH_NEXT_MONTH = 32
 

--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -26,14 +26,6 @@ STATS_CALCULATION_WINDOW = 1
 
 STEPS_TO_REACH_NEXT_MONTH = 32
 
-# number of recommendations to generate
-RECOMMENDATION_TOP_ARTIST_LIMIT = 30
-RECOMMENDATION_SIMILAR_ARTIST_LIMIT = 30
-
-# candidate sets
-TOP_ARTISTS_LIMIT = 20
-SIMILAR_ARTISTS_LIMIT = 10
-
 LOG_SENTRY = {
     'dsn':'',
     'environment': 'development',

--- a/listenbrainz_spark/recommendations/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/tests/test_candidate.py
@@ -10,6 +10,7 @@ import pyspark.sql.functions as f
 class CandidateSetsTestClass(SparkTestCase):
 
     date = None
+    recommendation_generation_window = 7
 
     @classmethod
     def setUpClass(cls):
@@ -38,7 +39,7 @@ class CandidateSetsTestClass(SparkTestCase):
     def get_listens(cls):
         cls.date = datetime.utcnow()
         df1 = utils.create_dataframe(cls.get_listen_row(cls.date, 'vansika', 1), schema=None)
-        shifted_date = stats.adjust_days(cls.date, config.RECOMMENDATION_GENERATION_WINDOW + 1)
+        shifted_date = stats.adjust_days(cls.date, cls.recommendation_generation_window + 1)
         df2 = utils.create_dataframe(cls.get_listen_row(shifted_date, 'vansika', 1), schema=None)
         shifted_date = stats.adjust_days(cls.date, 1)
         df3 = utils.create_dataframe(cls.get_listen_row(shifted_date, 'rob', 2), schema=None)
@@ -49,14 +50,16 @@ class CandidateSetsTestClass(SparkTestCase):
 
     def test_get_dates_to_generate_candidate_sets(self):
         mapped_df = self.get_listens()
-        from_date, to_date = candidate_sets.get_dates_to_generate_candidate_sets(mapped_df)
+        from_date, to_date = candidate_sets.get_dates_to_generate_candidate_sets(mapped_df,
+                                                                                 self.recommendation_generation_window)
         self.assertEqual(to_date, self.date)
-        expected_date = stats.adjust_days(self.date, config.RECOMMENDATION_GENERATION_WINDOW).replace(hour=0, minute=0, second=0)
+        expected_date = stats.adjust_days(self.date, self.recommendation_generation_window).replace(hour=0, minute=0, second=0)
         self.assertEqual(from_date, expected_date)
 
     def test_get_listens_to_fetch_top_artists(self):
         mapped_df = self.get_listens()
-        from_date, to_date = candidate_sets.get_dates_to_generate_candidate_sets(mapped_df)
+        from_date, to_date = candidate_sets.get_dates_to_generate_candidate_sets(mapped_df,
+                                                                                 self.recommendation_generation_window)
         mapped_listens_subset = candidate_sets.get_listens_to_fetch_top_artists(mapped_df, from_date, to_date)
         self.assertEqual(mapped_listens_subset.count(), 3)
 

--- a/listenbrainz_spark/recommendations/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/tests/test_candidate.py
@@ -65,7 +65,8 @@ class CandidateSetsTestClass(SparkTestCase):
 
     def test_get_top_artists(self):
         mapped_listens = self.get_mapped_listens()
-        test_top_artist = candidate_sets.get_top_artists(mapped_listens)
+        top_artist_limit = 10
+        test_top_artist = candidate_sets.get_top_artists(mapped_listens, top_artist_limit)
 
         cols = ['mb_artist_credit_id', 'msb_artist_credit_name_matchable', 'user_name']
         self.assertListEqual(cols, test_top_artist.columns)
@@ -107,7 +108,8 @@ class CandidateSetsTestClass(SparkTestCase):
             schema=None
         )
 
-        similar_artist_df = candidate_sets.get_top_similar_artists(top_artist_df, artist_relation_df)
+        similar_artist_limit = 10
+        similar_artist_df = candidate_sets.get_top_similar_artists(top_artist_df, artist_relation_df, similar_artist_limit)
         self.assertEqual(similar_artist_df.count(), 2)
 
         cols = [

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -16,6 +16,8 @@ MODEL_PATH = '/test/model'
 class RecommendTestClass(SparkTestCase):
 
     model_save_path = None
+    recommendation_top_artist_limit = 10
+    recommendation_similar_artist_limit = 10
 
     @classmethod
     def setUpClass(cls):
@@ -60,7 +62,8 @@ class RecommendTestClass(SparkTestCase):
         similar_artist_candidate_set = self.get_candidate_set()
 
         messages = recommend.get_recommendations_for_all(recordings_df, model, top_artist_candidate_set,
-                                                         similar_artist_candidate_set)
+                                                         similar_artist_candidate_set, self.recommendation_top_artist_limit,
+                                                         self.recommendation_similar_artist_limit)
         self.assertEqual(len(messages), 2)
 
         message = messages[0]
@@ -81,7 +84,9 @@ class RecommendTestClass(SparkTestCase):
                 model, user_id,
                 user_name, recordings_df,
                 top_artists_candidate_set,
-                similar_artists_candidate_set
+                similar_artists_candidate_set,
+                self.recommendation_top_artist_limit,
+                self.recommendation_similar_artist_limit
         )
         # often model gives no recommendations if candidate set has less data
         # therefore we check only for the type of return which should be a list

--- a/spark_manage.py
+++ b/spark_manage.py
@@ -15,9 +15,11 @@ from py4j.protocol import Py4JJavaError
 
 app = utils.create_app(debug=True)
 
+
 @click.group()
 def cli():
     pass
+
 
 @cli.command(name='init_dir')
 @click.option('--rm', is_flag=True, help='Delete existing directories from HDFS.')
@@ -74,6 +76,7 @@ def init_dir(rm, recursive, create_dir):
                 type(err).__name__, str(err)))
             sys.exit(-1)
 
+
 @cli.command(name='upload_mapping')
 @click.option("--force", "-f", is_flag=True, help="Deletes existing mapping.")
 def upload_mapping(force):
@@ -86,6 +89,7 @@ def upload_mapping(force):
         src = downloader_obj.download_msid_mbid_mapping(path.FTP_FILES_PATH)
         uploader_obj = ListenbrainzDataUploader()
         uploader_obj.upload_mapping(src, force=force)
+
 
 @cli.command(name='upload_listens')
 @click.option('--incremental', '-i', is_flag=True, default=False, help="Use a smaller dump (more for testing purposes)")
@@ -103,6 +107,7 @@ def upload_listens(force, incremental, id):
         uploader_obj = ListenbrainzDataUploader()
         uploader_obj.upload_listens(src, force=force)
 
+
 @cli.command(name='upload_artist_relation')
 @click.option("--force", "-f", is_flag=True, help="Deletes existing artist relation.")
 def upload_artist_relation(force):
@@ -116,6 +121,7 @@ def upload_artist_relation(force):
         uploader_obj = ListenbrainzDataUploader()
         uploader_obj.upload_artist_relation(src, force=force)
 
+
 @cli.command(name='dataframe')
 @click.option("--days", type=int, default=180, help="Request model to be trained on data of given number of days")
 def dataframes(days):
@@ -125,6 +131,7 @@ def dataframes(days):
     with app.app_context():
         create_dataframes.main(train_model_window=days)
 
+
 @cli.command(name='model')
 def model():
     """ Invoke script responsible for training data.
@@ -133,13 +140,16 @@ def model():
     with app.app_context():
         train_models.main()
 
+
 @cli.command(name='candidate')
-def candidate():
+@click.option("--days", type=int, default=7, help="Request recommendations to be generated on history of given number of days")
+def candidate(days):
     """ Invoke script responsible for generating candidate sets.
     """
     from listenbrainz_spark.recommendations import candidate_sets
     with app.app_context():
-        candidate_sets.main()
+        candidate_sets.main(recommendation_generation_window=days)
+
 
 @cli.command(name='recommend')
 def recommend():
@@ -149,6 +159,7 @@ def recommend():
     with app.app_context():
         recommend.main()
 
+
 @cli.command(name='user')
 def user():
     """ Invoke script responsible for calculating user statistics.
@@ -156,6 +167,7 @@ def user():
     from listenbrainz_spark.stats import user
     with app.app_context():
         user.main()
+
 
 @cli.command(name='request_consumer')
 def request_consumer():
@@ -165,11 +177,13 @@ def request_consumer():
     with app.app_context():
         main('request-consumer-%s' % str(int(time.time())))
 
+
 @cli.resultcallback()
 def remove_zip(result, **kwargs):
     """ Remove zip created by spark-submit.
     """
     os.remove(os.path.join('/', 'rec', 'listenbrainz_spark.zip'))
+
 
 if __name__ == '__main__':
     # The root logger always defaults to WARNING level

--- a/spark_manage.py
+++ b/spark_manage.py
@@ -129,7 +129,7 @@ def dataframes(days):
     """
     from listenbrainz_spark.recommendations import create_dataframes
     with app.app_context():
-        create_dataframes.main(train_model_window=days)
+        _ = create_dataframes.main(train_model_window=days)
 
 
 @cli.command(name='model')
@@ -138,26 +138,30 @@ def model():
     """
     from listenbrainz_spark.recommendations import train_models
     with app.app_context():
-        train_models.main()
+        _ = train_models.main()
 
 
 @cli.command(name='candidate')
 @click.option("--days", type=int, default=7, help="Request recommendations to be generated on history of given number of days")
-def candidate(days):
+@click.option("--top", type=int, default=20, help="Calculate given number of top artist.")
+@click.option("--similar", type=int, default=20, help="Calculate given number of similar artist.")
+def candidate(days, top, similar):
     """ Invoke script responsible for generating candidate sets.
     """
     from listenbrainz_spark.recommendations import candidate_sets
     with app.app_context():
-        candidate_sets.main(recommendation_generation_window=days)
+        _ = candidate_sets.main(recommendation_generation_window=days, top_artist_limit=top, similar_artist_limit=similar)
 
 
 @cli.command(name='recommend')
-def recommend():
+@click.option("--top", type=int, default=200, help="Generate given number of top artist recommendations")
+@click.option("--similar", type=int, default=200, help="Generate given number of similar artist recommendations")
+def recommend(top, similar):
     """ Invoke script responsible for generating recommendations.
     """
     from listenbrainz_spark.recommendations import recommend
     with app.app_context():
-        recommend.main()
+        _ = recommend.main(recommendation_top_artist_limit=top, recommendation_similar_artist_limit=similar)
 
 
 @cli.command(name='user')


### PR DESCRIPTION
This PR is a follow up of [#875](https://github.com/metabrainz/listenbrainz-server/pull/875). It is better to send params with spark request then having to change them on spark cluster.