### PR TITLE
Improve feedback module

### DIFF
--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -8,6 +8,7 @@ def insert(feedback: Feedback):
     """ Inserts a feedback record for a user's loved/hated recording into the database.
         If the record is already present for the user, the score is updated to the new
         value passed.
+
         Args:
             feedback: An object of class Feedback
     """
@@ -28,7 +29,8 @@ def insert(feedback: Feedback):
 
 
 def delete(feedback: Feedback):
-    """ Deletes the feedback record for a given recording for the user from the database.
+    """ Deletes the feedback record for a given recording for the user from the database
+
         Args:
             feedback: An object of class Feedback
     """
@@ -45,66 +47,110 @@ def delete(feedback: Feedback):
         )
 
 
-def get_feedback_by_user_id(user_id: int):
-    """ Get a list of recording feedbacks given by the user.
+def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = None):
+    """ Get a list of recording feedbacks given by the user
+
         Args:
             user_id: the row ID of the user in the DB
+            score: the score value by which the results are to be filtered. If 1 then returns the loved recordings,
+                   if -1 returns hated recordings.
+            limit: number of rows to be returned
+            offset: number of feedback to skip from the beginning
+
         Returns:
-            A list of Feedback objects
+            A list of Feedback objects.
     """
 
+    args = {"user_id": user_id, "limit": limit, "offset": offset}
+    query = """ SELECT user_id, "user".musicbrainz_id AS user_name, recording_msid::text, score
+                  FROM recording_feedback
+                 JOIN "user"
+                  ON "user".id = recording_feedback.user_id
+                 WHERE user_id = :user_id """
+
+    if score:
+        query += "AND score = :score"
+        args["score"] = score
+
+    query += """ ORDER BY recording_feedback.created DESC
+                 LIMIT :limit OFFSET :offset """
+
     with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT user_id, recording_msid::text, score
-              FROM recording_feedback
-          ORDER BY created DESC
-            """), {
-                'user_id': user_id
-            }
-        )
+        result = connection.execute(sqlalchemy.text(query), args)
         return [Feedback(**dict(row)) for row in result.fetchall()]
 
 
-def get_feedback_by_user_id_and_score(user_id: int, score: int):
-    """ Get a list of recording feedbacks of particular type (loved or hated) given by the user.
-        If score is +1 then get loved recordings, if -1 then get hated recordings.
+def get_feedback_count_for_user(user_id: int):
+    """ Get total number recording feedbacks given by the user
+
         Args:
-            user_id: the row ID of the user
+            user_id: the row ID of the user in the DB
+
         Returns:
-            A list of Feedback objects
+            The total number recording feedbacks given by the user
     """
 
+    query = "SELECT count(*) AS value FROM recording_feedback WHERE user_id = :user_id"
+
     with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT user_id, recording_msid::text, score
-              FROM recording_feedback
-             WHERE user_id = :user_id
-               AND score = :score
-          ORDER BY created DESC
-            """), {
+        result = connection.execute(sqlalchemy.text(query), {
                 'user_id': user_id,
-                'score': score
             }
         )
-        return [Feedback(**dict(row)) for row in result.fetchall()]
+        count = int(result.fetchone()["value"])
 
+    return count
 
-def get_feedback_by_recording_msid(recording_msid: str):
-    """ Get a list of feedbacks for a given recording.
+def get_feedback_for_recording(recording_msid: str, limit: int, offset: int, score: int = None):
+    """ Get a list of recording feedbacks for a given recording
+
         Args:
             recording_msid: the MessyBrainz ID of the recording
+            score: the score value by which the results are to be filtered. If 1 then returns the loved recordings,
+                   if -1 returns hated recordings.
+            limit: number of rows to be returned
+            offset: number of feedback to skip from the beginning
+
         Returns:
-            A list of Feedback objects
+            A list of Feedback objects.
     """
 
+    args = {"recording_msid": recording_msid, "limit": limit, "offset": offset}
+    query = """ SELECT user_id, "user".musicbrainz_id AS user_name, recording_msid::text, score
+                  FROM recording_feedback
+                 JOIN "user"
+                  ON "user".id = recording_feedback.user_id
+                 WHERE recording_msid = :recording_msid """
+
+    if score:
+        query += "AND score = :score"
+        args["score"] = score
+
+    query += """ ORDER BY recording_feedback.created DESC
+                 LIMIT :limit OFFSET :offset """
+
     with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT user_id, recording_msid::text, score
-              FROM recording_feedback
-             WHERE recording_msid = :recording_msid
-          ORDER BY created DESC
-            """), {
-                'recording_msid': recording_msid
+        result = connection.execute(sqlalchemy.text(query), args)
+        return [Feedback(**dict(row)) for row in result.fetchall()]
+
+
+def get_feedback_count_for_recording(recording_msid: str):
+    """ Get total number recording feedbacks for a given recording
+
+        Args:
+            recording_msid: the MessyBrainz ID of the recording
+
+        Returns:
+            The total number recording feedbacks given by the user
+    """
+
+    query = "SELECT count(*) AS value FROM recording_feedback WHERE recording_msid = :recording_msid"
+
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text(query), {
+                'recording_msid': recording_msid,
             }
         )
-        return [Feedback(**dict(row)) for row in result.fetchall()]
+        count = int(result.fetchone()["value"])
+
+    return count

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -48,7 +48,7 @@ def delete(feedback: Feedback):
 
 
 def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = None):
-    """ Get a list of recording feedbacks given by the user
+    """ Get a list of recording feedback given by the user in descending order of their creation
 
         Args:
             user_id: the row ID of the user in the DB
@@ -81,13 +81,13 @@ def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = No
 
 
 def get_feedback_count_for_user(user_id: int):
-    """ Get total number recording feedbacks given by the user
+    """ Get total number of recording feedback given by the user
 
         Args:
             user_id: the row ID of the user in the DB
 
         Returns:
-            The total number recording feedbacks given by the user
+            The total number of recording feedback given by the user
     """
 
     query = "SELECT count(*) AS value FROM recording_feedback WHERE user_id = :user_id"
@@ -103,7 +103,7 @@ def get_feedback_count_for_user(user_id: int):
 
 
 def get_feedback_for_recording(recording_msid: str, limit: int, offset: int, score: int = None):
-    """ Get a list of recording feedbacks for a given recording
+    """ Get a list of recording feedback for a given recording in descending order of their creation
 
         Args:
             recording_msid: the MessyBrainz ID of the recording
@@ -136,13 +136,13 @@ def get_feedback_for_recording(recording_msid: str, limit: int, offset: int, sco
 
 
 def get_feedback_count_for_recording(recording_msid: str):
-    """ Get total number recording feedbacks for a given recording
+    """ Get total number of recording feedback for a given recording
 
         Args:
             recording_msid: the MessyBrainz ID of the recording
 
         Returns:
-            The total number recording feedbacks given by the user
+            The total number of recording feedback for a given recording
     """
 
     query = "SELECT count(*) AS value FROM recording_feedback WHERE recording_msid = :recording_msid"

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -58,7 +58,7 @@ def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = No
             offset: number of feedback to skip from the beginning
 
         Returns:
-            A list of Feedback objects.
+            A list of Feedback objects
     """
 
     args = {"user_id": user_id, "limit": limit, "offset": offset}
@@ -101,6 +101,7 @@ def get_feedback_count_for_user(user_id: int):
 
     return count
 
+
 def get_feedback_for_recording(recording_msid: str, limit: int, offset: int, score: int = None):
     """ Get a list of recording feedbacks for a given recording
 
@@ -112,7 +113,7 @@ def get_feedback_for_recording(recording_msid: str, limit: int, offset: int, sco
             offset: number of feedback to skip from the beginning
 
         Returns:
-            A list of Feedback objects.
+            A list of Feedback objects
     """
 
     args = {"recording_msid": recording_msid, "limit": limit, "offset": offset}

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -36,7 +36,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase):
                     score=fb["score"]
                 )
             )
-        
+
         return len(self.sample_feedback)
 
     def test_insert(self):

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -12,7 +12,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         DatabaseTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, 'recording_feedback_user')
+        self.user = db_user.get_or_create(1, "recording_feedback_user")
 
         self.sample_feedback = [
             {
@@ -21,16 +21,6 @@ class FeedbackDatabaseTestCase(DatabaseTestCase):
             },
             {
                 "recording_msid": "222eb00d-9ead-42de-aec9-8f8c1509413d",
-                "score": 1
-            }
-        ]
-        self.sample_feedback_neg_score = [
-            {
-                "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
-                "score": -1
-            },
-            {
-                "recording_msid": "31c2af1a-9968-47d3-b7a1-4a40d3a25f4f",
                 "score": -1
             }
         ]
@@ -38,19 +28,6 @@ class FeedbackDatabaseTestCase(DatabaseTestCase):
     def insert_test_data(self, user_id, neg_score=False):
         """ Insert test data into the database """
 
-        if neg_score:
-            # Insert the two records with negative score
-            for fb_neg in self.sample_feedback_neg_score:
-                db_feedback.insert(
-                    Feedback(
-                        user_id=user_id,
-                        recording_msid=fb_neg["recording_msid"],
-                        score=fb_neg["score"]
-                    )
-                )
-            return
-
-        # Insert the two records with positive score
         for fb in self.sample_feedback:
             db_feedback.insert(
                 Feedback(
@@ -59,93 +36,154 @@ class FeedbackDatabaseTestCase(DatabaseTestCase):
                     score=fb["score"]
                 )
             )
+        
+        return len(self.sample_feedback)
 
     def test_insert(self):
-        self.insert_test_data(self.user['id'])
-        result = db_feedback.get_feedback_by_user_id(self.user['id'])
-        self.assertEqual(len(result), 2)
+        count = self.insert_test_data(self.user["id"])
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), count)
 
     def test_update_score_when_feedback_already_exits(self):
-        self.insert_test_data(self.user['id'])
-        result = db_feedback.get_feedback_by_user_id(self.user['id'])
-        self.assertEqual(len(result), 2)
+        update_fb = self.sample_feedback[0]
 
-        # insert the negative score records, where 1 recording_msid already exists
-        # with postive score for the given user
-        self.insert_test_data(self.user['id'], neg_score=True)
-        result = db_feedback.get_feedback_by_user_id(self.user['id'])
-        self.assertEqual(len(result), 3)
+        count = self.insert_test_data(self.user["id"])
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), count)
+
+        self.assertEqual(result[1].recording_msid, update_fb["recording_msid"])
+        self.assertEqual(result[1].score, 1)
+
+        update_fb["score"] = -1  # change the score to -1
+
+        # update a record by inserting a record with updated score value
+        db_feedback.insert(
+            Feedback(
+                user_id=self.user["id"],
+                recording_msid=update_fb["recording_msid"],
+                score=update_fb["score"]
+            )
+        )
+
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), count)
+
+        self.assertEqual(result[0].recording_msid, update_fb["recording_msid"])
+        self.assertEqual(result[0].score, -1)
 
     def test_delete(self):
         del_fb = self.sample_feedback[0]
 
-        self.insert_test_data(self.user['id'])
-        result = db_feedback.get_feedback_by_user_id(self.user['id'])
-        self.assertEqual(len(result), 2)
+        count = self.insert_test_data(self.user["id"])
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), count)
         self.assertEqual(result[1].recording_msid, del_fb["recording_msid"])
 
         # delete one record for the user
         db_feedback.delete(
             Feedback(
-                user_id=self.user['id'],
+                user_id=self.user["id"],
                 recording_msid=del_fb["recording_msid"],
                 score=del_fb["score"]
             )
         )
 
-        result = db_feedback.get_feedback_by_user_id(self.user['id'])
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
         self.assertNotEqual(result[0].recording_msid, del_fb["recording_msid"])
 
-    def test_get_feedback_by_user_id(self):
-        self.insert_test_data(self.user['id'])
-        result = db_feedback.get_feedback_by_user_id(self.user['id'])
-        self.assertEqual(len(result), 2)
+    def test_get_feedback_for_user(self):
+        count = self.insert_test_data(self.user["id"])
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), count)
 
+        self.assertEqual(result[0].user_id, self.user["id"])
+        self.assertEqual(result[0].user_name, self.user["musicbrainz_id"])
+        self.assertEqual(result[0].recording_msid, self.sample_feedback[1]["recording_msid"])
+        self.assertEqual(result[0].score, self.sample_feedback[1]["score"])
+
+        self.assertEqual(result[1].user_id, self.user["id"])
+        self.assertEqual(result[1].user_name, self.user["musicbrainz_id"])
+        self.assertEqual(result[1].recording_msid, self.sample_feedback[0]["recording_msid"])
+        self.assertEqual(result[1].score, self.sample_feedback[0]["score"])
+
+        # test the score argument
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0, score=1)
+        self.assertEqual(len(result), 1)
         self.assertEqual(result[0].score, 1)
-        self.assertEqual(result[1].score, 1)
 
-        # insert the negative score records
-        self.insert_test_data(self.user['id'], neg_score=True)
-        result = db_feedback.get_feedback_by_user_id(self.user['id'])
-        self.assertEqual(len(result), 3)
-
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0, score=-1)
+        self.assertEqual(len(result), 1)
         self.assertEqual(result[0].score, -1)
-        self.assertEqual(result[1].score, -1)
-        self.assertEqual(result[2].score, 1)
 
-    def test_get_feedback_by_user_id_and_score(self):
-        self.insert_test_data(self.user['id'])
-        result = db_feedback.get_feedback_by_user_id_and_score(self.user['id'], 1)
-        self.assertEqual(len(result), 2)
+        # test the limit argument
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=1, offset=0)
+        self.assertEqual(len(result), 1)
 
-        self.assertEqual(result[0].score, 1)
-        self.assertEqual(result[1].score, 1)
+        # test the offset argument
+        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=1)
+        self.assertEqual(len(result), 1)
 
-        # insert the negative score records
-        self.insert_test_data(self.user['id'], neg_score=True)
-        result = db_feedback.get_feedback_by_user_id_and_score(self.user['id'], -1)
-        self.assertEqual(len(result), 2)
+    def test_get_feedback_count_for_user(self):
+        count = self.insert_test_data(self.user["id"])
+        result = db_feedback.get_feedback_count_for_user(user_id=self.user["id"])
+        self.assertEqual(result, count)
 
-        self.assertEqual(result[0].score, -1)
-        self.assertEqual(result[1].score, -1)
-
-    def test_get_feedback_by_recording_msid(self):
+    def test_get_feedback_for_recording(self):
         fb_msid_1 = self.sample_feedback[0]["recording_msid"]
-        fb_msid_2 = self.sample_feedback[1]["recording_msid"]
 
-        self.insert_test_data(self.user['id'])
-
-        result = db_feedback.get_feedback_by_recording_msid(fb_msid_1)
-        self.assertEqual(len(result), 1)
-        result = db_feedback.get_feedback_by_recording_msid(fb_msid_2)
+        self.insert_test_data(self.user["id"])
+        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
-        user2 = db_user.get_or_create(2, 'recording_feedback_other_user')
-        self.insert_test_data(user2['id'])
+        self.assertEqual(result[0].user_id, self.user["id"])
+        self.assertEqual(result[0].user_name, self.user["musicbrainz_id"])
+        self.assertEqual(result[0].recording_msid, fb_msid_1)
+        self.assertEqual(result[0].score, self.sample_feedback[0]["score"])
 
-        result = db_feedback.get_feedback_by_recording_msid(fb_msid_1)
+        user2 = db_user.get_or_create(2, "recording_feedback_other_user")
+        self.insert_test_data(user2["id"])
+
+        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0)
         self.assertEqual(len(result), 2)
-        result = db_feedback.get_feedback_by_recording_msid(fb_msid_2)
+
+        self.assertEqual(result[0].user_id, user2["id"])
+        self.assertEqual(result[0].user_name, user2["musicbrainz_id"])
+        self.assertEqual(result[0].recording_msid, fb_msid_1)
+        self.assertEqual(result[0].score, self.sample_feedback[0]["score"])
+
+        self.assertEqual(result[1].user_id, self.user["id"])
+        self.assertEqual(result[1].user_name, self.user["musicbrainz_id"])
+        self.assertEqual(result[1].recording_msid, fb_msid_1)
+        self.assertEqual(result[1].score, self.sample_feedback[0]["score"])
+
+        # test the score argument
+        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0, score=1)
         self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].score, 1)
+        self.assertEqual(result[1].score, 1)
+
+        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0, score=-1)
+        self.assertEqual(len(result), 0)
+
+        # test the limit argument
+        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=1, offset=0)
+        self.assertEqual(len(result), 1)
+
+        # test the offset argument
+        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=1)
+        self.assertEqual(len(result), 1)
+
+    def test_get_feedback_count_for_recording(self):
+        fb_msid_1 = self.sample_feedback[0]["recording_msid"]
+
+        self.insert_test_data(self.user["id"])
+        result = db_feedback.get_feedback_count_for_recording(recording_msid=fb_msid_1)
+        self.assertEqual(result, 1)
+
+        user2 = db_user.get_or_create(2, "recording_feedback_other_user")
+        self.insert_test_data(user2["id"])
+
+        result = db_feedback.get_feedback_count_for_recording(recording_msid=fb_msid_1)
+        self.assertEqual(result, 2)

--- a/listenbrainz/feedback.py
+++ b/listenbrainz/feedback.py
@@ -8,11 +8,13 @@ class Feedback(BaseModel):
     """ Represents a feedback object
         Args:
             user_id: the row id of the user in the DB
+            user_name: (Optional) the MusicBrainz ID of the user
             recording_msid: the MessyBrainz ID of the recording
             score: The score associated with the recording (+1/-1 for love/hate respectively)
     """
 
     user_id: int
+    user_name: str = None
     recording_msid: str
     score: int
 


### PR DESCRIPTION
# Problem

The module did not serve the purpose properly for the APIs.

- We had to make separate access for getting `user_name`
- We were fetching all the records and then applying offset and count at the API level.
- There was a lot of repetitive code.

# Solution

This PR aims to address these issues by:

- Using SQL JOINs to fetch `username` along with feedback records.
- Apply LIMIT and OFFSET in SQL queries.
- Remove repetitive code.
