### PR TITLE
save dataframe and model metdata in HDFS

### DIFF
--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -32,6 +32,11 @@ SENTRY_DSN_PUBLIC = ''
 # The following var defines the string of which the model id is made up of.
 MODEL_ID_PREFIX = 'listenbrainz-recommendation-model'
 
+# Dataframe id is made up of two parts.
+# String + UUID
+# The following var defines the string of which the dataframe id is made up of.
+DATAFRAME_ID_PREFIX = 'listenbrainz-recommendation-dataframe'
+
 FTP_SERVER_URI = 'ftp.eu.metabrainz.org'
 FTP_MSID_MBID_DIR = '/pub/musicbrainz/listenbrainz/labs/mappings/msid-mbid-mapping/'
 FTP_ARTIST_RELATION_DIR = '/pub/musicbrainz/listenbrainz/labs/artist-credit-artist-credit-relations/'

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -32,8 +32,6 @@ TOP_ARTIST_CANDIDATE_SET = os.path.join(CANDIDATE_SET_DIR, 'top_artist', 'top_ar
 SIMILAR_ARTIST_CANDIDATE_SET = os.path.join(CANDIDATE_SET_DIR, 'similar_artist', 'similar_artist.parquet')
 # Absolute path to model metadata.
 MODEL_METADATA = MODEL_DIR + '/' + 'model_metadata.parquet'
-# Absolute path to save model index
-INDEX = MODEL_DIR + '/' + 'index.parquet'
 # Absolute path to recording mbid->msid and artist mbid-msid mapping.
 MBID_MSID_MAPPING = os.path.join('/', 'mapping', 'msid_mbid_mapping.parquet')
 # Absolute path to mapped listens.

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -38,6 +38,8 @@ INDEX = MODEL_DIR + '/' + 'index.parquet'
 MBID_MSID_MAPPING = os.path.join('/', 'mapping', 'msid_mbid_mapping.parquet')
 # Absolute path to mapped listens.
 MAPPED_LISTENS = DATAFRAME_DIR + '/' + 'mapped_listens_df.parquet'
+# Absolute path to save dataframe metadata
+DATAFRAME_METADATA = DATAFRAME_DIR + '/' + 'dataframe_metadata.parquet'
 
 # Path to files downloaded from FTP.
 FTP_FILES_PATH = '/rec/listenbrainz_spark'

--- a/listenbrainz_spark/recommendations/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/create_dataframes.py
@@ -56,6 +56,7 @@ SAVE_DATAFRAME_HTML = True
 #       'user_id', 'recording_id', 'count'
 #   ]
 
+
 def generate_dataframe_id(metadata):
     """ Generate dataframe id.
     """

--- a/listenbrainz_spark/recommendations/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/create_dataframes.py
@@ -56,10 +56,10 @@ SAVE_DATAFRAME_HTML = True
 #       'user_id', 'recording_id', 'count'
 #   ]
 
-def generate_best_model_id(metadata):
-    """ Generate best model id.
+def generate_dataframe_id(metadata):
+    """ Generate dataframe id.
     """
-    metadata['model_id'] = '{}-{}'.format(config.MODEL_ID_PREFIX, uuid.uuid4())
+    metadata['dataframe_id'] = '{}-{}'.format(config.DATAFRAME_ID_PREFIX, uuid.uuid4())
 
 
 def save_dataframe(df, dest_path):
@@ -96,21 +96,21 @@ def save_dataframe_html(users_df_time, recordings_df_time, playcounts_df_time, t
     save_html(queries_html, context, 'queries.html')
 
 
-def save_dataframe_metadata_to_HDFS(metadata):
-    """ Save dataframe metadata to model_metadata dataframe.
+def save_dataframe_metadata_to_hdfs(metadata):
+    """ Save dataframe metadata.
     """
     # Convert metadata to row object.
-    metadata_row = schema.convert_model_metadata_to_row(metadata)
+    metadata_row = schema.convert_dataframe_metadata_to_row(metadata)
     try:
         # Create dataframe from the row object.
-        dataframe_metadata = utils.create_dataframe(metadata_row, schema.model_metadata_schema)
+        dataframe_metadata = utils.create_dataframe(metadata_row, schema.dataframe_metadata_schema)
     except DataFrameNotCreatedException as err:
         current_app.logger.error(str(err), exc_info=True)
         sys.exit(-1)
 
     try:
-        # Append the dataframe to existing dataframe if already exist or create a new one.
-        utils.append(dataframe_metadata, path.MODEL_METADATA)
+        # Append the dataframe to existing dataframe if already exists or create a new one.
+        utils.append(dataframe_metadata, path.DATAFRAME_METADATA)
     except DataFrameNotAppendedException as err:
         current_app.logger.error(str(err), exc_info=True)
         sys.exit(-1)
@@ -308,8 +308,8 @@ def main(train_model_window=None):
     playcounts_df = get_playcounts_df(listens_df, recordings_df, users_df, metadata)
     playcounts_df_time = '{:.2f}'.format((time() - t0) / 60)
 
-    generate_best_model_id(metadata)
-    save_dataframe_metadata_to_HDFS(metadata)
+    generate_dataframe_id(metadata)
+    save_dataframe_metadata_to_hdfs(metadata)
     total_time = '{:.2f}'.format((time() - ti) / 60)
 
     if SAVE_DATAFRAME_HTML:

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -67,7 +67,7 @@ def load_model():
     best_model_id = get_best_model_id()
     dest_path = get_best_model_path(best_model_id)
     try:
-        model =  MatrixFactorizationModel.load(listenbrainz_spark.context, dest_path)
+        model = MatrixFactorizationModel.load(listenbrainz_spark.context, dest_path)
         return model
     except Py4JJavaError as err:
         current_app.logger.error('Unable to load model "{}"\n{}\nAborting...'.format(best_model_id, str(err.java_exception)),

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -60,7 +60,7 @@ def get_most_recent_model_id():
 
 
 def load_model():
-    """ Load best model from given path in HDFS.
+    """ Load model from given path in HDFS.
     """
     model_id = get_most_recent_model_id()
     dest_path = get_model_path(model_id)

--- a/listenbrainz_spark/recommendations/recommendation-metadata.json
+++ b/listenbrainz_spark/recommendations/recommendation-metadata.json
@@ -1,1 +1,0 @@
-{"user_name": ["rob", "Vansika Pareek", "iliekcomputers", "invalid_name"], "best_model_id": "listenbrainz-recommendation-model-93174daf-f453-4ff3-afd5-384570ba0af0"}

--- a/listenbrainz_spark/recommendations/templates/model.html
+++ b/listenbrainz_spark/recommendations/templates/model.html
@@ -45,7 +45,7 @@ td, th {
 			<th>Best model lmbda</th>
 			<th>Best model iteration</th>
 			<th>Best model RMSE</th>
-			<th>Best model RMSE computation time(min)</th>			
+			<th>Best model RMSE computation time(min)</th>
 		</tr>
 		<tr>
 			<td>{{ best_model.model_id }}</td>
@@ -53,7 +53,7 @@ td, th {
 			<td>{{ best_model.rank }}</td>
 			<td>{{ best_model.lmbda }}</td>
 			<td>{{ best_model.iteration }}</td>
-			<td>{{ best_model.error }}</td>
+			<td>{{ best_model.validation_rmse }}</td>
 			<td>{{ best_model.rmse_time }}</td>
 		</tr>
 	</table>

--- a/listenbrainz_spark/recommendations/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/tests/test_models.py
@@ -18,6 +18,7 @@ class TrainModelsTestCase(SparkTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        super().upload_test_playcounts()
 
     @classmethod
     def tearDownClass(cls):
@@ -102,6 +103,7 @@ class TrainModelsTestCase(SparkTestCase):
             model_id="xxx",
             training_time="3.1",
             rmse_time="2.1",
+            alpha=3.0,
         )
 
         metadata = train_models.get_best_model_metadata(best_model)

--- a/listenbrainz_spark/recommendations/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/tests/test_models.py
@@ -1,13 +1,16 @@
+import re
 import os
 import uuid
 import unittest
+from unittest.mock import patch, Mock
 
 import listenbrainz_spark
 from listenbrainz_spark.tests import SparkTestCase, TEST_PLAYCOUNTS_PATH, PLAYCOUNTS_COUNT
-from listenbrainz_spark import utils, config, hdfs_connection
+from listenbrainz_spark import utils, config, hdfs_connection, path, schema
 from listenbrainz_spark.recommendations import train_models
 
 from pyspark.sql import Row
+
 from pyspark.sql.types import StructType, StructField, IntegerType
 
 class TrainModelsTestCase(SparkTestCase):
@@ -15,36 +18,45 @@ class TrainModelsTestCase(SparkTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        super().upload_test_playcounts()
 
     @classmethod
     def tearDownClass(cls):
         super().delete_dir()
         super().tearDownClass()
 
-    def test_train(self):
-        training_data, validation_data, test_data = super().split_playcounts()
-
-        best_model, model_metadata, best_model_metadata = train_models.train(
-            training_data, validation_data, validation_data.count(), self.ranks,
-            self.lambdas, self.iterations, self.alpha
-        )
-        self.assertTrue(best_model)
-        self.assertEqual(len(model_metadata), 1)
-        self.assertEqual(model_metadata[0][0], best_model_metadata['model_id'])
-        self.assertEqual(model_metadata[0][1], best_model_metadata['training_time'])
-        self.assertEqual(model_metadata[0][2], best_model_metadata['rank'])
-        self.assertEqual(model_metadata[0][3], best_model_metadata['lmbda'])
-        self.assertEqual(model_metadata[0][4], best_model_metadata['iteration'])
-        self.assertEqual(model_metadata[0][5], best_model_metadata['error'])
-        self.assertEqual(model_metadata[0][6], best_model_metadata['rmse_time'])
-
     def test_parse_dataset(self):
-        row = Row(user_id=1, recording_id=1, count=1)
+        row = Row(user_id=1, recording_id=2, count=3)
         rating_object = train_models.parse_dataset(row)
         self.assertEqual(rating_object.user, 1)
-        self.assertEqual(rating_object.product, 1)
-        self.assertEqual(rating_object.rating, 1)
+        self.assertEqual(rating_object.product, 2)
+        self.assertEqual(rating_object.rating, 3)
+
+    @patch('listenbrainz_spark.recommendations.train_models.sqrt')
+    @patch('listenbrainz_spark.recommendations.train_models.RDD')
+    @patch('listenbrainz_spark.recommendations.train_models.train')
+    @patch('listenbrainz_spark.recommendations.train_models.add')
+    def test_compute_rmse(self, mock_add, mock_train, mock_rdd, mock_sqrt):
+        n = 1
+        model_id = "281c4177-f33a-441d-b15d-910acaf18b07"
+        _ = train_models.compute_rmse(mock_train.return_value, mock_rdd, n, model_id)
+
+        mock_predict_all = mock_train.return_value.predictAll
+        mock_map = mock_rdd.map()
+        mock_predict_all.assert_called_once_with(mock_map)
+
+        mock_predictions = mock_predict_all.return_value.map
+        mock_predictions.assert_called_once()
+
+        mock_join = mock_predictions.return_value.join
+        mock_join.assert_called_once_with(mock_map)
+
+        mock_values = mock_join.return_value.values
+        mock_values.assert_called_once()
+
+        mock_reduce = mock_values.return_value.map.return_value.reduce
+        mock_reduce.assert_called_once_with(mock_add)
+        # test division operator
+        mock_sqrt.assert_called_once_with(mock_reduce.return_value.__truediv__())
 
     def test_preprocess_data(self):
         test_playcounts_df = utils.read_files_from_HDFS(TEST_PLAYCOUNTS_PATH)
@@ -52,14 +64,117 @@ class TrainModelsTestCase(SparkTestCase):
         total_playcounts = training_data.count() + validation_data.count() + test_data.count()
         self.assertEqual(total_playcounts, PLAYCOUNTS_COUNT)
 
-    def test_save_model(self):
-        training_data, validation_data, test_data = super().split_playcounts()
+    def test_generate_model_id(self):
+        model_id = train_models.generate_model_id()
+        assert re.match('{}-*'.format(config.MODEL_ID_PREFIX), model_id)
 
-        best_model, _, best_model_metadata = train_models.train(
-            training_data, validation_data, validation_data.count(), self.ranks,
-            self.lambdas, self.iterations, self.alpha
+    def test_get_best_model_path(self):
+        model_id = "a36d6fc9-49d0-4789-a7dd-a2b72369ca45"
+        actual_path = train_models.get_best_model_path(model_id)
+        expected_path = config.HDFS_CLUSTER_URI + path.DATA_DIR + '/' + model_id
+        self.assertEqual(actual_path, expected_path)
+
+    def test_get_latest_dataframe_id(self):
+        df_id_1 = "a36d6fc9-49d0-4789-a7dd-a2b72369ca45"
+        df_metadata_dict_1 = self.get_dataframe_metadata(df_id_1)
+        df_1 = utils.create_dataframe(schema.convert_dataframe_metadata_to_row(df_metadata_dict_1),
+                                      schema.dataframe_metadata_schema)
+
+        df_id_2 = "bbbd6fc9-49d0-4789-a7dd-a2b72369ca45"
+        df_metadata_dict_2 = self.get_dataframe_metadata(df_id_2)
+        df_2 = utils.create_dataframe(schema.convert_dataframe_metadata_to_row(df_metadata_dict_2),
+                                      schema.dataframe_metadata_schema)
+
+        df_metadata = df_1.union(df_2)
+        model_metadata = {}
+
+        train_models.get_latest_dataframe_id(df_metadata, model_metadata)
+        self.assertEqual(model_metadata['dataframe_id'], df_id_2)
+
+    @patch('listenbrainz_spark.recommendations.train_models.train')
+    def test_get_best_model_metadata(self, mock_train):
+        best_model = train_models.Model(
+            model=mock_train.return_value,
+            validation_rmse=3.9,
+            rank=4,
+            lmbda=2.1,
+            iteration=1,
+            model_id="xxx",
+            training_time="3.1",
+            rmse_time="2.1",
         )
-        model_save_path = os.path.join('/test/model', best_model_metadata['model_id'])
-        train_models.save_model(model_save_path, best_model_metadata['model_id'], best_model)
-        model_exist = utils.path_exists(model_save_path)
-        self.assertTrue(model_exist)
+
+        metadata = train_models.get_best_model_metadata(best_model)
+        self.assertEqual(best_model.validation_rmse, metadata['validation_rmse'])
+        self.assertEqual(best_model.rank, metadata['rank'])
+        self.assertEqual(best_model.lmbda, metadata['lmbda'])
+        self.assertEqual(best_model.iteration, metadata['iteration'])
+        self.assertEqual(best_model.model_id, metadata['model_id'])
+        self.assertEqual(best_model.training_time, metadata['training_time'])
+        self.assertEqual(best_model.rmse_time, metadata['rmse_time'])
+        self.assertEqual(best_model.alpha, metadata['alpha'])
+
+    @patch('listenbrainz_spark.recommendations.train_models.RDD')
+    @patch('listenbrainz_spark.recommendations.train_models.ALS')
+    def test_train(self, mock_als, mock_rdd):
+        rank = 2
+        iteration = 2
+        lmbda = 2.0
+        alpha = 1.0
+        model_id = 'xxxxxxx'
+        _ = train_models.train(mock_rdd, rank, iteration, lmbda, alpha, model_id)
+
+        mock_als.trainImplicit.assert_called_once_with(mock_rdd, rank, iterations=iteration, lambda_=lmbda, alpha=alpha)
+
+    @patch('listenbrainz_spark.recommendations.train_models.compute_rmse')
+    @patch('listenbrainz_spark.recommendations.train_models.train')
+    @patch('listenbrainz_spark.recommendations.train_models.generate_model_id')
+    def test_get_best_model(self, mock_id, mock_train, mock_rmse):
+        mock_rdd_training = Mock()
+        mock_rdd_validation = Mock()
+        num_validation = 4
+        ranks = [3]
+        lambdas = [4.8]
+        iterations = [2]
+        alpha = 3.0
+
+        mock_rmse.return_value = 6.999
+        best_model, model_metadata = train_models.get_best_model(mock_rdd_training, mock_rdd_validation, num_validation,
+                                                                 ranks, lambdas, iterations, alpha)
+
+        mock_id.assert_called_once()
+        mock_train.assert_called_once_with(mock_rdd_training, ranks[0], iterations[0], lambdas[0],
+                                           alpha, mock_id.return_value)
+        mock_rmse.assert_called_once_with(mock_train.return_value, mock_rdd_validation, num_validation, mock_id.return_value)
+
+    def test_delete_best_model(self):
+        df = utils.create_dataframe(Row(col1=1, col2=1), None)
+        utils.save_parquet(df, path.DATA_DIR)
+        train_models.delete_best_model()
+
+        dir_exists = utils.path_exists(path.DATA_DIR)
+        self.assertFalse(dir_exists)
+
+    def test_save_model_metadata_to_hdfs(self):
+        model_id = "3acb406f-c716-45f8-a8bd-96ca3939c2e5"
+        metadata = self.get_model_metadata(model_id)
+
+        train_models.save_model_metadata_to_hdfs(metadata)
+
+        status = utils.path_exists(path.MODEL_METADATA)
+        self.assertTrue(status)
+
+        df = utils.read_files_from_HDFS(path.MODEL_METADATA)
+        self.assertTrue(sorted(df.columns), sorted(schema.model_metadata_schema.fieldNames()))
+
+    @patch('listenbrainz_spark.recommendations.train_models.train')
+    @patch('listenbrainz_spark.recommendations.train_models.listenbrainz_spark')
+    @patch('listenbrainz_spark.recommendations.train_models.get_best_model_path')
+    @patch('listenbrainz_spark.recommendations.train_models.delete_best_model')
+    def test_save_best_model(self, mock_del, mock_path, mock_context, mock_train):
+        model_id = 'xxxxxx'
+        train_models.save_best_model(model_id, mock_train.return_value)
+
+        mock_del.assert_called_once()
+        mock_path.assert_called_once_with(model_id)
+        mock_train.return_value.save.assert_called_once_with(mock_context.context, mock_path.return_value)

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -59,8 +59,8 @@ class RecommendTestClass(SparkTestCase):
 
     @patch('listenbrainz_spark.recommendations.recommend.MatrixFactorizationModel')
     @patch('listenbrainz_spark.recommendations.recommend.listenbrainz_spark')
-    @patch('listenbrainz_spark.recommendations.recommend.get_best_model_path')
-    @patch('listenbrainz_spark.recommendations.recommend.get_best_model_id')
+    @patch('listenbrainz_spark.recommendations.recommend.get_model_path')
+    @patch('listenbrainz_spark.recommendations.recommend.get_most_recent_model_id')
     def test_load_model(self, mock_id, mock_model_path, mock_lb, mock_matrix_model):
         model = recommend.load_model()
         mock_id.assert_called_once()

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -14,39 +14,24 @@ from pyspark.rdd import RDD
 from pyspark.mllib.recommendation import Rating
 
 # for test data/dataframes refer to listenbrainzspark/tests/__init__.py
-MODEL_PATH = '/test/model'
 
 class RecommendTestClass(SparkTestCase):
 
-    model_save_path = None
     recommendation_top_artist_limit = 10
     recommendation_similar_artist_limit = 10
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        super().upload_test_playcounts()
-        cls.upload_test_model()
 
     @classmethod
     def tearDownClass(cls):
         super().delete_dir()
         super().tearDownClass()
 
-    @classmethod
-    def upload_test_model(cls):
-        training_data, validation_data, test_data = super().split_playcounts()
-
-        best_model, _, best_model_metadata = train_models.train(
-            training_data, validation_data, validation_data.count(), cls.ranks,
-            cls.lambdas, cls.iterations, cls.alpha
-        )
-        cls.model_save_path = os.path.join(MODEL_PATH, best_model_metadata['model_id'])
-        train_models.save_model(cls.model_save_path, best_model_metadata['model_id'], best_model)
-    '''
     def test_recommendation_params_init(self):
         recordings = utils.create_dataframe(Row(col1=3, col2=9), schema=None)
-        model = recommend.load_model(config.HDFS_CLUSTER_URI + self.model_save_path)
+        mock_model = MagicMock()
         top_artist_candidate_set = utils.create_dataframe(Row(col1=4, col2=5, col3=5), schema=None)
         similar_artist_candidate_set = utils.create_dataframe(Row(col1=1), schema=None)
         recommendation_top_artist_limit = 20
@@ -58,15 +43,11 @@ class RecommendTestClass(SparkTestCase):
                                                 recommendation_similar_artist_limit)
 
         self.assertEqual(sorted(params.recordings.columns), sorted(recordings.columns))
-        self.assertEqual(params.model, model)
+        self.assertEqual(params.model, mock_model)
         self.assertEqual(sorted(params.top_artist_candidate_set.columns), sorted(top_artist_candidate_set.columns))
         self.assertEqual(sorted(params.similar_artist_candidate_set.columns), sorted(similar_artist_candidate_set.columns))
         self.assertEqual(params.recommendation_top_artist_limit, recommendation_top_artist_limit)
         self.assertEqual(params.recommendation_similar_artist_limit, recommendation_similar_artist_limit)
-
-    def test_load_model(self):
-        model = recommend.load_model(config.HDFS_CLUSTER_URI + self.model_save_path)
-        self.assertTrue(model)
 
     def test_get_recording_mbids(self):
         params = self.get_recommendation_params()
@@ -76,28 +57,32 @@ class RecommendTestClass(SparkTestCase):
         self.assertEqual(recording_mbids.count(), 1)
         self.assertEqual(recording_mbids.collect()[0].mb_recording_mbid, "3acb406f-c716-45f8-a8bd-96ca3939c2e5")
 
-    @patch('listenbrainz_spark.recommendations.recommend.get_recording_mbids')
-    @patch('listenbrainz_spark.recommendations.recommend.generate_recommendations')
-    def test_get_recommended_mbids(self, mock_gen_rec, mock_get_mbids):
-        candidate_set = self.get_candidate_set()
-        params = self.get_recommendation_params()
-        limit = 2
+    @patch('listenbrainz_spark.recommendations.recommend.MatrixFactorizationModel')
+    @patch('listenbrainz_spark.recommendations.recommend.listenbrainz_spark')
+    @patch('listenbrainz_spark.recommendations.recommend.get_best_model_path')
+    @patch('listenbrainz_spark.recommendations.recommend.get_best_model_id')
+    def test_load_model(self, mock_id, mock_model_path, mock_lb, mock_matrix_model):
+        model = recommend.load_model()
+        mock_id.assert_called_once()
+        mock_model_path.assert_called_once_with(mock_id.return_value)
+        mock_matrix_model.load.assert_called_once_with(mock_lb.context, mock_model_path.return_value)
 
-        rdd = candidate_set.rdd.map(lambda r: (r['user_id'], r['recording_id']))
+    def test_get_most_recent_model_id(self):
+        model_id_1 = "a36d6fc9-49d0-4789-a7dd-a2b72369ca45"
+        model_metadata_dict_1 = self.get_model_metadata(model_id_1)
+        df_1 = utils.create_dataframe(schema.convert_model_metadata_to_row(model_metadata_dict_1),
+                                      schema.model_metadata_schema)
 
-        mock_gen_rec.return_value = [Rating(user=2, product=2, rating=1.2)]
-        mock_get_mbids.return_value = utils.create_dataframe(Row(mb_recording_mbid='xxxx'), schema=None)
-        recommended_mbids = recommend.get_recommended_mbids(rdd, params, limit)
+        model_id_2 = "bbbd6fc9-49d0-4789-a7dd-a2b72369ca45"
+        model_metadata_dict_2 = self.get_model_metadata(model_id_2)
+        df_2 = utils.create_dataframe(schema.convert_model_metadata_to_row(model_metadata_dict_2),
+                                      schema.model_metadata_schema)
 
-        mock_gen_rec.assert_called_once_with(rdd, params, limit)
-        mock_get_mbids.assert_called_once_with(params, [2])
+        model_metadata = df_1.union(df_2)
+        utils.save_parquet(model_metadata, path.MODEL_METADATA)
 
-        self.assertEqual(recommended_mbids, ['xxxx'])
-
-        mock_gen_rec.return_value = []
-
-        with self.assertRaises(RecommendationsNotGeneratedException):
-            _ = recommend.get_recommended_mbids(rdd, params, limit)
+        expected_model_id = recommend.get_most_recent_model_id()
+        self.assertEqual(expected_model_id, model_id_2)
 
     def test_generate_recommendations(self):
         params = self.get_recommendation_params()
@@ -147,7 +132,7 @@ class RecommendTestClass(SparkTestCase):
             call(mock_candidate_set.return_value, params, params.recommendation_top_artist_limit),
             call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit)
         ])
-    '''
+
     def test_get_users(self):
         params = self.get_recommendation_params()
         df = utils.create_dataframe(
@@ -210,7 +195,7 @@ class RecommendTestClass(SparkTestCase):
 
     def get_recommendation_params(self):
         recordings = self.get_recordings_df()
-        model = recommend.load_model(config.HDFS_CLUSTER_URI + self.model_save_path)
+        model = MagicMock()
         top_artist_candidate_set = self.get_candidate_set()
         similar_artist_candidate_set = self.get_candidate_set()
         recommendation_top_artist_limit = 2

--- a/listenbrainz_spark/recommendations/train_models.py
+++ b/listenbrainz_spark/recommendations/train_models.py
@@ -52,8 +52,8 @@ def compute_rmse(model, data, n, model_id):
     try:
         predictions = model.predictAll(data.map(lambda x: (x.user, x.product)))
         predictionsAndRatings = predictions.map(lambda x: ((x[0], x[1]), x[2])) \
-          .join(data.map(lambda x: ((x[0], x[1]), x[2]))) \
-          .values()
+                                           .join(data.map(lambda x: ((x[0], x[1]), x[2]))) \
+                                           .values()
         return sqrt(predictionsAndRatings.map(lambda x: (x[0] - x[1]) ** 2).reduce(add) / float(n))
     except Py4JJavaError as err:
         current_app.logger.error('Root Mean Squared Error for model "{}" not computed\n{}'.format(
@@ -107,8 +107,7 @@ def get_latest_dataframe_id(dataframe_metadata_df, best_model_metadata):
             best_model_metadata: Dict of best model metadata.
     """
     # get timestamp of recently saved dataframe.
-    timestamp = dataframe_metadata_df.select(f.max('dataframe_created') \
-                                     .alias('recent_dataframe_timestamp')).take(1)[0]
+    timestamp = dataframe_metadata_df.select(f.max('dataframe_created').alias('recent_dataframe_timestamp')).take(1)[0]
     # get dataframe id corresponding to most recent timestamp.
     df = dataframe_metadata_df.select('dataframe_id') \
                               .where(f.col('dataframe_created') == timestamp.recent_dataframe_timestamp).take(1)[0]
@@ -235,7 +234,7 @@ def save_best_model(model_id, model):
         current_app.logger.info('Model saved!')
     except Py4JJavaError as err:
         current_app.logger.error('Unable to save best model "{}"\n{}. Aborting...'.format(model_id,
-            str(err.java_exception)), exc_info=True)
+                                 str(err.java_exception)), exc_info=True)
         sys.exit(-1)
 
 
@@ -360,7 +359,6 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
 
     best_model_metadata = get_best_model_metadata(best_model)
     best_model_metadata['test_rmse'] = compute_rmse(best_model.model, test_data, num_test, best_model.model_id)
-
 
     best_model_metadata['training_data_count'] = num_training
     best_model_metadata['validation_data_count'] = num_validation

--- a/listenbrainz_spark/recommendations/train_models.py
+++ b/listenbrainz_spark/recommendations/train_models.py
@@ -225,6 +225,7 @@ def save_best_model(model_id, model):
             model_id (str): Best model identification string.
             model: Trained best model
     """
+    # delete previously saved model before saving a new model
     delete_best_model()
 
     dest_path = get_model_path(model_id)

--- a/listenbrainz_spark/recommendations/train_models.py
+++ b/listenbrainz_spark/recommendations/train_models.py
@@ -13,20 +13,23 @@ from py4j.protocol import Py4JJavaError
 
 import listenbrainz_spark
 from listenbrainz_spark import hdfs_connection
-from listenbrainz_spark import config, utils, path
+from listenbrainz_spark import config, utils, path, schema
 from listenbrainz_spark.recommendations.utils import save_html
 from listenbrainz_spark.exceptions import SparkSessionNotInitializedException, PathNotFoundException, FileNotFetchedException, \
-    HDFSDirectoryNotDeletedException
+    HDFSDirectoryNotDeletedException, PathNotFoundException, DataFrameNotCreatedException, DataFrameNotAppendedException
 
+import pyspark.sql.functions as f
+from pyspark import RDD
 from pyspark.sql import Row
 from flask import current_app
 from pyspark.sql.utils import AnalysisException
 from pyspark.mllib.recommendation import ALS, Rating
 
-Model = namedtuple('Model', 'model error rank lmbda iteration model_id training_time rmse_time')
+Model = namedtuple('Model', 'model validation_rmse rank lmbda iteration model_id training_time rmse_time, alpha')
 
 # training HTML is generated if set to true
 SAVE_TRAINING_HTML = True
+
 
 def parse_dataset(row):
     """ Convert each RDD element to object of class Rating.
@@ -36,19 +39,27 @@ def parse_dataset(row):
     """
     return Rating(row['user_id'], row['recording_id'], row['count'])
 
-def compute_rmse(model, data, n):
+
+def compute_rmse(model, data, n, model_id):
     """ Compute RMSE (Root Mean Squared Error).
 
         Args:
             model: Trained model.
             data (rdd): Rdd used for validation i.e validation_data
             n (int): Number of rows/elements in validation_data.
+            model_id (str): Model identification string.
     """
-    predictions = model.predictAll(data.map(lambda x: (x.user, x.product)))
-    predictionsAndRatings = predictions.map(lambda x: ((x[0], x[1]), x[2])) \
-      .join(data.map(lambda x: ((x[0], x[1]), x[2]))) \
-      .values()
-    return sqrt(predictionsAndRatings.map(lambda x: (x[0] - x[1]) ** 2).reduce(add) / float(n))
+    try:
+        predictions = model.predictAll(data.map(lambda x: (x.user, x.product)))
+        predictionsAndRatings = predictions.map(lambda x: ((x[0], x[1]), x[2])) \
+          .join(data.map(lambda x: ((x[0], x[1]), x[2]))) \
+          .values()
+        return sqrt(predictionsAndRatings.map(lambda x: (x[0] - x[1]) ** 2).reduce(add) / float(n))
+    except Py4JJavaError as err:
+        current_app.logger.error('Root Mean Squared Error for model "{}" not computed\n{}'.format(
+                                 model_id, str(err.java_exception)), exc_info=True)
+        sys.exit(-1)
+
 
 def preprocess_data(playcounts_df):
     """ Convert and split the dataframe into three RDDs; training data, validation data, test data.
@@ -69,8 +80,89 @@ def preprocess_data(playcounts_df):
     return training_data, validation_data, test_data
 
 
-def train(training_data, validation_data, num_validation, ranks, lambdas, iterations, alpha):
-    """ Train the data and get models as per given parameters i.e. ranks, lambdas and iterations.
+def generate_model_id():
+    """ Generate model id.
+    """
+    return '{}-{}'.format(config.MODEL_ID_PREFIX, uuid.uuid4())
+
+
+def get_best_model_path(model_id):
+    """ Get path to save best model
+
+        Args:
+            model_id (str): Model identification string of best model.
+
+        Returns:
+            path to save best model.
+    """
+
+    return config.HDFS_CLUSTER_URI + path.DATA_DIR + '/' + model_id
+
+
+def get_latest_dataframe_id(dataframe_metadata_df, best_model_metadata):
+    """ Get dataframe id of dataframe on which model has been trained.
+
+        Args:
+            dataframe_metadata_df (dataframe): Refer to listenbrainz_spark.schema.dataframe_metadata_schema
+            best_model_metadata: Dict of best model metadata.
+    """
+    # get timestamp of recently saved dataframe.
+    timestamp = dataframe_metadata_df.select(f.max('dataframe_created') \
+                                     .alias('recent_dataframe_timestamp')).take(1)[0]
+    # get dataframe id corresponding to most recent timestamp.
+    df = dataframe_metadata_df.select('dataframe_id') \
+                              .where(f.col('dataframe_created') == timestamp.recent_dataframe_timestamp).take(1)[0]
+
+    best_model_metadata['dataframe_id'] = df.dataframe_id
+
+
+def get_best_model_metadata(best_model):
+    """ Get best model metadata.
+
+        Args:
+            best_model (namedtuple): contains best model and related data.
+
+        Returns:
+            dict containing best model metadata.
+    """
+
+    return {
+        'alpha': best_model.alpha,
+        'iteration': best_model.iteration,
+        'lmbda': best_model.lmbda,
+        'model_id': best_model.model_id,
+        'rank': best_model.rank,
+        'rmse_time': best_model.rmse_time,
+        'training_time': best_model.training_time,
+        'validation_rmse': best_model.validation_rmse,
+    }
+
+
+def train(training_data, rank, iteration, lmbda, alpha, model_id):
+    """ Train model.
+
+        Args:
+            training_data (rdd): Used for training.
+            rank (int): Number of factors in ALS model.
+            iteration (int): Number of iterations to run.
+            lmbda (float): Controls regularization.
+            alpha (float): Constant for computing confidence.
+            model_id (str): Model identification string.
+
+        Returns:
+            model: Trained model.
+
+    """
+    try:
+        model = ALS.trainImplicit(training_data, rank, iterations=iteration, lambda_=lmbda, alpha=alpha)
+        return model
+    except Py4JJavaError as err:
+        current_app.logger.error('Unable to train model "{}"\n{}'.format(model_id, str(err.java_exception)), exc_info=True)
+        sys.exit(-1)
+
+
+def get_best_model(training_data, validation_data, num_validation, ranks, lambdas, iterations, alpha):
+    """ Train models and get the best model.
 
         Args:
             training_data (rdd): Used for training.
@@ -84,41 +176,95 @@ def train(training_data, validation_data, num_validation, ranks, lambdas, iterat
         Returns:
             best_model: Model with least RMSE value.
             model_metadata (dict): Models information such as model id, error etc.
-            best_model_metadata (dict): Best Model information such as model id, error etc.
     """
     best_model = None
     best_model_metadata = defaultdict(dict)
-    model_metadata = []
+    model_metadata = list()
 
     for rank, lmbda, iteration in itertools.product(ranks, lambdas, iterations):
-        t0 = time()
-        model_id = 'listenbrainz-recommendation-model-{}'.format(uuid.uuid4())
-        try:
-            model = ALS.trainImplicit(training_data, rank, iterations=iteration, lambda_=lmbda, alpha=alpha)
-        except Py4JJavaError as err:
-            current_app.logger.error('Unable to train model "{}"\n{}'.format(model_id, str(err.java_exception)), exc_info=True)
-            sys.exit(-1)
-        mt = '{:.2f}'.format((time() - t0) / 60)
-        t0 = time()
-        try:
-            validation_rmse = compute_rmse(model, validation_data, num_validation)
-        except Py4JJavaError as err:
-            current_app.logger.error('Root Mean Squared Error for model "{}" for validation data not computed\n{}'.format(
-                model_id, str(err.java_exception)), exc_info=True)
-            sys.exit(-1)
-        vt = '{:.2f}'.format((time() - t0) / 60)
-        model_metadata.append((model_id, mt, rank, lmbda, iteration, "%.2f" % (validation_rmse), vt))
-        if best_model is None or validation_rmse < best_model.error:
-            best_model = Model(model=model, error=validation_rmse, rank=rank, lmbda=lmbda, iteration=iteration,
-                model_id=model_id, training_time=mt, rmse_time=vt)
+        model_id = generate_model_id()
 
-    best_model_metadata = {'error': '{:.2f}'.format(best_model.error), 'rank': best_model.rank, 'lmbda':
-            best_model.lmbda, 'iteration': best_model.iteration, 'model_id': best_model.model_id, 'training_time':
-                best_model.training_time, 'rmse_time': best_model.rmse_time}
-    return best_model, model_metadata, best_model_metadata
+        t0 = time()
+        model = train(training_data, rank, iteration, lmbda, alpha, model_id)
+        mt = '{:.2f}'.format((time() - t0) / 60)
+
+        t0 = time()
+        validation_rmse = compute_rmse(model, validation_data, num_validation, model_id)
+        vt = '{:.2f}'.format((time() - t0) / 60)
+
+        model_metadata.append((model_id, mt, rank, '{:.1f}'.format(lmbda), iteration, round(validation_rmse, 2), vt))
+
+        if best_model is None or validation_rmse < best_model.validation_rmse:
+            best_model = Model(
+                model=model,
+                validation_rmse=round(validation_rmse, 2),
+                rank=rank,
+                lmbda=lmbda,
+                iteration=iteration,
+                model_id=model_id,
+                training_time=mt,
+                rmse_time=vt,
+                alpha=alpha,
+            )
+
+    return best_model, model_metadata
+
+
+def delete_best_model():
+    """ Delete best model.
+        Note: At any point in time, only one model is in HDFS
+    """
+    dir_exists = utils.path_exists(path.DATA_DIR)
+    if dir_exists:
+        utils.delete_dir(path.DATA_DIR, recursive=True)
+
+
+def save_best_model(model_id, model):
+    """ Save best model to HDFS.
+
+        Args:
+            model_id (str): Best model identification string.
+            model: Trained best model
+    """
+    delete_best_model()
+
+    dest_path = get_best_model_path(model_id)
+    try:
+        current_app.logger.info('Saving model...')
+        model.save(listenbrainz_spark.context, dest_path)
+        current_app.logger.info('Model saved!')
+    except Py4JJavaError as err:
+        current_app.logger.error('Unable to save best model "{}"\n{}. Aborting...'.format(model_id,
+            str(err.java_exception)), exc_info=True)
+        sys.exit(-1)
+
+
+def save_model_metadata_to_hdfs(metadata):
+    """ Save model metadata.
+
+        Args:
+            metadata: dict containing best model metadata.
+    """
+    metadata_row = schema.convert_model_metadata_to_row(metadata)
+    try:
+        # Create dataframe from the row object.
+        model_metadata_df = utils.create_dataframe(metadata_row, schema.model_metadata_schema)
+    except DataFrameNotCreatedException as err:
+        current_app.logger.error(str(err), exc_info=True)
+        sys.exit(-1)
+
+    try:
+        current_app.logger.info('Saving model metadata...')
+        # Append the dataframe to existing dataframe if already exist or create a new one.
+        utils.append(model_metadata_df, path.MODEL_METADATA)
+        current_app.logger.info('Model metadata saved...')
+    except DataFrameNotAppendedException as err:
+        current_app.logger.error(str(err), exc_info=True)
+        sys.exit(-1)
+
 
 def save_training_html(time_, num_training, num_validation, num_test, model_metadata, best_model_metadata, ti,
-        models_training_time):
+                       models_training_time):
     """ Prepare and save taraining HTML.
 
         Args:
@@ -149,20 +295,6 @@ def save_training_html(time_, num_training, num_validation, num_test, model_meta
     }
     save_html(model_html, context, 'model.html')
 
-def save_model(dest_path, model_id, model):
-    """ Save model to HDFS.
-
-        Args:
-            dest_path (str): HDFS path to save model.
-            model_id (str): Model Identification string.
-            model : Model to save.
-    """
-    try:
-        model.model.save(listenbrainz_spark.context, config.HDFS_CLUSTER_URI + dest_path)
-    except Py4JJavaError as err:
-        current_app.logger.error('Unable to save best model "{}"\n{}. Aborting...'.format(model_id,
-            str(err.java_exception)), exc_info=True)
-        sys.exit(-1)
 
 
 def main(ranks=None, lambdas=None, iterations=None, alpha=None):
@@ -196,9 +328,14 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
 
     try:
         playcounts_df = utils.read_files_from_HDFS(path.PLAYCOUNTS_DATAFRAME_PATH)
+        dataframe_metadata_df = utils.read_files_from_HDFS(path.DATAFRAME_METADATA)
+    except PathNotFoundException as err:
+        current_app.logger.error('{}\nConsider running create_dataframes.py'.format(str(err)), exc_info=True)
+        sys.exit(-1)
     except FileNotFetchedException as err:
         current_app.logger.error(str(err), exc_info=True)
         sys.exit(-1)
+
     time_['load_playcounts'] = '{:.2f}'.format((time() - ti) / 60)
 
     t0 = time()
@@ -217,28 +354,29 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
 
     current_app.logger.info('Training models...')
     t0 = time()
-    model, model_metadata, best_model_metadata = train(training_data, validation_data, num_validation, ranks,
-                                                       lambdas, iterations, alpha)
+    best_model, model_metadata = get_best_model(training_data, validation_data, num_validation, ranks,
+                                                lambdas, iterations, alpha)
     models_training_time = '{:.2f}'.format((time() - t0) / 3600)
 
-    try:
-        best_model_test_rmse = compute_rmse(model.model, test_data, num_test)
-    except Py4JJavaError as err:
-        current_app.logger.error('Root mean squared error for best model for test data not computed\n{}\nAborting...'.format(
-            str(err.java_exception)), exc_info=True)
-        sys.exit(-1)
+    best_model_metadata = get_best_model_metadata(best_model)
+    best_model_metadata['test_rmse'] = compute_rmse(best_model.model, test_data, num_test, best_model.model_id)
+
+
+    best_model_metadata['training_data_count'] = num_training
+    best_model_metadata['validation_data_count'] = num_validation
+    best_model_metadata['test_data_count'] = num_test
+    get_latest_dataframe_id(dataframe_metadata_df, best_model_metadata)
 
     # Cached data must be cleared to avoid OOM.
     training_data.unpersist()
     validation_data.unpersist()
 
-    current_app.logger.info('Saving model...')
+    hdfs_connection.init_hdfs(config.HDFS_HTTP_URI)
     t0 = time()
-    model_save_path = os.path.join(path.DATA_DIR, best_model_metadata['model_id'])
-    save_model(model_save_path, best_model_metadata['model_id'], model)
+    save_best_model(best_model.model_id, best_model.model)
     time_['save_model'] = '{:.2f}'.format((time() - t0) / 60)
 
-    hdfs_connection.init_hdfs(config.HDFS_HTTP_URI)
+    save_model_metadata_to_hdfs(best_model_metadata)
     # Delete checkpoint dir as saved lineages would eat up space, we won't be using them anyway.
     try:
         utils.delete_dir(path.CHECKPOINT_DIR, recursive=True)
@@ -248,15 +386,7 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
 
     if SAVE_TRAINING_HTML:
         save_training_html(time_, num_training, num_validation, num_test, model_metadata, best_model_metadata, ti,
-            models_training_time)
-
-    # Save best model id to a JSON file
-    metadata_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'recommendation-metadata.json')
-    with open(metadata_file_path, 'r') as f:
-        recommendation_metadata = json.load(f)
-        recommendation_metadata['best_model_id'] = best_model_metadata['model_id']
-    with open(metadata_file_path, 'w') as f:
-        json.dump(recommendation_metadata,f)
+                           models_training_time)
 
     message = [{
         'type': 'cf_recording_model',

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -25,22 +25,22 @@ listen_schema = [
 model_param_schema = [
     StructField('alpha', FloatType(), nullable=True), # Baseline level of confidence weighting applied.
     StructField('lmbda', FloatType(), nullable=True), # Controls over fitting.
-    StructField('iteration', IntegerType(), nullable=True), # Number of iterations to run.
+    StructField('iteration', IntegerType(), nullable=True), #  Number of iterations to run.
     StructField('rank', IntegerType(), nullable=True), # Number of hidden features in our low-rank approximation matrices.
 ]
 model_param_schema = StructType(sorted(model_param_schema, key=lambda field: field.name))
 
 
 model_metadata_schema = [
-    StructField('dataframe_id', StringType(), nullable=False), # dataframe id or identification string of dataframe.
-    StructField('model_created', TimestampType(), nullable=False), # Timestamp when the model is saved in HDFS.
-    StructField('model_param', model_param_schema, nullable=False), # Parameters used to train the model.
-    StructField('model_id', StringType(), nullable=False), # Model id or identification string of best model.
-    StructField('test_data_count', IntegerType(), nullable=False), # Number of listens used to test the model.
-    StructField('test_rmse', FloatType(), nullable=False), # Root mean squared error for test data.
-    StructField('training_data_count', IntegerType(), nullable=False), # Number of listens used to train the model.
-    StructField('validation_data_count', IntegerType(), nullable=False), # Number of listens used to validate the model.
-    StructField('validation_rmse', FloatType(), nullable=False), # Root mean squared error for validation data.
+    StructField('dataframe_id', StringType(), nullable=False), #  dataframe id or identification string of dataframe.
+    StructField('model_created', TimestampType(), nullable=False), #  Timestamp when the model is saved in HDFS.
+    StructField('model_param', model_param_schema, nullable=False), #  Parameters used to train the model.
+    StructField('model_id', StringType(), nullable=False), #  Model id or identification string of best model.
+    StructField('test_data_count', IntegerType(), nullable=False), #  Number of listens used to test the model.
+    StructField('test_rmse', FloatType(), nullable=False), #  Root mean squared error for test data.
+    StructField('training_data_count', IntegerType(), nullable=False), #  Number of listens used to train the model.
+    StructField('validation_data_count', IntegerType(), nullable=False), #  Number of listens used to validate the model.
+    StructField('validation_rmse', FloatType(), nullable=False), #  Root mean squared error for validation data.
 ]
 
 
@@ -71,14 +71,14 @@ artist_relation_schema = [
 
 
 dataframe_metadata_schema = [
-    StructField('dataframe_created', TimestampType(), nullable=False), # Timestamp when dataframes are created and saved in HDFS.
-    StructField('dataframe_id', StringType(), nullable=False), # dataframe id or identification string of dataframe.
+    StructField('dataframe_created', TimestampType(), nullable=False), # T imestamp when dataframes are created and saved in HDFS.
+    StructField('dataframe_id', StringType(), nullable=False), #  dataframe id or identification string of dataframe.
     # Timestamp from when listens have been used to train, validate and test the model.
     StructField('from_date', TimestampType(), nullable=False),
     # Number of listens recorded in a given time frame (between from_date and to_date, both inclusive).
     StructField('listens_count', IntegerType(), nullable=False),
-    StructField('playcounts_count', IntegerType(), nullable=False), # Summation of training data, validation data and test data.
-    StructField('recordings_count', IntegerType(), nullable=False), # Number of distinct recordings heard in a given time frame.
+    StructField('playcounts_count', IntegerType(), nullable=False), #  Summation of training data, validation data and test data.
+    StructField('recordings_count', IntegerType(), nullable=False), #  Number of distinct recordings heard in a given time frame.
     # Timestamp till when listens have been used to train, validate and test the model.
     StructField('to_date', TimestampType(), nullable=False),
     StructField('users_count', IntegerType(), nullable=False), # Number of users active in a given time frame.

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -25,22 +25,22 @@ listen_schema = [
 model_param_schema = [
     StructField('alpha', FloatType(), nullable=True), # Baseline level of confidence weighting applied.
     StructField('lmbda', FloatType(), nullable=True), # Controls over fitting.
-    StructField('iteration', IntegerType(), nullable=True), #  Number of iterations to run.
+    StructField('iteration', IntegerType(), nullable=True),  # Number of iterations to run.
     StructField('rank', IntegerType(), nullable=True), # Number of hidden features in our low-rank approximation matrices.
 ]
 model_param_schema = StructType(sorted(model_param_schema, key=lambda field: field.name))
 
 
 model_metadata_schema = [
-    StructField('dataframe_id', StringType(), nullable=False), #  dataframe id or identification string of dataframe.
-    StructField('model_created', TimestampType(), nullable=False), #  Timestamp when the model is saved in HDFS.
-    StructField('model_param', model_param_schema, nullable=False), #  Parameters used to train the model.
-    StructField('model_id', StringType(), nullable=False), #  Model id or identification string of best model.
-    StructField('test_data_count', IntegerType(), nullable=False), #  Number of listens used to test the model.
-    StructField('test_rmse', FloatType(), nullable=False), #  Root mean squared error for test data.
-    StructField('training_data_count', IntegerType(), nullable=False), #  Number of listens used to train the model.
-    StructField('validation_data_count', IntegerType(), nullable=False), #  Number of listens used to validate the model.
-    StructField('validation_rmse', FloatType(), nullable=False), #  Root mean squared error for validation data.
+    StructField('dataframe_id', StringType(), nullable=False),  # dataframe id or identification string of dataframe.
+    StructField('model_created', TimestampType(), nullable=False),  # Timestamp when the model is saved in HDFS.
+    StructField('model_param', model_param_schema, nullable=False),  # Parameters used to train the model.
+    StructField('model_id', StringType(), nullable=False),  # Model id or identification string of best model.
+    StructField('test_data_count', IntegerType(), nullable=False),  # Number of listens used to test the model.
+    StructField('test_rmse', FloatType(), nullable=False),  # Root mean squared error for test data.
+    StructField('training_data_count', IntegerType(), nullable=False),  # Number of listens used to train the model.
+    StructField('validation_data_count', IntegerType(), nullable=False),  # Number of listens used to validate the model.
+    StructField('validation_rmse', FloatType(), nullable=False),  # Root mean squared error for validation data.
 ]
 
 
@@ -71,17 +71,17 @@ artist_relation_schema = [
 
 
 dataframe_metadata_schema = [
-    StructField('dataframe_created', TimestampType(), nullable=False), # T imestamp when dataframes are created and saved in HDFS.
-    StructField('dataframe_id', StringType(), nullable=False), #  dataframe id or identification string of dataframe.
+    StructField('dataframe_created', TimestampType(), nullable=False),  # Timestamp when dataframes are created and saved in HDFS.
+    StructField('dataframe_id', StringType(), nullable=False),  # dataframe id or identification string of dataframe.
     # Timestamp from when listens have been used to train, validate and test the model.
     StructField('from_date', TimestampType(), nullable=False),
     # Number of listens recorded in a given time frame (between from_date and to_date, both inclusive).
     StructField('listens_count', IntegerType(), nullable=False),
-    StructField('playcounts_count', IntegerType(), nullable=False), #  Summation of training data, validation data and test data.
-    StructField('recordings_count', IntegerType(), nullable=False), #  Number of distinct recordings heard in a given time frame.
+    StructField('playcounts_count', IntegerType(), nullable=False),  # Summation of training data, validation data and test data.
+    StructField('recordings_count', IntegerType(), nullable=False),  # Number of distinct recordings heard in a given time frame.
     # Timestamp till when listens have been used to train, validate and test the model.
     StructField('to_date', TimestampType(), nullable=False),
-    StructField('users_count', IntegerType(), nullable=False), # Number of users active in a given time frame.
+    StructField('users_count', IntegerType(), nullable=False),  # Number of users active in a given time frame.
 ]
 
 

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -20,38 +20,29 @@ listen_schema = [
     StructField('user_name', StringType(), nullable=False),
 ]
 
+
 # schema to contain model parameters.
 model_param_schema = [
     StructField('alpha', FloatType(), nullable=True), # Baseline level of confidence weighting applied.
     StructField('lmbda', FloatType(), nullable=True), # Controls over fitting.
-    StructField('num_iterations', IntegerType(), nullable=True), # Number of iterations to run.
+    StructField('iteration', IntegerType(), nullable=True), # Number of iterations to run.
     StructField('rank', IntegerType(), nullable=True), # Number of hidden features in our low-rank approximation matrices.
 ]
-
 model_param_schema = StructType(sorted(model_param_schema, key=lambda field: field.name))
 
+
 model_metadata_schema = [
-    StructField('dataframe_created', TimestampType(), nullable=False), # Timestamp when dataframes are created and saved in HDFS.
-    # Timestamp from when listens have been used to train, validate and test the model.
-    StructField('from_date', TimestampType(), nullable=False),
-    # Number of listens recorded in a given time frame (between from_date and to_date, both inclusive).
-    StructField('listens_count', IntegerType(), nullable=False),
-    StructField('model_created', TimestampType(), nullable=True), # Timestamp when the model is saved in HDFS.
-    StructField('model_deleted', TimestampType(), nullable=True), # Timestamp when the model is deleted from HDFS.
+    StructField('dataframe_id', StringType(), nullable=False), # dataframe id or identification string of dataframe.
+    StructField('model_created', TimestampType(), nullable=False), # Timestamp when the model is saved in HDFS.
+    StructField('model_param', model_param_schema, nullable=False), # Parameters used to train the model.
     StructField('model_id', StringType(), nullable=False), # Model id or identification string of best model.
-    StructField('model_param', model_param_schema, nullable=True), # Parameters used to train the model.
-    StructField('playcounts_count', IntegerType(), nullable=False), # Summation of training data, validation data and test data.
-    StructField('recordings_count', IntegerType(), nullable=False), # Number of distinct recordings heard in a given time frame.
-    StructField('test_data_count', IntegerType(), nullable=True), # Number of listens used to test the model.
-    StructField('test_rmse', FloatType(), nullable=True), # Root mean squared error for test data.
-    # Timestamp till when listens have been used to train, validate and test the model.
-    StructField('to_date', TimestampType(), nullable=False),
-    StructField('training_data_count', IntegerType(), nullable=True), # Number of listens used to train the model.
-    StructField('updated', BooleanType(), nullable=False), # false by default, set to true when all other fields are non empty.
-    StructField('users_count', IntegerType(), nullable=False), # Number of users active in a given time frame.
-    StructField('validation_data_count', IntegerType(), nullable=True), # Number of listens used to validate the model.
-    StructField('validation_rmse', FloatType(), nullable=True), # Root mean squared error for validation data.
+    StructField('test_data_count', IntegerType(), nullable=False), # Number of listens used to test the model.
+    StructField('test_rmse', FloatType(), nullable=False), # Root mean squared error for test data.
+    StructField('training_data_count', IntegerType(), nullable=False), # Number of listens used to train the model.
+    StructField('validation_data_count', IntegerType(), nullable=False), # Number of listens used to validate the model.
+    StructField('validation_rmse', FloatType(), nullable=False), # Root mean squared error for validation data.
 ]
+
 
 msid_mbid_mapping_schema = [
     StructField('mb_artist_credit_id', IntegerType(), nullable=False),
@@ -69,13 +60,15 @@ msid_mbid_mapping_schema = [
     StructField('msb_release_name_matchable', StringType(), nullable=False),
 ]
 
-artist_relation_schema =[
+
+artist_relation_schema = [
     StructField('id_0', IntegerType(), nullable=False), # artist credit
     StructField('name_1', StringType(), nullable=False), # artist name
     StructField('name_0', StringType(), nullable=False),
     StructField('id_1', IntegerType(), nullable=False),
     StructField('score', FloatType(), nullable=False),
 ]
+
 
 dataframe_metadata_schema = [
     StructField('dataframe_created', TimestampType(), nullable=False), # Timestamp when dataframes are created and saved in HDFS.
@@ -91,6 +84,7 @@ dataframe_metadata_schema = [
     StructField('users_count', IntegerType(), nullable=False), # Number of users active in a given time frame.
 ]
 
+
 # The field names of the schema need to be sorted, otherwise we get weird
 # errors due to type mismatches when creating DataFrames using the schema
 # Although, we try to keep it sorted in the actual definition itself, we
@@ -100,6 +94,7 @@ model_metadata_schema = StructType(sorted(model_metadata_schema, key=lambda fiel
 msid_mbid_mapping_schema = StructType(sorted(msid_mbid_mapping_schema, key=lambda field: field.name))
 artist_relation_schema = StructType(sorted(artist_relation_schema, key=lambda field: field.name))
 dataframe_metadata_schema = StructType(sorted(dataframe_metadata_schema, key=lambda field: field.name))
+
 
 def convert_listen_to_row(listen):
     """ Convert a listen to a pyspark.sql.Row object.
@@ -126,6 +121,7 @@ def convert_listen_to_row(listen):
         tags=meta['additional_info'].get('tags', []),
     )
 
+
 def convert_model_metadata_to_row(meta):
     """ Convert model metadata to row object.
 
@@ -136,29 +132,22 @@ def convert_model_metadata_to_row(meta):
         pyspark.sql.Row object - A Spark SQL row.
     """
     return Row(
-        dataframe_created=datetime.utcnow(),
-        from_date=meta.get('from_date'),
-        listens_count=meta.get('listens_count'),
-        model_created=meta.get('model_created'),
-        model_deleted=meta.get('model_deleted'),
+        dataframe_id=meta.get('dataframe_id'),
+        model_created=datetime.utcnow(),
         model_id=meta.get('model_id'),
         model_param=Row(
             alpha=meta.get('alpha'),
             lmbda=meta.get('lmbda'),
-            num_iterations=meta.get('num_iterations'),
+            iteration=meta.get('iteration'),
             rank=meta.get('rank'),
         ),
-        playcounts_count=meta.get('playcounts_count'),
-        recordings_count=meta.get('recordings_count'),
         test_data_count=meta.get('test_data_count'),
         test_rmse=meta.get('test_rmse'),
-        to_date=meta.get('to_date'),
         training_data_count=meta.get('training_data_count'),
-        updated=meta.get('updated'),
-        users_count=meta.get('users_count'),
         validation_data_count=meta.get('validation_data_count'),
         validation_rmse=meta.get('validation_rmse'),
     )
+
 
 def convert_to_spark_json(listen):
     meta = listen
@@ -176,6 +165,7 @@ def convert_to_spark_json(listen):
         recording_mbid=meta.get('recording_mbid', ''),
         tags=meta.get('tags', []),
     )
+
 
 def convert_mapping_to_row(mapping):
     """ Convert model metadata to row object.

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -77,6 +77,20 @@ artist_relation_schema =[
     StructField('score', FloatType(), nullable=False),
 ]
 
+dataframe_metadata_schema = [
+    StructField('dataframe_created', TimestampType(), nullable=False), # Timestamp when dataframes are created and saved in HDFS.
+    StructField('dataframe_id', StringType(), nullable=False), # dataframe id or identification string of dataframe.
+    # Timestamp from when listens have been used to train, validate and test the model.
+    StructField('from_date', TimestampType(), nullable=False),
+    # Number of listens recorded in a given time frame (between from_date and to_date, both inclusive).
+    StructField('listens_count', IntegerType(), nullable=False),
+    StructField('playcounts_count', IntegerType(), nullable=False), # Summation of training data, validation data and test data.
+    StructField('recordings_count', IntegerType(), nullable=False), # Number of distinct recordings heard in a given time frame.
+    # Timestamp till when listens have been used to train, validate and test the model.
+    StructField('to_date', TimestampType(), nullable=False),
+    StructField('users_count', IntegerType(), nullable=False), # Number of users active in a given time frame.
+]
+
 # The field names of the schema need to be sorted, otherwise we get weird
 # errors due to type mismatches when creating DataFrames using the schema
 # Although, we try to keep it sorted in the actual definition itself, we
@@ -85,6 +99,7 @@ listen_schema = StructType(sorted(listen_schema, key=lambda field: field.name))
 model_metadata_schema = StructType(sorted(model_metadata_schema, key=lambda field: field.name))
 msid_mbid_mapping_schema = StructType(sorted(msid_mbid_mapping_schema, key=lambda field: field.name))
 artist_relation_schema = StructType(sorted(artist_relation_schema, key=lambda field: field.name))
+dataframe_metadata_schema = StructType(sorted(dataframe_metadata_schema, key=lambda field: field.name))
 
 def convert_listen_to_row(listen):
     """ Convert a listen to a pyspark.sql.Row object.
@@ -185,4 +200,25 @@ def convert_mapping_to_row(mapping):
         msb_recording_name_matchable=mapping.get('msb_recording_name_matchable'),
         msb_release_name=mapping.get('msb_release_name'),
         msb_release_name_matchable=mapping.get('msb_release_name_matchable'),
+    )
+
+
+def convert_dataframe_metadata_to_row(meta):
+    """ Convert dataframe metadata to a pyspark.sql.Row object.
+
+        Args:
+            meta (dict): a single dictionary representing model metadata.
+
+        Returns:
+            pyspark.sql.Row object - a Spark SQL Row based on the defined dataframe metadata schema.
+    """
+    return Row(
+        dataframe_created=datetime.utcnow(),
+        dataframe_id=meta.get('dataframe_id'),
+        from_date=meta.get('from_date'),
+        listens_count=meta.get('listens_count'),
+        playcounts_count=meta.get('playcounts_count'),
+        recordings_count=meta.get('recordings_count'),
+        to_date=meta.get('to_date'),
+        users_count=meta.get('users_count'),
     )

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -167,3 +167,16 @@ class SparkTestCase(unittest.TestCase):
                 file_name: the name of the data file
         """
         return os.path.join(TEST_DATA_PATH, file_name)
+
+    @classmethod
+    def get_dataframe_metadata(cls, df_id):
+        metadata = {
+            'dataframe_id': df_id,
+            'from_date': datetime.utcnow(),
+            'listens_count': 100,
+            'playcounts_count': 100,
+            'recordings_count': 100,
+            'to_date': datetime.utcnow(),
+            'users_count': 100,
+        }
+        return metadata

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -180,3 +180,20 @@ class SparkTestCase(unittest.TestCase):
             'users_count': 100,
         }
         return metadata
+
+    @classmethod
+    def get_model_metadata(cls, model_id):
+        metadata = {
+            'dataframe_id': 'xxxxx',
+            'model_id': model_id,
+            'alpha': 3.0,
+            'lmbda': 2.0,
+            'iteration': 2,
+            'rank': 4,
+            'test_data_count': 3,
+            'test_rmse': 2.0,
+            'training_data_count': 4,
+            'validation_data_count': 3,
+            'validation_rmse': 2.0,
+        }
+        return metadata

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -18,11 +18,6 @@ PLAYCOUNTS_COUNT = 100
 
 class SparkTestCase(unittest.TestCase):
 
-    ranks = [8]
-    lambdas = [0.1]
-    iterations = [5]
-    alpha = 3.0
-
     @classmethod
     def setUpClass(cls):
         listenbrainz_spark.init_test_session('spark-test-run-{}'.format(str(uuid.uuid4())))


### PR DESCRIPTION
# Problem
- dataframe metadata is not being saved
- model metdata is not being saved
- using [a json file ](https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz_spark/recommendations/recommendation-metadata.json) to track model id of model saved in HDFS.

# Solution

- save dataframe metadata
- save model metadata
- track model id from metadata parquets instead of using a json file.

# Action

dataframe metadata schema
- dataframe_created
- dataframe_id
- from_date
- listens_count
- playcounts_count
- recordings_count 
- to_date
- users_count

model metadata will always store the most recently created dataframe id because this dataframe will be used to train the model

model metdata schema
- dataframe_id
- model_created
- model_id  
- alpha
- lmbda
- iteration
- rank
- test_data_count
- test_rmse
- training_data_count
 - validation_data_count
 - validation_rmse

recommend.py will use the most recently saved model id to load the model.
For now, at any point in time, only one model will be saved in HDFS and the previous model will be deleted. 