### PR TITLE
LB-603: Fix spark crash on calculation of all_time release stats

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -91,7 +91,8 @@ def send_request_to_spark_cluster(message):
 @click.option("--month", is_flag=True, help="Request monthly statistics")
 @click.option("--year", is_flag=True, help="Request yearly statistics")
 @click.option("--all-time", is_flag=True, help="Request all time statistics")
-def request_user_stats(week, month, year, all_time):
+@click.option("--all-time-release", is_flag=True, help="Request all time release statistics")
+def request_user_stats(week, month, year, all_time, all_time_release):
     """ Send a user stats request to the spark cluster
     """
     if week:
@@ -111,8 +112,11 @@ def request_user_stats(week, month, year, all_time):
 
     if all_time:
         send_request_to_spark_cluster(_prepare_query_message('stats.user.entity.all_time', params={'entity': 'artists'}))
-        # not calculating release stats because the spark cluster can't handle getting listen counts for ALL releases
-        # for all users
+        send_request_to_spark_cluster(_prepare_query_message('stats.user.entity.all_time', params={'entity': 'releases'}))
+        return
+
+    if all_time_release:
+        send_request_to_spark_cluster(_prepare_query_message('stats.user.entity.all_time', params={'entity': 'releases'}))
         return
 
     # Default if no specific flag is provided

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -27,6 +27,8 @@ response_handler_map = {
     'cf_recording_recommendations': handle_recommendations,
 }
 
+RABBITMQ_HEARTBEAT_TIME = 60 * 60 # 1 hour, in seconds
+
 
 class SparkReader:
     def __init__(self):
@@ -48,6 +50,7 @@ class SparkReader:
             port=current_app.config['RABBITMQ_PORT'],
             virtual_host=current_app.config['RABBITMQ_VHOST'],
             error_logger=current_app.logger.error,
+            heartbeat=RABBITMQ_HEARTBEAT_TIME,
         )
 
     def process_response(self, response):

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -80,12 +80,6 @@ class SparkReader:
         current_app.logger.debug("Received a message, processing...")
         response = ujson.loads(body)
         self.process_response(response)
-        while True:
-            try:
-                self.incoming_ch.basic_ack(delivery_tag=method.delivery_tag)
-                break
-            except pika.exceptions.ConnectionClosed:
-                self.init_rabbitmq_connection()
         current_app.logger.debug("Done!")
 
     def start(self):
@@ -101,6 +95,7 @@ class SparkReader:
                     exchange=current_app.config['SPARK_RESULT_EXCHANGE'],
                     queue=current_app.config['SPARK_RESULT_QUEUE'],
                     callback_function=self.callback,
+                    no_ack=True,
                 )
                 self.incoming_ch.basic_qos(prefetch_count=1)
                 current_app.logger.info('Spark consumer started!')

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -102,6 +102,7 @@ class SparkReader:
                     queue=current_app.config['SPARK_RESULT_QUEUE'],
                     callback_function=self.callback,
                 )
+                self.incoming_ch.basic_qos(prefetch_count=1)
                 current_app.logger.info('Spark consumer started!')
                 try:
                     self.incoming_ch.start_consuming()

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -132,7 +132,7 @@ def init_cache(host, port, namespace):
     cache.init(host=host, port=port, namespace=namespace)
 
 
-def create_channel_to_consume(connection, exchange, queue, callback_function):
+def create_channel_to_consume(connection, exchange, queue, callback_function, no_ack=False):
     """ Returns a newly created channel that can consume from the specified queue.
 
     Args:
@@ -148,7 +148,7 @@ def create_channel_to_consume(connection, exchange, queue, callback_function):
     ch.exchange_declare(exchange=exchange, exchange_type='fanout')
     ch.queue_declare(queue, durable=True)
     ch.queue_bind(exchange=exchange, queue=queue)
-    ch.basic_consume(callback_function, queue=queue, no_ack=False)
+    ch.basic_consume(callback_function, queue=queue, no_ack=no_ack)
     return ch
 
 

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -95,7 +95,8 @@ def connect_to_rabbitmq(username, password,
                         connection_type=pika.BlockingConnection,
                         credentials_type=pika.PlainCredentials,
                         error_logger=print,
-                        error_retry_delay=3):
+                        error_retry_delay=3,
+                        heartbeat=None):
     """Connects to RabbitMQ
 
     Args:
@@ -116,6 +117,7 @@ def connect_to_rabbitmq(username, password,
                 port=port,
                 virtual_host=virtual_host,
                 credentials=credentials,
+                heartbeat=heartbeat,
             )
             return connection_type(connection_parameters)
         except Exception as err:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -237,7 +237,7 @@ def _process_entity(user_name, stats, stats_range, offset, count, entity):
     count = min(count, MAX_ITEMS_PER_GET)
     try:
         total_entity_count = stats[entity][stats_range]['count']
-    except KeyError:
+    except (TypeError, KeyError):
         raise APINoContent('')
 
     count = count + offset

--- a/listenbrainz_spark/stats/user/all.py
+++ b/listenbrainz_spark/stats/user/all.py
@@ -1,19 +1,21 @@
+import itertools
+
 import listenbrainz_spark.stats.user.entity as user_entity
 
 
 def calculate():
-    messages = []
+    messages = itertools.chain()
 
     # Calculate artist stats
-    messages = messages + user_entity.get_entity_week('artists')
-    messages = messages + user_entity.get_entity_month('artists')
-    messages = messages + user_entity.get_entity_year('artists')
-    messages = messages + user_entity.get_entity_all_time('artists')
+    messages = itertools.chain(messages, user_entity.get_entity_week('artists'))
+    messages = itertools.chain(messages, user_entity.get_entity_month('artists'))
+    messages = itertools.chain(messages, user_entity.get_entity_year('artists'))
+    messages = itertools.chain(messages, user_entity.get_entity_all_time('artists'))
 
     # Calculate release stats
-    messages = messages + user_entity.get_entity_week('releases')
-    messages = messages + user_entity.get_entity_month('releases')
-    messages = messages + user_entity.get_entity_year('releases')
-    messages = messages + user_entity.get_entity_all_time('releases')
+    messages = itertools.chain(messages, user_entity.get_entity_week('releases'))
+    messages = itertools.chain(messages, user_entity.get_entity_month('releases'))
+    messages = itertools.chain(messages, user_entity.get_entity_year('releases'))
+    messages = itertools.chain(messages, user_entity.get_entity_all_time('releases'))
 
     return messages

--- a/listenbrainz_spark/stats/user/artist.py
+++ b/listenbrainz_spark/stats/user/artist.py
@@ -33,7 +33,6 @@ def get_artists(table):
                  , artist_name
                  , artist_msid
                  , artist_mbids
-          ORDER BY listen_count DESC
             """.format(table=table))
 
     iterator = result \

--- a/listenbrainz_spark/stats/user/release.py
+++ b/listenbrainz_spark/stats/user/release.py
@@ -43,7 +43,6 @@ def get_releases(table):
                  , artist_name
                  , artist_msid
                  , artist_mbids
-          ORDER BY listen_count DESC
         """.format(table))
 
     iterator = result \

--- a/listenbrainz_spark/stats/user/release.py
+++ b/listenbrainz_spark/stats/user/release.py
@@ -1,7 +1,5 @@
-import time
-from collections import defaultdict
-
 from listenbrainz_spark.stats import run_query
+from pyspark.sql.functions import collect_list, sort_array, struct
 
 
 def get_releases(table):
@@ -14,7 +12,7 @@ def get_releases(table):
         table: name of the temporary table
 
     Returns:
-        releases: A dict of dicts which can be depicted as:
+        iterator (iter): an iterator over result
                 {
                     'user1' : [{
                         'release_name': str
@@ -28,8 +26,7 @@ def get_releases(table):
                     'user2' : [{...}],
                 }
     """
-    t0 = time.time()
-    query = run_query("""
+    result = run_query("""
             SELECT user_name
                  , release_name
                  , release_msid
@@ -37,8 +34,8 @@ def get_releases(table):
                  , artist_name
                  , artist_msid
                  , artist_mbids
-                 , count(release_msid) as cnt
-              FROM %s
+                 , count(release_msid) as listen_count
+              FROM {}
           GROUP BY user_name
                  , release_name
                  , release_msid
@@ -46,19 +43,14 @@ def get_releases(table):
                  , artist_name
                  , artist_msid
                  , artist_mbids
-          ORDER BY cnt DESC
-        """ % (table))
-    rows = query.collect()
-    releases = defaultdict(list)
-    for row in rows:
-        releases[row['user_name']].append({
-            'release_name': row['release_name'],
-            'release_msid': row['release_msid'],
-            'release_mbid': row['release_mbid'],
-            'artist_name': row['artist_name'],
-            'artist_msid': row['artist_msid'],
-            'artist_mbids': row['artist_mbids'],
-            'listen_count': row['cnt'],
-        })
-    print("Query to calculate release stats processed in %.2f s" % (time.time() - t0))
-    return releases
+          ORDER BY listen_count DESC
+        """.format(table))
+
+    iterator = result \
+        .withColumn("releases", struct("listen_count", "release_name", "release_msid", "release_mbid", "artist_name",
+                                       "artist_msid", "artist_mbids")) \
+        .groupBy("user_name") \
+        .agg(sort_array(collect_list("releases"), asc=False).alias("releases")) \
+        .toLocalIterator()
+
+    return iterator

--- a/listenbrainz_spark/stats/user/tests/test_artist.py
+++ b/listenbrainz_spark/stats/user/tests/test_artist.py
@@ -57,7 +57,10 @@ class ArtistTestCase(SparkTestCase):
         for user_name, user_artists in expected.items():
             user_artists.sort(key=lambda artist: artist['listen_count'], reverse=True)
 
-        received = artist_stats.get_artists('test_view')
+        data = artist_stats.get_artists('test_view')
+        received = defaultdict(list)
+        for entry in data:
+            _dict = entry.asDict(recursive=True)
+            received[_dict['user_name']] = _dict['artists']
 
         self.assertDictEqual(received, expected)
-

--- a/listenbrainz_spark/stats/user/tests/test_release.py
+++ b/listenbrainz_spark/stats/user/tests/test_release.py
@@ -62,6 +62,10 @@ class releaseTestCase(SparkTestCase):
         for user_name, user_releases in expected.items():
             user_releases.sort(key=lambda release: release['listen_count'], reverse=True)
 
-        received = release_stats.get_releases('test_view')
+        data = release_stats.get_releases('test_view')
+        received = defaultdict(list)
+        for entry in data:
+            _dict = entry.asDict(recursive=True)
+            received[_dict['user_name']] = _dict['releases']
 
         self.assertDictEqual(received, expected)

--- a/listenbrainz_spark/stats/user/utils.py
+++ b/listenbrainz_spark/stats/user/utils.py
@@ -61,20 +61,18 @@ def create_messages(data, entity, stats_type, stats_range, from_ts, to_ts):
     Returns:
         messages (list): A list of messages to be sent via RabbitMQ
     """
-    messages = []
-    for user_name, user_releases in data.items():
-        messages.append({
-            'musicbrainz_id': user_name,
+    for entry in data:
+        _dict = entry.asDict(recursive=True)
+        yield {
+            'musicbrainz_id': _dict['user_name'],
             'type': stats_type,
             'range': stats_range,
             'from_ts': from_ts,
             'to_ts': to_ts,
-            'data': user_releases,
+            'data': _dict[entity],
             'entity': entity,
-            'count': len(user_releases)
-        })
-
-    return messages
+            'count': len(_dict[entity])
+        }
 
 
 def get_recordings(table):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
The spark cluster crashes when calculating all_time release stats because of memory issues.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
The `collect` command collects all the data and dumps it into the driver, hence running out of memory. We should use `toLocalIterator` to iterate over the instead of collecting it at once.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
We should test if the updated code works correctly without crashing on production. The flag `--all-time-release` can be used to trigger all_time release stats calculation only.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


