### PR TITLE
LB-611: The week date shown on the page ends up on a Tuesday

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
@@ -377,16 +377,22 @@ export default class UserHistory extends React.Component<
                 </ul>
               </span>
               {range === "week"
-                ? `of ${startDate.getDate()} ${startDate.toLocaleString(
+                ? `of ${startDate.getUTCDate()} ${startDate.toLocaleString(
                     "en-us",
-                    { month: "long" }
+                    { month: "long", timeZone: "UTC" }
                   )} `
                 : ""}
               {range === "month"
-                ? `${startDate.toLocaleString("en-us", { month: "long" })} `
+                ? `${startDate.toLocaleString("en-us", {
+                    month: "long",
+                    timeZone: "UTC",
+                  })} `
                 : ""}
               {range !== "all_time"
-                ? startDate.toLocaleString("en-us", { year: "numeric" })
+                ? startDate.toLocaleString("en-us", {
+                    year: "numeric",
+                    timeZone: "UTC",
+                  })
                 : ""}
             </h3>
           </div>


### PR DESCRIPTION
# Problem
The week date show on page ends up on  Tuesday for users having non UTC timezone.

# Solution
Specifying the timezone to be UTC fixes the issue.
