### PR TITLE
LB-619: Improve page navigation on History page

### DIFF
--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -276,6 +276,13 @@ Also, run the **integration tests** for ListenBrainz.
 When the tests complete, you will see if your changes are valid or not. These tests
 are a helpful way to validate new changes without a lot of work.
 
+.. note::
+
+    If you are working on frontend for statistics and don't wan't to go through the
+    process of generating the statistics locally, you can change the `API_URL` in config
+    to `api.listenbrainz.org`_ so that the statistics are fetched from the production server.
+
+.. _api.listenbrainz.org: https://api.listenbrainz.org
 
 Lint your code
 --------------

--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -276,14 +276,6 @@ Also, run the **integration tests** for ListenBrainz.
 When the tests complete, you will see if your changes are valid or not. These tests
 are a helpful way to validate new changes without a lot of work.
 
-.. note::
-
-    If you are working on frontend for statistics and don't wan't to go through the
-    process of generating the statistics locally, you can change the `API_URL` in config
-    to `api.listenbrainz.org`_ so that the statistics are fetched from the production server.
-
-.. _api.listenbrainz.org: https://api.listenbrainz.org
-
 Lint your code
 --------------
 

--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -276,6 +276,7 @@ Also, run the **integration tests** for ListenBrainz.
 When the tests complete, you will see if your changes are valid or not. These tests
 are a helpful way to validate new changes without a lot of work.
 
+
 Lint your code
 --------------
 

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -123,7 +123,9 @@ MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB
 # The path must be absolute path
 UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 
-
+# Set to "https://api.listenbrainz.org" if you want to work on frontend for user statistics
+# without going through the process of generating the stats in local environment. Otherwise,
+# set it to "http://localhost"
 API_URL = 'https://api.listenbrainz.org'
 LASTFM_PROXY_URL = 'http://localhost:8080/'
 SERVER_ROOT_URL = 'http://localhost'

--- a/listenbrainz/webserver/static/js/src/Loader.test.tsx
+++ b/listenbrainz/webserver/static/js/src/Loader.test.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { mount } from "enzyme";
+
+import Loader from "./Loader";
+
+const ChildComponent = () => {
+  return <div>Child Component</div>;
+};
+
+describe("Loader", () => {
+  it('renders loader when "isLoading" is true', () => {
+    const wrapper = mount(
+      <Loader isLoading>
+        <ChildComponent />
+      </Loader>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders child component when "isLoading" is false', () => {
+    const wrapper = mount(
+      <Loader isLoading>
+        <ChildComponent />
+      </Loader>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/listenbrainz/webserver/static/js/src/Loader.tsx
+++ b/listenbrainz/webserver/static/js/src/Loader.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable react/prefer-stateless-function */
+import * as React from "react";
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
+
+type withLoaderProps = {
+  isLoading: boolean;
+};
+
+const withLoader = <P extends object>(Component: React.ComponentType<P>) => {
+  return class WithLoader extends React.Component<P & withLoaderProps> {
+    render() {
+      const { isLoading, ...props } = this.props;
+      // TODO: Replace with Bootstrap 4 spinner when we upgrade
+      return isLoading ? (
+        <FontAwesomeIcon icon={faSpinner as IconProp} size="4x" spin />
+      ) : (
+        <Component {...(props as P)} />
+      );
+    }
+  };
+};
+
+export default withLoader;

--- a/listenbrainz/webserver/static/js/src/Loader.tsx
+++ b/listenbrainz/webserver/static/js/src/Loader.tsx
@@ -1,25 +1,20 @@
-/* eslint-disable react/prefer-stateless-function */
 import * as React from "react";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 
-type withLoaderProps = {
+type LoaderProps = {
   isLoading: boolean;
 };
 
-const withLoader = <P extends object>(Component: React.ComponentType<P>) => {
-  return class WithLoader extends React.Component<P & withLoaderProps> {
-    render() {
-      const { isLoading, ...props } = this.props;
-      // TODO: Replace with Bootstrap 4 spinner when we upgrade
-      return isLoading ? (
-        <FontAwesomeIcon icon={faSpinner as IconProp} size="4x" spin />
-      ) : (
-        <Component {...(props as P)} />
-      );
-    }
-  };
+const Loader: React.SFC<LoaderProps> = (props) => {
+  // eslint-disable-next-line react/prop-types
+  const { isLoading, children } = props;
+  return isLoading ? (
+    <FontAwesomeIcon icon={faSpinner as IconProp} size="4x" spin />
+  ) : (
+    <>{children}</>
+  );
 };
 
-export default withLoader;
+export default Loader;

--- a/listenbrainz/webserver/static/js/src/__snapshots__/Loader.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/__snapshots__/Loader.test.tsx.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Loader renders child component when "isLoading" is false 1`] = `
+<Loader
+  isLoading={true}
+>
+  <FontAwesomeIcon
+    border={false}
+    className=""
+    fixedWidth={false}
+    flip={null}
+    icon={
+      Object {
+        "icon": Array [
+          512,
+          512,
+          Array [],
+          "f110",
+          "M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z",
+        ],
+        "iconName": "spinner",
+        "prefix": "fas",
+      }
+    }
+    inverse={false}
+    listItem={false}
+    mask={null}
+    pull={null}
+    pulse={false}
+    rotation={null}
+    size="4x"
+    spin={true}
+    swapOpacity={false}
+    symbol={false}
+    title=""
+    transform={null}
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-spinner fa-w-16 fa-spin fa-4x "
+      data-icon="spinner"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </FontAwesomeIcon>
+</Loader>
+`;
+
+exports[`Loader renders loader when "isLoading" is true 1`] = `
+<Loader
+  isLoading={true}
+>
+  <FontAwesomeIcon
+    border={false}
+    className=""
+    fixedWidth={false}
+    flip={null}
+    icon={
+      Object {
+        "icon": Array [
+          512,
+          512,
+          Array [],
+          "f110",
+          "M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z",
+        ],
+        "iconName": "spinner",
+        "prefix": "fas",
+      }
+    }
+    inverse={false}
+    listItem={false}
+    mask={null}
+    pull={null}
+    pulse={false}
+    rotation={null}
+    size="4x"
+    spin={true}
+    swapOpacity={false}
+    symbol={false}
+    title=""
+    transform={null}
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-spinner fa-w-16 fa-spin fa-4x "
+      data-icon="spinner"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </FontAwesomeIcon>
+</Loader>
+`;

--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.test.tsx
@@ -100,37 +100,26 @@ describe("componentWillUnmount", () => {
 });
 
 describe("changePage", () => {
-  it("sets state correctly", async () => {
+  it("calls setURLParams with correct parameters", () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
-    instance.getData = jest
-      .fn()
-      .mockImplementationOnce(() => Promise.resolve(userArtistsResponse));
-    instance.processData = jest
-      .fn()
-      .mockImplementationOnce(() => userArtistsProcessDataOutput);
     instance.setURLParams = jest.fn();
-    await instance.changePage(2);
-
-    expect(wrapper.state("data")).toBe(userArtistsProcessDataOutput);
-    expect(wrapper.state("currPage")).toBe(2);
-  });
-
-  it("calls setURLParams with correct parameters", async () => {
-    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest
-      .fn()
-      .mockImplementationOnce(() => Promise.resolve(userArtistsResponse));
-    instance.processData = jest
-      .fn()
-      .mockImplementationOnce(() => userArtistsProcessDataOutput);
-    instance.setURLParams = jest.fn();
-    await instance.changePage(2);
+    instance.syncStateWithURL = jest.fn();
+    instance.changePage(2);
 
     expect(instance.setURLParams).toHaveBeenCalledWith(2, "", "");
+  });
+
+  it("calls syncStateWithURL once", () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.setURLParams = jest.fn();
+    instance.syncStateWithURL = jest.fn();
+    instance.changeRange("week");
+
+    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.test.tsx
@@ -33,54 +33,207 @@ describe("UserHistory Page", () => {
 });
 
 describe("componentDidMount", () => {
-  it("extracts range from the URL if present", async () => {
+  it('adds event listener for "popstate" event', () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
-    delete window.location;
-    window.location = {
-      href: "https://foobar/user/bazfoo/artists?range=week",
-    } as Window["location"];
+    const spy = jest.spyOn(window, "addEventListener");
+    spy.mockImplementationOnce(() => {});
+    instance.syncStateWithURL = jest.fn();
+    instance.componentDidMount();
 
-    instance.changeRange = jest.fn();
-    await instance.componentDidMount();
-
-    expect(instance.changeRange).toHaveBeenCalledWith("week");
+    expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
   });
 
-  it("extracts page from the URL if present", async () => {
+  it("calls getURLParams once", () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
-    delete window.location;
-    window.location = {
-      href: "https://foobar/user/bazfoo/artists?page=3",
-    } as Window["location"];
-    instance.changeRange = jest.fn();
-    instance.changePage = jest.fn();
-    await instance.componentDidMount();
+    instance.getURLParams = jest.fn().mockImplementationOnce(() => {
+      return { page: 1, range: "all_time", entity: "artist" };
+    });
+    instance.syncStateWithURL = jest.fn();
+    instance.componentDidMount();
 
-    expect(instance.changePage).toHaveBeenCalledWith(3);
+    expect(instance.getURLParams).toHaveBeenCalledTimes(1);
   });
 
-  it("extracts entity from the URL if present", async () => {
+  it("calls replaceState with correct parameters", () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
-    delete window.location;
-    window.location = {
-      href: "https://foobar/user/bazfoo/artists?entity=release",
-    } as Window["location"];
-    instance.changeRange = jest.fn();
-    instance.changePage = jest.fn();
-    await instance.componentDidMount();
+    const spy = jest.spyOn(window.history, "replaceState");
+    spy.mockImplementationOnce(() => {});
+    instance.syncStateWithURL = jest.fn();
+    instance.componentDidMount();
 
-    expect(wrapper.state("entity")).toEqual("release");
+    expect(spy).toHaveBeenCalledWith(
+      null,
+      "",
+      "?page=1&range=all_time&entity=artist"
+    );
+  });
+
+  it("calls syncStateWithURL", () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.syncStateWithURL = jest.fn();
+    instance.componentDidMount();
+
+    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("componentWillUnmount", () => {
+  it('removes "popstate" event listener', () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    const spy = jest.spyOn(window, "removeEventListener");
+    spy.mockImplementationOnce(() => {});
+    instance.syncStateWithURL = jest.fn();
+    instance.componentWillUnmount();
+
+    expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
+  });
+});
+
+describe("changePage", () => {
+  it("sets state correctly", async () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.getData = jest
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve(userArtistsResponse));
+    instance.processData = jest
+      .fn()
+      .mockImplementationOnce(() => userArtistsProcessDataOutput);
+    instance.setURLParams = jest.fn();
+    await instance.changePage(2);
+
+    expect(wrapper.state("data")).toBe(userArtistsProcessDataOutput);
+    expect(wrapper.state("currPage")).toBe(2);
+  });
+
+  it("calls setURLParams with correct parameters", async () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.getData = jest
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve(userArtistsResponse));
+    instance.processData = jest
+      .fn()
+      .mockImplementationOnce(() => userArtistsProcessDataOutput);
+    instance.setURLParams = jest.fn();
+    await instance.changePage(2);
+
+    expect(instance.setURLParams).toHaveBeenCalledWith(2, "", "");
+  });
+});
+
+describe("changeRange", () => {
+  it("calls setURLParams with correct parameters", () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.setURLParams = jest.fn();
+    instance.syncStateWithURL = jest.fn();
+    instance.changeRange("week");
+
+    expect(instance.setURLParams).toHaveBeenCalledWith(1, "week", "");
+  });
+
+  it("calls syncStateWithURL once", () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.setURLParams = jest.fn();
+    instance.syncStateWithURL = jest.fn();
+    instance.changeRange("week");
+
+    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("changeEntity", () => {
+  it("calls setURLParams with correct parameters", () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.setURLParams = jest.fn();
+    instance.syncStateWithURL = jest.fn();
+    instance.changeEntity("release");
+
+    expect(instance.setURLParams).toHaveBeenCalledWith(1, "", "release");
+  });
+
+  it("calls syncStateWithURL once", () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    instance.setURLParams = jest.fn();
+    instance.syncStateWithURL = jest.fn();
+    instance.changeEntity("release");
+
+    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getInitData", () => {
+  it("gets data correctly for artist", async () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    const spy = jest.spyOn(instance.APIService, "getUserEntity");
+    spy.mockImplementation((): any => {
+      return Promise.resolve(userArtistsResponse);
+    });
+
+    const {
+      maxListens,
+      totalPages,
+      entityCount,
+      startDate,
+    } = await instance.getInitData("all_time", "artist");
+
+    expect(maxListens).toEqual(385);
+    expect(totalPages).toEqual(7);
+    expect(entityCount).toEqual(175);
+    expect(startDate).toEqual(
+      new Date(userArtistsResponse.payload.from_ts * 1000)
+    );
+  });
+
+  it("gets data correctly for release", async () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
+    const spy = jest.spyOn(instance.APIService, "getUserEntity");
+    spy.mockImplementation((): any => {
+      return Promise.resolve(userReleasesResponse);
+    });
+
+    const {
+      maxListens,
+      totalPages,
+      entityCount,
+      startDate,
+    } = await instance.getInitData("all_time", "release");
+
+    expect(maxListens).toEqual(26);
+    expect(totalPages).toEqual(7);
+    expect(entityCount).toEqual(165);
+    expect(startDate).toEqual(
+      new Date(userReleasesResponse.payload.from_ts * 1000)
+    );
   });
 });
 
 describe("getData", () => {
-  it("calls getUserHistory with correct parameters", async () => {
+  it("calls getUserEntity with correct parameters", async () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
@@ -124,231 +277,97 @@ describe("processData", () => {
   });
 });
 
-describe("changePage", () => {
+describe("syncStateWithURL", () => {
   it("sets state correctly", async () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userArtistsResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userArtistsProcessDataOutput;
-    });
-    await instance.changePage(2);
+    instance.getURLParams = jest.fn().mockImplementationOnce(() => ({
+      page: 1,
+      range: "all_time",
+      entity: "artist",
+    }));
+    instance.getInitData = jest.fn().mockImplementationOnce(() =>
+      Promise.resolve({
+        startDate: new Date(0),
+        totalPages: 2,
+        maxListens: 100,
+        entityCount: 50,
+      })
+    );
+    instance.getData = jest
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve(userArtistsResponse));
+    instance.processData = jest
+      .fn()
+      .mockImplementationOnce(() => userArtistsProcessDataOutput);
+    await instance.syncStateWithURL();
 
-    expect(instance.processData).toHaveBeenCalledWith(userArtistsResponse, 2);
-    expect(wrapper.state("data")).toEqual(userArtistsProcessDataOutput);
-    expect(wrapper.state("currPage")).toBe(2);
+    expect(wrapper.state()).toMatchObject({
+      data: userArtistsProcessDataOutput,
+      currPage: 1,
+      range: "all_time",
+      entity: "artist",
+      startDate: new Date(0),
+      totalPages: 2,
+      maxListens: 100,
+      entityCount: 50,
+    });
   });
 
-  it("calls changeURL with correct parameters", async () => {
+  it("throws error if fetch fails", async () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userArtistsResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userArtistsProcessDataOutput;
-    });
-    instance.changeURL = jest.fn();
-    await instance.changePage(2);
+    instance.getInitData = jest
+      .fn()
+      .mockImplementationOnce(() => Promise.reject(Error("failed")));
 
-    expect(instance.changeURL).toHaveBeenCalledWith(2, "all_time", "release");
+    await expect(instance.syncStateWithURL()).rejects.toThrowError("failed");
   });
 });
 
-describe("changeRange", () => {
-  it("sets state correctly for artists", async () => {
+describe("getURLParams", () => {
+  it("gets default parameters if none are provided in the URL", () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
-    instance.getData = jest.fn().mockImplementationOnce(() => {
-      return Promise.resolve(userArtistsResponse);
-    });
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userArtistsResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userArtistsProcessDataOutput;
-    });
-    wrapper.setState({ entity: "artist" });
-    await instance.changeRange("all_time");
+    const { page, range, entity } = instance.getURLParams();
 
-    expect(instance.processData).toHaveBeenCalledWith(userArtistsResponse, 1);
-    expect(wrapper.state("data")).toEqual(userArtistsProcessDataOutput);
-    expect(wrapper.state("range")).toEqual("all_time");
-    expect(wrapper.state("currPage")).toEqual(1);
-    expect(wrapper.state("startDate")).toEqual(
-      new Date(userArtistsResponse.payload.from_ts * 1000)
-    );
-    expect(wrapper.state("totalPages")).toBe(7);
-    expect(wrapper.state("maxListens")).toBe(385);
-    expect(wrapper.state("entityCount")).toBe(175);
+    expect(page).toEqual(1);
+    expect(range).toEqual("all_time");
+    expect(entity).toEqual("artist");
   });
 
-  it("sets state correctly for releases", async () => {
-    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest.fn().mockImplementationOnce(() => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userReleasesProcessDataOutput;
-    });
-    wrapper.setState({ entity: "release" });
-    await instance.changeRange("all_time");
-
-    expect(instance.processData).toHaveBeenCalledWith(userReleasesResponse, 1);
-    expect(wrapper.state("data")).toEqual(userReleasesProcessDataOutput);
-    expect(wrapper.state("range")).toEqual("all_time");
-    expect(wrapper.state("currPage")).toEqual(1);
-    expect(wrapper.state("startDate")).toEqual(
-      new Date(userReleasesResponse.payload.from_ts * 1000)
-    );
-    expect(wrapper.state("totalPages")).toBe(7);
-    expect(wrapper.state("maxListens")).toBe(26);
-    expect(wrapper.state("entityCount")).toBe(165);
-  });
-
-  it("calls changeURL with correct parameters", async () => {
-    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest.fn().mockImplementationOnce(() => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userReleasesProcessDataOutput;
-    });
-    instance.changeURL = jest.fn();
-    wrapper.setState({ entity: "release" });
-    await instance.changeRange("all_time");
-
-    expect(instance.changeURL).toHaveBeenCalledWith(1, "all_time", "release");
-  });
-});
-
-describe("changeEntity", () => {
-  it("sets state correctly for artists", async () => {
-    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest.fn().mockImplementationOnce(() => {
-      return Promise.resolve(userArtistsResponse);
-    });
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userArtistsResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userArtistsProcessDataOutput;
-    });
-    wrapper.setState({ range: "all_time" });
-    await instance.changeEntity("artist");
-
-    expect(instance.processData).toHaveBeenCalledWith(
-      userArtistsResponse,
-      1,
-      "artist"
-    );
-    expect(wrapper.state("data")).toEqual(userArtistsProcessDataOutput);
-    expect(wrapper.state("entity")).toEqual("artist");
-    expect(wrapper.state("currPage")).toEqual(1);
-    expect(wrapper.state("startDate")).toEqual(
-      new Date(userArtistsResponse.payload.from_ts * 1000)
-    );
-    expect(wrapper.state("totalPages")).toBe(7);
-    expect(wrapper.state("maxListens")).toBe(385);
-    expect(wrapper.state("entityCount")).toBe(175);
-  });
-
-  it("sets state correctly for releases", async () => {
-    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest.fn().mockImplementationOnce(() => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userReleasesProcessDataOutput;
-    });
-    wrapper.setState({ range: "all_time" });
-    await instance.changeEntity("release");
-
-    expect(instance.processData).toHaveBeenCalledWith(
-      userReleasesResponse,
-      1,
-      "release"
-    );
-    expect(wrapper.state("data")).toEqual(userReleasesProcessDataOutput);
-    expect(wrapper.state("entity")).toEqual("release");
-    expect(wrapper.state("currPage")).toEqual(1);
-    expect(wrapper.state("startDate")).toEqual(
-      new Date(userReleasesResponse.payload.from_ts * 1000)
-    );
-    expect(wrapper.state("totalPages")).toBe(7);
-    expect(wrapper.state("maxListens")).toBe(26);
-    expect(wrapper.state("entityCount")).toBe(165);
-  });
-
-  it("calls changeURL with correct parameters", async () => {
-    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest.fn().mockImplementationOnce(() => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userReleasesResponse);
-    });
-    instance.processData = jest.fn().mockImplementationOnce(() => {
-      return userReleasesProcessDataOutput;
-    });
-    instance.changeURL = jest.fn();
-    wrapper.setState({ range: "all_time" });
-    await instance.changeEntity("release");
-
-    expect(instance.changeURL).toHaveBeenCalledWith(1, "all_time", "release");
-  });
-});
-
-describe("changeURL", () => {
-  it("changes the URL", () => {
+  it("gets parameters if provided in the URL", () => {
     const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
     const instance = wrapper.instance();
 
     delete window.location;
     window.location = {
-      origin: "https://foobar/",
-      pathname: "user/bazfoo/history",
+      href: "https://foobar.org?page=2&range=week&entity=release",
     } as Window["location"];
+    const { page, range, entity } = instance.getURLParams();
+
+    expect(page).toEqual(2);
+    expect(range).toEqual("week");
+    expect(entity).toEqual("release");
+  });
+});
+
+describe("setURLParams", () => {
+  it("sets URL parameters", () => {
+    const wrapper = shallow<UserHistory>(<UserHistory {...props} />);
+    const instance = wrapper.instance();
+
     const spy = jest.spyOn(window.history, "pushState");
     spy.mockImplementationOnce(() => {});
 
-    instance.changeURL(2, "all_time", "release");
+    instance.setURLParams(2, "all_time", "release");
     expect(spy).toHaveBeenCalledWith(
       null,
       "",
-      "https://foobar/user/bazfoo/history?page=2&range=all_time&entity=release"
+      "?page=2&range=all_time&entity=release"
     );
   });
 });

--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import * as ReactDOM from "react-dom";
 import * as React from "react";
 
@@ -70,7 +71,14 @@ export default class UserHistory extends React.Component<
     window.removeEventListener("popstate", this.syncStateWithURL);
   }
 
-  changePage = async (newPage: number): Promise<void> => {
+  changePage = async (
+    newPage: number,
+    event?: React.MouseEvent<HTMLElement>
+  ): Promise<void> => {
+    if (event) {
+      event.preventDefault();
+    }
+
     const { entity, range } = this.state;
     const data = await this.getData(newPage, range, entity);
 
@@ -81,13 +89,27 @@ export default class UserHistory extends React.Component<
     });
   };
 
-  changeRange = (newRange: UserEntityAPIRange): void => {
+  changeRange = (
+    newRange: UserEntityAPIRange,
+    event?: React.MouseEvent<HTMLElement>
+  ): void => {
+    if (event) {
+      event.preventDefault();
+    }
+
     const { entity } = this.state;
     this.setURLParams(1, newRange, entity);
     this.syncStateWithURL();
   };
 
-  changeEntity = (newEntity: Entity): void => {
+  changeEntity = (
+    newEntity: Entity,
+    event?: React.MouseEvent<HTMLElement>
+  ): void => {
+    if (event) {
+      event.preventDefault();
+    }
+
     const { range } = this.state;
     this.setURLParams(1, range, newEntity);
     this.syncStateWithURL();
@@ -298,20 +320,22 @@ export default class UserHistory extends React.Component<
                 </button>
                 <ul className="dropdown-menu" role="menu">
                   <li>
-                    <button
-                      type="button"
-                      onClick={() => this.changeEntity("artist")}
+                    <a
+                      href=""
+                      role="button"
+                      onClick={(event) => this.changeEntity("artist", event)}
                     >
                       Artists
-                    </button>
+                    </a>
                   </li>
                   <li>
-                    <button
-                      type="button"
-                      onClick={() => this.changeEntity("release")}
+                    <a
+                      href=""
+                      role="button"
+                      onClick={(event) => this.changeEntity("release", event)}
                     >
                       Releases
-                    </button>
+                    </a>
                   </li>
                 </ul>
               </span>
@@ -327,36 +351,40 @@ export default class UserHistory extends React.Component<
                 </button>
                 <ul className="dropdown-menu" role="menu">
                   <li>
-                    <button
-                      type="button"
-                      onClick={() => this.changeRange("week")}
+                    <a
+                      href=""
+                      role="button"
+                      onClick={(event) => this.changeRange("week", event)}
                     >
                       Week
-                    </button>
+                    </a>
                   </li>
                   <li>
-                    <button
-                      type="button"
-                      onClick={() => this.changeRange("month")}
+                    <a
+                      href=""
+                      role="button"
+                      onClick={(event) => this.changeRange("month", event)}
                     >
                       Month
-                    </button>
+                    </a>
                   </li>
                   <li>
-                    <button
-                      type="button"
-                      onClick={() => this.changeRange("year")}
+                    <a
+                      href=""
+                      role="button"
+                      onClick={(event) => this.changeRange("year", event)}
                     >
                       Year
-                    </button>
+                    </a>
                   </li>
                   <li>
-                    <button
-                      type="button"
-                      onClick={() => this.changeRange("all_time")}
+                    <a
+                      href=""
+                      role="button"
+                      onClick={(event) => this.changeRange("all_time", event)}
                     >
                       All Time
-                    </button>
+                    </a>
                   </li>
                 </ul>
               </span>
@@ -400,16 +428,24 @@ export default class UserHistory extends React.Component<
           <div className="col-xs-12">
             <ul className="pager">
               <li className={`previous ${!(prevPage > 0) ? "hidden" : ""}`}>
-                <button type="button" onClick={() => this.changePage(prevPage)}>
+                <a
+                  href=""
+                  role="button"
+                  onClick={(event) => this.changePage(prevPage, event)}
+                >
                   &larr; Previous
-                </button>
+                </a>
               </li>
               <li
                 className={`next ${!(nextPage <= totalPages) ? "hidden" : ""}`}
               >
-                <button type="button" onClick={() => this.changePage(nextPage)}>
+                <a
+                  href=""
+                  role="button"
+                  onClick={(event) => this.changePage(nextPage, event)}
+                >
                   Next &rarr;
-                </button>
+                </a>
               </li>
             </ul>
           </div>

--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import APIService from "../APIService";
 import Bar from "./Bar";
-import withLoader from "../Loader";
+import Loader from "../Loader";
 import ErrorBoundary from "../ErrorBoundary";
 
 export type UserEntityData = Array<{
@@ -28,8 +28,6 @@ export type UserHistoryState = {
   startDate: Date;
   loading: boolean;
 };
-
-const BarWithLoader = withLoader(Bar);
 
 export default class UserHistory extends React.Component<
   UserHistoryProps,
@@ -420,11 +418,9 @@ export default class UserHistory extends React.Component<
             className="col-md-12 text-center"
             style={{ height: `${(75 / this.ROWS_PER_PAGE) * data.length}em` }}
           >
-            <BarWithLoader
-              isLoading={loading}
-              data={data}
-              maxValue={maxListens}
-            />
+            <Loader isLoading={loading}>
+              <Bar data={data} maxValue={maxListens} />
+            </Loader>
           </div>
         </div>
         <div className="row">

--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
@@ -315,7 +315,7 @@ export default class UserHistory extends React.Component<
                   data-toggle="dropdown"
                   type="button"
                 >
-                  {`${entity}s`}
+                  {entity ? `${entity}s` : ""}
                   <span className="caret" />
                 </button>
                 <ul className="dropdown-menu" role="menu">

--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
@@ -54,7 +54,7 @@ export default class UserHistory extends React.Component<
     };
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     window.addEventListener("popstate", this.syncStateWithURL);
 
     // Fetch initial data and set URL correspondingly

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserHistory.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserHistory.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`UserHistory Page renders 1`] = `
               data-toggle="dropdown"
               type="button"
             >
-              artist
               s
               <span
                 className="caret"
@@ -39,7 +38,7 @@ exports[`UserHistory Page renders 1`] = `
             >
               <li>
                 <a
-                  href="#"
+                  href=""
                   onClick={[Function]}
                   role="button"
                 >
@@ -48,7 +47,7 @@ exports[`UserHistory Page renders 1`] = `
               </li>
               <li>
                 <a
-                  href="#"
+                  href=""
                   onClick={[Function]}
                   role="button"
                 >
@@ -58,6 +57,7 @@ exports[`UserHistory Page renders 1`] = `
             </ul>
           </span>
           of 
+          the
           <span
             className="dropdown"
           >
@@ -66,7 +66,6 @@ exports[`UserHistory Page renders 1`] = `
               data-toggle="dropdown"
               type="button"
             >
-              all time
               <span
                 className="caret"
               />
@@ -77,7 +76,7 @@ exports[`UserHistory Page renders 1`] = `
             >
               <li>
                 <a
-                  href="#"
+                  href=""
                   onClick={[Function]}
                   role="button"
                 >
@@ -86,7 +85,7 @@ exports[`UserHistory Page renders 1`] = `
               </li>
               <li>
                 <a
-                  href="#"
+                  href=""
                   onClick={[Function]}
                   role="button"
                 >
@@ -95,7 +94,7 @@ exports[`UserHistory Page renders 1`] = `
               </li>
               <li>
                 <a
-                  href="#"
+                  href=""
                   onClick={[Function]}
                   role="button"
                 >
@@ -104,7 +103,7 @@ exports[`UserHistory Page renders 1`] = `
               </li>
               <li>
                 <a
-                  href="#"
+                  href=""
                   onClick={[Function]}
                   role="button"
                 >
@@ -113,6 +112,7 @@ exports[`UserHistory Page renders 1`] = `
               </li>
             </ul>
           </span>
+          2020
         </h3>
       </div>
     </div>
@@ -129,7 +129,6 @@ exports[`UserHistory Page renders 1`] = `
             }
           }
         >
-          artist
            count - 
           <b>
             0
@@ -330,7 +329,7 @@ exports[`UserHistory Page renders 1`] = `
             className="previous hidden"
           >
             <a
-              href="#"
+              href=""
               onClick={[Function]}
               role="button"
             >
@@ -341,7 +340,7 @@ exports[`UserHistory Page renders 1`] = `
             className="next hidden"
           >
             <a
-              href="#"
+              href=""
               onClick={[Function]}
               role="button"
             >

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserHistory.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserHistory.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`UserHistory Page renders 1`] = `
               data-toggle="dropdown"
               type="button"
             >
-              s
               <span
                 className="caret"
               />
@@ -140,68 +139,17 @@ exports[`UserHistory Page renders 1`] = `
       className="row"
     >
       <div
-        className="col-md-12"
+        className="col-md-12 text-center"
         style={
           Object {
             "height": "30em",
           }
         }
       >
-        <Bar
-          data={
-            Array [
-              Object {
-                "count": 41,
-                "id": "10. The Fray",
-              },
-              Object {
-                "count": 44,
-                "id": "9. The Chainsmokers",
-              },
-              Object {
-                "count": 52,
-                "id": "8. The Weeknd",
-              },
-              Object {
-                "count": 65,
-                "id": "7. OneRepublic",
-              },
-              Object {
-                "count": 108,
-                "id": "6. Ellie Goulding",
-              },
-              Object {
-                "count": 118,
-                "id": "5. Maroon 5",
-              },
-              Object {
-                "count": 176,
-                "id": "4. Imagine Dragons",
-              },
-              Object {
-                "count": 321,
-                "id": "3. Coldplay",
-              },
-              Object {
-                "count": 333,
-                "id": "2. Lenka",
-              },
-              Object {
-                "count": 385,
-                "id": "1. The Local train",
-              },
-            ]
-          }
-          maxValue={385}
+        <Loader
+          isLoading={false}
         >
-          <ResponsiveBar
-            animate={false}
-            axisLeft={
-              Object {
-                "renderTick": [Function],
-              }
-            }
-            colors="#FD8D3C"
+          <Bar
             data={
               Array [
                 Object {
@@ -246,74 +194,129 @@ exports[`UserHistory Page renders 1`] = `
                 },
               ]
             }
-            enableGridY={false}
-            indexBy="id"
-            keys={
-              Array [
-                "count",
-              ]
-            }
-            labelFormat={[Function]}
-            labelSkipWidth={0}
-            layout="horizontal"
-            margin={
-              Object {
-                "left": 204.8,
-              }
-            }
             maxValue={385}
-            padding={0.15}
-            theme={
-              Object {
-                "axis": Object {
-                  "ticks": Object {
+          >
+            <ResponsiveBar
+              animate={false}
+              axisLeft={
+                Object {
+                  "renderTick": [Function],
+                }
+              }
+              colors="#FD8D3C"
+              data={
+                Array [
+                  Object {
+                    "count": 41,
+                    "id": "10. The Fray",
+                  },
+                  Object {
+                    "count": 44,
+                    "id": "9. The Chainsmokers",
+                  },
+                  Object {
+                    "count": 52,
+                    "id": "8. The Weeknd",
+                  },
+                  Object {
+                    "count": 65,
+                    "id": "7. OneRepublic",
+                  },
+                  Object {
+                    "count": 108,
+                    "id": "6. Ellie Goulding",
+                  },
+                  Object {
+                    "count": 118,
+                    "id": "5. Maroon 5",
+                  },
+                  Object {
+                    "count": 176,
+                    "id": "4. Imagine Dragons",
+                  },
+                  Object {
+                    "count": 321,
+                    "id": "3. Coldplay",
+                  },
+                  Object {
+                    "count": 333,
+                    "id": "2. Lenka",
+                  },
+                  Object {
+                    "count": 385,
+                    "id": "1. The Local train",
+                  },
+                ]
+              }
+              enableGridY={false}
+              indexBy="id"
+              keys={
+                Array [
+                  "count",
+                ]
+              }
+              labelFormat={[Function]}
+              labelSkipWidth={0}
+              layout="horizontal"
+              margin={
+                Object {
+                  "left": 204.8,
+                }
+              }
+              maxValue={385}
+              padding={0.15}
+              theme={
+                Object {
+                  "axis": Object {
+                    "ticks": Object {
+                      "text": Object {
+                        "fontSize": "14px",
+                      },
+                    },
+                  },
+                  "labels": Object {
                     "text": Object {
                       "fontSize": "14px",
                     },
                   },
-                },
-                "labels": Object {
-                  "text": Object {
-                    "fontSize": "14px",
-                  },
-                },
+                }
               }
-            }
-            tooltip={[Function]}
-          >
-            <ResponsiveWrapper>
-              <Measure
-                bounds={true}
-                onResize={[Function]}
-              >
-                <Component
+              tooltip={[Function]}
+            >
+              <ResponsiveWrapper>
+                <Measure
                   bounds={true}
-                  contentRect={
-                    Object {
-                      "bounds": Object {},
-                      "client": Object {},
-                      "entry": Object {},
-                      "margin": Object {},
-                      "offset": Object {},
-                      "scroll": Object {},
-                    }
-                  }
-                  measure={[Function]}
-                  measureRef={[Function]}
+                  onResize={[Function]}
                 >
-                  <div
-                    style={
+                  <Component
+                    bounds={true}
+                    contentRect={
                       Object {
-                        "height": "100%",
-                        "width": "100%",
+                        "bounds": Object {},
+                        "client": Object {},
+                        "entry": Object {},
+                        "margin": Object {},
+                        "offset": Object {},
+                        "scroll": Object {},
                       }
                     }
-                  />
-                </Component>
-              </Measure>
-            </ResponsiveWrapper>
-          </ResponsiveBar>
-        </Bar>
+                    measure={[Function]}
+                    measureRef={[Function]}
+                  >
+                    <div
+                      style={
+                        Object {
+                          "height": "100%",
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </Component>
+                </Measure>
+              </ResponsiveWrapper>
+            </ResponsiveBar>
+          </Bar>
+        </Loader>
       </div>
     </div>
     <div


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
- If an user directly goes to a page `/user/u/history?page=4&range=all_time&entity=artist`, they see the page flash with the contents of page 1, before being replaced with the contents of page 4. Ideally the page should just show the data of page 4 immediately.
- If an user goes to a page, and then click the next button, the URL updates, and the data updates, but if they click the browser's back button, the URL changes but the data on the page doesn't change.

Jira Ticket - [LB-619](https://tickets.metabrainz.org/browse/LB-619)
# Solution
Using the `popstate` event to restore the data when back or forward button is pressed solves the issue.