### PR TITLE
LB-617: Fix empty fields in release stats

### DIFF
--- a/listenbrainz_spark/stats/user/release.py
+++ b/listenbrainz_spark/stats/user/release.py
@@ -34,8 +34,9 @@ def get_releases(table):
                  , artist_name
                  , artist_msid
                  , artist_mbids
-                 , count(release_msid) as listen_count
+                 , count(release_name) as listen_count
               FROM {}
+             WHERE release_name <> ''
           GROUP BY user_name
                  , release_name
                  , release_msid

--- a/listenbrainz_spark/stats/user/tests/test_release.py
+++ b/listenbrainz_spark/stats/user/tests/test_release.py
@@ -19,10 +19,10 @@ class releaseTestCase(SparkTestCase):
         if path_found:
             utils.delete_dir(self.path_, recursive=True)
 
-    def save_dataframe(self):
+    def save_dataframe(self, filename):
         now = datetime.now()
 
-        with open(self.path_to_data_file('user_top_releases.json')) as f:
+        with open(self.path_to_data_file(filename)) as f:
             data = json.load(f)
 
         df = None
@@ -39,7 +39,7 @@ class releaseTestCase(SparkTestCase):
         utils.save_parquet(df, os.path.join(self.path_, '{}/{}.parquet'.format(now.year, now.month)))
 
     def test_get_releases(self):
-        self.save_dataframe()
+        self.save_dataframe('user_top_releases.json')
         df = utils.get_listens(datetime.now(), datetime.now(), self.path_)
         df.createOrReplaceTempView('test_view')
 
@@ -70,3 +70,19 @@ class releaseTestCase(SparkTestCase):
             received[_dict['user_name']] = _dict['releases']
 
         self.assertDictEqual(received, expected)
+
+    def test_get_releases_empty(self):
+        self.save_dataframe('user_top_releases_empty.json')
+        df = utils.get_listens(datetime.now(), datetime.now(), self.path_)
+        df.createOrReplaceTempView('test_view')
+
+        with open(self.path_to_data_file('user_top_releases.json')) as f:
+            data = json.load(f)
+
+        received = defaultdict(list)
+        data = release_stats.get_releases('test_view')
+        for entry in data:
+            _dict = entry.asDict(recursive=True)
+            received[_dict['user_name']] = _dict['releases']
+
+        self.assertDictEqual(received, {})

--- a/listenbrainz_spark/stats/user/tests/test_release.py
+++ b/listenbrainz_spark/stats/user/tests/test_release.py
@@ -48,15 +48,16 @@ class releaseTestCase(SparkTestCase):
             data = json.load(f)
 
         for entry in data:
-            expected[entry['user_name']].append({
-                'release_name': entry['release_name'],
-                'release_msid': entry['release_msid'],
-                'release_mbid': entry['release_mbid'],
-                'artist_name': entry['artist_name'],
-                'artist_msid': entry['artist_msid'],
-                'artist_mbids': entry['artist_mbids'],
-                'listen_count': entry['count']
-            })
+            if entry['release_name'] != '':
+                expected[entry['user_name']].append({
+                    'release_name': entry['release_name'],
+                    'release_msid': entry['release_msid'],
+                    'release_mbid': entry['release_mbid'],
+                    'artist_name': entry['artist_name'],
+                    'artist_msid': entry['artist_msid'],
+                    'artist_mbids': entry['artist_mbids'],
+                    'listen_count': entry['count']
+                })
 
         # Sort in descending order w.r.t to listen_count
         for user_name, user_releases in expected.items():

--- a/listenbrainz_spark/testdata/user_top_releases.json
+++ b/listenbrainz_spark/testdata/user_top_releases.json
@@ -68,5 +68,15 @@
     "artist_msid": 1,
     "artist_mbids": 1,
     "count": 2
+  },
+  {
+    "user_name": "user3",
+    "release_name": "",
+    "release_msid": 1,
+    "release_mbid": 1,
+    "artist_name": "artist1",
+    "artist_msid": 1,
+    "artist_mbids": 1,
+    "count": 2
   }
 ]

--- a/listenbrainz_spark/testdata/user_top_releases_empty.json
+++ b/listenbrainz_spark/testdata/user_top_releases_empty.json
@@ -1,0 +1,83 @@
+[
+  {
+    "user_name": "user1",
+    "release_name": "",
+    "release_msid": 1,
+    "release_mbid": 1,
+    "artist_name": "artist1",
+    "artist_msid": 1,
+    "artist_mbids": 1,
+    "count": 8
+  },
+  {
+    "user_name": "user1",
+    "release_name": "",
+    "release_msid": 2,
+    "release_mbid": 2,
+    "artist_name": "artist2",
+    "artist_msid": 2,
+    "artist_mbids": 2,
+    "count": 3
+  },
+  {
+    "user_name": "user1",
+    "release_name": "",
+    "release_msid": 3,
+    "release_mbid": 3,
+    "artist_name": "artist3",
+    "artist_msid": 3,
+    "artist_mbids": 3,
+    "count": 4
+  },
+  {
+    "user_name": "user2",
+    "release_name": "",
+    "release_msid": 1,
+    "release_mbid": 1,
+    "artist_name": "artist1",
+    "artist_msid": 1,
+    "artist_mbids": 1,
+    "count": 4
+  },
+  {
+    "user_name": "user2",
+    "release_name": "",
+    "release_msid": 3,
+    "release_mbid": 3,
+    "artist_name": "artist3",
+    "artist_msid": 3,
+    "artist_mbids": 3,
+    "count": 7
+  },
+  {
+    "user_name": "user2",
+    "release_name": "",
+    "release_msid": 4,
+    "release_mbid": 4,
+    "artist_name": "artist4",
+    "artist_msid": 4,
+    "artist_mbids": 4,
+    "count": 2
+  },
+  {
+    "user_name": "user3",
+    "release_name": "",
+    "release_msid": 1,
+    "release_mbid": 1,
+    "artist_name": "artist1",
+    "artist_msid": 1,
+    "artist_mbids": 1,
+    "count": 2
+  },
+  {
+    "user_name": "user3",
+    "release_name": "",
+    "release_msid": 1,
+    "release_mbid": 1,
+    "artist_name": "artist1",
+    "artist_msid": 1,
+    "artist_mbids": 1,
+    "count": 2
+  }
+]
+


### PR DESCRIPTION
# Problem
The release page shows blank entries for listens not having release name present. We should filter out listens not having the release page to solve the issue.

Example-
https://listenbrainz.org/user/marc2k3/history?page=3&range=month&entity=release
https://api.listenbrainz.org/1/stats/user/marc2k3/releases?offset=50&range=month&count=25

# Solution
Adding a `WHERE` clause for listens not having release name in it fixes the issue