### PR TITLE
update candidate sets path to avoid race condition

### DIFF
--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -28,8 +28,8 @@ PLAYCOUNTS_DATAFRAME_PATH = DATAFRAME_DIR + '/' + 'playcounts_df.parquet'
 # Absolute path to similar artist relation.
 SIMILAR_ARTIST_DATAFRAME_PATH = SIMILAR_ARTIST_DIR + '/' + 'artist_credit_artist_credit_relations.parquet'
 # Absolute path to candidate sets.
-TOP_ARTIST_CANDIDATE_SET = CANDIDATE_SET_DIR + '/' + 'top_artist.parquet'
-SIMILAR_ARTIST_CANDIDATE_SET = CANDIDATE_SET_DIR + '/' + 'similar_artist.parquet'
+TOP_ARTIST_CANDIDATE_SET = os.path.join(CANDIDATE_SET_DIR, 'top_artist', 'top_artist.parquet')
+SIMILAR_ARTIST_CANDIDATE_SET = os.path.join(CANDIDATE_SET_DIR, 'similar_artist', 'similar_artist.parquet')
 # Absolute path to model metadata.
 MODEL_METADATA = MODEL_DIR + '/' + 'model_metadata.parquet'
 # Absolute path to save model index


### PR DESCRIPTION
# Problem
Spark creates _temporary files in the parent directory of parquet files while writing to storage and later deletes them. The temporary files created for top_artist and similar_artist [candidate sets](https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz_spark/recommendations/candidate_sets.py#L214) are saved inside `/recommendation/candidate_sets`.

While the temporary files are still being accessed for similar_artist parquet, spark deletes them considering them to be temp files for top_artists which leads to error.

# Solution
make a different directory for each parquet. Now the temp files will be stored in
- `/recommendation/candidate_sets/top_artist` for top artist parquet
- `/recommendation/candidate_sets/similar_artist` for similar artist parquet.



