### PR TITLE
LB-623: Release Graphs render incorrectly on latest master

### DIFF
--- a/listenbrainz/webserver/static/js/src/__mocks__/userArtistsProcessData.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/userArtistsProcessData.json
@@ -1,149 +1,174 @@
 [
   {
+    "id": "24",
     "entity": "The Lumineers",
     "entityType": "artist",
     "idx": 25,
     "count": 6
   },
   {
+    "id": "23",
     "entity": "Train",
     "entityType": "artist",
     "idx": 24,
     "count": 6
   },
   {
+    "id": "22",
     "entity": "Backstreet Boys",
     "entityType": "artist",
     "idx": 23,
     "count": 8
   },
   {
+    "id": "21",
     "entity": "The Weeknd",
     "entityType": "artist",
     "idx": 22,
     "count": 8
   },
   {
+    "id": "20",
     "entity": "Linkin Park",
     "entityType": "artist",
     "idx": 21,
     "count": 10
   },
   {
+    "id": "19",
     "entity": "M.I.A.",
     "entityType": "artist",
     "idx": 20,
     "count": 10
   },
   {
+    "id": "18",
     "entity": "Of Monsters and Men",
     "entityType": "artist",
     "idx": 19,
     "count": 11
   },
   {
+    "id": "17",
     "entity": "Sia",
     "entityType": "artist",
     "idx": 18,
     "count": 12
   },
   {
+    "id": "16",
     "entity": "The Chainsmokers",
     "entityType": "artist",
     "idx": 17,
     "count": 12
   },
   {
+    "id": "15",
     "entity": "Tommee Profitt",
     "entityType": "artist",
     "idx": 16,
     "count": 12
   },
   {
+    "id": "14",
     "entity": "The Local train",
     "entityType": "artist",
     "idx": 15,
     "count": 13
   },
   {
+    "id": "13",
     "entity": "The Script",
     "entityType": "artist",
     "idx": 14,
     "count": 15
   },
   {
+    "id": "12",
     "entity": "Christina Perri",
     "entityType": "artist",
     "idx": 13,
     "count": 16
   },
   {
+    "id": "11",
     "entity": "George Ezra",
     "entityType": "artist",
     "idx": 12,
     "count": 17
   },
   {
+    "id": "10",
     "entity": "Ed Sheeran",
     "entityType": "artist",
     "idx": 11,
     "count": 19
   },
   {
+    "id": "9",
     "entity": "Taylor Swift",
     "entityType": "artist",
     "idx": 10,
     "count": 20
   },
   {
+    "id": "8",
     "entity": "Vance Joy",
     "entityType": "artist",
     "idx": 9,
     "count": 20
   },
   {
+    "id": "7",
     "entity": "Lenka",
     "entityType": "artist",
     "idx": 8,
     "count": 25
   },
   {
+    "id": "6",
     "entity": "Imagine Dragons",
     "entityType": "artist",
     "idx": 7,
     "count": 26
   },
   {
+    "id": "5",
     "entity": "Ritviz",
     "entityType": "artist",
     "idx": 6,
     "count": 26
   },
   {
+    "id": "4",
     "entity": "The Fray",
     "entityType": "artist",
     "idx": 5,
     "count": 31
   },
   {
+    "id": "3",
     "entity": "OneRepublic",
     "entityType": "artist",
     "idx": 4,
     "count": 36
   },
   {
+    "id": "2",
     "entity": "Maroon 5",
     "entityType": "artist",
     "idx": 3,
     "count": 38
   },
   {
+    "id": "1",
     "entity": "Ellie Goulding",
     "entityType": "artist",
     "idx": 2,
     "count": 54
   },
   {
+    "id": "0",
     "entity": "Coldplay",
     "entityType": "artist",
     "idx": 1,

--- a/listenbrainz/webserver/static/js/src/__mocks__/userReleasesProcessData.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/userReleasesProcessData.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "24",
     "entity": "The Hits--Chapter One",
     "entityType": "release",
     "entityMBID": "",
@@ -9,6 +10,7 @@
     "count": 8
   },
   {
+    "id": "23",
     "entity": "Aalas Ka Pedh",
     "entityType": "release",
     "entityMBID": "",
@@ -18,6 +20,7 @@
     "count": 9
   },
   {
+    "id": "22",
     "entity": "Kala",
     "entityType": "release",
     "entityMBID": "",
@@ -27,6 +30,7 @@
     "count": 10
   },
   {
+    "id": "21",
     "entity": "One More Light",
     "entityType": "release",
     "entityMBID": "",
@@ -36,6 +40,7 @@
     "count": 10
   },
   {
+    "id": "20",
     "entity": "Cheap Thrills (feat. Sean Paul)",
     "entityType": "release",
     "entityMBID": "",
@@ -45,6 +50,7 @@
     "count": 11
   },
   {
+    "id": "19",
     "entity": "My Head Is an Animal",
     "entityType": "release",
     "entityMBID": "",
@@ -54,6 +60,7 @@
     "count": 11
   },
   {
+    "id": "18",
     "entity": "Overexposed",
     "entityType": "release",
     "entityMBID": "",
@@ -63,6 +70,7 @@
     "count": 11
   },
   {
+    "id": "17",
     "entity": "Singles",
     "entityType": "release",
     "entityMBID": "",
@@ -72,6 +80,7 @@
     "count": 11
   },
   {
+    "id": "16",
     "entity": "#3",
     "entityType": "release",
     "entityMBID": "",
@@ -81,6 +90,7 @@
     "count": 12
   },
   {
+    "id": "15",
     "entity": "In The End",
     "entityType": "release",
     "entityMBID": "",
@@ -90,6 +100,7 @@
     "count": 12
   },
   {
+    "id": "14",
     "entity": "13 Reasons Why (Season 2)",
     "entityType": "release",
     "entityMBID": "",
@@ -99,6 +110,7 @@
     "count": 13
   },
   {
+    "id": "13",
     "entity": "Two (Expanded Edition)",
     "entityType": "release",
     "entityMBID": "",
@@ -108,6 +120,7 @@
     "count": 13
   },
   {
+    "id": "12",
     "entity": "Staying at Tamara's",
     "entityType": "release",
     "entityMBID": "",
@@ -117,6 +130,7 @@
     "count": 15
   },
   {
+    "id": "11",
     "entity": "A Head Full Of Dreams",
     "entityType": "release",
     "entityMBID": "",
@@ -126,6 +140,7 @@
     "count": 16
   },
   {
+    "id": "10",
     "entity": "A Thousand Years",
     "entityType": "release",
     "entityMBID": "",
@@ -135,6 +150,7 @@
     "count": 16
   },
   {
+    "id": "9",
     "entity": "Halcyon Days",
     "entityType": "release",
     "entityMBID": "",
@@ -144,6 +160,7 @@
     "count": 16
   },
   {
+    "id": "8",
     "entity": "1989",
     "entityType": "release",
     "entityMBID": "",
@@ -153,6 +170,7 @@
     "count": 17
   },
   {
+    "id": "7",
     "entity": "Night Visions (Deluxe)",
     "entityType": "release",
     "entityMBID": "",
@@ -162,6 +180,7 @@
     "count": 17
   },
   {
+    "id": "6",
     "entity": "÷ (Deluxe)",
     "entityType": "release",
     "entityMBID": "",
@@ -171,6 +190,7 @@
     "count": 17
   },
   {
+    "id": "5",
     "entity": "Dream Your Life Away (Special Edition)",
     "entityType": "release",
     "entityMBID": "",
@@ -180,6 +200,7 @@
     "count": 18
   },
   {
+    "id": "4",
     "entity": "Native",
     "entityType": "release",
     "entityMBID": "",
@@ -189,6 +210,7 @@
     "count": 18
   },
   {
+    "id": "3",
     "entity": "Udd Gaye (Bacardi House Party Sessions)",
     "entityType": "release",
     "entityMBID": "",
@@ -198,6 +220,7 @@
     "count": 20
   },
   {
+    "id": "2",
     "entity": "Delirium (Deluxe)",
     "entityType": "release",
     "entityMBID": "",
@@ -207,6 +230,7 @@
     "count": 25
   },
   {
+    "id": "1",
     "entity": "How to Save a Life",
     "entityType": "release",
     "entityMBID": "",
@@ -216,6 +240,7 @@
     "count": 25
   },
   {
+    "id": "0",
     "entity": "Live in Buenos Aires",
     "entityType": "release",
     "entityMBID": "",

--- a/listenbrainz/webserver/static/js/src/stats/Bar.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/Bar.tsx
@@ -84,32 +84,46 @@ export default class Bar extends React.Component<BarProps, BarState> {
 
     const leftAlignedTick = (tick: Tick) => {
       const datum = data[tick.tickIndex];
-      let { entity, artist } = datum;
-      const { idx } = datum;
+      const { entity, artist, idx } = datum;
 
-      if (entity.length + String(idx).length + 3 > marginLeft / 10) {
-        entity = `${entity.slice(0, marginLeft / 10)}...`;
-      }
-      if (artist && artist.length + String(idx).length + 3 > marginLeft / 10) {
-        artist = `${artist.slice(0, marginLeft / 10)}...`;
-      }
       return (
         <g transform={`translate(${tick.x - marginLeft}, ${tick.y})`}>
           <foreignObject
-            height="100%"
-            width="100%"
+            height="3em"
+            width={marginLeft}
             y={datum.entityType === "artist" ? -10 : -20}
           >
-            <table style={{ textAlign: "start" }}>
+            <table
+              style={{
+                width: "90%",
+                textAlign: "start",
+                whiteSpace: "nowrap",
+              }}
+            >
               <tbody>
                 <tr style={{ color: "black" }}>
-                  <td>{idx}.&nbsp;</td>
-                  <td>{this.getEntityLink(datum, entity)}</td>
+                  <td style={{ width: 1 }}>{idx}.&nbsp;</td>
+                  <td
+                    style={{
+                      maxWidth: 0,
+                      textOverflow: "ellipsis",
+                      overflow: "hidden",
+                    }}
+                  >
+                    {this.getEntityLink(datum, entity)}
+                  </td>
                 </tr>
                 {artist && (
                   <tr>
                     <td />
-                    <td style={{ fontSize: 12 }}>
+                    <td
+                      style={{
+                        fontSize: 12,
+                        maxWidth: 0,
+                        textOverflow: "ellipsis",
+                        overflow: "hidden",
+                      }}
+                    >
                       {this.getArtistLink(datum, artist)}
                     </td>
                   </tr>
@@ -132,7 +146,7 @@ export default class Bar extends React.Component<BarProps, BarState> {
     const customTooltip = (datum: any) => {
       return (
         <div>
-          {datum.indexValue}: <strong>{datum.value} Listens</strong>
+          {datum.data.entity}: <strong>{datum.value} Listens</strong>
         </div>
       );
     };
@@ -158,7 +172,7 @@ export default class Bar extends React.Component<BarProps, BarState> {
         maxValue={maxValue}
         layout="horizontal"
         colors="#FD8D3C"
-        indexBy="entity"
+        indexBy="id"
         enableGridY={false}
         padding={0.15}
         labelFormat={labelFormatter}

--- a/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserHistory.tsx
@@ -192,6 +192,7 @@ export default class UserHistory extends React.Component<
             ? elem.artist_mbids[0]
             : undefined;
           return {
+            id: idx.toString(),
             entity: elem.artist_name,
             entityType: entity as Entity,
             idx: offset + idx + 1,
@@ -204,6 +205,7 @@ export default class UserHistory extends React.Component<
       result = (data as UserReleasesResponse).payload.releases
         .map((elem, idx: number) => {
           return {
+            id: idx.toString(),
             entity: elem.release_name,
             entityType: entity as Entity,
             entityMBID: elem.release_mbid,

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserHistory.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserHistory.test.tsx.snap
@@ -156,150 +156,175 @@ exports[`UserHistory Page renders correctly for artists 1`] = `
                   "count": 6,
                   "entity": "The Lumineers",
                   "entityType": "artist",
+                  "id": "24",
                   "idx": 25,
                 },
                 Object {
                   "count": 6,
                   "entity": "Train",
                   "entityType": "artist",
+                  "id": "23",
                   "idx": 24,
                 },
                 Object {
                   "count": 8,
                   "entity": "Backstreet Boys",
                   "entityType": "artist",
+                  "id": "22",
                   "idx": 23,
                 },
                 Object {
                   "count": 8,
                   "entity": "The Weeknd",
                   "entityType": "artist",
+                  "id": "21",
                   "idx": 22,
                 },
                 Object {
                   "count": 10,
                   "entity": "Linkin Park",
                   "entityType": "artist",
+                  "id": "20",
                   "idx": 21,
                 },
                 Object {
                   "count": 10,
                   "entity": "M.I.A.",
                   "entityType": "artist",
+                  "id": "19",
                   "idx": 20,
                 },
                 Object {
                   "count": 11,
                   "entity": "Of Monsters and Men",
                   "entityType": "artist",
+                  "id": "18",
                   "idx": 19,
                 },
                 Object {
                   "count": 12,
                   "entity": "Sia",
                   "entityType": "artist",
+                  "id": "17",
                   "idx": 18,
                 },
                 Object {
                   "count": 12,
                   "entity": "The Chainsmokers",
                   "entityType": "artist",
+                  "id": "16",
                   "idx": 17,
                 },
                 Object {
                   "count": 12,
                   "entity": "Tommee Profitt",
                   "entityType": "artist",
+                  "id": "15",
                   "idx": 16,
                 },
                 Object {
                   "count": 13,
                   "entity": "The Local train",
                   "entityType": "artist",
+                  "id": "14",
                   "idx": 15,
                 },
                 Object {
                   "count": 15,
                   "entity": "The Script",
                   "entityType": "artist",
+                  "id": "13",
                   "idx": 14,
                 },
                 Object {
                   "count": 16,
                   "entity": "Christina Perri",
                   "entityType": "artist",
+                  "id": "12",
                   "idx": 13,
                 },
                 Object {
                   "count": 17,
                   "entity": "George Ezra",
                   "entityType": "artist",
+                  "id": "11",
                   "idx": 12,
                 },
                 Object {
                   "count": 19,
                   "entity": "Ed Sheeran",
                   "entityType": "artist",
+                  "id": "10",
                   "idx": 11,
                 },
                 Object {
                   "count": 20,
                   "entity": "Taylor Swift",
                   "entityType": "artist",
+                  "id": "9",
                   "idx": 10,
                 },
                 Object {
                   "count": 20,
                   "entity": "Vance Joy",
                   "entityType": "artist",
+                  "id": "8",
                   "idx": 9,
                 },
                 Object {
                   "count": 25,
                   "entity": "Lenka",
                   "entityType": "artist",
+                  "id": "7",
                   "idx": 8,
                 },
                 Object {
                   "count": 26,
                   "entity": "Imagine Dragons",
                   "entityType": "artist",
+                  "id": "6",
                   "idx": 7,
                 },
                 Object {
                   "count": 26,
                   "entity": "Ritviz",
                   "entityType": "artist",
+                  "id": "5",
                   "idx": 6,
                 },
                 Object {
                   "count": 31,
                   "entity": "The Fray",
                   "entityType": "artist",
+                  "id": "4",
                   "idx": 5,
                 },
                 Object {
                   "count": 36,
                   "entity": "OneRepublic",
                   "entityType": "artist",
+                  "id": "3",
                   "idx": 4,
                 },
                 Object {
                   "count": 38,
                   "entity": "Maroon 5",
                   "entityType": "artist",
+                  "id": "2",
                   "idx": 3,
                 },
                 Object {
                   "count": 54,
                   "entity": "Ellie Goulding",
                   "entityType": "artist",
+                  "id": "1",
                   "idx": 2,
                 },
                 Object {
                   "count": 70,
                   "entity": "Coldplay",
                   "entityType": "artist",
+                  "id": "0",
                   "idx": 1,
                 },
               ]
@@ -320,156 +345,181 @@ exports[`UserHistory Page renders correctly for artists 1`] = `
                     "count": 6,
                     "entity": "The Lumineers",
                     "entityType": "artist",
+                    "id": "24",
                     "idx": 25,
                   },
                   Object {
                     "count": 6,
                     "entity": "Train",
                     "entityType": "artist",
+                    "id": "23",
                     "idx": 24,
                   },
                   Object {
                     "count": 8,
                     "entity": "Backstreet Boys",
                     "entityType": "artist",
+                    "id": "22",
                     "idx": 23,
                   },
                   Object {
                     "count": 8,
                     "entity": "The Weeknd",
                     "entityType": "artist",
+                    "id": "21",
                     "idx": 22,
                   },
                   Object {
                     "count": 10,
                     "entity": "Linkin Park",
                     "entityType": "artist",
+                    "id": "20",
                     "idx": 21,
                   },
                   Object {
                     "count": 10,
                     "entity": "M.I.A.",
                     "entityType": "artist",
+                    "id": "19",
                     "idx": 20,
                   },
                   Object {
                     "count": 11,
                     "entity": "Of Monsters and Men",
                     "entityType": "artist",
+                    "id": "18",
                     "idx": 19,
                   },
                   Object {
                     "count": 12,
                     "entity": "Sia",
                     "entityType": "artist",
+                    "id": "17",
                     "idx": 18,
                   },
                   Object {
                     "count": 12,
                     "entity": "The Chainsmokers",
                     "entityType": "artist",
+                    "id": "16",
                     "idx": 17,
                   },
                   Object {
                     "count": 12,
                     "entity": "Tommee Profitt",
                     "entityType": "artist",
+                    "id": "15",
                     "idx": 16,
                   },
                   Object {
                     "count": 13,
                     "entity": "The Local train",
                     "entityType": "artist",
+                    "id": "14",
                     "idx": 15,
                   },
                   Object {
                     "count": 15,
                     "entity": "The Script",
                     "entityType": "artist",
+                    "id": "13",
                     "idx": 14,
                   },
                   Object {
                     "count": 16,
                     "entity": "Christina Perri",
                     "entityType": "artist",
+                    "id": "12",
                     "idx": 13,
                   },
                   Object {
                     "count": 17,
                     "entity": "George Ezra",
                     "entityType": "artist",
+                    "id": "11",
                     "idx": 12,
                   },
                   Object {
                     "count": 19,
                     "entity": "Ed Sheeran",
                     "entityType": "artist",
+                    "id": "10",
                     "idx": 11,
                   },
                   Object {
                     "count": 20,
                     "entity": "Taylor Swift",
                     "entityType": "artist",
+                    "id": "9",
                     "idx": 10,
                   },
                   Object {
                     "count": 20,
                     "entity": "Vance Joy",
                     "entityType": "artist",
+                    "id": "8",
                     "idx": 9,
                   },
                   Object {
                     "count": 25,
                     "entity": "Lenka",
                     "entityType": "artist",
+                    "id": "7",
                     "idx": 8,
                   },
                   Object {
                     "count": 26,
                     "entity": "Imagine Dragons",
                     "entityType": "artist",
+                    "id": "6",
                     "idx": 7,
                   },
                   Object {
                     "count": 26,
                     "entity": "Ritviz",
                     "entityType": "artist",
+                    "id": "5",
                     "idx": 6,
                   },
                   Object {
                     "count": 31,
                     "entity": "The Fray",
                     "entityType": "artist",
+                    "id": "4",
                     "idx": 5,
                   },
                   Object {
                     "count": 36,
                     "entity": "OneRepublic",
                     "entityType": "artist",
+                    "id": "3",
                     "idx": 4,
                   },
                   Object {
                     "count": 38,
                     "entity": "Maroon 5",
                     "entityType": "artist",
+                    "id": "2",
                     "idx": 3,
                   },
                   Object {
                     "count": 54,
                     "entity": "Ellie Goulding",
                     "entityType": "artist",
+                    "id": "1",
                     "idx": 2,
                   },
                   Object {
                     "count": 70,
                     "entity": "Coldplay",
                     "entityType": "artist",
+                    "id": "0",
                     "idx": 1,
                   },
                 ]
               }
               enableGridY={false}
-              indexBy="entity"
+              indexBy="id"
               keys={
                 Array [
                   "count",
@@ -736,6 +786,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "The Hits--Chapter One",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "24",
                   "idx": 25,
                 },
                 Object {
@@ -745,6 +796,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Aalas Ka Pedh",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "23",
                   "idx": 24,
                 },
                 Object {
@@ -754,6 +806,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Kala",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "22",
                   "idx": 23,
                 },
                 Object {
@@ -763,6 +816,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "One More Light",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "21",
                   "idx": 22,
                 },
                 Object {
@@ -772,6 +826,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Cheap Thrills (feat. Sean Paul)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "20",
                   "idx": 21,
                 },
                 Object {
@@ -781,6 +836,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "My Head Is an Animal",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "19",
                   "idx": 20,
                 },
                 Object {
@@ -790,6 +846,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Overexposed",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "18",
                   "idx": 19,
                 },
                 Object {
@@ -799,6 +856,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Singles",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "17",
                   "idx": 18,
                 },
                 Object {
@@ -808,6 +866,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "#3",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "16",
                   "idx": 17,
                 },
                 Object {
@@ -817,6 +876,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "In The End",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "15",
                   "idx": 16,
                 },
                 Object {
@@ -826,6 +886,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "13 Reasons Why (Season 2)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "14",
                   "idx": 15,
                 },
                 Object {
@@ -835,6 +896,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Two (Expanded Edition)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "13",
                   "idx": 14,
                 },
                 Object {
@@ -844,6 +906,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Staying at Tamara's",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "12",
                   "idx": 13,
                 },
                 Object {
@@ -853,6 +916,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "A Head Full Of Dreams",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "11",
                   "idx": 12,
                 },
                 Object {
@@ -862,6 +926,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "A Thousand Years",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "10",
                   "idx": 11,
                 },
                 Object {
@@ -871,6 +936,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Halcyon Days",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "9",
                   "idx": 10,
                 },
                 Object {
@@ -880,6 +946,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "1989",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "8",
                   "idx": 9,
                 },
                 Object {
@@ -889,6 +956,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Night Visions (Deluxe)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "7",
                   "idx": 8,
                 },
                 Object {
@@ -898,6 +966,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "÷ (Deluxe)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "6",
                   "idx": 7,
                 },
                 Object {
@@ -907,6 +976,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Dream Your Life Away (Special Edition)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "5",
                   "idx": 6,
                 },
                 Object {
@@ -916,6 +986,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Native",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "4",
                   "idx": 5,
                 },
                 Object {
@@ -925,6 +996,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Udd Gaye (Bacardi House Party Sessions)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "3",
                   "idx": 4,
                 },
                 Object {
@@ -934,6 +1006,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Delirium (Deluxe)",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "2",
                   "idx": 3,
                 },
                 Object {
@@ -943,6 +1016,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "How to Save a Life",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "1",
                   "idx": 2,
                 },
                 Object {
@@ -952,6 +1026,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                   "entity": "Live in Buenos Aires",
                   "entityMBID": "",
                   "entityType": "release",
+                  "id": "0",
                   "idx": 1,
                 },
               ]
@@ -975,6 +1050,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "The Hits--Chapter One",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "24",
                     "idx": 25,
                   },
                   Object {
@@ -984,6 +1060,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Aalas Ka Pedh",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "23",
                     "idx": 24,
                   },
                   Object {
@@ -993,6 +1070,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Kala",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "22",
                     "idx": 23,
                   },
                   Object {
@@ -1002,6 +1080,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "One More Light",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "21",
                     "idx": 22,
                   },
                   Object {
@@ -1011,6 +1090,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Cheap Thrills (feat. Sean Paul)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "20",
                     "idx": 21,
                   },
                   Object {
@@ -1020,6 +1100,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "My Head Is an Animal",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "19",
                     "idx": 20,
                   },
                   Object {
@@ -1029,6 +1110,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Overexposed",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "18",
                     "idx": 19,
                   },
                   Object {
@@ -1038,6 +1120,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Singles",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "17",
                     "idx": 18,
                   },
                   Object {
@@ -1047,6 +1130,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "#3",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "16",
                     "idx": 17,
                   },
                   Object {
@@ -1056,6 +1140,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "In The End",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "15",
                     "idx": 16,
                   },
                   Object {
@@ -1065,6 +1150,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "13 Reasons Why (Season 2)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "14",
                     "idx": 15,
                   },
                   Object {
@@ -1074,6 +1160,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Two (Expanded Edition)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "13",
                     "idx": 14,
                   },
                   Object {
@@ -1083,6 +1170,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Staying at Tamara's",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "12",
                     "idx": 13,
                   },
                   Object {
@@ -1092,6 +1180,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "A Head Full Of Dreams",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "11",
                     "idx": 12,
                   },
                   Object {
@@ -1101,6 +1190,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "A Thousand Years",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "10",
                     "idx": 11,
                   },
                   Object {
@@ -1110,6 +1200,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Halcyon Days",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "9",
                     "idx": 10,
                   },
                   Object {
@@ -1119,6 +1210,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "1989",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "8",
                     "idx": 9,
                   },
                   Object {
@@ -1128,6 +1220,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Night Visions (Deluxe)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "7",
                     "idx": 8,
                   },
                   Object {
@@ -1137,6 +1230,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "÷ (Deluxe)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "6",
                     "idx": 7,
                   },
                   Object {
@@ -1146,6 +1240,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Dream Your Life Away (Special Edition)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "5",
                     "idx": 6,
                   },
                   Object {
@@ -1155,6 +1250,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Native",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "4",
                     "idx": 5,
                   },
                   Object {
@@ -1164,6 +1260,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Udd Gaye (Bacardi House Party Sessions)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "3",
                     "idx": 4,
                   },
                   Object {
@@ -1173,6 +1270,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Delirium (Deluxe)",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "2",
                     "idx": 3,
                   },
                   Object {
@@ -1182,6 +1280,7 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "How to Save a Life",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "1",
                     "idx": 2,
                   },
                   Object {
@@ -1191,12 +1290,13 @@ exports[`UserHistory Page renders correctly for releases 1`] = `
                     "entity": "Live in Buenos Aires",
                     "entityMBID": "",
                     "entityType": "release",
+                    "id": "0",
                     "idx": 1,
                   },
                 ]
               }
               enableGridY={false}
-              indexBy="entity"
+              indexBy="id"
               keys={
                 Array [
                   "count",

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -177,6 +177,7 @@ declare type UserReleasesResponse = {
 declare type UserEntityAPIRange = "all_time" | "year" | "month" | "week";
 
 declare type UserEntityDatum = {
+  id: string;
   entity: string;
   entityType: Entity;
   entityMBID?: string;


### PR DESCRIPTION
# Problem
The release graph renders incorrectly on master.

# Solution
The issue is caused because we use "Release" names as a key for drawing the graph. However sometimes "Release" names are not unique causing the incorrect rendering. Changing the key to the index of release solves the issue. This PR also improves text clipping for long entity names using `CSS`.

# Screenshots
![2020-06-11-123442_1349x697_scrot](https://user-images.githubusercontent.com/25200200/84356273-95f3de00-abe1-11ea-8bf4-17b2c4c0449a.png)
![2020-06-11-123530_322x578_scrot](https://user-images.githubusercontent.com/25200200/84356295-9d1aec00-abe1-11ea-8ec5-f7ab5201a837.png)