### PR TITLE
LB-627: Avoid validation error whenever possible

### DIFF
--- a/listenbrainz/db/model/user_artist_stat.py
+++ b/listenbrainz/db/model/user_artist_stat.py
@@ -35,9 +35,8 @@ class UserArtistStatJson(pydantic.BaseModel):
     all_time: Optional[UserArtistStatRange]
 
 
-class UserArtistStat(pydantic.BaseModel):
+class UserArtistStat(UserArtistStatJson):
     """ Model for stats around a user's most listened artists
     """
     user_id: int
-    artist: UserArtistStatJson
     last_updated: datetime

--- a/listenbrainz/db/model/user_recording_stat.py
+++ b/listenbrainz/db/model/user_recording_stat.py
@@ -38,9 +38,8 @@ class UserRecordingStatJson(pydantic.BaseModel):
     all_time: Optional[UserRecordingStatRange]
 
 
-class UserRecordingStat(pydantic.BaseModel):
+class UserRecordingStat(UserRecordingStatJson):
     """ Model for stats around a user's most listened recordings
     """
     user_id: int
-    recording: UserRecordingStatJson
     last_updated: datetime

--- a/listenbrainz/db/model/user_release_stat.py
+++ b/listenbrainz/db/model/user_release_stat.py
@@ -35,9 +35,8 @@ class UserReleaseStatJson(pydantic.BaseModel):
     all_time: Optional[UserReleaseStatRange]
 
 
-class UserReleaseStat(pydantic.BaseModel):
+class UserReleaseStat(UserReleaseStatJson):
     """ Model for stats around a user's most listened releases
     """
     user_id: int
-    release: UserReleaseStatJson
     last_updated: datetime

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -134,40 +134,67 @@ def get_user_stats(user_id, columns):
     return dict(row) if row else None
 
 
-def get_user_artists(user_id: int) -> Optional[UserArtistStat]:
-    """Get top artists for user with given ID.
+def get_user_artists(user_id: int, stats_range: str) -> Optional[UserArtistStat]:
+    """Get top artists in a tine range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
+            stats_range: the time range to fetch the stats for
     """
-    data = get_user_stats(user_id, 'artist')
-    if (not data) or (not data['artist']):
-        return None
-    return UserArtistStat(**data)
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT user_id, artist->:range AS {range}, last_updated
+              FROM statistics.user
+             WHERE user_id = :user_id
+            """.format(range=stats_range)), {
+            'range': stats_range,
+            'user_id': user_id
+        })
+        row = result.fetchone()
+
+    return UserArtistStat(**dict(row)) if row else None
 
 
-def get_user_releases(user_id: int) -> Optional[UserReleaseStat]:
-    """Get top releases for user with given ID.
+def get_user_releases(user_id: int, stats_range: str) -> Optional[UserReleaseStat]:
+    """Get top releases in a tine range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
+            stats_range: the time range to fetch the stats for
     """
-    data = get_user_stats(user_id, 'release')
-    if (not data) or (not data['release']):
-        return None
-    return UserReleaseStat(**data)
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT user_id, release->:range AS {range}, last_updated
+              FROM statistics.user
+             WHERE user_id = :user_id
+            """.format(range=stats_range)), {
+            'range': stats_range,
+            'user_id': user_id
+        })
+        row = result.fetchone()
+
+    return UserReleaseStat(**dict(row)) if row else None
 
 
-def get_user_recordings(user_id: int) -> Optional[UserRecordingStat]:
-    """Get top recordings for user with given ID.
+def get_user_recordings(user_id: int, stats_range: str) -> Optional[UserRecordingStat]:
+    """Get top recordings in a tine range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
+            stats_range: the time range to fetch the stats for
     """
-    data = get_user_stats(user_id, 'recording')
-    if (not data) or (not data['recording']):
-        return None
-    return UserRecordingStat(**data)
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT user_id, recording->:range AS {range}, last_updated
+              FROM statistics.user
+             WHERE user_id = :user_id
+            """.format(range=stats_range)), {
+            'range': stats_range,
+            'user_id': user_id
+        })
+        row = result.fetchone()
+
+    return UserRecordingStat(**dict(row)) if row else None
 
 
 def valid_stats_exist(user_id, days):

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -135,7 +135,7 @@ def get_user_stats(user_id, columns):
 
 
 def get_user_artists(user_id: int, stats_range: str) -> Optional[UserArtistStat]:
-    """Get top artists in a tine range for user with given ID.
+    """Get top artists in a time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
@@ -156,7 +156,7 @@ def get_user_artists(user_id: int, stats_range: str) -> Optional[UserArtistStat]
 
 
 def get_user_releases(user_id: int, stats_range: str) -> Optional[UserReleaseStat]:
-    """Get top releases in a tine range for user with given ID.
+    """Get top releases in a time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
@@ -177,7 +177,7 @@ def get_user_releases(user_id: int, stats_range: str) -> Optional[UserReleaseSta
 
 
 def get_user_recordings(user_id: int, stats_range: str) -> Optional[UserRecordingStat]:
-    """Get top recordings in a tine range for user with given ID.
+    """Get top recordings in a time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -23,8 +23,8 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
         db_stats.insert_user_artists(user_id=self.user['id'], artists=UserArtistStatJson(**{'all_time': artists_data}))
 
-        result = db_stats.get_user_artists(user_id=self.user['id'])
-        self.assertDictEqual(result.artist.all_time.dict(), artists_data)
+        result = db_stats.get_user_artists(user_id=self.user['id'], stats_range='all_time')
+        self.assertDictEqual(result.all_time.dict(), artists_data)
 
     def test_insert_user_releases(self):
         """ Test if release stats are inserted correctly """
@@ -32,8 +32,8 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             releases_data = json.load(f)
         db_stats.insert_user_releases(user_id=self.user['id'], releases=UserReleaseStatJson(**{'all_time': releases_data}))
 
-        result = db_stats.get_user_releases(user_id=self.user['id'])
-        self.assertDictEqual(result.release.all_time.dict(), releases_data)
+        result = db_stats.get_user_releases(user_id=self.user['id'], stats_range='all_time')
+        self.assertDictEqual(result.all_time.dict(), releases_data)
 
     def test_insert_user_recordings(self):
         """ Test if recording stats are inserted correctly """
@@ -42,8 +42,8 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         db_stats.insert_user_recordings(user_id=self.user['id'],
                                         recordings=UserRecordingStatJson(**{'all_time': recordings_data}))
 
-        result = db_stats.get_user_recordings(user_id=self.user['id'])
-        self.assertDictEqual(result.recording.all_time.dict(), recordings_data)
+        result = db_stats.get_user_recordings(user_id=self.user['id'], stats_range='all_time')
+        self.assertDictEqual(result.all_time.dict(), recordings_data)
 
     def test_insert_user_stats_mult_ranges_artist(self):
         """ Test if multiple time range data is inserted correctly """
@@ -53,10 +53,11 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         db_stats.insert_user_artists(user_id=self.user['id'], artists=UserArtistStatJson(**{'all_time': artists_data}))
         db_stats.insert_user_artists(user_id=self.user['id'], artists=UserArtistStatJson(**{'year': artists_data}))
 
-        result = db_stats.get_user_artists(1)
+        result = db_stats.get_user_artists(1, 'all_time')
+        self.assertDictEqual(result.all_time.dict(), artists_data)
 
-        self.assertDictEqual(result.artist.all_time.dict(), artists_data)
-        self.assertDictEqual(result.artist.year.dict(), artists_data)
+        result = db_stats.get_user_artists(1, 'year')
+        self.assertDictEqual(result.year.dict(), artists_data)
 
     def test_insert_user_stats_mult_ranges_release(self):
         """ Test if multiple time range data is inserted correctly """
@@ -66,10 +67,11 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         db_stats.insert_user_releases(user_id=self.user['id'], releases=UserReleaseStatJson(**{'year': releases_data}))
         db_stats.insert_user_releases(user_id=self.user['id'], releases=UserReleaseStatJson(**{'all_time': releases_data}))
 
-        result = db_stats.get_user_releases(1)
+        result = db_stats.get_user_releases(1, 'all_time')
+        self.assertDictEqual(result.all_time.dict(), releases_data)
 
-        self.assertDictEqual(result.release.all_time.dict(), releases_data)
-        self.assertDictEqual(result.release.year.dict(), releases_data)
+        result = db_stats.get_user_releases(1, 'year')
+        self.assertDictEqual(result.year.dict(), releases_data)
 
     def test_insert_user_stats_mult_ranges_recording(self):
         """ Test if multiple time range data is inserted correctly """
@@ -80,10 +82,11 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         db_stats.insert_user_recordings(user_id=self.user['id'],
                                         recordings=UserRecordingStatJson(**{'all_time': recordings_data}))
 
-        result = db_stats.get_user_recordings(1)
+        result = db_stats.get_user_recordings(1, 'all_time')
+        self.assertDictEqual(result.all_time.dict(), recordings_data)
 
-        self.assertDictEqual(result.recording.all_time.dict(), recordings_data)
-        self.assertDictEqual(result.recording.year.dict(), recordings_data)
+        result = db_stats.get_user_recordings(1, 'year')
+        self.assertDictEqual(result.year.dict(), recordings_data)
 
     def insert_test_data(self):
         """ Insert test data into the database """
@@ -113,18 +116,18 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
     def test_get_user_artists(self):
         data_inserted = self.insert_test_data()
-        result = db_stats.get_user_artists(self.user['id'])
-        self.assertDictEqual(result.artist.all_time.dict(), data_inserted['user_artists'])
+        result = db_stats.get_user_artists(self.user['id'], 'all_time')
+        self.assertDictEqual(result.all_time.dict(), data_inserted['user_artists'])
 
     def test_get_user_releases(self):
         data_inserted = self.insert_test_data()
-        result = db_stats.get_user_releases(self.user['id'])
-        self.assertDictEqual(result.release.all_time.dict(), data_inserted['user_releases'])
+        result = db_stats.get_user_releases(self.user['id'], 'all_time')
+        self.assertDictEqual(result.all_time.dict(), data_inserted['user_releases'])
 
     def test_get_user_recordings(self):
         data_inserted = self.insert_test_data()
-        result = db_stats.get_user_recordings(self.user['id'])
-        self.assertDictEqual(result.recording.all_time.dict(), data_inserted['user_recordings'])
+        result = db_stats.get_user_recordings(self.user['id'], 'all_time')
+        self.assertDictEqual(result.all_time.dict(), data_inserted['user_recordings'])
 
     def test_valid_stats_exist(self):
         self.assertFalse(db_stats.valid_stats_exist(self.user['id'], 7))

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -136,13 +136,13 @@ class UserTestCase(DatabaseTestCase):
             user_id=user_id,
             artists=UserArtistStatJson(**{'all_time': artists_data}),
         )
-        user_stats = db_stats.get_user_artists(user_id)
+        user_stats = db_stats.get_user_artists(user_id, 'all_time')
         self.assertIsNotNone(user_stats)
 
         db_user.delete(user_id)
         user = db_user.get(user_id)
         self.assertIsNone(user)
-        user_stats = db_stats.get_user_artists(user_id)
+        user_stats = db_stats.get_user_artists(user_id, 'all_time')
         self.assertIsNone(user_stats)
 
     def test_delete_when_spotify_import_activated(self):

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -291,7 +291,7 @@ def get_recording(user_name):
     .. note::
         - This endpoint is currently in beta
         - ``artist_mbids``, ``artist_msid``,``release_name``, ``release_mbid``, ``release_msid``,
-          ``recording_mbid`` and ``recording_msid`` are optional fields and may not be present in all the respon
+          ``recording_mbid`` and ``recording_msid`` are optional fields and may not be present in all the responses
 
     :param count: Optional, number of recordings to return, Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET`
         Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -1,14 +1,18 @@
 from datetime import datetime
 from enum import Enum
-from typing import Union, List
+from pydantic import ValidationError
+from typing import List, Union
 
 from flask import Blueprint, current_app, jsonify, request
 
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
-from listenbrainz.db.model.user_artist_stat import UserArtistStat, UserArtistRecord
-from listenbrainz.db.model.user_release_stat import UserReleaseStat, UserReleaseRecord
-from listenbrainz.db.model.user_recording_stat import UserRecordingStat, UserRecordingRecord
+from listenbrainz.db.model.user_artist_stat import (UserArtistRecord,
+                                                    UserArtistStat)
+from listenbrainz.db.model.user_recording_stat import (UserRecordingRecord,
+                                                       UserRecordingStat)
+from listenbrainz.db.model.user_release_stat import (UserReleaseRecord,
+                                                     UserReleaseStat)
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import (APIBadRequest,
                                            APIInternalServerError,
@@ -19,6 +23,7 @@ from listenbrainz.webserver.rate_limiter import ratelimit
 from listenbrainz.webserver.views.api_tools import (DEFAULT_ITEMS_PER_GET,
                                                     MAX_ITEMS_PER_GET,
                                                     _get_non_negative_param)
+
 stats_api_bp = Blueprint('stats_api_v1', __name__)
 
 
@@ -94,10 +99,6 @@ def get_artist(user_name):
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
-    stats = db_stats.get_user_artists(user['id'])
-    if stats is None:
-        raise APINoContent('')
-
     stats_range = request.args.get('range', default='all_time')
     if not _is_valid_range(stats_range):
         raise APIBadRequest("Invalid range: {}".format(stats_range))
@@ -105,13 +106,18 @@ def get_artist(user_name):
     offset = _get_non_negative_param('offset', default=0)
     count = _get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
-    entity_list, total_entity_count = _process_entity(user_name, stats, stats_range, offset, count, entity='artist')
     try:
-        from_ts = int(getattr(stats.artist, stats_range).from_ts)
-        to_ts = int(getattr(stats.artist, stats_range).to_ts)
-        last_updated = int(stats.last_updated.timestamp())
-    except AttributeError:
+        stats = db_stats.get_user_artists(user['id'], stats_range)
+    except ValidationError:
+        # If the stored stats are not correct, we should should not return them
         raise APINoContent('')
+    if stats is None or getattr(stats, stats_range) is None:
+        raise APINoContent('')
+
+    entity_list, total_entity_count = _process_entity(stats, stats_range, offset, count, entity='artist')
+    from_ts = int(getattr(stats, stats_range).from_ts)
+    to_ts = int(getattr(stats, stats_range).to_ts)
+    last_updated = int(stats.last_updated.timestamp())
 
     return jsonify({'payload': {
         "user_id": user_name,
@@ -201,10 +207,6 @@ def get_release(user_name):
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
-    stats = db_stats.get_user_releases(user['id'])
-    if stats is None:
-        raise APINoContent('')
-
     stats_range = request.args.get('range', default='all_time')
     if not _is_valid_range(stats_range):
         raise APIBadRequest("Invalid range: {}".format(stats_range))
@@ -212,13 +214,18 @@ def get_release(user_name):
     offset = _get_non_negative_param('offset', default=0)
     count = _get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
-    entity_list, total_entity_count = _process_entity(user_name, stats, stats_range, offset, count, entity='release')
     try:
-        from_ts = int(getattr(stats.release, stats_range).from_ts)
-        to_ts = int(getattr(stats.release, stats_range).to_ts)
-        last_updated = int(stats.last_updated.timestamp())
-    except AttributeError:
+        stats = db_stats.get_user_releases(user['id'], stats_range)
+    except ValidationError:
+        # If the stored stats are not correct, we should should not return them
         raise APINoContent('')
+    if stats is None or getattr(stats, stats_range) is None:
+        raise APINoContent('')
+
+    entity_list, total_entity_count = _process_entity(stats, stats_range, offset, count, entity='release')
+    from_ts = int(getattr(stats, stats_range).from_ts)
+    to_ts = int(getattr(stats, stats_range).to_ts)
+    last_updated = int(stats.last_updated.timestamp())
 
     return jsonify({'payload': {
         "user_id": user_name,
@@ -283,8 +290,8 @@ def get_recording(user_name):
 
     .. note::
         - This endpoint is currently in beta
-        - ``artist_mbids``, ``artist_msid``, ``recording_mbid`` and ``recording_msid`` are optional fields and
-            may not be present in all the responses
+        - ``artist_mbids``, ``artist_msid``,``release_name``, ``release_mbid``, ``release_msid``,
+          ``recording_mbid`` and ``recording_msid`` are optional fields and may not be present in all the respon
 
     :param count: Optional, number of recordings to return, Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET`
         Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
@@ -305,10 +312,6 @@ def get_recording(user_name):
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
-    stats = db_stats.get_user_recordings(user['id'])
-    if stats is None:
-        raise APINoContent('')
-
     stats_range = request.args.get('range', default='all_time')
     if not _is_valid_range(stats_range):
         raise APIBadRequest("Invalid range: {}".format(stats_range))
@@ -316,13 +319,18 @@ def get_recording(user_name):
     offset = _get_non_negative_param('offset', default=0)
     count = _get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
-    entity_list, total_entity_count = _process_entity(user_name, stats, stats_range, offset, count, entity='recording')
     try:
-        from_ts = int(getattr(stats.recording, stats_range).from_ts)
-        to_ts = int(getattr(stats.recording, stats_range).to_ts)
-        last_updated = int(stats.last_updated.timestamp())
-    except AttributeError:
+        stats = db_stats.get_user_recordings(user['id'], stats_range)
+    except ValidationError:
+        # If the stored stats are not correct, we should should not return them
         raise APINoContent('')
+    if stats is None or getattr(stats, stats_range) is None:
+        raise APINoContent('')
+
+    entity_list, total_entity_count = _process_entity(stats, stats_range, offset, count, entity='recording')
+    from_ts = int(getattr(stats, stats_range).from_ts)
+    to_ts = int(getattr(stats, stats_range).to_ts)
+    last_updated = int(stats.last_updated.timestamp())
 
     return jsonify({'payload': {
         "user_id": user_name,
@@ -337,11 +345,10 @@ def get_recording(user_name):
     }})
 
 
-def _process_entity(user_name, stats, stats_range, offset, count, entity):
+def _process_entity(stats, stats_range, offset, count, entity):
     """ Process the statistics data according to query params
 
         Args:
-            user_name (str): musicbrainz_id of the user
             stats (dict): the dictionary containing statistic data
             stats_range (str): time interval for which statistics should be collected
             offset (int): number of entities to skip from the beginning
@@ -356,7 +363,7 @@ def _process_entity(user_name, stats, stats_range, offset, count, entity):
 
     count = min(count, MAX_ITEMS_PER_GET)
     count = count + offset
-    total_entity_count = _get_total_entity_count(stats, stats_range, entity)
+    total_entity_count = getattr(stats, stats_range).count
     entity_list = [x.dict() for x in _get_entity_list(stats, stats_range, entity, offset, count)]
 
     return entity_list, total_entity_count
@@ -374,25 +381,6 @@ def _is_valid_range(stats_range: str) -> bool:
     return stats_range in StatisticsRange.__members__
 
 
-def _get_total_entity_count(
-    stats: Union[UserArtistStat, UserReleaseStat, UserRecordingStat],
-    stats_range: StatisticsRange,
-    entity: int
-) -> int:
-    """ Returns the total entity count
-    """
-    try:
-        if entity == 'artist':
-            return getattr(stats.artist, stats_range).count
-        elif entity == 'release':
-            return getattr(stats.release, stats_range).count
-        elif entity == 'recording':
-            return getattr(stats.recording, stats_range).count
-        raise APIBadRequest("Unknown entity: %s" % entity)
-    except AttributeError:
-        raise APINoContent('')
-
-
 def _get_entity_list(
     stats: Union[UserArtistStat, UserReleaseStat, UserRecordingStat],
     stats_range: StatisticsRange,
@@ -402,13 +390,10 @@ def _get_entity_list(
 ) -> List[Union[UserArtistRecord, UserReleaseRecord, UserRecordingRecord]]:
     """ Gets a list of entity records from the stat passed based on the offset and count
     """
-    try:
-        if entity == 'artist':
-            return getattr(stats.artist, stats_range).artists[offset:count]
-        elif entity == 'release':
-            return getattr(stats.release, stats_range).releases[offset:count]
-        elif entity == 'recording':
-            return getattr(stats.recording, stats_range).recordings[offset:count]
-        raise APIBadRequest("Unknown entity: %s" % entity)
-    except AttributeError:
-        raise APINoContent('')
+    if entity == 'artist':
+        return getattr(stats, stats_range).artists[offset:count]
+    elif entity == 'release':
+        return getattr(stats, stats_range).releases[offset:count]
+    elif entity == 'recording':
+        return getattr(stats, stats_range).recordings[offset:count]
+    raise APIBadRequest("Unknown entity: %s" % entity)

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -18,6 +18,7 @@ from listenbrainz.webserver.views.api_tools import publish_data_to_queue
 import time
 from datetime import datetime
 from werkzeug.exceptions import NotFound, BadRequest, RequestEntityTooLarge, InternalServerError
+from pydantic import ValidationError
 
 LISTENS_PER_PAGE = 25
 
@@ -104,10 +105,10 @@ def profile(user_name):
             }
             listens.insert(0, listen)
 
-    user_stats = db_stats.get_user_artists(user.id)
+    user_stats = db_stats.get_user_artists(user.id, 'all_time')
     try:
-        artist_count = user_stats.artist.all_time.count
-    except AttributeError:
+        artist_count = user_stats.all_time.count
+    except (AttributeError, ValidationError):
         artist_count = None
 
     spotify_data = {}


### PR DESCRIPTION
# Problem
We get `ValidationError` when getting data for "Top Recordings" for some users. I suspect that this has to do with the fact that the "All Time" stats are not getting written in the DB correctly. We are fetching data for all the time ranges even though we only need one of them leading to `ValidationError` for "Year" statistics even though they have been calculated correctly. Loading all the stats is also inefficient and increases memory consumption in the server.

# Solution
This is part 1 of a two part PR which temporarily fixes the `ValidationError` for statistics which have been calculated correctly by fetching data for the requested time range only. If in any particular scenario we need to get all the ranges together, we can use the `get_user_stats` function to do that.
I plan to make a further PR after investigating why the `ValidationError` is happening in the first place.