### PR TITLE
Create dumps for recording_feedback

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -285,7 +285,7 @@ def create_private_dump(location, dump_time, threads=DUMP_DEFAULT_THREAD_COUNT):
 
 def create_public_dump(location, dump_time, threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Create postgres database dump for statistics and user info in db.
-        This includes a sanitized dump of the "user"' and recording_feedback table and dumps of all tables
+        This includes a sanitized dump of the "user" table and dumps of all tables
         in the statistics schema:
             statistics.user
             statistics.artist

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -90,6 +90,13 @@ PUBLIC_TABLES = {
         'listen_count',
         'last_updated',
     ),
+    'recording_feedback': (
+        'id',
+        'user_id',
+        'recording_msid',
+        'score',
+        'created'
+    ),
 }
 
 # this dict contains the tables dumped in the private dump as keys
@@ -278,7 +285,7 @@ def create_private_dump(location, dump_time, threads=DUMP_DEFAULT_THREAD_COUNT):
 
 def create_public_dump(location, dump_time, threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Create postgres database dump for statistics and user info in db.
-        This includes a sanitized dump of the "user"' table and dumps of all tables
+        This includes a sanitized dump of the "user"' and recording_feedback table and dumps of all tables
         in the statistics schema:
             statistics.user
             statistics.artist

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -133,7 +133,8 @@ class DumpTestCase(DatabaseTestCase):
             db_dump.import_postgres_dump(private_dump, public_dump)
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
-            dumped_feedback = db_feedback.get_feedback_for_user(user_id=one_id, limit=1,offset=0)
+
+            dumped_feedback = db_feedback.get_feedback_for_user(user_id=one_id, limit=1, offset=0)
             self.assertEqual(len(dumped_feedback), 1)
             self.assertEqual(dumped_feedback[0].user_id, feedback.user_id)
             self.assertEqual(dumped_feedback[0].recording_msid, feedback.recording_msid)
@@ -143,10 +144,13 @@ class DumpTestCase(DatabaseTestCase):
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)
+            dumped_feedback = []
 
             db_dump.import_postgres_dump(private_dump, public_dump, threads=2)
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
+
+            dumped_feedback = db_feedback.get_feedback_for_user(user_id=one_id, limit=1, offset=0)
             self.assertEqual(len(dumped_feedback), 1)
             self.assertEqual(dumped_feedback[0].user_id, feedback.user_id)
             self.assertEqual(dumped_feedback[0].recording_msid, feedback.recording_msid)


### PR DESCRIPTION
This PR adds the `recording_feedback` table to the list of PUBLIC_TABLES so that it can be dumped into the LB public dumps