### PR TITLE
LB-635: Always return JSON for 500s in the API

### DIFF
--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -5,6 +5,7 @@ import ujson
 import collections
 
 from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver import API_PREFIX
 
 LastFMError = collections.namedtuple('LastFMError', ['code', 'message'])
 
@@ -161,7 +162,11 @@ def init_error_handlers(app):
 
     @app.errorhandler(500)
     def internal_server_error(error):
-        return handle_error(error, 500)
+        if request.path.startswith(API_PREFIX):
+            error = APIError("An unknown error occured.", 500)
+            return jsonify(error.to_dict()), error.status_code
+        else:
+            return handle_error(error, 500)
 
     @app.errorhandler(503)
     def service_unavailable(error):

--- a/listenbrainz/webserver/test/test_api_errors.py
+++ b/listenbrainz/webserver/test/test_api_errors.py
@@ -1,0 +1,19 @@
+from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.webserver.testing import ServerTestCase
+
+from unittest import mock
+from werkzeug.exceptions import InternalServerError
+
+
+class APIErrorTestCase(DatabaseTestCase, ServerTestCase):
+
+    def setUp(self):
+        ServerTestCase.setUp(self)
+        DatabaseTestCase.setUp(self)
+
+    @mock.patch('listenbrainz.webserver.views.stats_api.db_user.get_by_mb_id')
+    def test_api_error_unexpected_error_returns_json(self, mock_db_get):
+        mock_db_get.side_effect = InternalServerError("Some bad thing happened")
+        r = self.client.get('/1/stats/user/iliekcomputers/artists')
+        self.assert500(r)
+        self.assertEqual(r.json['error'], 'An unknown error occured.')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
We were returning HTML for unexpected errors in the API


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add some logic to the handler to check if it's the endpoint and return a generic error message in JSON. The error will be logged to Sentry so devs should have access to the logs that way, we don't need to show it to users.


