### PR TITLE
Fix release links on Recordings Chart

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/Bar.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/Bar.test.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import Bar, { BarProps } from "./Bar";
+import * as userRecordingsProcessDataOutput from "../__mocks__/userRecordingsProcessData.json";
+
+const props: BarProps = {
+  data: userRecordingsProcessDataOutput as UserEntityData,
+  maxValue: userRecordingsProcessDataOutput[24].count,
+};
+
+describe("getEntityLink", () => {
+  it("returns anchor element if entityMBID is present", () => {
+    const wrapper = shallow<Bar>(<Bar {...props} />);
+    const instance = wrapper.instance();
+
+    const result = shallow(
+      instance.getEntityLink(
+        {
+          id: "0",
+          idx: 0,
+          entity: "test",
+          entityType: "recording",
+          entityMBID: "1234",
+          count: 0,
+        },
+        "test"
+      )
+    );
+
+    expect(
+      result.equals(
+        <a
+          href="http://musicbrainz.org/recording/1234"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          test
+        </a>
+      )
+    ).toEqual(true);
+  });
+
+  it("returns string if entityMBID is not present", () => {
+    const wrapper = shallow<Bar>(<Bar {...props} />);
+    const instance = wrapper.instance();
+
+    const result = instance.getEntityLink(
+      {
+        id: "0",
+        idx: 0,
+        entity: "test",
+        entityType: "recording",
+        count: 0,
+      },
+      "test"
+    );
+
+    expect(result).toEqual(<>test</>);
+  });
+});
+
+describe("getArtistLink", () => {
+  it("returns anchor element if artistMBID is present", () => {
+    const wrapper = shallow<Bar>(<Bar {...props} />);
+    const instance = wrapper.instance();
+
+    const result = shallow(
+      instance.getArtistLink(
+        {
+          id: "0",
+          idx: 0,
+          entity: "test",
+          entityType: "recording",
+          artist: "foobar",
+          artistMBID: ["1234"],
+          count: 0,
+        },
+        "foobar"
+      )
+    );
+
+    expect(
+      result.equals(
+        <a
+          href="http://musicbrainz.org/artist/1234"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          foobar
+        </a>
+      )
+    ).toEqual(true);
+  });
+
+  it("returns string if artistMBID is not present", () => {
+    const wrapper = shallow<Bar>(<Bar {...props} />);
+    const instance = wrapper.instance();
+
+    const result = instance.getArtistLink(
+      {
+        id: "0",
+        idx: 0,
+        entity: "test",
+        entityType: "recording",
+        artist: "foobar",
+        count: 0,
+      },
+      "foobar"
+    );
+
+    expect(result).toEqual(<>foobar</>);
+  });
+});
+
+describe("getReleaseLink", () => {
+  it("returns anchor element if releaseMBID is present", () => {
+    const wrapper = shallow<Bar>(<Bar {...props} />);
+    const instance = wrapper.instance();
+
+    const result = shallow(
+      instance.getReleaseLink(
+        {
+          id: "0",
+          idx: 0,
+          entity: "test",
+          entityType: "recording",
+          release: "barfoo",
+          releaseMBID: "1234",
+          count: 0,
+        },
+        "barfoo"
+      )
+    );
+
+    expect(
+      result.equals(
+        <a
+          href="http://musicbrainz.org/release/1234"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          barfoo
+        </a>
+      )
+    ).toEqual(true);
+  });
+
+  it("returns string if artistMBID is not present", () => {
+    const wrapper = shallow<Bar>(<Bar {...props} />);
+    const instance = wrapper.instance();
+
+    const result = instance.getReleaseLink(
+      {
+        id: "0",
+        idx: 0,
+        entity: "test",
+        entityType: "recording",
+        artist: "foobar",
+        count: 0,
+      },
+      "barfoo"
+    );
+
+    expect(result).toEqual(<>barfoo</>);
+  });
+});

--- a/listenbrainz/webserver/static/js/src/stats/Bar.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/Bar.tsx
@@ -27,7 +27,7 @@ type Tick = {
 };
 
 export default class Bar extends React.Component<BarProps, BarState> {
-  getEntityLink = (data: UserEntityDatum, entity: string) => {
+  getEntityLink = (data: UserEntityDatum, entity: string): JSX.Element => {
     if (data.entityMBID) {
       return (
         <a
@@ -39,10 +39,10 @@ export default class Bar extends React.Component<BarProps, BarState> {
         </a>
       );
     }
-    return entity;
+    return <>{entity}</>;
   };
 
-  getArtistLink = (data: UserEntityDatum, artist: string) => {
+  getArtistLink = (data: UserEntityDatum, artist: string): JSX.Element => {
     if (data.artistMBID && data.artistMBID.length) {
       return (
         <a
@@ -54,10 +54,10 @@ export default class Bar extends React.Component<BarProps, BarState> {
         </a>
       );
     }
-    return artist;
+    return <>{artist}</>;
   };
 
-  getReleaseLink = (data: UserEntityDatum, release: string) => {
+  getReleaseLink = (data: UserEntityDatum, release: string): JSX.Element => {
     if (data.release && data.releaseMBID) {
       const res = (
         <a
@@ -70,7 +70,7 @@ export default class Bar extends React.Component<BarProps, BarState> {
       );
       return res;
     }
-    return release;
+    return <>{release}</>;
   };
 
   render() {

--- a/listenbrainz/webserver/static/js/src/stats/Bar.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/Bar.tsx
@@ -61,7 +61,7 @@ export default class Bar extends React.Component<BarProps, BarState> {
     if (data.release && data.releaseMBID) {
       const res = (
         <a
-          href={`http://musicbrainz.org/artist/${data.releaseMBID}`}
+          href={`http://musicbrainz.org/release/${data.releaseMBID}`}
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
# Problem
The release links on Recording charts are incorrect.

# Solution
Changing the entity from artist to release fixes the issue.