### PR TITLE
Remove the Stats Calculation Request Section

### DIFF
--- a/docs/dev/api.rst
+++ b/docs/dev/api.rst
@@ -62,12 +62,12 @@ Core API Endpoints
   :statuscode 401: invalid authorization. See error message for details.
 
 Statistics API Endpoints
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 ListenBrainz now has a statistics infrastructure that collects and computes statistics
 from the listen data that has been stored in the database. The endpoints in this section
-offer a way to get this data programmatically. Right now, we only calculate statistics
-for the top artists that a user has listened to.However, we plan to add more statistics
-in the near future.
+offer a way to get this data programmatically. Right now, we calculate statistics
+for the top artists, releases and recordings that a user has listened to. However, we plan
+to add more statistics in the near future.
 
 .. autoflask:: listenbrainz.webserver:create_app_rtfd()
    :blueprints: stats_api_v1

--- a/docs/dev/faqs.rst
+++ b/docs/dev/faqs.rst
@@ -10,7 +10,6 @@ FAQs
     sudo usermod -aG docker $USER
 
 - After this command, restart the computer and then again run ``./develop.sh build.``
-|
 
 **How to resolve 'datanode is running as process 1. Stop it first' or 'namenode is running as process 1. Stop it first'?**
 
@@ -21,7 +20,6 @@ FAQs
     ./develop.sh spark down
 
 - When the containers shut down, run ``./develop.sh spark up`` again.
-|
 
 **How to resolve 'sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) FATAL: role "listenbrainz" does not exist' on running './test.sh'?**
 

--- a/docs/dev/feedback-json.rst
+++ b/docs/dev/feedback-json.rst
@@ -36,19 +36,19 @@ Fetching feedback JSON
 
 The JSON documents returned from our API for recording feedback look like the following::
 
-{
-   count: 1,
-   feedback: [
-      {
-         "user_id": "-- the MusicBrainz ID of the user --",
-         "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
-         "score": 1
-      },
-      "-- more feedback data here ---"
-   ],
-   offset: 0,
-   total_count: 1
-}
+    {
+      count: 1,
+      feedback: [
+        {
+            "user_id": "-- the MusicBrainz ID of the user --",
+            "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+            "score": 1
+        },
+        "-- more feedback data here ---"
+      ],
+      offset: 0,
+      total_count: 1
+    }
 
 The number of feedback items in the document are returned by the top-level ``count`` element. The total number of
 feedback items for the user/recording are returned by the top-level ``total_count``. ``offset`` specifies the

--- a/docs/dev/listenbrainz-dumps.rst
+++ b/docs/dev/listenbrainz-dumps.rst
@@ -81,7 +81,7 @@ Here is some example code to parse the listens dump:
 
 
 Incremental dumps (BETA)
-=================
+========================
 
 .. warning::
 

--- a/listenbrainz/webserver/templates/profile/info.html
+++ b/listenbrainz/webserver/templates/profile/info.html
@@ -51,14 +51,6 @@
       <span class="btn btn-info btn-lg" style="width: 200px"><a href="{{ url_for("profile.reset_token") }}" style="color: white;">Reset token</a></span>
     </p>
 
-    <h3> Request Statistics Calculation </h3>
-
-    <p>
-      There have been some problems with our statistics infrastructure which used Google BigQuery. We're currently in
-      the process of fixing it. In the meantime, new statistics will not be calculated. Please bear with us while
-      we work on getting statistics back, hopefully very soon!
-    </p>
-
   </div>
 
 {% endblock %}

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -42,7 +42,7 @@ def get_artist(user_name):
     Get top artists for user ``user_name``.
 
 
-    An sample response from the endpoint may look like::
+    A sample response from the endpoint may look like::
 
         {
             "payload": {
@@ -140,7 +140,7 @@ def get_release(user_name):
     Get top releases for user ``user_name``.
 
 
-    An sample response from the endpoint may look like::
+    A sample response from the endpoint may look like::
 
         {
             "payload": {
@@ -186,7 +186,7 @@ def get_release(user_name):
     .. note::
         - This endpoint is currently in beta
         - ``artist_mbids``, ``artist_msid``, ``release_mbid`` and ``release_msid`` are optional fields and
-            may not be present in all the responses
+          may not be present in all the responses
 
     :param count: Optional, number of releases to return, Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET`
         Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
@@ -248,7 +248,7 @@ def get_recording(user_name):
     Get top recordings for user ``user_name``.
 
 
-    An sample response from the endpoint may look like::
+    A sample response from the endpoint may look like::
 
         {
             "payload": {
@@ -290,7 +290,7 @@ def get_recording(user_name):
 
     .. note::
         - This endpoint is currently in beta
-        - ``artist_mbids``, ``artist_msid``,``release_name``, ``release_mbid``, ``release_msid``,
+        - ``artist_mbids``, ``artist_msid``, ``release_name``, ``release_mbid``, ``release_msid``,
           ``recording_mbid`` and ``recording_msid`` are optional fields and may not be present in all the responses
 
     :param count: Optional, number of recordings to return, Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET`


### PR DESCRIPTION
This PR aims to remove the "Request Statistics Calculation" section under the "My Profile" page, since the new pipeline based on Apache Spark is in proper action.