### PR TITLE
Improve query for all time "Listening Activity" statsistics

### DIFF
--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -388,6 +388,8 @@ def get_listening_activity(user_name: str):
         - The example above shows the data for three days only, however we calculate the statistics for
           the current time range and the previous time range. For example for weekly statistics the data
           is calculated for the current as well as the past week.
+        - For ``all_time`` listening activity statistics we only return the years which have more than
+          zero listens.
 
     :param range: Optional, time interval for which statistics should be returned, possible values are ``week``,
         ``month``, ``year``, ``all_time``, defaults to ``all_time``

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -171,7 +171,7 @@ def get_listening_activity_all_time() -> Iterator[UserListeningActivityStatMessa
                            count(user_name) as listen_count
                       FROM listens
                   GROUP BY user_name
-                """.format(year=year))
+                  """)
         year_df = year_df.withColumn('time_range', lit(str(year))).withColumn(
             'from_ts', lit(year_start.timestamp())).withColumn('to_ts', lit(year_end.timestamp()))
         result_without_zero_years = result_without_zero_years.union(year_df) if result_without_zero_years else year_df

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -6,11 +7,30 @@ import listenbrainz_spark.stats.user.listening_activity as listening_activity_st
 import listenbrainz_spark
 from listenbrainz_spark import utils
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
+from listenbrainz_spark.exceptions import HDFSException
 from listenbrainz_spark.path import LISTENBRAINZ_DATA_DIRECTORY
 from listenbrainz_spark.stats import (adjust_days, adjust_months, get_day_end,
                                       get_month_end, get_year_end, run_query)
 from listenbrainz_spark.tests import SparkTestCase
 from pyspark.sql import Row
+
+
+def _mock_get_listens_all_time(from_date: datetime, to_date: datetime):
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../..', 'testdata')
+    file_ = os.path.join(path, 'user_listening_activity_all_time.json')
+    with open(file_) as f:
+        data = json.load(f)
+
+    listens_df = None
+    for entry in data:
+        if entry['year'] == from_date.year:
+            row = utils.create_dataframe(Row(user_name=entry['user_name'], listened_at=from_date), schema=None)
+            listens_df = listens_df.union(row) if listens_df else row
+
+    if listens_df is None:
+        raise HDFSException('')
+
+    listens_df.createOrReplaceTempView('listens')
 
 
 class ListeningActivityTestCase(SparkTestCase):
@@ -137,30 +157,23 @@ class ListeningActivityTestCase(SparkTestCase):
                                                 from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
     @patch('listenbrainz_spark.stats.user.listening_activity.get_latest_listen_ts', return_value=datetime(2020, 6, 19))
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_listens')
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_listening_activity', return_value='listening_activity_table')
-    @patch('listenbrainz_spark.stats.user.listening_activity.create_messages')
-    def test_get_listening_activity_all_time(self, mock_create_messages, mock_get_listening_activity,
-                                             mock_get_listens, mock_get_latest_listen_ts):
-        mock_df = MagicMock()
-        mock_get_listens.return_value = mock_df
+    @patch('listenbrainz_spark.stats.user.listening_activity._get_listens', side_effect=_mock_get_listens_all_time)
+    @patch('listenbrainz_spark.stats.user.listening_activity.create_messages',
+           side_effect=lambda data, stats_range, from_ts, to_ts: data)
+    def test_get_listening_activity_all_time(self, mock_create_messages, mock_get_listens, mock_get_latest_listen_ts):
+        with open(self.path_to_data_file('user_listening_activity_all_time.json')) as f:
+            data = json.load(f)
 
-        listening_activity_stats.get_listening_activity_all_time()
-        to_date = datetime(2020, 6, 19)
-        from_date = month = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
+        expected = self._calculate_expected_all_time(data)
 
-        time_range = []
-        for year in range(from_date.year, to_date.year+1):
-            time_range.append([str(year), datetime(year, 1, 1), get_year_end(year)])
-        time_range_df = run_query("SELECT * FROM time_range")
-        time_range_result = time_range_df.rdd.map(list).collect()
-        self.assertListEqual(time_range_result, time_range)
+        # Get the result calculated by the function we want to test
+        data = listening_activity_stats.get_listening_activity_all_time()
+        received = {}
+        for entry in data:
+            _dict = entry.asDict(recursive=True)
+            received[_dict['user_name']] = _dict['listening_activity']
 
-        mock_get_latest_listen_ts.assert_called_once()
-        mock_get_listens.assert_called_with(from_date, to_date, LISTENBRAINZ_DATA_DIRECTORY)
-        mock_df.createOrReplaceTempView.assert_called_with('listens')
-        mock_create_messages.assert_called_with(data='listening_activity_table', stats_range='all_time',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+        self.assertDictEqual(received, expected)
 
     def _calculate_expected(self, data: dict) -> dict:
         expected = {}
@@ -176,5 +189,47 @@ class ListeningActivityTestCase(SparkTestCase):
             for range_ in expected[entry['user_name']]:
                 if range_['from_ts'] <= entry['timestamp'] <= range_['to_ts']:
                     range_['listen_count'] += 1
+
+        return expected
+
+    def _calculate_expected_all_time(self, data: dict) -> dict:
+        expected = {}
+        for entry in data:
+            if not entry['user_name'] in expected:
+                expected[entry['user_name']] = [
+                    {
+                        'time_range': '2017',
+                        'from_ts': datetime(2017, 1, 1).timestamp(),
+                        'to_ts': datetime(2017, 12, 31, 23, 59, 59).timestamp(),
+                        'listen_count': 0
+                    },
+                    {
+                        'time_range': '2018',
+                        'from_ts': datetime(2018, 1, 1).timestamp(),
+                        'to_ts': datetime(2018, 12, 31, 23, 59, 59).timestamp(),
+                        'listen_count': 0
+                    },
+                    {
+                        'time_range': '2019',
+                        'from_ts': datetime(2019, 1, 1).timestamp(),
+                        'to_ts': datetime(2019, 12, 31, 23, 59, 59).timestamp(),
+                        'listen_count': 0
+                    },
+                    {
+                        'time_range': '2020',
+                        'from_ts': datetime(2020, 1, 1).timestamp(),
+                        'to_ts': datetime(2020, 12, 31, 23, 59, 59).timestamp(),
+                        'listen_count': 0
+                    }
+                ]
+
+        for entry in data:
+            for range_ in expected[entry['user_name']]:
+                if range_['time_range'] == str(entry['year']):
+                    range_['listen_count'] += 1
+
+        # Remove entries with zero listens
+        for entry in data:
+            expected[entry['user_name']] = [range_ for range_ in expected[entry['user_name']] if range_['listen_count'] > 0]
 
         return expected

--- a/listenbrainz_spark/testdata/user_listening_activity_all_time.json
+++ b/listenbrainz_spark/testdata/user_listening_activity_all_time.json
@@ -1,0 +1,54 @@
+[
+  {
+    "user_name": "user_1",
+    "year": 2017
+  },
+  {
+    "user_name": "user_1",
+    "year": 2017
+  },
+  {
+    "user_name": "user_1",
+    "year": 2017
+  },
+  {
+    "user_name": "user_2",
+    "year": 2017
+  },
+  {
+    "user_name": "user_1",
+    "year": 2018
+  },
+  {
+    "user_name": "user_2",
+    "year": 2018
+  },
+  {
+    "user_name": "user_2",
+    "year": 2018
+  },
+  {
+    "user_name": "user_3",
+    "year": 2018
+  },
+  {
+    "user_name": "user_2",
+    "year": 2019
+  },
+  {
+    "user_name": "user_3",
+    "year": 2019
+  },
+  {
+    "user_name": "user_3",
+    "year": 2019
+  },
+  {
+    "user_name": "user_1",
+    "year": 2020
+  },
+  {
+    "user_name": "user_2",
+    "year": 2020
+  }
+]


### PR DESCRIPTION
# Problem
The current query for calculation "Listening Activity" is not efficient and does not work for calculating all time statistics.

# Solution
A better way to calculate all time statistics is to calculate the data year wise and merge it in a later stage.