### PR TITLE
LB-639: Send only top 1000 recordings for each user

### DIFF
--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -78,7 +78,6 @@ def get_artist(user_name):
 
     .. note::
         - This endpoint is currently in beta
-        - We only calculate the top 750 artists
         - ``artist_mbids`` and ``artist_msid`` are optional fields and may not be present in all the responses
 
     :param count: Optional, number of artists to return, Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET`
@@ -182,7 +181,6 @@ def get_release(user_name):
 
     .. note::
         - This endpoint is currently in beta
-        - We only calculate the top 750 releases
         - ``artist_mbids``, ``artist_msid``, ``release_mbid`` and ``release_msid`` are optional fields and
           may not be present in all the responses
 
@@ -284,7 +282,7 @@ def get_recording(user_name):
 
     .. note::
         - This endpoint is currently in beta
-        - We only calculate the top 750 recordings
+        - We only calculate the top 1000 recordings
         - ``artist_mbids``, ``artist_msid``, ``release_name``, ``release_mbid``, ``release_msid``,
           ``recording_mbid`` and ``recording_msid`` are optional fields and may not be present in all the responses
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -282,7 +282,7 @@ def get_recording(user_name):
 
     .. note::
         - This endpoint is currently in beta
-        - We only calculate the top 1000 recordings
+        - We only calculate the top 1000 all_time recordings
         - ``artist_mbids``, ``artist_msid``, ``release_name``, ``release_mbid``, ``release_msid``,
           ``recording_mbid`` and ``recording_msid`` are optional fields and may not be present in all the responses
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -78,6 +78,7 @@ def get_artist(user_name):
 
     .. note::
         - This endpoint is currently in beta
+        - We only calculate the top 750 artists
         - ``artist_mbids`` and ``artist_msid`` are optional fields and may not be present in all the responses
 
     :param count: Optional, number of artists to return, Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET`
@@ -181,6 +182,7 @@ def get_release(user_name):
 
     .. note::
         - This endpoint is currently in beta
+        - We only calculate the top 750 releases
         - ``artist_mbids``, ``artist_msid``, ``release_mbid`` and ``release_msid`` are optional fields and
           may not be present in all the responses
 
@@ -282,6 +284,7 @@ def get_recording(user_name):
 
     .. note::
         - This endpoint is currently in beta
+        - We only calculate the top 750 recordings
         - ``artist_mbids``, ``artist_msid``, ``release_name``, ``release_mbid``, ``release_msid``,
           ``recording_mbid`` and ``recording_msid`` are optional fields and may not be present in all the responses
 

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -80,7 +80,12 @@ class RequestConsumer:
                     self.rabbitmq.close()
                     self.connect_to_rabbitmq()
                     self.init_rabbitmq_channels()
-        current_app.logger.debug("Done!")
+
+        avg_size_of_message //= num_of_messages
+
+        current_app.logger.info("Done!")
+        current_app.logger.info("Number of messages sent: {}".format(num_of_messages))
+        current_app.logger.info("Average size of message: {} bytes".format(avg_size_of_message))
 
     def callback(self, channel, method, properties, body):
         request = json.loads(body.decode('utf-8'))

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -130,6 +130,11 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
     """
     for entry in data:
         _dict = entry.asDict(recursive=True)
+
+        # Clip the recordings to top 1000 so that we don't drop messages
+        if entity == "recordings":
+            _dict[entity] = _dict[entity][:1000]
+
         try:
             model = UserEntityStatMessage(**{
                 'musicbrainz_id': _dict['user_name'],
@@ -137,7 +142,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
                 'stats_range': stats_range,
                 'from_ts': from_ts,
                 'to_ts': to_ts,
-                'data': _dict[entity][:750],
+                'data': _dict[entity],
                 'entity': entity,
                 'count': len(_dict[entity])
             })

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -137,7 +137,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
                 'stats_range': stats_range,
                 'from_ts': from_ts,
                 'to_ts': to_ts,
-                'data': _dict[entity],
+                'data': _dict[entity][:750],
                 'entity': entity,
                 'count': len(_dict[entity])
             })

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -132,7 +132,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
         _dict = entry.asDict(recursive=True)
 
         # Clip the recordings to top 1000 so that we don't drop messages
-        if entity == "recordings":
+        if entity == "recordings" and stats_range == "all_time":
             _dict[entity] = _dict[entity][:1000]
 
         try:


### PR DESCRIPTION
# Problem
All Time recording stats are not getting stored in the DB for some users because they are getting dropped by the request consumer.

# Solution
Most probably this is because of large message size which RMQ has trouble handling. Reducing the message size by limiting the number of entities calculated should fix this issue.

# Action
We should test this on production.