### PR TITLE
get unique recording mbid recommendations

### DIFF
--- a/listenbrainz_spark/recommendations/candidate_sets.py
+++ b/listenbrainz_spark/recommendations/candidate_sets.py
@@ -128,7 +128,6 @@ def get_top_artists(mapped_listens_subset, top_artist_limit, users):
                 top_artist_given_users_df (dataframe): Top Y artists listened to by a user for given users where
                                                        Y = TOP_ARTISTS_LIMIT
     """
-<<<<<<< HEAD
     df = mapped_listens_subset.select('mb_artist_credit_id',
                                       'msb_artist_credit_name_matchable',
                                       'user_name') \
@@ -354,7 +353,7 @@ def get_candidate_html_data(similar_artist_candidate_set_df_html, top_artist_can
             row.similar_artist_name,
             row.similar_artist_credit_id
         )
-        user_data[row.user_name]['top_similar_artist'].append(data)
+        user_data[row.user_name]['similar_artist'].append(data)
 
     for row in top_artist_candidate_set_df_html.collect():
         data = (
@@ -380,7 +379,7 @@ def get_candidate_html_data(similar_artist_candidate_set_df_html, top_artist_can
             row.msb_recording_name_matchable,
             row.recording_id
         )
-        user_data[row.user_name]['imilar_artist_candidate_set'].append(data)
+        user_data[row.user_name]['similar_artist_candidate_set'].append(data)
 
     return user_data
 

--- a/listenbrainz_spark/recommendations/candidate_sets.py
+++ b/listenbrainz_spark/recommendations/candidate_sets.py
@@ -213,7 +213,7 @@ def get_top_artist_candidate_set(top_artist_df, recordings_df, users_df):
         Returns:
             top_artist_candidate_set_df (dataframe): recording ids that belong to top artists
                                                      corresponding to user ids.
-            top_artist_candidate_set_df_html (dataframe): top artists and related info.
+            top_artists_candidate_set_df_html (dataframe): top artist info required for html file
     """
     condition = [
         top_artist_df.top_artist_credit_id == recordings_df.mb_artist_credit_id,
@@ -250,7 +250,7 @@ def get_similar_artist_candidate_set(similar_artist_df, recordings_df, users_df)
         Returns:
             similar_artist_candidate_set_df (dataframe): recording ids that belong to similar artists
                                                          corresponding to user ids.
-            similar_artist_candidate_set_df_html (dataframe): similar artists and related info.
+            similar_artist_candidate_set_df_html (dataframe): similar artist info for html file
     """
     condition = [
         similar_artist_df.similar_artist_credit_id == recordings_df.mb_artist_credit_id,
@@ -313,7 +313,7 @@ def save_candidate_sets(top_artist_candidate_set_df, similar_artist_candidate_se
 def get_candidate_html_data(similar_artist_candidate_set_df_html, top_artist_candidate_set_df_html,
                             top_artist_df, similar_artist_df):
 
-    """ Get top and similar artists associated to users. The function is invoked
+    """ Get artists and recordings associated with users for HTML. The function is invoked
         when candidate set HTML is to be generated.
 
         Args:
@@ -323,7 +323,18 @@ def get_candidate_html_data(similar_artist_candidate_set_df_html, top_artist_can
             similar_artist_df (dataframe): artists similar to top artists.
 
         Returns:
-            user_data: Dictionary of
+            user_data: Dictionary can be depicted as:
+                {
+                    'user 1' : {
+                        'top_artist': [],
+                        'top_similar_artist': [],
+                        'top_artist_candidate_set': [],
+                        'top_similar_artist_candidate_set': []
+                    }
+                    .
+                    .
+                    .
+                }
     """
     user_data = defaultdict(list)
     for row in top_artist_df.collect():
@@ -339,7 +350,7 @@ def get_candidate_html_data(similar_artist_candidate_set_df_html, top_artist_can
             row.similar_artist_name,
             row.similar_artist_credit_id
         )
-        user_data[row.user_name]['similar_artist'].append(data)
+        user_data[row.user_name]['top_similar_artist'].append(data)
 
     for row in top_artist_candidate_set_df_html.collect():
         data = (

--- a/listenbrainz_spark/recommendations/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/create_dataframes.py
@@ -41,7 +41,7 @@ from pyspark.sql.functions import rank
 #       'mb_recording_mbid',
 #       'mb_release_mbid',
 #       'msb_artist_credit_name_matchable',
-#       'track_name',
+#       'msb_recording_name_matchable',
 #       'user_name'
 #   ]
 #
@@ -58,7 +58,7 @@ from pyspark.sql.functions import rank
 #       'mb_recording_mbid',
 #       'mb_release_mbid',
 #       'msb_artist_credit_name_matchable',
-#       'track_name'
+#       'msb_recording_name_matchable'
 #   ]
 #
 # users_df:
@@ -183,7 +183,7 @@ def get_mapped_artist_and_recording_mbids(partial_listens_df, msid_mbid_mapping_
                                   'mb_recording_mbid',
                                   'mb_release_mbid',
                                   'msb_artist_credit_name_matchable',
-                                  'track_name',
+                                  'msb_recording_name_matchable',
                                   'user_name')
 
     save_dataframe(mapped_listens_df, path.MAPPED_LISTENS)
@@ -247,7 +247,7 @@ def get_recordings_df(mapped_listens_df, metadata):
                                              'mb_recording_mbid',
                                              'mb_release_mbid',
                                              'msb_artist_credit_name_matchable',
-                                             'track_name') \
+                                             'msb_recording_name_matchable') \
                                      .distinct() \
                                      .withColumn('recording_id', rank().over(recording_window))
 

--- a/listenbrainz_spark/recommendations/templates/candidate.html
+++ b/listenbrainz_spark/recommendations/templates/candidate.html
@@ -20,7 +20,8 @@ td, th {
 	<center>
 		<h1>Data Preprocessing to generate recommendations</h1>
 	</center>
-	<p>To get personalized recommendations for users, candidate sets are generated for each user consisting of recording ids and the user id using the underlying procedure.</p>
+	<p>To get personalized recommendations for users, candidate sets are generated for each user consisting of recording ids and the user id.</p>
+    <p>The candidate sets have been generated using listens from <b>{{ from_date }}</b> to <b>{{ to_date }}</b></p>
     <p>Total time taken to generate candidates set for all users: <b>{{ total_time }}m</b></p>
 	{% for user_name, data in user_data.items() -%}
 	<p><center><h4>{{ user_name }}</h4></center></p>
@@ -29,11 +30,13 @@ td, th {
                 <tr>
                     <th>Top artist name</th>
                     <th>Top artist credit id</th>
+                    <th>Count</th>
                 </tr>
                 {% for i in data['top_artist'] -%}
                 <tr>
                     <td>{{ i[0] }}</td>
                     <td>{{ i[1] }}</td>
+                    <td>{{ i[2] }}</td>
                 </tr>
                 {% endfor -%}
             </table>

--- a/listenbrainz_spark/recommendations/templates/candidate.html
+++ b/listenbrainz_spark/recommendations/templates/candidate.html
@@ -46,7 +46,7 @@ td, th {
                     <th>Similar artist name</th>
                     <th>Similar artist credit id</th>
                 </tr>
-                {% for i in data['top_similar_artist'] -%}
+                {% for i in data['similar_artist'] -%}
                 <tr>
                     <td>{{ i[0] }}</td>
                     <td>{{ i[1] }}</td>

--- a/listenbrainz_spark/recommendations/templates/candidate.html
+++ b/listenbrainz_spark/recommendations/templates/candidate.html
@@ -43,7 +43,7 @@ td, th {
                     <th>Similar artist name</th>
                     <th>Similar artist credit id</th>
                 </tr>
-                {% for i in data['similar_artist'] -%}
+                {% for i in data['top_similar_artist'] -%}
                 <tr>
                     <td>{{ i[0] }}</td>
                     <td>{{ i[1] }}</td>

--- a/listenbrainz_spark/recommendations/templates/candidate.html
+++ b/listenbrainz_spark/recommendations/templates/candidate.html
@@ -23,21 +23,83 @@ td, th {
 	<p>To get personalized recommendations for users, candidate sets are generated for each user consisting of recording ids and the user id using the underlying procedure.</p>
     <p>Total time taken to generate candidates set for all users: <b>{{ total_time }}m</b></p>
 	{% for user_name, data in user_data.items() -%}
-	<p>Similar artists set for <b>{{ user_name }}</b></p>
-		<table>
-			<tr>
-				<th>Top Artist</th>
-				<th>Similar artist</th>
-				<th>Score</th>
-			</tr>
-			{% for i in data -%}
-			<tr>
-				<td>{{ i[0] }}</td>
-				<td>{{ i[1] }}</td>
-				<td>{{ i[2] }}</td>
-			</tr>
-			{% endfor -%}
-		</table>
+	<p><center><h4>{{ user_name }}</h4></center></p>
+        <p>Top Artist</p>
+            <table>
+                <tr>
+                    <th>Top artist name</th>
+                    <th>Top artist credit id</th>
+                </tr>
+                {% for i in data['top_artist'] -%}
+                <tr>
+                    <td>{{ i[0] }}</td>
+                    <td>{{ i[1] }}</td>
+                </tr>
+                {% endfor -%}
+            </table>
+        <p>Similar Artist</p>
+            <table>
+                <tr>
+                    <th>Similar artist name</th>
+                    <th>Similar artist credit id</th>
+                </tr>
+                {% for i in data['similar_artist'] -%}
+                <tr>
+                    <td>{{ i[0] }}</td>
+                    <td>{{ i[1] }}</td>
+                </tr>
+                {% endfor -%}
+            </table>
+        <p>Top Artist Candidate Set</p>
+            <table>
+                <tr>
+                    <th>Top artist credit id</th>
+                    <th>Top artist name</th>
+                    <th>MB artist credit id</th>
+                    <th>MB artist credit mbids</th>
+                    <th>MB recording mbid</th>
+                    <th>MSB artist credit name matchable</th>
+                    <th>MSB recording name matchable</th>
+                    <th>Recording id</th>
+                </tr>
+                {% for i in data['top_artist_candidate_set'] -%}
+                <tr>
+                    <td>{{ i[0] }}</td>
+                    <td>{{ i[1] }}</td>
+                    <td>{{ i[2] }}</td>
+                    <td>{{ i[3] }}</td>
+                    <td>{{ i[4] }}</td>
+                    <td>{{ i[5] }}</td>
+                    <td>{{ i[6] }}</td>
+                    <td>{{ i[7] }}</td>
+                </tr>
+                {% endfor -%}
+            </table>
+        <p>Similar Candidate Set</p>
+		    <table>
+    			<tr>
+    				<th>Similar artist credit id</th>
+                    <th>Similar artist name</th>
+                    <th>MB artist credit id</th>
+                    <th>MB artist credit mbids</th>
+                    <th>MB recording mbid</th>
+                    <th>MSB artist credit name matchable</th>
+                    <th>MSB recording name matchable</th>
+                    <th>Recording id</th>
+    			</tr>
+    			{% for i in data['similar_artist_candidate_set'] -%}
+    			<tr>
+    				<td>{{ i[0] }}</td>
+    				<td>{{ i[1] }}</td>
+    				<td>{{ i[2] }}</td>
+                    <td>{{ i[3] }}</td>
+                    <td>{{ i[4] }}</td>
+                    <td>{{ i[5] }}</td>
+                    <td>{{ i[6] }}</td>
+                    <td>{{ i[7] }}</td>
+    			</tr>
+    			{% endfor -%}
+		    </table>
 	{% endfor -%}
 </body>
 </html>

--- a/listenbrainz_spark/recommendations/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/tests/test_candidate.py
@@ -68,7 +68,7 @@ class CandidateSetsTestClass(SparkTestCase):
         top_artist_limit = 10
         test_top_artist = candidate_sets.get_top_artists(mapped_listens, top_artist_limit, [])
 
-        cols = ['top_artist_credit_id', 'top_artist_name', 'user_name']
+        cols = ['top_artist_credit_id', 'top_artist_name', 'user_name', 'total_count']
         self.assertListEqual(cols, test_top_artist.columns)
         self.assertEqual(test_top_artist.count(), 2)
 

--- a/listenbrainz_spark/recommendations/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/tests/test_candidate.py
@@ -68,11 +68,11 @@ class CandidateSetsTestClass(SparkTestCase):
         top_artist_limit = 10
         test_top_artist = candidate_sets.get_top_artists(mapped_listens, top_artist_limit, [])
 
-        cols = ['mb_artist_credit_id', 'msb_artist_credit_name_matchable', 'user_name']
+        cols = ['top_artist_credit_id', 'top_artist_name', 'user_name']
         self.assertListEqual(cols, test_top_artist.columns)
         self.assertEqual(test_top_artist.count(), 2)
 
-        top_artist_id = sorted([row.mb_artist_credit_id for row in test_top_artist.collect()])
+        top_artist_id = sorted([row.top_artist_credit_id for row in test_top_artist.collect()])
         self.assertEqual(top_artist_id[0], 1)
         self.assertEqual(top_artist_id[1], 2)
 
@@ -88,6 +88,17 @@ class CandidateSetsTestClass(SparkTestCase):
             schema=None
         )
 
+        df = df.union(utils.create_dataframe(
+            Row(
+                score=1.0,
+                id_0=2,
+                name_0="Wolfgang Amadeus Mozart",
+                id_1=3,
+                name_1="Katty Peri"
+            ),
+            schema=None
+        ))
+
         artist_relation_df = df.union(utils.create_dataframe(
             Row(
                 score=1.0,
@@ -99,28 +110,41 @@ class CandidateSetsTestClass(SparkTestCase):
             schema=None
         ))
 
-        top_artist_df = utils.create_dataframe(
+        df = utils.create_dataframe(
             Row(
-                mb_artist_credit_id=1,
-                msb_artist_credit_name_matchable="Less Than Jake",
-                user_name='vansika'
+                top_artist_credit_id=2,
+                top_artist_name="blahblah",
+                user_name='vansika_1'
             ),
             schema=None
         )
 
+        df = df.union(utils.create_dataframe(
+            Row(
+                top_artist_credit_id=2,
+                top_artist_name="Less Than Jake",
+                user_name='vansika'
+            ),
+            schema=None
+        ))
+
+        top_artist_df = df.union(utils.create_dataframe(
+            Row(
+                top_artist_credit_id=1,
+                top_artist_name="Less Than Jake",
+                user_name='vansika'
+            ),
+            schema=None
+        ))
+
         similar_artist_limit = 10
         similar_artist_df = candidate_sets.get_similar_artists(top_artist_df, artist_relation_df, similar_artist_limit)
-        self.assertEqual(similar_artist_df.count(), 2)
+        self.assertEqual(similar_artist_df.count(), 5)
 
         cols = [
-            'top_artist_credit_id', 'top_artist_name', 'similar_artist_credit_id', 'similar_artist_name',
-            'score', 'user_name'
+            'similar_artist_credit_id', 'similar_artist_name', 'user_name'
         ]
         self.assertListEqual(cols, similar_artist_df.columns)
-
-        similar_artist_id = sorted([row.similar_artist_credit_id for row in similar_artist_df.collect()])
-        self.assertEqual(similar_artist_id[0], 2)
-        self.assertEqual(similar_artist_id[1], 3)
 
     def test_get_top_artist_candidate_set(self):
         recordings_df = self.get_recordings_df()
@@ -128,8 +152,8 @@ class CandidateSetsTestClass(SparkTestCase):
 
         df = utils.create_dataframe(
             Row(
-                mb_artist_credit_id=1,
-                msb_artist_credit_name_matchable="lessthanjake",
+                top_artist_credit_id=1,
+                top_artist_name="lessthanjake",
                 user_name='vansika'
             ),
             schema=None
@@ -137,19 +161,37 @@ class CandidateSetsTestClass(SparkTestCase):
 
         top_artist_df = df.union(utils.create_dataframe(
             Row(
-                mb_artist_credit_id=2,
-                msb_artist_credit_name_matchable="kishorekumar",
+                top_artist_credit_id=2,
+                top_artist_name="kishorekumar",
                 user_name='rob'
             ),
             schema=None
         ))
 
-        recording_ids = candidate_sets.get_top_artist_candidate_set(top_artist_df, recordings_df, users)
+        top_artist_candidate_set_df, top_artist_candidate_set_df_html = candidate_sets.get_top_artist_candidate_set(top_artist_df,
+                                                                                                                 recordings_df,
+                                                                                                                 users)
         cols = ['recording_id', 'user_id', 'user_name']
-        self.assertListEqual(sorted(cols), sorted(recording_ids.columns))
-        self.assertEqual(recording_ids.count(), 2)
+        self.assertListEqual(sorted(cols), sorted(top_artist_candidate_set_df.columns))
+        self.assertEqual(top_artist_candidate_set_df.count(), 2)
 
-    def test_get_similar_artist_candidate_set(self):
+        cols = [
+            'top_artist_credit_id',
+            'top_artist_name',
+            'mb_artist_credit_id',
+            'mb_artist_credit_mbids',
+            'mb_recording_mbid',
+            'msb_artist_credit_name_matchable',
+            'msb_recording_name_matchable',
+            'recording_id',
+            'user_name',
+            'user_id'
+        ]
+
+        self.assertListEqual(sorted(cols), sorted(top_artist_candidate_set_df_html.columns))
+        self.assertEqual(top_artist_candidate_set_df_html.count(), 2)
+
+    def test_get_similar_artist_candidate_set_df(self):
         df = utils.create_dataframe(
             Row(
                 top_artist_credit_id=1,
@@ -177,16 +219,35 @@ class CandidateSetsTestClass(SparkTestCase):
         recordings_df = self.get_recordings_df()
         users = self.get_users_df()
 
-        recording_ids = candidate_sets.get_similar_artist_candidate_set(similar_artist_df, recordings_df, users)
+        similar_artist_candidate_set_df, similar_artist_candidate_set_df_html = candidate_sets.get_similar_artist_candidate_set(
+                                                                                        similar_artist_df, recordings_df, users
+                                                                                    )
+
         cols = ['recording_id', 'user_id', 'user_name']
-        self.assertListEqual(sorted(cols), sorted(recording_ids.columns))
-        self.assertEqual(recording_ids.count(), 1)
+        self.assertListEqual(sorted(cols), sorted(similar_artist_candidate_set_df.columns))
+        self.assertEqual(similar_artist_candidate_set_df.count(), 1)
+
+        cols = [
+            'similar_artist_credit_id',
+            'similar_artist_name',
+            'mb_artist_credit_id',
+            'mb_artist_credit_mbids',
+            'mb_recording_mbid',
+            'msb_artist_credit_name_matchable',
+            'msb_recording_name_matchable',
+            'recording_id',
+            'user_name',
+            'user_id'
+        ]
+
+        self.assertListEqual(sorted(cols), sorted(similar_artist_candidate_set_df_html.columns))
+        self.assertEqual(similar_artist_candidate_set_df_html.count(), 1)
 
     def test_save_candidate_sets(self):
-        top_artist_candidate_sets_df = self.get_candidate_set()
-        similar_artist_candidate_sets_df = self.get_candidate_set()
+        top_artist_candidate_set_df_df = self.get_candidate_set()
+        similar_artist_candidate_set_dfs_df = self.get_candidate_set()
 
-        candidate_sets.save_candidate_sets(top_artist_candidate_sets_df, similar_artist_candidate_sets_df)
+        candidate_sets.save_candidate_sets(top_artist_candidate_set_df_df, similar_artist_candidate_set_dfs_df)
         top_artist_exist = utils.path_exists(path.TOP_ARTIST_CANDIDATE_SET)
         self.assertTrue(top_artist_exist)
 

--- a/listenbrainz_spark/recommendations/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/tests/test_candidate.py
@@ -170,8 +170,8 @@ class CandidateSetsTestClass(SparkTestCase):
         ))
 
         top_artist_candidate_set_df, top_artist_candidate_set_df_html = candidate_sets.get_top_artist_candidate_set(top_artist_df,
-                                                                                                                 recordings_df,
-                                                                                                                 users)
+                                                                                                                    recordings_df,
+                                                                                                                    users)
         cols = ['recording_id', 'user_id', 'user_name']
         self.assertListEqual(sorted(cols), sorted(top_artist_candidate_set_df.columns))
         self.assertEqual(top_artist_candidate_set_df.count(), 2)

--- a/listenbrainz_spark/recommendations/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/tests/test_candidate.py
@@ -30,7 +30,7 @@ class CandidateSetsTestClass(SparkTestCase):
             mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
             mb_release_mbid="xxxxxx",
             msb_artist_credit_name_matchable="lessthanjake",
-            track_name="Al's War",
+            msb_recording_name_matchable="Al's War",
             user_name=user_name,
         )
         return test_mapped_listens
@@ -139,6 +139,7 @@ class CandidateSetsTestClass(SparkTestCase):
 
         similar_artist_limit = 10
         similar_artist_df = candidate_sets.get_similar_artists(top_artist_df, artist_relation_df, similar_artist_limit)
+
         self.assertEqual(similar_artist_df.count(), 5)
 
         cols = [
@@ -194,11 +195,8 @@ class CandidateSetsTestClass(SparkTestCase):
     def test_get_similar_artist_candidate_set_df(self):
         df = utils.create_dataframe(
             Row(
-                top_artist_credit_id=1,
-                top_artist_name="lessthanjake",
                 similar_artist_credit_id=2,
                 similar_artist_name='kishorekumar',
-                score=1.0,
                 user_name='rob'
             ),
             schema=None
@@ -206,11 +204,8 @@ class CandidateSetsTestClass(SparkTestCase):
 
         similar_artist_df = df.union(utils.create_dataframe(
             Row(
-                top_artist_credit_id=2,
-                top_artist_name="lessthanjake",
                 similar_artist_credit_id=3,
                 similar_artist_name="kattyperi",
-                score=0.5,
                 user_name='vansika'
             ),
             schema=None

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -90,7 +90,7 @@ class SparkTestCase(unittest.TestCase):
                 mb_release_mbid="xxxxxx",
                 msb_artist_credit_name_matchable="lessthanjake",
                 recording_id=1,
-                track_name="Al's War",
+                msb_recording_name_matchable="Al's War",
             ),
             schema=None
         )
@@ -102,7 +102,7 @@ class SparkTestCase(unittest.TestCase):
                 mb_release_mbid="xxxxxx",
                 msb_artist_credit_name_matchable="kishorekumar",
                 recording_id=2,
-                track_name="Mere Sapno ki Rani",
+                msb_recording_name_matchable="Mere Sapno ki Rani",
             ),
             schema=None
         ))
@@ -137,7 +137,7 @@ class SparkTestCase(unittest.TestCase):
             mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
             mb_release_mbid="xxxxxx",
             msb_artist_credit_name_matchable="lessthanjake",
-            track_name="Al's War",
+            msb_recording_name_matchable="Al's War",
             user_name='vansika',
         )
         df = utils.create_dataframe(mapped_listens_row_1, schema=None)
@@ -149,7 +149,7 @@ class SparkTestCase(unittest.TestCase):
             mb_recording_mbid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
             mb_release_mbid="xxxxxx",
             msb_artist_credit_name_matchable="kishorekumar",
-            track_name="Mere Sapno ki Rani",
+            msb_recording_name_matchable="Mere Sapno ki Rani",
             user_name='rob',
         )
         mapped_listens_df = df.union(utils.create_dataframe(mapped_listens_row_2, schema=None))


### PR DESCRIPTION
# Problem
The cluster is recommending non-unique mbids [LB-650](https://tickets.metabrainz.org/browse/LB-650)

# Solution

- use `msb_recording_name_matchable`  instead of `track_name` in [mapped_listens](https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz_spark/recommendations/create_dataframes.py#L183)
- more than one top artists for a user can have the same similar artists which will lead to repeating recording ids. Filter distinct similar artists for each user. 
- Update candidate sets HTML for easy debugging

*Note:* I was able to spot the above-mentioned prob/sol on my local machine. There may be more to it which I can understand once I have HTML files generated in prod.
