### PR TITLE
LB-654: Skip entities with incorrect data while calculating entity statistics

### DIFF
--- a/data/model/user_entity.py
+++ b/data/model/user_entity.py
@@ -15,5 +15,7 @@ class UserEntityStatMessage(pydantic.BaseModel):
     stats_range: str  # The range for which the stats are calculated, i.e week, month, year or all_time
     from_ts: int
     to_ts: int
+    # Order of the records in union is important and should be from more specific to less specific
+    # For more info read https://pydantic-docs.helpmanual.io/usage/types/#unions
     data: List[Union[UserRecordingRecord, UserReleaseRecord, UserArtistRecord]]
     count: int

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -6,6 +6,9 @@ from flask import current_app
 from pydantic import ValidationError
 
 from data.model.user_entity import UserEntityStatMessage
+from data.model.user_artist_stat import UserArtistRecord
+from data.model.user_release_stat import UserReleaseRecord
+from data.model.user_recording_stat import UserRecordingRecord
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.path import LISTENBRAINZ_DATA_DIRECTORY
 from listenbrainz_spark.stats import (adjust_days, replace_days,
@@ -22,6 +25,12 @@ entity_handler_map = {
     'artists': get_artists,
     'releases': get_releases,
     'recordings': get_recordings
+}
+
+entity_model_map = {
+    'artists': UserArtistRecord,
+    'releases': UserReleaseRecord,
+    'recordings': UserRecordingRecord
 }
 
 
@@ -135,6 +144,14 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
         if entity == "recordings" and stats_range == "all_time":
             _dict[entity] = _dict[entity][:1000]
 
+        entity_list = []
+        for item in _dict[entity]:
+            try:
+                entity_list.append(entity_model_map[entity](**item))
+            except ValidationError:
+                current_app.logger.warn("""Invalid entry present in {stats_range} top {entity} for
+                                        user: {user_name}, skipping""".format(stats_range=stats_range, entity=entity,
+                                                                              user_name=_dict['user_name']))
         try:
             model = UserEntityStatMessage(**{
                 'musicbrainz_id': _dict['user_name'],
@@ -142,7 +159,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
                 'stats_range': stats_range,
                 'from_ts': from_ts,
                 'to_ts': to_ts,
-                'data': _dict[entity],
+                'data': entity_list,
                 'entity': entity,
                 'count': len(_dict[entity])
             })

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -149,7 +149,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
             try:
                 entity_list.append(entity_model_map[entity](**item))
             except ValidationError:
-                current_app.logger.warn("""Invalid entry present in {stats_range} top {entity} for
+                current_app.logger.warning("""Invalid entry present in {stats_range} top {entity} for
                                         user: {user_name}, skipping""".format(stats_range=stats_range, entity=entity,
                                                                               user_name=_dict['user_name']))
         try:

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -117,3 +118,54 @@ class EntityTestCase(SparkTestCase):
 
         self.assertEqual(len(received_list), 1000)
         self.assertListEqual(expected_list, received_list)
+
+    def test_skip_incorrect_artists_stats(self):
+        """ Test to check if entries with incorrect data is skipped for top user artists """
+        with open(self.path_to_data_file('user_top_artists_incorrect.json')) as f:
+            data = json.load(f)
+
+        mock_result = MagicMock()
+        mock_result.asDict.return_value = {
+            'user_name': "test",
+            'artists': data
+        }
+
+        messages = entity_stats.create_messages([mock_result], 'artists', 'all_time', 0, 10)
+        received_list = next(messages)['data']
+
+        # Only the first entry in file is valid, all others must be skipped
+        self.assertListEqual(data[:1], received_list)
+
+    def test_skip_incorrect_releases_stats(self):
+        """ Test to check if entries with incorrect data is skipped for top user releases """
+        with open(self.path_to_data_file('user_top_releases_incorrect.json')) as f:
+            data = json.load(f)
+
+        mock_result = MagicMock()
+        mock_result.asDict.return_value = {
+            'user_name': "test",
+            'releases': data
+        }
+
+        messages = entity_stats.create_messages([mock_result], 'releases', 'all_time', 0, 10)
+        received_list = next(messages)['data']
+
+        # Only the first entry in file is valid, all others must be skipped
+        self.assertListEqual(data[:1], received_list)
+
+    def test_skip_incorrect_recordings_stats(self):
+        """ Test to check if entries with incorrect data is skipped for top user recordings """
+        with open(self.path_to_data_file('user_top_recordings_incorrect.json')) as f:
+            data = json.load(f)
+
+        mock_result = MagicMock()
+        mock_result.asDict.return_value = {
+            'user_name': "test",
+            'recordings': data
+        }
+
+        messages = entity_stats.create_messages([mock_result], 'recordings', 'all_time', 0, 10)
+        received_list = next(messages)['data']
+
+        # Only the first entry in file is valid, all others must be skipped
+        self.assertListEqual(data[:1], received_list)

--- a/listenbrainz_spark/testdata/user_top_artists_incorrect.json
+++ b/listenbrainz_spark/testdata/user_top_artists_incorrect.json
@@ -1,0 +1,20 @@
+[
+  {
+    "artist_name": "artist_1",
+    "artist_mbids": [],
+    "artist_msid": "1",
+    "listen_count": 1
+  },
+  {
+    "artist_name": null,
+    "artist_mbids": [],
+    "artist_msid": "",
+    "listen_count": 1
+  },
+  {
+    "artist_name": "artist_2",
+    "artist_mbids": [],
+    "artist_msid": "2",
+    "listen_count": null
+  }
+]

--- a/listenbrainz_spark/testdata/user_top_recordings_incorrect.json
+++ b/listenbrainz_spark/testdata/user_top_recordings_incorrect.json
@@ -1,0 +1,50 @@
+[
+  {
+    "artist_name": "artist_1",
+    "artist_mbids": [],
+    "artist_msid": "1",
+    "release_name": "release_1",
+    "release_msid": "1",
+    "release_mbid": "",
+    "track_name": "track_1",
+    "recording_msid": "1",
+    "recording_mbid": "",
+    "listen_count": 1
+  },
+  {
+    "artist_name": null,
+    "artist_mbids": [],
+    "artist_msid": "",
+    "release_name": "release_1",
+    "release_msid": "1",
+    "release_mbid": null,
+    "track_name": "track_1",
+    "recording_msid": "1",
+    "recording_mbid": "",
+    "listen_count": 1
+  },
+  {
+    "artist_name": "artist_2",
+    "artist_mbids": [],
+    "artist_msid": "2",
+    "release_name": "release_2",
+    "release_msid": "2",
+    "release_mbid": null,
+    "track_name": "track_2",
+    "recording_msid": "2",
+    "recording_mbid": "",
+    "listen_count": null
+  },
+  {
+    "artist_name": "artist_2",
+    "artist_mbids": [],
+    "artist_msid": "2",
+    "release_name": "release_2",
+    "release_msid": "2",
+    "release_mbid": null,
+    "track_name": null,
+    "recording_msid": "2",
+    "recording_mbid": "",
+    "listen_count": null
+  }
+]

--- a/listenbrainz_spark/testdata/user_top_releases_incorrect.json
+++ b/listenbrainz_spark/testdata/user_top_releases_incorrect.json
@@ -1,0 +1,29 @@
+[
+  {
+    "artist_name": "artist_1",
+    "artist_mbids": [],
+    "artist_msid": "1",
+    "release_name": "release_1",
+    "release_msid": "1",
+    "release_mbid": "",
+    "listen_count": 1
+  },
+  {
+    "artist_name": null,
+    "artist_mbids": [],
+    "artist_msid": "",
+    "release_name": "release_1",
+    "release_msid": "1",
+    "release_mbid": null,
+    "listen_count": 1
+  },
+  {
+    "artist_name": "artist_2",
+    "artist_mbids": [],
+    "artist_msid": "2",
+    "release_name": "release_2",
+    "release_msid": "2",
+    "release_mbid": null,
+    "listen_count": null
+  }
+]


### PR DESCRIPTION
# Problem
Some users have incorrect data which leads to validation error while calculating stats for the user.
https://sentry.metabrainz.org/metabrainz/listenbrainz-beta/issues/96963/?query=is%3Aunresolved

# Solution
Iterating over each entry and validating it individually solves the issue. 

# Action
This should be merged after #936