### PR TITLE
LB-659: Add ability to revert back to older dump if the import fails

### DIFF
--- a/listenbrainz_spark/exceptions.py
+++ b/listenbrainz_spark/exceptions.py
@@ -80,6 +80,16 @@ class DumpNotFoundException(SparkException):
     def __init__(self, message):
         super(DumpNotFoundException, self).__init__(message)
 
+
+class DumpInvalidException(SparkException):
+    """ The given dump is invalid, i.e the SHA256 checksum
+        doesn't match or is not present 
+    """
+
+    def __init__(self, message):
+        super(DumpInvalidException, self).__init__(message)
+
+
 class RecommendationsNotGeneratedException(SparkException):
     """ No recommendations generated for the given user.
     """

--- a/listenbrainz_spark/exceptions.py
+++ b/listenbrainz_spark/exceptions.py
@@ -83,7 +83,7 @@ class DumpNotFoundException(SparkException):
 
 class DumpInvalidException(SparkException):
     """ The given dump is invalid, i.e the SHA256 checksum
-        doesn't match or is not present 
+        doesn't match or is not present
     """
 
     def __init__(self, message):

--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -1,9 +1,12 @@
 import os
 import ftplib
+import hashlib
 
 from listenbrainz_spark import config
+from listenbrainz_spark.exceptions import DumpInvalidException
 
 from flask import current_app
+
 
 class ListenBrainzFTPDownloader:
 
@@ -61,7 +64,32 @@ class ListenBrainzFTPDownloader:
             Returns:
                 dest_path (str): Local path where dump has been downloaded.
         """
+        # Check if sha256 is present to validate the download, if not present don't download
+        sha_filename = filename + '.sha256'
+        dir_content = self.list_dir()
+        sha_dest_path = os.path.join(directory, '.sha256')
+        if sha_filename in dir_content:
+            self.download_file_binary(sha_filename, sha_dest_path)
+        else:
+            raise DumpInvalidException("SHA256 checksum for the given file missing, aborting download.")
         dest_path = os.path.join(directory, filename)
         self.download_file_binary(filename, dest_path)
+
+        current_app.logger.info("Verifying dump integrity...")
+        calculated_sha = hashlib.sha256()
+        with open(dest_path, "rb") as f:
+            # Read and update hash string value in blocks of 4K
+            for byte_block in iter(lambda: f.read(4096), b""):
+                calculated_sha.update(byte_block)
+
+        with open(sha_dest_path, "r") as f:
+            received_sha = f.read().replace('\n', '')
+
+        os.remove(sha_dest_path)
+        if calculated_sha.hexdigest() != received_sha:
+            # Cleanup
+            os.remove(dest_path)
+            raise DumpInvalidException("Received SHA256 checksum doesn't match the calculated checksum, aborting.")
+
         self.connection.cwd('/')
         return dest_path

--- a/listenbrainz_spark/ftp/tests/test_init.py
+++ b/listenbrainz_spark/ftp/tests/test_init.py
@@ -1,46 +1,84 @@
 import os
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, call, MagicMock
 
 import listenbrainz_spark
 from listenbrainz_spark import config
+from listenbrainz_spark.exceptions import DumpInvalidException
+from listenbrainz_spark.tests import SparkTestCase
 
-class FTPTestCase(unittest.TestCase):
 
-	@patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.connect')
-	def test_init(self, mock_connect):
-		listenbrainz_spark.ftp.ListenBrainzFTPDownloader()
-		mock_connect.assert_called_once()
+class FTPTestCase(SparkTestCase):
 
-	@patch('ftplib.FTP')
-	def test_connect(self, mock_ftp_cons):
-		listenbrainz_spark.ftp.ListenBrainzFTPDownloader().connect()
-		mock_ftp_cons.assert_called_with(config.FTP_SERVER_URI)
-		mock_ftp = mock_ftp_cons.return_value
-		self.assertTrue(mock_ftp.login.called)
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.connect')
+    def test_init(self, mock_connect):
+        listenbrainz_spark.ftp.ListenBrainzFTPDownloader()
+        mock_connect.assert_called_once()
 
-	@patch('ftplib.FTP')
-	def test_list(self, mock_ftp_cons):
-		mock_ftp = mock_ftp_cons.return_value
-		dirs = listenbrainz_spark.ftp.ListenBrainzFTPDownloader().list_dir()
-		self.assertTrue(mock_ftp.retrlines.called)
-		self.assertEqual(dirs, [])
+    @patch('ftplib.FTP')
+    def test_connect(self, mock_ftp_cons):
+        listenbrainz_spark.ftp.ListenBrainzFTPDownloader().connect()
+        mock_ftp_cons.assert_called_with(config.FTP_SERVER_URI)
+        mock_ftp = mock_ftp_cons.return_value
+        self.assertTrue(mock_ftp.login.called)
 
-	@patch('ftplib.FTP')
-	def test_download_file_binary(self, mock_ftp_cons):
-		mock_ftp = mock_ftp_cons.return_value
-		with patch('listenbrainz_spark.ftp.open', mock_open(), create=True) as mock_file:
-			listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_file_binary('fake/src', 'fake/dest')
-		mock_file.assert_called_once_with('fake/dest', 'wb')
-		mock_ftp.retrbinary.assert_called_once_with('RETR {}'.format('fake/src'), mock_file().write)
+    @patch('ftplib.FTP')
+    def test_list(self, mock_ftp_cons):
+        mock_ftp = mock_ftp_cons.return_value
+        dirs = listenbrainz_spark.ftp.ListenBrainzFTPDownloader().list_dir()
+        self.assertTrue(mock_ftp.retrlines.called)
+        self.assertEqual(dirs, [])
 
-	@patch('ftplib.FTP')
-	@patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_file_binary')
-	def test_download_dump(self, mock_binary, mock_ftp_cons):
-		mock_ftp = mock_ftp_cons.return_value
-		filename = 'fakefile.txt'
-		directory = 'fakedir'
-		dest_path = listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump(filename, directory)
-		self.assertEqual(os.path.join(directory, filename), dest_path)
-		mock_binary.assert_called_once_with(filename, dest_path)
-		mock_ftp.cwd.assert_called_once_with('/')
+    @patch('ftplib.FTP')
+    def test_download_file_binary(self, mock_ftp_cons):
+        mock_ftp = mock_ftp_cons.return_value
+        with patch('listenbrainz_spark.ftp.open', mock_open(), create=True) as mock_file:
+            listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_file_binary('fake/src', 'fake/dest')
+        mock_file.assert_called_once_with('fake/dest', 'wb')
+        mock_ftp.retrbinary.assert_called_once_with('RETR {}'.format('fake/src'), mock_file().write)
+
+    @patch('ftplib.FTP')
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_file_binary')
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir', return_value=['fakefile.txt', 'fakefile.txt.sha256'])
+    @patch('listenbrainz_spark.ftp.os.remove')
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader._calc_sha256', return_value='test')
+    def test_download_dump(self, mock_sha_calc, mock_remove, mock_list_dir, mock_binary, mock_ftp_cons):
+        mock_ftp = mock_ftp_cons.return_value
+        filename = 'fakefile.txt'
+        sha_filename = filename + '.sha256'
+        directory = 'fakedir'
+        sha_dest_path = os.path.join(directory, sha_filename)
+        calls = [call(sha_filename, sha_dest_path), call(filename, 'fakedir/' + filename)]
+
+        with patch('listenbrainz_spark.ftp.open', mock_open(read_data='test'), create=True) as mock_file:
+            dest_path = listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump(filename, directory)
+
+        self.assertEqual(os.path.join(directory, filename), dest_path)
+        mock_list_dir.assert_called_once()
+        mock_binary.assert_has_calls(calls)
+        mock_remove.assert_called_once_with(sha_dest_path)
+        mock_sha_calc.assert_called_once()
+        mock_ftp.cwd.assert_called_once_with('/')
+
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir', return_value=['fakefile.txt'])
+    def test_download_dump_sha_not_available(self, mock_list_dir):
+        filename = 'fakefile.txt'
+        directory = 'fakedir'
+
+        self.assertRaises(DumpInvalidException,
+                          listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump, filename, directory)
+
+    @patch('ftplib.FTP')
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_file_binary')
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir', return_value=['fakefile.txt', 'fakefile.txt.sha256'])
+    @patch('listenbrainz_spark.ftp.os.remove')
+    @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader._calc_sha256', return_value='tset')
+    def test_download_dump_sha_not_matching(self, mock_sha_calc, mock_remove, mock_list_dir, mock_binary, mock_ftp_cons):
+        mock_ftp = mock_ftp_cons.return_value
+        filename = 'fakefile.txt'
+        directory = 'fakedir'
+
+        with patch('listenbrainz_spark.ftp.open', mock_open(read_data='test'), create=True) as mock_file:
+            self.assertRaises(DumpInvalidException,
+                              listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump, filename, directory)
+

--- a/listenbrainz_spark/ftp/tests/test_init.py
+++ b/listenbrainz_spark/ftp/tests/test_init.py
@@ -60,8 +60,10 @@ class FTPTestCase(SparkTestCase):
         mock_sha_calc.assert_called_once()
         mock_ftp.cwd.assert_called_once_with('/')
 
+    @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir', return_value=['fakefile.txt'])
-    def test_download_dump_sha_not_available(self, mock_list_dir):
+    def test_download_dump_sha_not_available(self, mock_list_dir, mock_ftp_cons):
+        mock_ftp = mock_ftp_cons.return_value
         filename = 'fakefile.txt'
         directory = 'fakedir'
 
@@ -81,4 +83,3 @@ class FTPTestCase(SparkTestCase):
         with patch('listenbrainz_spark.ftp.open', mock_open(read_data='test'), create=True) as mock_file:
             self.assertRaises(DumpInvalidException,
                               listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump, filename, directory)
-

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -62,14 +62,14 @@ class ListenbrainzHDFSUploader:
             raise NotImplementedError('Callback to process JSON missing. Aboritng...')
 
         # Extract all files in tmp_dump_dir
-        t = time.time()
+        t0 = time.time()
         current_app.logger.info("Extracting dump in temporary directory")
         try:
             tar.extractall(path=tmp_dump_dir)
         except TarError as err:
-            current_app.logger.error("{} while extracting tarfile, aborting import".format(type(err).__name__))
+            current_app.logger.error("{} while extracting tarfile, aborting import".format(type(err).__name__), exc_info=True)
             return
-        time_taken = time.time() - t
+        time_taken = time.time() - t0
         current_app.logger.info("Extraction completed in {:.2f} seconds".format(time_taken))
 
         if force:

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -68,6 +68,7 @@ class ListenbrainzHDFSUploader:
             tar.extractall(path=tmp_dump_dir)
         except TarError as err:
             current_app.logger.error("{} while extracting tarfile, aborting import".format(type(err).__name__), exc_info=True)
+            shutil.rmtree(tmp_dump_dir)
             return
         time_taken = time.time() - t0
         current_app.logger.info("Extraction completed in {:.2f} seconds".format(time_taken))

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -3,12 +3,14 @@ import sys
 import time
 import shutil
 import subprocess
+from tarfile import TarError
 
 import listenbrainz_spark
 from listenbrainz_spark import utils, config, hdfs_connection
 from listenbrainz_spark.exceptions import SparkSessionNotInitializedException
 
 from flask import current_app
+
 
 class ListenbrainzHDFSUploader:
 
@@ -59,6 +61,17 @@ class ListenbrainzHDFSUploader:
         if callback is None:
             raise NotImplementedError('Callback to process JSON missing. Aboritng...')
 
+        # Extract all files in tmp_dump_dir
+        t = time.time()
+        current_app.logger.info("Extracting dump in temporary directory")
+        try:
+            tar.extractall(path=tmp_dump_dir)
+        except TarError as err:
+            current_app.logger.error("{} while extracting tarfile, aborting import".format(type(err).__name__))
+            return
+        time_taken = time.time() - t
+        current_app.logger.info("Extraction completed in {:.2f} seconds".format(time_taken))
+
         if force:
             current_app.logger.info('Removing {} from HDFS...'.format(dest_path))
             utils.delete_dir(dest_path, recursive=True)
@@ -66,22 +79,24 @@ class ListenbrainzHDFSUploader:
 
         file_count = 0
         total_time = 0.0
-        for member in tar:
-            if member.isfile() and self._is_json_file(member.name):
-                current_app.logger.info('Loading {}...'.format(member.name))
-                t = time.time()
-                tar.extract(member)
-                tmp_hdfs_path = os.path.join(tmp_dump_dir, member.name)
-                utils.upload_to_HDFS(tmp_hdfs_path, member.name)
-                callback(member.name, dest_path, tmp_hdfs_path, schema)
-                utils.delete_dir(tmp_hdfs_path, recursive=True)
-                os.remove(member.name)
-                file_count += 1
-                time_taken = time.time() - t
-                current_app.logger.info("Done! Processed {} files. Current file done in {:.2f} sec".format(
-                    file_count, time_taken))
-                total_time += time_taken
-                average_time = total_time / file_count
-                current_app.logger.info("Total time: {:.2f}, average time: {:.2f}".format(total_time, average_time))
+        for (dirpath, dirnames, filenames) in os.walk(tmp_dump_dir):
+            for filename in filenames:
+                if self._is_json_file(filename):
+                    current_app.logger.info('Loading {}...'.format(filename))
+                    t0 = time.time()
+                    file_path = os.path.join(dirpath, filename)
+                    tmp_hdfs_path = file_path
+                    utils.upload_to_HDFS(tmp_hdfs_path, file_path)
+                    callback(file_path, dest_path, tmp_hdfs_path, schema)
+                    utils.delete_dir(tmp_hdfs_path, recursive=True)
+                    os.remove(file_path)
+                    file_count += 1
+                    time_taken = time.time() - t0
+                    current_app.logger.info(
+                        "Done! Processed {} files. Current file done in {:.2f} sec".format(file_count, time_taken))
+                    total_time += time_taken
+                    average_time = total_time / file_count
+                    current_app.logger.info("Total time: {:.2f}, average time: {:.2f}".format(total_time, average_time))
+
         utils.delete_dir(tmp_dump_dir, recursive=True)
         shutil.rmtree(tmp_dump_dir)

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -59,45 +59,52 @@ class ListenbrainzHDFSUploader:
                 force: If True deletes dir at dest_path
         """
         if callback is None:
-            raise NotImplementedError('Callback to process JSON missing. Aboritng...')
+            raise NotImplementedError('Callback to process JSON missing. Aborting...')
 
-        # Extract all files in tmp_dump_dir
-        t0 = time.time()
-        current_app.logger.info("Extracting dump in temporary directory")
-        try:
-            tar.extractall(path=tmp_dump_dir)
-        except TarError as err:
-            current_app.logger.error("{} while extracting tarfile, aborting import".format(type(err).__name__), exc_info=True)
-            shutil.rmtree(tmp_dump_dir)
-            return
-        time_taken = time.time() - t0
-        current_app.logger.info("Extraction completed in {:.2f} seconds".format(time_taken))
+        current_app.logger.info("Uploading listens to temporary directory in HDFS...")
+        total_files = 0
+        total_time = 0.0
+        for member in tar:
+            if member.isfile() and self._is_json_file(member.name):
+                current_app.logger.info("Uploading {}...".format(member.name))
+                t0 = time.time()
+
+                try:
+                    tar.extract(member)
+                except TarError as err:
+                    current_app.logger.error("{} while extracting {}, aborting import".format(
+                        type(err).__name__, member.name), exc_info=True)
+                    # Cleanup
+                    if utils.path_exists('/temp'):
+                        utils.delete_dir('/temp', recursive=True)
+                    if utils.path_exists(tmp_dump_dir):
+                        utils.delete_dir(tmp_dump_dir, recursive=True)
+                    shutil.rmtree(tmp_dump_dir)
+                    return
+
+                tmp_hdfs_path = os.path.join(tmp_dump_dir, member.name)
+                utils.upload_to_HDFS(tmp_hdfs_path, member.name)
+                callback(member.name, '/temp', tmp_hdfs_path, schema)
+                utils.delete_dir(tmp_hdfs_path, recursive=True)
+                os.remove(member.name)
+                time_taken = time.time() - t0
+                total_files += 1
+                total_time += time_taken
+                current_app.logger.info("Done! Current file processed in {:.2f} sec".format(time_taken))
+        current_app.logger.info("Done! Total files processed {}. Average time taken: {:.2f}".format(
+            total_files, total_time / total_files
+        ))
 
         if force:
             current_app.logger.info('Removing {} from HDFS...'.format(dest_path))
             utils.delete_dir(dest_path, recursive=True)
             current_app.logger.info('Done!')
 
-        file_count = 0
-        total_time = 0.0
-        for (dirpath, dirnames, filenames) in os.walk(tmp_dump_dir):
-            for filename in filenames:
-                if self._is_json_file(filename):
-                    current_app.logger.info('Loading {}...'.format(filename))
-                    t0 = time.time()
-                    file_path = os.path.join(dirpath, filename)
-                    tmp_hdfs_path = file_path
-                    utils.upload_to_HDFS(tmp_hdfs_path, file_path)
-                    callback(file_path, dest_path, tmp_hdfs_path, schema)
-                    utils.delete_dir(tmp_hdfs_path, recursive=True)
-                    os.remove(file_path)
-                    file_count += 1
-                    time_taken = time.time() - t0
-                    current_app.logger.info(
-                        "Done! Processed {} files. Current file done in {:.2f} sec".format(file_count, time_taken))
-                    total_time += time_taken
-                    average_time = total_time / file_count
-                    current_app.logger.info("Total time: {:.2f}, average time: {:.2f}".format(total_time, average_time))
+        current_app.logger.info("Moving the processed files to {}".format(dest_path))
+        t0 = time.time()
+        utils.rename('/temp', dest_path)
+        utils.current_app.logger.info("Done! Time taken: {:.2f}".format(time.time() - t0))
 
+        # Cleanup
         utils.delete_dir(tmp_dump_dir, recursive=True)
         shutil.rmtree(tmp_dump_dir)

--- a/listenbrainz_spark/hdfs/tests/test_init.py
+++ b/listenbrainz_spark/hdfs/tests/test_init.py
@@ -111,7 +111,9 @@ class HDFSTestCase(unittest.TestCase):
 
     def test_upload_archive_failed(self):
         faulty_tar = MagicMock()
-        faulty_tar.extractall.side_effect = tarfile.ReadError()
+        faulty_tar.extract.side_effect = tarfile.ReadError()
+        member = MagicMock()
+        faulty_tar.__iter__.return_value = [member]
 
         tmp_dump_dir = tempfile.mkdtemp()
         ListenbrainzHDFSUploader().upload_archive(tmp_dump_dir, faulty_tar, '/test', schema.listen_schema,

--- a/listenbrainz_spark/hdfs/tests/test_init.py
+++ b/listenbrainz_spark/hdfs/tests/test_init.py
@@ -10,6 +10,7 @@ from unittest.mock import patch, Mock, call, MagicMock
 
 import listenbrainz_spark
 from listenbrainz_spark import config, utils, schema
+from listenbrainz_spark.exceptions import DumpInvalidException
 from listenbrainz_spark.hdfs import ListenbrainzHDFSUploader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
 
@@ -116,8 +117,8 @@ class HDFSTestCase(unittest.TestCase):
         faulty_tar.__iter__.return_value = [member]
 
         tmp_dump_dir = tempfile.mkdtemp()
-        ListenbrainzHDFSUploader().upload_archive(tmp_dump_dir, faulty_tar, '/test', schema.listen_schema,
-                                                  ListenbrainzDataUploader().process_json_listens)
+        self.assertRaises(DumpInvalidException, ListenbrainzHDFSUploader().upload_archive, tmp_dump_dir,
+                          faulty_tar, '/test', schema.listen_schema, ListenbrainzDataUploader().process_json_listens)
 
         status = utils.path_exists('/test')
         self.assertFalse(status)

--- a/listenbrainz_spark/tests/test_utils.py
+++ b/listenbrainz_spark/tests/test_utils.py
@@ -7,6 +7,7 @@ from listenbrainz_spark import utils, hdfs_connection, config
 
 from pyspark.sql import Row
 
+
 class UtilsTestCase(SparkTestCase):
     # use path_ as prefix for all paths in this class.
     path_ = '/test'
@@ -83,3 +84,14 @@ class UtilsTestCase(SparkTestCase):
         utils.upload_to_HDFS(self.path_, local_path)
         status = utils.path_exists(self.path_)
         self.assertTrue(status)
+
+    def test_rename(self):
+        utils.create_dir(self.path_)
+        test_exists = utils.path_exists(self.path_)
+        self.assertTrue(test_exists)
+        utils.rename(self.path_, '/temp')
+        test_exists = utils.path_exists(self.path_)
+        self.assertFalse(test_exists)
+        temp_exists = utils.path_exists('/temp')
+        self.assertTrue(temp_exists)
+        utils.delete_dir('/temp')

--- a/listenbrainz_spark/utils.py
+++ b/listenbrainz_spark/utils.py
@@ -38,6 +38,7 @@ from time import sleep
 # }
 # All the keys in the dict are column/field names in a Spark dataframe.
 
+
 def append(df, dest_path):
     """ Append a dataframe to existing dataframe in HDFS or write a new one
         if dataframe does not exist.
@@ -51,6 +52,7 @@ def append(df, dest_path):
         df.write.mode('append').parquet(config.HDFS_CLUSTER_URI + dest_path)
     except Py4JJavaError as err:
         raise DataFrameNotAppendedException(err.java_exception, df.schema)
+
 
 def create_app(debug=None):
     """ Uses brainzutils (https://github.com/metabrainz/brainzutils-python) to log exceptions to sentry.
@@ -109,12 +111,14 @@ def create_dataframe(row, schema):
     except Py4JJavaError as err:
         raise DataFrameNotCreatedException(err.java_exception, row)
 
+
 def create_path(path):
     try:
         os.makedirs(path)
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
+
 
 def register_dataframe(df, table_name):
     """ Creates a view to be used for Spark SQL, etc. Replaces the view if a view with the
@@ -128,6 +132,7 @@ def register_dataframe(df, table_name):
         df.createOrReplaceTempView(table_name)
     except Py4JJavaError as err:
         raise ViewNotRegisteredException(err.java_exception, table_name)
+
 
 def read_files_from_HDFS(path):
     """ Loads the dataframe stored at the given path in HDFS.
@@ -214,6 +219,7 @@ def save_parquet(df, path):
     except Py4JJavaError as err:
         raise FileNotSavedException(err.java_exception, path)
 
+
 def create_dir(path):
     """ Creates a directory in HDFS.
 
@@ -224,6 +230,7 @@ def create_dir(path):
               >> The function does not throw an error if the directory path already exists.
     """
     hdfs_connection.client.makedirs(path)
+
 
 def delete_dir(path, recursive=False):
     """ Deletes a directory recursively from HDFS.
@@ -239,6 +246,7 @@ def delete_dir(path, recursive=False):
     if not deleted:
         raise HDFSDirectoryNotDeletedException('', path)
 
+
 def path_exists(path):
     """ Checks if the path exists in HDFS. The function returns False if the path
         does not exist otherwise returns True.
@@ -252,6 +260,7 @@ def path_exists(path):
     if path_found:
         return True
     return False
+
 
 def hdfs_walk(path, depth=0):
     """ Depth-first walk of HDFS filesystem.
@@ -269,6 +278,7 @@ def hdfs_walk(path, depth=0):
     except HdfsError as err:
         raise PathNotFoundException(str(err), path)
 
+
 def read_json(hdfs_path, schema):
     """ Upload JSON file to HDFS as parquet.
 
@@ -282,6 +292,7 @@ def read_json(hdfs_path, schema):
     df = listenbrainz_spark.session.read.json(config.HDFS_CLUSTER_URI + hdfs_path, schema=schema)
     return df
 
+
 def upload_to_HDFS(hdfs_path, local_path):
     """ Upload local file to HDFS.
 
@@ -290,3 +301,13 @@ def upload_to_HDFS(hdfs_path, local_path):
             local_path (str): Local path of file to be uploaded.
     """
     hdfs_connection.client.upload(hdfs_path=hdfs_path, local_path=local_path)
+
+
+def rename(hdfs_src_path: str, hdfs_dst_path: str):
+    """ Move a file or folder in HDFS
+
+        Args:
+            hdfs_src_path – Source path.
+            hdfs_dst_path – Destination path. If the path already exists and is a directory, the source will be moved into it.
+    """
+    hdfs_connection.client.rename(hdfs_src_path, hdfs_dst_path)


### PR DESCRIPTION
# Problem
The stats pipeline calculates incorrect data if the import is incorrect. We should automatically fall back to older data if the import fails.

# Solution
We can extract the whole `tarfile` first and then process all the files afterwards. This way if the `tarfile` is corrupt we can abort the import and avoid having incorrect data in `HDFS`.