### PR TITLE
LB-660: Fix incorrect recording count on charts page

### DIFF
--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -130,6 +130,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
     """
     for entry in data:
         _dict = entry.asDict(recursive=True)
+        total_entity_count = len(_dict[entity])
 
         # Clip the recordings to top 1000 so that we don't drop messages
         if entity == "recordings" and stats_range == "all_time":
@@ -144,7 +145,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
                 'to_ts': to_ts,
                 'data': _dict[entity],
                 'entity': entity,
-                'count': len(_dict[entity])
+                'count': total_entity_count
             })
             result = model.dict(exclude_none=True)
             yield result

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -112,8 +112,13 @@ class EntityTestCase(SparkTestCase):
 
         messages = entity_stats.create_messages([mock_result], 'recordings', 'all_time', 0, 10)
 
-        received_list = next(messages)['data']
+        message = next(messages)
+        received_list = message['data']
         expected_list = recordings[:1000]
 
         self.assertEqual(len(received_list), 1000)
         self.assertListEqual(expected_list, received_list)
+
+        received_count = message['count']
+        expected_count = 2000
+        self.assertEqual(received_count, expected_count)


### PR DESCRIPTION
# Problem
We are calculating only top 1000 recordings to avoid dropping stats in RMQ. However we should show the actual number of distinct recordings the user has listened to, instead of 1000.

# Solution
Calculating the entity count before clipping it to top 1000 fixes the issue.