### PR TITLE
remove beta from navbar and the spotify import description

### DIFF
--- a/docs/dev/api.rst
+++ b/docs/dev/api.rst
@@ -11,10 +11,6 @@ site [#]_.
 
 *Note*: All ListenBrainz services are only available on **HTTPS**!
 
-.. [#] The beta endpoints (i.e. ``beta.listenbrainz.org``) were deprecated in
-   Fall 2017. If you were using this endpoint, please use the current,
-   production endpoints instead.
-
 Reference
 ---------
 
@@ -127,4 +123,3 @@ Constants that are relevant to using the API:
 .. autodata:: listenbrainz.webserver.views.api_tools.DEFAULT_ITEMS_PER_GET
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_TAGS_PER_LISTEN
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_TAG_SIZE
-

--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -10,7 +10,7 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand logo" href="{{ url_for('index.index') }}">
-          <img src="{{ url_for('static', filename='img/navbar_logo.svg') }}" alt="ListenBrainz" /><span class="beta">beta</span>
+          <img src="{{ url_for('static', filename='img/navbar_logo.svg') }}" alt="ListenBrainz" />
       </a>
     </div>
 

--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -35,10 +35,6 @@
       ListenBrainz can automatically import songs from Spotify as you listen to them.
     </p>
     <p>
-      This is a beta feature and we're still testing code and ironing out bugs. Please make sure that the Spotify
-      import is not the only way you're archiving your listen history.
-    </p>
-    <p>
       Importing the same listens from two different sources such as Last.FM and Spotify may cause the creation
       of duplicates in your listen history. If you opt into our automatic Spotify import, please do not use the
       Last.FM import or submit listens from other ListenBrainz clients. This is a temporary limitation while we


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
We're mentioning stuff is in beta when it's been stable for years.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Remove the beta tag from the site navbar and from the spotify importer. Also remove a mention from the API docs.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Deploy!
