### PR TITLE
get_user_timestamps improvements

### DIFF
--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -192,6 +192,20 @@ class TestTimescaleListenStore(DatabaseTestCase):
         listen_count = self.logstore.get_listen_count_for_user(user_name=testuser_name)
         self.assertEqual(count, listen_count)
 
+    def test_get_timestamps_for_user(self):
+        uid = random.randint(2000, 1 << 31)
+        testuser = db_user.get_or_create(uid, "user_%d" % uid)
+        testuser_name = testuser['musicbrainz_id']
+
+        (min_ts, max_ts) = self.logstore.get_timestamps_for_user(user_name=testuser_name)
+        self.assertEqual(min_ts, 0)
+        self.assertEqual(max_ts, 0)
+
+        self._create_test_data(testuser_name)
+        (min_ts, max_ts) = self.logstore.get_timestamps_for_user(user_name=testuser_name)
+        self.assertEqual(min_ts, 1400000000)
+        self.assertEqual(max_ts, 1400000200)
+
     def test_fetch_recent_listens(self):
         user = db_user.get_or_create(2, 'someuser')
         user_name = user['musicbrainz_id']

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -117,7 +117,7 @@ class TimescaleListenStore(ListenStore):
                 result = connection.execute(sqlalchemy.text(query), {
                     "user_name": user_name
                 })
-                val = result.fetchone()["value"]
+                val = result.fetchone()["value"] or 0
                 return val
         except psycopg2.OperationalError as e:
             self.log.error("Cannot query timescale listened_at_min/max: %s" % str(e), exc_info=True)


### PR DESCRIPTION
# Problem

https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/97474/?environment=production&referrer=alert_email

# Solution

Return 0 if No timestamps are available. add test.


