### PR TITLE
Remove the broken stats from the status page

### DIFF
--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -32,12 +32,12 @@
       </table>
 
       <p>
-        If you are curious about the state of our Listens ingestion pipelines, you can
-        create yourself a free account on our <a href="https://stats.metabrainz.org">infrastructure 
+        If you are curious about the state of our Listen ingestion pipelines, you can
+        create yourself a free account on our <a href="https://stats.metabrainz.org">infrastructure
         statistics site</a>. In particular,
-        the 
+        the
         <a href="https://stats.metabrainz.org/d/000000059/rabbitmq?orgId=1&refresh=1m&var-queue_vhost=%2Flistenbrainz">
-        Rabbit MQ ListenBrainz view</a> shows how many listens we are currently processing, and the number of incoming listens currently queued for processing.
+        RabbitMQ ListenBrainz view</a> shows how many listens we are currently processing, and the number of incoming listens currently queued for processing.
       </p>
 
       <h3>load average</h3>

--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -37,7 +37,7 @@
         statistics site</a>. In particular,
         the 
         <a href="https://stats.metabrainz.org/d/000000059/rabbitmq?orgId=1&refresh=1m&var-queue_vhost=%2Flistenbrainz">
-        Rabbit MQ ListenBrainz view</a> is relevant to the current status of the pipeline.
+        Rabbit MQ ListenBrainz view</a> shows how many listens we are currently processing, and the number of incoming listens currently queued for processing.
       </p>
 
       <h3>load average</h3>

--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -28,16 +28,17 @@
             <td>{{ listen_count }}</td>
           </tr>
         {% endif %}
-          <tr>
-            <td>Number of incoming batches queued</td>
-            <td>{{ incoming_len }}</td>
-          </tr>
-          <tr>
-            <td>Number of unique incoming batches queued</td>
-            <td>{{ unique_len }}</td>
-          </tr>
         </tbody>
       </table>
+
+      <p>
+        If you are curious about the state of our Listens ingestion pipelines, you can
+        create yourself a free account on our <a href="https://stats.metabrainz.org">infrastructure 
+        statistics site</a>. In particular,
+        the 
+        <a href="https://stats.metabrainz.org/d/000000059/rabbitmq?orgId=1&refresh=1m&var-queue_vhost=%2Flistenbrainz">
+        Rabbit MQ ListenBrainz view</a> is relevant to the current status of the pipeline.
+      </p>
 
       <h3>load average</h3>
 

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -1,25 +1,23 @@
+import locale
+import os
+import requests
+import subprocess
 
-#TODO(param): alphabetize these
 from brainzutils import cache
 from flask import Blueprint, render_template, current_app, redirect, url_for, request, jsonify
 from flask_login import current_user, login_required
-from werkzeug.exceptions import Unauthorized, NotFound
 from requests.exceptions import HTTPError
-import os
-import subprocess
-import requests
-import locale
 import ujson
+from werkzeug.exceptions import Unauthorized, NotFound
+
 import listenbrainz.db.user as db_user
 from listenbrainz.db.exceptions import DatabaseException
-from listenbrainz import webserver
 from listenbrainz.domain import spotify
+from listenbrainz import webserver
 from listenbrainz.webserver import flash
 from listenbrainz.webserver.timescale_connection import _ts
 from listenbrainz.webserver.redis_connection import _redis
 from listenbrainz.webserver.views.user import delete_user
-import pika
-import listenbrainz.webserver.rabbitmq_connection as rabbitmq_connection
 
 
 index_bp = Blueprint('index', __name__)

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -99,19 +99,6 @@ def current_status():
 
     load = "%.2f %.2f %.2f" % os.getloadavg()
 
-    try:
-        with rabbitmq_connection._rabbitmq.get() as connection:
-            queue = connection.channel.queue_declare(current_app.config['INCOMING_QUEUE'], passive=True, durable=True)
-            incoming_len_msg = format(int(queue.method.message_count), ',d')
-
-            queue = connection.channel.queue_declare(current_app.config['UNIQUE_QUEUE'], passive=True, durable=True)
-            unique_len_msg = format(int(queue.method.message_count), ',d')
-
-    except (pika.exceptions.ConnectionClosed, pika.exceptions.ChannelClosed):
-        current_app.logger.error('Unable to get the length of queues', exc_info=True)
-        incoming_len_msg = 'Unknown'
-        unique_len_msg = 'Unknown'
-
     listen_count = _ts.get_total_listen_count()
     try:
         user_count = format(int(_get_user_count()), ',d')
@@ -122,8 +109,6 @@ def current_status():
         "index/current-status.html",
         load=load,
         listen_count=format(int(listen_count), ",d"),
-        incoming_len=incoming_len_msg,
-        unique_len=unique_len_msg,
         user_count=user_count,
     )
 

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -79,20 +79,6 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         resp = self.client.get(url_for('index.current_status'))
         self.assert200(resp)
 
-    @mock.patch('listenbrainz.webserver.views.index.rabbitmq_connection')
-    def test_current_status_ise(self, mock_rabbitmq_connection_module):
-        mock_rabbitmq_connection_module._rabbitmq.get.side_effect = InternalServerError
-        r = self.client.get(url_for('index.current_status'))
-        self.assert500(r)
-
-        mock_rabbitmq_connection_module._rabbitmq.get.side_effect = ConnectionClosed
-        r = self.client.get(url_for('index.current_status'))
-        self.assert200(r)
-
-        mock_rabbitmq_connection_module._rabbitmq.get.side_effect = ConnectionClosed
-        r = self.client.get(url_for('index.current_status'))
-        self.assert200(r)
-
     @mock.patch('listenbrainz.db.user.get')
     def test_menu_not_logged_in(self, mock_user_get):
         resp = self.client.get(url_for('index.index'))


### PR DESCRIPTION
The queue stats on the status page were broken, so I removed them and added a link to grafana.

