### PR TITLE
don't join on msb_artist_credit_name_matchable to get similar artists

### DIFF
--- a/listenbrainz_spark/recommendations/candidate_sets.py
+++ b/listenbrainz_spark/recommendations/candidate_sets.py
@@ -228,8 +228,7 @@ def get_top_artist_candidate_set(top_artist_df, recordings_df, users_df):
             top_artists_candidate_set_df_html (dataframe): top artist info required for html file
     """
     condition = [
-        top_artist_df.top_artist_credit_id == recordings_df.mb_artist_credit_id,
-        top_artist_df.top_artist_name == recordings_df.msb_artist_credit_name_matchable
+        top_artist_df.top_artist_credit_id == recordings_df.mb_artist_credit_id
     ]
 
     df = top_artist_df.join(recordings_df, condition, 'inner')
@@ -265,8 +264,7 @@ def get_similar_artist_candidate_set(similar_artist_df, recordings_df, users_df)
             similar_artist_candidate_set_df_html (dataframe): similar artist info for html file
     """
     condition = [
-        similar_artist_df.similar_artist_credit_id == recordings_df.mb_artist_credit_id,
-        similar_artist_df.similar_artist_name == recordings_df.msb_artist_credit_name_matchable
+        similar_artist_df.similar_artist_credit_id == recordings_df.mb_artist_credit_id
     ]
 
     df = similar_artist_df.join(recordings_df, condition, 'inner')


### PR DESCRIPTION
The `similar_artist_df` gets the artist names from `artist-relations` which aren't matchable. The artist names in `recordings_df` are matchable. Therefore joining the `similar_artist_df` and `recordings_df` yields nothing at all. 

The simple solution is to join them only on `artist_credit_id`. We need not worry about repetitions since 'artist_credit_id` is unique.