### PR TITLE
Improve SHA verification

### DIFF
--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -105,8 +105,6 @@ class ListenBrainzFTPDownloader:
         """ Reads the SHA file and returns the string stripped of any whitespace and extra characters
         """
         with open(filepath, "r") as f:
-            sha = f.read().replace('\n', '')  # Get rid of new line characters
-            sha = sha.lstrip().rstrip()  # Get rid of any leading or trailing whitespace
-            sha = sha.split(' ')[0]  # Get rid of filenames if present
+            sha = f.read().lstrip().split(" ", 1)[0]
 
         return sha

--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -77,14 +77,15 @@ class ListenBrainzFTPDownloader:
 
         current_app.logger.info("Verifying dump integrity...")
         calculated_sha = self._calc_sha256(dest_path)
-        with open(sha_dest_path, "r") as f:
-            received_sha = f.read().replace('\n', '')
+        received_sha = self._read_sha_file(sha_dest_path)
 
         os.remove(sha_dest_path)
         if calculated_sha != received_sha:
             # Cleanup
             os.remove(dest_path)
-            raise DumpInvalidException("Received SHA256 checksum doesn't match the calculated checksum, aborting.")
+            raise DumpInvalidException("""Received SHA256 checksum doesn't match the calculated checksum, aborting.
+                                       Calculated SHA: {calculated_sha}. Received SHA: {received_sha}""".format(
+                calculated_sha=calculated_sha, received_sha=received_sha))
 
         self.connection.cwd('/')
         return dest_path
@@ -99,3 +100,13 @@ class ListenBrainzFTPDownloader:
                 calculated_sha.update(byte_block)
 
         return calculated_sha.hexdigest()
+
+    def _read_sha_file(self, filepath: str) -> str:
+        """ Reads the SHA file and returns the string stripped of any whitespace and extra characters
+        """
+        with open(filepath, "r") as f:
+            sha = f.read().replace('\n', '')  # Get rid of new line characters
+            sha = sha.lstrip().rstrip()  # Get rid of any leading or trailing whitespace
+            sha = sha.split(' ')[0]  # Get rid of filenames if present
+
+        return sha

--- a/listenbrainz_spark/ftp/tests/test_init.py
+++ b/listenbrainz_spark/ftp/tests/test_init.py
@@ -88,7 +88,9 @@ class FTPTestCase(SparkTestCase):
             self.assertRaises(DumpInvalidException,
                               listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump, filename, directory)
 
-    def test_read_sha_file_(self):
+    @patch('ftplib.FTP')
+    def test_read_sha_file_(self, mock_ftp_cons):
+        mock_ftp = mock_ftp_cons.return_value
         with patch('listenbrainz_spark.ftp.open', mock_open(read_data='  test  filename  \n'), create=True) as mock_file:
             result = listenbrainz_spark.ftp.ListenBrainzFTPDownloader()._read_sha_file("/sha_file.sha256")
             self.assertEqual('test', result)

--- a/listenbrainz_spark/ftp/tests/test_init.py
+++ b/listenbrainz_spark/ftp/tests/test_init.py
@@ -78,7 +78,8 @@ class FTPTestCase(SparkTestCase):
     @patch('listenbrainz_spark.ftp.os.remove')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader._calc_sha256', return_value='tset')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader._read_sha_file', return_value='test')
-    def test_download_dump_sha_not_matching(self, mock_sha_read, mock_sha_calc, mock_remove, mock_list_dir, mock_binary, mock_ftp_cons):
+    def test_download_dump_sha_not_matching(self, mock_sha_read, mock_sha_calc, mock_remove,
+                                            mock_list_dir, mock_binary, mock_ftp_cons):
         mock_ftp = mock_ftp_cons.return_value
         filename = 'fakefile.txt'
         directory = 'fakedir'


### PR DESCRIPTION
# Problem
`SHA` verification was failing because of trailing whitespaces and presence of filenames.

# Solution
Stripping all the extra whitespaces and removing everything after the first space fixes the issue.