### PR TITLE
Change cron jobs for data dumps

### DIFF
--- a/docker/dump-crontab
+++ b/docker/dump-crontab
@@ -1,6 +1,14 @@
-# Full Data dumps creation for backup and public use, every Sunday
-00 00 * * 0 /code/listenbrainz/admin/create-dumps.sh full
+# Full dump creation takes the ID of the last incremental
+# dump and creates a full dump for that ID. So, we'll
+# start creating full dumps and incremental dumps in pairs
+# for now.
 
-# Incremental listen data dumps at 00:00 every Monday and Thursday
-00 00 * * 4,6 /code/listenbrainz/admin/create-dumps.sh incremental
+# Every Monday and Thursday
+## incremental
+10 00 * * 1,4 /code/listenbrainz/admin/create-dumps.sh incremental
 
+## full -- a few hours after incremental for safety
+10 02 * * 1,4 /code/listenbrainz/admin/create-dumps.sh full
+
+## Around 24 hours later, trigger an import into the spark cluster
+00 02 * * 2,5 /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full

--- a/docker/stats-crontab
+++ b/docker/stats-crontab
@@ -57,6 +57,3 @@
 
 # user weekly daily_activity
 30 16 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=all_time
-
-# Request full data dump import into spark cluster, every Wednesday
-00 00 * * 3 /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
Our stats are out of date. It's because we're creating and importing dumps at non-ideal times.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Change the timings, create the dumps on monday and thursday. Each full dump takes ~16h, for safety trigger a dump import job 24 hours after the dump creation started.

