### PR TITLE
Enable passing offset arg to recommendation API endpoint

### DIFF
--- a/listenbrainz/tests/integration/test_recommendations_cf_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_api.py
@@ -68,14 +68,20 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         received_count = data['count']
         self.assertEqual(received_count, 25)
 
-        received_total_count = data['total_recording_mbids_count']
+        received_type = data['type']
+        self.assertEqual(received_type, 'top')
+
+        recieved_entity = data['entity']
+        self.assertEqual(recieved_entity, 'recording')
+
+        received_total_count = data['total_mbid_count']
         expected_total_count = len(self.user_recommendations['recording_mbid']['top_artist'])
 
         received_ts = data['last_updated']
         expected_ts = int(self.user_recommendations['created'].timestamp())
         self.assertEqual(received_ts, expected_ts)
 
-        received_top_artist_recommendations = data['top_artist']['recording_mbid']
+        received_top_artist_recommendations = data['mbids']
         expected_top_artist_recommendations = self.user_recommendations['recording_mbid']['top_artist'][:25]
         self.assertEqual(expected_top_artist_recommendations, received_top_artist_recommendations)
 
@@ -92,14 +98,20 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         received_count = data['count']
         self.assertEqual(received_count, 10)
 
-        received_total_count = data['total_recording_mbids_count']
+        received_type = data['type']
+        self.assertEqual(received_type, 'similar')
+
+        recieved_entity = data['entity']
+        self.assertEqual(recieved_entity, 'recording')
+
+        received_total_count = data['total_mbid_count']
         expected_total_count = len(self.user_recommendations['recording_mbid']['similar_artist'])
 
         received_ts = data['last_updated']
         expected_ts = int(self.user2_recommendations['created'].timestamp())
         self.assertEqual(received_ts, expected_ts)
 
-        received_top_artist_recommendations = data['similar_artist']['recording_mbid']
+        received_top_artist_recommendations = data['mbids']
         expected_top_artist_recommendations = self.user2_recommendations['recording_mbid']['similar_artist'][:10]
         self.assertEqual(expected_top_artist_recommendations, received_top_artist_recommendations)
 
@@ -116,13 +128,50 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         received_count = data['count']
         self.assertEqual(received_count, 100)
 
-        received_total_count = data['total_recording_mbids_count']
+        received_type = data['type']
+        self.assertEqual(received_type, 'similar')
+
+        recieved_entity = data['entity']
+        self.assertEqual(recieved_entity, 'recording')
+
+        received_total_count = data['total_mbid_count']
         expected_total_count = len(self.user_recommendations['recording_mbid']['similar_artist'])
 
         received_ts = data['last_updated']
         expected_ts = int(self.user2_recommendations['created'].timestamp())
         self.assertEqual(received_ts, expected_ts)
 
-        received_top_artist_recommendations = data['similar_artist']['recording_mbid']
+        received_top_artist_recommendations = data['mbids']
         expected_top_artist_recommendations = self.user2_recommendations['recording_mbid']['similar_artist'][:100]
+        self.assertEqual(expected_top_artist_recommendations, received_top_artist_recommendations)
+
+    def test_recommendations_with_offset(self):
+        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations',
+                                           user_name=self.user['musicbrainz_id']),
+                                           query_string={'artist_type': 'top', 'offset': 10})
+
+        self.assert200(response)
+        data = json.loads(response.data)['payload']
+
+        received_user_name = data['user_name']
+        self.assertEqual(received_user_name, self.user['musicbrainz_id'])
+
+        received_count = data['count']
+        self.assertEqual(received_count, 15)
+
+        received_type = data['type']
+        self.assertEqual(received_type, 'top')
+
+        recieved_entity = data['entity']
+        self.assertEqual(recieved_entity, 'recording')
+
+        received_total_count = data['total_mbid_count']
+        expected_total_count = len(self.user_recommendations['recording_mbid']['top_artist'])
+
+        received_ts = data['last_updated']
+        expected_ts = int(self.user_recommendations['created'].timestamp())
+        self.assertEqual(received_ts, expected_ts)
+
+        received_top_artist_recommendations = data['mbids']
+        expected_top_artist_recommendations = self.user_recommendations['recording_mbid']['top_artist'][10:25]
         self.assertEqual(expected_top_artist_recommendations, received_top_artist_recommendations)

--- a/listenbrainz/tests/integration/test_recommendations_cf_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_api.py
@@ -68,6 +68,9 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         received_count = data['count']
         self.assertEqual(received_count, 25)
 
+        received_offset = data['offset']
+        self.assertEqual(received_offset, 0)
+
         received_type = data['type']
         self.assertEqual(received_type, 'top')
 
@@ -97,6 +100,9 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
 
         received_count = data['count']
         self.assertEqual(received_count, 10)
+
+        received_offset = data['offset']
+        self.assertEqual(received_offset, 0)
 
         received_type = data['type']
         self.assertEqual(received_type, 'similar')
@@ -128,6 +134,9 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         received_count = data['count']
         self.assertEqual(received_count, 100)
 
+        received_offset = data['offset']
+        self.assertEqual(received_offset, 0)
+
         received_type = data['type']
         self.assertEqual(received_type, 'similar')
 
@@ -158,6 +167,9 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
 
         received_count = data['count']
         self.assertEqual(received_count, 15)
+
+        received_offset = data['offset']
+        self.assertEqual(received_offset, 10)
 
         received_type = data['type']
         self.assertEqual(received_type, 'top')

--- a/listenbrainz/webserver/views/recommendations_cf_recording_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_api.py
@@ -45,6 +45,7 @@ def get_recommendations(user_name):
             "user_name": "unclejohn69"
             'count': 10,
             'total_mbid_count': 30
+            'offset': 10
           }
         }
 
@@ -100,7 +101,8 @@ def get_recommendations(user_name):
             'user_name': user_name,
             'last_updated': int(recommendations['created'].timestamp()),
             'count': len(mbid_list),
-            'total_mbid_count': total_mbid_count
+            'total_mbid_count': total_mbid_count,
+            'offset': offset
         }
     }
 


### PR DESCRIPTION
Till now, we were able to fetch only 100 recommendations for a user using the API endpoint because we did not allow passing offset as an arg to the endpoint. This PR adds enables passing offset to the endpoint. Also, it changes the format of payload according to [LB-665](https://tickets.metabrainz.org/browse/LB-665)