### PR TITLE
LB-669: Fix various frontend bugs

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -204,7 +204,14 @@ export default class UserTopEntity extends React.Component<
                         </tr>
                         <tr>
                           <td />
-                          <td style={{ fontSize: 12 }}>
+                          <td
+                            style={{
+                              fontSize: 12,
+                              textOverflow: "ellipsis",
+                              overflow: "hidden",
+                              paddingRight: 10,
+                            }}
+                          >
                             {getEntityLink(
                               "artist",
                               release.artist_name,
@@ -247,7 +254,14 @@ export default class UserTopEntity extends React.Component<
                         </tr>
                         <tr>
                           <td />
-                          <td style={{ fontSize: 12 }}>
+                          <td
+                            style={{
+                              fontSize: 12,
+                              textOverflow: "ellipsis",
+                              overflow: "hidden",
+                              paddingRight: 10,
+                            }}
+                          >
                             {getEntityLink(
                               "artist",
                               recording.artist_name,

--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -112,26 +112,25 @@ export default class UserTopEntity extends React.Component<
         }}
       >
         <h3 className="capitalize-bold">Top {entityTextOnCard}</h3>
-        <table
+        <Loader
+          isLoading={loading}
           style={{
-            whiteSpace: "nowrap",
-            tableLayout: "fixed",
-            width: "90%",
-            height: 450,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "80%",
           }}
         >
-          <tbody>
-            <Loader
-              isLoading={loading}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                height: "100%",
-              }}
-            >
+          <table
+            style={{
+              whiteSpace: "nowrap",
+              tableLayout: "fixed",
+              width: "90%",
+            }}
+          >
+            <tbody>
               {hasError && (
-                <tr>
+                <tr style={{ height: 440 }}>
                   <td
                     style={{
                       fontSize: 24,
@@ -151,7 +150,7 @@ export default class UserTopEntity extends React.Component<
                   (artist, index) => {
                     return (
                       // eslint-disable-next-line react/no-array-index-key
-                      <tr key={index}>
+                      <tr key={index} style={{ height: 44 }}>
                         <td style={{ width: "10%", textAlign: "end" }}>
                           {index + 1}.&nbsp;
                         </td>
@@ -181,7 +180,7 @@ export default class UserTopEntity extends React.Component<
                     return (
                       // eslint-disable-next-line react/no-array-index-key
                       <React.Fragment key={index}>
-                        <tr>
+                        <tr style={{ height: 22 }}>
                           <td style={{ width: "10%", textAlign: "end" }}>
                             {index + 1}.&nbsp;
                           </td>
@@ -202,7 +201,7 @@ export default class UserTopEntity extends React.Component<
                             {release.listen_count}
                           </td>
                         </tr>
-                        <tr>
+                        <tr style={{ height: 22 }}>
                           <td />
                           <td
                             style={{
@@ -231,7 +230,7 @@ export default class UserTopEntity extends React.Component<
                     return (
                       // eslint-disable-next-line react/no-array-index-key
                       <React.Fragment key={index}>
-                        <tr>
+                        <tr style={{ height: 22 }}>
                           <td style={{ width: "10%", textAlign: "end" }}>
                             {index + 1}.&nbsp;
                           </td>
@@ -252,7 +251,7 @@ export default class UserTopEntity extends React.Component<
                             {recording.listen_count}
                           </td>
                         </tr>
-                        <tr>
+                        <tr style={{ height: 22 }}>
                           <td />
                           <td
                             style={{
@@ -274,9 +273,9 @@ export default class UserTopEntity extends React.Component<
                     );
                   }
                 )}
-            </Loader>
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        </Loader>
         <a
           href={`${window.location.origin}/user/${user.name}/charts?range=${range}&entity=${entity}`}
           style={{ marginTop: 10 }}

--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -114,12 +114,8 @@ export default class UserTopEntity extends React.Component<
         <h3 className="capitalize-bold">Top {entityTextOnCard}</h3>
         <Loader
           isLoading={loading}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            height: "80%",
-          }}
+          className="flex-center"
+          style={{ height: "80%" }}
         >
           <table
             style={{

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserTopEntity.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserTopEntity.test.tsx.snap
@@ -45,29 +45,34 @@ exports[`UserTopEntity renders corectly when range is invalid 1`] = `
         Top 
         artists
       </h3>
-      <table
+      <Loader
+        isLoading={false}
         style={
           Object {
-            "height": 450,
-            "tableLayout": "fixed",
-            "whiteSpace": "nowrap",
-            "width": "90%",
+            "alignItems": "center",
+            "display": "flex",
+            "height": "80%",
+            "justifyContent": "center",
           }
         }
       >
-        <tbody>
-          <Loader
-            isLoading={false}
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "height": "100%",
-                "justifyContent": "center",
-              }
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
             }
-          >
-            <tr>
+          }
+        >
+          <tbody>
+            <tr
+              style={
+                Object {
+                  "height": 440,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -130,9 +135,9 @@ exports[`UserTopEntity renders corectly when range is invalid 1`] = `
                 Invalid range: invalid_range
               </td>
             </tr>
-          </Loader>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </Loader>
       <a
         href="http://localhost/user/test_user/charts?range=invalid_range&entity=artist"
         style={
@@ -193,30 +198,34 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
         Top 
         artists
       </h3>
-      <table
+      <Loader
+        isLoading={false}
         style={
           Object {
-            "height": 450,
-            "tableLayout": "fixed",
-            "whiteSpace": "nowrap",
-            "width": "90%",
+            "alignItems": "center",
+            "display": "flex",
+            "height": "80%",
+            "justifyContent": "center",
           }
         }
       >
-        <tbody>
-          <Loader
-            isLoading={false}
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "height": "100%",
-                "justifyContent": "center",
-              }
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
             }
-          >
+          }
+        >
+          <tbody>
             <tr
               key="0"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -252,6 +261,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="1"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -287,6 +301,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="2"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -322,6 +341,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="3"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -357,6 +381,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="4"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -392,6 +421,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="5"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -427,6 +461,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="6"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -462,6 +501,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="7"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -497,6 +541,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="8"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -532,6 +581,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="9"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -567,6 +621,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="10"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -602,6 +661,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="11"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -637,6 +701,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="12"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -672,6 +741,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="13"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -707,6 +781,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="14"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -742,6 +821,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="15"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -777,6 +861,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="16"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -812,6 +901,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="17"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -847,6 +941,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="18"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -882,6 +981,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="19"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -917,6 +1021,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="20"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -952,6 +1061,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="21"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -987,6 +1101,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="22"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -1022,6 +1141,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="23"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -1057,6 +1181,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
             </tr>
             <tr
               key="24"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
             >
               <td
                 style={
@@ -1090,9 +1219,9 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
                 6
               </td>
             </tr>
-          </Loader>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </Loader>
       <a
         href="http://localhost/user/test_user/charts?range=week&entity=artist"
         style={
@@ -1153,29 +1282,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
         Top 
         recordings
       </h3>
-      <table
+      <Loader
+        isLoading={false}
         style={
           Object {
-            "height": 450,
-            "tableLayout": "fixed",
-            "whiteSpace": "nowrap",
-            "width": "90%",
+            "alignItems": "center",
+            "display": "flex",
+            "height": "80%",
+            "justifyContent": "center",
           }
         }
       >
-        <tbody>
-          <Loader
-            isLoading={false}
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "height": "100%",
-                "justifyContent": "center",
-              }
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
             }
-          >
-            <tr>
+          }
+        >
+          <tbody>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1215,19 +1349,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 25
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ellie Goulding
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1267,19 +1416,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 23
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 The Fray
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1312,19 +1476,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 20
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ritviz
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1364,19 +1543,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 18
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 OneRepublic
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1416,19 +1610,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 16
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ellie Goulding
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1468,19 +1677,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 16
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Taylor Swift
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1520,19 +1744,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 16
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Christina Perri
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1572,19 +1811,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 15
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Vance Joy
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1624,19 +1878,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 14
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ed Sheeran
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1669,19 +1938,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 13
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 OneRepublic
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1721,19 +2005,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 12
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 George Ezra
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1766,19 +2065,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 12
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Tommee Profitt
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1818,19 +2132,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 12
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 The Script
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1863,19 +2192,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 11
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Maroon 5
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1915,19 +2259,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 11
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Of Monsters and Men
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -1960,19 +2319,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 11
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Sia
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2012,19 +2386,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 10
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Maroon 5
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2064,19 +2453,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 10
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 M.I.A.
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2116,19 +2520,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 10
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Linkin Park
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2168,19 +2587,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 8
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Backstreet Boys
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2220,19 +2654,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 8
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Lenka
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2265,19 +2714,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 8
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 The Local train
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2317,19 +2781,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 6
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Coldplay
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2369,19 +2848,34 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 6
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Imagine Dragons
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2414,21 +2908,30 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
                 6
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ellie Goulding
               </td>
             </tr>
-          </Loader>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </Loader>
       <a
         href="http://localhost/user/test_user/charts?range=week&entity=recording"
         style={
@@ -2489,29 +2992,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
         Top 
         releases
       </h3>
-      <table
+      <Loader
+        isLoading={false}
         style={
           Object {
-            "height": 450,
-            "tableLayout": "fixed",
-            "whiteSpace": "nowrap",
-            "width": "90%",
+            "alignItems": "center",
+            "display": "flex",
+            "height": "80%",
+            "justifyContent": "center",
           }
         }
       >
-        <tbody>
-          <Loader
-            isLoading={false}
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "height": "100%",
-                "justifyContent": "center",
-              }
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
             }
-          >
-            <tr>
+          }
+        >
+          <tbody>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2544,19 +3052,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 26
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Coldplay
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2589,19 +3112,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 25
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 The Fray
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2634,19 +3172,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 25
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ellie Goulding
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2679,19 +3232,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 20
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ritviz
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2724,19 +3292,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 18
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 OneRepublic
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2769,19 +3352,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 18
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Vance Joy
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2814,19 +3412,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 17
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ed Sheeran
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2859,19 +3472,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 17
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Imagine Dragons
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2904,19 +3532,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 17
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Taylor Swift
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2949,19 +3592,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 16
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Ellie Goulding
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -2994,19 +3652,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 16
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Christina Perri
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3039,19 +3712,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 16
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Coldplay
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3084,19 +3772,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 15
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 George Ezra
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3129,19 +3832,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 13
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Lenka
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3174,19 +3892,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 13
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 OneRepublic
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3219,19 +3952,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 12
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Tommee Profitt
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3264,19 +4012,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 12
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 The Script
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3309,19 +4072,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 11
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Maroon 5
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3354,19 +4132,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 11
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Maroon 5
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3399,19 +4192,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 11
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Of Monsters and Men
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3444,19 +4252,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 11
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Sia
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3489,19 +4312,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 10
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Linkin Park
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3534,19 +4372,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 10
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 M.I.A.
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3579,19 +4432,34 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 9
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 The Local train
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td
                 style={
                   Object {
@@ -3624,21 +4492,30 @@ exports[`UserTopEntity renders correctly for release 1`] = `
                 8
               </td>
             </tr>
-            <tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
               <td />
               <td
                 style={
                   Object {
                     "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
                   }
                 }
               >
                 Backstreet Boys
               </td>
             </tr>
-          </Loader>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </Loader>
       <a
         href="http://localhost/user/test_user/charts?range=week&entity=release"
         style={

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserTopEntity.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserTopEntity.test.tsx.snap
@@ -46,13 +46,11 @@ exports[`UserTopEntity renders corectly when range is invalid 1`] = `
         artists
       </h3>
       <Loader
+        className="flex-center"
         isLoading={false}
         style={
           Object {
-            "alignItems": "center",
-            "display": "flex",
             "height": "80%",
-            "justifyContent": "center",
           }
         }
       >
@@ -199,13 +197,11 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
         artists
       </h3>
       <Loader
+        className="flex-center"
         isLoading={false}
         style={
           Object {
-            "alignItems": "center",
-            "display": "flex",
             "height": "80%",
-            "justifyContent": "center",
           }
         }
       >
@@ -1283,13 +1279,11 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
         recordings
       </h3>
       <Loader
+        className="flex-center"
         isLoading={false}
         style={
           Object {
-            "alignItems": "center",
-            "display": "flex",
             "height": "80%",
-            "justifyContent": "center",
           }
         }
       >
@@ -2993,13 +2987,11 @@ exports[`UserTopEntity renders correctly for release 1`] = `
         releases
       </h3>
       <Loader
+        className="flex-center"
         isLoading={false}
         style={
           Object {
-            "alignItems": "center",
-            "display": "flex",
             "height": "80%",
-            "justifyContent": "center",
           }
         }
       >


### PR DESCRIPTION
# Problem
- Artist names on the cards in the reports page rolls over.
- If an user has less than 10 top entities then the vertical spacing is calculated incorrectly.
- React throws a warning about `div` tag being nested inside `tbody` tag.

# Solution
- Set `textOverflow` property to `ellipses` and `overflow` to `hidden`.
- Set height for each row individually instead of setting the height for the whole table
- Pull the `Loader` component outside the `tbody` tag.