### PR TITLE
Improve HDFS setup and startup scripts

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -37,7 +37,8 @@ function invoke_docker_compose_spark {
 }
 
 function format_namenode {
-    invoke_docker_compose_spark down
+    # run in a subshell to swallow the exec
+    (invoke_docker_compose_spark down)
     docker volume rm -f listenbrainzspark_datanode
     docker volume rm -f listenbrainzspark_namenode
     invoke_docker_compose_spark run --rm hadoop-master \

--- a/develop.sh
+++ b/develop.sh
@@ -37,6 +37,9 @@ function invoke_docker_compose_spark {
 }
 
 function format_namenode {
+    invoke_docker_compose_spark down
+    docker volume rm -f listenbrainzspark_datanode
+    docker volume rm -f listenbrainzspark_namenode
     invoke_docker_compose_spark run --rm hadoop-master \
             hdfs namenode -format -nonInteractive -force
 }

--- a/docker/docker-compose.spark.yml
+++ b/docker/docker-compose.spark.yml
@@ -19,7 +19,7 @@ services:
 
   hadoop-master:
     image: metabrainz/hadoop-yarn:beta
-    command: hdfs namenode
+    command: bash -c "rm -f /tmp/hadoop-root-namenode.pid && hdfs namenode"
     volumes:
       - namenode:/home/hadoop/hdfs:z
 
@@ -31,9 +31,11 @@ services:
 
   datanode:
     image: metabrainz/hadoop-yarn:beta
-    command: hdfs datanode
+    command: bash -c "rm -f /tmp/hadoop-root-datanode.pid && hdfs datanode"
     volumes:
       - datanode:/home/hadoop/hdfs:z
+    depends_on:
+      - hadoop-master
 
   request_consumer:
     build:

--- a/docs/dev/spark-devel-env.rst
+++ b/docs/dev/spark-devel-env.rst
@@ -43,10 +43,11 @@ container.
 
     ./develop.sh spark format
 
-.. warning::
+.. info::
 
-    You should run ``./develop.sh spark format`` only once, during setup. Running the command again
-    can lead to the spark environment breaking. We're looking into ways to fix this issue.
+    You can run ``./develop.sh spark format`` any time that you want to delete all of the
+    data that is loaded in spark. This will shut down the spark docker cluster, remove
+    the docker volumes used to store the data, and recreate the HDFS filesystem.
 
 
 Your development environment is now ready. Now, let's actually see ListenBrainz Spark


### PR DESCRIPTION
# Problem

* When you stop your spark containers and restart them you get an error: `namenode is running as process 1.  Stop it first.`
* When you format the namenode, the datanode stops connecting

# Solution

When a datanode connects to a namenode for the first time, it obtains the namenode's ID, and stores it locally. This means that it doesn't make sense to format a namenode without also formatting the datanode.
In order to simplify the format command, remove the stored data of both the namenode and datanode before formatting, so that the next time the datanode connects it will get the new namenode ID.

When hdfs starts, it writes a pid file. When you stop but don't remove a container, this file remains in the filesystem.
When hdfs starts, it checks if the pid file exists, and if there is a process running with that pid. The problem is that it doesn't check if the process with that pid is actually hdfs.
This causes an error message on second startup:
>  namenode is running as process 1.  Stop it first.

In our case, it's actually the startup script (bash) which has pid 1, It later execs to hdfs.
In this case it's safe to just remove the pid file before starting hdfs, allowing us to stop and restart the hdfs containers without having to do a `docker-compose down` between the two.