### PR TITLE
Change time.time to time.monotonic

### DIFF
--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -419,7 +419,7 @@ class TimescaleListenStore(ListenStore):
             start_time and end_time (datetime): the range of time for the listens dump.
             temp_dir (str): the dir to use to write files before adding to archive
         """
-        t0 = time.time()
+        t0 = time.monotonic()
         offset = 0
         listen_count = 0
 
@@ -454,7 +454,7 @@ class TimescaleListenStore(ListenStore):
 
         self.write_incremental_listens_to_disk(unwritten_listens, temp_dir)
         self.log.info("%d listens dumped at %.2f listens / sec", listen_count,
-                      listen_count / (time.time() - t0))
+                      listen_count / (time.monotonic() - t0))
 
 
     def write_listens(self, temp_dir, tar_file, archive_name, start_time_range = None, end_time_range = None):
@@ -464,7 +464,7 @@ class TimescaleListenStore(ListenStore):
             end_time_range (datetime): the range of time for the listens dump.
             temp_dir (str): the dir to use to write files before adding to archive
         """
-        t0 = time.time()
+        t0 = time.monotonic()
         listen_count = 0
 
         # This right here is why we should ONLY be using seconds timestamps. Someone could
@@ -521,7 +521,7 @@ class TimescaleListenStore(ListenStore):
 
                     listen_count += rows_added
                     self.log.info("%d listens dumped for %s at %.2f listens/s", listen_count, start_time.strftime("%Y-%m-%d"),
-                                  listen_count / (time.time() - t0))
+                                  listen_count / (time.monotonic() - t0))
 
             month = next_month
             year = next_year

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -347,11 +347,11 @@ def main():
     with app.app_context():
         current_app.logger.info('Spotify Reader started...')
         while True:
-            t = time.time()
+            t = time.monotonic()
             success, failure = process_all_spotify_users()
             if success + failure > 0:
                 current_app.logger.info('All %d users in batch have been processed.', success + failure)
-                current_app.logger.info('Total time taken: %.2f s, average time per user: %.2f s.', time.time() - t, (time.time() - t) / (success + failure))
+                current_app.logger.info('Total time taken: %.2f s, average time per user: %.2f s.', time.monotonic() - t, (time.monotonic() - t) / (success + failure))
             time.sleep(10)
 
 

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -1,5 +1,5 @@
 import re
-from time import time
+import time
 
 from listenbrainz_spark.ftp import ListenBrainzFTPDownloader
 from listenbrainz_spark.exceptions import DumpNotFoundException
@@ -125,10 +125,10 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
 
         mapping_file_name = self.get_latest_mapping(mapping)
 
-        t0 = time()
+        t0 = time.monotonic()
         current_app.logger.info('Downloading {} from FTP...'.format(mapping_file_name))
         dest_path = self.download_dump(mapping_file_name, directory)
-        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time() - t0))
+        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
         return dest_path, mapping_file_name
 
     def download_listens(self, directory, listens_dump_id=None, dump_type=FULL):
@@ -153,10 +153,10 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         self.connection.cwd(req_listens_dump)
         listens_file_name = self.get_listens_dump_file_name(req_listens_dump)
 
-        t0 = time()
+        t0 = time.monotonic()
         current_app.logger.info('Downloading {} from FTP...'.format(listens_file_name))
         dest_path = self.download_dump(listens_file_name, directory)
-        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time() - t0))
+        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
         return dest_path, listens_file_name
 
     def download_artist_relation(self, directory, artist_relation_dump_id=None):
@@ -178,9 +178,9 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         self.connection.cwd(req_dump)
         artist_relation_file_name = self.get_dump_archive_name(req_dump)
 
-        t0 = time()
+        t0 = time.monotonic()
         current_app.logger.info('Downloading {} from FTP...'.format(artist_relation_file_name))
         dest_path = self.download_dump(artist_relation_file_name, directory)
-        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time() - t0))
+        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
 
         return dest_path, artist_relation_file_name

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -68,7 +68,7 @@ class ListenbrainzHDFSUploader:
         for member in tar:
             if member.isfile() and self._is_json_file(member.name):
                 current_app.logger.info("Uploading {}...".format(member.name))
-                t0 = time.time()
+                t0 = time.monotonic()
 
                 try:
                     tar.extract(member)
@@ -86,7 +86,7 @@ class ListenbrainzHDFSUploader:
                 callback(member.name, '/temp', tmp_hdfs_path, schema)
                 utils.delete_dir(tmp_hdfs_path, recursive=True)
                 os.remove(member.name)
-                time_taken = time.time() - t0
+                time_taken = time.monotonic() - t0
                 total_files += 1
                 total_time += time_taken
                 current_app.logger.info("Done! Current file processed in {:.2f} sec".format(time_taken))
@@ -100,7 +100,7 @@ class ListenbrainzHDFSUploader:
             current_app.logger.info('Done!')
 
         current_app.logger.info("Moving the processed files to {}".format(dest_path))
-        t0 = time.time()
+        t0 = time.monotonic()
 
         # Check if parent directory exists, if not create a directory
         dest_path_parent = pathlib.Path(dest_path).parent
@@ -108,7 +108,7 @@ class ListenbrainzHDFSUploader:
             utils.create_dir(dest_path_parent)
 
         utils.rename('/temp', dest_path)
-        utils.current_app.logger.info("Done! Time taken: {:.2f}".format(time.time() - t0))
+        utils.current_app.logger.info("Done! Time taken: {:.2f}".format(time.monotonic() - t0))
 
         # Cleanup
         utils.delete_dir(tmp_dump_dir, recursive=True)

--- a/listenbrainz_spark/hdfs/upload.py
+++ b/listenbrainz_spark/hdfs/upload.py
@@ -19,13 +19,13 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
                 dest_path (str): HDFS path to upload JSON as parquet.
                 tmp_hdfs_path (str): HDFS path where JSON has been uploaded.
         """
-        start_time = time.time()
+        start_time = time.monotonic()
         df = utils.read_json(tmp_hdfs_path, schema=schema)
         current_app.logger.info("Processing {} rows...".format(df.count()))
 
         current_app.logger.info("Uploading to {}...".format(dest_path))
         utils.save_parquet(df, dest_path)
-        current_app.logger.info("File processed in {:.2f} seconds!".format(time.time() - start_time))
+        current_app.logger.info("File processed in {:.2f} seconds!".format(time.monotonic() - start_time))
 
     def process_json_listens(self, filename, data_dir, tmp_hdfs_path, schema):
         """ Process a file containing listens from the ListenBrainz dump and add listens to
@@ -36,7 +36,7 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
                 data_dir (str): Dir to save listens to in HDFS as parquet.
                 tmp_HDFS_path (str): HDFS path where listens JSON has been uploaded.
         """
-        start_time = time.time()
+        start_time = time.monotonic()
         df = utils.read_json(tmp_hdfs_path, schema=schema)
 
         if filename.split('/')[-1] == 'invalid.json':
@@ -48,7 +48,7 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
 
         current_app.logger.info("Uploading to {}...".format(dest_path))
         utils.save_parquet(df, dest_path)
-        current_app.logger.info("File processed in {:.2f} seconds!".format(time.time() - start_time))
+        current_app.logger.info("File processed in {:.2f} seconds!".format(time.monotonic() - start_time))
 
     def upload_mapping(self, archive, force=False):
         """ Decompress archive and upload mapping to HDFS.

--- a/listenbrainz_spark/recommendations/candidate_sets.py
+++ b/listenbrainz_spark/recommendations/candidate_sets.py
@@ -2,7 +2,7 @@ import os
 import sys
 import uuid
 import logging
-from time import time
+import time
 from datetime import datetime
 from collections import defaultdict
 from py4j.protocol import Py4JJavaError
@@ -416,7 +416,7 @@ def save_candidate_html(user_data, total_time, from_date, to_date):
 def main(recommendation_generation_window=None, top_artist_limit=None, similar_artist_limit=None,
          users=None, html_flag=False):
 
-    time_initial = time()
+    time_initial = time.monotonic()
     try:
         listenbrainz_spark.init_spark_session('Candidate_set')
     except SparkSessionNotInitializedException as err:
@@ -463,7 +463,7 @@ def main(recommendation_generation_window=None, top_artist_limit=None, similar_a
         sys.exit(-1)
 
     # time taken to generate candidate_sets
-    total_time = '{:.2f}'.format((time() - time_initial) / 60)
+    total_time = '{:.2f}'.format((time.monotonic() - time_initial) / 60)
     if html_flag:
         user_data = get_candidate_html_data(similar_artist_candidate_set_df_html, top_artist_candidate_set_df_html,
                                             top_artist_df, similar_artist_df_html)

--- a/listenbrainz_spark/recommendations/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/create_dataframes.py
@@ -1,7 +1,7 @@
 import sys
 import uuid
 import logging
-from time import time
+import time
 from datetime import datetime
 
 import listenbrainz_spark
@@ -278,7 +278,7 @@ def get_users_dataframe(mapped_listens_df, metadata):
 
 def main(train_model_window=None):
 
-    ti = time()
+    ti = time.monotonic()
     # dict to save dataframe metadata which would be later merged in model_metadata dataframe.
     metadata = {}
     # "updated" should always be set to False in this script.
@@ -310,7 +310,7 @@ def main(train_model_window=None):
 
     generate_dataframe_id(metadata)
     save_dataframe_metadata_to_hdfs(metadata)
-    total_time = '{:.2f}'.format((time() - ti) / 60)
+    total_time = '{:.2f}'.format((time.monotonic() - ti) / 60)
 
     message = [{
         'type': 'cf_recording_dataframes',


### PR DESCRIPTION

# Problem
LB-677

# Solution
When calculating time taken for something use time.monotonic instead of
time.time to avoid errors due to system clock time shifting.

# Action
code review



