### PR TITLE
Add count parameter while requesting data from labs API

### DIFF
--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -1112,6 +1112,8 @@ class StatsAPITestCase(IntegrationTestCase):
             }
         ]
         self.assertListEqual(expected, received)
+        self.assertTrue('count' in mock_requests.request_history[0].qs)
+        self.assertTrue('count' in mock_requests.request_history[1].qs)
 
     @requests_mock.Mocker()
     def test_get_country_code_msid_mbid_mapping_failure(self, mock_requests):

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -721,9 +721,9 @@ def _get_mbids_from_msids(artist_msids: list) -> list:
     request_data = [{"artist_msid": artist_msid} for artist_msid in artist_msids]
     artist_mbids = []
     try:
-        result = requests.post("{}/artist-credit-from-artist-msid/json?count={}"
-                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL'], len(request_data)),
-                               json=request_data)
+        result = requests.post("{}/artist-credit-from-artist-msid/json"
+                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL']),
+                               json=request_data, params={'count': len(request_data)})
         # Raise error if non 200 response is received
         result.raise_for_status()
         data = result.json()
@@ -733,7 +733,7 @@ def _get_mbids_from_msids(artist_msids: list) -> list:
         current_app.logger.error("Error while getting artist_mbids, {}".format(err), exc_info=True)
         error_msg = ("An error occurred while calculating artist_map data, "
                      "try setting 'force_recalculate' to 'false' to get a cached copy if available."
-                     "Payload: {}".format(request_data))
+                     "Payload: {}. Response: {}".format(request_data, result.text))
         raise APIInternalServerError(error_msg)
 
     return artist_mbids
@@ -745,9 +745,9 @@ def _get_country_code_from_mbids(artist_mbids: set) -> list:
     request_data = [{"artist_mbid": artist_mbid} for artist_mbid in artist_mbids]
     country_codes = []
     try:
-        result = requests.post("{}/artist-country-code-from-artist-mbid/json?count={}"
-                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL'], len(request_data)),
-                               json=request_data)
+        result = requests.post("{}/artist-country-code-from-artist-mbid/json"
+                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL']),
+                               json=request_data, params={'count': len(request_data)})
         # Raise error if non 200 response is received
         result.raise_for_status()
         data = result.json()
@@ -757,7 +757,7 @@ def _get_country_code_from_mbids(artist_mbids: set) -> list:
         current_app.logger.error("Error while getting artist_country_codes, {}".format(err), exc_info=True)
         error_msg = ("An error occurred while calculating artist_map data, "
                      "try setting 'force_recalculate' to 'false' to get a cached copy if available"
-                     "Payload: {}".format(request_data))
+                     "Payload: {}. Response: {}".format(request_data, result.text))
         raise APIInternalServerError(error_msg)
 
     return country_codes

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -721,8 +721,9 @@ def _get_mbids_from_msids(artist_msids: list) -> list:
     request_data = [{"artist_msid": artist_msid} for artist_msid in artist_msids]
     artist_mbids = []
     try:
-        result = requests.post(
-            "{}/artist-credit-from-artist-msid/json".format(current_app.config['LISTENBRAINZ_LABS_API_URL']), json=request_data)
+        result = requests.post("{}/artist-credit-from-artist-msid/json?count={}"
+                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL'], len(request_data)),
+                               json=request_data)
         # Raise error if non 200 response is received
         result.raise_for_status()
         data = result.json()
@@ -731,7 +732,8 @@ def _get_mbids_from_msids(artist_msids: list) -> list:
     except requests.RequestException as err:
         current_app.logger.error("Error while getting artist_mbids, {}".format(err), exc_info=True)
         error_msg = ("An error occurred while calculating artist_map data, "
-                     "try setting 'force_recalculate' to 'false' to get a cached copy if available")
+                     "try setting 'force_recalculate' to 'false' to get a cached copy if available."
+                     "Payload: {}".format(request_data))
         raise APIInternalServerError(error_msg)
 
     return artist_mbids
@@ -743,9 +745,9 @@ def _get_country_code_from_mbids(artist_mbids: set) -> list:
     request_data = [{"artist_mbid": artist_mbid} for artist_mbid in artist_mbids]
     country_codes = []
     try:
-        result = requests.post("{}/artist-country-code-from-artist-mbid/json".format(
-            current_app.config['LISTENBRAINZ_LABS_API_URL']),
-            json=request_data)
+        result = requests.post("{}/artist-country-code-from-artist-mbid/json?count={}"
+                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL'], len(request_data)),
+                               json=request_data)
         # Raise error if non 200 response is received
         result.raise_for_status()
         data = result.json()
@@ -754,7 +756,8 @@ def _get_country_code_from_mbids(artist_mbids: set) -> list:
     except requests.RequestException as err:
         current_app.logger.error("Error while getting artist_country_codes, {}".format(err), exc_info=True)
         error_msg = ("An error occurred while calculating artist_map data, "
-                     "try setting 'force_recalculate' to 'false' to get a cached copy if available")
+                     "try setting 'force_recalculate' to 'false' to get a cached copy if available"
+                     "Payload: {}".format(request_data))
         raise APIInternalServerError(error_msg)
 
     return country_codes


### PR DESCRIPTION
# Problem
The labs API returns 100 artist MBIDs by default if count parameter is not provided. This leads to incomplete data shown on `Artist Origin` map.

# Solution
Adding a count parameter to the URL fixes the issue.

# Action
Test it on Beta and if it is stable deploy to production. We should also truncate the `artist_map` column in PG before deploying.