### PR TITLE
Scale the CF generated ratings so that they fall on a range from 0.0 -> 1.0.

### DIFF
--- a/listenbrainz_spark/exceptions.py
+++ b/listenbrainz_spark/exceptions.py
@@ -95,3 +95,10 @@ class RecommendationsNotGeneratedException(SparkException):
     """
     def __init__(self, message):
         super(RecommendationsNotGeneratedException, self).__init__(message)
+
+
+class RatingOutOfRangeException(SparkException):
+    """ CF generated rating is out of range i.e. rating > 1 or rating < -1
+    """
+    def __init__(self, message):
+        super(RatingOutOfRangeException, self).__init__(message)


### PR DESCRIPTION
As discussed, we'd want to scale negative ratings (CF generated) and keep a record of ratings (log to sentry) that don't fall in the expected range i.e. rating > 1 or rating < -1.