### PR TITLE
LB-518: Allow users to specify both max_ts and min_ts in the get listens endpoint

### DIFF
--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -62,11 +62,8 @@ class ListenStore(object):
         """ Check from_ts, to_ts, and limit for fetching listens
             and set them to default values if not given.
         """
-        if from_ts and to_ts:
-            raise ValueError("You cannot specify from_ts and to_ts at the same time.")
-
-        if from_ts is None and to_ts is None:
-            raise ValueError("You must specify either from_ts or to_ts.")
+        if from_ts and to_ts and from_ts >= to_ts:
+            raise ValueError("from_ts should be less than to_ts")
 
         if from_ts:
             order = ORDER_ASC

--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -64,7 +64,8 @@ class ListenStore(object):
         """
         if from_ts and to_ts and from_ts >= to_ts:
             raise ValueError("from_ts should be less than to_ts")
-
+        if from_ts is None and to_ts is None:
+            raise ValueError("You must specify either from_ts or to_ts.")
         if from_ts:
             order = ORDER_ASC
         else:

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -127,6 +127,18 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
+    def test_fetch_listens_4(self):
+        self._create_test_data(self.testuser_name)
+        listens = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000049, to_ts=1400000101)
+        self.assertEqual(len(listens), 2)
+        self.assertEqual(listens[0].ts_since_epoch, 1400000100)
+        self.assertEqual(listens[1].ts_since_epoch, 1400000050)
+
+    def test_fetch_listens_5(self):
+        self._create_test_data(self.testuser_name)
+        with self.assertRaises(ValueError):
+            self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000101, to_ts=1400000001)
+
     def test_fetch_listens_time_range(self):
         self._create_test_data(self.testuser_name,
                                test_data_file_name='timescale_listenstore_test_listens_over_greater_time_range.json')

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -237,9 +237,9 @@ class TimescaleListenStore(ListenStore):
             max_timestamp_window = 432000 * time_range
             if from_ts is not None:
                 to_ts = from_ts + max_timestamp_window
-            else:
+            elif to_ts is not None:
                 from_ts = to_ts - max_timestamp_window
-
+                
         query = """SELECT listened_at, track_name, created, data
                      FROM listen
                     WHERE user_name = :user_name """

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -235,9 +235,9 @@ class TimescaleListenStore(ListenStore):
             max_timestamp_window = -1
         else:
             max_timestamp_window = 432000 * time_range
-            if from_ts is not None:
+            if to_ts is None:
                 to_ts = from_ts + max_timestamp_window
-            elif to_ts is not None:
+            elif from_ts is None:
                 from_ts = to_ts - max_timestamp_window
                 
         query = """SELECT listened_at, track_name, created, data

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -235,7 +235,9 @@ class TimescaleListenStore(ListenStore):
             max_timestamp_window = -1
         else:
             max_timestamp_window = 432000 * time_range
-            if from_ts is not None:
+            if from_ts and to_ts:
+                pass
+            elif from_ts is not None:
                 to_ts = from_ts + max_timestamp_window
             elif to_ts is not None:
                 from_ts = to_ts - max_timestamp_window
@@ -243,9 +245,13 @@ class TimescaleListenStore(ListenStore):
         query = """SELECT listened_at, track_name, created, data
                      FROM listen
                     WHERE user_name = :user_name """
+                  
 
         if max_timestamp_window < 0:
-            if from_ts is not None:
+            if from_ts and to_ts:
+                query += """AND listened_at > :from_ts
+                            AND listened_at < :to_ts """
+            elif from_ts is not None:
                 query += "AND listened_at > :from_ts "
             else:
                 query += "AND listened_at < :to_ts "

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -32,6 +32,7 @@ DUMP_CHUNK_SIZE = 100000
 NUMBER_OF_USERS_PER_DIRECTORY = 1000
 DUMP_FILE_SIZE_LIMIT = 1024 * 1024 * 1024  # 1 GB
 DATA_START_YEAR = 2005
+SECONDS_IN_TIME_RANGE = 432000
 
 
 class TimescaleListenStore(ListenStore):
@@ -234,7 +235,7 @@ class TimescaleListenStore(ListenStore):
         if time_range < 0:
             max_timestamp_window = -1
         else:
-            max_timestamp_window = 432000 * time_range
+            max_timestamp_window = SECONDS_IN_TIME_RANGE * time_range
             if to_ts is None:
                 to_ts = from_ts + max_timestamp_window
             elif from_ts is None:

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -235,9 +235,7 @@ class TimescaleListenStore(ListenStore):
             max_timestamp_window = -1
         else:
             max_timestamp_window = 432000 * time_range
-            if from_ts and to_ts:
-                pass
-            elif from_ts is not None:
+            if from_ts is not None:
                 to_ts = from_ts + max_timestamp_window
             elif to_ts is not None:
                 from_ts = to_ts - max_timestamp_window

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -109,6 +109,27 @@ class APITestCase(IntegrationTestCase):
         self.assertListEqual(response.json['payload']['listens'], [])
         self.assertEqual(response.json['payload']['latest_listen_ts'], ts)
 
+        # test request with both max_ts and min_ts is working
+        url = url_for('api_v1.get_listens', user_name=self.user['musicbrainz_id'])
+        
+        response = self.client.get(url, query_string={'max_ts': ts + 1000,'min_ts': ts - 1000})
+        self.assert200(response)
+        data = json.loads(response.data)['payload']
+
+        self.assertEqual(data['user_id'], self.user['musicbrainz_id'])
+
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(len(data['listens']), 1)
+
+        sent_time = payload['payload'][0]['listened_at']
+        self.assertEqual(data['listens'][0]['listened_at'], sent_time)
+        self.assertEqual(data['listens'][0]['track_metadata']['track_name'], 'Fade')
+        self.assertEqual(data['listens'][0]['track_metadata']['artist_name'], 'Kanye West')
+        self.assertEqual(data['listens'][0]['track_metadata']['release_name'], 'The Life of Pablo')
+
+        # CHeck api throws error 400 if min_ts is greater than max_ts    
+        response = self.client.get(url, query_string={'max_ts': '1400000000','min_ts':'1500000000'})
+            
         # check that recent listens are fetched correctly
         url = url_for('api_v1.get_recent_listens_for_user_list', user_list=self.user['musicbrainz_id'])
         response = self.client.get(url, query_string={'limit': '1'})

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -11,7 +11,7 @@ from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400
     MAX_LISTEN_SIZE, MAX_ITEMS_PER_GET, DEFAULT_ITEMS_PER_GET, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
 from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400, validate_listen, MAX_LISTEN_SIZE, MAX_ITEMS_PER_GET,\
     DEFAULT_ITEMS_PER_GET, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
-from listenstore.timescale_listenstore import SECONDS_IN_TIME_RANGE
+from listenbrainz.listenstore.timescale_listenstore import SECONDS_IN_TIME_RANGE
 import time
 import psycopg2
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -107,7 +107,10 @@ def get_listens(user_name):
         log_raise_400("time_range must be between 1 and %d." % MAX_TIME_RANGE)
 
     if max_ts and min_ts and max_ts < min_ts:
-        log_raise_400("If both are given, max_ts should be greater than min_ts")
+        log_raise_400("max_ts should be greater than min_ts")
+
+    if (max_ts - min_ts) > MAX_TIME_RANGE * 432000:
+        log_raise_400("time_range specified by min_ts and max_ts should be less than %d." % MAX_TIME_RANGE)
 
     db_conn = webserver.create_timescale(current_app)
     (min_ts_per_user, max_ts_per_user) = db_conn.get_timestamps_for_user(user_name)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -106,11 +106,12 @@ def get_listens(user_name):
     if time_range < 1 or time_range > MAX_TIME_RANGE:
         log_raise_400("time_range must be between 1 and %d." % MAX_TIME_RANGE)
 
-    if max_ts and min_ts and max_ts < min_ts:
-        log_raise_400("max_ts should be greater than min_ts")
-
-    if (max_ts - min_ts) > MAX_TIME_RANGE * 432000:
-        log_raise_400("time_range specified by min_ts and max_ts should be less than %d." % MAX_TIME_RANGE)
+    if max_ts and min_ts:
+        if max_ts < min_ts:
+            log_raise_400("max_ts should be greater than min_ts")
+        
+        if (max_ts - min_ts) > MAX_TIME_RANGE * 432000:
+            log_raise_400("time_range specified by min_ts and max_ts should be less than %d." % MAX_TIME_RANGE)
 
     db_conn = webserver.create_timescale(current_app)
     (min_ts_per_user, max_ts_per_user) = db_conn.get_timestamps_for_user(user_name)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -9,6 +9,9 @@ from listenbrainz.webserver.rate_limiter import ratelimit
 import listenbrainz.webserver.redis_connection as redis_connection
 from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400, validate_listen, parse_param_list,\
     MAX_LISTEN_SIZE, MAX_ITEMS_PER_GET, DEFAULT_ITEMS_PER_GET, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
+from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400, validate_listen, MAX_LISTEN_SIZE, MAX_ITEMS_PER_GET,\
+    DEFAULT_ITEMS_PER_GET, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
+from listenstore.timescale_listenstore import SECONDS_IN_TIME_RANGE
 import time
 import psycopg2
 
@@ -110,8 +113,8 @@ def get_listens(user_name):
         if max_ts < min_ts:
             log_raise_400("max_ts should be greater than min_ts")
         
-        if (max_ts - min_ts) > MAX_TIME_RANGE * 432000:
-            log_raise_400("time_range specified by min_ts and max_ts should be less than %d." % MAX_TIME_RANGE)
+        if (max_ts - min_ts) > MAX_TIME_RANGE * SECONDS_IN_TIME_RANGE:
+            log_raise_400("time_range specified by min_ts and max_ts should be less than %d days." % MAX_TIME_RANGE * 5)
 
     db_conn = webserver.create_timescale(current_app)
     (min_ts_per_user, max_ts_per_user) = db_conn.get_timestamps_for_user(user_name)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -106,9 +106,8 @@ def get_listens(user_name):
     if time_range < 1 or time_range > MAX_TIME_RANGE:
         log_raise_400("time_range must be between 1 and %d." % MAX_TIME_RANGE)
 
-    # if no max given, use now()
-    if max_ts and min_ts:
-        log_raise_400("You may only specify max_ts or min_ts, not both.")
+    if max_ts and min_ts and max_ts < min_ts:
+        log_raise_400("If both are given, max_ts should be greater than min_ts")
 
     db_conn = webserver.create_timescale(current_app)
     (min_ts_per_user, max_ts_per_user) = db_conn.get_timestamps_for_user(user_name)


### PR DESCRIPTION
# Problem
LB-518

# Solution
In fetch_listens:
Removed the condition checking if both max_ts and min_ts allowing .
In fetch_listens_from_storage:
Modified the if conditions adjusting the value of from_ts and to_ts depending upon the value of which of  the both variables is given. 
In get_listens:
Added a condition to check if both max_ts and min_ts are given then max_ts should be greater than min_ts ,otherwise raising a respective error .


