### PR TITLE
LB-692: Fix 500s on artist-map endpoint

### DIFF
--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -1155,14 +1155,14 @@ class StatsAPITestCase(IntegrationTestCase):
                      "try setting 'force_recalculate' to 'false' to get a cached copy if available")
         self.assert500(response, message=error_msg)
 
-    def test_get_country_code_no_msids_and_mbids(self, mock_requests):
+    def test_get_country_code_no_msids_and_mbids(self):
         """ Test to check if no error is thrown if no msids and mbids are present"""
 
         # Overwrite the artist stats so that no artist has msids or mbids present
         artist_stats = deepcopy(self.artist_payload)
         for artist in artist_stats["artists"]:
             artist['artist_mbids'] = []
-            artist['artist_msid'] = ""
+            artist['artist_msid'] = None
         db_stats.insert_user_artists(self.user['id'], UserArtistStatJson(**{'all_time': artist_stats}))
 
         response = self.client.get(url_for('stats_api_v1.get_artist_map',

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -723,21 +723,22 @@ def _get_mbids_from_msids(artist_msids: list) -> list:
     """
     request_data = [{"artist_msid": artist_msid} for artist_msid in artist_msids]
     artist_mbids = []
-    try:
-        result = requests.post("{}/artist-credit-from-artist-msid/json"
-                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL']),
-                               json=request_data, params={'count': len(request_data)})
-        # Raise error if non 200 response is received
-        result.raise_for_status()
-        data = result.json()
-        for entry in data:
-            artist_mbids += entry['[artist_credit_mbid]']
-    except requests.RequestException as err:
-        current_app.logger.error("Error while getting artist_mbids, {}".format(err), exc_info=True)
-        error_msg = ("An error occurred while calculating artist_map data, "
-                     "try setting 'force_recalculate' to 'false' to get a cached copy if available."
-                     "Payload: {}. Response: {}".format(request_data, result.text))
-        raise APIInternalServerError(error_msg)
+    if len(request_data) > 0:
+        try:
+            result = requests.post("{}/artist-credit-from-artist-msid/json"
+                                   .format(current_app.config['LISTENBRAINZ_LABS_API_URL']),
+                                   json=request_data, params={'count': len(request_data)})
+            # Raise error if non 200 response is received
+            result.raise_for_status()
+            data = result.json()
+            for entry in data:
+                artist_mbids += entry['[artist_credit_mbid]']
+        except requests.RequestException as err:
+            current_app.logger.error("Error while getting artist_mbids, {}".format(err), exc_info=True)
+            error_msg = ("An error occurred while calculating artist_map data, "
+                         "try setting 'force_recalculate' to 'false' to get a cached copy if available."
+                         "Payload: {}. Response: {}".format(request_data, result.text))
+            raise APIInternalServerError(error_msg)
 
     return artist_mbids
 
@@ -747,20 +748,21 @@ def _get_country_code_from_mbids(artist_mbids: set) -> list:
     """
     request_data = [{"artist_mbid": artist_mbid} for artist_mbid in artist_mbids]
     country_codes = []
-    try:
-        result = requests.post("{}/artist-country-code-from-artist-mbid/json"
-                               .format(current_app.config['LISTENBRAINZ_LABS_API_URL']),
-                               json=request_data, params={'count': len(request_data)})
-        # Raise error if non 200 response is received
-        result.raise_for_status()
-        data = result.json()
-        for entry in data:
-            country_codes.append(entry['country_code'])
-    except requests.RequestException as err:
-        current_app.logger.error("Error while getting artist_country_codes, {}".format(err), exc_info=True)
-        error_msg = ("An error occurred while calculating artist_map data, "
-                     "try setting 'force_recalculate' to 'false' to get a cached copy if available"
-                     "Payload: {}. Response: {}".format(request_data, result.text))
-        raise APIInternalServerError(error_msg)
+    if len(request_data) > 0:
+        try:
+            result = requests.post("{}/artist-country-code-from-artist-mbid/json"
+                                   .format(current_app.config['LISTENBRAINZ_LABS_API_URL']),
+                                   json=request_data, params={'count': len(request_data)})
+            # Raise error if non 200 response is received
+            result.raise_for_status()
+            data = result.json()
+            for entry in data:
+                country_codes.append(entry['country_code'])
+        except requests.RequestException as err:
+            current_app.logger.error("Error while getting artist_country_codes, {}".format(err), exc_info=True)
+            error_msg = ("An error occurred while calculating artist_map data, "
+                         "try setting 'force_recalculate' to 'false' to get a cached copy if available"
+                         "Payload: {}. Response: {}".format(request_data, result.text))
+            raise APIInternalServerError(error_msg)
 
     return country_codes


### PR DESCRIPTION
# Problem
We still get some 500s from the artist map endpoint.

# Solution
Making sure we don't send empty arrays to the Labs API fixes the issue.