### PR TITLE
remove redundant sentry log messages

### DIFF
--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -153,7 +153,7 @@ def scale_ratings(mbids_and_ratings, ratings_beyond_range):
         row[1] = round(min(max(scaled_rating, -1.0), 1.0), 3)
 
 
-def get_recommended_mbids(candidate_set, params, limit, ratings_beyond_range, user_name):
+def get_recommended_mbids(candidate_set, params, limit, ratings_beyond_range):
     """ Generate recommendations from the candidate set.
 
         Args:
@@ -178,11 +178,7 @@ def get_recommended_mbids(candidate_set, params, limit, ratings_beyond_range, us
 
     mbids_and_ratings = [[row.mb_recording_mbid, round(row.rating, 3)] for row in recording_mbids_df.collect()]
 
-    current_app.logger.critical('Recommendations for {} before scaling.\n{}'.format(user_name, mbids_and_ratings))
-
     scale_ratings(mbids_and_ratings, ratings_beyond_range)
-
-    current_app.logger.critical('Recommendations for {} after scaling.\n{}'.format(user_name, mbids_and_ratings))
 
     return mbids_and_ratings
 
@@ -228,8 +224,7 @@ def get_recommendations_for_user(user_id, user_name, params, ratings_beyond_rang
         top_artist_candidate_set_user = get_candidate_set_rdd_for_user(params.top_artist_candidate_set_df, user_id)
         user_recommendations_top_artist = get_recommended_mbids(top_artist_candidate_set_user, params,
                                                                 params.recommendation_top_artist_limit,
-                                                                ratings_beyond_range,
-                                                                user_name)
+                                                                ratings_beyond_range)
     except IndexError:
         current_app.logger.error('Top artist candidate set not found for "{}"'.format(user_name))
     except RecommendationsNotGeneratedException:
@@ -240,8 +235,7 @@ def get_recommendations_for_user(user_id, user_name, params, ratings_beyond_rang
         similar_artist_candidate_set_user = get_candidate_set_rdd_for_user(params.similar_artist_candidate_set_df, user_id)
         user_recommendations_similar_artist = get_recommended_mbids(similar_artist_candidate_set_user, params,
                                                                     params.recommendation_similar_artist_limit,
-                                                                    ratings_beyond_range,
-                                                                    user_name)
+                                                                    ratings_beyond_range)
     except IndexError:
         current_app.logger.error('Similar artist candidate set not found for "{}"'.format(user_name))
     except RecommendationsNotGeneratedException:

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -162,8 +162,8 @@ class RecommendTestClass(SparkTestCase):
         ])
 
         mock_mbids.assert_has_calls([
-            call(mock_candidate_set.return_value, params, params.recommendation_top_artist_limit, [], 'vansika'),
-            call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit, [], 'vansika')
+            call(mock_candidate_set.return_value, params, params.recommendation_top_artist_limit, []),
+            call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit, [])
         ])
 
     def test_scale_ratings(self):
@@ -193,7 +193,7 @@ class RecommendTestClass(SparkTestCase):
 
         ratings_beyond_range = []
 
-        recommended_mbids = recommend.get_recommended_mbids(rdd, params, limit, ratings_beyond_range, 'vansika')
+        recommended_mbids = recommend.get_recommended_mbids(rdd, params, limit, ratings_beyond_range)
 
         mock_gen_rec.assert_called_once_with(rdd, params, limit)
         self.assertEqual(recommended_mbids[0][0], '2acb406f-c716-45f8-a8bd-96ca3939c2e5')
@@ -205,7 +205,7 @@ class RecommendTestClass(SparkTestCase):
 
         mock_gen_rec.return_value = []
         with self.assertRaises(RecommendationsNotGeneratedException):
-            recommend.get_recommended_mbids(rdd, params, limit, ratings_beyond_range, 'vansika')
+            recommend.get_recommended_mbids(rdd, params, limit, ratings_beyond_range)
 
 
     def test_get_user_name_and_user_id(self):


### PR DESCRIPTION
Earlier we introduced sentry log messages to debug ratings beyond the scale, since the purpose of that has been fulfilled the log messages are no more useful.
