### PR TITLE
Show number of listens submitted today and yesterday on status page.

### DIFF
--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -4,14 +4,18 @@ import ujson
 import redis
 from time import time
 from redis import Redis
+from typing import Optional
 
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore import ListenStore
+from datetime import datetime
+
 
 class RedisListenStore(ListenStore):
 
     RECENT_LISTENS_KEY = "lb_recent_sorted"
-    RECENT_LISTENS_MAX = 100 
+    RECENT_LISTENS_MAX = 100
+    LISTEN_COUNT_PER_DAY_EXPIRY_TIME = 3 * 24 * 60 * 60  # 3 days in seconds
 
     def __init__(self, log, conf):
         super(RedisListenStore, self).__init__(log)

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -95,6 +95,9 @@ class RedisListenStore(ListenStore):
         return recent
 
     def increment_listen_count_for_day(self, day: datetime, count: int):
+        """ Increment the number of listens submitted on the day `day`
+        by `count`.
+        """
         key = self.LISTEN_COUNT_PER_DAY_KEY_FORMAT.format(day.strftime('%Y%m%d'))
         if self.redis.exists(key):
             self.redis.incrby(key, count)
@@ -102,6 +105,8 @@ class RedisListenStore(ListenStore):
             self.redis.setex(key, self.LISTEN_COUNT_PER_DAY_EXPIRY_TIME, count)
 
     def get_listen_count_for_day(self, day: datetime) -> Optional[int]:
+        """ Get the number of listens submitted for day `day`, return None if not available.
+        """
         key = self.LISTEN_COUNT_PER_DAY_KEY_FORMAT.format(day.strftime('%Y%m%d'))
         listen_count = self.redis.get(key)
         if listen_count:

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -16,6 +16,8 @@ class RedisListenStore(ListenStore):
     RECENT_LISTENS_KEY = "lb_recent_sorted"
     RECENT_LISTENS_MAX = 100
     LISTEN_COUNT_PER_DAY_EXPIRY_TIME = 3 * 24 * 60 * 60  # 3 days in seconds
+    LISTEN_COUNT_PER_DAY_KEY_FORMAT = "lb_listen_count_for_day_{}"
+
 
     def __init__(self, log, conf):
         super(RedisListenStore, self).__init__(log)
@@ -93,14 +95,14 @@ class RedisListenStore(ListenStore):
         return recent
 
     def increment_listen_count_for_day(self, day: datetime, count: int):
-        key = "listens_for_{}".format(day.strftime('%Y%m%d'))
+        key = self.LISTEN_COUNT_PER_DAY_KEY_FORMAT.format(day.strftime('%Y%m%d'))
         if self.redis.exists(key):
             self.redis.incrby(key, count)
         else:
             self.redis.setex(key, self.LISTEN_COUNT_PER_DAY_EXPIRY_TIME, count)
 
     def get_listen_count_for_day(self, day: datetime) -> Optional[int]:
-        key = "listens_for_{}".format(day.strftime('%Y%m%d'))
+        key = self.LISTEN_COUNT_PER_DAY_KEY_FORMAT.format(day.strftime('%Y%m%d'))
         listen_count = self.redis.get(key)
         if listen_count:
             return int(listen_count)

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -87,3 +87,17 @@ class RedisListenStore(ListenStore):
             recent.append(Listen.from_json(ujson.loads(listen)))
 
         return recent
+
+    def increment_listen_count_for_day(self, day: datetime, count: int):
+        key = "listens_for_{}".format(day.strftime('%Y%m%d'))
+        if self.redis.exists(key):
+            self.redis.incrby(key, count)
+        else:
+            self.redis.setex(key, self.LISTEN_COUNT_PER_DAY_EXPIRY_TIME, count)
+
+    def get_listen_count_for_day(self, day: datetime) -> Optional[int]:
+        key = "listens_for_{}".format(day.strftime('%Y%m%d'))
+        listen_count = self.redis.get(key)
+        if listen_count:
+            return int(listen_count)
+        return None

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -6,6 +6,7 @@ import time
 import ujson
 import uuid
 
+from dateutil.relativedelta import relativedelta
 from redis.connection import Connection
 
 import listenbrainz.db.user as db_user
@@ -79,3 +80,23 @@ class RedisListenStoreTestCase(DatabaseTestCase):
         self.assertEqual(len(recent), 5)
         for i, r in enumerate(recent):
             self.assertEqual(r.timestamp, listens[i].timestamp)
+
+    def test_incr_listen_count_for_day(self):
+        today = datetime.datetime.utcnow()
+        # get without setting any value, should return None
+        self.assertIsNone(self._redis.get_listen_count_for_day(today))
+
+        # set a value to a key that doesn't exists
+        self._redis.increment_listen_count_for_day(today, 2)
+        self.assertEqual(2, self._redis.get_listen_count_for_day(today))
+
+        # increment again
+        self._redis.increment_listen_count_for_day(today, 3)
+        self.assertEqual(5, self._redis.get_listen_count_for_day(today))
+
+        # check for a different day
+        yesterday = today - relativedelta(days=1)
+        self.assertIsNone(self._redis.get_listen_count_for_day(yesterday))
+
+        self._redis.increment_listen_count_for_day(today, 2)
+        self.assertEqual(2, self._redis.get_listen_count_for_day(yesterday))

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -69,7 +69,7 @@ class RedisListenStoreTestCase(DatabaseTestCase):
             )
             listens.append(listen)
             self._redis.update_recent_listens(listens)
-      
+
         recent = self._redis.get_recent_listens()
         self.assertEqual(len(recent), RedisListenStore.RECENT_LISTENS_MAX)
         self.assertIsInstance(recent[0], Listen)
@@ -98,5 +98,5 @@ class RedisListenStoreTestCase(DatabaseTestCase):
         yesterday = today - relativedelta(days=1)
         self.assertIsNone(self._redis.get_listen_count_for_day(yesterday))
 
-        self._redis.increment_listen_count_for_day(today, 2)
+        self._redis.increment_listen_count_for_day(yesterday, 2)
         self.assertEqual(2, self._redis.get_listen_count_for_day(yesterday))

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -29,6 +29,9 @@ class TimescaleWriterTestCase(IntegrationTestCase):
                                    'REDIS_PORT': config.REDIS_PORT,
                                    'REDIS_NAMESPACE': config.REDIS_NAMESPACE})
 
+    def tearDown(self):
+        self.rs.redis.flushall()
+
     def send_listen(self, user, filename):
         with open(self.path_to_data_file(filename)) as f:
             payload = json.load(f)

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -14,6 +14,7 @@ import time
 import json
 
 from listenbrainz import config
+from datetime import datetime
 
 
 class TimescaleWriterTestCase(IntegrationTestCase):
@@ -62,7 +63,7 @@ class TimescaleWriterTestCase(IntegrationTestCase):
         """ Tests that timescale writer updates the listen count for the
         day in redis for each successful batch written
         """
-        user = db_user.get_or_create(1, 'testtimescaleuser %d' % randint(1,50000))
+        user = db_user.get_or_create(1, 'testtimescaleuser %d' % randint(1, 50000))
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
         time.sleep(2)

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -58,6 +58,16 @@ class TimescaleWriterTestCase(IntegrationTestCase):
         self.assertEqual(len(recent), 1)
         self.assertIsInstance(recent[0], Listen)
 
+    def test_update_listen_count_per_day(self):
+        """ Tests that timescale writer updates the listen count for the
+        day in redis for each successful batch written
+        """
+        user = db_user.get_or_create(1, 'testtimescaleuser %d' % randint(1,50000))
+        r = self.send_listen(user, 'valid_single.json')
+        self.assert200(r)
+        time.sleep(2)
+
+        self.assertEqual(1, self.rs.get_listen_count_for_day(datetime.utcnow()))
 
     def test_dedup_user_special_characters(self):
 

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -3,6 +3,7 @@
 import sys
 import traceback
 from time import sleep
+from datetime import datetime
 
 import pika
 import ujson
@@ -73,6 +74,12 @@ class TimescaleWriterSubscriber(ListenWriter):
 
         if not rows_inserted:
             return len(data)
+
+        try:
+            self.redis_listenstore.increment_listen_count_for_day(day=datetime.utcnow(), count=len(rows_inserted))
+        except Exception:
+            # Not critical, so if this errors out, just log it to Sentry and move forward
+            current_app.logger.error("Could not update listen count per day in redis", exc_info=True)
 
         unique = []
         inserted_index = {}

--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -28,6 +28,14 @@
             <td>{{ listen_count }}</td>
           </tr>
         {% endif %}
+        {% if listen_counts_per_day %}
+          {% for data in listen_counts_per_day %}
+          <tr>
+            <td>Number of listens submitted on {{ data['date'] }}</td>
+            <td>{{ data['listen_count'] }}</td>
+          </tr>
+          {% endfor %}
+        {% endif %}
         </tbody>
       </table>
 

--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -31,7 +31,7 @@
         {% if listen_counts_per_day %}
           {% for data in listen_counts_per_day %}
           <tr>
-            <td>Number of listens submitted on {{ data['date'] }}</td>
+            <td>Number of listens submitted {{ data['label'] }} ({{ data['date'] }})</td>
             <td>{{ data['listen_count'] }}</td>
           </tr>
           {% endfor %}

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -112,7 +112,7 @@ def current_status():
             day = datetime.utcnow() - relativedelta(days=delta)
             day_listen_count = _redis.get_listen_count_for_day(day)
         except:
-            current_app.logger.error("Could not get today's listen count from redis", exc_info=True)
+            current_app.logger.error("Could not get %s listen count from redis", day.strftime('%Y-%m-%d'), exc_info=True)
             day_listen_count = None
         listen_counts_per_day.append({
             "date": day.strftime('%Y-%m-%d'),

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -116,7 +116,8 @@ def current_status():
             day_listen_count = None
         listen_counts_per_day.append({
             "date": day.strftime('%Y-%m-%d'),
-            "listen_count": format(day_listen_count, ',d') if day_listen_count else "0"
+            "listen_count": format(day_listen_count, ',d') if day_listen_count else "0",
+            "label": "today" if delta == 0 else "yesterday",
         })
 
     return render_template(

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -4,6 +4,9 @@ import requests
 import subprocess
 
 from brainzutils import cache
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from typing import List
 from flask import Blueprint, render_template, current_app, redirect, url_for, request, jsonify
 from flask_login import current_user, login_required
 from requests.exceptions import HTTPError
@@ -103,11 +106,28 @@ def current_status():
     except DatabaseException as e:
         user_count = 'Unknown'
 
+    listen_counts_per_day: List[dict] = []
+    for delta in range(2):
+        try:
+            day = datetime.utcnow() - relativedelta(days=delta)
+            listen_count = _redis.get_listen_count_for_day(day)
+        except:
+            current_app.logger.error("Could not get today's listen count from redis", exc_info=True)
+            listen_count = None
+        listen_counts_per_day.append({
+            "date": day.strftime('%Y-%m-%d'),
+            "listen_count": format(listen_count, ',d') if listen_count else "0"
+        })
+
+    current_app.logger.error(listen_counts_per_day)
+
+
     return render_template(
         "index/current-status.html",
         load=load,
-        listen_count=format(int(listen_count), ",d"),
+        listen_count=format(int(listen_count), ",d") if listen_count else "0",
         user_count=user_count,
+        listen_counts_per_day=listen_counts_per_day,
     )
 
 

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -119,9 +119,6 @@ def current_status():
             "listen_count": format(listen_count, ',d') if listen_count else "0"
         })
 
-    current_app.logger.error(listen_counts_per_day)
-
-
     return render_template(
         "index/current-status.html",
         load=load,

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -110,13 +110,13 @@ def current_status():
     for delta in range(2):
         try:
             day = datetime.utcnow() - relativedelta(days=delta)
-            listen_count = _redis.get_listen_count_for_day(day)
+            day_listen_count = _redis.get_listen_count_for_day(day)
         except:
             current_app.logger.error("Could not get today's listen count from redis", exc_info=True)
-            listen_count = None
+            day_listen_count = None
         listen_counts_per_day.append({
             "date": day.strftime('%Y-%m-%d'),
-            "listen_count": format(listen_count, ',d') if listen_count else "0"
+            "listen_count": format(day_listen_count, ',d') if day_listen_count else "0"
         })
 
     return render_template(


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
I'd like to know how many listens get submitted to ListenBrainz on average per day.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Store that data in redis. Show current day's listens AND yesterday's so that it's easy to compare.

**Screenshot**

![Screenshot from 2020-08-12 22-40-45](https://user-images.githubusercontent.com/1837631/90071119-e88a6d00-dcec-11ea-85cd-c4dde6233012.png)


