### PR TITLE
LB-431: Save recording mbids from lastfm in a specific field, instead of saving in the recording mbid field

### DIFF
--- a/listenbrainz/webserver/static/js/src/Scrobble.ts
+++ b/listenbrainz/webserver/static/js/src/Scrobble.ts
@@ -91,7 +91,7 @@ export default class Scrobble {
         release_name: this.releaseName(),
         additional_info: {
           listening_from: "lastfm",
-          recording_mbid: this.trackMBID(),
+          lastfm_recording_mbid: this.trackMBID(),
           lastfm_release_mbid: this.releaseMBID(),
           lastfm_artist_mbid: this.artistMBID(),
         },

--- a/listenbrainz/webserver/static/js/src/Scrobble.ts
+++ b/listenbrainz/webserver/static/js/src/Scrobble.ts
@@ -91,7 +91,7 @@ export default class Scrobble {
         release_name: this.releaseName(),
         additional_info: {
           listening_from: "lastfm",
-          lastfm_recording_mbid: this.trackMBID(),
+          lastfm_track_mbid: this.trackMBID(),
           lastfm_release_mbid: this.releaseMBID(),
           lastfm_artist_mbid: this.artistMBID(),
         },

--- a/listenbrainz/webserver/static/js/src/__mocks__/encodeScrobbleOutput.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/encodeScrobbleOutput.json
@@ -6,7 +6,7 @@
       "release_name": "A Head Full Of Dreams",
       "additional_info": {
         "listening_from": "lastfm",
-        "recording_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
+        "lastfm_track_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
         "lastfm_release_mbid": "002183a5-c087-4c0a-9c47-65ef79261dd2",
         "lastfm_artist_mbid": "cc197bad-dc9c-440d-a5b5-d52ba2e14234"
       }
@@ -20,7 +20,7 @@
       "release_name": "Evolve",
       "additional_info": {
         "listening_from": "lastfm",
-        "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9",
+        "lastfm_track_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9",
         "lastfm_release_mbid": "25c11880-bc5e-43db-927b-522eb871dc9e",
         "lastfm_artist_mbid": "012151a8-0f9a-44c9-997f-ebd68b5389f9"
       }
@@ -34,7 +34,7 @@
       "release_name": "Evolve",
       "additional_info": {
         "listening_from": "lastfm",
-        "recording_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9"
+        "lastfm_track_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9"
       }
     },
     "listened_at": "1583222465"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

https://community.metabrainz.org/t/lb-431-last-fm-api-returns-track-mbid-instead-of-recording-mbid-for-new-scrobbles/431016/4

People have been complaining about this. 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
new last fm imported listens will now have the lastfm provided mbid in a custom field, not in the default recording mbid field, which means more accurate data in the future. 

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
This doesn't close the ticket, as we'll probably want to clean the old data up at some point.

