### PR TITLE
LB-571: Extra slash at the end of Listens Page URL leads to 404 error

### DIFF
--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -60,16 +60,18 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assert200(response)
 
         # these are permanent redirects to user/<username>/charts
-       
-        response = self.client.get('/user/iliekcomputers/history/')
-        self.assert301(response)
+        
+        response = self.client.get('/user/iliekcomputers/history/',follow_redirects=True)
+        assert(response.status_code == 200)
+    
         response = self.client.get('/user/iliekcomputers/history', follow_redirects=True)
-        self.assert301(response)
+        assert(response.status_code == 200)
 
-        response = self.client.get('/user/iliekcomputers/artists/')
-        self.assert301(response)
+        response = self.client.get('/user/iliekcomputers/artists/', follow_redirects=True)
+        assert(response.status_code == 200)
+
         response = self.client.get('/user/iliekcomputers/artists', follow_redirects=True)
-        self.assert301(response)
+        assert(response.status_code == 200)
 
     def test_user_page(self):
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -60,18 +60,16 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         self.assert200(response)
 
         # these are permanent redirects to user/<username>/charts
-        
+
         response = self.client.get('/user/iliekcomputers/history/',follow_redirects=True)
-        assert(response.status_code == 200)
-    
+        self.assert200(response)
         response = self.client.get('/user/iliekcomputers/history', follow_redirects=True)
-        assert(response.status_code == 200)
+        self.assert200(response)
 
         response = self.client.get('/user/iliekcomputers/artists/', follow_redirects=True)
-        assert(response.status_code == 200)
-
+        self.assert200(response)
         response = self.client.get('/user/iliekcomputers/artists', follow_redirects=True)
-        assert(response.status_code == 200)
+        self.assert200(response)
 
     def test_user_page(self):
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -43,6 +43,34 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
 
+    def test_user_redirects(self):
+        response = self.client.get('/user/iliekcomputers/')
+        self.assert200(response)
+        response = self.client.get('/user/iliekcomputers', follow_redirects=True)
+        self.assert200(response)
+
+        response = self.client.get('/user/iliekcomputers/charts/')
+        self.assert200(response)
+        response = self.client.get('/user/iliekcomputers/charts', follow_redirects=True)
+        self.assert200(response)
+
+        response = self.client.get('/user/iliekcomputers/reports/')
+        self.assert200(response)
+        response = self.client.get('/user/iliekcomputers/reports', follow_redirects=True)
+        self.assert200(response)
+
+        # these are permanent redirects to user/<username>/charts
+       
+        response = self.client.get('/user/iliekcomputers/history/')
+        self.assert301(response)
+        response = self.client.get('/user/iliekcomputers/history', follow_redirects=True)
+        self.assert301(response)
+
+        response = self.client.get('/user/iliekcomputers/artists/')
+        self.assert301(response)
+        response = self.client.get('/user/iliekcomputers/artists', follow_redirects=True)
+        self.assert301(response)
+
     def test_user_page(self):
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -28,7 +28,7 @@ LISTENS_PER_PAGE = 25
 user_bp = Blueprint("user", __name__)
 
 
-@user_bp.route("/<user_name>")
+@user_bp.route("/<user_name>/")
 def profile(user_name):
     # Which database to use to showing user listens.
     db_conn = webserver.timescale_connection._ts
@@ -128,7 +128,7 @@ def profile(user_name):
                            active_section='listens')
 
 
-@user_bp.route("/<user_name>/artists")
+@user_bp.route("/<user_name>/artists/")
 def artists(user_name):
     """ Redirect to charts page """
     page = request.args.get('page', default=1)
@@ -136,7 +136,7 @@ def artists(user_name):
     return redirect(url_for('user.charts', user_name=user_name, entity='artist', page=page, range=stats_range), code=301)
 
 
-@user_bp.route("/<user_name>/history")
+@user_bp.route("/<user_name>/history/")
 def history(user_name):
     """ Redirect to charts page """
     entity = request.args.get('entity', default="artist")
@@ -145,7 +145,7 @@ def history(user_name):
     return redirect(url_for('user.charts', user_name=user_name, entity=entity, page=page, range=stats_range), code=301)
 
 
-@user_bp.route("/<user_name>/charts")
+@user_bp.route("/<user_name>/charts/")
 def charts(user_name):
     """ Show the top entitys for the user. """
     user = _get_user(user_name)
@@ -168,7 +168,7 @@ def charts(user_name):
     )
 
 
-@user_bp.route("/<user_name>/reports")
+@user_bp.route("/<user_name>/reports/")
 def reports(user_name: str):
     """ Show user reports """
     user = _get_user(user_name)


### PR DESCRIPTION
# Problem

LB-571

# Solution

Add slash to end to user endpoints