### PR TITLE
Make release msid and release name field optional in the pydantic model

### DIFF
--- a/data/model/user_missing_musicbrainz_data.py
+++ b/data/model/user_missing_musicbrainz_data.py
@@ -11,8 +11,8 @@ class UserMissingMusicBrainzDataRecord(pydantic.BaseModel):
     artist_name: str
     listened_at: str
     recording_msid: str
-    release_msid: str
-    release_name: str
+    release_msid: Optional[str]
+    release_name: Optional[str]
     track_name: str
 
 

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -274,7 +274,7 @@ def handle_missing_musicbrainz_data(data):
         )
     except ValidationError:
         current_app.logger.error("""ValidationError while inserting missing MusicBrainz data from source "{source}" for user
-                                 with user_id: {user_id}. Data: {data}""".format(user_id=user['id'],
+                                 with musicbrainz_id: {musicbrainz_id}. Data: {data}""".format(musicbrainz_id=musicbrainz_id,
                                                                                  data=json.dumps(data, indent=3),
                                                                                  source=source), exc_info=True)
 


### PR DESCRIPTION
# Problem
`release_msid` and `release_name` can be `Null`. Since acc to pydantic model they should be mandatory, we were getting 
`validation errors`

# Solution
Make `release_msid` and `release_name` fields optional

