### PR TITLE
Don't spam with recommendations error mails

### DIFF
--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -21,7 +21,9 @@ from listenbrainz.spark.handlers import (handle_candidate_sets,
                                          handle_sitewide_entity,
                                          notify_artist_relation_import,
                                          notify_mapping_import,
-                                         handle_missing_musicbrainz_data)
+                                         handle_missing_musicbrainz_data,
+                                         notify_cf_recording_recommendations_generation)
+
 from listenbrainz.webserver import create_app
 
 response_handler_map = {
@@ -36,7 +38,8 @@ response_handler_map = {
     'cf_recording_recommendations': handle_recommendations,
     'import_mapping': notify_mapping_import,
     'import_artist_relation': notify_artist_relation_import,
-    'missing_musicbrainz_data': handle_missing_musicbrainz_data
+    'missing_musicbrainz_data': handle_missing_musicbrainz_data,
+    'cf_recording_recommendations_mail': notify_cf_recording_recommendations_generation
 }
 
 RABBITMQ_HEARTBEAT_TIME = 60 * 60  # 1 hour, in seconds

--- a/listenbrainz/webserver/templates/emails/cf_recording_recommendation_notification.txt
+++ b/listenbrainz/webserver/templates/emails/cf_recording_recommendation_notification.txt
@@ -3,6 +3,7 @@ Hey! 👋
 Recommendations were received by the spark consumer
 and are being written into the database.
 
-The first recommendation came in at {{ now }} UTC.
+It took {{ total_time }}h to generate the recommendations.
+Recommendations were generated for {{ user_count }} users.
 
 Your Friendly Neighbourhood Brainzbot 🤖

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -83,7 +83,7 @@ def load_model():
         raise
 
 
-def get_recording_mbids(params, recommendation_df):
+def get_recording_mbids(params: RecommendationParams, recommendation_df):
     """ Get recording mbids corresponding to recommended recording ids sorted on rating.
 
         Args:
@@ -100,7 +100,7 @@ def get_recording_mbids(params, recommendation_df):
     return recording_mbids_df
 
 
-def generate_recommendations(candidate_set, params, limit):
+def generate_recommendations(candidate_set, params: RecommendationParams, limit):
     """
         Args:
             candidate_set (rdd): RDD of user_id and recording_id.
@@ -139,7 +139,7 @@ def get_recommendation_df(recording_ids_and_ratings):
     return df
 
 
-def scale_ratings(mbids_and_ratings, params):
+def scale_ratings(mbids_and_ratings, params: RecommendationParams):
     """ Scale the ratings so that they fall on a range from 0.0 -> 1.0.
 
         Args:
@@ -157,7 +157,7 @@ def scale_ratings(mbids_and_ratings, params):
         row[1] = round(min(max(scaled_rating, -1.0), 1.0), 3)
 
 
-def get_recommended_mbids(candidate_set, params, limit):
+def get_recommended_mbids(candidate_set, params: RecommendationParams, limit):
     """ Generate recommendations from the candidate set.
 
         Args:
@@ -208,7 +208,7 @@ def get_candidate_set_rdd_for_user(candidate_set_df, user_id):
     return candidate_set_rdd
 
 
-def get_recommendations_for_user(user_id, user_name, params):
+def get_recommendations_for_user(user_id, user_name, params: RecommendationParams):
     """ Get recommended recordings which belong to top artists and artists similar to top
         artists listened to by the user.
 
@@ -244,7 +244,7 @@ def get_recommendations_for_user(user_id, user_name, params):
     return user_recommendations_top_artist, user_recommendations_similar_artist
 
 
-def get_user_name_and_user_id(params, users):
+def get_user_name_and_user_id(params: RecommendationParams, users):
     """ Get users from top artist candidate set.
 
         Args:
@@ -291,7 +291,7 @@ def get_message_for_inactive_users(messages, active_users, users):
     return messages
 
 
-def get_recommendations_for_all(params, users, ti):
+def get_recommendations_for_all(params: RecommendationParams, users):
     """ Get recommendations for all active users.
 
         Args:
@@ -301,6 +301,7 @@ def get_recommendations_for_all(params, users, ti):
         Returns:
             messages (list): user recommendations.
     """
+    ti = time.monotonic()
     messages = []
     # users active in the last week/month.
     # users who are a part of top artist candidate set
@@ -391,8 +392,7 @@ def main(recommendation_top_artist_limit=None, recommendation_similar_artist_lim
                                   recommendation_top_artist_limit,
                                   recommendation_similar_artist_limit)
 
-    ti = time.monotonic()
-    messages = get_recommendations_for_all(params, users, ti)
+    messages = get_recommendations_for_all(params, users)
     # persisted data must be cleared from memory after usage to avoid OOM
     recordings_df.unpersist()
 

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -333,7 +333,7 @@ def get_recommendations_for_all(params: RecommendationParams, users):
     if params.ratings_beyond_range:
         current_app.logger.error('{} ratings are beyond the expected range i.e rating > 1 or rating < -1'
                                  '\nMax rating: {}\nMin rating: {}'.format(len(params.ratings_beyond_range),
-                                 max(params.ratings_beyond_range), min(params.ratings_beyond_range)))
+                                  max(params.ratings_beyond_range), min(params.ratings_beyond_range)))
 
     if params.top_artist_not_found:
         current_app.logger.error('Top artist candidate set not found for: \n"{}"\nYou might want to check the mapping.'
@@ -341,7 +341,7 @@ def get_recommendations_for_all(params: RecommendationParams, users):
 
     if params.similar_artist_not_found:
         current_app.logger.error('Similar artist candidate set not found for: \n"{}"'
-                                '\nYou might want to check the artist relation.'.format(params.similar_artist_not_found))
+                                 '\nYou might want to check the artist relation.'.format(params.similar_artist_not_found))
 
     if params.top_artist_rec_not_generated:
         current_app.logger.error('Top artist recommendations not generated for: \n"{}"\nYou might want to check the training set'

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -1,6 +1,7 @@
 import os
+import time
 from datetime import datetime
-from unittest.mock import patch, call, MagicMock
+from unittest.mock import patch, call, MagicMock, Mock
 
 from listenbrainz_spark.tests import SparkTestCase
 from listenbrainz_spark.recommendations import recommend
@@ -46,6 +47,11 @@ class RecommendTestClass(SparkTestCase):
         self.assertEqual(sorted(params.similar_artist_candidate_set_df.columns), sorted(similar_artist_candidate_set_df.columns))
         self.assertEqual(params.recommendation_top_artist_limit, recommendation_top_artist_limit)
         self.assertEqual(params.recommendation_similar_artist_limit, recommendation_similar_artist_limit)
+        self.assertEqual(params.ratings_beyond_range, [])
+        self.assertEqual(params.similar_artist_not_found, [])
+        self.assertEqual(params.top_artist_not_found, [])
+        self.assertEqual(params.top_artist_rec_not_generated, [])
+        self.assertEqual(params.similar_artist_rec_not_generated, [])
 
     def get_recommendation_df(self):
         df = utils.create_dataframe(
@@ -147,14 +153,14 @@ class RecommendTestClass(SparkTestCase):
         with self.assertRaises(IndexError):
             candidate_set_rdd = recommend.get_candidate_set_rdd_for_user(candidate_set, user_id)
 
-    @patch('listenbrainz_spark.recommendations.recommend.get_recommended_mbids')
     @patch('listenbrainz_spark.recommendations.recommend.get_candidate_set_rdd_for_user')
-    def test_get_recommendations_for_user(self, mock_candidate_set, mock_mbids):
+    @patch('listenbrainz_spark.recommendations.recommend.get_recommended_mbids')
+    def test_get_recommendations_for_user(self, mock_mbids, mock_candidate_set):
         params = self.get_recommendation_params()
         user_id = 1
         user_name = 'vansika'
 
-        _, _ = recommend.get_recommendations_for_user(user_id, user_name, params, [])
+        _, _ = recommend.get_recommendations_for_user(user_id, user_name, params)
 
         mock_candidate_set.assert_has_calls([
             call(params.top_artist_candidate_set_df, user_id),
@@ -162,21 +168,35 @@ class RecommendTestClass(SparkTestCase):
         ])
 
         mock_mbids.assert_has_calls([
-            call(mock_candidate_set.return_value, params, params.recommendation_top_artist_limit, []),
-            call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit, [])
+            call(mock_candidate_set.return_value, params, params.recommendation_top_artist_limit),
+            call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit)
         ])
 
-    def test_scale_ratings(self):
-        mbids_and_ratings = [['xxxx', -0.32], ['yyyy', 0.932], ['zzzz', 2.967]]
 
-        ratings_beyond_range = [2]
-        recommend.scale_ratings(mbids_and_ratings, ratings_beyond_range)
+        user_name = 'vansika_1'
+        mock_candidate_set.side_effect = IndexError
+        recommend.get_recommendations_for_user(user_id, user_name, params)
+        self.assertEqual(params.top_artist_not_found, ['vansika_1'])
+        self.assertEqual(params.similar_artist_not_found, ['vansika_1'])
+
+
+        user_name = 'vansika_2'
+        mock_candidate_set.side_effect = RecommendationsNotGeneratedException(message='Recommendations not generated')
+        recommend.get_recommendations_for_user(user_id, user_name, params)
+        self.assertEqual(params.top_artist_rec_not_generated, ['vansika_2'])
+        self.assertEqual(params.similar_artist_rec_not_generated, ['vansika_2'])
+
+    def test_scale_ratings(self):
+        mbids_and_ratings = [['xxxx', -0.32], ['yyyy', 1.932], ['zzzz', 2.967]]
+
+        params = self.get_recommendation_params()
+        recommend.scale_ratings(mbids_and_ratings, params)
 
         self.assertEqual(mbids_and_ratings[0][1], 0.34)
-        self.assertEqual(mbids_and_ratings[1][1], 0.966)
+        self.assertEqual(mbids_and_ratings[1][1], 1.0)
         self.assertEqual(mbids_and_ratings[2][1], 1.0)
 
-        self.assertEqual(ratings_beyond_range, [2, 2.967])
+        self.assertEqual(params.ratings_beyond_range, [1.932, 2.967])
 
 
     @patch('listenbrainz_spark.recommendations.recommend.generate_recommendations')
@@ -191,9 +211,7 @@ class RecommendTestClass(SparkTestCase):
             Rating(user=2, product=2, rating=1.994590001)
         ]
 
-        ratings_beyond_range = []
-
-        recommended_mbids = recommend.get_recommended_mbids(rdd, params, limit, ratings_beyond_range)
+        recommended_mbids = recommend.get_recommended_mbids(rdd, params, limit)
 
         mock_gen_rec.assert_called_once_with(rdd, params, limit)
         self.assertEqual(recommended_mbids[0][0], '2acb406f-c716-45f8-a8bd-96ca3939c2e5')
@@ -201,11 +219,11 @@ class RecommendTestClass(SparkTestCase):
         self.assertEqual(recommended_mbids[1][0], '3acb406f-c716-45f8-a8bd-96ca3939c2e5')
         self.assertEqual(recommended_mbids[1][1], 0.432)
 
-        self.assertEqual(ratings_beyond_range, [1.995])
+        self.assertEqual(params.ratings_beyond_range, [1.995])
 
         mock_gen_rec.return_value = []
         with self.assertRaises(RecommendationsNotGeneratedException):
-            recommend.get_recommended_mbids(rdd, params, limit, ratings_beyond_range)
+            recommend.get_recommended_mbids(rdd, params, limit)
 
 
     def test_get_user_name_and_user_id(self):
@@ -269,8 +287,9 @@ class RecommendTestClass(SparkTestCase):
             'similar_artist': [],
         })
 
+    @patch('listenbrainz_spark.recommendations.recommend.current_app')
     @patch('listenbrainz_spark.recommendations.recommend.get_recommendations_for_user')
-    def test_get_recommendations_for_all_without_users(self, mock_rec_user):
+    def test_get_recommendations_for_all_without_users(self, mock_rec_user, mock_current_app):
         params = self.get_recommendation_params()
         df = utils.create_dataframe(
             Row(
@@ -280,18 +299,45 @@ class RecommendTestClass(SparkTestCase):
             ),
             schema=None
         )
+
+        ti = time.monotonic()
         params.top_artist_candidate_set_df = df
+        params.ratings_beyond_range = [2, 3, 1, 5]
+        params.top_artist_rec_not_generated = ['vansika_1', 'vansika_2']
+        params.similar_artist_rec_not_generated = ['vansika_3', 'vansika_4']
+        params.top_artist_not_found = ['vansika_5', 'vansika_6']
+        params.similar_artist_not_found = ['vansika_7', 'vansika_8']
 
+        users = []
         mock_rec_user.return_value = 'recording_mbid_1', 'recording_mbid_2'
-        messages = recommend.get_recommendations_for_all(params, [])
-        mock_rec_user.assert_called_once_with(1, 'vansika', params, [])
+        messages = recommend.get_recommendations_for_all(params, users, ti)
+        mock_rec_user.assert_called_once_with(1, 'vansika', params)
 
-        self.assertEqual(len(messages), 1)
+        calls = [
+            call('{} ratings are beyond the expected range i.e rating > 1 or rating < -1\nMax rating: {}\nMin rating: {}'
+                 .format(4, 5, 1)),
+            call('Top artist candidate set not found for: \n"{}"\nYou might want to check the mapping.'
+                 .format(['vansika_5', 'vansika_6'])),
+            call('Similar artist candidate set not found for: \n"{}"\nYou might want to check the artist relation.'
+                 .format(['vansika_7', 'vansika_8'])),
+            call('Top artist recommendations not generated for: \n"{}"\nYou might want to check the training set'
+                 .format(['vansika_1', 'vansika_2'])),
+            call('Similar artist recommendations not generated for: "{}"\nYou might want to check the training set'
+                 .format(['vansika_3', 'vansika_4']))
+        ]
+        mock_current_app.logger.error.assert_has_calls(calls, any_order=True)
+
+        self.assertEqual(len(messages), 2)
         message = messages[0]
         self.assertEqual(message['musicbrainz_id'], 'vansika')
         self.assertEqual(message['type'], 'cf_recording_recommendations')
         self.assertEqual(message['top_artist'], 'recording_mbid_1')
         self.assertEqual(message['similar_artist'], 'recording_mbid_2')
+
+        message = messages[1]
+        self.assertEqual(message['type'], 'cf_recording_recommendations_mail')
+        self.assertEqual(message['user_count'], 1)
+        assert isinstance(message['total_time'], str)
 
     @patch('listenbrainz_spark.recommendations.recommend.get_recommendations_for_user')
     def test_get_recommendations_for_all_with_users(self, mock_rec_user):
@@ -304,12 +350,15 @@ class RecommendTestClass(SparkTestCase):
             ),
             schema=None
         )
+
+        ti = time.monotonic()
+        users = ['vansika_1', 'vansika']
         params.top_artist_candidate_set = df
         mock_rec_user.return_value = 'recording_mbid_3', 'recording_mbid_4'
-        messages = recommend.get_recommendations_for_all(params, ['vansika_1', 'vansika'])
-        mock_rec_user.assert_called_once_with(1, 'vansika', params, [])
+        messages = recommend.get_recommendations_for_all(params, users, ti)
+        mock_rec_user.assert_called_once_with(1, 'vansika', params)
 
-        self.assertEqual(len(messages), 2)
+        self.assertEqual(len(messages), 3)
 
         message = messages[0]
         self.assertEqual(message['musicbrainz_id'], 'vansika')
@@ -322,6 +371,11 @@ class RecommendTestClass(SparkTestCase):
         self.assertEqual(message['type'], 'cf_recording_recommendations')
         self.assertEqual(message['top_artist'], [])
         self.assertEqual(message['similar_artist'], [])
+
+        message = messages[2]
+        self.assertEqual(message['type'], 'cf_recording_recommendations_mail')
+        self.assertEqual(message['user_count'], 1)
+        assert isinstance(message['total_time'], str)
 
     def get_recommendation_params(self):
         recordings_df = self.get_recordings_df()

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -300,7 +300,6 @@ class RecommendTestClass(SparkTestCase):
             schema=None
         )
 
-        ti = time.monotonic()
         params.top_artist_candidate_set_df = df
         params.ratings_beyond_range = [2, 3, 1, 5]
         params.top_artist_rec_not_generated = ['vansika_1', 'vansika_2']
@@ -310,7 +309,7 @@ class RecommendTestClass(SparkTestCase):
 
         users = []
         mock_rec_user.return_value = 'recording_mbid_1', 'recording_mbid_2'
-        messages = recommend.get_recommendations_for_all(params, users, ti)
+        messages = recommend.get_recommendations_for_all(params, users)
         mock_rec_user.assert_called_once_with(1, 'vansika', params)
 
         calls = [
@@ -351,11 +350,10 @@ class RecommendTestClass(SparkTestCase):
             schema=None
         )
 
-        ti = time.monotonic()
         users = ['vansika_1', 'vansika']
         params.top_artist_candidate_set = df
         mock_rec_user.return_value = 'recording_mbid_3', 'recording_mbid_4'
-        messages = recommend.get_recommendations_for_all(params, users, ti)
+        messages = recommend.get_recommendations_for_all(params, users)
         mock_rec_user.assert_called_once_with(1, 'vansika', params)
 
         self.assertEqual(len(messages), 3)

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -172,13 +172,11 @@ class RecommendTestClass(SparkTestCase):
             call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit)
         ])
 
-
         user_name = 'vansika_1'
         mock_candidate_set.side_effect = IndexError
         recommend.get_recommendations_for_user(user_id, user_name, params)
         self.assertEqual(params.top_artist_not_found, ['vansika_1'])
         self.assertEqual(params.similar_artist_not_found, ['vansika_1'])
-
 
         user_name = 'vansika_2'
         mock_candidate_set.side_effect = RecommendationsNotGeneratedException(message='Recommendations not generated')


### PR DESCRIPTION
# Problem

error for each user is being logged to sentry leading to hundreds of emails. Also, we don't have any mail to inform about the number of users for whom recs have been generated and total time in generating recs.

# Solution
 - store all users_names in a list for whom recs have not been generated and log a single message to sentry.
- send an email informing total user count and total time in generating recs.
