### PR TITLE
Generate recommendations for all users at once.

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -356,12 +356,15 @@ def notify_cf_recording_recommendations_generation(data):
     if current_app.config['TESTING']:
         return
 
-    user_count = data['user_count']
+    active_user_count = data['active_user_count']
     total_time = data['total_time']
+    top_artist_user_count = data['top_artist_user_count']
+    similar_artist_user_count = data['similar_artist_user_count']
     send_mail(
         subject='Recommendations have been generated and pushed to the queue.',
         text=render_template('emails/cf_recording_recommendation_notification.txt',
-                             user_count=user_count, total_time=total_time),
+                             active_user_count=active_user_count, total_time=total_time,
+                             top_artist_user_count=top_artist_user_count, similar_artist_user_count=similar_artist_user_count),
         recipients=['listenbrainz-observability@metabrainz.org'],
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -254,13 +254,17 @@ class HandlersTestCase(unittest.TestCase):
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_notify_cf_recording_recommendations_generation(self, mock_send_mail):
         with self.app.app_context():
-            user_count = 10
+            active_user_count = 10
+            top_artist_user_count = 5
+            similar_artist_user_count = 4
             total_time = datetime.now()
 
             # testing, should not send a mail
             self.app.config['TESTING'] = True
             notify_cf_recording_recommendations_generation({
-                'user_count': user_count,
+                'active_user_count': active_user_count,
+                'top_artist_user_count': top_artist_user_count,
+                'similar_artist_user_count': similar_artist_user_count,
                 'total_time': str(total_time)
             })
             mock_send_mail.assert_not_called()
@@ -268,7 +272,9 @@ class HandlersTestCase(unittest.TestCase):
             # in prod now, should send it
             self.app.config['TESTING'] = False
             notify_cf_recording_recommendations_generation({
-                'user_count': user_count,
+                'active_user_count': active_user_count,
+                'top_artist_user_count': top_artist_user_count,
+                'similar_artist_user_count': similar_artist_user_count,
                 'total_time': str(total_time)
             })
             mock_send_mail.assert_called_once()

--- a/listenbrainz/webserver/templates/emails/cf_recording_recommendation_notification.txt
+++ b/listenbrainz/webserver/templates/emails/cf_recording_recommendation_notification.txt
@@ -4,6 +4,8 @@ Recommendations were received by the spark consumer
 and are being written into the database.
 
 It took {{ total_time }}h to generate the recommendations.
-Recommendations were generated for {{ user_count }} users.
+Users active in the last week: {{ active_user_count }}
+Top artist recommendations generated for {{ top_artist_user_count }} users.
+Similar artist recommendations generated for {{ similar_artist_user_count }} users.
 
 Your Friendly Neighbourhood Brainzbot 🤖

--- a/listenbrainz_spark/exceptions.py
+++ b/listenbrainz_spark/exceptions.py
@@ -116,3 +116,9 @@ class SimilarArtistNotFetchedException(SparkException):
     """
     def __init__(self, message):
         super(SimilarArtistNotFetchedException, self).__init__(message)
+
+class EmptyDataframeExcpetion(SparkException):
+    """ Dataframe is empty.
+    """
+    def __init__(self, message):
+        super(EmptyDataframeExcpetion, self).__init__(message)

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -245,7 +245,7 @@ def check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df):
 
     min_rating = top_artist_rec_df.select(func.min('rating').alias('rating')).take(1)[0].rating
 
-    min_rating = max(similar_artist_rec_df.select(func.min('rating').alias('rating')).take(1)[0].rating, min_rating)
+    min_rating = min(similar_artist_rec_df.select(func.min('rating').alias('rating')).take(1)[0].rating, min_rating)
 
     if max_rating > 1.0:
         current_app.logger.error('Some ratings are greater than 1 \nMax rating: {}'.format(max_rating))
@@ -269,7 +269,6 @@ def create_messages(top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_u
         Returns:
             messages: A list of messages to be sent via RabbitMQ
     """
-
     top_artist_rec_itr = top_artist_rec_mbid_df.toLocalIterator()
 
     user_rec = {}

--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -351,6 +351,12 @@ def get_recommendations_for_all(params: RecommendationParams, users):
             similar_artist_rec_df = similar_artist_rec_df.union(similar_artist_rec_user_df) if similar_artist_rec_df \
                                                                                             else similar_artist_rec_user_df
 
+    if _is_empty_dataframe(top_artist_rec_df):
+        raise RecommendationsNotGeneratedException('Top artist recommendations not generated for any user.')
+
+    if _is_empty_dataframe(similar_artist_rec_df):
+        raise RecommendationsNotGeneratedException('Similar artist recommendations not generated for any user.')
+
     check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df)
 
     top_artist_rec_df = scale_rating(top_artist_rec_df)

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -9,11 +9,13 @@ from listenbrainz_spark.recommendations import recommend
 from listenbrainz_spark.recommendations import train_models
 from listenbrainz_spark import schema, utils, config, path, stats
 from listenbrainz_spark.exceptions import (RecommendationsNotGeneratedException,
+                                           EmptyDataframeExcpetion,
                                            RatingOutOfRangeException)
 
 from pyspark.sql import Row
 import pyspark.sql.functions as f
 from pyspark.rdd import RDD
+from pyspark.sql.functions import col
 from pyspark.mllib.recommendation import Rating
 
 # for test data/dataframes refer to listenbrainzspark/tests/__init__.py
@@ -48,25 +50,40 @@ class RecommendTestClass(SparkTestCase):
         self.assertEqual(sorted(params.similar_artist_candidate_set_df.columns), sorted(similar_artist_candidate_set_df.columns))
         self.assertEqual(params.recommendation_top_artist_limit, recommendation_top_artist_limit)
         self.assertEqual(params.recommendation_similar_artist_limit, recommendation_similar_artist_limit)
-        self.assertEqual(params.ratings_beyond_range, [])
-        self.assertEqual(params.similar_artist_not_found, [])
-        self.assertEqual(params.top_artist_not_found, [])
-        self.assertEqual(params.top_artist_rec_not_generated, [])
-        self.assertEqual(params.similar_artist_rec_not_generated, [])
 
     def get_recommendation_df(self):
         df = utils.create_dataframe(
             Row(
+                user_id=1,
                 recording_id=1,
-                rating=3.13456
+                rating=0.313456
             ),
             schema=None
         )
 
-        recommendation_df = df.union(utils.create_dataframe(
+        df = df.union(utils.create_dataframe(
             Row(
+                user_id=1,
                 recording_id=2,
                 rating=6.994590001
+            ),
+            schema=None
+        ))
+
+        df = df.union(utils.create_dataframe(
+            Row(
+                user_id=2,
+                recording_id=2,
+                rating=-2.4587
+            ),
+            schema=None
+        ))
+
+        recommendation_df = df.union(utils.create_dataframe(
+            Row(
+                user_id=2,
+                recording_id=1,
+                rating=7.999
             ),
             schema=None
         ))
@@ -76,155 +93,152 @@ class RecommendTestClass(SparkTestCase):
     def test_get_recording_mbids(self):
         params = self.get_recommendation_params()
         recommendation_df = self.get_recommendation_df()
+        users = []
+        users_df = recommend.get_user_name_and_user_id(params, users)
 
-        recording_mbids = recommend.get_recording_mbids(params, recommendation_df)
-
-        self.assertEqual(recording_mbids.count(), 2)
-        self.assertEqual(sorted(recording_mbids.columns), sorted(["mb_recording_mbid", "rating"]))
-        self.assertEqual(recording_mbids.collect()[0].mb_recording_mbid, "2acb406f-c716-45f8-a8bd-96ca3939c2e5")
-        self.assertEqual(recording_mbids.collect()[1].mb_recording_mbid, "3acb406f-c716-45f8-a8bd-96ca3939c2e5")
-
-    def test_get_recommendation_df(self):
-        recording_ids_and_ratings = [[1, 3.1], [2, 6.0]]
-
-        df = recommend.get_recommendation_df(recording_ids_and_ratings)
-
-        self.assertEqual(sorted(df.columns), ['rating', 'recording_id'])
-
+        df = recommend.get_recording_mbids(params, recommendation_df, users_df)
+        self.assertEqual(df.count(), 4)
         row = df.collect()
-        self.assertEqual(row[0][0], 1)
-        self.assertEqual(round(row[0][1], 1), 3.1)
-        self.assertEqual(row[1][0], 2)
-        self.assertEqual(round(row[1][1], 1), 6.0)
 
-    @patch('listenbrainz_spark.recommendations.recommend.MatrixFactorizationModel')
+        self.assertEqual(row[0],
+            Row(mb_recording_mbid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
+                rank=1,
+                rating=6.994590001,
+                user_id=1,
+                user_name='vansika')
+
+        )
+
+        self.assertEqual(row[1],
+            Row(
+                mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
+                rank=2,
+                rating=0.313456,
+                user_id=1,
+                user_name='vansika'
+                )
+        )
+
+        self.assertEqual(row[2],
+            Row(
+                mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
+                rank=1,
+                rating=7.999,
+                user_id=2,
+                user_name='rob'
+                )
+        )
+
+        self.assertEqual(row[3],
+            Row(
+                mb_recording_mbid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
+                rank=2,
+                rating=-2.4587,
+                user_id=2,
+                user_name='rob'
+                )
+        )
+
+
+    def test_filter_recommendations_on_rating(self):
+        df = self.get_recommendation_df()
+        recommendation_df = df.select(col('user_id').alias('user'),
+                                      col('recording_id').alias('product'),
+                                      col('rating'))
+        limit = 1
+
+        df = recommend.filter_recommendations_on_rating(recommendation_df, limit)
+        self.assertEqual(df.count(), 2)
+        row = df.collect()
+
+        self.assertEqual(row[0],
+            Row(
+                rating=6.994590001,
+                recording_id=2,
+                user_id=1)
+        )
+
+        self.assertEqual(row[1],
+            Row(
+                rating=7.999,
+                recording_id=1,
+                user_id=2)
+        )
+
+    @patch('listenbrainz_spark.recommendations.recommend.filter_recommendations_on_rating')
     @patch('listenbrainz_spark.recommendations.recommend.listenbrainz_spark')
-    @patch('listenbrainz_spark.recommendations.recommend.get_model_path')
-    @patch('listenbrainz_spark.recommendations.recommend.get_most_recent_model_id')
-    def test_load_model(self, mock_id, mock_model_path, mock_lb, mock_matrix_model):
-        model = recommend.load_model()
-        mock_id.assert_called_once()
-        mock_model_path.assert_called_once_with(mock_id.return_value)
-        mock_matrix_model.load.assert_called_once_with(mock_lb.context, mock_model_path.return_value)
-
-    def test_get_most_recent_model_id(self):
-        model_id_1 = "a36d6fc9-49d0-4789-a7dd-a2b72369ca45"
-        model_metadata_dict_1 = self.get_model_metadata(model_id_1)
-        df_1 = utils.create_dataframe(schema.convert_model_metadata_to_row(model_metadata_dict_1),
-                                      schema.model_metadata_schema)
-
-        model_id_2 = "bbbd6fc9-49d0-4789-a7dd-a2b72369ca45"
-        model_metadata_dict_2 = self.get_model_metadata(model_id_2)
-        df_2 = utils.create_dataframe(schema.convert_model_metadata_to_row(model_metadata_dict_2),
-                                      schema.model_metadata_schema)
-
-        model_metadata = df_1.union(df_2)
-        utils.save_parquet(model_metadata, path.MODEL_METADATA)
-
-        expected_model_id = recommend.get_most_recent_model_id()
-        self.assertEqual(expected_model_id, model_id_2)
-
-    def test_generate_recommendations(self):
+    def test_generate_recommendations(self, mock_lb, mock_filter):
         params = self.get_recommendation_params()
         limit = 1
-        mock_candidate_set = MagicMock()
 
         mock_model = MagicMock()
         params.model = mock_model
 
-        _ = recommend.generate_recommendations(mock_candidate_set, params, limit)
-
         mock_predict = mock_model.predictAll
-        mock_predict.assert_called_once_with(mock_candidate_set)
+        candidate_set = self.get_candidate_set()
+        users = []
 
-        mock_take_ordered = mock_predict.return_value.takeOrdered
-        self.assertEqual(mock_take_ordered.call_args[0][0], limit)
+        rdd = recommend.get_candidate_set_rdd_for_user(candidate_set, users)
+        mock_predict.return_value = rdd
+
+        df = recommend.generate_recommendations(candidate_set, params, limit)
+
+        mock_predict.assert_called_once_with(candidate_set)
+
+        mock_df = mock_lb.session.createDataFrame
+        mock_df.assert_called_once_with(mock_predict.return_value, schema=None)
+
+        mock_filter.assert_called_once_with(mock_df.return_value, limit)
+
+        with self.assertRaises(RecommendationsNotGeneratedException):
+            # empty rdd
+            mock_predict.return_value = MagicMock()
+            recommend.generate_recommendations(candidate_set, params, limit)
+
+    def test_get_scale_rating_udf(self):
+        rating = 1.6
+        res = recommend.get_scale_rating_udf(rating)
+        self.assertEqual(res, 1.0)
+
+        rating = -1.6
+        res = recommend.get_scale_rating_udf(rating)
+        self.assertEqual(res, -0.3)
+
+        rating = 0.65579
+        res = recommend.get_scale_rating_udf(rating)
+        self.assertEqual(res, 0.828)
+
+        rating = -0.9999
+        res = recommend.get_scale_rating_udf(rating)
+        self.assertEqual(res, 0.0)
+
+    def test_scale_rating(self):
+        df = self.get_recommendation_df()
+
+        df = recommend.scale_rating(df)
+        self.assertEqual(sorted(df.columns), ['rating', 'recording_id', 'user_id'])
+        received_ratings = sorted([row.rating for row in df.collect()])
+        expected_ratings = [-0.729, 0.657, 1.0, 1.0]
 
     def test_get_candidate_set_rdd_for_user(self):
         candidate_set = self.get_candidate_set()
-        user_id = 1
+        users = []
 
-        candidate_set_rdd = recommend.get_candidate_set_rdd_for_user(candidate_set, user_id)
+        candidate_set_rdd = recommend.get_candidate_set_rdd_for_user(candidate_set, users)
+        self.assertTrue(isinstance(candidate_set_rdd, RDD))
+        res = sorted([row for row in candidate_set_rdd.collect()])
+        self.assertEqual(res, [(1, 1), (2, 2)])
+
+        users = ['vansika']
+        candidate_set_rdd = recommend.get_candidate_set_rdd_for_user(candidate_set, users)
 
         self.assertTrue(isinstance(candidate_set_rdd, RDD))
-        self.assertEqual(candidate_set_rdd.collect()[0][0], user_id)
-        self.assertEqual(candidate_set_rdd.collect()[0][1], 1)
+        row = candidate_set_rdd.collect()
+        self.assertEqual([(1, 1)], row)
 
-        user_id = 10
-        with self.assertRaises(IndexError):
-            candidate_set_rdd = recommend.get_candidate_set_rdd_for_user(candidate_set, user_id)
-
-    @unittest.skip("Till we are testing for runtime of stuff...")
-    @patch('listenbrainz_spark.recommendations.recommend.get_candidate_set_rdd_for_user')
-    @patch('listenbrainz_spark.recommendations.recommend.get_recommended_mbids')
-    def test_get_recommendations_for_user(self, mock_mbids, mock_candidate_set):
-        params = self.get_recommendation_params()
-        user_id = 1
-        user_name = 'vansika'
-
-        _, _ = recommend.get_recommendations_for_user(user_id, user_name, params)
-
-        mock_candidate_set.assert_has_calls([
-            call(params.top_artist_candidate_set_df, user_id),
-            call(params.similar_artist_candidate_set_df, user_id)
-        ])
-
-        mock_mbids.assert_has_calls([
-            call(mock_candidate_set.return_value, params, params.recommendation_top_artist_limit),
-            call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit)
-        ])
-
-        user_name = 'vansika_1'
-        mock_candidate_set.side_effect = IndexError
-        recommend.get_recommendations_for_user(user_id, user_name, params)
-        self.assertEqual(params.top_artist_not_found, ['vansika_1'])
-        self.assertEqual(params.similar_artist_not_found, ['vansika_1'])
-
-        user_name = 'vansika_2'
-        mock_candidate_set.side_effect = RecommendationsNotGeneratedException(message='Recommendations not generated')
-        recommend.get_recommendations_for_user(user_id, user_name, params)
-        self.assertEqual(params.top_artist_rec_not_generated, ['vansika_2'])
-        self.assertEqual(params.similar_artist_rec_not_generated, ['vansika_2'])
-
-    def test_scale_ratings(self):
-        mbids_and_ratings = [['xxxx', -0.32], ['yyyy', 1.932], ['zzzz', 2.967]]
-
-        params = self.get_recommendation_params()
-        recommend.scale_ratings(mbids_and_ratings, params)
-
-        self.assertEqual(mbids_and_ratings[0][1], 0.34)
-        self.assertEqual(mbids_and_ratings[1][1], 1.0)
-        self.assertEqual(mbids_and_ratings[2][1], 1.0)
-
-        self.assertEqual(params.ratings_beyond_range, [1.932, 2.967])
-
-
-    @patch('listenbrainz_spark.recommendations.recommend.generate_recommendations')
-    def test_get_recommended_mbids(self, mock_gen_rec):
-        candidate_set = self.get_candidate_set()
-        params = self.get_recommendation_params()
-        limit = 2
-
-        rdd = candidate_set.rdd.map(lambda r: (r['user_id'], r['recording_id']))
-        mock_gen_rec.return_value = [
-            Rating(user=2, product=1, rating=-0.13456),
-            Rating(user=2, product=2, rating=1.994590001)
-        ]
-
-        recommended_mbids = recommend.get_recommended_mbids(rdd, params, limit)
-
-        mock_gen_rec.assert_called_once_with(rdd, params, limit)
-        self.assertEqual(recommended_mbids[0][0], '2acb406f-c716-45f8-a8bd-96ca3939c2e5')
-        self.assertEqual(recommended_mbids[0][1], 1.0)
-        self.assertEqual(recommended_mbids[1][0], '3acb406f-c716-45f8-a8bd-96ca3939c2e5')
-        self.assertEqual(recommended_mbids[1][1], 0.432)
-
-        self.assertEqual(params.ratings_beyond_range, [1.995])
-
-        mock_gen_rec.return_value = []
-        with self.assertRaises(RecommendationsNotGeneratedException):
-            recommend.get_recommended_mbids(rdd, params, limit)
-
+        users = ['vansika_1']
+        with self.assertRaises(EmptyDataframeExcpetion):
+            recommend.get_candidate_set_rdd_for_user(candidate_set, users)
 
     def test_get_user_name_and_user_id(self):
         params = self.get_recommendation_params()
@@ -257,123 +271,86 @@ class RecommendTestClass(SparkTestCase):
 
         params.top_artist_candidate_set_df = df
 
-        users = recommend.get_user_name_and_user_id(params, [])
-
-        self.assertEqual(users.count(), 2)
-        self.assertEqual(sorted(users.columns), sorted(['user_id', 'user_name']))
-
-        users = recommend.get_user_name_and_user_id(params, ['vansika'])
-        self.assertEqual(users.count(), 1)
-        self.assertEqual(sorted(users.columns), sorted(['user_id', 'user_name']))
-
-    def test_get_message_for_inactive_users(self):
-        message_arg = [{
-            'musicbrainz_id': 'vansika',
-            'type': 'cf_recording_recommendations',
-            'top_artist': ["181c4177-f33a-441d-b15d-910acaf18b07"],
-            'similar_artist': ["281c4177-f33a-441d-b15d-910acaf18b07"],
-        }]
-
-        active_users = ['vansika']
-        users = ['vansika', 'vansika_1']
-        messages = recommend.get_message_for_inactive_users(message_arg, active_users, users)
-
-        self.assertEqual(len(messages), 2)
-        self.assertEqual(messages[0], message_arg[0])
-        self.assertEqual(messages[1], {
-            'musicbrainz_id': 'vansika_1',
-            'type': 'cf_recording_recommendations',
-            'top_artist': [],
-            'similar_artist': [],
-        })
-
-    @patch('listenbrainz_spark.recommendations.recommend.current_app')
-    @patch('listenbrainz_spark.recommendations.recommend.get_recommendations_for_user')
-    def test_get_recommendations_for_all_without_users(self, mock_rec_user, mock_current_app):
-        params = self.get_recommendation_params()
-        df = utils.create_dataframe(
-            Row(
-                user_id=1,
-                user_name='vansika',
-                recording_id=1
-            ),
-            schema=None
-        )
-
-        params.top_artist_candidate_set_df = df
-        params.ratings_beyond_range = [2, 3, 1, 5]
-        params.top_artist_rec_not_generated = ['vansika_1', 'vansika_2']
-        params.similar_artist_rec_not_generated = ['vansika_3', 'vansika_4']
-        params.top_artist_not_found = ['vansika_5', 'vansika_6']
-        params.similar_artist_not_found = ['vansika_7', 'vansika_8']
-
         users = []
-        mock_rec_user.return_value = 'recording_mbid_1', 'recording_mbid_2'
-        messages = recommend.get_recommendations_for_all(params, users)
-        mock_rec_user.assert_called_once_with(1, 'vansika', params)
+        users_df = recommend.get_user_name_and_user_id(params, [])
 
-        calls = [
-            call('{} ratings are beyond the expected range i.e rating > 1 or rating < -1\nMax rating: {}\nMin rating: {}'
-                 .format(4, 5, 1)),
-            call('Top artist candidate set not found for: \n"{}"\nYou might want to check the mapping.'
-                 .format(['vansika_5', 'vansika_6'])),
-            call('Similar artist candidate set not found for: \n"{}"\nYou might want to check the artist relation.'
-                 .format(['vansika_7', 'vansika_8'])),
-            call('Top artist recommendations not generated for: \n"{}"\nYou might want to check the training set'
-                 .format(['vansika_1', 'vansika_2'])),
-            call('Similar artist recommendations not generated for: "{}"\nYou might want to check the training set'
-                 .format(['vansika_3', 'vansika_4']))
-        ]
-        mock_current_app.logger.error.assert_has_calls(calls, any_order=True)
+        self.assertEqual(users_df.count(), 2)
+        user_name = sorted([row.user_name for row in users_df.collect()])
+        user_id = sorted([row.user_id for row in users_df.collect()])
+        self.assertEqual(sorted(users_df.columns), sorted(['user_id', 'user_name']))
+        self.assertEqual(['rob', 'vansika'], user_name)
+        self.assertEqual([1, 2], user_id)
 
-        self.assertEqual(len(messages), 2)
-        message = messages[0]
-        self.assertEqual(message['musicbrainz_id'], 'vansika')
-        self.assertEqual(message['type'], 'cf_recording_recommendations')
-        self.assertEqual(message['top_artist'], 'recording_mbid_1')
-        self.assertEqual(message['similar_artist'], 'recording_mbid_2')
+        users = ['vansika', 'invalid']
+        users_df = recommend.get_user_name_and_user_id(params, users)
+        self.assertEqual(users_df.count(), 1)
+        self.assertEqual(sorted(users_df.columns), sorted(['user_id', 'user_name']))
+        user_name = [row.user_name for row in users_df.collect()]
+        user_id = [row.user_id for row in users_df.collect()]
+        self.assertEqual(['vansika'], user_name)
+        self.assertEqual([1], user_id)
 
-        message = messages[1]
-        self.assertEqual(message['type'], 'cf_recording_recommendations_mail')
-        self.assertEqual(message['user_count'], 1)
-        assert isinstance(message['total_time'], str)
+        with self.assertRaises(EmptyDataframeExcpetion):
+            users = ['invalid']
+            recommend.get_user_name_and_user_id(params, users)
 
-    @patch('listenbrainz_spark.recommendations.recommend.get_recommendations_for_user')
-    def test_get_recommendations_for_all_with_users(self, mock_rec_user):
+    @patch('listenbrainz_spark.recommendations.recommend.MatrixFactorizationModel')
+    @patch('listenbrainz_spark.recommendations.recommend.listenbrainz_spark')
+    @patch('listenbrainz_spark.recommendations.recommend.get_model_path')
+    @patch('listenbrainz_spark.recommendations.recommend.get_most_recent_model_id')
+    def test_load_model(self, mock_id, mock_model_path, mock_lb, mock_matrix_model):
+        model = recommend.load_model()
+        mock_id.assert_called_once()
+        mock_model_path.assert_called_once_with(mock_id.return_value)
+        mock_matrix_model.load.assert_called_once_with(mock_lb.context, mock_model_path.return_value)
+
+    def test_get_most_recent_model_id(self):
+        model_id_1 = "a36d6fc9-49d0-4789-a7dd-a2b72369ca45"
+        model_metadata_dict_1 = self.get_model_metadata(model_id_1)
+        df_1 = utils.create_dataframe(schema.convert_model_metadata_to_row(model_metadata_dict_1),
+                                      schema.model_metadata_schema)
+
+        model_id_2 = "bbbd6fc9-49d0-4789-a7dd-a2b72369ca45"
+        model_metadata_dict_2 = self.get_model_metadata(model_id_2)
+        df_2 = utils.create_dataframe(schema.convert_model_metadata_to_row(model_metadata_dict_2),
+                                      schema.model_metadata_schema)
+
+        model_metadata = df_1.union(df_2)
+        utils.save_parquet(model_metadata, path.MODEL_METADATA)
+
+        expected_model_id = recommend.get_most_recent_model_id()
+        self.assertEqual(expected_model_id, model_id_2)
+
+    @patch('listenbrainz_spark.recommendations.recommend.get_candidate_set_rdd_for_user')
+    @patch('listenbrainz_spark.recommendations.recommend.get_recommended_mbids')
+    def test_get_recommendations_for_user(self, mock_mbids, mock_candidate_set):
         params = self.get_recommendation_params()
-        df = utils.create_dataframe(
-            Row(
-                user_id=1,
-                user_name='vansika',
-                recording_id=1
-            ),
-            schema=None
-        )
+        user_id = 1
+        user_name = 'vansika'
 
-        users = ['vansika_1', 'vansika']
-        params.top_artist_candidate_set = df
-        mock_rec_user.return_value = 'recording_mbid_3', 'recording_mbid_4'
-        messages = recommend.get_recommendations_for_all(params, users)
-        mock_rec_user.assert_called_once_with(1, 'vansika', params)
+        _, _ = recommend.get_recommendations_for_user(user_id, user_name, params)
 
-        self.assertEqual(len(messages), 3)
+        mock_candidate_set.assert_has_calls([
+            call(params.top_artist_candidate_set_df, user_id),
+            call(params.similar_artist_candidate_set_df, user_id)
+        ])
 
-        message = messages[0]
-        self.assertEqual(message['musicbrainz_id'], 'vansika')
-        self.assertEqual(message['type'], 'cf_recording_recommendations')
-        self.assertEqual(message['top_artist'], 'recording_mbid_3')
-        self.assertEqual(message['similar_artist'], 'recording_mbid_4')
+        mock_mbids.assert_has_calls([
+            call(mock_candidate_set.return_value, params, params.recommendation_top_artist_limit),
+            call(mock_candidate_set.return_value, params, params.recommendation_similar_artist_limit)
+        ])
 
-        message = messages[1]
-        self.assertEqual(message['musicbrainz_id'], 'vansika_1')
-        self.assertEqual(message['type'], 'cf_recording_recommendations')
-        self.assertEqual(message['top_artist'], [])
-        self.assertEqual(message['similar_artist'], [])
+        user_name = 'vansika_1'
+        mock_candidate_set.side_effect = IndexError
+        recommend.get_recommendations_for_user(user_id, user_name, params)
+        self.assertEqual(params.top_artist_not_found, ['vansika_1'])
+        self.assertEqual(params.similar_artist_not_found, ['vansika_1'])
 
-        message = messages[2]
-        self.assertEqual(message['type'], 'cf_recording_recommendations_mail')
-        self.assertEqual(message['user_count'], 1)
-        assert isinstance(message['total_time'], str)
+        user_name = 'vansika_2'
+        mock_candidate_set.side_effect = RecommendationsNotGeneratedException(message='Recommendations not generated')
+        recommend.get_recommendations_for_user(user_id, user_name, params)
+        self.assertEqual(params.top_artist_rec_not_generated, ['vansika_2'])
+        self.assertEqual(params.similar_artist_rec_not_generated, ['vansika_2'])
 
     def get_recommendation_params(self):
         recordings_df = self.get_recordings_df()


### PR DESCRIPTION
# Problem
It took around 16 hours to generate recommendations for around 1700 users. We have to generate recommendations for each user separately since the candidate set for each user is different but the operations which are performed on each set of recommendations can definitely be done for all users at once. I think it will reduce time to some extent.

# Solution
Get mbids corresponding to recording_ids for all users at once.
Scale the ratings for all users at once.

***EDIT***
I have lately realised that recommendations can be generated for all users at once. So in this script, we are performing all operations for all users at once. I am expecting runtime to fall greatly. 

