### PR TITLE
Show listen count on Artist Origin map (Backend)

### DIFF
--- a/data/model/user_artist_map.py
+++ b/data/model/user_artist_map.py
@@ -12,6 +12,7 @@ class UserArtistMapRecord(pydantic.BaseModel):
     """
     country: str
     artist_count: int
+    listen_count: int
 
 
 class UserArtistMapStatRange(pydantic.BaseModel):

--- a/data/model/user_artist_map.py
+++ b/data/model/user_artist_map.py
@@ -12,7 +12,7 @@ class UserArtistMapRecord(pydantic.BaseModel):
     """
     country: str
     artist_count: int
-    listen_count: int
+    listen_count: Optional[int]  # Make field optional to maintain backward compatibility
 
 
 class UserArtistMapStatRange(pydantic.BaseModel):

--- a/listenbrainz/testdata/user_artist_map_db.json
+++ b/listenbrainz/testdata/user_artist_map_db.json
@@ -5,15 +5,18 @@
   "artist_map": [
     {
       "country": "USA",
-      "artist_count": 56
+      "artist_count": 56,
+      "listen_count": 100
     },
     {
       "country": "GBR",
-      "artist_count": 67
+      "artist_count": 67,
+      "listen_count": 150
     },
     {
       "country": "IND",
-      "artist_count": 32
+      "artist_count": 32,
+      "listen_count": 56
     }
   ]
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test.json
@@ -1,83 +1,78 @@
 {
   "artist_map": [
     {
-      "artist_count": 51,
-      "country": "USA"
+      "artist_count": 15,
+      "country": "GBR",
+      "listen_count": 173
     },
     {
-      "artist_count": 5,
-      "country": "CAN"
-    },
-    {
-      "artist_count": 7,
-      "country": "IND"
-    },
-    {
-      "artist_count": 1,
-      "country": "DNK"
-    },
-    {
-      "artist_count": 21,
-      "country": "GBR"
-    },
-    {
-      "artist_count": 1,
-      "country": "ISR"
+      "artist_count": 38,
+      "country": "USA",
+      "listen_count": 231
     },
     {
       "artist_count": 4,
-      "country": "AUS"
+      "country": "AUS",
+      "listen_count": 58
+    },
+    {
+      "artist_count": 1,
+      "country": "ISL",
+      "listen_count": 11
+    },
+    {
+      "artist_count": 1,
+      "country": "ARG",
+      "listen_count": 10
     },
     {
       "artist_count": 3,
-      "country": "FRA"
+      "country": "CAN",
+      "listen_count": 10
+    },
+    {
+      "artist_count": 1,
+      "country": "DEU",
+      "listen_count": 6
+    },
+    {
+      "artist_count": 1,
+      "country": "NLD",
+      "listen_count": 5
+    },
+    {
+      "artist_count": 3,
+      "country": "SWE",
+      "listen_count": 7
     },
     {
       "artist_count": 4,
-      "country": "SWE"
-    },
-    {
-      "artist_count": 3,
-      "country": "DEU"
-    },
-    {
-      "artist_count": 1,
-      "country": "PRT"
+      "country": "IND",
+      "listen_count": 7
     },
     {
       "artist_count": 2,
-      "country": "IRL"
+      "country": "IRL",
+      "listen_count": 3
     },
     {
       "artist_count": 1,
-      "country": "ISL"
-    },
-    {
-      "artist_count": 2,
-      "country": "NOR"
+      "country": "DNK",
+      "listen_count": 1
     },
     {
       "artist_count": 1,
-      "country": "ARG"
+      "country": "PRI",
+      "listen_count": 1
     },
     {
       "artist_count": 1,
-      "country": "PRI"
-    },
-    {
-      "artist_count": 1,
-      "country": "ESP"
-    },
-    {
-      "artist_count": 1,
-      "country": "NLD"
-    },
-    {
-      "artist_count": 1,
-      "country": "FIN"
+      "country": "FRA",
+      "listen_count": 1
     }
   ],
   "from_ts": 1009843200,
-  "last_updated": 0,
-  "to_ts": 1589496658
+  "last_updated": 1599918137,
+  "to_ts": 1589496658,
+  "user_id": "ishaanshah"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_month.json
@@ -1,59 +1,58 @@
 {
   "artist_map": [
     {
-      "artist_count": 20,
-      "country": "USA"
+      "artist_count": 6,
+      "country": "GBR",
+      "listen_count": 92
     },
     {
-      "artist_count": 1,
-      "country": "DNK"
-    },
-    {
-      "artist_count": 8,
-      "country": "GBR"
-    },
-    {
-      "artist_count": 3,
-      "country": "AUS"
+      "artist_count": 14,
+      "country": "USA",
+      "listen_count": 91
     },
     {
       "artist_count": 3,
-      "country": "DEU"
+      "country": "AUS",
+      "listen_count": 25
     },
     {
       "artist_count": 1,
-      "country": "PRT"
+      "country": "ISL",
+      "listen_count": 7
     },
     {
       "artist_count": 1,
-      "country": "IND"
+      "country": "ARG",
+      "listen_count": 6
     },
     {
       "artist_count": 1,
-      "country": "ISL"
+      "country": "DEU",
+      "listen_count": 3
     },
     {
       "artist_count": 1,
-      "country": "SWE"
+      "country": "CAN",
+      "listen_count": 3
     },
     {
       "artist_count": 1,
-      "country": "ARG"
+      "country": "NLD",
+      "listen_count": 2
     },
     {
       "artist_count": 1,
-      "country": "CAN"
+      "country": "DNK",
+      "listen_count": 1
     },
     {
       "artist_count": 1,
-      "country": "ESP"
-    },
-    {
-      "artist_count": 1,
-      "country": "NLD"
+      "country": "SWE",
+      "listen_count": 1
     }
   ],
   "from_ts": 1588373458,
-  "last_updated": 0,
-  "to_ts": 1589496658
+  "last_updated": 1599918137,
+  "to_ts": 1589496658,
+  "user_id": "ishaanshah"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_week.json
@@ -1,47 +1,53 @@
 {
   "artist_map": [
     {
-      "artist_count": 16,
-      "country": "USA"
+      "artist_count": 11,
+      "country": "USA",
+      "listen_count": 62
     },
     {
-      "artist_count": 4,
-      "country": "IND"
-    },
-    {
-      "artist_count": 7,
-      "country": "GBR"
-    },
-    {
-      "artist_count": 3,
-      "country": "DEU"
-    },
-    {
-      "artist_count": 1,
-      "country": "ISL"
+      "artist_count": 5,
+      "country": "GBR",
+      "listen_count": 37
     },
     {
       "artist_count": 2,
-      "country": "AUS"
+      "country": "AUS",
+      "listen_count": 8
     },
     {
       "artist_count": 1,
-      "country": "ARG"
+      "country": "CAN",
+      "listen_count": 2
     },
     {
       "artist_count": 1,
-      "country": "CAN"
+      "country": "ISL",
+      "listen_count": 2
     },
     {
       "artist_count": 1,
-      "country": "ESP"
+      "country": "ARG",
+      "listen_count": 2
     },
     {
       "artist_count": 1,
-      "country": "NLD"
+      "country": "NLD",
+      "listen_count": 1
+    },
+    {
+      "artist_count": 1,
+      "country": "DEU",
+      "listen_count": 1
+    },
+    {
+      "artist_count": 3,
+      "country": "IND",
+      "listen_count": 3
     }
   ],
   "from_ts": 1592265583,
-  "last_updated": 0,
-  "to_ts": 1592870383
+  "last_updated": 1599918137,
+  "to_ts": 1592870383,
+  "user_id": "ishaanshah"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_year.json
@@ -1,83 +1,78 @@
 {
   "artist_map": [
     {
-      "artist_count": 51,
-      "country": "USA"
+      "artist_count": 15,
+      "country": "GBR",
+      "listen_count": 173
     },
     {
-      "artist_count": 5,
-      "country": "CAN"
-    },
-    {
-      "artist_count": 7,
-      "country": "IND"
-    },
-    {
-      "artist_count": 1,
-      "country": "DNK"
-    },
-    {
-      "artist_count": 21,
-      "country": "GBR"
-    },
-    {
-      "artist_count": 1,
-      "country": "ISR"
+      "artist_count": 38,
+      "country": "USA",
+      "listen_count": 231
     },
     {
       "artist_count": 4,
-      "country": "AUS"
+      "country": "AUS",
+      "listen_count": 58
+    },
+    {
+      "artist_count": 1,
+      "country": "ISL",
+      "listen_count": 11
+    },
+    {
+      "artist_count": 1,
+      "country": "ARG",
+      "listen_count": 10
     },
     {
       "artist_count": 3,
-      "country": "FRA"
+      "country": "CAN",
+      "listen_count": 10
+    },
+    {
+      "artist_count": 1,
+      "country": "DEU",
+      "listen_count": 6
+    },
+    {
+      "artist_count": 1,
+      "country": "NLD",
+      "listen_count": 5
+    },
+    {
+      "artist_count": 3,
+      "country": "SWE",
+      "listen_count": 7
     },
     {
       "artist_count": 4,
-      "country": "SWE"
-    },
-    {
-      "artist_count": 3,
-      "country": "DEU"
-    },
-    {
-      "artist_count": 1,
-      "country": "PRT"
+      "country": "IND",
+      "listen_count": 7
     },
     {
       "artist_count": 2,
-      "country": "IRL"
+      "country": "IRL",
+      "listen_count": 3
     },
     {
       "artist_count": 1,
-      "country": "ISL"
-    },
-    {
-      "artist_count": 2,
-      "country": "NOR"
+      "country": "DNK",
+      "listen_count": 1
     },
     {
       "artist_count": 1,
-      "country": "ARG"
+      "country": "PRI",
+      "listen_count": 1
     },
     {
       "artist_count": 1,
-      "country": "PRI"
-    },
-    {
-      "artist_count": 1,
-      "country": "ESP"
-    },
-    {
-      "artist_count": 1,
-      "country": "NLD"
-    },
-    {
-      "artist_count": 1,
-      "country": "FIN"
+      "country": "FRA",
+      "listen_count": 1
     }
   ],
   "from_ts": 1577919058,
-  "last_updated": 0,
-  "to_ts": 1589496658
+  "to_ts": 1589496658,
+  "last_updated": 1599918137,
+  "user_id": "ishaanshah"
 }

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -1115,7 +1115,8 @@ class StatsAPITestCase(IntegrationTestCase):
         expected = [
             {
                 "country": "GBR",
-                "artist_count": 4
+                "artist_count": 1,
+                "listen_count": 321,
             }
         ]
         self.assertListEqual(expected, received)

--- a/listenbrainz/webserver/static/js/src/stats/Choropleth.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/Choropleth.tsx
@@ -1,6 +1,7 @@
 import { Theme } from "@nivo/core";
 import { Choropleth } from "@nivo/geo";
 import { BoxLegendSvg, LegendProps } from "@nivo/legends";
+import { BasicTooltip } from "@nivo/tooltip";
 import { scaleThreshold } from "d3-scale";
 import { schemeOranges } from "d3-scale-chromatic";
 import { format } from "d3-format";
@@ -12,6 +13,7 @@ import * as features from "./world_countries.json";
 export type ChoroplethProps = {
   data: UserArtistMapData;
   width?: number;
+  countOf: "artist" | "listen";
 };
 
 export default function CustomChoropleth(props: ChoroplethProps) {
@@ -121,6 +123,25 @@ export default function CustomChoropleth(props: ChoroplethProps) {
     />
   );
 
+  const CustomTooltip = ({ feature }: { feature: any }) => {
+    if (feature.data === undefined) {
+      return null;
+    }
+
+    const { countOf } = props;
+
+    return (
+      <BasicTooltip
+        id={feature.label}
+        color={feature.color}
+        value={`${
+          feature.formattedValue
+        } ${countOf[0].toUpperCase()}${countOf.slice(1)}s`}
+        enableChip
+      />
+    );
+  };
+
   return (
     <Choropleth
       data={data}
@@ -132,6 +153,7 @@ export default function CustomChoropleth(props: ChoroplethProps) {
       domain={domain}
       theme={isMobile ? themes.mobile : themes.desktop}
       valueFormat=".2s"
+      tooltip={CustomTooltip}
       unknownColor="#efefef"
       label="properties.name"
       projectionScale={width / 5.5}

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -15,11 +15,12 @@ export type UserArtistMapProps = {
 };
 
 export type UserArtistMapState = {
-  loading: boolean;
-  hasError?: boolean;
-  errorMessage?: string;
   data: UserArtistMapData;
+  errorMessage?: string;
   graphContainerWidth?: number;
+  hasError?: boolean;
+  loading: boolean;
+  countOf: "artist" | "listen";
 };
 
 export default class UserArtistMap extends React.Component<
@@ -41,6 +42,7 @@ export default class UserArtistMap extends React.Component<
       loading: false,
       errorMessage: "",
       hasError: false,
+      countOf: "artist",
     };
 
     this.graphContainer = React.createRef();
@@ -106,10 +108,12 @@ export default class UserArtistMap extends React.Component<
   };
 
   processData = (data: UserArtistMapResponse): UserArtistMapData => {
+    const { countOf } = this.state;
     return data.payload.artist_map.map((country) => {
       return {
         id: country.country,
-        value: country.artist_count,
+        value:
+          countOf === "artist" ? country.artist_count : country.listen_count,
       };
     });
   };
@@ -122,11 +126,12 @@ export default class UserArtistMap extends React.Component<
 
   render() {
     const {
-      loading,
-      hasError,
-      errorMessage,
+      countOf,
       data,
+      errorMessage,
       graphContainerWidth,
+      hasError,
+      loading,
     } = this.state;
 
     return (
@@ -173,7 +178,11 @@ export default class UserArtistMap extends React.Component<
           {!hasError && (
             <div className="row">
               <div className="col-xs-12">
-                <Choropleth data={data} width={graphContainerWidth} />
+                <Choropleth
+                  data={data}
+                  width={graphContainerWidth}
+                  countOf={countOf}
+                />
               </div>
             </div>
           )}

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserArtistMap.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserArtistMap.test.tsx.snap
@@ -294,6 +294,7 @@ exports[`UserArtistMap renders correctly 1`] = `
         className="col-xs-12"
       >
         <CustomChoropleth
+          countOf="artist"
           data={
             Array [
               Object {

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -284,6 +284,7 @@ declare type UserArtistMapResponse = {
     artist_map: Array<{
       country: string;
       artist_count: number;
+      listen_count: number;
     }>;
   };
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nivo/geo": "^0.62.0",
     "@nivo/heatmap": "^0.62.0",
     "@nivo/legends": "^0.62.0",
+    "@nivo/tooltip": "^0.62.0",
     "clean-css": "^4.2.1",
     "d3-format": "^1.4.4",
     "d3-scale": "^3.2.1",


### PR DESCRIPTION
This PR adds backend support for coloring  the Artist Origin map by listen counts. Opening a different PR for frontend so that we can safely deploy it in a week from when this PR is deployed.