### PR TITLE
LB-690: Minor improvements to Listening Activity graph

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.test.tsx
@@ -189,6 +189,44 @@ describe("getData", () => {
   });
 });
 
+describe("getNumberOfDaysInMonth", () => {
+  it("calculates correctly for non leap February", () => {
+    const wrapper = shallow<UserListeningActivity>(
+      <UserListeningActivity {...props} />
+    );
+    const instance = wrapper.instance();
+
+    expect(instance.getNumberOfDaysInMonth(new Date(2019, 1, 1))).toEqual(28);
+  });
+
+  it("calculates correctly for leap February", () => {
+    const wrapper = shallow<UserListeningActivity>(
+      <UserListeningActivity {...props} />
+    );
+    const instance = wrapper.instance();
+
+    expect(instance.getNumberOfDaysInMonth(new Date(2020, 1, 1))).toEqual(29);
+  });
+
+  it("calculates correctly for December", () => {
+    const wrapper = shallow<UserListeningActivity>(
+      <UserListeningActivity {...props} />
+    );
+    const instance = wrapper.instance();
+
+    expect(instance.getNumberOfDaysInMonth(new Date(2020, 11, 1))).toEqual(31);
+  });
+
+  it("calculates correctly for November", () => {
+    const wrapper = shallow<UserListeningActivity>(
+      <UserListeningActivity {...props} />
+    );
+    const instance = wrapper.instance();
+
+    expect(instance.getNumberOfDaysInMonth(new Date(2020, 10, 1))).toEqual(30);
+  });
+});
+
 describe("processData", () => {
   it("processes data correctly for week", () => {
     const wrapper = shallow<UserListeningActivity>(

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -128,6 +128,14 @@ export default class UserListeningActivity extends React.Component<
     return {} as UserListeningActivityResponse;
   };
 
+  getNumberOfDaysInMonth = (month: Date): number => {
+    return new Date(
+      month.getUTCFullYear(),
+      month.getUTCMonth() + 1,
+      0
+    ).getDate();
+  };
+
   processData = (
     data: UserListeningActivityResponse
   ): UserListeningActivityData => {
@@ -206,11 +214,7 @@ export default class UserListeningActivity extends React.Component<
     const startOfLastMonth = new Date(
       data.payload.listening_activity[0].from_ts * 1000
     );
-    const numOfDaysInLastMonth = new Date(
-      startOfLastMonth.getUTCFullYear(),
-      startOfLastMonth.getUTCMonth() + 1,
-      0
-    ).getDate();
+    const numOfDaysInLastMonth = this.getNumberOfDaysInMonth(startOfLastMonth);
 
     const lastMonth = data.payload.listening_activity.slice(
       0,

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -206,12 +206,11 @@ export default class UserListeningActivity extends React.Component<
     const startOfLastMonth = new Date(
       data.payload.listening_activity[0].from_ts * 1000
     );
-    const numOfDaysInLastMonth =
-      new Date(
-        startOfLastMonth.getUTCFullYear(),
-        startOfLastMonth.getUTCMonth(),
-        0
-      ).getDate() + 1;
+    const numOfDaysInLastMonth = new Date(
+      startOfLastMonth.getUTCFullYear(),
+      startOfLastMonth.getUTCMonth() + 1,
+      0
+    ).getDate();
 
     const lastMonth = data.payload.listening_activity.slice(
       0,

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -70,11 +70,11 @@ def get_listening_activity_week() -> Iterator[Optional[UserListeningActivityStat
     current_app.logger.debug("Calculating listening_activity_week")
 
     date = get_latest_listen_ts()
-    to_date = get_last_monday(date)
+    to_date = date
     # Set time to 00:00
     to_date = datetime(to_date.year, to_date.month, to_date.day)
-    from_date = offset_days(to_date, 14)
-    day = offset_days(to_date, 14)
+    from_date = offset_days(get_last_monday(to_date), 7)
+    day = from_date
 
     # Genarate a dataframe containing days of last and current week along with start and end time
     time_range = []

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -75,7 +75,7 @@ class ListeningActivityTestCase(SparkTestCase):
 
         self.assertDictEqual(received, expected)
 
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_latest_listen_ts', return_value=datetime(2020, 6, 19))
+    @patch('listenbrainz_spark.stats.user.listening_activity.get_latest_listen_ts', return_value=datetime(2020, 9, 10))
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listens')
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listening_activity', return_value='listening_activity_table')
     @patch('listenbrainz_spark.stats.user.listening_activity.create_messages')
@@ -85,8 +85,8 @@ class ListeningActivityTestCase(SparkTestCase):
         mock_get_listens.return_value = mock_df
 
         listening_activity_stats.get_listening_activity_week()
-        to_date = datetime(2020, 6, 15)
-        from_date = day = datetime(2020, 6, 1)
+        to_date = datetime(2020, 9, 10)
+        from_date = day = datetime(2020, 8, 31)
 
         time_range = []
         while day < to_date:


### PR DESCRIPTION
# Problem
- The date shown on hover is not the same as the date on the label, for the listening activity graph in the reports page (month range).
- The weekly listening activity stats are too old, i.e for last to last week and last week.

# Solution
- There was a bug in the code for finding number of days in a month which was causing the issue, the bug has now been fixed.
- Now that incremental dump support has been added, we should compare the stats for current week with last week.