### PR TITLE
Update crontab: generate recommendations daily.

### DIFF
--- a/docker/stats-crontab
+++ b/docker/stats-crontab
@@ -58,5 +58,5 @@
 # user weekly daily_activity
 10 03 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=all_time
 
-# Request recommendations every Tuesday after listens dump is imported into the spark cluster
-00 23 * * 2 /usr/local/bin/python /code/listenbrainz/docker/cf_recommendation.sh cf
+# Request recommendations every day at 23:00
+00 23 * * * /usr/local/bin/python /code/listenbrainz/docker/cf_recommendation.sh cf


### PR DESCRIPTION
Before showing recs on the website, we'd want to monitor the general flow. I have updated the crontab to generate recs daily and not weekly.