### PR TITLE
Animate the follow button

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -385,3 +385,18 @@
     letter-spacing: 1px;
   } 
 }
+
+#follow-button {
+  margin-left: 10px;
+  > .text {
+    width: 0px;
+    display: inherit;
+    vertical-align: inherit;
+    transition: width 0.42s;
+    overflow-x: hidden;
+  }
+  &:hover > .text,
+  &:focus > .text {
+    width: 4.2em;
+  }
+}

--- a/listenbrainz/webserver/static/js/src/FollowButton.tsx
+++ b/listenbrainz/webserver/static/js/src/FollowButton.tsx
@@ -150,11 +150,10 @@ class FollowButton extends React.Component<
         onMouseEnter={() => this.setHover(true)}
         onMouseLeave={() => this.setHover(false)}
         className={buttonClass}
-        style={{ marginLeft: "10px" }}
         role="button"
         tabIndex={0}
       >
-        <FontAwesomeIcon icon={buttonIcon} /> {buttonText}
+        <FontAwesomeIcon icon={buttonIcon} /> <div className="text">{buttonText}</div>
       </div>
     );
   }

--- a/listenbrainz/webserver/static/js/src/FollowButton.tsx
+++ b/listenbrainz/webserver/static/js/src/FollowButton.tsx
@@ -153,7 +153,8 @@ class FollowButton extends React.Component<
         role="button"
         tabIndex={0}
       >
-        <FontAwesomeIcon icon={buttonIcon} /> <div className="text">{buttonText}</div>
+        <FontAwesomeIcon icon={buttonIcon} />{" "}
+        <div className="text">{buttonText}</div>
       </div>
     );
   }


### PR DESCRIPTION
I thought the follow icon is quite big next to the name, and with those clear icons and colors I figured we could do something to solve that.
We can show the icon only until the user hovers to reveal the text, with a short animated transition.
<img width="319" alt="Capture d’écran 2020-09-12 à 19 59 08" src="https://user-images.githubusercontent.com/6179856/93001913-c3c72680-f532-11ea-9329-ffcea3eb2be8.png"><img width="339" alt="Capture d’écran 2020-09-12 à 19 58 41" src="https://user-images.githubusercontent.com/6179856/93001909-c164cc80-f532-11ea-87e8-3311671c2ce2.png">


<img width="373" alt="Capture d’écran 2020-09-12 à 19 58 59" src="https://user-images.githubusercontent.com/6179856/93001912-c32e9000-f532-11ea-8255-177738216c93.png"><img width="373" alt="Capture d’écran 2020-09-12 à 19 58 50" src="https://user-images.githubusercontent.com/6179856/93001910-c295f980-f532-11ea-8d33-d0df79f70136.png">




