### PR TITLE
Make sure incremental dump import is not skipped if RC crashes

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -199,7 +199,7 @@ def handle_dump_imported(data):
     import_completion_time = data['time']
     send_mail(
         subject='A {} has been imported into the Spark cluster'.format(' '.join(data['type'].split('_')[1:])),
-        text=render_template('emails/dump_import_notification.txt', dump_name=dump_name, time=import_completion_time),
+        text=render_template('emails/dump_import_notification.txt', dump_name=", ".join(dump_name), time=import_completion_time),
         recipients=['listenbrainz-observability@metabrainz.org'],
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -158,7 +158,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         current_app.logger.info('Downloading {} from FTP...'.format(listens_file_name))
         dest_path = self.download_dump(listens_file_name, directory)
         current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
-        return dest_path, listens_file_name, dump_id
+        return dest_path, listens_file_name, int(dump_id)
 
     def download_artist_relation(self, directory, artist_relation_dump_id=None):
         """ Download artist relation to dir passed as an argument.

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -13,6 +13,7 @@ ARTIST_RELATION_DUMP_ID_POS = 5
 FULL = 'full'
 INCREMENTAL = 'incremental'
 
+
 class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
 
     def get_dump_name_to_download(self, dump, dump_id, dump_id_pos):
@@ -148,7 +149,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         self.connection.cwd(ftp_cwd)
         listens_dump_list = sorted(self.list_dir(), key=lambda x: int(x.split('-')[2]))
         req_listens_dump = self.get_dump_name_to_download(listens_dump_list, listens_dump_id, 2)
-
+        dump_id = req_listens_dump.split('-')[2]
 
         self.connection.cwd(req_listens_dump)
         listens_file_name = self.get_listens_dump_file_name(req_listens_dump)
@@ -157,7 +158,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         current_app.logger.info('Downloading {} from FTP...'.format(listens_file_name))
         dest_path = self.download_dump(listens_file_name, directory)
         current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
-        return dest_path, listens_file_name
+        return dest_path, listens_file_name, dump_id
 
     def download_artist_relation(self, directory, artist_relation_dump_id=None):
         """ Download artist relation to dir passed as an argument.

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -128,7 +128,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_full_dump(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-123-20190101-000000-spark-full.tar.xz'
-        dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='full')
+        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='full')
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls(
             [call(config.FTP_LISTENS_DIR + 'fullexport/'), call('listenbrainz-dump-123-20190101-000000/')])
@@ -137,6 +137,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_get_f_name.assert_called_once()
         mock_download_dump.assert_called_once_with(mock_get_f_name.return_value, 'fakedir')
         self.assertEqual(dest_path, mock_download_dump.return_value)
+        self.assertEqual(dump_id, 123)
 
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_dump')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.get_listens_dump_file_name')
@@ -145,7 +146,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_full_dump_by_id(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-45-20190201-000000-spark-full.tar.xz'
-        dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45, dump_type='full')
+        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45, dump_type='full')
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls([
             call(config.FTP_LISTENS_DIR + 'fullexport/'),
@@ -156,6 +157,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_get_f_name.assert_called_once()
         mock_download_dump.assert_called_once_with(mock_get_f_name.return_value, 'fakedir')
         self.assertEqual(dest_path, mock_download_dump.return_value)
+        self.assertEqual(dump_id, 45)
 
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_dump')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.get_listens_dump_file_name')
@@ -164,7 +166,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_incremental_dump(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-123-20190101-000000-spark-incremental.tar.xz'
-        dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='incremental')
+        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='incremental')
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls(
             [call(config.FTP_LISTENS_DIR + 'incremental/'), call('listenbrainz-dump-123-20190101-000000/')])
@@ -173,6 +175,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_get_f_name.assert_called_once()
         mock_download_dump.assert_called_once_with(mock_get_f_name.return_value, 'fakedir')
         self.assertEqual(dest_path, mock_download_dump.return_value)
+        self.assertEqual(dump_id, 123)
 
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_dump')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.get_listens_dump_file_name')
@@ -181,8 +184,8 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_incremental_dump_by_id(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-45-20190201-000000-spark-incremental.tar.xz'
-        dest_path, filename = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45,
-                                                                            dump_type='incremental')
+        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45,
+                                                                                     dump_type='incremental')
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls([
             call(config.FTP_LISTENS_DIR + 'incremental/'),
@@ -193,6 +196,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_get_f_name.assert_called_once()
         mock_download_dump.assert_called_once_with(mock_get_f_name.return_value, 'fakedir')
         self.assertEqual(dest_path, mock_download_dump.return_value)
+        self.assertEqual(dump_id, 45)
 
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.get_dump_archive_name')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_dump')

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -71,7 +71,6 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_ftp_cons.return_value.cwd.assert_called_once_with(config.FTP_MSID_MBID_DIR)
         mock_available_dump.assert_called_once_with(mock_list_dir.return_value, 'msid-mbid-mapping-with-matchable')
 
-
         mock_latest_mapping.assert_called_once_with([
             'msid-mbid-mapping-with-matchable-20200603-203731.tar.bz2',
             'msid-mbid-mapping-with-matchable-20200603-202732.tar.bz2',
@@ -146,7 +145,8 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_full_dump_by_id(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-45-20190201-000000-spark-full.tar.xz'
-        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45, dump_type='full')
+        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir',
+                                                                                     listens_dump_id=45, dump_type='full')
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls([
             call(config.FTP_LISTENS_DIR + 'fullexport/'),

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -39,5 +39,8 @@ MAPPED_LISTENS = DATAFRAME_DIR + '/' + 'mapped_listens_df.parquet'
 # Absolute path to save dataframe metadata
 DATAFRAME_METADATA = DATAFRAME_DIR + '/' + 'dataframe_metadata.parquet'
 
+# Absolute path to save import metadata
+IMPORT_METADATA = "/import_metadata.parquet"
+
 # Path to files downloaded from FTP.
 FTP_FILES_PATH = '/rec/listenbrainz_spark'

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -45,9 +45,10 @@ def import_full_dump_by_id_handler(id: int):
 def import_newest_incremental_dump_handler():
     imported_dumps = []
     latest_full_dump = utils.get_latest_full_dump()
-    if not latest_full_dump:
+    if latest_full_dump is None:
         # If no prior full dump is present, just import the lates incremental dump
         imported_dumps.append(import_dump_to_hdfs('incremental', overwrite=False))
+        current_app.logger.warn("No previous full dump found, importing latest incremental dump", exc_info=True)
     else:
         # Import all missing dumps from last full dump import
         dump_id = latest_full_dump["dump_id"] + 1

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -4,6 +4,7 @@
 import shutil
 import tempfile
 import time
+from flask import current_app
 
 import listenbrainz_spark.request_consumer.jobs.utils as utils
 from datetime import datetime
@@ -56,6 +57,10 @@ def import_newest_incremental_dump_handler():
                 try:
                     imported_dumps.append(import_dump_to_hdfs('incremental', False, dump_id))
                 except DumpNotFoundException:
+                    break
+                except Exception as e:
+                    # Exit if any other error occurs during import
+                    current_app.logger.error(f"Error while importing incremental dump with ID {dump_id}: {e}", exc_info=True)
                     break
             dump_id += 1
     return [{

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -5,17 +5,20 @@ import shutil
 import tempfile
 import time
 
+import listenbrainz_spark.request_consumer.jobs.utils as utils
 from datetime import datetime
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
+from listenbrainz_spark.exceptions import DumpNotFoundException
 
 
 def import_dump_to_hdfs(dump_type, overwrite, dump_id=None):
     temp_dir = tempfile.mkdtemp()
     dump_type = 'incremental' if dump_type == 'incremental' else 'full'
-    src, dump_name = ListenbrainzDataDownloader().download_listens(directory=temp_dir, dump_type=dump_type,
-                                                                   listens_dump_id=dump_id)
+    src, dump_name, dump_id = ListenbrainzDataDownloader().download_listens(directory=temp_dir, dump_type=dump_type,
+                                                                            listens_dump_id=dump_id)
     ListenbrainzDataUploader().upload_listens(src, overwrite=overwrite)
+    utils.insert_dump_data(dump_id, dump_type, datetime.utcnow())
     shutil.rmtree(temp_dir)
     return dump_name
 
@@ -24,7 +27,7 @@ def import_newest_full_dump_handler():
     dump_name = import_dump_to_hdfs('full', overwrite=True)
     return [{
         'type': 'import_full_dump',
-        'imported_dump': dump_name,
+        'imported_dump': [dump_name],
         'time': str(datetime.utcnow()),
     }]
 
@@ -33,16 +36,31 @@ def import_full_dump_by_id_handler(id: int):
     dump_name = import_dump_to_hdfs('full', overwrite=True, dump_id=id)
     return [{
         'type': 'import_full_dump',
-        'imported_dump': dump_name,
+        'imported_dump': [dump_name],
         'time': str(datetime.utcnow()),
     }]
 
 
 def import_newest_incremental_dump_handler():
-    dump_name = import_dump_to_hdfs('incremental', overwrite=False)
+    imported_dumps = []
+    latest_full_dump = utils.get_latest_full_dump()
+    if not latest_full_dump:
+        # If no prior full dump is present, just import the lates incremental dump
+        imported_dumps.append(import_dump_to_hdfs('incremental', overwrite=False))
+    else:
+        # Import all missing dumps from last full dump import
+        dump_id = latest_full_dump["dump_id"] + 1
+        imported_at = latest_full_dump["imported_at"]
+        while True:
+            if not utils.search_dump(dump_id, 'incremental', imported_at):
+                try:
+                    imported_dumps.append(import_dump_to_hdfs('incremental', False, dump_id))
+                except DumpNotFoundException:
+                    break
+            dump_id += 1
     return [{
         'type': 'import_incremental_dump',
-        'imported_dump': dump_name,
+        'imported_dump': imported_dumps,
         'time': str(datetime.utcnow()),
     }]
 
@@ -51,7 +69,7 @@ def import_incremental_dump_by_id_handler(id: int):
     dump_name = import_dump_to_hdfs('incremental', overwrite=False, dump_id=id)
     return [{
         'type': 'import_incremental_dump',
-        'imported_dump': dump_name,
+        'imported_dump': [dump_name],
         'time': str(datetime.utcnow()),
     }]
 

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -1,51 +1,80 @@
 import unittest
+from datetime import datetime
 
 from unittest.mock import patch, MagicMock
-from listenbrainz_spark.utils import create_app
+from listenbrainz_spark.tests import SparkTestCase
+from listenbrainz_spark.utils import read_files_from_HDFS, path_exists, delete_dir
+from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.request_consumer.jobs.import_dump import (import_newest_full_dump_handler,
                                                                   import_full_dump_by_id_handler,
                                                                   import_mapping_to_hdfs,
                                                                   import_artist_relation_to_hdfs)
 
 
-class DumpImporterJobTestCase(unittest.TestCase):
+class DumpImporterJobTestCase(SparkTestCase):
+    # use path_ as prefix for all paths in this class.
+    path_ = IMPORT_METADATA
+
+    def tearDown(self):
+        path_found = path_exists(self.path_)
+        if path_found:
+            delete_dir(self.path_, recursive=True)
 
     @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_listens')
     @patch('listenbrainz_spark.hdfs.upload.ListenbrainzDataUploader.upload_listens')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.shutil.rmtree')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.tempfile')
-    def test_import_full_dump_handler(self, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
+    def test_import_full_dump_handler(self, mock_datetime, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+        mock_src = MagicMock()
         mock_temp.mkdtemp.return_value = 'best_dir_ever'
-        mock_download.return_value = (MagicMock(), 'listenbrainz-listens-dump-20190101-000000-spark-full.tar.xz')
+        mock_download.return_value = (mock_src, 'listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz', 202)
+        mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
+
         messages = import_newest_full_dump_handler()
-        mock_download.assert_called_once()
-        self.assertEqual(mock_download.call_args[1]['dump_type'], 'full')
-        self.assertEqual(mock_download.call_args[1]['directory'], 'best_dir_ever')
-        mock_upload.assert_called_once()
+        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type='full',  listens_dump_id=None)
+        mock_upload.assert_called_once_with(mock_src, overwrite=True)
         mock_rmtree.assert_called_once_with('best_dir_ever')
 
+        # Check if appripriate entry has been made in the table
+        import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
+        expected_count = import_meta_df \
+            .filter(import_meta_df.imported_at == datetime(2020, 8, 18)) \
+            .filter("dump_id == 202 AND dump_type == 'full'") \
+            .count()
+
+        self.assertEqual(expected_count, 1)
         self.assertEqual(len(messages), 1)
-        self.assertEqual('listenbrainz-listens-dump-20190101-000000-spark-full.tar.xz', messages[0]['imported_dump'])
+        self.assertEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz'], messages[0]['imported_dump'])
 
     @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_listens')
     @patch('listenbrainz_spark.hdfs.upload.ListenbrainzDataUploader.upload_listens')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.shutil.rmtree')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.tempfile')
-    def test_import_full_dump_by_id_handler(self, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
+    def test_import_full_dump_by_id_handler(self, mock_datetime, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+        mock_src = MagicMock()
         mock_temp.mkdtemp.return_value = 'best_dir_ever'
-        mock_download.return_value = (MagicMock(), 'listenbrainz-listens-dump-20190101-000000-spark-full.tar.xz')
-        messages = import_full_dump_by_id_handler(100)
-        mock_download.assert_called_once()
-        self.assertEqual(mock_download.call_args[1]['dump_type'], 'full')
-        self.assertEqual(mock_download.call_args[1]['directory'], 'best_dir_ever')
-        self.assertEqual(mock_download.call_args[1]['listens_dump_id'], 100)
-        mock_upload.assert_called_once()
+        mock_download.return_value = (mock_src, 'listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz', 202)
+        mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
+
+        messages = import_full_dump_by_id_handler(202)
+        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type='full',  listens_dump_id=202)
+        mock_upload.assert_called_once_with(mock_src, overwrite=True)
         mock_rmtree.assert_called_once_with('best_dir_ever')
 
+        # Check if appripriate entry has been made in the table
+        import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
+        expected_count = import_meta_df \
+            .filter(import_meta_df.imported_at == datetime(2020, 8, 18)) \
+            .filter("dump_id == 202 AND dump_type == 'full'") \
+            .count()
+
+        self.assertEqual(expected_count, 1)
         self.assertEqual(len(messages), 1)
-        self.assertEqual('listenbrainz-listens-dump-20190101-000000-spark-full.tar.xz', messages[0]['imported_dump'])
+        self.assertEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz'], messages[0]['imported_dump'])
 
     @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_msid_mbid_mapping')

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -52,7 +52,8 @@ class DumpImporterJobTestCase(SparkTestCase):
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.shutil.rmtree')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.tempfile')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
-    def test_import_full_dump_handler(self, mock_datetime, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+    def test_import_full_dump_handler(self, mock_datetime, mock_temp, mock_rmtree,
+                                      mock_upload, mock_download, mock_ftp_constructor):
         mock_src = MagicMock()
         mock_temp.mkdtemp.return_value = 'best_dir_ever'
         mock_download.return_value = (mock_src, 'listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz', 202)
@@ -80,7 +81,8 @@ class DumpImporterJobTestCase(SparkTestCase):
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.shutil.rmtree')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.tempfile')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
-    def test_import_full_dump_by_id_handler(self, mock_datetime, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+    def test_import_full_dump_by_id_handler(self, mock_datetime, mock_temp, mock_rmtree,
+                                            mock_upload, mock_download, mock_ftp_constructor):
         mock_src = MagicMock()
         mock_temp.mkdtemp.return_value = 'best_dir_ever'
         mock_download.return_value = (mock_src, 'listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz', 202)
@@ -165,7 +167,8 @@ class DumpImporterJobTestCase(SparkTestCase):
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.shutil.rmtree')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.tempfile')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
-    def test_import_incremental_dump_by_id_handler(self, mock_datetime, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+    def test_import_incremental_dump_by_id_handler(self, mock_datetime, mock_temp,
+                                                   mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
         mock_src = MagicMock()
         mock_temp.mkdtemp.return_value = 'best_dir_ever'
         mock_download.return_value = (mock_src, 'listenbrainz-listens-dump-202-20200915-180002-spark-incremental.tar.xz', 202)

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -1,14 +1,40 @@
 import unittest
 from datetime import datetime
+from unittest.mock import MagicMock, call, patch
 
-from unittest.mock import patch, MagicMock
-from listenbrainz_spark.tests import SparkTestCase
-from listenbrainz_spark.utils import read_files_from_HDFS, path_exists, delete_dir
+from listenbrainz_spark.exceptions import (DumpInvalidException,
+                                           DumpNotFoundException)
 from listenbrainz_spark.path import IMPORT_METADATA
-from listenbrainz_spark.request_consumer.jobs.import_dump import (import_newest_full_dump_handler,
-                                                                  import_full_dump_by_id_handler,
-                                                                  import_mapping_to_hdfs,
-                                                                  import_artist_relation_to_hdfs)
+from listenbrainz_spark.request_consumer.jobs.import_dump import (
+    import_artist_relation_to_hdfs, import_full_dump_by_id_handler,
+    import_incremental_dump_by_id_handler, import_mapping_to_hdfs,
+    import_newest_full_dump_handler, import_newest_incremental_dump_handler)
+from listenbrainz_spark.tests import SparkTestCase
+from listenbrainz_spark.utils import (delete_dir, path_exists,
+                                      read_files_from_HDFS)
+
+
+def mock_import_dump_to_hdfs(dump_type: str, overwrite: bool, dump_id: int):
+    """ Mock function returning dump name all dump ids less than 210, else raising DumpNotFoundException """
+    if (dump_id < 210):
+        return f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz"
+    else:
+        raise DumpNotFoundException
+
+
+def mock_import_dump_to_hdfs_error(dump_type: str, overwrite: bool, dump_id: int):
+    """ Mock function returning dump name all dump ids less than 210, else raise DumpInvalidException"""
+    if (dump_id < 210) or (dump_id > 210 and dump_id < 213):
+        return f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz"
+    elif dump_id == 210:
+        raise DumpInvalidException
+    else:
+        raise DumpNotFoundException
+
+
+def mock_search_dump(dump_id: int, dump_type: str, imported_at: datetime):
+    """ Mock function which returns True for all IDs not divisible by 3, else returns False """
+    return dump_id % 3 != 0
 
 
 class DumpImporterJobTestCase(SparkTestCase):
@@ -37,7 +63,7 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_upload.assert_called_once_with(mock_src, overwrite=True)
         mock_rmtree.assert_called_once_with('best_dir_ever')
 
-        # Check if appripriate entry has been made in the table
+        # Check if appropriate entry has been made in the table
         import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
         expected_count = import_meta_df \
             .filter(import_meta_df.imported_at == datetime(2020, 8, 18)) \
@@ -46,7 +72,7 @@ class DumpImporterJobTestCase(SparkTestCase):
 
         self.assertEqual(expected_count, 1)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz'], messages[0]['imported_dump'])
+        self.assertListEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz'], messages[0]['imported_dump'])
 
     @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_listens')
@@ -65,7 +91,7 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_upload.assert_called_once_with(mock_src, overwrite=True)
         mock_rmtree.assert_called_once_with('best_dir_ever')
 
-        # Check if appripriate entry has been made in the table
+        # Check if appropriate entry has been made in the table
         import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
         expected_count = import_meta_df \
             .filter(import_meta_df.imported_at == datetime(2020, 8, 18)) \
@@ -74,7 +100,93 @@ class DumpImporterJobTestCase(SparkTestCase):
 
         self.assertEqual(expected_count, 1)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz'], messages[0]['imported_dump'])
+        self.assertListEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-full.tar.xz'], messages[0]['imported_dump'])
+
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.import_dump_to_hdfs', side_effect=mock_import_dump_to_hdfs)
+    @patch('listenbrainz_spark.request_consumer.jobs.utils.search_dump', side_effect=mock_search_dump)
+    @patch('listenbrainz_spark.request_consumer.jobs.utils.get_latest_full_dump')
+    def test_import_newest_incremental_dump_handler(self, mock_latest_full_dump, mock_search, mock_import_dump):
+        """ Test to make sure required incremental dumps are imported. """
+        mock_latest_full_dump.return_value = {
+            "dump_id": 202,
+            "imported_at": datetime(2020, 9, 29),
+            "dump_type": "incremental"
+        }
+        mock_import_calls = []
+        expected_import_list = []
+        for dump_id in range(204, 210, 3):
+            mock_import_calls.append(call('incremental', False, dump_id))
+            expected_import_list.append(f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz")
+
+        messages = import_newest_incremental_dump_handler()
+
+        mock_import_dump.assert_has_calls(mock_import_calls)
+        self.assertListEqual(expected_import_list, messages[0]['imported_dump'])
+
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.import_dump_to_hdfs', side_effect=mock_import_dump_to_hdfs_error)
+    @patch('listenbrainz_spark.request_consumer.jobs.utils.search_dump', side_effect=mock_search_dump)
+    @patch('listenbrainz_spark.request_consumer.jobs.utils.get_latest_full_dump')
+    def test_import_newest_incremental_dump_handler_error(self, mock_latest_full_dump, mock_search, mock_import_dump):
+        """ Test to make sure import is aborted if there is a fatal error. """
+        mock_latest_full_dump.return_value = {
+            "dump_id": 202,
+            "imported_at": datetime(2020, 9, 29),
+            "dump_type": "incremental"
+        }
+        mock_import_calls = []
+        expected_import_list = []
+        for dump_id in range(204, 210, 3):
+            mock_import_calls.append(call('incremental', False, dump_id))
+            expected_import_list.append(f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz")
+
+        messages = import_newest_incremental_dump_handler()
+
+        mock_import_dump.assert_has_calls(mock_import_calls)
+        # Only three calls should be made
+        self.assertEqual(mock_import_dump.call_count, 3)
+        self.assertListEqual(expected_import_list, messages[0]['imported_dump'])
+
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.import_dump_to_hdfs')
+    @patch('listenbrainz_spark.request_consumer.jobs.utils.get_latest_full_dump', return_value=None)
+    def test_import_newest_incremental_dump_handler_no_full_dump(self, mock_latest_full_dump, mock_import_dump):
+        """ Test to make sure only latest incremental dump is imported if no full dump is found """
+        mock_import_dump.return_value = 'listenbrainz-listens-dump-202-20200915-180002-spark-incremental.tar.xz'
+
+        messages = import_newest_incremental_dump_handler()
+
+        mock_import_dump.assert_called_once_with('incremental', overwrite=False)
+        self.assertEqual(len(messages), 1)
+        self.assertListEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-incremental.tar.xz'],
+                             messages[0]['imported_dump'])
+
+    @patch('ftplib.FTP')
+    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_listens')
+    @patch('listenbrainz_spark.hdfs.upload.ListenbrainzDataUploader.upload_listens')
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.shutil.rmtree')
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.tempfile')
+    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
+    def test_import_incremental_dump_by_id_handler(self, mock_datetime, mock_temp, mock_rmtree, mock_upload, mock_download, mock_ftp_constructor):
+        mock_src = MagicMock()
+        mock_temp.mkdtemp.return_value = 'best_dir_ever'
+        mock_download.return_value = (mock_src, 'listenbrainz-listens-dump-202-20200915-180002-spark-incremental.tar.xz', 202)
+        mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
+
+        messages = import_incremental_dump_by_id_handler(202)
+        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type='incremental',  listens_dump_id=202)
+        mock_upload.assert_called_once_with(mock_src, overwrite=False)
+        mock_rmtree.assert_called_once_with('best_dir_ever')
+
+        # Check if appropriate entry has been made in the table
+        import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
+        expected_count = import_meta_df \
+            .filter(import_meta_df.imported_at == datetime(2020, 8, 18)) \
+            .filter("dump_id == 202 AND dump_type == 'incremental'") \
+            .count()
+
+        self.assertEqual(expected_count, 1)
+        self.assertEqual(len(messages), 1)
+        self.assertListEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-incremental.tar.xz'],
+                             messages[0]['imported_dump'])
 
     @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_msid_mbid_mapping')

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
@@ -1,0 +1,109 @@
+import json
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import listenbrainz_spark.request_consumer.jobs.utils as import_utils
+from listenbrainz_spark.path import IMPORT_METADATA
+from listenbrainz_spark.schema import import_metadata_schema
+from listenbrainz_spark.tests import SparkTestCase
+from listenbrainz_spark.utils import (create_dataframe, delete_dir,
+                                      path_exists, read_files_from_HDFS, save_parquet, rename)
+from pyspark.sql import Row
+
+
+class ImporterUtilsTestCase(SparkTestCase):
+    # use path_ as prefix for all paths in this class.
+    path_ = IMPORT_METADATA
+
+    def setUp(self):
+        """ Store the testdata as parquet in HDFS before each test. """
+        with open(self.path_to_data_file("import_metadata.json")) as f:
+            data = json.load(f)
+
+        df = None
+        for entry in data:
+            row = create_dataframe(Row(dump_id=entry["dump_id"],
+                                       dump_type=entry["dump_type"],
+                                       imported_at=datetime.fromtimestamp(entry["imported_at"])),
+                                   schema=import_metadata_schema)
+            df = df.union(row) if df else row
+
+        save_parquet(df, self.path_)
+
+        return super().setUp()
+
+    def tearDown(self):
+        """ Delete the parquet file stored to ensure that the tests are independant. """
+        path_found = path_exists(self.path_)
+        if path_found:
+            delete_dir(self.path_, recursive=True)
+
+        return super().tearDown()
+
+    def test_get_latest_full_dump_present(self):
+        """ Test to ensure correct dump is returned if full dump has been imported. """
+        self.assertDictEqual(import_utils.get_latest_full_dump(), {
+            "dump_id": 7,
+            "dump_type": "full",
+            "imported_at": datetime.fromtimestamp(7)
+        })
+
+    def test_get_latest_full_dump_file_missing(self):
+        """ Test to ensure 'None' is returned if metadata file is missing. """
+        path_found = path_exists(self.path_)
+        if path_found:
+            delete_dir(self.path_, recursive=True)
+
+        self.assertIsNone(import_utils.get_latest_full_dump())
+
+    def test_get_latest_full_dump_no_full(self):
+        """ Test to ensure 'None' is returned if not full import has been made. """
+        # Remove full dump entries from parquet
+        import_meta_df = read_files_from_HDFS(self.path_)
+        result = import_meta_df.filter(import_meta_df.dump_type != "full")
+
+        # We have to save the dataframe as a different file and move it as the df itself is read from the file
+        save_parquet(result, '/temp.parquet')
+        delete_dir(self.path_, recursive=True)
+        rename('/temp.parquet', self.path_)
+
+        self.assertIsNone(import_utils.get_latest_full_dump())
+
+    def test_search_dump(self):
+        """ Test to ensure 'True' is returned if appropriate dump is found and 'False' if it isn't found. """
+        self.assertTrue(import_utils.search_dump(4, "full", datetime.fromtimestamp(3)))
+        self.assertFalse(import_utils.search_dump(4, "full", datetime.fromtimestamp(5)))
+        self.assertFalse(import_utils.search_dump(5, "full", datetime.fromtimestamp(5)))
+
+        self.assertTrue(import_utils.search_dump(4, "incremental", datetime.fromtimestamp(4)))
+        self.assertFalse(import_utils.search_dump(4, "incremental", datetime.fromtimestamp(5)))
+
+    def test_search_dump_file_missing(self):
+        """ Test to ensure 'False' is returned if metadata file is missing. """
+        path_found = path_exists(self.path_)
+        if path_found:
+            delete_dir(self.path_, recursive=True)
+
+        self.assertFalse(import_utils.search_dump(1, "full", datetime.fromtimestamp(1)))
+
+    def test_insert_dump_data(self):
+        """ Test to ensure that data is inserted correctly. """
+        import_utils.insert_dump_data(9, "full", datetime.fromtimestamp(9))
+        self.assertTrue(import_utils.search_dump(9, "full", datetime.fromtimestamp(9)))
+
+    def test_insert_dump_data_update_date(self):
+        """ Test to ensure date is updated if entry already exists. """
+        self.assertFalse(import_utils.search_dump(7, "incremental", datetime.fromtimestamp(9)))
+        import_utils.insert_dump_data(7, "incremental", datetime.fromtimestamp(9))
+        self.assertTrue(import_utils.search_dump(7, "incremental", datetime.fromtimestamp(9)))
+
+    def test_insert_dump_data_file_missing(self):
+        """ Test to ensure a file is created if it is missing. """
+        path_found = path_exists(self.path_)
+        if path_found:
+            delete_dir(self.path_, recursive=True)
+
+        self.assertFalse(import_utils.search_dump(1, "full", datetime.fromtimestamp(1)))
+        import_utils.insert_dump_data(1, "full", datetime.fromtimestamp(1))
+        self.assertTrue(import_utils.search_dump(1, "full", datetime.fromtimestamp(1)))

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -1,0 +1,69 @@
+""" Bunch of utilility functions needed for import jobs """
+from datetime import datetime
+from typing import Optional
+
+from flask import current_app
+from listenbrainz_spark.exceptions import PathNotFoundException
+from listenbrainz_spark.path import IMPORT_METADATA
+from listenbrainz_spark.schema import import_metadata_schema
+from listenbrainz_spark.utils import (create_dataframe, read_files_from_HDFS,
+                                      save_parquet)
+from pyspark.sql import Row
+from pyspark.sql.functions import col
+
+
+def get_latest_full_dump() -> Optional[dict]:
+    """ Get the latest imported dump information.
+
+        Returns:
+            Dictionary containing information about latest full dump import if found else None.
+    """
+    try:
+        import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
+    except PathNotFoundException:
+        return None
+
+    result = import_meta_df.filter('dump_type == "full"') \
+        .sort(col('imported_at').desc()) \
+        .toLocalIterator()
+    try:
+        return next(result).asDict()
+    except StopIteration:
+        return None
+
+
+def search_dump(dump_id: int, dump_type: str, imported_at: datetime) -> bool:
+    """ Search if a particular dump has been imported after a particular timestamp.
+
+        Returns:
+            True if dump is found else False
+    """
+    try:
+        import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
+    except PathNotFoundException:
+        return False
+
+    result = import_meta_df \
+        .filter(import_meta_df.imported_at >= imported_at) \
+        .filter(f"dump_id == {dump_id} AND dump_type == {dump_type}") \
+        .count()
+
+    return result > 0
+
+
+def insert_dump_data(dump_id: int, dump_type: str, imported_at: datetime):
+    """ Insert information about dump imported """
+    try:
+        import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
+    except PathNotFoundException:
+        current_app.logger.info("Import metadata file not found, creating...")
+
+    data = create_dataframe(Row(dump_id, dump_type, imported_at), schema=import_metadata_schema)
+    if import_meta_df:
+        result = import_meta_df \
+            .filter(f"dump_id != {dump_id} AND dump_type != {dump_type}") \
+            .union(data)
+    else:
+        result = data
+
+    save_parquet(result, IMPORT_METADATA)

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -45,7 +45,7 @@ def search_dump(dump_id: int, dump_type: str, imported_at: datetime) -> bool:
 
     result = import_meta_df \
         .filter(import_meta_df.imported_at >= imported_at) \
-        .filter(f"dump_id == {dump_id} AND dump_type == {dump_type}") \
+        .filter(f"dump_id == '{dump_id}' AND dump_type == '{dump_type}'") \
         .count()
 
     return result > 0
@@ -53,6 +53,7 @@ def search_dump(dump_id: int, dump_type: str, imported_at: datetime) -> bool:
 
 def insert_dump_data(dump_id: int, dump_type: str, imported_at: datetime):
     """ Insert information about dump imported """
+    import_meta_df = None
     try:
         import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
     except PathNotFoundException:
@@ -61,7 +62,7 @@ def insert_dump_data(dump_id: int, dump_type: str, imported_at: datetime):
     data = create_dataframe(Row(dump_id, dump_type, imported_at), schema=import_metadata_schema)
     if import_meta_df:
         result = import_meta_df \
-            .filter(f"dump_id != {dump_id} AND dump_type != {dump_type}") \
+            .filter(f"dump_id != '{dump_id}' AND dump_type != '{dump_type}'") \
             .union(data)
     else:
         result = data

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -7,7 +7,7 @@ from listenbrainz_spark.exceptions import PathNotFoundException
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.utils import (create_dataframe, read_files_from_HDFS,
-                                      save_parquet)
+                                      save_parquet, path_exists, delete_dir, rename)
 from pyspark.sql import Row
 from pyspark.sql.functions import col
 
@@ -67,4 +67,8 @@ def insert_dump_data(dump_id: int, dump_type: str, imported_at: datetime):
     else:
         result = data
 
-    save_parquet(result, IMPORT_METADATA)
+    # We have to save the dataframe as a different file and move it as the df itself is read from the file
+    save_parquet(result, "/temp.parquet")
+    if path_exists(IMPORT_METADATA):
+        delete_dir(IMPORT_METADATA, recursive=True)
+    rename("/temp.parquet", IMPORT_METADATA)

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -23,10 +23,10 @@ listen_schema = [
 
 # schema to contain model parameters.
 model_param_schema = [
-    StructField('alpha', FloatType(), nullable=True), # Baseline level of confidence weighting applied.
-    StructField('lmbda', FloatType(), nullable=True), # Controls over fitting.
+    StructField('alpha', FloatType(), nullable=True),  # Baseline level of confidence weighting applied.
+    StructField('lmbda', FloatType(), nullable=True),  # Controls over fitting.
     StructField('iteration', IntegerType(), nullable=True),  # Number of iterations to run.
-    StructField('rank', IntegerType(), nullable=True), # Number of hidden features in our low-rank approximation matrices.
+    StructField('rank', IntegerType(), nullable=True),  # Number of hidden features in our low-rank approximation matrices.
 ]
 model_param_schema = StructType(sorted(model_param_schema, key=lambda field: field.name))
 
@@ -84,6 +84,12 @@ dataframe_metadata_schema = [
     StructField('users_count', IntegerType(), nullable=False),  # Number of users active in a given time frame.
 ]
 
+import_metadata_schema = [
+    StructField('dump_id', IntegerType(), nullable=False),   # Id of the dump imported
+    StructField('dump_type', StringType(), nullable=False),  # The type of dump imported
+    StructField('imported_at', TimestampType(), nullable=False)   # Timestamp when dump is imported
+]
+
 
 # The field names of the schema need to be sorted, otherwise we get weird
 # errors due to type mismatches when creating DataFrames using the schema
@@ -94,6 +100,7 @@ model_metadata_schema = StructType(sorted(model_metadata_schema, key=lambda fiel
 msid_mbid_mapping_schema = StructType(sorted(msid_mbid_mapping_schema, key=lambda field: field.name))
 artist_relation_schema = StructType(sorted(artist_relation_schema, key=lambda field: field.name))
 dataframe_metadata_schema = StructType(sorted(dataframe_metadata_schema, key=lambda field: field.name))
+import_metadata_schema = StructType(sorted(import_metadata_schema, key=lambda field: field.name))
 
 
 def convert_listen_to_row(listen):

--- a/listenbrainz_spark/testdata/import_metadata.json
+++ b/listenbrainz_spark/testdata/import_metadata.json
@@ -1,0 +1,52 @@
+[
+  {
+    "dump_id": 1,
+    "dump_type": "full",
+    "imported_at": 1
+  },
+  {
+    "dump_id": 4,
+    "dump_type": "full",
+    "imported_at": 4
+  },
+  {
+    "dump_id": 7,
+    "dump_type": "full",
+    "imported_at": 7
+  },
+  {
+    "dump_id": 2,
+    "dump_type": "incremental",
+    "imported_at": 2
+  },
+  {
+    "dump_id": 3,
+    "dump_type": "incremental",
+    "imported_at": 3
+  },
+  {
+    "dump_id": 4,
+    "dump_type": "incremental",
+    "imported_at": 4
+  },
+  {
+    "dump_id": 5,
+    "dump_type": "incremental",
+    "imported_at": 5
+  },
+  {
+    "dump_id": 6,
+    "dump_type": "incremental",
+    "imported_at": 6
+  },
+  {
+    "dump_id": 7,
+    "dump_type": "incremental",
+    "imported_at": 7
+  },
+  {
+    "dump_id": 8,
+    "dump_type": "incremental",
+    "imported_at": 8
+  }
+]


### PR DESCRIPTION
# Problem
We do not store any information about the current state of listens in HDFS i.e which dumps have been imported. This can easily lead to incorrect state if RC crashes or any other error occurs.

# Solution
Storing information about the dumps imported and their timestamp will solve this issue as we can determine which dumps need to imported.