### PR TITLE
Add recording mbid query to labs-api

### DIFF
--- a/docker/docker-compose-labs-api.yml
+++ b/docker/docker-compose-labs-api.yml
@@ -1,0 +1,26 @@
+version: "3.4"
+
+# IMPORTANT NOTE: Volume paths mounted on containers are relative to the
+# directory that this file is in (`docker/`) and so probably need to start with
+# `../` to refer to a directory in the main code checkout
+
+services:
+
+  labs_api:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      target: listenbrainz-dev
+    environment:
+      FLASK_APP: listenbrainz.labs_api.labs.main 
+      FLASK_ENV: development
+    command: flask run -h 0.0.0.0 -p 80
+    volumes:
+      - ..:/code/listenbrainz:z
+    ports:
+      - "3000:80"
+
+networks:
+  default:
+    external:
+      name: musicbrainzdocker_default

--- a/docker/start-labs-api.sh
+++ b/docker/start-labs-api.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose -f docker/docker-compose-labs-api.yml -p listenbrainz "$@"

--- a/listenbrainz/labs_api/labs/api/artist_credit_from_artist_msid.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_from_artist_msid.py
@@ -60,7 +60,7 @@ class ArtistCreditIdFromArtistMSIDQuery(Query):
 
                     r = dict(row)
                     r['artist_msid'] = str(r['artist_msid'])
-                    r['[artist_credit_mbid]'] = [str(u) for u in r['artist_credit_mbid'][1:-1].split(',')]
+                    r['[artist_credit_mbid]'] = [str(u) for u in r['artist_credit_mbid']]
                     del r['artist_credit_mbid']
                     results.append(r)
 

--- a/listenbrainz/labs_api/labs/api/msb_mapping_stats.py
+++ b/listenbrainz/labs_api/labs/api/msb_mapping_stats.py
@@ -1,0 +1,52 @@
+import json
+from operator import itemgetter
+
+import psycopg2
+import psycopg2.extras
+from flask import current_app
+from datasethoster import Query
+
+
+class MSBMappingStatsQuery(Query):
+
+    def names(self):
+        return ("msb-mapping-stats", "MSB mapping stats")
+
+    def inputs(self):
+        return ['num_entries']
+
+    def introduction(self):
+        return """See the latest X stats entries for the MSB Mapping"""
+
+    def outputs(self):
+        return ['stats_json', 'created']
+
+    def fetch(self, params, count=-1, offset=-1):
+
+        with psycopg2.connect(current_app.config['MB_DATABASE_URI']) as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+
+                query = """SELECT stats AS stats_json,
+                                  created
+                             FROM mapping.mapping_stats
+                         ORDER BY created DESC"""
+                args = []
+                if count > 0:
+                    query += " LIMIT %s"
+                    args.append(count)
+                if offset >= 0:
+                    query += " OFFSET %s"
+                    args.append(offset)
+
+                curs.execute(query, tuple(args))
+                output = []
+                while True:
+                    row = curs.fetchone()
+                    if not row:
+                        break
+
+                    r = dict(row)
+                    r['stats_json'] = json.dumps(r['stats_json'], sort_keys=True, indent=4)
+                    output.append(r)
+
+                return output

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -9,6 +9,7 @@ from datasethoster.main import app, register_query
 
 psycopg2.extras.register_uuid()
 
+
 class RecordingFromRecordingMBIDQuery(Query):
     '''
         Look up a musicbrainz data for a list of recordings, based on MBID.
@@ -29,7 +30,7 @@ class RecordingFromRecordingMBIDQuery(Query):
 
     def fetch(self, params, offset=-1, count=-1):
 
-        mbids = [ p['[recording_mbid]'] for p in params ]
+        mbids = [p['[recording_mbid]'] for p in params]
         with psycopg2.connect(current_app.config['MB_DATABASE_URI']) as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
 
@@ -41,7 +42,7 @@ class RecordingFromRecordingMBIDQuery(Query):
                                ON r.id = rgr.new_id
                             where rgr.gid in %s'''
 
-                args = [tuple([ psycopg2.extensions.adapt(p) for p in mbids ])]
+                args = [tuple([psycopg2.extensions.adapt(p) for p in mbids])]
                 curs.execute(query, tuple(args))
 
                 redirect_index = {}
@@ -72,7 +73,7 @@ class RecordingFromRecordingMBIDQuery(Query):
                          GROUP BY r.gid, r.id, r.name, r.length, r.comment, ac.id, ac.name
                          ORDER BY r.gid'''
 
-                args = [tuple([ psycopg2.extensions.adapt(p) for p in mbids ])]
+                args = [tuple([psycopg2.extensions.adapt(p) for p in mbids])]
                 if count > 0:
                     query += " LIMIT %s"
                     args.append(count)
@@ -90,7 +91,7 @@ class RecordingFromRecordingMBIDQuery(Query):
 
                     r = dict(row)
                     r['recording_mbid'] = str(r['recording_mbid'])
-                    r['[artist_credit_mbids]'] = [ str(r) for r in r['artist_credit_mbids'] ]
+                    r['[artist_credit_mbids]'] = [str(r) for r in r['artist_credit_mbids']]
                     del r['artist_credit_mbids']
                     output.append(r)
 

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -1,0 +1,97 @@
+import sys
+import uuid
+
+import psycopg2
+import psycopg2.extras
+from flask import current_app
+from datasethoster import Query
+from datasethoster.main import app, register_query
+
+psycopg2.extras.register_uuid()
+
+class RecordingFromRecordingMBIDQuery(Query):
+    '''
+        Look up a musicbrainz data for a list of recordings, based on MBID.
+    '''
+
+    def names(self):
+        return ("recording-mbid-lookup", "MusicBrainz Recording by MBID Lookup")
+
+    def inputs(self):
+        return ['[recording_mbid]']
+
+    def introduction(self):
+        return """Look up recording and artist information given a recording MBID"""
+
+    def outputs(self):
+        return ['recording_mbid', 'recording_name', 'length', 'comment',
+                'artist_credit_id', 'artist_credit_name', '[artist_credit_mbids]']
+
+    def fetch(self, params, offset=-1, count=-1):
+
+        mbids = [ p['[recording_mbid]'] for p in params ]
+        with psycopg2.connect(current_app.config['MB_DATABASE_URI']) as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+
+                # First lookup and MBIDs that may have been redirected
+                query = '''SELECT rgr.gid AS recording_mbid_old,
+                                  r.gid AS recording_mbid_new
+                             FROM recording_gid_redirect rgr
+                             JOIN recording r
+                               ON r.id = rgr.new_id
+                            where rgr.gid in %s'''
+
+                args = [tuple([ psycopg2.extensions.adapt(p) for p in mbids ])]
+                curs.execute(query, tuple(args))
+
+                redirect_index = {}
+                while True:
+                    row = curs.fetchone()
+                    if not row:
+                        break
+
+                    r = dict(row)
+                    redirect_index[str(r['recording_mbid_old'])] = str(r['recording_mbid_new'])
+
+                for i, mbid in enumerate(mbids):
+                    if mbid in redirect_index:
+                        mbids[i] = redirect_index[mbid]
+
+                query = '''SELECT r.gid AS recording_mbid, r.name AS recording_name, r.length, r.comment,
+                                  ac.id AS artist_credit_id, ac.name AS artist_credit_name,
+                                  array_agg(a.gid) AS artist_credit_mbids
+                             FROM recording r
+                             JOIN artist_credit ac
+                               ON r.artist_credit = ac.id
+                             JOIN artist_credit_name acn
+                               ON ac.id = acn.artist_credit
+                             JOIN artist a
+                               ON acn.artist = a.id
+                            WHERE r.gid
+                               IN %s
+                         GROUP BY r.gid, r.id, r.name, r.length, r.comment, ac.id, ac.name
+                         ORDER BY r.gid'''
+
+                args = [tuple([ psycopg2.extensions.adapt(p) for p in mbids ])]
+                if count > 0:
+                    query += " LIMIT %s"
+                    args.append(count)
+                if offset >= 0:
+                    query += " OFFSET %s"
+                    args.append(offset)
+
+                curs.execute(query, tuple(args))
+
+                output = []
+                while True:
+                    row = curs.fetchone()
+                    if not row:
+                        break
+
+                    r = dict(row)
+                    r['recording_mbid'] = str(r['recording_mbid'])
+                    r['[artist_credit_mbids]'] = [ str(r) for r in r['artist_credit_mbids'] ]
+                    del r['artist_credit_mbids']
+                    output.append(r)
+
+        return output

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -4,10 +4,14 @@ from datasethoster.main import app, register_query
 from listenbrainz.labs_api.labs.api.artist_country_from_artist_mbid import ArtistCountryFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_mbid import ArtistCreditIdFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_msid import ArtistCreditIdFromArtistMSIDQuery
+from listenbrainz.labs_api.labs.api.msb_mapping_stats import MSBMappingStatsQuery
+from listenbrainz.labs_api.labs.api.recording_from_recording_mbid import RecordingFromRecordingMBIDQuery
 from listenbrainz.webserver import load_config
 
 register_query(ArtistCountryFromArtistMBIDQuery())
 register_query(ArtistCreditIdFromArtistMBIDQuery())
 register_query(ArtistCreditIdFromArtistMSIDQuery())
+register_query(MSBMappingStatsQuery())
+register_query(RecordingFromRecordingMBIDQuery())
 
 load_config(app)

--- a/listenbrainz/labs_api/labs/tests/test_artist_credit_from_artist_msid.py
+++ b/listenbrainz/labs_api/labs/tests/test_artist_credit_from_artist_msid.py
@@ -20,14 +20,14 @@ json_request = [
 
 json_data = [
     {
-        "artist_credit_mbid": "{51ed973d-95c7-4a12-a11c-8c8581a5872a}",
+        "artist_credit_mbid": [ "51ed973d-95c7-4a12-a11c-8c8581a5872a" ],
         "artist_msid": "ea7e58c9-949d-4843-a869-6a93b96ae786",
         "artist_credit_id": 129493,
         "artist_credit_name": "Frank Reyes",
         "artist_msid": "ea7e58c9-949d-4843-a869-6a93b96ae786"
     },
     {
-        "artist_credit_mbid": "{0383dadf-2a4e-4d10-a46a-e9e041da8eb3,5441c29d-3602-4898-b1a1-b77fa23b8e50}",
+        "artist_credit_mbid": [ "0383dadf-2a4e-4d10-a46a-e9e041da8eb3","5441c29d-3602-4898-b1a1-b77fa23b8e50"],
         "artist_msid": "9c1d9739-e40a-47b8-b3be-8076344e51ed",
         "artist_credit_id": 810828,
         "artist_credit_name": "Queen & David Bowie",

--- a/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
@@ -1,0 +1,160 @@
+import os
+import unittest
+from unittest.mock import patch, call, MagicMock
+
+import flask_testing
+import flask
+import psycopg2
+from datasethoster.main import app
+from listenbrainz.labs_api.labs.api.recording_from_recording_mbid import RecordingFromRecordingMBIDQuery
+
+
+json_request = [
+    {
+        "[recording_mbid]": "a96bf3b6-651d-49f4-9a89-eee27cecc18e"
+    },
+    {
+        "[recording_mbid]": "ec5b8aa9-7483-4791-a185-1f599a0cdc35"
+    },
+    {
+        "[recording_mbid]": "1234a7ae-2af2-4291-aa84-bd0bafe291a1"
+    }
+]
+
+redirect_db_response = [
+    {
+        "recording_mbid_old" : "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
+        "recording_mbid_new" : "2f020e89-6e85-4be9-9f04-519ec8ec8cfa"
+    },
+    {
+        "recording_mbid_old" : "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
+        "recording_mbid_new" : "6efd976a-109e-4146-9277-fb2af7d44910"
+    },
+]
+
+json_db_response = [
+    {
+        "artist_credit_mbids": [
+            "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+        ],
+        "artist_credit_id": 65,
+        "artist_credit_name": "Portishead",
+        "comment": "",
+        "length": 253000,
+        "recording_mbid": "1234a7ae-2af2-4291-aa84-bd0bafe291a1",
+        "recording_name": "Sour Times"
+    },
+    {
+        "artist_credit_mbids": [
+            "31810c40-932a-4f2d-8cfd-17849844e2a6"
+        ],
+        "artist_credit_id": 11,
+        "artist_credit_name": "Squirrel Nut Zippers",
+        "comment": "",
+        "length": 228533,
+        "recording_mbid": "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
+        "recording_name": "Bad Businessman"
+    },
+    {
+        "artist_credit_mbids": [
+            "31810c40-932a-4f2d-8cfd-17849844e2a6"
+        ],
+        "artist_credit_id": 11,
+        "artist_credit_name": "Squirrel Nut Zippers",
+        "comment": "",
+        "length": 275333,
+        "recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
+        "recording_name": "Blue Angel"
+    }
+
+]
+
+json_response = [
+    {
+        "[artist_credit_mbids]": [
+            "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+        ],
+        "artist_credit_id": 65,
+        "artist_credit_name": "Portishead",
+        "comment": "",
+        "length": 253000,
+        "recording_mbid": "1234a7ae-2af2-4291-aa84-bd0bafe291a1",
+        "recording_name": "Sour Times"
+    },
+    {
+        "[artist_credit_mbids]": [
+            "31810c40-932a-4f2d-8cfd-17849844e2a6"
+        ],
+        "artist_credit_id": 11,
+        "artist_credit_name": "Squirrel Nut Zippers",
+        "comment": "",
+        "length": 228533,
+        "recording_mbid": "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
+        "recording_name": "Bad Businessman"
+    },
+    {
+        "[artist_credit_mbids]": [
+            "31810c40-932a-4f2d-8cfd-17849844e2a6"
+        ],
+        "artist_credit_id": 11,
+        "artist_credit_name": "Squirrel Nut Zippers",
+        "comment": "",
+        "length": 275333,
+        "recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
+        "recording_name": "Blue Angel"
+    }
+
+]
+
+
+
+
+class MainTestCase(flask_testing.TestCase):
+
+    def create_app(self):
+        app.config['MB_DATABASE_URI'] = 'yermom'
+        return app
+
+    def setUp(self):
+        flask_testing.TestCase.setUp(self)
+
+    def tearDown(self):
+        flask_testing.TestCase.tearDown(self)
+
+    def test_basics(self):
+        q = RecordingFromRecordingMBIDQuery()
+        self.assertEqual(q.names()[0], "recording-mbid-lookup")
+        self.assertEqual(q.names()[1], "MusicBrainz Recording by MBID Lookup")
+        self.assertNotEqual(q.introduction(), "")
+        self.assertEqual(q.inputs(), ['[recording_mbid]'])
+        self.assertEqual(q.outputs(), ['recording_mbid', 'recording_name', 'length', 'comment',
+            'artist_credit_id', 'artist_credit_name', '[artist_credit_mbids]'])
+
+    @patch('psycopg2.connect')
+    def test_fetch(self, mock_connect):
+        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
+            redirect_db_response[1], None, json_db_response[0], json_db_response[1], json_db_response[2], None]
+        q = RecordingFromRecordingMBIDQuery()
+        resp = q.fetch(json_request)
+        self.assertDictEqual(resp[0], json_response[0])
+        self.assertDictEqual(resp[1], json_response[1])
+        self.assertEqual(len(resp), 3)
+
+    @patch('psycopg2.connect')
+    def test_count(self, mock_connect):
+        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
+            redirect_db_response[1], None, json_db_response[0], None]
+        q = RecordingFromRecordingMBIDQuery()
+        resp = q.fetch(json_request, count=1)
+        self.assertEqual(len(resp), 1)
+        self.assertDictEqual(resp[0], json_response[0])
+
+    @patch('psycopg2.connect')
+    def test_offset(self, mock_connect):
+        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
+            redirect_db_response[1], None, json_db_response[1], json_db_response[2], None]
+        q = RecordingFromRecordingMBIDQuery()
+        resp = q.fetch(json_request, offset=1)
+        self.assertEqual(len(resp), 2)
+        self.assertDictEqual(resp[0], json_response[1])
+        self.assertDictEqual(resp[1], json_response[2])

--- a/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
@@ -23,12 +23,12 @@ json_request = [
 
 redirect_db_response = [
     {
-        "recording_mbid_old" : "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
-        "recording_mbid_new" : "2f020e89-6e85-4be9-9f04-519ec8ec8cfa"
+        "recording_mbid_old": "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
+        "recording_mbid_new": "2f020e89-6e85-4be9-9f04-519ec8ec8cfa"
     },
     {
-        "recording_mbid_old" : "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
-        "recording_mbid_new" : "6efd976a-109e-4146-9277-fb2af7d44910"
+        "recording_mbid_old": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
+        "recording_mbid_new": "6efd976a-109e-4146-9277-fb2af7d44910"
     },
 ]
 
@@ -133,7 +133,12 @@ class MainTestCase(flask_testing.TestCase):
     @patch('psycopg2.connect')
     def test_fetch(self, mock_connect):
         mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
-            redirect_db_response[1], None, json_db_response[0], json_db_response[1], json_db_response[2], None]
+                                                                                redirect_db_response[1], 
+                                                                                None, 
+                                                                                json_db_response[0], 
+                                                                                json_db_response[1], 
+                                                                                json_db_response[2], 
+                                                                                None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request)
         self.assertDictEqual(resp[0], json_response[0])
@@ -143,7 +148,10 @@ class MainTestCase(flask_testing.TestCase):
     @patch('psycopg2.connect')
     def test_count(self, mock_connect):
         mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
-            redirect_db_response[1], None, json_db_response[0], None]
+                                                                                redirect_db_response[1], 
+                                                                                None, 
+                                                                                json_db_response[0], 
+                                                                                None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request, count=1)
         self.assertEqual(len(resp), 1)
@@ -152,7 +160,11 @@ class MainTestCase(flask_testing.TestCase):
     @patch('psycopg2.connect')
     def test_offset(self, mock_connect):
         mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
-            redirect_db_response[1], None, json_db_response[1], json_db_response[2], None]
+                                                                                redirect_db_response[1], 
+                                                                                None, 
+                                                                                json_db_response[1], 
+                                                                                json_db_response[2], 
+                                                                                None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request, offset=1)
         self.assertEqual(len(resp), 2)

--- a/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
@@ -132,12 +132,12 @@ class MainTestCase(flask_testing.TestCase):
 
     @patch('psycopg2.connect')
     def test_fetch(self, mock_connect):
-        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
-                                                                                redirect_db_response[1], 
-                                                                                None, 
-                                                                                json_db_response[0], 
-                                                                                json_db_response[1], 
-                                                                                json_db_response[2], 
+        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0],
+                                                                                redirect_db_response[1],
+                                                                                None,
+                                                                                json_db_response[0],
+                                                                                json_db_response[1],
+                                                                                json_db_response[2],
                                                                                 None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request)
@@ -147,10 +147,10 @@ class MainTestCase(flask_testing.TestCase):
 
     @patch('psycopg2.connect')
     def test_count(self, mock_connect):
-        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
-                                                                                redirect_db_response[1], 
-                                                                                None, 
-                                                                                json_db_response[0], 
+        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0],
+                                                                                redirect_db_response[1],
+                                                                                None,
+                                                                                json_db_response[0],
                                                                                 None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request, count=1)
@@ -159,11 +159,11 @@ class MainTestCase(flask_testing.TestCase):
 
     @patch('psycopg2.connect')
     def test_offset(self, mock_connect):
-        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
-                                                                                redirect_db_response[1], 
-                                                                                None, 
-                                                                                json_db_response[1], 
-                                                                                json_db_response[2], 
+        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0],
+                                                                                redirect_db_response[1],
+                                                                                None,
+                                                                                json_db_response[1],
+                                                                                json_db_response[2],
                                                                                 None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request, offset=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ xmltodict == 0.12.0
 oauth2client == 4.1.3
 pika == 0.13.0
 git+https://github.com/metabrainz/brainzutils-python.git@v1.14.1
-git+https://github.com/metabrainz/data-set-hoster.git@v-2020-08-05.0#egg=datasethoster
 spotipy == 2.14.0
+git+https://github.com/metabrainz/data-set-hoster.git@v-2020-08-21.0#egg=datasethoster
 pyyaml == 5.3.1
 eventlet == 0.26.1
 Flask-CORS == 3.0.9


### PR DESCRIPTION
This PR adds the following:

1. Add recording_mbid lookup query to the labs-api
2. add a docker-compose file for local development.
3. A quick-and-dirty MSB mapping stats fetcher -- this has no tests, since this needs a better solution, but for right this second it is better than nothing.