### PR TITLE
generate recommendations weekly to show on website 

### DIFF
--- a/docker/stats-crontab
+++ b/docker/stats-crontab
@@ -59,4 +59,4 @@
 10 03 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=all_time
 
 # Request recommendations every day at 23:00
-00 23 * * * /code/listenbrainz/docker/cf_recommendation.sh cf
+00 23 * * 1 /code/listenbrainz/docker/cf_recommendation.sh cf

--- a/docker/stats-crontab
+++ b/docker/stats-crontab
@@ -58,5 +58,5 @@
 # user weekly daily_activity
 10 03 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=all_time
 
-# Request recommendations every day at 23:00
+# Request recommendations every Monday at 23:00
 00 23 * * 1 /code/listenbrainz/docker/cf_recommendation.sh cf


### PR DESCRIPTION
I have monitored recommendations generation process for a week now; they look stable. Before [#1042](https://github.com/metabrainz/listenbrainz-server/pull/1042) is merged, I want to merge this one since our plan rn is to update recommendations weekly on the site.

With this PR, recommendations will be generated every Monday after incremental/full dump is imported into the spark cluster.