### PR TITLE
Fix bug in SHA validation

### DIFF
--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -105,6 +105,6 @@ class ListenBrainzFTPDownloader:
         """ Reads the SHA file and returns the string stripped of any whitespace and extra characters
         """
         with open(filepath, "r") as f:
-            sha = f.read().lstrip().split(" ", 1)[0]
+            sha = f.read().lstrip().split(" ", 1)[0].strip()
 
         return sha

--- a/listenbrainz_spark/ftp/tests/test_init.py
+++ b/listenbrainz_spark/ftp/tests/test_init.py
@@ -91,6 +91,6 @@ class FTPTestCase(SparkTestCase):
     @patch('ftplib.FTP')
     def test_read_sha_file_(self, mock_ftp_cons):
         mock_ftp = mock_ftp_cons.return_value
-        with patch('listenbrainz_spark.ftp.open', mock_open(read_data='  test  filename  \n'), create=True) as mock_file:
+        with patch('listenbrainz_spark.ftp.open', mock_open(read_data='  test\n filename  \n'), create=True) as mock_file:
             result = listenbrainz_spark.ftp.ListenBrainzFTPDownloader()._read_sha_file("/sha_file.sha256")
             self.assertEqual('test', result)


### PR DESCRIPTION
# Problem
Newline characters in the SHA file cause the SHA validation to fail.

# Solution
Stripping all the leading and trailing whitespaces (including `\n` and `\t`) fixes the issue.