### PR TITLE
Add feed endpoint

### DIFF
--- a/docs/dev/api.rst
+++ b/docs/dev/api.rst
@@ -21,7 +21,7 @@ Core API Endpoints
    :blueprints: api_v1
    :include-empty-docstring:
    :undoc-static:
-   :undoc-endpoints: api_v1.latest_import
+   :undoc-endpoints: api_v1.latest_import, api_v1.user_feed
 
 .. http:get:: /1/latest-import
 

--- a/listenbrainz/db/tests/test_user_relationship.py
+++ b/listenbrainz/db/tests/test_user_relationship.py
@@ -52,3 +52,39 @@ class UserRelationshipTestCase(DatabaseTestCase):
     def test_delete_raises_value_error_for_invalid_relationships(self):
         with self.assertRaises(ValueError):
             db_user_relationship.delete(self.main_user['id'], self.followed_user_1['id'], 'idkwhatrelationshipthisis')
+
+    def test_get_followers_of_user_returns_correct_data(self):
+        # no relationships yet, should return an empty list
+        followers = db_user_relationship.get_followers_of_user(self.followed_user_1['id'])
+        self.assertListEqual(followers, [])
+
+        # add two relationships
+        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
+        self.following_user_1 = db_user.get_or_create(3, 'following_user_1')
+        db_user_relationship.insert(self.following_user_1['id'], self.followed_user_1['id'], 'follow')
+
+        # At this point, the main_user and following_user_1 follow followed_user_1
+        # So, if we get the followers of followed_user_1, we'll get back two users
+        followers = db_user_relationship.get_followers_of_user(self.followed_user_1['id'])
+        self.assertEqual(2, len(followers))
+
+    def test_get_following_for_user_returns_correct_data(self):
+
+        # no relationships yet, should return an empty list
+        following = db_user_relationship.get_following_for_user(self.main_user['id'])
+        self.assertListEqual(following, [])
+
+        # make the main_user follow followed_user_1
+        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
+
+        # the list of users main_user is following should have 1 element now
+        following = db_user_relationship.get_following_for_user(self.main_user['id'])
+        self.assertEqual(1, len(following))
+
+        # make it so that the main user follows two users, followed_user_1 and followed_user_2
+        self.followed_user_2 = db_user.get_or_create(3, 'followed_user_2')
+        db_user_relationship.insert(self.main_user['id'], self.followed_user_2['id'], 'follow')
+
+        # the list of users main_user is following should have 2 elements now
+        following = db_user_relationship.get_following_for_user(self.main_user['id'])
+        self.assertEqual(2, len(following))

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def create(musicbrainz_row_id, musicbrainz_id):
+def create(musicbrainz_row_id: int, musicbrainz_id: str) -> int:
     """Create a new user.
 
     Args:
@@ -177,7 +177,7 @@ def get_user_count():
             raise
 
 
-def get_or_create(musicbrainz_row_id, musicbrainz_id):
+def get_or_create(musicbrainz_row_id: int, musicbrainz_id: str) -> dict:
     """Get user with a specified MusicBrainz ID, or create if there's no account.
 
     Args:

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -76,7 +76,7 @@ def delete(user_0: int, user_1: int, relationship_type: str) -> None:
 def get_followers_for_user(followed: int) -> list:
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT "user".musicbrainz_id AS user_name
+            SELECT "user".musicbrainz_id AS musicbrainz_id
               FROM user_relationship
               JOIN "user"
                 ON "user".id = user_0
@@ -91,7 +91,7 @@ def get_followers_for_user(followed: int) -> list:
 def get_following_for_user(follower: int) -> list:
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT "user".musicbrainz_id AS user_name
+            SELECT "user".musicbrainz_id AS musicbrainz_id
               FROM user_relationship
               JOIN "user"
                 ON "user".id = user_1

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -16,6 +16,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+from typing import List
+
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
 
@@ -73,7 +75,10 @@ def delete(user_0: int, user_1: int, relationship_type: str) -> None:
             "relationship_type": relationship_type,
         })
 
-def get_followers_for_user(followed: int) -> list:
+
+def get_followers_of_user(user: int) -> List[dict]:
+    """ Returns a list of users who follow the specified user.
+    """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT "user".musicbrainz_id AS musicbrainz_id
@@ -84,21 +89,24 @@ def get_followers_for_user(followed: int) -> list:
                AND relationship_type = 'follow'
 
         """), {
-            "followed": followed,
+            "followed": user,
         })
         return [dict(row) for row in result.fetchall()]
 
-def get_following_for_user(follower: int) -> list:
+
+def get_following_for_user(user: int) -> List[dict]:
+    """ Returns a list of users who the specified user follows.
+    """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT "user".musicbrainz_id AS musicbrainz_id
               FROM user_relationship
               JOIN "user"
                 ON "user".id = user_1
-             WHERE user_0 = :follower
+             WHERE user_0 = :user
                AND relationship_type = 'follow'
 
         """), {
-            "follower": follower,
+            "user": user,
         })
         return [dict(row) for row in result.fetchall()]

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -72,3 +72,33 @@ def delete(user_0: int, user_1: int, relationship_type: str) -> None:
             "user_1": user_1,
             "relationship_type": relationship_type,
         })
+
+def get_followers_for_user(followed: int) -> list:
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT "user".musicbrainz_id AS user_name
+              FROM user_relationship
+              JOIN "user"
+                ON "user".id = user_0
+             WHERE user_1 = :followed
+               AND relationship_type = 'follow'
+
+        """), {
+            "followed": followed,
+        })
+        return [dict(row) for row in result.fetchall()]
+
+def get_following_for_user(follower: int) -> list:
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT "user".musicbrainz_id AS user_name
+              FROM user_relationship
+              JOIN "user"
+                ON "user".id = user_1
+             WHERE user_0 = :follower
+               AND relationship_type = 'follow'
+
+        """), {
+            "follower": follower,
+        })
+        return [dict(row) for row in result.fetchall()]

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -232,7 +232,6 @@ class TimescaleListenStore(ListenStore):
 
         return self.fetch_listens_for_multiple_users_from_storage([user_name], from_ts, to_ts, limit, order, time_range)
 
-
     def fetch_listens_for_multiple_users_from_storage(self, user_names: List[str], from_ts: float, to_ts: float, limit: int, order: int, time_range: int=3):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
             the value they are converted to the local server's timezone. So to compare

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -230,10 +230,10 @@ class TimescaleListenStore(ListenStore):
                         which is slow and should be avoided if at all possible.
         """
 
-        return self.fetch_listen_for_multiple_users_from_storage([user_name], from_ts, to_ts, limit, order, time_range)
+        return self.fetch_listens_for_multiple_users_from_storage([user_name], from_ts, to_ts, limit, order, time_range)
 
 
-    def fetch_listen_for_multiple_users_from_storage(self, user_names: List[str], from_ts: float, to_ts: float, limit: int, order: int, time_range: int=3):
+    def fetch_listens_for_multiple_users_from_storage(self, user_names: List[str], from_ts: float, to_ts: float, limit: int, order: int, time_range: int=3):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
             the value they are converted to the local server's timezone. So to compare
             datetime object we need to create a object in the same timezone as the server.

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -23,6 +23,7 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
 
+
 class ListenAPIIntegrationTestCase(IntegrationTestCase):
     def setUp(self):
         super(ListenAPIIntegrationTestCase, self).setUp()

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -1,9 +1,17 @@
-
+import json
 import sys
 import os
+import listenbrainz.db.user as db_user
+from flask import current_app, url_for
 
+from redis import Redis
+from listenbrainz import config
 from listenbrainz.webserver.testing import ServerTestCase, APICompatServerTestCase
 from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.db import timescale as ts
+
+TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'admin', 'timescale')
+
 
 class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
 
@@ -14,6 +22,47 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
     def tearDown(self):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
+
+class ListenAPIIntegrationTestCase(IntegrationTestCase):
+    def setUp(self):
+        super(ListenAPIIntegrationTestCase, self).setUp()
+        self.user = db_user.get_or_create(1, 'testuserpleaseignore')
+
+    def tearDown(self):
+        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
+        r.flushall()
+        self.reset_timescale_db()
+        super(ListenAPIIntegrationTestCase, self).tearDown()
+
+    def reset_timescale_db(self):
+
+        ts.init_db_connection(config.TIMESCALE_ADMIN_URI)
+        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'drop_db.sql'))
+        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_db.sql'))
+        ts.engine.dispose()
+
+        ts.init_db_connection(config.TIMESCALE_ADMIN_LB_URI)
+        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_extensions.sql'))
+        ts.engine.dispose()
+
+        ts.init_db_connection(config.SQLALCHEMY_TIMESCALE_URI)
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_tables.sql'))
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_functions.sql'))
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_views.sql'))
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_indexes.sql'))
+        ts.engine.dispose()
+
+    def send_data(self, payload, user=None):
+        """ Sends payload to api.submit_listen and return the response
+        """
+        if not user:
+            user = self.user
+        return self.client.post(
+            url_for('api_v1.submit_listen'),
+            data=json.dumps(payload),
+            headers={'Authorization': 'Token {}'.format(user['auth_token'])},
+            content_type='application/json'
+        )
 
 
 class APICompatIntegrationTestCase(APICompatServerTestCase, DatabaseTestCase):

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -15,7 +15,6 @@ from listenbrainz import config
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
 
-
 class APITestCase(ListenAPIIntegrationTestCase):
 
     def test_get_listens(self):
@@ -82,7 +81,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
         # test request with both max_ts and min_ts is working
         url = url_for('api_v1.get_listens', user_name=self.user['musicbrainz_id'])
-        
+
         response = self.client.get(url, query_string={'max_ts': ts + 1000,'min_ts': ts - 1000})
         self.assert200(response)
         data = json.loads(response.data)['payload']
@@ -98,9 +97,9 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(data['listens'][0]['track_metadata']['artist_name'], 'Kanye West')
         self.assertEqual(data['listens'][0]['track_metadata']['release_name'], 'The Life of Pablo')
 
-        # CHeck api throws error 400 if min_ts is greater than max_ts    
+        # CHeck api throws error 400 if min_ts is greater than max_ts
         response = self.client.get(url, query_string={'max_ts': '1400000000','min_ts':'1500000000'})
-            
+
         # check that recent listens are fetched correctly
         url = url_for('api_v1.get_recent_listens_for_user_list', user_list=self.user['musicbrainz_id'])
         response = self.client.get(url, query_string={'limit': '1'})

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -3,7 +3,7 @@ import os
 import uuid
 import unittest
 
-from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from listenbrainz.db import timescale as ts
 from listenbrainz.webserver.errors import APINotFound
 from flask import url_for, current_app
@@ -14,38 +14,9 @@ import json
 from listenbrainz import config
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
-TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'admin', 'timescale')
 
 
-class APITestCase(IntegrationTestCase):
-
-    def setUp(self):
-        super(APITestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'testuserpleaseignore')
-
-    def tearDown(self):
-        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
-        r.flushall()
-        self.reset_timescale_db()
-        super(APITestCase, self).tearDown()
-
-    def reset_timescale_db(self):
-
-        ts.init_db_connection(config.TIMESCALE_ADMIN_URI)
-        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'drop_db.sql'))
-        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_db.sql'))
-        ts.engine.dispose()
-
-        ts.init_db_connection(config.TIMESCALE_ADMIN_LB_URI)
-        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_extensions.sql'))
-        ts.engine.dispose()
-
-        ts.init_db_connection(config.SQLALCHEMY_TIMESCALE_URI)
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_tables.sql'))
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_functions.sql'))
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_views.sql'))
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_indexes.sql'))
-        ts.engine.dispose()
+class APITestCase(ListenAPIIntegrationTestCase):
 
     def test_get_listens(self):
         """ Test to make sure that the api sends valid listens on get requests.
@@ -245,17 +216,6 @@ class APITestCase(IntegrationTestCase):
         self.assertEqual(data['listens'][1]['listened_at'], 1400000100)
         self.assertEqual(data['listens'][2]['listened_at'], 1400000000)
 
-    def send_data(self, payload, user=None):
-        """ Sends payload to api.submit_listen and return the response
-        """
-        if not user:
-            user=self.user
-        return self.client.post(
-            url_for('api_v1.submit_listen'),
-            data=json.dumps(payload),
-            headers={'Authorization': 'Token {}'.format(self.user['auth_token'])},
-            content_type='application/json'
-        )
 
     def test_zero_listens_payload(self):
         """ Test that API returns 400 for payloads with no listens

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -1,0 +1,13 @@
+from listenbrainz.tests.integration.test_api import APITestCase
+from flask import url_for, current_app
+
+class FeedAPITestCase(APITestCase):
+
+    def test_it_sends_listens_for_users_that_are_being_followed(self):
+        pass
+
+    def test_it_returns_not_found_for_non_existent_user(self):
+        pass
+
+    def test_it_honors_max_ts_and_min_ts(self):
+        pass

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -24,6 +24,7 @@ import listenbrainz.db.user_relationship as db_user_relationship
 import time
 import json
 
+
 class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
     def create_and_follow_user(self, user: int, mb_row_id: int, name: str) -> dict:
@@ -73,7 +74,6 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(ts, payload['feed'][1]['listened_at'])
         self.assertEqual('following_1', payload['feed'][1]['user_name'])
 
-
     def test_it_returns_not_found_for_non_existent_user(self):
         r = self.client.get('/1/user/doesntexistlol/feed/listens')
         self.assert404(r)
@@ -96,14 +96,13 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         time.sleep(5)
 
-
         # max_ts = 2, should have sent back 2 listens
-        r = self.client.get('/1/user/param/feed/listens', query_string={'max_ts': ts +  2})
+        r = self.client.get('/1/user/param/feed/listens', query_string={'max_ts': ts + 2})
         self.assert200(r)
         self.assertEqual(2, r.json['payload']['count'])
 
         # max_ts = 4, should have sent back 6 listens
-        r = self.client.get('/1/user/param/feed/listens', query_string={'max_ts': ts +  2})
+        r = self.client.get('/1/user/param/feed/listens', query_string={'max_ts': ts + 2})
         self.assert200(r)
         self.assertEqual(2, r.json['payload']['count'])
 

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -1,13 +1,128 @@
-from listenbrainz.tests.integration.test_api import APITestCase
+# listenbrainz-server - Server for the ListenBrainz project.
+#
+# Copyright (C) 2020 Param Singh <iliekcomputers@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from flask import url_for, current_app
 
-class FeedAPITestCase(APITestCase):
+import listenbrainz.db.user as db_user
+import listenbrainz.db.user_relationship as db_user_relationship
+import time
+import json
+
+class FeedAPITestCase(ListenAPIIntegrationTestCase):
+
+    def create_and_follow_user(self, user: int, mb_row_id: int, name: str) -> dict:
+        following_user = db_user.get_or_create(mb_row_id, name)
+        db_user_relationship.insert(user, following_user['id'], 'follow')
+        return following_user
+
+    def setUp(self):
+        super(FeedAPITestCase, self).setUp()
+        self.main_user = db_user.get_or_create(100, 'param')
+        self.following_user_1 = self.create_and_follow_user(self.main_user['id'], 102, 'following_1')
+        self.following_user_2 = self.create_and_follow_user(self.main_user['id'], 103, 'following_2')
 
     def test_it_sends_listens_for_users_that_are_being_followed(self):
-        pass
+        with open(self.path_to_data_file('valid_single.json'), 'r') as f:
+            payload = json.load(f)
+
+        ts = int(time.time())
+        # send a listen for the following_user_1
+        payload['payload'][0]['listened_at'] = ts
+        response = self.send_data(payload, user=self.following_user_1)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
+
+        # send a listen with a higher timestamp for following_user_2
+        payload['payload'][0]['listened_at'] = ts + 1
+        response = self.send_data(payload, user=self.following_user_2)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
+
+        # This sleep allows for the timescale subscriber to take its time in getting
+        # the listen submitted from redis and writing it to timescale.
+        time.sleep(2)
+
+        response = self.client.get(url_for('api_v1.user_feed', user_name=self.main_user['musicbrainz_id']))
+        self.assert200(response)
+        payload = response.json['payload']
+
+        # should contain 2 listens
+        self.assertEqual(2, payload['count'])
+
+        # first listen should have higher timestamp and user should be following_2
+        self.assertEqual(ts + 1, payload['feed'][0]['listened_at'])
+        self.assertEqual('following_2', payload['feed'][0]['user_name'])
+
+        # second listen should have lower timestamp and user should be following_1
+        self.assertEqual(ts, payload['feed'][1]['listened_at'])
+        self.assertEqual('following_1', payload['feed'][1]['user_name'])
+
 
     def test_it_returns_not_found_for_non_existent_user(self):
-        pass
+        r = self.client.get('/1/user/doesntexistlol/feed/listens')
+        self.assert404(r)
 
-    def test_it_honors_max_ts_and_min_ts(self):
-        pass
+    def test_it_honors_request_parameters(self):
+        with open(self.path_to_data_file('valid_single.json'), 'r') as f:
+            payload = json.load(f)
+
+        # send a listen per user with timestamp 1, 2, 3
+        ts = int(time.time())
+        for i in range(1, 4):
+            payload['payload'][0]['listened_at'] = ts + i
+            response = self.send_data(payload, user=self.following_user_1)
+            self.assert200(response)
+            self.assertEqual(response.json['status'], 'ok')
+
+            response = self.send_data(payload, user=self.following_user_2)
+            self.assert200(response)
+            self.assertEqual(response.json['status'], 'ok')
+
+        time.sleep(5)
+
+
+        # max_ts = 2, should have sent back 2 listens
+        r = self.client.get('/1/user/param/feed/listens', query_string={'max_ts': ts +  2})
+        self.assert200(r)
+        self.assertEqual(2, r.json['payload']['count'])
+
+        # max_ts = 4, should have sent back 6 listens
+        r = self.client.get('/1/user/param/feed/listens', query_string={'max_ts': ts +  2})
+        self.assert200(r)
+        self.assertEqual(2, r.json['payload']['count'])
+
+        # min_ts = 1, should have sent back 4 listens
+        r = self.client.get('/1/user/param/feed/listens', query_string={'min_ts': ts + 1})
+        self.assert200(r)
+        self.assertEqual(4, r.json['payload']['count'])
+
+        # min_ts = 2, should have sent back 2 listens
+        r = self.client.get('/1/user/param/feed/listens', query_string={'min_ts': ts + 2})
+        self.assert200(r)
+        self.assertEqual(2, r.json['payload']['count'])
+
+        # min_ts = 1, max_ts = 3, should have sent back 2 listens
+        r = self.client.get('/1/user/param/feed/listens', query_string={'min_ts': ts + 1, 'max_ts': ts + 3})
+        self.assert200(r)
+        self.assertEqual(2, r.json['payload']['count'])
+
+        # should honor count
+        r = self.client.get('/1/user/param/feed/listens', query_string={'count': 1})
+        self.assert200(r)
+        self.assertEqual(1, r.json['payload']['count'])

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -140,7 +140,7 @@ def user_feed(user_name: str):
     if min_ts is None and max_ts is None:
         max_ts = int(time.time())
 
-    user =  db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(user_name)
     if not user:
         raise APINotFound(f"User {user_name} not found")
 
@@ -152,7 +152,7 @@ def user_feed(user_name: str):
         from_ts=min_ts,
         to_ts=max_ts,
         time_range=time_range,
-        order=1, # descending
+        order=1,  # descending
     )
     listen_data = []
     for listen in listens:

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -127,6 +127,11 @@ def get_listens(user_name):
     }})
 
 
+@api_bp.route('/user/<user_name>/feed/events', methods=['OPTIONS', 'GET'])
+def user_feed():
+    return jsonify({"data": []})
+
+
 @api_bp.route("/user/<user_name>/listen-count")
 @crossdomain()
 @ratelimit()

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -229,6 +229,12 @@ def unfollow_user(user_name: str):
 
     return jsonify({"status": 200, "message": "Success!"})
 
+@user_bp.route('/feed/events', methods=['OPTIONS', 'GET'])
+@login_required
+def user_feed():
+    user = _get_user(user_name)
+    return jsonify({"data": [])
+
 
 def _get_user(user_name):
     """ Get current username """

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -236,6 +236,30 @@ def user_feed():
     return jsonify({"data": [])
 
 
+@user_bp.route('/<user_name>/get-followers')
+def get_followers(user_name: str):
+    user = _get_user(user_name)
+    try:
+        followers = db_user_relationship.get_followers_for_user(user.id)
+    except Exception:
+        current_app.logger.critical("Error while trying to fetch followers", exc_info=True)
+        raise APIInternalServerError("Something went wrong, please try again later")
+
+    return jsonify({"followers": followers})
+
+
+@user_bp.route('/<user_name>/get-following')
+def get_following(user_name: str):
+    user = _get_user(user_name)
+    try:
+        following = db_user_relationship.get_following_for_user(user.id)
+    except Exception:
+        current_app.logger.critical("Error while trying to fetch following", exc_info=True)
+        raise APIInternalServerError("Something went wrong, please try again later")
+
+    return jsonify({"following": following})
+
+
 def _get_user(user_name):
     """ Get current username """
     if current_user.is_authenticated and \

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -229,12 +229,6 @@ def unfollow_user(user_name: str):
 
     return jsonify({"status": 200, "message": "Success!"})
 
-@user_bp.route('/feed/events', methods=['OPTIONS', 'GET'])
-@login_required
-def user_feed():
-    user = _get_user(user_name)
-    return jsonify({"data": [])
-
 
 @user_bp.route('/<user_name>/get-followers')
 def get_followers(user_name: str):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -230,30 +230,6 @@ def unfollow_user(user_name: str):
     return jsonify({"status": 200, "message": "Success!"})
 
 
-@user_bp.route('/<user_name>/get-followers')
-def get_followers(user_name: str):
-    user = _get_user(user_name)
-    try:
-        followers = db_user_relationship.get_followers_for_user(user.id)
-    except Exception:
-        current_app.logger.critical("Error while trying to fetch followers", exc_info=True)
-        raise APIInternalServerError("Something went wrong, please try again later")
-
-    return jsonify({"followers": followers})
-
-
-@user_bp.route('/<user_name>/get-following')
-def get_following(user_name: str):
-    user = _get_user(user_name)
-    try:
-        following = db_user_relationship.get_following_for_user(user.id)
-    except Exception:
-        current_app.logger.critical("Error while trying to fetch following", exc_info=True)
-        raise APIInternalServerError("Something went wrong, please try again later")
-
-    return jsonify({"following": following})
-
-
 def _get_user(user_name):
     """ Get current username """
     if current_user.is_authenticated and \


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
The followers table isn't used anywhere. We need a feed endpoint that lists listens of the people you follow.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

* Add a new endpoint which takes the exact same parameters as the get-listens endpoint. I've done some refactoring of the timescale listenstore code and the get listens API code to do this.
* Add tests for the Feed API endpoint, I wanted the tests in a different file because the test_api file is already huge, so I refactored some common logic out into a seperate class which both api tests and feed api tests inherit from.
* I'm not documenting the endpoint yet because it will most probably change as we start seeing how it works and figure out kinks.



