### PR TITLE
Update youtube track title if in "buffering" state

### DIFF
--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -53,7 +53,10 @@ export default class YoutubePlayer
       onTrackEnd();
       return;
     }
-    if (state === YouTube.PlayerState.UNSTARTED) {
+    if (
+      state === YouTube.PlayerState.UNSTARTED ||
+      state === YouTube.PlayerState.BUFFERING
+    ) {
       const { onTrackInfoChange } = this.props;
       const title = _get(player, "playerInfo.videoData.title", "");
       onTrackInfoChange(title);


### PR DESCRIPTION
There was an issue when playing a youtube video right after one that didn't play (for example not allowed to play video outside of youtube website), where the player would be in state "buffering" instead of state "unstarted".
Consequently the beginning of a new video wasn't recognised and the previous video's title would stay on the player.
This PR reacts to the "buffering" state in the same way as "unstarted" and sets the video title of the new video correctly.
