### PR TITLE
update logging level from error to info of rating beyond the range messages

### DIFF
--- a/listenbrainz_spark/recommendations/recommend.py
+++ b/listenbrainz_spark/recommendations/recommend.py
@@ -262,10 +262,10 @@ def check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df):
     min_rating = min(similar_artist_rec_df.select(func.min('rating').alias('rating')).take(1)[0].rating, min_rating)
 
     if max_rating > 1.0:
-        current_app.logger.error('Some ratings are greater than 1 \nMax rating: {}'.format(max_rating))
+        current_app.logger.info('Some ratings are greater than 1 \nMax rating: {}'.format(max_rating))
 
     if min_rating < -1.0:
-        current_app.logger.error('Some ratings are less than -1 \nMin rating: {}'.format(min_rating))
+        current_app.logger.info('Some ratings are less than -1 \nMin rating: {}'.format(min_rating))
 
 
 def create_messages(top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_user_count, total_time,

--- a/listenbrainz_spark/recommendations/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/tests/test_recommend.py
@@ -407,7 +407,7 @@ class RecommendTestClass(SparkTestCase):
 
         recommend.check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df)
 
-        mock_current_app.logger.error.assert_has_calls([
+        mock_current_app.logger.info.assert_has_calls([
             call('Some ratings are greater than 1 \nMax rating: 1.8'),
             call('Some ratings are less than -1 \nMin rating: -2.8')
         ])


### PR DESCRIPTION
We now have an idea about the range of ratings assigned by the recommender to the recordings, therefore the logs in sentry aren't required. 