### PR TITLE
Add original_recording_mbid

### DIFF
--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -95,7 +95,10 @@ class RecordingFromRecordingMBIDQuery(Query):
                     r['recording_mbid'] = str(r['recording_mbid'])
                     r['[artist_credit_mbids]'] = [str(r) for r in r['artist_credit_mbids']]
                     del r['artist_credit_mbids']
-                    r['original_recording_mbid'] = inverse_redirect_index[str(r['recording_mbid'])]
+                    try:
+                        r['original_recording_mbid'] = inverse_redirect_index[str(r['recording_mbid'])]
+                    except KeyError:
+                        r['original_recording_mbid'] = str(r['recording_mbid'])
                     output.append(r)
 
         return output

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -36,8 +36,8 @@ class RecordingFromRecordingMBIDQuery(Query):
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
 
                 # First lookup and MBIDs that may have been redirected
-                query = '''SELECT rgr.gid AS recording_mbid_old,
-                                  r.gid AS recording_mbid_new
+                query = '''SELECT rgr.gid::TEXT AS recording_mbid_old,
+                                  r.gid::TEXT AS recording_mbid_new
                              FROM recording_gid_redirect rgr
                              JOIN recording r
                                ON r.id = rgr.new_id
@@ -54,16 +54,16 @@ class RecordingFromRecordingMBIDQuery(Query):
                         break
 
                     r = dict(row)
-                    redirect_index[str(r['recording_mbid_old'])] = str(r['recording_mbid_new'])
+                    redirect_index[r['recording_mbid_old']] = r['recording_mbid_new']
 
                 # Now start looking up actual recordings
                 for i, mbid in enumerate(mbids):
                     if mbid in redirect_index:
                         mbids[i] = redirect_index[mbid]
 
-                query = '''SELECT r.gid AS recording_mbid, r.name AS recording_name, r.length, r.comment,
+                query = '''SELECT r.gid::TEXT AS recording_mbid, r.name AS recording_name, r.length, r.comment,
                                   ac.id AS artist_credit_id, ac.name AS artist_credit_name,
-                                  array_agg(a.gid) AS artist_credit_mbids,
+                                  array_agg(a.gid)::TEXT[] AS artist_credit_mbids,
                                   first_release_date_year AS year
                              FROM recording r
                              JOIN artist_credit ac
@@ -90,43 +90,40 @@ class RecordingFromRecordingMBIDQuery(Query):
                 args = [tuple([psycopg2.extensions.adapt(p) for p in mbids])]
                 curs.execute(query, tuple(args))
 
-                # Build an index of all the fetched recordings and clean up UUID() -> str
+                # Build an index of all the fetched recordings
                 recording_index = {}
                 while True:
                     row = curs.fetchone()
                     if not row:
                         break
 
-                    r = dict(row)
-                    mbid = str(r['recording_mbid'])
-                    r['recording_mbid'] = mbid
-                    recording_index[mbid] = dict(row)
+                    recording_index[row['recording_mbid']] = dict(row)
 
-                # Finally collate all the results, ensuring that we have one entry with original_recording_mbid for each 
+                # Finally collate all the results, ensuring that we have one entry with original_recording_mbid for each
                 # input argument
                 output = []
                 for p in params:
-                    mbid = p['[recording_mbid]'] 
+                    mbid = p['[recording_mbid]']
                     try:
                         r = copy.copy(recording_index[mbid])
                     except KeyError:
                         try:
                             r = copy.copy(recording_index[redirect_index[mbid]])
                         except KeyError:
-                            out = {} 
-                            for k in self.outputs():
-                                if k == 'original_recording_mbid':
-                                    out['original_recording_mbid'] = mbid
-                                else:
-                                    out['original_recording_mbid'] = None
+                            out = dict.fromkeys(self.outputs(), None)
+                            out['original_recording_mbid'] = mbid
                             output.append(out)
                             continue
 
-                    r['[artist_credit_mbids]'] = list(set([str(r) for r in r['artist_credit_mbids']]))
+                    r['[artist_credit_mbids]'] = list(set([r for r in r['artist_credit_mbids']]))
                     del r['artist_credit_mbids']
                     r['original_recording_mbid'] = mbid
                     output.append(r)
 
+                # Ideally offset and count should be handled by the postgres query itself, but the 1:1 relationship
+                # of what the user requests and what we need to fetch is no longer true, so we can't easily use LIMIT/OFFSET.
+                # We might be able to use a RIGHT JOIN to fix this, but for now I'm happy to leave this as it. We need to
+                # revisit this when we get closer to pushing recommendation tools to production.
                 if offset > 0 and count > 0:
                     return output[offset:offset+count]
 

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -25,8 +25,8 @@ class RecordingFromRecordingMBIDQuery(Query):
         return """Look up recording and artist information given a recording MBID"""
 
     def outputs(self):
-        return ['recording_mbid', 'recording_name', 'length', 'comment',
-                'artist_credit_id', 'artist_credit_name', '[artist_credit_mbids]']
+        return ['recording_mbid', 'recording_name', 'length', 'comment', 'artist_credit_id',
+                'artist_credit_name', '[artist_credit_mbids]', 'original_recording_mbid']
 
     def fetch(self, params, offset=-1, count=-1):
 
@@ -46,6 +46,7 @@ class RecordingFromRecordingMBIDQuery(Query):
                 curs.execute(query, tuple(args))
 
                 redirect_index = {}
+                inverse_redirect_index = {}
                 while True:
                     row = curs.fetchone()
                     if not row:
@@ -53,6 +54,7 @@ class RecordingFromRecordingMBIDQuery(Query):
 
                     r = dict(row)
                     redirect_index[str(r['recording_mbid_old'])] = str(r['recording_mbid_new'])
+                    inverse_redirect_index[str(r['recording_mbid_new'])] = str(r['recording_mbid_old'])
 
                 for i, mbid in enumerate(mbids):
                     if mbid in redirect_index:
@@ -93,6 +95,7 @@ class RecordingFromRecordingMBIDQuery(Query):
                     r['recording_mbid'] = str(r['recording_mbid'])
                     r['[artist_credit_mbids]'] = [str(r) for r in r['artist_credit_mbids']]
                     del r['artist_credit_mbids']
+                    r['original_recording_mbid'] = inverse_redirect_index[str(r['recording_mbid'])]
                     output.append(r)
 
         return output

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -115,7 +115,7 @@ class RecordingFromRecordingMBIDQuery(Query):
                             output.append(out)
                             continue
 
-                    r['[artist_credit_mbids]'] = list(set([r for r in r['artist_credit_mbids']]))
+                    r['[artist_credit_mbids]'] = list(set(r['artist_credit_mbids']))
                     del r['artist_credit_mbids']
                     r['original_recording_mbid'] = mbid
                     output.append(r)

--- a/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
@@ -15,21 +15,14 @@ json_request = [
     },
     {
         "[recording_mbid]": "ec5b8aa9-7483-4791-a185-1f599a0cdc35"
-    },
-    {
-        "[recording_mbid]": "1234a7ae-2af2-4291-aa84-bd0bafe291a1"
     }
 ]
 
 redirect_db_response = [
     {
         "recording_mbid_old": "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
-        "recording_mbid_new": "2f020e89-6e85-4be9-9f04-519ec8ec8cfa"
-    },
-    {
-        "recording_mbid_old": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
-        "recording_mbid_new": "6efd976a-109e-4146-9277-fb2af7d44910"
-    },
+        "recording_mbid_new": "1234a7ae-2af2-4291-aa84-bd0bafe291a1"
+    }
 ]
 
 json_db_response = [
@@ -43,17 +36,6 @@ json_db_response = [
         "length": 253000,
         "recording_mbid": "1234a7ae-2af2-4291-aa84-bd0bafe291a1",
         "recording_name": "Sour Times"
-    },
-    {
-        "artist_credit_mbids": [
-            "31810c40-932a-4f2d-8cfd-17849844e2a6"
-        ],
-        "artist_credit_id": 11,
-        "artist_credit_name": "Squirrel Nut Zippers",
-        "comment": "",
-        "length": 228533,
-        "recording_mbid": "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
-        "recording_name": "Bad Businessman"
     },
     {
         "artist_credit_mbids": [
@@ -79,18 +61,8 @@ json_response = [
         "comment": "",
         "length": 253000,
         "recording_mbid": "1234a7ae-2af2-4291-aa84-bd0bafe291a1",
-        "recording_name": "Sour Times"
-    },
-    {
-        "[artist_credit_mbids]": [
-            "31810c40-932a-4f2d-8cfd-17849844e2a6"
-        ],
-        "artist_credit_id": 11,
-        "artist_credit_name": "Squirrel Nut Zippers",
-        "comment": "",
-        "length": 228533,
-        "recording_mbid": "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
-        "recording_name": "Bad Businessman"
+        "recording_name": "Sour Times",
+        "original_recording_mbid": "a96bf3b6-651d-49f4-9a89-eee27cecc18e"
     },
     {
         "[artist_credit_mbids]": [
@@ -101,7 +73,8 @@ json_response = [
         "comment": "",
         "length": 275333,
         "recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
-        "recording_name": "Blue Angel"
+        "recording_name": "Blue Angel",
+        "original_recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35"
     }
 
 ]
@@ -128,27 +101,24 @@ class MainTestCase(flask_testing.TestCase):
         self.assertNotEqual(q.introduction(), "")
         self.assertEqual(q.inputs(), ['[recording_mbid]'])
         self.assertEqual(q.outputs(), ['recording_mbid', 'recording_name', 'length', 'comment',
-            'artist_credit_id', 'artist_credit_name', '[artist_credit_mbids]'])
+            'artist_credit_id', 'artist_credit_name', '[artist_credit_mbids]', 'original_recording_mbid'])
 
     @patch('psycopg2.connect')
     def test_fetch(self, mock_connect):
         mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0],
-                                                                                redirect_db_response[1],
                                                                                 None,
                                                                                 json_db_response[0],
                                                                                 json_db_response[1],
-                                                                                json_db_response[2],
                                                                                 None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request)
         self.assertDictEqual(resp[0], json_response[0])
         self.assertDictEqual(resp[1], json_response[1])
-        self.assertEqual(len(resp), 3)
+        self.assertEqual(len(resp), 2)
 
     @patch('psycopg2.connect')
     def test_count(self, mock_connect):
         mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0],
-                                                                                redirect_db_response[1],
                                                                                 None,
                                                                                 json_db_response[0],
                                                                                 None]
@@ -160,13 +130,10 @@ class MainTestCase(flask_testing.TestCase):
     @patch('psycopg2.connect')
     def test_offset(self, mock_connect):
         mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0],
-                                                                                redirect_db_response[1],
                                                                                 None,
                                                                                 json_db_response[1],
-                                                                                json_db_response[2],
                                                                                 None]
         q = RecordingFromRecordingMBIDQuery()
         resp = q.fetch(json_request, offset=1)
-        self.assertEqual(len(resp), 2)
+        self.assertEqual(len(resp), 1)
         self.assertDictEqual(resp[0], json_response[1])
-        self.assertDictEqual(resp[1], json_response[2])

--- a/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
@@ -45,7 +45,8 @@ json_db_response = [
         "comment": "",
         "length": 253000,
         "recording_mbid": "1234a7ae-2af2-4291-aa84-bd0bafe291a1",
-        "recording_name": "Sour Times"
+        "recording_name": "Sour Times",
+        "year": None
     },
     {
         "artist_credit_mbids": [
@@ -56,7 +57,8 @@ json_db_response = [
         "comment": "",
         "length": 275333,
         "recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
-        "recording_name": "Blue Angel"
+        "recording_name": "Blue Angel",
+        "year": 2009
     },
     {
         "artist_credit_mbids": [
@@ -67,7 +69,8 @@ json_db_response = [
         "comment": "",
         "length": 111666,
         "recording_mbid": "1636e7a9-229d-446d-aa81-e33071b42d7a",
-        "recording_name": "Strange Ways"
+        "recording_name": "Strange Ways",
+        "year": 2004
     }
 ]
 
@@ -82,7 +85,8 @@ json_response = [
         "length": 253000,
         "recording_mbid": "1234a7ae-2af2-4291-aa84-bd0bafe291a1",
         "recording_name": "Sour Times",
-        "original_recording_mbid": "a96bf3b6-651d-49f4-9a89-eee27cecc18e"
+        "original_recording_mbid": "a96bf3b6-651d-49f4-9a89-eee27cecc18e",
+        "year": None
     },
     {
         "[artist_credit_mbids]": [
@@ -94,7 +98,8 @@ json_response = [
         "length": 275333,
         "recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
         "recording_name": "Blue Angel",
-        "original_recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35"
+        "original_recording_mbid": "ec5b8aa9-7483-4791-a185-1f599a0cdc35",
+        "year": 2009
     },
     {
         "[artist_credit_mbids]": [
@@ -106,7 +111,8 @@ json_response = [
         "length": 111666,
         "recording_mbid": "1636e7a9-229d-446d-aa81-e33071b42d7a",
         "recording_name": "Strange Ways",
-        "original_recording_mbid": "5948f779-0b96-4eba-b6a7-d1f0f6c7cf9f"
+        "original_recording_mbid": "5948f779-0b96-4eba-b6a7-d1f0f6c7cf9f",
+        "year": 2004
     },
     {
         "[artist_credit_mbids]": [
@@ -119,6 +125,7 @@ json_response = [
         "recording_mbid": "1636e7a9-229d-446d-aa81-e33071b42d7a",
         "recording_name": "Strange Ways",
         "original_recording_mbid": "1636e7a9-229d-446d-aa81-e33071b42d7a",
+        "year": 2004
     }
 ]
 
@@ -141,7 +148,7 @@ class MainTestCase(flask_testing.TestCase):
         self.assertNotEqual(q.introduction(), "")
         self.assertEqual(q.inputs(), ['[recording_mbid]'])
         self.assertEqual(q.outputs(), ['recording_mbid', 'recording_name', 'length', 'comment',
-            'artist_credit_id', 'artist_credit_name', '[artist_credit_mbids]', 'original_recording_mbid'])
+            'artist_credit_id', 'artist_credit_name', '[artist_credit_mbids]', 'original_recording_mbid', 'year'])
 
     @patch('psycopg2.connect')
     def test_fetch(self, mock_connect):

--- a/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
@@ -152,7 +152,7 @@ class MainTestCase(flask_testing.TestCase):
 
     @patch('psycopg2.connect')
     def test_fetch(self, mock_connect):
-        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0], 
+        mock_connect().__enter__().cursor().__enter__().fetchone.side_effect = [redirect_db_response[0],
                                                                                 redirect_db_response[1],
                                                                                 None,
                                                                                 json_db_response[0],
@@ -207,4 +207,3 @@ class MainTestCase(flask_testing.TestCase):
         resp = q.fetch(json_request, count=1, offset=1)
         self.assertEqual(len(resp), 1)
         self.assertDictEqual(resp[0], json_response[1])
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ oauth2client == 4.1.3
 pika == 0.13.0
 git+https://github.com/metabrainz/brainzutils-python.git@v1.14.1
 spotipy == 2.14.0
-git+https://github.com/metabrainz/data-set-hoster.git@v-2020-08-21.0#egg=datasethoster
+git+https://github.com/metabrainz/data-set-hoster.git@v-2020-10-20.0#egg=datasethoster
 pyyaml == 5.3.1
 eventlet == 0.26.1
 Flask-CORS == 3.0.9


### PR DESCRIPTION
If more than one recording in a lookup was redirected it was impossible to reconcile which one was redirected. Adding the original_recording_mbid column fixes this problem.