### PR TITLE
[WIP]LB-547: Use mapping for calculating artist statistics

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -93,12 +93,14 @@ def send_request_to_spark_cluster(message):
               help="Time range of statistics to calculate", required=True)
 @click.option("--entity", type=click.Choice(['artists', 'releases', 'recordings']),
               help="Entity for which statistics should be calculated")
-def request_user_stats(type_, range_, entity):
+@click.option("--use-mapping", type=bool, help="Set to true if MSID-MBID mapping should be used while calculating statistics")
+def request_user_stats(type_, range_, entity, use_mapping):
     """ Send a user stats request to the spark cluster
     """
     params = {}
     if type_ == 'entity' and entity:
         params['entity'] = entity
+        params['use_mapping'] = use_mapping
     try:
         send_request_to_spark_cluster(_prepare_query_message(
             'stats.user.{type}.{range}'.format(range=range_, type=type_), params=params))

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -2,22 +2,22 @@
   "stats.user.entity.week": {
     "name": "stats.user.entity.week",
     "description": "Entity statistics for all users in the last week",
-    "params": ["entity"]
+    "params": ["entity", "use_mapping"]
   },
   "stats.user.entity.month": {
     "name": "stats.user.entity.month",
     "description": "Entity statistics for all users in the last month",
-    "params": ["entity"]
+    "params": ["entity", "use_mapping"]
   },
   "stats.user.entity.year": {
     "name": "stats.user.entity.year",
     "description": "Entity statistics for all users in the last year",
-    "params": ["entity"]
+    "params": ["entity", "use_mapping"]
   },
   "stats.user.entity.all_time": {
     "name": "stats.user.entity.all_time",
     "description": "All time entity statistics for all users",
-    "params": ["entity"]
+    "params": ["entity", "use_mapping"]
   },
   "stats.user.listening_activity.week": {
     "name": "stats.user.listening_activity.week",

--- a/listenbrainz/spark/test_request_manage.py
+++ b/listenbrainz/spark/test_request_manage.py
@@ -61,20 +61,25 @@ class RequestManageTestCase(unittest.TestCase):
             request_manage._prepare_query_message('stats.user.entity.week', {})
 
     def test_prepare_query_message_happy_path(self):
-        expected_message = ujson.dumps({'query': 'stats.user.entity.week', 'params': {'entity': 'test'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity.week', params={'entity': 'test'})
+        expected_message = ujson.dumps({'query': 'stats.user.entity.week', 'params': {'entity': 'test', 'use_mapping': False}})
+        received_message = request_manage._prepare_query_message('stats.user.entity.week',
+                                                                 params={'entity': 'test', 'use_mapping': False})
         self.assertEqual(expected_message, received_message)
 
-        expected_message = ujson.dumps({'query': 'stats.user.entity.month', 'params': {'entity': 'test'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity.month', params={'entity': 'test'})
+        expected_message = ujson.dumps({'query': 'stats.user.entity.month', 'params': {'entity': 'test', 'use_mapping': False}})
+        received_message = request_manage._prepare_query_message('stats.user.entity.month',
+                                                                 params={'entity': 'test', 'use_mapping': False})
         self.assertEqual(expected_message, received_message)
 
-        expected_message = ujson.dumps({'query': 'stats.user.entity.year', 'params': {'entity': 'test'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity.year', params={'entity': 'test'})
+        expected_message = ujson.dumps({'query': 'stats.user.entity.year', 'params': {'entity': 'test', 'use_mapping': False}})
+        received_message = request_manage._prepare_query_message('stats.user.entity.year',
+                                                                 params={'entity': 'test', 'use_mapping': False})
         self.assertEqual(expected_message, received_message)
 
-        expected_message = ujson.dumps({'query': 'stats.user.entity.all_time', 'params': {'entity': 'test'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity.all_time', params={'entity': 'test'})
+        expected_message = ujson.dumps({'query': 'stats.user.entity.all_time', 'params': {
+                                       'entity': 'test', 'use_mapping': False}})
+        received_message = request_manage._prepare_query_message('stats.user.entity.all_time',
+                                                                 params={'entity': 'test', 'use_mapping': False})
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.listening_activity.week'})

--- a/listenbrainz_spark/stats/user/artist.py
+++ b/listenbrainz_spark/stats/user/artist.py
@@ -1,13 +1,15 @@
+import listenbrainz_spark.stats.utils as stat_utils
 from listenbrainz_spark.stats import run_query
 from pyspark.sql.functions import collect_list, sort_array, struct
 
 
-def get_artists(table):
+def get_artists(table: str, use_mapping: bool):
     """ Get artist information (artist_name, artist_msid etc) for every user
         ordered by listen count
 
         Args:
-            table (str): name of the temporary table.
+            table: Name of the temporary table.
+            use_mapping: True if MSID-MBID mapping should be used.
 
         Returns:
             iterator (iter): an iterator over result
@@ -21,9 +23,16 @@ def get_artists(table):
                         user2: [{...}],
                     }
     """
+    listens_df = run_query(f"SELECT * FROM {table}")
+    if use_mapping:
+        mapped_listens, unmapped_listens = stat_utils.create_mapped_dataframe(listens_df)
+    else:
+        unmapped_listens = listens_df
 
+    # Calculate stats for unmapped listens
+    unmapped_listens.createOrReplaceTempView("unmapped_listens")
     result = run_query("""
-              WITH intermediate_table as (
+              WITH intermediate_table AS (
                 SELECT user_name
                      , artist_name
                      , CASE
@@ -31,16 +40,38 @@ def get_artists(table):
                          ELSE nullif(artist_msid, '')
                        END as artist_msid
                      , artist_mbids
-                  FROM {table}
+                  FROM unmapped_listens
               )
             SELECT *
-                 , count(*) as listen_count
+                 , COUNT(*) AS listen_count
               FROM intermediate_table
           GROUP BY user_name
                  , artist_name
                  , artist_msid
                  , artist_mbids
-            """.format(table=table))
+            """)
+
+    # Calculate stats for mapped listens and merge it with the stats for unmapped listens
+    if use_mapping:
+        mapped_listens.createOrReplaceTempView("mapped_listens")
+        result.union(run_query("""
+                  WITH intermediate_table AS (
+                    SELECT user_name
+                         , mb_artist_credit_name AS artist_name
+                         , CASE
+                             WHEN cardinality(artist_mbids) > 0 THEN artist_mbids
+                             ELSE mb_artist_credit_mbids
+                           END as artist_mbids
+                         , NULL AS artist_msid
+                      FROM mapped_listens
+                  )
+                SELECT *
+                     , COUNT(*) AS listen_count
+                  FROM intermediate_table
+              GROUP BY user_name
+                     , artist_name
+                     , artist_mbids
+            """))
 
     iterator = result \
         .withColumn("artists", struct("listen_count", "artist_name", "artist_msid", "artist_mbids")) \

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -34,7 +34,7 @@ entity_model_map = {
 }
 
 
-def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
+def get_entity_week(entity: str, use_mapping: bool) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the weekly top entity for all users """
     current_app.logger.debug("Calculating {}_week...".format(entity))
 
@@ -49,7 +49,7 @@ def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     filtered_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
-    data = handler(table_name)
+    data = handler(table_name, use_mapping)
     messages = create_messages(data=data, entity=entity, stats_range='week',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
@@ -58,7 +58,7 @@ def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     return messages
 
 
-def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
+def get_entity_month(entity: str, use_mapping: bool) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the month top entity for all users """
     current_app.logger.debug("Calculating {}_month...".format(entity))
 
@@ -70,7 +70,7 @@ def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
-    data = handler(table_name)
+    data = handler(table_name, use_mapping)
 
     messages = create_messages(data=data, entity=entity, stats_range='month',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
@@ -80,7 +80,7 @@ def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     return messages
 
 
-def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
+def get_entity_year(entity: str, use_mapping: bool) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the year top entity for all users """
     current_app.logger.debug("Calculating {}_year...".format(entity))
 
@@ -92,7 +92,7 @@ def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
-    data = handler(table_name)
+    data = handler(table_name, use_mapping)
     messages = create_messages(data=data, entity=entity, stats_range='year',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
@@ -101,7 +101,7 @@ def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     return messages
 
 
-def get_entity_all_time(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
+def get_entity_all_time(entity: str, use_mapping: bool) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the all_time top entity for all users """
     current_app.logger.debug("Calculating {}_all_time...".format(entity))
 
@@ -113,7 +113,7 @@ def get_entity_all_time(entity: str) -> Iterator[Optional[UserEntityStatMessage]
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
-    data = handler(table_name)
+    data = handler(table_name, use_mapping)
     messages = create_messages(data=data, entity=entity, stats_range='all_time',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 

--- a/listenbrainz_spark/stats/user/recording.py
+++ b/listenbrainz_spark/stats/user/recording.py
@@ -2,7 +2,8 @@ from listenbrainz_spark.stats import run_query
 from pyspark.sql.functions import collect_list, sort_array, struct
 
 
-def get_recordings(table):
+# TODO: Use mapping for improving stats quality
+def get_recordings(table: str, use_mapping: bool):
     """
     Get recording information (recording_name, recording_mbid etc) for every user
     ordered by listen count (number of times a user has listened to the track/recording).

--- a/listenbrainz_spark/stats/user/release.py
+++ b/listenbrainz_spark/stats/user/release.py
@@ -2,7 +2,8 @@ from listenbrainz_spark.stats import run_query
 from pyspark.sql.functions import collect_list, sort_array, struct
 
 
-def get_releases(table):
+# TODO: Use mapping for improving stats quality
+def get_releases(table: str, use_mapping: bool):
     """
     Get release information (release_name, release_mbid etc) for every user
     ordered by listen count (number of times a user has listened to tracks

--- a/listenbrainz_spark/stats/utils.py
+++ b/listenbrainz_spark/stats/utils.py
@@ -59,17 +59,17 @@ def create_mapped_dataframe(listens_df):
         unmapped_listens: DataFrame consisting unmapped listens
     """
     # Fetch mapping from HDFS
-    msid_mbid_mapping_df = utils.get_unique_rows_from_mapping(utils.read_files_from_HDFS(MBID_MSID_MAPPING))
+    msid_mbid_mapping_df = mapping_utils.get_unique_rows_from_mapping(utils.read_files_from_HDFS(MBID_MSID_MAPPING))
 
     # Create matchable fields from listens table
-    matchable_df = utils.convert_text_fields_to_matchable(listens_df)
+    matchable_df = mapping_utils.convert_text_fields_to_matchable(listens_df)
 
     # Map listens
     join_condition = [
-        listens_df.track_name_matchable == msid_mbid_mapping_df.msb_recording_name_matchable,
-        listens_df.artist_name_matchable == msid_mbid_mapping_df.msb_artist_credit_name_matchable
+        matchable_df.track_name_matchable == msid_mbid_mapping_df.msb_recording_name_matchable,
+        matchable_df.artist_name_matchable == msid_mbid_mapping_df.msb_artist_credit_name_matchable
     ]
-    mapped_listens = listens_df.join(msid_mbid_mapping_df, join_condition, 'inner')
-    unmapped_listens = listens_df.join(msid_mbid_mapping_df, join_condition, 'left_anti')
+    mapped_listens = matchable_df.join(msid_mbid_mapping_df, join_condition, 'inner')
+    unmapped_listens = matchable_df.join(msid_mbid_mapping_df, join_condition, 'left_anti')
 
     return mapped_listens, unmapped_listens


### PR DESCRIPTION
# Problem
Some artists get entries get repeated because of slight difference in names, different MSIDs because of different metadata. All these entries should be combined into one.

# Solution
Using MSID-MBID mapping to get clean data from MusicBrainz should fix this issue. It also provides benefits such as getting MBIDs for artists and correcting their names.

# Action
I have tested the code using subset of mapping on my local machine but we should test it with the full mapping on production server to make sure that we don't run into `OOM` issues and the results are actually better than before.

# Note
Should be merged after #1115