### PR TITLE
Upgrade pip in to avoid random failing builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /code
 
 RUN mkdir /code/listenbrainz
 WORKDIR /code/listenbrainz
-
+RUN pip3 install -U pip
 COPY requirements.txt /code/listenbrainz/
 RUN pip3 install --no-cache-dir -r requirements.txt
 RUN useradd --create-home --shell /bin/bash listenbrainz


### PR DESCRIPTION
Travis builds are failing randomly with the error.
```
Exception:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 176, in main
    status = self.run(options, args)
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 346, in run
    session=session, autobuilding=True
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/wheel.py", line 886, in build
    assert have_directory_for_build
AssertionError
You are using pip version 19.0.1,
```
According to https://github.com/pypa/pip/issues/6197, this is fixed in 19.0.2. Hence, upgrading `pip`.