### PR TITLE
Add test interface to BU metrics storage

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -236,6 +236,7 @@ def _register_blueprints(app):
     from listenbrainz.webserver.views.login import login_bp
     from listenbrainz.webserver.views.api import api_bp
     from listenbrainz.webserver.views.api_compat import api_bp as api_bp_compat
+    from listenbrainz.webserver.views.api_metrics import api_metrics_bp
     from listenbrainz.webserver.views.user import user_bp
     from listenbrainz.webserver.views.profile import profile_bp
     from listenbrainz.webserver.views.follow import follow_bp
@@ -253,6 +254,7 @@ def _register_blueprints(app):
     app.register_blueprint(profile_bp, url_prefix='/profile')
     app.register_blueprint(follow_bp, url_prefix='/follow')
     app.register_blueprint(player_bp, url_prefix='/player')
+    app.register_blueprint(api_metrics_bp, url_prefix='/internal/metrics')
     app.register_blueprint(api_bp, url_prefix=API_PREFIX)
     app.register_blueprint(follow_api_bp, url_prefix=API_PREFIX+'/follow')
     app.register_blueprint(stats_api_bp, url_prefix=API_PREFIX+'/stats')

--- a/listenbrainz/webserver/views/api_metrics.py
+++ b/listenbrainz/webserver/views/api_metrics.py
@@ -1,0 +1,17 @@
+# Internal metrics stored by LB for use in MetaBrainz monitoring systems
+from flask import Blueprint, jsonify
+
+from brainzutils import metrics
+
+api_metrics_bp = Blueprint('api_metrics', __name__)
+
+
+@api_metrics_bp.route('/increment/<metric_name>')
+def increment_metric(metric_name):
+    metrics.increment(metric_name)
+    return jsonify({'status': 'ok'})
+
+
+@api_metrics_bp.route('/stats/<metric_name>')
+def stats(metric_name):
+    return jsonify(metrics.stats(metric_name))

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ yattag == 1.14.0
 xmltodict == 0.12.0
 oauth2client == 4.1.3
 pika == 0.13.0
-git+https://github.com/metabrainz/brainzutils-python.git@v1.14.1
+git+https://github.com/metabrainz/brainzutils-python.git@timeseries-stats
 spotipy == 2.14.0
 git+https://github.com/metabrainz/data-set-hoster.git@v-2020-08-21.0#egg=datasethoster
 pyyaml == 5.3.1


### PR DESCRIPTION
# Problem

This is a test branch to integrate numerical metrics storage in redis and make it available to the metabrainz granfa stats system.

# Solution

Add two internal api methods, `/internal/metrics/increment/<metricname>` and `/internal/metrics/stats/<metricname>` to store and retrieve stats.

I wasn't sure if we should add the stats endpoint to the existing API url structure, as it's not something that needs to be used by end-users. Should we stay with a separate prefix like `/internal/`?

# Action

Deploy this branch on test or beta, and check that we can read the stats from telegraf and show on granfa. If it works as expected, release a new version of BU and use it to add stats to LB

