### PR TITLE
Moved listen sumbitters from api docs to separate page.

### DIFF
--- a/listenbrainz/webserver/templates/index/api-docs.html
+++ b/listenbrainz/webserver/templates/index/api-docs.html
@@ -6,16 +6,4 @@
   If you would like to use our API to submit/fetch listens from ListenBrainz, please take a look at
   <a href="https://listenbrainz.readthedocs.org">API documentation</a>.
 
-  <h2>Listen Submitters</h2>
-    These are programs that submit listens to ListenBrainz.
-  <ul>
-    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, a flexible, powerful, server-side application for playing music: <a href="https://github.com/kori/libra"><code>libra</code></a></li>
-    <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>
-    <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
-    <li><em><a href="https://github.com/InputUsername/rescrobbled">Rescrobbled</a></em>, a universal Linux scrobbler for MPRIS enabled players</li>
-    <li><em><a href="https://add0n.com/lastfm-scrobbler.html">Last.fm Scrobbler</a></em>, an extension for Firefox and Chrome</li>
-    <li><em><a href="https://github.com/tgwizard/sls">Simple Last.fm Scrobbler</a></em>, for Android devices</li>
-    <li><em><a href="https://github.com/amCap1712/vlc-listenbrainz-plugin">VLC Listenbrainz plugin</a></em>, cross-platform plugin for VLC player</li>
-  </ul>
-
 {%- endblock -%}

--- a/listenbrainz/webserver/templates/index/listen-submitters.html
+++ b/listenbrainz/webserver/templates/index/listen-submitters.html
@@ -1,0 +1,17 @@
+{%- extends 'base.html' -%}
+{%- block title -%}Listen Submitters< - ListenBrainz{%- endblock -%}
+{%- block content -%}
+
+  <h2 class="page-title">Listen Submitters</h2>
+    These are programs that submit listens to ListenBrainz.
+  <ul>
+    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, a flexible, powerful, server-side application for playing music: <a href="https://github.com/kori/libra"><code>libra</code></a></li>
+    <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>
+    <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
+    <li><em><a href="https://github.com/InputUsername/rescrobbled">Rescrobbled</a></em>, a universal Linux scrobbler for MPRIS enabled players</li>
+    <li><em><a href="https://add0n.com/lastfm-scrobbler.html">Last.fm Scrobbler</a></em>, an extension for Firefox and Chrome</li>
+    <li><em><a href="https://github.com/tgwizard/sls">Simple Last.fm Scrobbler</a></em>, for Android devices</li>
+    <li><em><a href="https://github.com/amCap1712/vlc-listenbrainz-plugin">VLC Listenbrainz plugin</a></em>, cross-platform plugin for VLC player</li>
+  </ul>
+
+{%- endblock -%}

--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -48,6 +48,7 @@
             <li><a href="{{ url_for('index.data') }}">Data</a></li>
             <li><a href="{{ url_for('index.api_docs') }}">API Docs</a></li>
             <li><a href="{{ url_for('index.roadmap') }}">Roadmap</a></li>
+            <li><a href="{{ url_for('index.listen_submitters') }}">Listen Submitters</a></li>
           </ul>
         </li>
     </ul>

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -85,6 +85,11 @@ def api_docs():
     return render_template("index/api-docs.html")
 
 
+@index_bp.route("/listen-submitters")
+def listen_submitters():
+    return render_template("index/listen-submitters.html")
+
+
 @index_bp.route("/lastfm-proxy")
 def proxy():
     return render_template("index/lastfm-proxy.html")


### PR DESCRIPTION
# Problem 
Listen submitters is different fro api docs. Thus, it would be difficult for the user to find it.

# Solution
Moved listen submitters from api docs to it's separate pages. Made required changes  in the navigation bar.
