### PR TITLE
Fix bug in code for tracking imported data into spark cluster

### DIFF
--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -4,13 +4,14 @@
 import shutil
 import tempfile
 import time
-from flask import current_app
+from datetime import datetime
 
 import listenbrainz_spark.request_consumer.jobs.utils as utils
-from datetime import datetime
+from flask import current_app
+from listenbrainz_spark.exceptions import DumpNotFoundException
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
-from listenbrainz_spark.exceptions import DumpNotFoundException
+from listenbrainz_spark.request_consumer import request_consumer
 
 
 def import_dump_to_hdfs(dump_type, overwrite, dump_id=None):
@@ -64,6 +65,7 @@ def import_newest_incremental_dump_handler():
                     current_app.logger.error(f"Error while importing incremental dump with ID {dump_id}: {e}", exc_info=True)
                     break
             dump_id += 1
+            request_consumer.rc.ping()
     return [{
         'type': 'import_incremental_dump',
         'imported_dump': imported_dumps,

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
@@ -97,6 +97,7 @@ class ImporterUtilsTestCase(SparkTestCase):
         self.assertFalse(import_utils.search_dump(7, "incremental", datetime.fromtimestamp(9)))
         import_utils.insert_dump_data(7, "incremental", datetime.fromtimestamp(9))
         self.assertTrue(import_utils.search_dump(7, "incremental", datetime.fromtimestamp(9)))
+        self.assertTrue(import_utils.search_dump(2, "incremental", datetime.fromtimestamp(2)))
 
     def test_insert_dump_data_file_missing(self):
         """ Test to ensure a file is created if it is missing. """

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -62,7 +62,7 @@ def insert_dump_data(dump_id: int, dump_type: str, imported_at: datetime):
     data = create_dataframe(Row(dump_id, dump_type, imported_at), schema=import_metadata_schema)
     if import_meta_df:
         result = import_meta_df \
-            .filter(f"dump_id != '{dump_id}' AND dump_type != '{dump_type}'") \
+            .filter(f"dump_id != '{dump_id}' OR dump_type != '{dump_type}'") \
             .union(data)
     else:
         result = data

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -33,6 +33,8 @@ from py4j.protocol import Py4JJavaError
 
 RABBITMQ_HEARTBEAT_TIME = 2 * 60 * 60  # 2 hours -- a full dump import takes 40 minutes right now
 
+rc = None
+
 
 class RequestConsumer:
 
@@ -157,10 +159,16 @@ class RequestConsumer:
                 current_app.logger.critical("Error in spark-request-consumer: %s", str(e), exc_info=True)
                 time.sleep(2)
 
+    def ping(self):
+        """ Sends a heartbeat to rabbitmq to avoid closing the connection during long processes """
+        self.rabbitmq.process_data_events(0)
+
 
 def main(app_name):
     listenbrainz_spark.init_spark_session(app_name)
-    RequestConsumer().run()
+    global rc
+    rc = RequestConsumer()
+    rc.run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Problem
There was a bug in the code that inserted information about latest imported dump which lead to multiple imports of the same dump.

# Solution
The above mentioned bug has been fixed and the tests have been modified to ensure that it doesn't occur in the future again.

# Action
We should test this on the cluster once and then re-enable the cron-job for importing data daily.