### PR TITLE
Improve error management in BrainzPlayer

### DIFF
--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
   isEqual as _isEqual,
+  isNil as _isNil,
   isString as _isString,
   get as _get,
 } from "lodash";
@@ -164,7 +165,7 @@ export default class BrainzPlayer extends React.Component<
       title || "Playback error",
       _isString(error)
         ? error
-        : `${error.status && `Error ${error.status}:`} ${
+        : `${!_isNil(error.status) && `Error ${error.status}:`} ${
             error.message || error.statusText
           }`
     );

--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -28,7 +28,7 @@ export type DataSourceProps = {
   onTrackInfoChange: (title: string, artist?: string) => void;
   onTrackEnd: () => void;
   onTrackNotFound: () => void;
-  handleError: (error: string | Error, title?: string) => void;
+  handleError: (error: ErrorForAlert, title?: string) => void;
   handleWarning: (message: string | JSX.Element, title?: string) => void;
   handleSuccess: (message: string | JSX.Element, title?: string) => void;
   onInvalidateDataSource: (
@@ -154,7 +154,7 @@ export default class BrainzPlayer extends React.Component<
     this.playListen(nextListen);
   };
 
-  handleError = (error: string | Error, title?: string): void => {
+  handleError = (error: ErrorForAlert, title?: string): void => {
     const { newAlert } = this.props;
     if (!error) {
       return;
@@ -162,7 +162,11 @@ export default class BrainzPlayer extends React.Component<
     newAlert(
       "danger",
       title || "Playback error",
-      typeof error === "object" ? error.message : error
+      _isString(error)
+        ? error
+        : `${error.status && `Error ${error.status}:`} ${
+            error.message || error.statusText
+          }`
     );
   };
 
@@ -276,7 +280,7 @@ export default class BrainzPlayer extends React.Component<
       }
       await dataSource.togglePlay();
     } catch (error) {
-      this.handleError(error.message);
+      this.handleError(error);
     }
   };
 

--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -29,7 +29,7 @@ export type DataSourceProps = {
   onTrackInfoChange: (title: string, artist?: string) => void;
   onTrackEnd: () => void;
   onTrackNotFound: () => void;
-  handleError: (error: ErrorForAlert, title?: string) => void;
+  handleError: (error: BrainzPlayerError, title?: string) => void;
   handleWarning: (message: string | JSX.Element, title?: string) => void;
   handleSuccess: (message: string | JSX.Element, title?: string) => void;
   onInvalidateDataSource: (
@@ -155,7 +155,7 @@ export default class BrainzPlayer extends React.Component<
     this.playListen(nextListen);
   };
 
-  handleError = (error: ErrorForAlert, title?: string): void => {
+  handleError = (error: BrainzPlayerError, title?: string): void => {
     const { newAlert } = this.props;
     if (!error) {
       return;

--- a/listenbrainz/webserver/static/js/src/SoundcloudPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SoundcloudPlayer.test.tsx
@@ -13,7 +13,7 @@ const props = {
   onTrackInfoChange: (title: string, artist?: string) => {},
   onTrackEnd: () => {},
   onTrackNotFound: () => {},
-  handleError: (error: ErrorForAlert, title?: string) => {},
+  handleError: (error: BrainzPlayerError, title?: string) => {},
   handleWarning: (message: string | JSX.Element, title?: string) => {},
   handleSuccess: (message: string | JSX.Element, title?: string) => {},
   onInvalidateDataSource: (

--- a/listenbrainz/webserver/static/js/src/SoundcloudPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SoundcloudPlayer.test.tsx
@@ -13,7 +13,7 @@ const props = {
   onTrackInfoChange: (title: string, artist?: string) => {},
   onTrackEnd: () => {},
   onTrackNotFound: () => {},
-  handleError: (error: string | Error, title?: string) => {},
+  handleError: (error: ErrorForAlert, title?: string) => {},
   handleWarning: (message: string | JSX.Element, title?: string) => {},
   handleSuccess: (message: string | JSX.Element, title?: string) => {},
   onInvalidateDataSource: (

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
@@ -19,7 +19,7 @@ const props = {
   onTrackInfoChange: (title: string, artist?: string) => {},
   onTrackEnd: () => {},
   onTrackNotFound: () => {},
-  handleError: (error: ErrorForAlert, title?: string) => {},
+  handleError: (error: BrainzPlayerError, title?: string) => {},
   handleWarning: (message: string | JSX.Element, title?: string) => {},
   handleSuccess: (message: string | JSX.Element, title?: string) => {},
   onInvalidateDataSource: (

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
@@ -19,7 +19,7 @@ const props = {
   onTrackInfoChange: (title: string, artist?: string) => {},
   onTrackEnd: () => {},
   onTrackNotFound: () => {},
-  handleError: (error: string | Error, title?: string) => {},
+  handleError: (error: ErrorForAlert, title?: string) => {},
   handleWarning: (message: string | JSX.Element, title?: string) => {},
   handleSuccess: (message: string | JSX.Element, title?: string) => {},
   onInvalidateDataSource: (

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.test.tsx
@@ -13,7 +13,7 @@ const props = {
   onTrackInfoChange: (title: string, artist?: string) => {},
   onTrackEnd: () => {},
   onTrackNotFound: () => {},
-  handleError: (error: ErrorForAlert, title?: string) => {},
+  handleError: (error: BrainzPlayerError, title?: string) => {},
   handleWarning: (message: string | JSX.Element, title?: string) => {},
   handleSuccess: (message: string | JSX.Element, title?: string) => {},
   onInvalidateDataSource: (

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.test.tsx
@@ -13,7 +13,7 @@ const props = {
   onTrackInfoChange: (title: string, artist?: string) => {},
   onTrackEnd: () => {},
   onTrackNotFound: () => {},
-  handleError: (error: string | Error, title?: string) => {},
+  handleError: (error: ErrorForAlert, title?: string) => {},
   handleWarning: (message: string | JSX.Element, title?: string) => {},
   handleSuccess: (message: string | JSX.Element, title?: string) => {},
   onInvalidateDataSource: (

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
@@ -169,15 +169,17 @@ describe("submitFeedback", () => {
     const instance = wrapper.instance();
     instance.handleError = jest.fn();
 
+    const error = new Error("error");
     const spy = jest.spyOn(instance.APIService, "submitFeedback");
     spy.mockImplementation(() => {
-      throw new Error("error");
+      throw error;
     });
 
     instance.submitFeedback(-1);
     expect(instance.handleError).toHaveBeenCalledTimes(1);
     expect(instance.handleError).toHaveBeenCalledWith(
-      "Error while submitting feedback - error"
+      error,
+      "Error while submitting feedback"
     );
   });
 });
@@ -281,15 +283,17 @@ describe("deleteListen", () => {
     const instance = wrapper.instance();
     instance.handleError = jest.fn();
 
+    const error = new Error("error");
     const spy = jest.spyOn(instance.APIService, "deleteListen");
     spy.mockImplementation(() => {
-      throw new Error("error");
+      throw error;
     });
 
     instance.deleteListen();
     expect(instance.handleError).toHaveBeenCalledTimes(1);
     expect(instance.handleError).toHaveBeenCalledWith(
-      "Error while deleting listen - error"
+      error,
+      "Error while deleting listen"
     );
   });
 });

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -1,7 +1,7 @@
 import * as timeago from "time-ago";
 
 import * as React from "react";
-import { get as _get, isNil as _isNil, isString as _isString } from "lodash";
+import { get as _get } from "lodash";
 import MediaQuery from "react-responsive";
 import {
   faMusic,
@@ -130,7 +130,7 @@ export default class ListenCard extends React.Component<
     }
   };
 
-  handleError = (error: ErrorForAlert, title?: string): void => {
+  handleError = (error: string | Error, title?: string): void => {
     const { newAlert } = this.props;
     if (!error) {
       return;
@@ -138,11 +138,7 @@ export default class ListenCard extends React.Component<
     newAlert(
       "danger",
       title || "Error",
-      _isString(error)
-        ? error
-        : `${!_isNil(error.status) && `Error ${error.status}:`} ${
-            error.message || error.statusText
-          }`
+      typeof error === "object" ? error.message : error
     );
   };
 

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -1,7 +1,7 @@
 import * as timeago from "time-ago";
 
 import * as React from "react";
-import { get as _get, isString as _isString } from "lodash";
+import { get as _get, isNil as _isNil, isString as _isString } from "lodash";
 import MediaQuery from "react-responsive";
 import {
   faMusic,
@@ -140,7 +140,9 @@ export default class ListenCard extends React.Component<
       title || "Error",
       _isString(error)
         ? error
-        : `${error.status && `Error ${error.status}:`} ${error.message}`
+        : `${!_isNil(error.status) && `Error ${error.status}:`} ${
+            error.message || error.statusText
+          }`
     );
   };
 

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -1,7 +1,7 @@
 import * as timeago from "time-ago";
 
 import * as React from "react";
-import { get as _get } from "lodash";
+import { get as _get, isString as _isString } from "lodash";
 import MediaQuery from "react-responsive";
 import {
   faMusic,
@@ -90,7 +90,7 @@ export default class ListenCard extends React.Component<
           updateFeedback(recordingMSID, score);
         }
       } catch (error) {
-        this.handleError(`Error while submitting feedback - ${error.message}`);
+        this.handleError(error, "Error while submitting feedback");
       }
     }
   };
@@ -125,12 +125,12 @@ export default class ListenCard extends React.Component<
           }, 1000);
         }
       } catch (error) {
-        this.handleError(`Error while deleting listen - ${error.message}`);
+        this.handleError(error, "Error while deleting listen");
       }
     }
   };
 
-  handleError = (error: string | Error, title?: string): void => {
+  handleError = (error: ErrorForAlert, title?: string): void => {
     const { newAlert } = this.props;
     if (!error) {
       return;
@@ -138,7 +138,9 @@ export default class ListenCard extends React.Component<
     newAlert(
       "danger",
       title || "Error",
-      typeof error === "object" ? error.message : error
+      _isString(error)
+        ? error
+        : `${error.status && `Error ${error.status}:`} ${error.message}`
     );
   };
 

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -126,6 +126,11 @@ declare type Alert = {
   message: string | JSX.Element;
 };
 
+// Expect either a string or an Error or an html Response object
+declare type ErrorForAlert =
+  | string
+  | { message?: string; status?: number; statusText?: string };
+
 declare type FollowUsersPlayingNow = {
   [user: string]: Listen;
 };

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -127,7 +127,7 @@ declare type Alert = {
 };
 
 // Expect either a string or an Error or an html Response object
-declare type ErrorForAlert =
+declare type BrainzPlayerError =
   | string
   | { message?: string; status?: number; statusText?: string };
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->
We want to be a bit more permissive with what type of error we're receiving to display in alerts.
We want to be able to receive regular node Errors, but also to receive HTTP errors which are in another format.

Subsequently, we can take advantage of these changes to display more information from SpotifyPlayer SDK so users have better error messages/codes to quote when running into a bug.