### PR TITLE
Re-enable cronjob for importing incremental dumps everyday

### DIFF
--- a/docker/dump-crontab
+++ b/docker/dump-crontab
@@ -7,4 +7,4 @@
 ## Trigger an incremental dump everyday
 00 18 * * * /code/listenbrainz/admin/create-dumps.sh incremental
 ## Around 3 hours later, trigger an incremental import into the spark cluster
-## 00 21 1,3-15,17-31 * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental
+00 21 * * * /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental


### PR DESCRIPTION
# Description
Now that the import process has been fixed on spark side, we can import incremental dumps everyday without worrying about multiple imports of the same file.