### PR TITLE
Utils for shareable dataframe functions

### DIFF
--- a/listenbrainz_spark/recommendations/dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/dataframe_utils.py
@@ -1,0 +1,104 @@
+import uuid
+
+from listenbrainz_spark import path
+import listenbrainz_spark.utils.mapping as mapping_utils
+from listenbrainz_spark.stats import (replace_days,
+                                      offset_days)
+from listenbrainz_spark.stats.utils import get_latest_listen_ts
+from listenbrainz_spark.utils import save_parquet, get_listens
+from listenbrainz_spark.exceptions import (FileNotSavedException,
+                                           FileNotFetchedException)
+
+from flask import current_app
+
+def get_dataframe_id(prefix):
+    """ Generate dataframe id.
+    """
+    return '{}-{}'.format(prefix, uuid.uuid4())
+
+
+def save_dataframe(df, dest_path):
+    """ Save dataframe to HDFS.
+
+        Args:
+            df : Dataframe to save.
+            dest_path (str): HDFS path to save dataframe.
+    """
+    try:
+        save_parquet(df, dest_path)
+    except FileNotSavedException as err:
+        current_app.logger.error(str(err), exc_info=True)
+        raise
+
+
+def get_dates_to_train_data(train_model_window):
+    """ Get window to fetch listens to train data.
+
+        Args:
+            train_model_window (int): model to be trained on data of given number of days.
+
+        Returns:
+            from_date (datetime): Date from which start fetching listens.
+            to_date (datetime): Date upto which fetch listens.
+    """
+    to_date = get_latest_listen_ts()
+    from_date = offset_days(to_date, train_model_window)
+    # shift to the first of the month
+    from_date = replace_days(from_date, 1)
+    return to_date, from_date
+
+
+def get_mapped_artist_and_recording_mbids(partial_listens_df, msid_mbid_mapping_df):
+    """ Map recording msid->mbid and artist msid->mbids so that every listen has an mbid.
+
+        Args:
+            partial_listens_df (dataframe): listens without artist mbid and recording mbid.
+            msid_mbid_mapping_df (dataframe): msid->mbid mapping. For columns refer to
+                                              msid_mbid_mapping_schema in listenbrainz_spark/schema.py
+
+        Returns:
+            mapped_listens_df (dataframe): listens mapped with msid_mbid_mapping.
+    """
+    condition = [
+        partial_listens_df.track_name_matchable == msid_mbid_mapping_df.msb_recording_name_matchable,
+        partial_listens_df.artist_name_matchable == msid_mbid_mapping_df.msb_artist_credit_name_matchable
+    ]
+
+    df = partial_listens_df.join(msid_mbid_mapping_df, condition, 'inner')
+    # msb_release_name_matchable is skipped till the bug in mapping is resolved.
+    # bug : release_name in listens and mb_release_name in mapping is different.
+    mapped_listens_df = df.select('listened_at',
+                                  'mb_artist_credit_id',
+                                  'mb_artist_credit_mbids',
+                                  'mb_recording_mbid',
+                                  'mb_release_mbid',
+                                  'msb_artist_credit_name_matchable',
+                                  'msb_recording_name_matchable',
+                                  'user_name')
+
+    save_dataframe(mapped_listens_df, path.MAPPED_LISTENS)
+    return mapped_listens_df
+
+
+def get_listens_for_training_model_window(to_date, from_date, dest_path):
+    """  Prepare dataframe of listens to train.
+
+        Args:
+            from_date (datetime): Date from which start fetching listens.
+            to_date (datetime): Date upto which fetch listens.
+            dest_path (str): HDFS path.
+
+        Returns:
+            partial_listens_df (dataframe): dataframe of listens.
+    """
+    try:
+        training_df = get_listens(from_date, to_date, dest_path)
+    except ValueError as err:
+        current_app.logger.error(str(err), exc_info=True)
+        raise
+    except FileNotFetchedException as err:
+        current_app.logger.error(str(err), exc_info=True)
+        raise
+
+    partial_listens_df = mapping_utils.convert_text_fields_to_matchable(training_df)
+    return partial_listens_df

--- a/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
@@ -1,0 +1,83 @@
+import re
+from datetime import datetime
+
+from listenbrainz_spark.tests import SparkTestCase
+
+from listenbrainz_spark.recommendations import dataframe_utils
+from listenbrainz_spark import utils, path, stats
+from listenbrainz_spark.stats.utils import get_latest_listen_ts
+import listenbrainz_spark.utils.mapping as mapping_utils
+
+from pyspark.sql import Row
+
+
+class DataframeUtilsTestCase(SparkTestCase):
+    listens_path = path.LISTENBRAINZ_DATA_DIRECTORY
+    mapping_path = path.MBID_MSID_MAPPING
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.upload_test_listen_to_hdfs(cls.listens_path)
+        cls.upload_test_mapping_to_hdfs(cls.mapping_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().delete_dir()
+        super().tearDownClass()
+
+    def test_generate_dataframe_id(self):
+        prefix = 'listenbrainz-recommendation-dataframe'
+        dataframe_id = dataframe_utils.get_dataframe_id(prefix)
+        assert re.match('{}-*'.format(prefix), dataframe_id)
+
+    def test_get_dates_to_train_data(self):
+        train_model_window = 12
+        to_date, from_date = dataframe_utils.get_dates_to_train_data(train_model_window)
+        d = stats.offset_days(to_date, train_model_window)
+        d = stats.replace_days(d, 1)
+        # refer to testdata/listens.json
+        self.assertEqual(to_date, datetime(2019, 1, 21, 0, 0))
+        self.assertEqual(from_date, d)
+
+    def test_get_listens_for_training_model_window(self):
+        to_date = get_latest_listen_ts()
+        from_date = stats.offset_days(to_date, 2)
+        print(to_date, from_date)
+        test_df = dataframe_utils.get_listens_for_training_model_window(to_date, from_date, self.listens_path)
+        self.assertIn('artist_name_matchable', test_df.columns)
+        self.assertIn('track_name_matchable', test_df.columns)
+        self.assertEqual(test_df.count(), 11)
+
+    def test_get_mapped_artist_and_recording_mbids(self):
+        to_date = get_latest_listen_ts()
+        partial_listen_df = dataframe_utils.get_listens_for_training_model_window(to_date, to_date, self.listens_path)
+
+        df = utils.read_files_from_HDFS(self.mapping_path)
+        mapping_df = mapping_utils.get_unique_rows_from_mapping(df)
+
+        mapped_listens = dataframe_utils.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df)
+        self.assertEqual(mapped_listens.count(), 8)
+
+        cols = [
+            'listened_at',
+            'mb_artist_credit_id',
+            'mb_artist_credit_mbids',
+            'mb_recording_mbid',
+            'mb_release_mbid',
+            'msb_artist_credit_name_matchable',
+            'msb_recording_name_matchable',
+            'user_name'
+        ]
+
+        self.assertListEqual(sorted(cols), sorted(mapped_listens.columns))
+        status = utils.path_exists(path.MAPPED_LISTENS)
+        self.assertTrue(status)
+
+    def test_save_dataframe(self):
+        path_ = '/test_df.parquet'
+        df = utils.create_dataframe(Row(column1=1, column2=2), schema=None)
+        dataframe_utils.save_dataframe(df, path_)
+
+        status = utils.path_exists(path_)
+        self.assertTrue(status)

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import listenbrainz_spark
 import listenbrainz_spark.utils.mapping as mapping_utils
+from listenbrainz_spark.recommendations import dataframe_utils
 from listenbrainz_spark import hdfs_connection, utils, config, schema
 from listenbrainz_spark.stats.utils import get_latest_listen_ts
 from listenbrainz_spark.recommendations import create_dataframes
@@ -200,9 +201,9 @@ class SparkTestCase(unittest.TestCase):
 
     @classmethod
     def upload_test_mapped_listens_to_hdfs(cls, listens_path, mapping_path, mapped_listens_path):
-        partial_listen_df = create_dataframes.get_listens_for_training_model_window(cls.date, cls.date, {}, listens_path)
+        partial_listen_df = dataframe_utils.get_listens_for_training_model_window(cls.date, cls.date, listens_path)
         df = utils.read_files_from_HDFS(mapping_path)
         mapping_df = mapping_utils.get_unique_rows_from_mapping(df)
 
-        mapped_listens = create_dataframes.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df)
+        mapped_listens = dataframe_utils.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df)
         utils.save_parquet(mapped_listens, mapped_listens_path)

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -150,33 +150,6 @@ def read_files_from_HDFS(path):
         raise FileNotFetchedException(err.java_exception, path)
 
 
-def get_listens_without_artist_and_recording_mbids(df):
-    """ Get dataframe with all fields that a typical listen has
-        except artist_mbids and recording_mbid.
-
-        Args:
-            df: Dataframe of listens.
-
-        Returns:
-            A dataframe with columns that a typical listen has
-            except artist_mbids and recording_mbid.
-
-    """
-    # Not all listens in ListenBrainz contain mbids but every listen has an msid.
-    # We fetch listens such that the mbid fields are not selected.
-    # We then map the msids with mbids so that every listen has an mbid too.
-    return df.select('artist_msid',
-                     'artist_name',
-                     'listened_at',
-                     'recording_msid',
-                     'release_mbid',
-                     'release_msid',
-                     'release_name',
-                     'tags',
-                     'track_name',
-                     'user_name')
-
-
 def get_listens(from_date, to_date, dest_path):
     """ Prepare dataframe of months falling between from_date and to_date (both inclusive).
 


### PR DESCRIPTION
I am working on artist recommendations. The general flow for it will be the same as recording recommendations. The functions used in create_dataframes for recording and artist recommendations are dumped into a single utils files so that they can be shared.