### PR TITLE
LB-752: BrainzPlayer: Check Spotify permissions before adding datasource

### DIFF
--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -81,10 +81,8 @@ export default class BrainzPlayer extends React.Component<
   constructor(props: BrainzPlayerProps) {
     super(props);
 
-    const { access_token, permission } = props.spotifyUser;
-
     this.spotifyPlayer = React.createRef<SpotifyPlayer>();
-    if (access_token && permission) {
+    if (SpotifyPlayer.hasPermissions(props.spotifyUser)) {
       this.dataSources.push(this.spotifyPlayer);
     }
 

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
@@ -60,7 +60,7 @@ describe("SpotifyPlayer", () => {
     expect(instance.searchAndPlayTrack).not.toHaveBeenCalled();
   });
 
-  describe("checkSpotifyToken", () => {
+  describe("hasPermissions", () => {
     it("calls onInvalidateDataSource (via handleAccountError) if no access token or no permission", () => {
       const onInvalidateDataSource = jest.fn();
       const mockProps = {
@@ -68,12 +68,15 @@ describe("SpotifyPlayer", () => {
         onInvalidateDataSource,
         spotifyUser: {},
       };
+      expect(SpotifyPlayer.hasPermissions(mockProps.spotifyUser)).toEqual(
+        false
+      );
       const wrapper = shallow<SpotifyPlayer>(<SpotifyPlayer {...mockProps} />);
       const instance = wrapper.instance();
       const errorMsg = (
         <p>
-          In order to play music, it is required that you link your Spotify
-          Premium account.
+          In order to play music with Spotify, you will need a Spotify Premium
+          account linked to your ListenBrainz account.
           <br />
           Please try to{" "}
           <a href="/profile/connect-spotify" target="_blank">
@@ -94,6 +97,9 @@ describe("SpotifyPlayer", () => {
         ...props,
         onInvalidateDataSource,
       };
+      expect(SpotifyPlayer.hasPermissions(mockProps.spotifyUser)).toEqual(
+        false
+      );
       const wrapper = shallow<SpotifyPlayer>(<SpotifyPlayer {...mockProps} />);
       const instance = wrapper.instance();
       expect(instance.props.onInvalidateDataSource).toHaveBeenCalledTimes(1);
@@ -108,6 +114,7 @@ describe("SpotifyPlayer", () => {
         access_token: "FNORD",
         permission: "streaming user-read-email user-read-private" as SpotifyPermission,
       };
+      expect(SpotifyPlayer.hasPermissions(spotifyUser)).toEqual(true);
       const mockProps = {
         ...props,
         onInvalidateDataSource,
@@ -118,12 +125,6 @@ describe("SpotifyPlayer", () => {
 
       expect.assertions(2);
       expect(instance.props.onInvalidateDataSource).not.toHaveBeenCalled();
-      await expect(
-        instance.checkSpotifyToken(
-          spotifyUser.access_token,
-          spotifyUser.permission
-        )
-      ).resolves.toEqual(true);
     });
   });
 
@@ -148,8 +149,8 @@ describe("SpotifyPlayer", () => {
       expect(instance.props.onInvalidateDataSource).toHaveBeenCalledTimes(1);
       const errorMsg = (
         <p>
-          In order to play music, it is required that you link your Spotify
-          Premium account.
+          In order to play music with Spotify, you will need a Spotify Premium
+          account linked to your ListenBrainz account.
           <br />
           Please try to{" "}
           <a href="/profile/connect-spotify" target="_blank">

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
@@ -29,6 +29,18 @@ const props = {
 };
 
 describe("SpotifyPlayer", () => {
+  const permissionsErrorMessage = (
+    <p>
+      In order to play music with Spotify, you will need a Spotify Premium
+      account linked to your ListenBrainz account.
+      <br />
+      Please try to{" "}
+      <a href="/profile/connect-spotify" target="_blank">
+        link for &quot;playing music&quot; feature
+      </a>{" "}
+      and refresh this page
+    </p>
+  );
   it("renders", () => {
     window.fetch = jest.fn();
     const wrapper = mount(<SpotifyPlayer {...props} />);
@@ -73,21 +85,9 @@ describe("SpotifyPlayer", () => {
       );
       const wrapper = shallow<SpotifyPlayer>(<SpotifyPlayer {...mockProps} />);
       const instance = wrapper.instance();
-      const errorMsg = (
-        <p>
-          In order to play music with Spotify, you will need a Spotify Premium
-          account linked to your ListenBrainz account.
-          <br />
-          Please try to{" "}
-          <a href="/profile/connect-spotify" target="_blank">
-            link for &quot;playing music&quot; feature
-          </a>{" "}
-          and refresh this page
-        </p>
-      );
       expect(instance.props.onInvalidateDataSource).toHaveBeenCalledWith(
         instance,
-        errorMsg
+        permissionsErrorMessage
       );
     });
 
@@ -105,7 +105,7 @@ describe("SpotifyPlayer", () => {
       expect(instance.props.onInvalidateDataSource).toHaveBeenCalledTimes(1);
       expect(instance.props.onInvalidateDataSource).toHaveBeenCalledWith(
         instance,
-        "Permission to play songs not granted"
+        permissionsErrorMessage
       );
     });
     it("should not call onInvalidateDataSource if permissions are accurate", async () => {
@@ -147,21 +147,9 @@ describe("SpotifyPlayer", () => {
 
       instance.handleAccountError();
       expect(instance.props.onInvalidateDataSource).toHaveBeenCalledTimes(1);
-      const errorMsg = (
-        <p>
-          In order to play music with Spotify, you will need a Spotify Premium
-          account linked to your ListenBrainz account.
-          <br />
-          Please try to{" "}
-          <a href="/profile/connect-spotify" target="_blank">
-            link for &quot;playing music&quot; feature
-          </a>{" "}
-          and refresh this page
-        </p>
-      );
       expect(instance.props.onInvalidateDataSource).toHaveBeenCalledWith(
         instance,
-        errorMsg
+        permissionsErrorMessage
       );
     });
   });

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -94,10 +94,6 @@ export default class SpotifyPlayer
       const spotifyPlayerSDKLib = require("../lib/spotify-player-sdk-1.7.1"); // eslint-disable-line global-require
     } else {
       this.handleAccountError();
-      props.onInvalidateDataSource(
-        this,
-        "Permission to play songs not granted"
-      );
     }
   }
 


### PR DESCRIPTION
Currently, we only check if  there is a non-empty permissions string before adding a SpotifyPlayer datasource, instead of checking the scope as well, which breaks playback for Spotify free users.

See https://tickets.metabrainz.org/browse/LB-752