### PR TITLE
Fix incremental dump creation

### DIFF
--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -74,9 +74,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         return len(test_data)
 
     def _insert_with_created(self, listens):
-        """
-            Insert a batch of listens. Returns a list of (listened_at, track_name, user_name) that indicates
-            which rows were inserted into the DB. If the row is not listed in the return values, it was a duplicate.
+        """ Insert a batch of listens with 'created' field.
         """
         submit = []
         for listen in listens:
@@ -288,12 +286,11 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.reset_timescale_db()
         self.logstore.import_listens_dump(dump_location)
         listens = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=base + 11)
-        self.assertEqual(len(listens), 5)
+        self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, base + 5)
         self.assertEqual(listens[1].ts_since_epoch, base + 4)
         self.assertEqual(listens[2].ts_since_epoch, base + 3)
         self.assertEqual(listens[3].ts_since_epoch, base + 2)
-        self.assertEqual(listens[4].ts_since_epoch, base + 1)
 
         shutil.rmtree(temp_dir)
 

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -14,6 +14,7 @@ import ujson
 import psycopg2
 import sqlalchemy
 import listenbrainz.db.user as db_user
+from psycopg2.extras import execute_values
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.db import timescale as ts
 from listenbrainz import config
@@ -71,6 +72,27 @@ class TestTimescaleListenStore(DatabaseTestCase):
         test_data = create_test_data_for_timescalelistenstore(user_name, test_data_file_name)
         self.logstore.insert(test_data)
         return len(test_data)
+
+    def _insert_with_created(self, listens):
+        """
+            Insert a batch of listens. Returns a list of (listened_at, track_name, user_name) that indicates
+            which rows were inserted into the DB. If the row is not listed in the return values, it was a duplicate.
+        """
+        submit = []
+        for listen in listens:
+            submit.append((*listen.to_timescale(), listen.inserted_timestamp))
+
+        query = """INSERT INTO listen (listened_at, track_name, user_name, data, created)
+                        VALUES %s
+                   ON CONFLICT (listened_at, track_name, user_name)
+                    DO NOTHING
+                """
+
+        conn = ts.engine.raw_connection()
+        with conn.cursor() as curs:
+            execute_values(curs, query, submit, template=None)
+
+        conn.commit()
 
     def test_check_listen_count_view_exists(self):
         try:
@@ -251,10 +273,10 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
     def test_incremental_dump(self):
         base = 1500000000
-        listens = generate_data(1, self.testuser_name, base + 1, 5)  # generate 5 listens with ts 1-5
-        self.logstore.insert(listens)
-        listens = generate_data(1, self.testuser_name, base + 6, 5)  # generate 5 listens with ts 6-10
-        self.logstore.insert(listens)
+        listens = generate_data(1, self.testuser_name, base-4, 5, base+1)  # generate 5 listens with inserted_ts 1-5
+        self._insert_with_created(listens)
+        listens = generate_data(1, self.testuser_name, base+1, 5, base+6)  # generate 5 listens with inserted_ts 6-10
+        self._insert_with_created(listens)
         temp_dir = tempfile.mkdtemp()
         dump_location = self.logstore.dump_listens(
             location=temp_dir,
@@ -267,11 +289,11 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.logstore.import_listens_dump(dump_location)
         listens = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=base + 11)
         self.assertEqual(len(listens), 5)
-        self.assertEqual(listens[0].ts_since_epoch, base + 10)
-        self.assertEqual(listens[1].ts_since_epoch, base + 9)
-        self.assertEqual(listens[2].ts_since_epoch, base + 8)
-        self.assertEqual(listens[3].ts_since_epoch, base + 7)
-        self.assertEqual(listens[4].ts_since_epoch, base + 6)
+        self.assertEqual(listens[0].ts_since_epoch, base + 5)
+        self.assertEqual(listens[1].ts_since_epoch, base + 4)
+        self.assertEqual(listens[2].ts_since_epoch, base + 3)
+        self.assertEqual(listens[3].ts_since_epoch, base + 2)
+        self.assertEqual(listens[4].ts_since_epoch, base + 1)
 
         shutil.rmtree(temp_dir)
 

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -11,11 +11,15 @@ from listenbrainz.listen import Listen
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'testdata')
 
 
-def generate_data(test_user_id, user_name, from_ts, num_records):
+def generate_data(test_user_id, user_name, from_ts, num_records, inserted_ts=None):
     test_data = []
     artist_msid = str(uuid.uuid4())
 
     for i in range(num_records):
+        if not inserted_ts:
+            inserted_timestamp = datetime.utcnow()
+        else:
+            inserted_timestamp = datetime.utcfromtimestamp(inserted_ts)
         timestamp = datetime.utcfromtimestamp(from_ts)
         item = Listen(
             user_name=user_name,
@@ -23,6 +27,7 @@ def generate_data(test_user_id, user_name, from_ts, num_records):
             timestamp=timestamp,
             artist_msid=artist_msid,
             recording_msid=str(uuid.uuid4()),
+            inserted_timestamp=inserted_timestamp,
             data={
                 'artist_name': 'Frank Ocean',
                 'track_name': 'Crack Rock',
@@ -31,6 +36,8 @@ def generate_data(test_user_id, user_name, from_ts, num_records):
         )
         test_data.append(item)
         from_ts += 1   # Add one second
+        if inserted_ts:
+            inserted_ts += 1   # Add one second
 
     return test_data
 

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -350,7 +350,7 @@ class TimescaleListenStore(ListenStore):
 
         query = """SELECT listened_at, track_name, user_name, created, data
                      FROM listen
-                    WHERE created > :start_ts
+                    WHERE created >= :start_ts
                       AND created <= :end_ts
                  ORDER BY created ASC"""
 
@@ -458,8 +458,7 @@ class TimescaleListenStore(ListenStore):
                 query, args = self.get_listens_query_for_dump(int(start_time.strftime('%s')),
                                                               int(end_time.strftime('%s')))
             else:
-                query, args = self.get_incremental_listens_query(int(start_time.strftime('%s')),
-                                                                 int(end_time.strftime('%s')))
+                query, args = self.get_incremental_listens_query(start_time, end_time)
 
             rows_added = 0
             with timescale.engine.connect() as connection:

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -350,7 +350,7 @@ class TimescaleListenStore(ListenStore):
 
         query = """SELECT listened_at, track_name, user_name, created, data
                      FROM listen
-                    WHERE created >= :start_ts
+                    WHERE created > :start_ts
                       AND created <= :end_ts
                  ORDER BY created ASC"""
 

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -342,7 +342,7 @@ class TimescaleListenStore(ListenStore):
 
         return (query, args)
 
-    def get_incremental_listens_query_batch(self, start_time, end_time, offset):
+    def get_incremental_listens_query(self, start_time, end_time):
         """
             Get a query for a batch of listens for an incremental listen dump.
             This uses the `created` column to fetch listens.
@@ -352,18 +352,13 @@ class TimescaleListenStore(ListenStore):
                      FROM listen
                     WHERE created > :start_ts
                       AND created <= :end_ts
-                 ORDER BY created ASC
-                    LIMIT :limit
-                   OFFSET :offset"""
+                 ORDER BY created ASC"""
 
         args = {
             'start_ts': start_time,
             'end_ts': end_time,
-            'offset': offset,
-            'limit': DUMP_CHUNK_SIZE
         }
         return (query, args)
-
 
     def write_dump_metadata(self, archive_name, start_time, end_time, temp_dir, tar, full_dump=True):
         """ Write metadata files (schema version, timestamps, license) into the dump archive.
@@ -413,78 +408,13 @@ class TimescaleListenStore(ListenStore):
             self.log.error('Exception while adding dump metadata: %s', str(e), exc_info=True)
             raise
 
-
-    def write_incremental_listens_to_disk(self, listens, temp_dir):
-        """ Write all spark listens in year/month dir format to disk.
-
-        Args:
-            listens : the listens to be written into the disk
-            temp_dir: the dir into which listens should be written
-        """
-        for year in listens:
-            for month in listens[year]:
-                if year < 2002:
-                    directory = temp_dir
-                    filename = os.path.join(directory, 'invalid.json')
-                else:
-                    directory = os.path.join(temp_dir, str(year))
-                    filename = os.path.join(directory, '{}.json'.format(str(month)))
-                create_path(directory)
-                with open(filename, 'a') as f:
-                    f.write('\n'.join([ujson.dumps(listen) for listen in listens[year][month]]))
-                    f.write('\n')
-
-    def write_incremental_listens(self, start_time, end_time, temp_dir):
-        """ Dump listens in the format for the ListenBrainz dump.
-
-        Args:
-            start_time and end_time (datetime): the range of time for the listens dump.
-            temp_dir (str): the dir to use to write files before adding to archive
-        """
-        t0 = time.monotonic()
-        offset = 0
-        listen_count = 0
-
-        unwritten_listens = {}
-
-        while True:
-            query, args = self.get_incremental_listens_query_batch(start_time, end_time, offset)
-            rows_added = 0
-            with timescale.engine.connect() as connection:
-                curs = connection.execute(sqlalchemy.text(query), args)
-                while True:
-                    result = curs.fetchone()
-                    if not result:
-                        break
-
-                    listen = Listen.from_timescale(result[0], result[1], result[2], result[3], result[4]).to_json()
-                    timestamp = listen['timestamp']
-
-                    if timestamp.year not in unwritten_listens:
-                        unwritten_listens[timestamp.year] = {}
-                    if timestamp.month not in unwritten_listens[timestamp.year]:
-                        unwritten_listens[timestamp.year][timestamp.month] = []
-
-                    unwritten_listens[timestamp.year][timestamp.month].append(listen)
-                    rows_added += 1
-
-            if rows_added == 0:
-                break
-
-            listen_count += rows_added
-            offset += DUMP_CHUNK_SIZE
-
-        self.write_incremental_listens_to_disk(unwritten_listens, temp_dir)
-        self.log.info("%d listens dumped at %.2f listens / sec", listen_count,
-                      listen_count / (time.monotonic() - t0))
-
-
-    def write_listens(self, temp_dir, tar_file, archive_name, start_time_range = None, end_time_range = None):
+    def write_listens(self, temp_dir, tar_file, archive_name, start_time_range=None, end_time_range=None, full_dump=True):
         """ Dump listens in the format for the ListenBrainz dump.
 
         Args:
             end_time_range (datetime): the range of time for the listens dump.
             temp_dir (str): the dir to use to write files before adding to archive
+            full_dump (bool): the type of dump
         """
         t0 = time.monotonic()
         listen_count = 0
@@ -523,8 +453,13 @@ class TimescaleListenStore(ListenStore):
             except FileExistsError:
                 pass
 
-            query, args = self.get_listens_query_for_dump(int(start_time.strftime('%s')),
-                                                          int(end_time.strftime('%s')))
+            query, args = None, None
+            if full_dump:
+                query, args = self.get_listens_query_for_dump(int(start_time.strftime('%s')),
+                                                              int(end_time.strftime('%s')))
+            else:
+                query, args = self.get_incremental_listens_query(int(start_time.strftime('%s')),
+                                                                 int(end_time.strftime('%s')))
 
             rows_added = 0
             with timescale.engine.connect() as connection:
@@ -548,7 +483,6 @@ class TimescaleListenStore(ListenStore):
             month = next_month
             year = next_year
             rows_added = 0
-
 
     def dump_listens(self, location, dump_id, start_time=datetime.utcfromtimestamp(0), end_time=None,
                      threads=DUMP_DEFAULT_THREAD_COUNT):
@@ -596,7 +530,7 @@ class TimescaleListenStore(ListenStore):
                 self.write_dump_metadata(archive_name, start_time, end_time, temp_dir, tar, full_dump)
 
                 listens_path = os.path.join(temp_dir, 'listens')
-                self.write_listens(listens_path, tar, archive_name, start_time, end_time)
+                self.write_listens(listens_path, tar, archive_name, start_time, end_time, full_dump)
 
                 # remove the temporary directory
                 shutil.rmtree(temp_dir)
@@ -650,7 +584,7 @@ class TimescaleListenStore(ListenStore):
                             line = tarf.readline()
                             if not line:
                                 break
-                                
+
                             listen = Listen.from_json(ujson.loads(line))
                             listens.append(listen)
 


### PR DESCRIPTION
# Problem
Incremental dumps were getting created using the `listened_at` field instead of `created`. This lead to missing data for people whole imported or submitted listens in bulk.

# Solution
Modifying the query to use `created` fixes the problem.

# Action
We should test this once on the production server and then recreate incremental dumps since the last full dump.