### PR TITLE
Fix monthly daily activity stats calculation

### DIFF
--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -89,7 +89,10 @@ class RequestConsumer:
                     self.connect_to_rabbitmq()
                     self.init_rabbitmq_channels()
 
-        avg_size_of_message //= num_of_messages
+        try:
+            avg_size_of_message //= num_of_messages
+        except ZeroDivisionError:
+            current_app.logger.warn("No messages calculated", exc_info=True)
 
         current_app.logger.info("Done!")
         current_app.logger.info("Number of messages sent: {}".format(num_of_messages))

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -92,6 +92,7 @@ class RequestConsumer:
         try:
             avg_size_of_message //= num_of_messages
         except ZeroDivisionError:
+            avg_size_of_message = 0
             current_app.logger.warn("No messages calculated", exc_info=True)
 
         current_app.logger.info("Done!")

--- a/listenbrainz_spark/stats/user/daily_activity.py
+++ b/listenbrainz_spark/stats/user/daily_activity.py
@@ -69,7 +69,6 @@ def get_daily_activity_week() -> Iterator[Optional[UserDailyActivityStatMessage]
     current_app.logger.debug("Calculating daily_activity_week")
 
     date = get_latest_listen_ts()
-    # Set time to 00:00
     to_date = get_last_monday(date)
     from_date = offset_days(to_date, 7)
 
@@ -86,12 +85,12 @@ def get_daily_activity_week() -> Iterator[Optional[UserDailyActivityStatMessage]
 
 def get_daily_activity_month() -> Iterator[Optional[UserDailyActivityStatMessage]]:
     """ Calculate number of listens for an user per hour on each day of week of the current month. """
-    current_app.logger.debug("Calculating listening_activity_month")
+    current_app.logger.debug("Calculating daily_activity_month")
 
     to_date = get_latest_listen_ts()
-    # Set time to 00:00
-    to_date = datetime(to_date.year, to_date.month, to_date.day)
     from_date = replace_days(to_date, 1)
+    # Set time to 00:00
+    from_date = datetime(from_date.year, from_date.month, from_date.day)
 
     _get_listens(from_date, to_date)
 
@@ -105,7 +104,7 @@ def get_daily_activity_month() -> Iterator[Optional[UserDailyActivityStatMessage
 
 def get_daily_activity_year() -> Iterator[Optional[UserDailyActivityStatMessage]]:
     """ Calculate number of listens for an user per hour on each day of week of the current year. """
-    current_app.logger.debug("Calculating listening_activity_year")
+    current_app.logger.debug("Calculating daily_activity_year")
 
     to_date = get_latest_listen_ts()
     from_date = datetime(to_date.year, 1, 1)
@@ -122,7 +121,7 @@ def get_daily_activity_year() -> Iterator[Optional[UserDailyActivityStatMessage]
 
 def get_daily_activity_all_time() -> Iterator[Optional[UserDailyActivityStatMessage]]:
     """ Calculate number of listens for an user per hour on each day of week. """
-    current_app.logger.debug("Calculating listening_activity_all_time")
+    current_app.logger.debug("Calculating daily_activity_all_time")
 
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -69,11 +69,10 @@ def get_listening_activity_week() -> Iterator[Optional[UserListeningActivityStat
     """ Calculate number of listens for an user on each day of the past and current week. """
     current_app.logger.debug("Calculating listening_activity_week")
 
-    date = get_latest_listen_ts()
-    to_date = date
-    # Set time to 00:00
-    to_date = datetime(to_date.year, to_date.month, to_date.day)
+    to_date = get_latest_listen_ts()
     from_date = offset_days(get_last_monday(to_date), 7)
+    # Set time to 00:00
+    from_date = datetime(from_date.year, from_date.month, from_date.day)
     day = from_date
 
     # Genarate a dataframe containing days of last and current week along with start and end time
@@ -100,10 +99,10 @@ def get_listening_activity_month() -> Iterator[Optional[UserListeningActivitySta
     current_app.logger.debug("Calculating listening_activity_month")
 
     to_date = get_latest_listen_ts()
-    # Set time to 00:00
-    to_date = datetime(to_date.year, to_date.month, to_date.day)
     from_date = offset_months(replace_days(to_date, 1), 1)
-    day = offset_months(replace_days(to_date, 1), 1)
+    # Set time to 00:00
+    from_date = datetime(from_date.year, from_date.month, from_date.day)
+    day = from_date
 
     # Genarate a dataframe containing days of last and current month along with start and end time
     time_range = []

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -75,7 +75,7 @@ class ListeningActivityTestCase(SparkTestCase):
 
         self.assertDictEqual(received, expected)
 
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_latest_listen_ts', return_value=datetime(2020, 9, 10))
+    @patch('listenbrainz_spark.stats.user.listening_activity.get_latest_listen_ts', return_value=datetime(2020, 9, 10, 12, 10))
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listens')
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listening_activity', return_value='listening_activity_table')
     @patch('listenbrainz_spark.stats.user.listening_activity.create_messages')
@@ -85,7 +85,7 @@ class ListeningActivityTestCase(SparkTestCase):
         mock_get_listens.return_value = mock_df
 
         listening_activity_stats.get_listening_activity_week()
-        to_date = datetime(2020, 9, 10)
+        to_date = datetime(2020, 9, 10, 12, 10)
         from_date = day = datetime(2020, 8, 31)
 
         time_range = []
@@ -102,7 +102,7 @@ class ListeningActivityTestCase(SparkTestCase):
         mock_create_messages.assert_called_with(data='listening_activity_table', stats_range='week',
                                                 from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_latest_listen_ts', return_value=datetime(2020, 6, 19))
+    @patch('listenbrainz_spark.stats.user.listening_activity.get_latest_listen_ts', return_value=datetime(2020, 6, 19, 12, 10))
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listens')
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listening_activity', return_value='listening_activity_table')
     @patch('listenbrainz_spark.stats.user.listening_activity.create_messages')
@@ -112,7 +112,7 @@ class ListeningActivityTestCase(SparkTestCase):
         mock_get_listens.return_value = mock_df
 
         listening_activity_stats.get_listening_activity_month()
-        to_date = datetime(2020, 6, 19)
+        to_date = datetime(2020, 6, 19, 12, 10)
         from_date = day = datetime(2020, 5, 1)
 
         time_range = []


### PR DESCRIPTION
# Problem
The time range for monthly daily activity was incorrect leading to listens for 0 days to get selected on 1st of each month.

# Solution
This PR changes the time range calculation to make sure at least a single day's listens are included and also catches `ZeroDivisionError` in request consumer.