### PR TITLE
update dataframe id prefix 

### DIFF
--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -30,11 +30,6 @@ SENTRY_DSN_PUBLIC = ''
 # The following var defines the string of which the model id is made up of.
 MODEL_ID_PREFIX = 'listenbrainz-recommendation-model'
 
-# Dataframe id is made up of two parts.
-# String + UUID
-# The following var defines the string of which the dataframe id is made up of.
-DATAFRAME_ID_PREFIX = 'listenbrainz-recommendation-dataframe'
-
 FTP_SERVER_URI = 'ftp.eu.metabrainz.org'
 FTP_MSID_MBID_DIR = '/pub/musicbrainz/listenbrainz/labs/mappings/msid-mbid-mapping/'
 FTP_ARTIST_RELATION_DIR = '/pub/musicbrainz/listenbrainz/labs/artist-credit-artist-credit-relations/'

--- a/listenbrainz_spark/recommendations/recording/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/recording/create_dataframes.py
@@ -122,9 +122,8 @@ from pyspark.sql.functions import rank, col, row_number
 #   ]
 
 
-# Dataframe id is made up of two parts.
-# String + UUID
 # The following var defines the string of which the dataframe id is made up of.
+# An UUID will be appended to the string to generate a dataframe id.
 DATAFRAME_ID_PREFIX = 'listenbrainz-dataframe-recording-recommendations'
 
 

--- a/listenbrainz_spark/recommendations/recording/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/recording/create_dataframes.py
@@ -122,6 +122,12 @@ from pyspark.sql.functions import rank, col, row_number
 #   ]
 
 
+# Dataframe id is made up of two parts.
+# String + UUID
+# The following var defines the string of which the dataframe id is made up of.
+DATAFRAME_ID_PREFIX = 'listenbrainz-dataframe-recording-recommendations'
+
+
 def save_dataframe_metadata_to_hdfs(metadata):
     """ Save dataframe metadata.
     """
@@ -380,7 +386,7 @@ def main(train_model_window=None):
 
     save_playcounts_df(listens_df, recordings_df, users_df, metadata)
 
-    metadata['dataframe_id'] = get_dataframe_id(config.DATAFRAME_ID_PREFIX)
+    metadata['dataframe_id'] = get_dataframe_id(DATAFRAME_ID_PREFIX)
     save_dataframe_metadata_to_hdfs(metadata)
 
     current_app.logger.info('Preparing missing MusicBrainz data...')


### PR DESCRIPTION
I have updated the dataframe id prefix in so that it reflects that the dataframes will be used in `recording recommendations`. The metadata saved using the previous prefix will still be there in the parquet!