### PR TITLE
LB-755: Solve 500 in feedback api

### DIFF
--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -666,7 +666,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["error"], "Cannot find user: nouser")
 
     def test_get_feedback_for_recordings_for_user_no_recordings(self):
-        """ Test to make sure that the API sends 400 if params recordings is not paased or has nothing. """
+        """ Test to make sure that the API sends 400 if param recordings is not passed or is empty. """
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
                                            user_name=self.user["musicbrainz_id"]))  # missing recordings param
         self.assert400(response)

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -666,12 +666,17 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["error"], "Cannot find user: nouser")
 
     def test_get_feedback_for_recordings_for_user_no_recordings(self):
-        """ Test to make sure that the API sends 400 if params recordings has nothing. """
+        """ Test to make sure that the API sends 400 if params recordings is not paased or has nothing. """
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                           user_name=self.user["musicbrainz_id"]))  # missing recordings param
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "'recordings' has no valid recording MSID.")
+
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
                                            user_name=self.user["musicbrainz_id"]),
                                    query_string={"recordings": ""})  # empty string
         self.assert400(response)
-        self.assertEqual(response.json["error"], "'recordings' has no valid recording_msid.")
+        self.assertEqual(response.json["error"], "'recordings' has no valid recording MSID.")
 
     def test_get_feedback_for_recordings_for_user_invalid_recording(self):
         """ Test to make sure that the API sends 400 if params recordings has invalid recording_msid. """

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -180,9 +180,12 @@ def get_feedback_for_recordings_for_user(user_name):
 
     recordings = request.args.get('recordings')
 
+    if not recordings:
+        log_raise_400("'recordings' has no valid recording MSID.")
+
     recording_list = parse_param_list(recordings)
     if not len(recording_list):
-        raise APIBadRequest("'recordings' has no valid recording_msid.")
+        raise APIBadRequest("'recordings' has no valid recording MSID.")
 
     user = db_user.get_by_mb_id(user_name)
     if user is None:


### PR DESCRIPTION
# Problem
The `/feedback/user/<user_name>/get-feedback-for-recordings` returns 500 in prod if `recordings` arg is not pased

# Solution
Raise 400 in such cases.