### PR TITLE
Don't select `total_count` while preparing top_artist df

### DIFF
--- a/listenbrainz_spark/recommendations/recording/candidate_sets.py
+++ b/listenbrainz_spark/recommendations/recording/candidate_sets.py
@@ -183,19 +183,16 @@ def explode_artist_collaborations(df):
             df: A dataframe
 
         Returns:
-            df with columns ['mb_artist_credit_mbids', 'user_name', 'total_count']
+            df with columns ['mb_artist_credit_mbids', 'user_name']
     """
     df = df.select(col('mb_artist_credit_mbids'),
-                   col('user_name'),
-                   col('total_count')) \
+                   col('user_name')) \
            .where(func.size('mb_artist_credit_mbids') > 1) \
            .withColumn('mb_artist_credit_mbids', func.explode('mb_artist_credit_mbids')) \
            .select(col('mb_artist_credit_mbids').alias('mbids'),
-                   col('total_count'),
                    col('user_name'))
 
     res_df = convert_string_datatype_to_array(df).select(col('mb_artist_credit_mbids'),
-                                                         col('total_count'),
                                                          col('user_name'))
 
     return res_df
@@ -233,7 +230,6 @@ def append_artists_from_collaborations(top_artist_df):
                                  .select(col('mb_artist_credit_mbids'),
                                          col('mb_artist_credit_id').alias('top_artist_credit_id'),
                                          col('msb_artist_credit_name_matchable').alias('top_artist_name'),
-                                         col('total_count'),
                                          col('user_name')) \
                                  .distinct()
 
@@ -241,7 +237,6 @@ def append_artists_from_collaborations(top_artist_df):
     top_artist_df = top_artist_df.union(res_df) \
                                  .select('top_artist_credit_id',
                                          'top_artist_name',
-                                         'total_count',
                                          'user_name') \
                                  .distinct()
     # using distinct for extra care since pyspark union ~ SQL union all.
@@ -283,7 +278,6 @@ def get_top_artists(mapped_listens_subset, top_artist_limit, users):
                       .select(col('mb_artist_credit_mbids'),
                               col('mb_artist_credit_id').alias('top_artist_credit_id'),
                               col('msb_artist_credit_name_matchable').alias('top_artist_name'),
-                              col('total_count'),
                               col('user_name'))
 
     top_artist_df = append_artists_from_collaborations(top_artist_df)
@@ -291,7 +285,6 @@ def get_top_artists(mapped_listens_subset, top_artist_limit, users):
     if users:
         top_artist_given_users_df = top_artist_df.select('top_artist_credit_id',
                                                          'top_artist_name',
-                                                         'total_count',
                                                          'user_name') \
                                                  .where(top_artist_df.user_name.isin(users))
 
@@ -564,8 +557,7 @@ def get_candidate_html_data(similar_artist_candidate_set_df_html, top_artist_can
 
         data = (
             row.top_artist_name,
-            row.top_artist_credit_id,
-            row.total_count
+            row.top_artist_credit_id
         )
         user_data[row.user_name]['top_artist'].append(data)
 

--- a/listenbrainz_spark/recommendations/templates/candidate.html
+++ b/listenbrainz_spark/recommendations/templates/candidate.html
@@ -30,13 +30,11 @@ td, th {
                 <tr>
                     <th>Top artist name</th>
                     <th>Top artist credit id</th>
-                    <th>Count</th>
                 </tr>
                 {% for i in data['top_artist'] -%}
                 <tr>
                     <td>{{ i[0] }}</td>
                     <td>{{ i[1] }}</td>
-                    <td>{{ i[2] }}</td>
                 </tr>
                 {% endfor -%}
             </table>


### PR DESCRIPTION
The `total_count` col is used to order artists to fetch the top artists for a user. It is not needed after that at any place in the candidate_sets script, also `distinct` filters rows where every col is identical except the total count which is undesirable because it causes repetition of artist names in top artist df leading to repetition of recordings and thus recommendations.