### PR TITLE
LB-717: Return array instead of object when no feedback

### DIFF
--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -502,7 +502,7 @@ export default class RecentListens extends React.Component<
         );
       }
     }
-    return {};
+    return [];
   };
 
   loadFeedback = async () => {


### PR DESCRIPTION
Like it says on the tin.
Returning an empty array instead of an object, since we call `.forEach(…)` on it afterwards (`{}.forEach` throws an error).
https://tickets.metabrainz.org/browse/LB-717