### PR TITLE
ignore dump_id from download_listens (see commit 765cbea92)

### DIFF
--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -142,6 +142,8 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
 
             Returns:
                 dest_path (str): Local path where listens have been downloaded.
+                listens_file_name (str): name of downloaded listens dump.
+                dump_id (int): Unique indentifier of downloaded listens dump.
         """
         ftp_cwd = current_app.config['FTP_LISTENS_DIR'] + 'fullexport/'
         if dump_type == INCREMENTAL:

--- a/spark_manage.py
+++ b/spark_manage.py
@@ -102,7 +102,7 @@ def upload_listens(overwrite, incremental, id):
     with app.app_context():
         downloader_obj = ListenbrainzDataDownloader()
         dump_type = 'incremental' if incremental else 'full'
-        src, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, listens_dump_id=id, dump_type=dump_type)
+        src, _, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, listens_dump_id=id, dump_type=dump_type)
         uploader_obj = ListenbrainzDataUploader()
         uploader_obj.upload_listens(src, overwrite=overwrite)
 


### PR DESCRIPTION
# Problem

spark_manage.py failed due to a new return value in ListenbrainzDataDownloader.download_listens()
./develop.sh spark run request_consumer python spark_manage.py upload_listens -i



# Solution

one-line code change ignores the new return value

# Action

note: comment in download_listens is also out of date, only 1 of 3 return values explained


