### PR TITLE
Fix URL encoding of SpotifyPlayer search requests

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -23,14 +23,13 @@ const searchForSpotifyTrack = async (
     // search for track was not provided a track name, cannot proceed
     return null;
   }
-  let queryString = `q=track:${trackName}`;
+  let queryString = `type=track&q=track:${encodeURIComponent(trackName)}`;
   if (artistName) {
-    queryString += ` artist:${artistName}`;
+    queryString += ` artist:${encodeURIComponent(artistName)}`;
   }
   if (releaseName) {
-    queryString += ` album:${releaseName}`;
+    queryString += ` album:${encodeURIComponent(releaseName)}`;
   }
-  queryString += "&type=track";
 
   const response = await fetch(
     `https://api.spotify.com/v1/search?${encodeURI(queryString)}`,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

Ruaok (and someone else previously) reported a consistent 400 error while trying to play a track with BrainzPlayer.
The issue was with the song title (contained a `#` character) and how it is encoded for the Spotify search request.


# Solution
`encodeURI` does not modify the `#` character since it is a valid URI character (HTML anchors).
So we have to first encode each search term with `encoreURIComponent` (and not the whole query string, because we need to keep the parameters as is [for example `&type=track` would become `%26type%3Dtrack`  with `encoreURIComponent`]).