### PR TITLE
Improve formatting of Spotify errors

### DIFF
--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -163,7 +163,7 @@ export default class BrainzPlayer extends React.Component<
       title || "Playback error",
       _isString(error)
         ? error
-        : `${!_isNil(error.status) && `Error ${error.status}:`} ${
+        : `${!_isNil(error.status) ? `Error ${error.status}:` : ""} ${
             error.message || error.statusText
           }`
     );

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -306,7 +306,7 @@ export default class SpotifyPlayer
     handleError(
       {
         status: error.status,
-        message: `${error.reason} - ${error.message}`,
+        message: `${error.reason ? `${error.reason} - ` : ""}${error.message}`,
       },
       "Spotify player error"
     );


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
I was seeing some `false` and `undefined` in my error messages.


# Solution
Don't do it dumb.



