### PR TITLE
Critical LB dump fixes

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -82,7 +82,7 @@ if [ -z "$DUMP_ID_FILE" ]; then
 fi
 
 HAS_EMPTY_DIRS_OR_FILES=$(find "$TMPDIR" -empty)
-if [ -z "$HAS_EMPTY_DIRS_OR_FILES" ]; then
+if [ ! -z "$HAS_EMPTY_DIRS_OR_FILES" ]; then
     echo "Empty files or dirs, exiting."
     echo "$HAS_EMPTY_DIRS_OR_FILES"
     exit 1

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -23,13 +23,13 @@ function add_rsync_include_rule {
     RULE_FILE=$1/.rsync-filter
     FILE_NAME=$2
     MAIN_FILE_RULE="include $FILE_NAME"
-    echo $MAIN_FILE_RULE >> $RULE_FILE
+    echo "$MAIN_FILE_RULE" >> "$RULE_FILE"
 
     MD5_FILE_RULE="include $FILE_NAME.md5"
-    echo $MD5_FILE_RULE >> $RULE_FILE
+    echo "$MD5_FILE_RULE" >> "$RULE_FILE"
 
     SHA256_FILE_RULE="include $FILE_NAME.sha256"
-    echo $SHA256_FILE_RULE >> $RULE_FILE
+    echo "$SHA256_FILE_RULE" >> "$RULE_FILE"
 }
 
 
@@ -41,34 +41,58 @@ trap 'echo "Disk space when create-dumps ends:" ; df -m' 0
 
 
 LB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
-cd "$LB_SERVER_ROOT"
+cd "$LB_SERVER_ROOT" || exit 1
 
-source admin/config.sh
-source admin/functions.sh
+source "admin/config.sh"
+source "admin/functions.sh"
 
-DUMP_TYPE=${1:-full}
+DUMP_TYPE="${1:-full}"
 
-if [ $DUMP_TYPE == "full" ]; then
+if [ "$DUMP_TYPE" == "full" ]; then
     SUB_DIR="fullexport"
 else
     SUB_DIR="incremental"
 fi
 
-if [ $DUMP_TYPE == "full" ]; then
-    /usr/local/bin/python manage.py dump create_full -l $TEMP_DIR/$SUB_DIR -t $DUMP_THREADS --last-dump-id
-elif [ $DUMP_TYPE == "incremental" ]; then
-    /usr/local/bin/python manage.py dump create_incremental -l $TEMP_DIR/$SUB_DIR -t $DUMP_THREADS
+TMPDIR=$(mktemp --tmpdir="$TEMP_DIR" -d -t "$SUB_DIR.XXXXXXXXXX")
+function finish {
+  rm -rf "$TMPDIR"
+}
+trap finish EXIT
+
+if [ "$DUMP_TYPE" == "full" ]; then
+    if ! /usr/local/bin/python manage.py dump create_full -l "$TMPDIR" -t $DUMP_THREADS --last-dump-id; then
+	echo "Full dump failed, exiting!"
+	exit 1
+    fi
+elif [ "$DUMP_TYPE" == "incremental" ]; then
+    if ! /usr/local/bin/python manage.py dump create_incremental -l "$TMPDIR" -t $DUMP_THREADS; then
+	echo "Incremental dump failed, exiting!"
+	exit 1
+    fi
 else
     echo "Not sure what type of dump to create, exiting!"
     exit 1
 fi
 
+DUMP_ID_FILE=$(find "$TMPDIR" -type f -name 'DUMP_ID.txt')
+if [ -z "$DUMP_ID_FILE" ]; then
+    echo "DUMP_ID.txt not found, exiting."
+    exit 1
+fi
 
-DUMP_NAME=`ls -t $TEMP_DIR/$SUB_DIR | head -1`
-DUMP_TIMESTAMP=`echo $DUMP_NAME | awk -F '-' '{ printf "%s-%s", $4, $5 }'`
-DUMP_ID=`echo $DUMP_NAME | awk -F '-' '{ printf "%s", $3}'`
+HAS_EMPTY_DIRS_OR_FILES=$(find "$TMPDIR" -empty)
+if [ -z "$HAS_EMPTY_DIRS_OR_FILES" ]; then
+    echo "Empty files or dirs, exiting."
+    echo "$HAS_EMPTY_DIRS_OR_FILES"
+    exit 1
+fi
+
+read -r DUMP_TIMESTAMP DUMP_ID DUMP_TYPE < "$DUMP_ID_FILE"
+
 echo "Dump created with timestamp $DUMP_TIMESTAMP"
-DUMP_DIR="$TEMP_DIR"/$SUB_DIR/"$DUMP_NAME"
+DUMP_DIR=$(dirname "$DUMP_ID_FILE")
+DUMP_NAME=$(basename "$DUMP_DIR")
 
 # Backup dumps to the backup volume
 # Create backup directories owned by user "listenbrainz"
@@ -77,19 +101,19 @@ mkdir -m "$BACKUP_DIR_MODE" -p \
          "$BACKUP_DIR"/$SUB_DIR/ \
          "$BACKUP_DIR"/$SUB_DIR/"$DUMP_NAME"
 chown "$BACKUP_USER:$BACKUP_GROUP" \
-      "$BACKUP_DIR"/$SUB_DIR/ \
-      "$BACKUP_DIR"/$SUB_DIR/"$DUMP_NAME"
+      "$BACKUP_DIR/$SUB_DIR/" \
+      "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
 echo "Backup directories created!"
 
 # Copy the files into the backup directory
 echo "Begin copying dumps to backup directory..."
-retry cp -a "$DUMP_DIR"/* "$BACKUP_DIR"/$SUB_DIR/"$DUMP_NAME"/
-chmod "$BACKUP_FILE_MODE" "$BACKUP_DIR"/"$SUB_DIR"/"$DUMP_NAME"/*
+retry cp -a "$DUMP_DIR"/* "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"/
+chmod "$BACKUP_FILE_MODE" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"/*
 echo "Dumps copied to backup directory!"
 
 
 # rsync the files into the FTP server
-FTP_CURRENT_DUMP_DIR="$FTP_DIR"/$SUB_DIR/"$DUMP_NAME"
+FTP_CURRENT_DUMP_DIR="$FTP_DIR/$SUB_DIR/$DUMP_NAME"
 
 # create the dir in which to copy the dumps before
 # changing their permissions to the FTP_FILE_MODE
@@ -99,7 +123,7 @@ mkdir -m "$FTP_DIR_MODE" -p "$FTP_CURRENT_DUMP_DIR"
 # make sure these dirs are owned by the correct user
 chown "$FTP_USER:$FTP_GROUP" \
       "$FTP_DIR" \
-      "$FTP_DIR"/$SUB_DIR \
+      "$FTP_DIR/$SUB_DIR" \
       "$FTP_CURRENT_DUMP_DIR"
 
 # make sure all dump files are owned by the correct user
@@ -110,26 +134,26 @@ chmod "$FTP_FILE_MODE" "$FTP_CURRENT_DUMP_DIR"/*
 
 # create an explicit rsync filter for the new private dump in the
 # ftp folder
-touch "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
+touch "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
-add_rsync_include_rule $FTP_CURRENT_DUMP_DIR "listenbrainz-public-dump-$DUMP_TIMESTAMP.tar.xz"
+add_rsync_include_rule "$FTP_CURRENT_DUMP_DIR" "listenbrainz-public-dump-$DUMP_TIMESTAMP.tar.xz"
 add_rsync_include_rule \
-    $FTP_CURRENT_DUMP_DIR \
+    "$FTP_CURRENT_DUMP_DIR" \
     "listenbrainz-listens-dump-$DUMP_ID-$DUMP_TIMESTAMP-$DUMP_TYPE.tar.xz"
 add_rsync_include_rule \
-    $FTP_CURRENT_DUMP_DIR \
+    "$FTP_CURRENT_DUMP_DIR" \
     "listenbrainz-listens-dump-$DUMP_ID-$DUMP_TIMESTAMP-spark-$DUMP_TYPE.tar.xz"
 
 EXCLUDE_RULE="exclude *"
-echo "$EXCLUDE_RULE" >> "$FTP_CURRENT_DUMP_DIR"/.rsync-filter
-cat $FTP_CURRENT_DUMP_DIR/.rsync-filter
+echo "$EXCLUDE_RULE" >> "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
+cat "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
 
-/usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR"/$SUB_DIR
-/usr/local/bin/python manage.py dump delete_old_dumps $BACKUP_DIR/$SUB_DIR
-/usr/local/bin/python manage.py dump delete_old_dumps  $TEMP_DIR/$SUB_DIR
+/usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR/$SUB_DIR"
+/usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"
+/usr/local/bin/python manage.py dump delete_old_dumps "$TEMP_DIR/$SUB_DIR"
 
 # rsync to ftp folder taking care of the rules
-./admin/rsync-dump-files.sh $DUMP_TYPE
+./admin/rsync-dump-files.sh "$DUMP_TYPE"
 
 echo "Dumps created, backed up and uploaded to the FTP server!"

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -188,7 +188,7 @@ def import_dump(private_archive, public_archive, listen_archive, threads):
             threads (int): the number of threads to use during decompression, defaults to 1
     """
     if not private_archive and not public_archive and not listen_archive:
-        print('You need to enter a path to the archive(s) to import!')
+        current_app.logger.critical('You need to enter a path to the archive(s) to import!')
         sys.exit(1)
 
     app = create_app()
@@ -235,7 +235,7 @@ def _cleanup_dumps(location):
     dump_files = [x for x in os.listdir(location) if full_dump_re.match(x)]
     full_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
     if not full_dumps:
-        print('No full dumps present in specified directory!')
+        current_app.logger.critical('No full dumps present in specified directory!')
     else:
         remove_dumps(location, full_dumps, NUMBER_OF_FULL_DUMPS_TO_KEEP)
 
@@ -243,7 +243,7 @@ def _cleanup_dumps(location):
     dump_files = [x for x in os.listdir(location) if incremental_dump_re.match(x)]
     incremental_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
     if not incremental_dumps:
-        print('No full dumps present in specified directory!')
+        current_app.logger.critical('No full dumps present in specified directory!')
     else:
         remove_dumps(location, incremental_dumps, NUMBER_OF_INCREMENTAL_DUMPS_TO_KEEP)
 
@@ -252,17 +252,17 @@ def remove_dumps(location, dumps, remaining_count):
     keep = dumps[0:remaining_count]
     keep_count = 0
     for dump in keep:
-        print('Keeping %s...' % dump)
+        current_app.logger.info('Keeping %s...' % dump)
         keep_count += 1
 
     remove = dumps[remaining_count:]
     remove_count = 0
     for dump in remove:
-        print('Removing %s...' % dump)
+        current_app.logger.info('Removing %s...' % dump)
         shutil.rmtree(os.path.join(location, dump))
         remove_count += 1
 
-    print('Deleted %d old exports, kept %d exports!' % (remove_count, keep_count))
+    current_app.logger.info('Deleted %d old exports, kept %d exports!' % (remove_count, keep_count))
     return keep_count, remove_count
 
 
@@ -304,7 +304,7 @@ def transmogrify_dump_file_to_spark_import_format(in_file, out_file, threads):
                         if member.name.endswith(".listens"):
                             filename = member.name.replace(".listens", ".json")
                             filename = filename.replace("-full", "-spark-full")
-                            print("mogrify: ", filename)
+                            current_app.logger.info("mogrify: ", filename)
                             tmp_file = tempfile.mkstemp()
                             with os.fdopen(tmp_file[0], "w") as out_f:
                                 with tarf.extractfile(member) as f:

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -182,7 +182,7 @@ def create_incremental(location, threads, dump_id):
         # Write the DUMP_ID file so that the FTP sync scripts can be more robust
         print(os.path.join(dump_path, "DUMP_ID.txt"))
         with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
-            f.write("%s %s incremental" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
+            f.write("%s %s incremental\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
 
         current_app.logger.info('Dumps created and hashes written at %s' % dump_path)
         sys.exit(0)

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -117,7 +117,7 @@ def create_full(location, threads, dump_id, last_dump_id):
         try:
             if not sanity_check_dumps(dump_path, 12):
                 return sys.exit(-1)
-        except IOError as e:
+        except OSError as e:
             sys.exit(-1)
 
         # if in production, send an email to interested people for observability
@@ -174,7 +174,7 @@ def create_incremental(location, threads, dump_id):
         try:
             if not sanity_check_dumps(dump_path, 6):
                 return sys.exit(-1)
-        except IOError as e:
+        except OSError as e:
             sys.exit(-1)
 
         # if in production, send an email to interested people for observability
@@ -308,6 +308,7 @@ def write_hashes(location):
 
 def sanity_check_dumps(location, expected_count):
     """ Sanity check the generated dumps to ensure that none are empty
+        and make sure that the right number of dump files exist.
 
     Args:
         location (str): the path in which the dump archive files are present

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -126,7 +126,7 @@ def create_full(location, threads, dump_id, last_dump_id):
 
         # Write the DUMP_ID file so that the FTP sync scripts can be more robust
         with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
-            f.write("%s %s full" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
+            f.write("%s %s full\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
 
         sys.exit(0)
 

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -180,7 +180,6 @@ def create_incremental(location, threads, dump_id):
         send_dump_creation_notification(dump_name, 'incremental')
 
         # Write the DUMP_ID file so that the FTP sync scripts can be more robust
-        print(os.path.join(dump_path, "DUMP_ID.txt"))
         with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
             f.write("%s %s incremental\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
 
@@ -301,13 +300,13 @@ def write_hashes(location):
             with open(os.path.join(location, '{}.sha256'.format(file)), 'w') as f:
                 sha256sum = subprocess.check_output(['sha256sum', os.path.join(location, file)]).decode('utf-8').split()[0]
                 f.write(sha256sum)
-        except IOError as e:
+        except OSError as e:
             current_app.logger.error('IOError while trying to write hash files for file %s: %s', file, str(e), exc_info=True)
             raise
 
 
 def sanity_check_dumps(location, expected_count):
-    """ Sanity check the generated dummps to ensure that none are empty
+    """ Sanity check the generated dumps to ensure that none are empty
 
     Args:
         location (str): the path in which the dump archive files are present
@@ -320,17 +319,14 @@ def sanity_check_dumps(location, expected_count):
     for file in os.listdir(location):
         try:
             dump_file = os.path.join(location, file)
-            print(dump_file)
             if os.path.getsize(dump_file) == 0:
                 print("Dump file %s is empty!" % dump_file)
                 return False
             count += 1
-        except IOError as e:
-            print("caught ioerror")
+        except OSError as e:
             return False
 
     if expected_count == count:
-        print("count ok")
         return True
 
     print("Expected %d dump files, found %d. Aborting." % (expected_count, count))

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -118,6 +118,11 @@ def create_full(location, threads, dump_id, last_dump_id):
         send_dump_creation_notification(dump_name, 'fullexport')
 
         current_app.logger.info('Dumps created and hashes written at %s' % dump_path)
+
+        # Write the DUMP_ID file so that the FTP sync scripts can be more robust
+        with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
+            f.write("%s %s full" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
+
         sys.exit(0)
 
 
@@ -162,6 +167,10 @@ def create_incremental(location, threads, dump_id):
 
         # if in production, send an email to interested people for observability
         send_dump_creation_notification(dump_name, 'incremental')
+
+        # Write the DUMP_ID file so that the FTP sync scripts can be more robust
+        with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
+            f.write("%s %s incremental" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
 
         current_app.logger.info('Dumps created and hashes written at %s' % dump_path)
         sys.exit(0)

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -96,14 +96,15 @@ def create_full(location, threads, dump_id, last_dump_id):
                 sys.exit(-1)
             end_time = dump_entry['created']
 
-        dump_name = 'listenbrainz-dump-{dump_id}-{time}-full'.format(dump_id=dump_id, time=end_time.strftime('%Y%m%d-%H%M%S'))
+        ts = end_time.strftime('%Y%m%d-%H%M%S')
+        dump_name = 'listenbrainz-dump-{dump_id}-{time}-full'.format(dump_id=dump_id, time=ts)
         dump_path = os.path.join(location, dump_name)
         create_path(dump_path)
         db_dump.dump_postgres_db(dump_path, end_time, threads)
 
         listens_dump_file = ls.dump_listens(dump_path, dump_id=dump_id, end_time=end_time, threads=threads)
         spark_dump_file = 'listenbrainz-listens-dump-{dump_id}-{time}-spark-full.tar.xz'.format(dump_id=dump_id,
-                           time=end_time.strftime('%Y%m%d-%H%M%S'))
+                           time=ts)
         spark_dump_path = os.path.join(location, dump_path, spark_dump_file)
         transmogrify_dump_file_to_spark_import_format(listens_dump_file, spark_dump_path, threads)
 
@@ -126,7 +127,7 @@ def create_full(location, threads, dump_id, last_dump_id):
 
         # Write the DUMP_ID file so that the FTP sync scripts can be more robust
         with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
-            f.write("%s %s full\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
+            f.write("%s %s full\n" % (ts, dump_id))
 
         sys.exit(0)
 

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -111,13 +111,14 @@ def create_full(location, threads, dump_id, last_dump_id):
             write_hashes(dump_path)
         except IOError as e:
             current_app.logger.error('Unable to create hash files! Error: %s', str(e), exc_info=True)
-            return
+            sys.exit(-1)
 
 
         # if in production, send an email to interested people for observability
         send_dump_creation_notification(dump_name, 'fullexport')
 
         current_app.logger.info('Dumps created and hashes written at %s' % dump_path)
+        sys.exit(0)
 
 
 @cli.command(name="create_incremental")
@@ -157,12 +158,13 @@ def create_incremental(location, threads, dump_id):
             write_hashes(dump_path)
         except IOError as e:
             current_app.logger.error('Unable to create hash files! Error: %s', str(e), exc_info=True)
-            return
+            sys.exit(-1)
 
         # if in production, send an email to interested people for observability
         send_dump_creation_notification(dump_name, 'incremental')
 
         current_app.logger.info('Dumps created and hashes written at %s' % dump_path)
+        sys.exit(0)
 
 
 @cli.command(name="import_dump")
@@ -206,11 +208,14 @@ def import_dump(private_archive, public_archive, listen_archive, threads):
             current_app.logger.critical('Unexpected error while importing data: %s', str(e), exc_info=True)
             raise
 
+    sys.exit(0)
+
 
 @cli.command(name="delete_old_dumps")
 @click.argument('location', type=str)
 def delete_old_dumps(location):
     _cleanup_dumps(location)
+    sys.exit(0)
 
 
 def get_dump_id(dump_name):


### PR DESCRIPTION
When the listenbrainz-cron-prod container is killed while dumps are being sync'ed to the FTP server, empty dump files may be left in the container which may end up being sync'ed to the FTP server. This has caused 0B *private* dump files to appear on the FTP server. While no private data has been leaked as part of this, we need to ensure that the dump creation process is more robust than it is now. This PR aims to accomplish this.