### PR TITLE
Make create-dumps.sh script safer

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -55,9 +55,15 @@ else
 fi
 
 if [ $DUMP_TYPE == "full" ]; then
-    /usr/local/bin/python manage.py dump create_full -l $TEMP_DIR/$SUB_DIR -t $DUMP_THREADS --last-dump-id
+    if ! /usr/local/bin/python manage.py dump create_full -l $TEMP_DIR/$SUB_DIR -t $DUMP_THREADS --last-dump-id; then
+	echo "Full dump failed, exiting!"
+	exit 1
+    fi
 elif [ $DUMP_TYPE == "incremental" ]; then
-    /usr/local/bin/python manage.py dump create_incremental -l $TEMP_DIR/$SUB_DIR -t $DUMP_THREADS
+    if ! /usr/local/bin/python manage.py dump create_incremental -l $TEMP_DIR/$SUB_DIR -t $DUMP_THREADS; then
+	echo "Incremental dump failed, exiting!"
+	exit 1
+    fi
 else
     echo "Not sure what type of dump to create, exiting!"
     exit 1


### PR DESCRIPTION
My changes are doing following: 

- dumps are stored in an unique temp dir, if script exits normally (=not kill -9 or power off), directory is cleaned at exit whatever happens
- it checks for DUMP_ID.txt file existence and parses it (else bail out)
- it checks for empty files or directories (none should exist), bail out if found
- proper quoting of strings