### PR TITLE
Make timescale test setup part of generic testing code

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
 
   timescale:
     image: timescale/timescaledb:latest-pg12
+    command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'
 

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -4,15 +4,16 @@ import unittest
 
 from listenbrainz import config
 from listenbrainz import db
+from listenbrainz.db import timescale as ts
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'admin', 'sql')
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'testdata')
+TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'admin', 'timescale')
 
 
 class DatabaseTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.config = config
         db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
         self.reset_db()
 
@@ -44,3 +45,29 @@ class DatabaseTestCase(unittest.TestCase):
                 file_name: the name of the data file
         """
         return os.path.join(TEST_DATA_PATH, file_name)
+
+
+class TimescaleTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Reset the database in setUp, this way if there is a test failure and you want
+        # to inspect data, it won't have been cleared away
+        self.reset_timescale_db()
+
+    def reset_timescale_db(self):
+        ts.init_db_connection(config.TIMESCALE_ADMIN_URI)
+        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'drop_db.sql'))
+        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_db.sql'))
+        ts.engine.dispose()
+
+        ts.init_db_connection(config.TIMESCALE_ADMIN_LB_URI)
+        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_extensions.sql'))
+        ts.engine.dispose()
+
+        ts.init_db_connection(config.SQLALCHEMY_TIMESCALE_URI)
+        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_extensions.sql'))
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_tables.sql'))
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_functions.sql'))
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_views.sql'))
+        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_indexes.sql'))
+        ts.engine.dispose()

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -3,7 +3,6 @@
 import datetime
 import logging
 import time
-import ujson
 import uuid
 
 from dateutil.relativedelta import relativedelta
@@ -11,8 +10,8 @@ from redis.connection import Connection
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz import config
 from listenbrainz.listen import Listen
-from listenbrainz.listenstore.tests.util import generate_data
 from listenbrainz.webserver.redis_connection import init_redis_connection
 from listenbrainz.listenstore.redis_listenstore import RedisListenStore
 
@@ -22,7 +21,8 @@ class RedisListenStoreTestCase(DatabaseTestCase):
     def setUp(self):
         super(RedisListenStoreTestCase, self).setUp()
         self.log = logging.getLogger()
-        self._redis = init_redis_connection(self.log, self.config.REDIS_HOST, self.config.REDIS_PORT, self.config.REDIS_NAMESPACE)
+        # TODO: Ideally this would use a config from a flask app, but this test case doesn't create an app
+        self._redis = init_redis_connection(self.log, config.REDIS_HOST, config.REDIS_PORT, config.REDIS_NAMESPACE)
         self.testuser = db_user.get_or_create(1, "test")
 
     def tearDown(self):
@@ -41,7 +41,7 @@ class RedisListenStoreTestCase(DatabaseTestCase):
                 'additional_info': {},
             },
         }
-        self._redis.put_playing_now(listen['user_id'], listen, self.config.PLAYING_NOW_MAX_DURATION)
+        self._redis.put_playing_now(listen['user_id'], listen, config.PLAYING_NOW_MAX_DURATION)
 
         playing_now = self._redis.get_playing_now(listen['user_id'])
         self.assertIsNotNone(playing_now)

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -1,14 +1,11 @@
 import json
-import sys
 import os
 import listenbrainz.db.user as db_user
 from flask import current_app, url_for
 
 from redis import Redis
-from listenbrainz import config
 from listenbrainz.webserver.testing import ServerTestCase, APICompatServerTestCase
-from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.db import timescale as ts
+from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
 
 TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'admin', 'timescale')
 
@@ -24,34 +21,17 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
         DatabaseTestCase.tearDown(self)
 
 
-class ListenAPIIntegrationTestCase(IntegrationTestCase):
+class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):
     def setUp(self):
-        super(ListenAPIIntegrationTestCase, self).setUp()
+        IntegrationTestCase.setUp(self)
+        TimescaleTestCase.setUp(self)
         self.user = db_user.get_or_create(1, 'testuserpleaseignore')
 
     def tearDown(self):
         r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
         r.flushall()
-        self.reset_timescale_db()
-        super(ListenAPIIntegrationTestCase, self).tearDown()
-
-    def reset_timescale_db(self):
-
-        ts.init_db_connection(config.TIMESCALE_ADMIN_URI)
-        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'drop_db.sql'))
-        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_db.sql'))
-        ts.engine.dispose()
-
-        ts.init_db_connection(config.TIMESCALE_ADMIN_LB_URI)
-        ts.run_sql_script_without_transaction(os.path.join(TIMESCALE_SQL_DIR, 'create_extensions.sql'))
-        ts.engine.dispose()
-
-        ts.init_db_connection(config.SQLALCHEMY_TIMESCALE_URI)
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_tables.sql'))
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_functions.sql'))
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_views.sql'))
-        ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_indexes.sql'))
-        ts.engine.dispose()
+        IntegrationTestCase.tearDown(self)
+        TimescaleTestCase.tearDown(self)
 
     def send_data(self, payload, user=None):
         """ Sends payload to api.submit_listen and return the response

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -1,17 +1,10 @@
-import sys
-import os
-import uuid
-import unittest
-
-from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
-from listenbrainz.db import timescale as ts
-from listenbrainz.webserver.errors import APINotFound
-from flask import url_for, current_app
-from redis import Redis
-import listenbrainz.db.user as db_user
-import time
 import json
-from listenbrainz import config
+import time
+
+from flask import url_for
+
+import listenbrainz.db.user as db_user
+from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
 


### PR DESCRIPTION

# Problem

We need to run unit tests against the timescale database

# Solution
Move timescale database setup to the generic testing module, rather than making it a part of an integration class testcase.

