### PR TITLE
Remove published ports on test containers

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -45,5 +45,3 @@ services:
 
   rabbitmq:
     image: rabbitmq:3.6.5
-    ports:
-      - "5672:5672"

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -23,8 +23,6 @@ services:
 
   rabbitmq:
     image: rabbitmq:3.6.5
-    ports:
-      - "5672:5672"
 
   listenbrainz:
     build:


### PR DESCRIPTION
# Problem

Unit and integration tests were both publishing the rabbitmq port to the docker host, but there's no reason to have access to this port during testing. We don't need to connect to rabbitmq while the tests are running.
Additionally, this prevents us from running both int and unit tests at the same time, as there is a port conflict.


# Solution
Don't publish the ports