### PR TITLE
name the timescale init_db method differently

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -149,7 +149,7 @@ def init_msb_db(force, create_db):
 @cli.command(name="init_ts_db")
 @click.option("--force", "-f", is_flag=True, help="Drop existing database and user.")
 @click.option("--create-db", is_flag=True, help="Create the database and user.")
-def init_db(force, create_db):
+def init_ts_db(force, create_db):
     """Initializes database.
     This process involves several steps:
     1. Table structure is created.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

`manage.py init_db` and `init_ts_db` both were defined with the same named function. How did this ever work? I don't know. I suspect there's some deep click magic with the `name=` parameter that was stopping this from exploding.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution

make function names unique

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


