### PR TITLE
Fix double encoding of spotify query

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -32,7 +32,7 @@ const searchForSpotifyTrack = async (
   }
 
   const response = await fetch(
-    `https://api.spotify.com/v1/search?${encodeURI(queryString)}`,
+    `https://api.spotify.com/v1/search?${queryString}`,
     {
       method: "GET",
       headers: {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
I introduced a regression with PR #1176 
We're double-encoding the query string which breaks the spotify track search:

We encode for example `hello world` into `hello%20world`, and then the `%` is encoded again into `%25` for a result of `hello%2520world`.

# Solution

Don't call encodeURI after already encoding each search input safely with `encodeURIComponent`.
The rest of the query parameters (`?track=` etc.)we write ourselves so we know it is safe and doesn't need encoding.



