### PR TITLE
Do not check for public field while adding tracks

### DIFF
--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -368,12 +368,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
                  {
                     "identifier": PLAYLIST_TRACK_URI_PREFIX + "4a77a078-e91a-4522-a409-3b58aa7de3ae"
                  }
-              ],
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
+              ]
            }
         }
         response = self.client.post(


### PR DESCRIPTION
While adding a new track to the playlist, we do not need to check for the public field. This PR goes a bit further to create separate validators for checking the type of the fields and the data of the playlist.

