### PR TITLE
Create a URL namespace to redirect users to their profile page

### DIFF
--- a/docs/dev/api.rst
+++ b/docs/dev/api.rst
@@ -57,9 +57,19 @@ Core API Endpoints
   :statuscode 400: invalid JSON sent, see error message for details.
   :statuscode 401: invalid authorization. See error message for details.
 
+Playlists API Endpoints
+^^^^^^^^^^^^^^^^^^^^^^^
+The playlists API allows for the creation and editing of lists of recordings
+
+.. autoflask:: listenbrainz.webserver:create_app_rtfd()
+   :blueprints: playlist_api_v1
+   :include-empty-docstring:
+   :undoc-static:
+
+
 Statistics API Endpoints
 ^^^^^^^^^^^^^^^^^^^^^^^^
-ListenBrainz now has a statistics infrastructure that collects and computes statistics
+ListenBrainz has a statistics infrastructure that collects and computes statistics
 from the listen data that has been stored in the database. The endpoints in this section
 offer a way to get this data programmatically.
 

--- a/listenbrainz/rtd_config.py
+++ b/listenbrainz/rtd_config.py
@@ -93,3 +93,5 @@ SPOTIFY_CLIENT_ID = ''
 SPOTIFY_CLIENT_SECRET = ''
 
 ADMINS = ['iliekcomputers']
+
+FEATURE_PLAYLIST = True

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -237,6 +237,7 @@ def _register_blueprints(app):
     from listenbrainz.webserver.views.api import api_bp
     from listenbrainz.webserver.views.api_compat import api_bp as api_bp_compat
     from listenbrainz.webserver.views.user import user_bp
+    from listenbrainz.webserver.views.user import redirect_bp
     from listenbrainz.webserver.views.profile import profile_bp
     from listenbrainz.webserver.views.follow import follow_bp
     from listenbrainz.webserver.views.follow_api import follow_api_bp
@@ -251,6 +252,7 @@ def _register_blueprints(app):
     from listenbrainz.webserver.views.playlist_api import playlist_api_bp
     app.register_blueprint(index_bp)
     app.register_blueprint(login_bp, url_prefix='/login')
+    app.register_blueprint(redirect_bp, url_prefix='/my')
     app.register_blueprint(user_bp, url_prefix='/user')
     app.register_blueprint(profile_bp, url_prefix='/profile')
     app.register_blueprint(follow_bp, url_prefix='/follow')

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -271,7 +271,7 @@ def create_playlist():
     :statuscode 200: playlist accepted.
     :statuscode 400: invalid JSON sent, see error message for details.
     :statuscode 401: invalid authorization. See error message for details.
-    :statuscode 403: forbidden. The subitting user is not allowed to submit playlists for other users.
+    :statuscode 403: forbidden. The submitting user is not allowed to create playlists for other users.
     :resheader Content-Type: *application/json*
     """
 

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -44,6 +44,25 @@ class UserViewsTestCase(ServerTestCase, DatabaseTestCase):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
 
+    def test_redirects(self):
+        # Not logged in
+        response = self.client.get(url_for("redirect.redirect_listens"))
+        self.assertEqual(response.status_code, 302)
+        assert response.location.endswith("/login/?next=%2Fmy%2Flistens")
+
+        self.temporary_login(self.user.login_id)
+        response = self.client.get(url_for("redirect.redirect_listens"))
+        self.assertEqual(response.status_code, 302)
+        assert response.location.endswith("/user/iliekcomputers")
+
+        response = self.client.get(url_for("redirect.redirect_charts"))
+        self.assertEqual(response.status_code, 302)
+        assert response.location.endswith("/user/iliekcomputers/charts")
+
+        response = self.client.get(url_for("redirect.redirect_charts") + "?foo=bar")
+        self.assertEqual(response.status_code, 302)
+        assert response.location.endswith("/user/iliekcomputers/charts?foo=bar")
+
     def test_user_page(self):
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)


### PR DESCRIPTION



# Problem
The user-facing informational pages contain a username in the url, and
so we don't have a specific URL where we can send everyone to with a
link on twitter, etc.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
 Make a new namespace /my/[page] that redirects
to /user/[username]/page if the user is logged in.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


