### PR TITLE
LB-579: Improve pagination buttons on "Recent Listens" and "User Artists" page

### DIFF
--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -659,7 +659,7 @@ export default class RecentListens extends React.Component<
       <ul className="pager" style={{ display: "flex" }}>
         <li
           className={`previous ${
-            currRecPage && currRecPage <= 1 ? "hidden" : ""
+            currRecPage && currRecPage <= 1 ? "disabled" : ""
           }`}
         >
           <a
@@ -675,7 +675,7 @@ export default class RecentListens extends React.Component<
         </li>
         <li
           className={`next ${
-            currRecPage && currRecPage >= totalRecPages ? "hidden" : ""
+            currRecPage && currRecPage >= totalRecPages ? "disabled" : ""
           }`}
           style={{ marginLeft: "auto" }}
         >

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -548,7 +548,7 @@ export default class UserEntityChart extends React.Component<
                 <div className="col-xs-12">
                   <ul className="pager">
                     <li
-                      className={`previous ${!(prevPage > 0) ? "hidden" : ""}`}
+                      className={`previous ${!(prevPage > 0) ? "disabled" : ""}`}
                     >
                       <a
                         href=""
@@ -560,7 +560,7 @@ export default class UserEntityChart extends React.Component<
                     </li>
                     <li
                       className={`next ${
-                        !(nextPage <= totalPages) ? "hidden" : ""
+                        !(nextPage <= totalPages) ? "disabled" : ""
                       }`}
                     >
                       <a

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserEntityChart.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserEntityChart.test.tsx.snap
@@ -663,7 +663,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
             className="pager"
           >
             <li
-              className="previous hidden"
+              className="previous disabled"
             >
               <a
                 href=""
@@ -674,7 +674,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
               </a>
             </li>
             <li
-              className="next hidden"
+              className="next disabled"
             >
               <a
                 href=""
@@ -1605,7 +1605,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
             className="pager"
           >
             <li
-              className="previous hidden"
+              className="previous disabled"
             >
               <a
                 href=""
@@ -1616,7 +1616,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
               </a>
             </li>
             <li
-              className="next hidden"
+              className="next disabled"
             >
               <a
                 href=""
@@ -2447,7 +2447,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
             className="pager"
           >
             <li
-              className="previous hidden"
+              className="previous disabled"
             >
               <a
                 href=""
@@ -2458,7 +2458,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
               </a>
             </li>
             <li
-              className="next hidden"
+              className="next disabled"
             >
               <a
                 href=""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem


    The pagination buttons in "Recent LIstens" and User Entity Chart"should use "disabled" style instead of "hidden".
    https://tickets.metabrainz.org/browse/LB-579


# Solution

Changed classname from  "hidden" to "disabled"


