### PR TITLE
Specify version of timescaledb image to be used

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -16,7 +16,7 @@ services:
     image: redis:5.0.3
 
   timescale:
-    image: timescale/timescaledb:latest-pg12
+    image: timescale/timescaledb:1.7.4-pg12
     environment:
       POSTGRES_PASSWORD: 'postgres'
 

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
     image: redis:5.0.3
 
   timescale:
-    image: timescale/timescaledb:latest-pg12
+    image: timescale/timescaledb:1.7.4-pg12
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - redis:/data:z
 
   timescale:
-    image: timescale/timescaledb:latest-pg12
+    image: timescale/timescaledb:1.7.4-pg12
     volumes:
       - timescaledb:/var/lib/postgresql/data:z
     environment:

--- a/docker/jenkins/docker-compose.integration.yml
+++ b/docker/jenkins/docker-compose.integration.yml
@@ -16,7 +16,7 @@ services:
     image: redis:5.0.3
 
   timescale:
-    image: timescale/timescaledb:latest-pg12
+    image: timescale/timescaledb:1.7.4-pg12
     environment:
       POSTGRES_PASSWORD: 'postgres'
 

--- a/docker/jenkins/docker-compose.unit.yml
+++ b/docker/jenkins/docker-compose.unit.yml
@@ -15,7 +15,7 @@ services:
     image: redis:5.0.3
 
   timescale:
-    image: timescale/timescaledb:latest-pg12
+    image: timescale/timescaledb:1.7.4-pg12
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: "postgres"


### PR DESCRIPTION
The `timescaledb:latest` image now points to 2.0.0 version of timescale. This is a release with breaking changes. Before closer examination of the necessary changes to upgrade timescale, temporarily use 1.7.4 release. The current sql scripts fail with the 2.0.0 release. This temporary fix will help in easier local development.