### PR TITLE
Document that Content-Type header is required for submit-listens

### DIFF
--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -47,6 +47,7 @@ def submit_listen():
     For complete details on the format of the JSON to be POSTed to this endpoint, see :ref:`json-doc`.
 
     :reqheader Authorization: Token <user token>
+    :reqheader Content-Type: *application/json*
     :statuscode 200: listen(s) accepted.
     :statuscode 400: invalid JSON sent, see error message for details.
     :statuscode 401: invalid authorization. See error message for details.

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -300,6 +300,7 @@ def latest_import():
     The JSON that needs to be posted must contain a field named `ts` in the root with a valid unix timestamp.
 
     :reqheader Authorization: Token <user token>
+    :reqheader Content-Type: *application/json*
     :statuscode 200: latest import timestamp updated
     :statuscode 400: invalid JSON sent, see error message for details.
     :statuscode 401: invalid authorization. See error message for details.
@@ -396,6 +397,7 @@ def delete_listen():
         }
 
     :reqheader Authorization: Token <user token>
+    :reqheader Content-Type: *application/json*
     :statuscode 200: listen deleted.
     :statuscode 400: invalid JSON sent, see error message for details.
     :statuscode 401: invalid authorization. See error message for details.


### PR DESCRIPTION
# Problem

If the client does not provide a `Content-Type` header in the `/1/submit-listens` request, then the response is

    {
      "code": 400,
      "error": "Cannot parse JSON document: Expected object or value"
    }

even if the body does contain a valid json document. It is not clear from the docs that a `Content-Type` header is needed.

# Solution

Mention the header in the docs.

# Action

It would be nice to re-deploy the docs to help future readers.