### PR TITLE
Remove unused configuration options

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -45,11 +45,6 @@ DB_CONNECT_MAPPING = "dbname=musicbrainz_json_dump user=musicbrainz host={{.Addr
 {{end}}
 {{end}}
 
-# Not currently used
-MAX_POSTGRES_LISTEN_HISTORY = "-1"
-PG_QUERY_TIMEOUT = "3000"
-PG_ASYNC_LISTEN_COMMIT = False
-
 {{if service "listenbrainz-redis"}}
 {{with index (service "listenbrainz-redis") 0}}
 REDIS_HOST = "{{.Address}}"

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -19,14 +19,6 @@ SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@timesca
 TIMESCALE_ADMIN_URI = "postgresql://postgres:postgres@timescale/postgres"
 TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@timescale/listenbrainz_ts"
 
-# Other postgres configuration options
-# Oldest listens which can be stored in the database, in days.
-MAX_POSTGRES_LISTEN_HISTORY = "-1"
-# Log Postgres queries if they execeed this time, in milliseconds.
-PG_QUERY_TIMEOUT = "3000"
-# Set to True to enable 'synchronous_commit' for Postgres. Default: False
-PG_ASYNC_LISTEN_COMMIT = False
-
 
 # Redis
 REDIS_HOST = "redis"

--- a/listenbrainz/rtd_config.py
+++ b/listenbrainz/rtd_config.py
@@ -15,15 +15,6 @@ SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@timesca
 TIMESCALE_ADMIN_URI = "postgresql://postgres:postgres@timescale/postgres"
 TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@timescale/listenbrainz_ts"
 
-# Other postgres configuration options
-# Oldest listens which can be stored in the database, in days.
-MAX_POSTGRES_LISTEN_HISTORY = "-1"
-# Log Postgres queries if they execeed this time, in milliseconds.
-PG_QUERY_TIMEOUT = "3000"
-# Set to True to enable 'synchronous_commit' for Postgres. Default: False
-PG_ASYNC_LISTEN_COMMIT = False
-
-
 # Redis
 REDIS_HOST = "redis"
 REDIS_PORT = 6379


### PR DESCRIPTION
# Problem

These were from the old postgres-based listenstore, and are no longer
used anywhere

# Solution
remove them!