### PR TITLE
LB-765: In development, use a single postgres server for all databases

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -16,7 +16,7 @@ SECRET_KEY = '''{{template "KEY" "secret_key"}}'''
 {{with index (service "pgbouncer-master") 0}}
 SQLALCHEMY_DATABASE_URI = "postgresql://listenbrainz:listenbrainz@{{.Address}}:{{.Port}}/listenbrainz"
 MESSYBRAINZ_SQLALCHEMY_DATABASE_URI = "postgresql://messybrainz:messybrainz@{{.Address}}:{{.Port}}/messybrainz"
-POSTGRES_ADMIN_URI="postgresql://postgres@{{.Address}}:{{.Port}}/template1"
+POSTGRES_ADMIN_URI="postgresql://postgres@{{.Address}}:{{.Port}}/postgres"
 {{end}}
 {{end}}
 
@@ -34,7 +34,7 @@ MB_DATABASE_URI = 'postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrain
 {{if service "timescale-listenbrainz"}}
 {{with index (service "timescale-listenbrainz") 0}}
 SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@{{.Address}}:{{.Port}}/listenbrainz_ts"
-TIMESCALE_ADMIN_URI="postgresql://postgres:postgres@{{.Address}}:{{.Port}}/template1"
+TIMESCALE_ADMIN_URI="postgresql://postgres:postgres@{{.Address}}:{{.Port}}/postgres"
 TIMESCALE_ADMIN_LB_URI="postgresql://postgres:postgres@{{.Address}}:{{.Port}}/listenbrainz_ts"
 {{end}}
 {{end}}

--- a/develop.sh
+++ b/develop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 POSTGRES_LB_URI="postgresql://listenbrainz:listenbrainz@db/listenbrainz"
-SQLALCHEMY_TIMESCALE_URI="postgresql://listenbrainz_ts:listenbrainz_ts@timescale/listenbrainz_ts"
+SQLALCHEMY_TIMESCALE_URI="postgresql://listenbrainz_ts:listenbrainz_ts@db/listenbrainz_ts"
 
 if [[ ! -d "docker" ]]; then
     echo "This script must be run from the top level directory of the listenbrainz-server source."

--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -7,18 +7,13 @@ version: "3.4"
 services:
 
   db:
-    image: postgres:12.3
+    image: timescale/timescaledb:1.7.4-pg12
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'
 
   redis:
     image: redis:5.0.3
-
-  timescale:
-    image: timescale/timescaledb:1.7.4-pg12
-    environment:
-      POSTGRES_PASSWORD: 'postgres'
 
   listenbrainz:
     build:
@@ -32,7 +27,6 @@ services:
     depends_on:
       - redis
       - db
-      - timescale
       - rabbitmq
 
   timescale_writer:
@@ -40,7 +34,7 @@ services:
     command: python3 -m "listenbrainz.timescale_writer.timescale_writer"
     depends_on:
       - redis
-      - timescale
+      - db
       - rabbitmq 
 
   rabbitmq:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -7,19 +7,13 @@ version: "3.4"
 services:
 
   db:
-    image: postgres:12.3
+    image: timescale/timescaledb:1.7.4-pg12
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'
 
   redis:
     image: redis:5.0.3
-
-  timescale:
-    image: timescale/timescaledb:1.7.4-pg12
-    command: postgres -F
-    environment:
-      POSTGRES_PASSWORD: 'postgres'
 
   rabbitmq:
     image: rabbitmq:3.6.5
@@ -34,7 +28,6 @@ services:
     depends_on:
       - redis
       - db
-      - timescale
       - rabbitmq
  
   frontend_tester:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,6 @@ version: "3.4"
 # `../` to refer to a directory in the main code checkout
 
 volumes:
-  postgres:
   redis:
   timescaledb:
   rabbitmq:
@@ -14,19 +13,12 @@ volumes:
 
 services:
 
-  db:
-    image: postgres:12.3
-    volumes:
-      - postgres:/var/lib/postgresql/data:z
-    environment:
-      POSTGRES_PASSWORD: 'postgres'
-
   redis:
     image: redis:5.0.3
     volumes:
       - redis:/data:z
 
-  timescale:
+  db:
     image: timescale/timescaledb:1.7.4-pg12
     volumes:
       - timescaledb:/var/lib/postgresql/data:z
@@ -57,7 +49,6 @@ services:
     depends_on:
       - redis
       - db
-      - timescale
       - rabbitmq
 
   api_compat:
@@ -70,7 +61,6 @@ services:
     depends_on:
       - redis
       - db
-      - timescale
       - rabbitmq
 
   timescale_writer:
@@ -80,7 +70,6 @@ services:
       - ..:/code/listenbrainz:z
     depends_on:
       - redis
-      - timescale
       - rabbitmq
 
   spotify_reader:
@@ -90,7 +79,6 @@ services:
     command: python3 -m "listenbrainz.spotify_updater.spotify_read_listens"
     depends_on:
       - redis
-      - timescale
       - rabbitmq
 
   follow_server:

--- a/docker/jenkins/docker-compose.integration.yml
+++ b/docker/jenkins/docker-compose.integration.yml
@@ -6,17 +6,12 @@ version: "3.4"
 
 services:
 
-  db:
-    image: postgres:12.3
-    command: postgres -F
-    environment:
-      POSTGRES_PASSWORD: 'postgres'
-
   redis:
     image: redis:5.0.3
 
-  timescale:
+  db:
     image: timescale/timescaledb:1.7.4-pg12
+    command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'
 
@@ -30,7 +25,6 @@ services:
     depends_on:
       - redis
       - db
-      - timescale
       - rabbitmq
 
   timescale_writer:
@@ -38,8 +32,8 @@ services:
     command: python3 -m "listenbrainz.timescale_writer.timescale_writer"
     depends_on:
       - redis
-      - timescale
-      - rabbitmq 
+      - db
+      - rabbitmq
 
   rabbitmq:
     image: rabbitmq:3.6.5

--- a/docker/jenkins/docker-compose.unit.yml
+++ b/docker/jenkins/docker-compose.unit.yml
@@ -5,16 +5,10 @@ version: "3.4"
 # `../` to refer to a directory in the main code checkout
 
 services:
-  db:
-    image: postgres:12.3
-    command: postgres -F
-    environment:
-      POSTGRES_PASSWORD: "postgres"
-
   redis:
     image: redis:5.0.3
 
-  timescale:
+  db:
     image: timescale/timescaledb:1.7.4-pg12
     command: postgres -F
     environment:
@@ -31,7 +25,6 @@ services:
     depends_on:
       - redis
       - db
-      - timescale
       - rabbitmq
 
   frontend_tester:

--- a/docker/jenkins/integration.sh
+++ b/docker/jenkins/integration.sh
@@ -40,7 +40,7 @@ function run_tests {
 
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                   up -d db timescale redis timescale_writer rabbitmq
+                   up -d db redis timescale_writer rabbitmq
 
     # List images and containers related to this build
     docker images | grep $COMPOSE_PROJECT_NAME | awk '{print $0}'

--- a/docker/jenkins/integration.sh
+++ b/docker/jenkins/integration.sh
@@ -49,7 +49,6 @@ function run_tests {
     docker-compose -f $COMPOSE_FILE_LOC -p $COMPOSE_PROJECT_NAME run --rm listenbrainz \
       dockerize \
       -wait tcp://db:5432 -timeout 60s \
-      -wait tcp://timescale:5432 -timeout 60s \
       bash -c "python3 manage.py init_db --create-db && \
                python3 manage.py init_msb_db --create-db && \
                python3 manage.py init_ts_db --create-db"
@@ -57,7 +56,6 @@ function run_tests {
     docker-compose -f $COMPOSE_FILE_LOC -p $COMPOSE_PROJECT_NAME run --name $TEST_CONTAINER_REF listenbrainz \
       dockerize \
         -wait tcp://db:5432 -timeout 60s \
-        -wait tcp://timescale:5432 -timeout 60s \
         -wait tcp://redis:6379 -timeout 60s \
         -wait tcp://rabbitmq:5672 -timeout 60s \
       pytest listenbrainz/tests/integration --junitxml=/data/test_report.xml \

--- a/docker/jenkins/unit.sh
+++ b/docker/jenkins/unit.sh
@@ -40,7 +40,7 @@ function run_tests {
 
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                   up -d db redis timescale rabbitmq
+                   up -d db redis rabbitmq
 
     # List images and containers related to this build
     docker images | grep $COMPOSE_PROJECT_NAME | awk '{print $0}'

--- a/docker/jenkins/unit.sh
+++ b/docker/jenkins/unit.sh
@@ -48,8 +48,7 @@ function run_tests {
 
     docker-compose -f $COMPOSE_FILE_LOC -p $COMPOSE_PROJECT_NAME run --rm listenbrainz \
       dockerize \
-      -wait tcp://db:5432 -timeout 60s \
-      -wait tcp://timescale:5432 -timeout 60s bash -c \
+      -wait tcp://db:5432 -timeout 60s bash -c \
       "ls && python3 manage.py init_db --create-db && \
        python3 manage.py init_msb_db --create-db && \
        python3 manage.py init_ts_db --create-db"
@@ -58,7 +57,6 @@ function run_tests {
                 listenbrainz \
                 dockerize \
                 -wait tcp://db:5432 -timeout 60s \
-                -wait tcp://timescale:5432 -timeout 60s \
                 -wait tcp://redis:6379 -timeout 60s \
                 py.test --junitxml=/data/test_report.xml \
                         --cov-report xml:/data/coverage.xml

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -15,9 +15,9 @@ POSTGRES_ADMIN_URI="postgresql://postgres:postgres@db/postgres"
 POSTGRES_ADMIN_LB_URI = "postgresql://postgres:postgres@db/listenbrainz"
 MB_DATABASE_URI = ""
 
-SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@timescale/listenbrainz_ts"
-TIMESCALE_ADMIN_URI = "postgresql://postgres:postgres@timescale/postgres"
-TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@timescale/listenbrainz_ts"
+SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@db/listenbrainz_ts"
+TIMESCALE_ADMIN_URI = "postgresql://postgres:postgres@db/postgres"
+TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@db/listenbrainz_ts"
 
 
 # Redis

--- a/listenbrainz/rtd_config.py
+++ b/listenbrainz/rtd_config.py
@@ -11,9 +11,9 @@ MESSYBRAINZ_SQLALCHEMY_DATABASE_URI = "postgresql://messybrainz:messybrainz@db:5
 
 POSTGRES_ADMIN_URI = "postgresql://postgres@db/postgres"
 
-SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@timescale/listenbrainz_ts"
-TIMESCALE_ADMIN_URI = "postgresql://postgres:postgres@timescale/postgres"
-TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@timescale/listenbrainz_ts"
+SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@db/listenbrainz_ts"
+TIMESCALE_ADMIN_URI = "postgresql://postgres:postgres@db/postgres"
+TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@db/listenbrainz_ts"
 
 # Redis
 REDIS_HOST = "redis"

--- a/messybrainz/custom_config.py.sample
+++ b/messybrainz/custom_config.py.sample
@@ -12,7 +12,7 @@ SQLALCHEMY_DATABASE_URI = "postgresql://messybrainz@db:5432/messybrainz"
 TEST_SQLALCHEMY_DATABASE_URI = "postgresql://msb_test@db:5432/msb_test"
 
 # Admin database
-POSTGRES_ADMIN_URI="postgresql://postgres@db/template1"
+POSTGRES_ADMIN_URI="postgresql://postgres@db/postgres"
 
 
 

--- a/test.sh
+++ b/test.sh
@@ -44,13 +44,13 @@ fi
 function build_unit_containers {
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                build db timescale redis rabbitmq listenbrainz
+                build db redis rabbitmq listenbrainz
 }
 
 function bring_up_unit_db {
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                up -d db timescale redis rabbitmq
+                up -d db redis rabbitmq
 }
 
 function unit_setup {
@@ -60,7 +60,6 @@ function unit_setup {
                    -p $COMPOSE_PROJECT_NAME \
                 run --rm listenbrainz dockerize \
                   -wait tcp://db:5432 -timeout 60s \
-                  -wait tcp://timescale:5432 -timeout 60s \
                   -wait tcp://rabbitmq:5672 -timeout 60s \
                 bash -c "python3 manage.py init_db --create-db && \
                          python3 manage.py init_msb_db --create-db && \
@@ -156,7 +155,6 @@ function int_setup {
                    -p $INT_COMPOSE_PROJECT_NAME \
                 run --rm listenbrainz dockerize \
                   -wait tcp://db:5432 -timeout 60s \
-                  -wait tcp://timescale:5432 -timeout 60s \
                 bash -c "python3 manage.py init_db --create-db && \
                          python3 manage.py init_msb_db --create-db && \
                          python3 manage.py init_ts_db --create-db"
@@ -165,7 +163,7 @@ function int_setup {
 function bring_up_int_containers {
     docker-compose -f $INT_COMPOSE_FILE_LOC \
                    -p $INT_COMPOSE_PROJECT_NAME \
-                up -d db timescale redis timescale_writer rabbitmq
+                up -d db redis timescale_writer rabbitmq
 }
 
 # Exit immediately if a command exits with a non-zero status.
@@ -215,7 +213,6 @@ if [ "$1" == "int" ]; then
                    -p $INT_COMPOSE_PROJECT_NAME \
                 run --rm listenbrainz dockerize \
                   -wait tcp://db:5432 -timeout 60s \
-                  -wait tcp://timescale:5432 -timeout 60s \
                   -wait tcp://redis:6379 -timeout 60s \
                   -wait tcp://rabbitmq:5672 -timeout 60s \
                 bash -c "py.test $TESTS_TO_RUN"


### PR DESCRIPTION
# Problem

Timescale is just a postgres database, so instead of starting up 2 servers we can just start one and put all data there


# Solution

Configure a single database server and create 3 databases.


# Action

Local developers will lose all of their user content, as it was in the old database volumes. You'll have to recreate it

