### PR TITLE
Add workflow-base release-drafter app

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Problem
In LB we use [release-drafter](https://github.com/marketplace/actions/release-drafter), which is now implemented as an action. There is an [old deprecated app](https://github.com/release-drafter/release-drafter/blob/master/docs/github-app.md) which is no longer maintained, which LB is configured to use


# Solution

Add action-based release-drafter


# Action

Need to disable the app at https://github.com/metabrainz/listenbrainz-server/settings/installations


