### PR TITLE
Set up dataset hoster sentry in listenbrainz labs

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -125,6 +125,7 @@ LOG_SENTRY = {
     'environment': '''{{template "KEY" "sentry/environment"}}''',
 }
 SENTRY_DSN_PUBLIC = '''{{template "KEY" "sentry/dsn_public"}}'''
+DATASETS_SENTRY_DSN = '''{{template "KEY" "sentry/datasets_dsn"}}'''
 
 
 # Stats

--- a/listenbrainz/labs_api/labs/api/artist_credit_from_artist_msid.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_from_artist_msid.py
@@ -3,7 +3,6 @@
 import psycopg2
 import psycopg2.extras
 from datasethoster import Query
-from datasethoster.main import register_query
 from flask import current_app
 
 

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -1,13 +1,7 @@
-import copy
-import sys
-import uuid
-import ujson
-
 import psycopg2
 import psycopg2.extras
 from flask import current_app
 from datasethoster import Query
-from datasethoster.main import app, register_query
 
 psycopg2.extras.register_uuid()
 

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from datasethoster.main import app, register_query
+from datasethoster.main import create_app, init_sentry, register_query
 from listenbrainz.labs_api.labs.api.artist_country_from_artist_mbid import ArtistCountryFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_mbid import ArtistCreditIdFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_msid import ArtistCreditIdFromArtistMSIDQuery
@@ -12,4 +12,6 @@ register_query(ArtistCreditIdFromArtistMBIDQuery())
 register_query(ArtistCreditIdFromArtistMSIDQuery())
 register_query(RecordingFromRecordingMBIDQuery())
 
+app = create_app()
 load_config(app)
+init_sentry(app, "DATASETS_SENTRY_DSN")

--- a/listenbrainz/labs_api/labs/tests/test_artist_country_code_from_artist_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_artist_country_code_from_artist_mbid.py
@@ -1,11 +1,7 @@
-import os
-import unittest
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 import flask_testing
-from flask import url_for
-import psycopg2
-from datasethoster.main import app
+from datasethoster.main import create_app
 from listenbrainz.labs_api.labs.api.artist_country_from_artist_mbid import ArtistCountryFromArtistMBIDQuery
 
 
@@ -44,6 +40,7 @@ country_response = [
 class MainTestCase(flask_testing.TestCase):
 
     def create_app(self):
+        app = create_app()
         app.config['MB_DATABASE_URI'] = 'yermom'
         return app
 

--- a/listenbrainz/labs_api/labs/tests/test_artist_credit_from_artist_mbid_query.py
+++ b/listenbrainz/labs_api/labs/tests/test_artist_credit_from_artist_mbid_query.py
@@ -1,11 +1,7 @@
-import os
-import unittest
-from unittest.mock import patch, call, MagicMock
+from unittest.mock import patch
 
 import flask_testing
-import flask
-import psycopg2
-from datasethoster.main import app
+from datasethoster.main import create_app
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_mbid import ArtistCreditIdFromArtistMBIDQuery
 
 
@@ -33,6 +29,7 @@ json_response = [
 class MainTestCase(flask_testing.TestCase):
 
     def create_app(self):
+        app = create_app()
         app.config['MB_DATABASE_URI'] = 'yermom'
         return app
 

--- a/listenbrainz/labs_api/labs/tests/test_artist_credit_from_artist_msid.py
+++ b/listenbrainz/labs_api/labs/tests/test_artist_credit_from_artist_msid.py
@@ -1,11 +1,7 @@
-import os
-import unittest
-from unittest.mock import patch, call, MagicMock
+from unittest.mock import patch
 
 import flask_testing
-import flask
-import psycopg2
-from datasethoster.main import app
+from datasethoster.main import create_app
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_msid import ArtistCreditIdFromArtistMSIDQuery
 
 
@@ -60,6 +56,7 @@ json_response = [
 class MainTestCase(flask_testing.TestCase):
 
     def create_app(self):
+        app = create_app()
         app.config['DB_CONNECT_MAPPING'] = 'yermom'
         return app
 

--- a/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_from_recording_mbid.py
@@ -1,12 +1,7 @@
-import ujson
-import os
-import unittest
-from unittest.mock import patch, call, MagicMock
+from unittest.mock import patch
 
 import flask_testing
-import flask
-import psycopg2
-from datasethoster.main import app
+from datasethoster.main import create_app
 from listenbrainz.labs_api.labs.api.recording_from_recording_mbid import RecordingFromRecordingMBIDQuery
 
 
@@ -139,6 +134,7 @@ json_response = [
 class MainTestCase(flask_testing.TestCase):
 
     def create_app(self):
+        app = create_app()
         app.config['MB_DATABASE_URI'] = 'yermom'
         return app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,11 +24,12 @@ oauth2client == 4.1.3
 pika == 0.13.0
 git+https://github.com/metabrainz/brainzutils-python.git@v1.14.1
 spotipy == 2.16.1
-git+https://github.com/metabrainz/data-set-hoster.git@v-2020-10-20.0#egg=datasethoster
+git+https://github.com/metabrainz/data-set-hoster.git@v-2021-01-12.0#egg=datasethoster
 pyyaml == 5.3.1
 eventlet == 0.30.0
 uWSGI == 2.0.19.1
 nose == 1.3.7
+sentry-sdk[flask]==0.19.3
 six == 1.15.0
 pydantic == 1.6.1
 pycountry == 20.7.3


### PR DESCRIPTION
# Problem
Errors in datasets hosted on labs.api.listenbrainz.org are swallowed and so developers have no visibility into when a dataset fails.


# Solution

We set up a sentry project for the dataset hoster, and are connecting the prod and test hosters to it. (metabrainz/data-set-hoster#2, metabrainz/bono-data-sets#1)


# Action

* [x] Need to add a new key to listenbrainz consul: `sentry/datasets_dsn`
* [ ] Need to make a new release of metabrainz/data-set-hoster#2 and update requirements.txt to point to that instead of the PR branch that it currently uses


