### PR TITLE
CI: Make 'prettier' linting warnings instead of error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
     "import/extensions": "off",
     "no-unused-vars": "off",
     camelcase: "warn",
-    "prettier/prettier": "error",
+    "prettier/prettier": "warn",
     "lines-between-class-members": [
       "error",
       "always",

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ pip-selfcheck.json
 
 # Javascript
 node_modules
+# Javascript linting
+eslint.xml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
We probably don't want this opinionated code formatter to throw errors during the linting process; It's breaking our CI for asinine formatting reasons.
This PR sets the prettier level to `warn` within the eslint configuration.

Also ignore the output file for CI setup.
