### PR TITLE
Return json in the error handler in the API

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -2,7 +2,6 @@ import os
 import pprint
 import sys
 from time import sleep
-from shutil import copyfile
 
 from brainzutils.flask import CustomFlask
 from flask import request, url_for, redirect
@@ -42,9 +41,8 @@ def create_rabbitmq(app):
         app.logger.error('Could not connect to RabbitMQ: %s', str(e))
         return
 
+
 def load_config(app):
-
-
     # Load configuration files: If we're running under a docker deployment, wait until
     config_file = os.path.join( os.path.dirname(os.path.realpath(__file__)), '..', 'config.py' )
     if deploy_env:
@@ -71,7 +69,7 @@ def load_config(app):
         print('Unable to retrieve git commit. Error: %s', str(e))
 
 
-def gen_app(config_path=None, debug=None):
+def gen_app(debug=None):
     """ Generate a Flask app for LB with all configurations done and connections established.
 
     In the Flask app returned, blueprints are not registered.
@@ -143,9 +141,8 @@ def gen_app(config_path=None, debug=None):
     return app
 
 
-def create_app(config_path=None, debug=None):
-
-    app = gen_app(config_path=config_path, debug=debug)
+def create_app(debug=None):
+    app = gen_app(debug=debug)
 
     # Static files
     import listenbrainz.webserver.static_manager
@@ -169,7 +166,6 @@ def create_app(config_path=None, debug=None):
     admin.add_view(UserAdminView(UserModel, model.db.session, endpoint='user_model'))
     admin.add_view(SpotifyAdminView(SpotifyModel, model.db.session, endpoint='spotify_model'))
 
-
     @app.before_request
     def before_request_gdpr_check():
         # skip certain pages, static content and the API
@@ -188,14 +184,14 @@ def create_app(config_path=None, debug=None):
     return app
 
 
-def create_api_compat_app(config_path=None, debug=None):
+def create_api_compat_app(debug=None):
     """ Creates application for the AudioScrobbler API.
 
     The AudioScrobbler API v1.2 requires special views for the root URL so we
     need to create a different app and only register the api_compat blueprints
     """
 
-    app = gen_app(config_path=config_path, debug=debug)
+    app = gen_app(debug=debug)
 
     from listenbrainz.webserver.views.api_compat import api_bp as api_compat_bp
     from listenbrainz.webserver.views.api_compat_deprecated import api_compat_old_bp

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -107,7 +107,6 @@ class CompatError(object):
 
 
 def init_error_handlers(app):
-
     def error_wrapper(template, error, code):
         hide_navbar_user_menu = False
         if code == 500:
@@ -136,7 +135,7 @@ def init_error_handlers(app):
                 A Response which will be a json error if request was made to the LB api and an html page
                 otherwise
         """
-        if current_app.config.get('IS_API_COMPAT_APP'):
+        if current_app.config.get('IS_API_COMPAT_APP') or request.path.startswith(API_PREFIX):
             return jsonify({'code': code, 'error': error.description}), code
         return error_wrapper('errors/{code}.html'.format(code=code), error, code)
 
@@ -168,11 +167,9 @@ def init_error_handlers(app):
         else:
             return handle_error(error, 500)
 
-    
     @app.errorhandler(502)
     def bad_gateway(error):
         return handle_error(error, 502)
-
 
     @app.errorhandler(503)
     def service_unavailable(error):
@@ -181,7 +178,6 @@ def init_error_handlers(app):
     @app.errorhandler(504)
     def gateway_timeout(error):
         return handle_error(error, 504)
-
 
     @app.errorhandler(APIError)
     @crossdomain()

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -160,8 +160,13 @@ def init_error_handlers(app):
     def file_size_too_large(error):
         return handle_error(error, 413)
 
-    @app.errorhandler(InternalServerError)
+    @app.errorhandler(500)
     def internal_server_error(error):
+        # This error handler gets triggered on any uncaught exception.
+        # `error` is always InternalServerError, and error.original_exception
+        # is the exception that was thrown
+        # https://flask.palletsprojects.com/en/1.1.x/errorhandling/#unhandled-exceptions
+        # We specifically return json in the case that the request was within our API path
         original = getattr(error, "original_exception", None)
 
         if request.path.startswith(API_PREFIX):

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -7,10 +7,7 @@ from listenbrainz.webserver import create_app, create_api_compat_app
 class ServerTestCase(flask_testing.TestCase):
 
     def create_app(self):
-        app = create_app(config_path=os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            '..', 'test_config.py'
-        ))
+        app = create_app()
         app.config['TESTING'] = True
         return app
 
@@ -23,9 +20,6 @@ class ServerTestCase(flask_testing.TestCase):
 class APICompatServerTestCase(flask_testing.TestCase):
 
     def create_app(self):
-        app = create_api_compat_app(config_path=os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            '..', 'test_config.py'
-        ))
+        app = create_api_compat_app()
         app.config['TESTING'] = True
         return app


### PR DESCRIPTION
# Problem

When an API endpoint raises one of our APIExceptions, it gets serialised as json, but if the error handling comes from flask (e.g. 404 or 500) the regular flask error handler is triggered, which returns html. Any error that happens inside the `/1/...` API path should return json.


# Solution

Return json

On a web page http500 errors look like this:
<img width="1212" alt="Screenshot 2021-03-18 at 3 30 33 PM" src="https://user-images.githubusercontent.com/19217/111643238-1691db80-87ff-11eb-87ea-5ed407bf5bff.png">

and on the api:
<img width="391" alt="Screenshot 2021-03-18 at 3 30 40 PM" src="https://user-images.githubusercontent.com/19217/111643255-1db8e980-87ff-11eb-8fd9-d7326eb8ee21.png">



