### PR TITLE
LB-519: Show the timestamp imported in the Last.FM importer

### DIFF
--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -312,3 +312,22 @@ describe("LastFmImporter Page", () => {
     expect(wrapper.find('input[type="submit"]').props().disabled).toBe(true);
   });
 });
+
+describe("LastFmImporter Page", () => {
+  it("should properly convert latest imported timestamp to string", () => {
+    // Check getlastImportedString() and formatting
+    let testDate = Number(page["recenttracks"]["track"][0]["date"]["uts"]);
+    let lastImportedDate = new Date(testDate * 1000);
+    let msg = lastImportedDate.toLocaleString("en-US", {
+        month: "short",
+        day: "2-digit",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+    });
+
+    expect(instance.getlastImportedString(testDate)).toMatch(msg);
+    expect(instance.getlastImportedString(testDate).length).not.toEqual(0);
+  });
+});

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -68,6 +68,7 @@ export default class LastFmImporter extends React.Component<
 
   private latestImportTime = 0; // the latest timestamp that we've imported earlier
   private maxTimestampForImport = 0; // the latest listen found in this import
+  private lastImportedString = ""; // date formatted string of first song on payload's timestamp 
   private incrementalImport = false;
 
   private numCompleted = 0; // number of pages completed till now
@@ -198,6 +199,19 @@ export default class LastFmImporter extends React.Component<
     return null;
   }
 
+  getlastImportedString(listenedAt: number) { 
+    // Retrieve first track's timestamp from payload and convert it into string for display
+    let lastImportedDate = new Date(listenedAt * 1000);
+    return lastImportedDate.toLocaleString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      hour12: true,
+  });
+  }
+
   getRateLimitDelay() {
     /* Get the amount of time we should wait according to LB rate limits before making a request to LB */
     let delay = 0;
@@ -275,16 +289,7 @@ export default class LastFmImporter extends React.Component<
 
       this.page -= 1;
       this.numCompleted += 1;
-      // Retrieve first track's timestamp from payload and convert it into string for display
-      const latestImportEpoch = new Date(payload[0].listened_at * 1000);
-      const timestampString = latestImportEpoch.toLocaleString("en-US", {
-        month: "short",
-        day: "2-digit",
-        year: "numeric",
-        hour: "numeric",
-        minute: "numeric",
-        hour12: true,
-      });
+      this.lastImportedString = this.getlastImportedString(payload[0].listened_at);
 
       // Update message
       const msg = (
@@ -303,7 +308,7 @@ export default class LastFmImporter extends React.Component<
               Please don&apos;t close this page while this is running.
             </span>{" "}
             <br /> <br />
-            <span> Last timestamp imported: {timestampString} </span>
+            <span> Last timestamp imported: {this.lastImportedString} </span>
           </span>
         </p>
       );

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -308,7 +308,7 @@ export default class LastFmImporter extends React.Component<
               Please don&apos;t close this page while this is running.
             </span>{" "}
             <br /> <br />
-            <span> Last timestamp imported: {this.lastImportedString} </span>
+            <span> Latest import timestamp: {this.lastImportedString} </span>
           </span>
         </p>
       );

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -275,6 +275,16 @@ export default class LastFmImporter extends React.Component<
 
       this.page -= 1;
       this.numCompleted += 1;
+      // Retrieve first track's timestamp from payload and convert it into string for display
+      const latestImportEpoch = new Date(payload[0].listened_at * 1000);
+      const timestampString = latestImportEpoch.toLocaleString("en-US", {
+        month: "short",
+        day: "2-digit",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+      });
 
       // Update message
       const msg = (
@@ -289,7 +299,11 @@ export default class LastFmImporter extends React.Component<
                 <br />
               </span>
             )}
-            <span>Please don&apos;t close this page while this is running</span>
+            <span>
+              Please don&apos;t close this page while this is running.
+            </span>{" "}
+            <br /> <br />
+            <span> Last timestamp imported: {timestampString} </span>
           </span>
         </p>
       );

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -548,7 +548,9 @@ export default class UserEntityChart extends React.Component<
                 <div className="col-xs-12">
                   <ul className="pager">
                     <li
-                      className={`previous ${!(prevPage > 0) ? "disabled" : ""}`}
+                      className={`previous ${
+                        !(prevPage > 0) ? "disabled" : ""
+                      }`}
                     >
                       <a
                         href=""


### PR DESCRIPTION
# Problem

JIRA ticket [LB-519](https://tickets.metabrainz.org/browse/LB-519)
The Last.FM import page doesn't show the timestamp of the last imported track, so users can't gauge the progress.

# Solution

I retrieved the first song's listened_to from the payload, which is the latest timestamp imported on that page.
I converted this to an epoch to display it as a string and add it to the message.

![image](https://user-images.githubusercontent.com/57575778/104384711-c8064f00-54e6-11eb-9d5c-9e81eac50bf4.png)




