### PR TITLE
LB-509

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - ..:/code/listenbrainz:z
       - ../listenbrainz/webserver/static:/static
     ports:
-      - "80:80"
+      - "9000:80"
     depends_on:
       - redis
       - db


### PR DESCRIPTION
### Problem
./develop.sh up does not work out of the box on a normal Linux box (which already has an apache running on port 80), because listenbrainz_web_1 wants to bind to port 80.
### Solution
changing the web section in docker/docker-compose.yml to "9000:80"

