### PR TITLE
LB-796: Correct link to playlist exported to Spotify

### DIFF
--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
@@ -631,13 +631,14 @@ export default class PlaylistPage extends React.Component<
         newPlaylist.id,
         spotifyURIs
       );
+      const playlistLink = `https://open.spotify.com/playlist/${newPlaylist.id}`;
       this.newAlert(
         "success",
         "Playlist exported to Spotify",
         <>
           Successfully exported playlist:{" "}
-          <a href={newPlaylist.href} target="_blank" rel="noopener noreferrer">
-            {newPlaylist.href}
+          <a href={playlistLink} target="_blank" rel="noopener noreferrer">
+            {playlistLink}
           </a>
           {spotifyURIs.length !== playlist.track.length && (
             <b>


### PR DESCRIPTION
The alert created after successfully exporting a ListenBrainz playlist shows a link like https://api.spotify.com/v1/playlists/<id>. This is an API link and visiting it without proper auth returns 401.

For the playlist to open in the Spotify player the playlist must be like https://open.spotify.com/playlist/<id> where <id> in both the cases is the same.