### PR TITLE
Don't allow playlist owner to be collaborator

### DIFF
--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -507,6 +507,8 @@ def copy_playlist(playlist: model_playlist.Playlist, creator_id: int):
     newplaylist.copied_from_id = playlist.id
     newplaylist.created_for_id = None
     newplaylist.created_for = None
+    newplaylist.collaborator_ids = []
+    newplaylist.collaborators = []
     # TODO: We need a copied_from_mbid (calculated) field in the playlist object so we can show the mbid in the ui
 
     return create(newplaylist)

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -335,7 +335,9 @@ class PlaylistAPITestCase(IntegrationTestCase):
         """ Test to ensure creating a playlist with collaborators works """
 
         playlist = get_test_data()
-        playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["collaborators"] = [self.user2["musicbrainz_id"]]
+        # Owner is in collaborators, should be filtered out
+        playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["collaborators"] = [self.user["musicbrainz_id"],
+                                                                                      self.user2["musicbrainz_id"]]
 
         response = self.client.post(
             url_for("playlist_api_v1.create_playlist"),
@@ -385,13 +387,15 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         playlist_mbid = response.json["playlist_mbid"]
 
-        # Test to ensure fetching a playlist works
+        # Test to ensure posting a playlist works
+        # Owner is in collaborators, should be filtered out
         response = self.client.post(
             url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
             json={"playlist": {"title": "new title",
                                "annotation": "new <b>desc</b> <script>noscript</script>",
                                "extension": {PLAYLIST_EXTENSION_URI: {"public": False,
-                                                                      "collaborators": [self.user2["musicbrainz_id"],
+                                                                      "collaborators": [self.user["musicbrainz_id"],
+                                                                                        self.user2["musicbrainz_id"],
                                                                                         self.user3["musicbrainz_id"]]}
                                              }}},
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -681,8 +681,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["playlist"]["creator"], "anothertestuserpleaseignore")
         # Ensure original playlist's collaborators have been scrubbed
         # The serialized JSPF playlist leaves out the "collaborators" key if there are none
-        self.assertNotIn(response.json["playlist"]["extension"]
-                         [PLAYLIST_EXTENSION_URI], "collaborators")
+        self.assertNotIn("collaborators", response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI])
 
         # Now delete the original playlist so that we can test copied from deleted playlist
         response = self.client.post(

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -335,8 +335,10 @@ class PlaylistAPITestCase(IntegrationTestCase):
         """ Test to ensure creating a playlist with collaborators works """
 
         playlist = get_test_data()
-        # Owner is in collaborators, should be filtered out
+        # If the owner is in collaborators, it should be filtered out
+        # If a collaborator is listed multiple times, it should only be added once
         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["collaborators"] = [self.user["musicbrainz_id"],
+                                                                                      self.user2["musicbrainz_id"],
                                                                                       self.user2["musicbrainz_id"]]
 
         response = self.client.post(

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -680,7 +680,6 @@ class PlaylistAPITestCase(IntegrationTestCase):
         # Ensure original playlist's collaborators have been scrubbed
         self.assertEqual(response.json["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["collaborators"], [])
-       
 
         # Now delete the original playlist so that we can test copied from deleted playlist
         response = self.client.post(

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -680,8 +680,9 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["playlist"]["title"], "Copy of my stupid playlist")
         self.assertEqual(response.json["playlist"]["creator"], "anothertestuserpleaseignore")
         # Ensure original playlist's collaborators have been scrubbed
-        self.assertEqual(response.json["playlist"]["extension"]
-                         [PLAYLIST_EXTENSION_URI]["collaborators"], [])
+        # The serialized JSPF playlist leaves out the "collaborators" key if there are none
+        self.assertNotIn(response.json["playlist"]["extension"]
+                         [PLAYLIST_EXTENSION_URI], "collaborators")
 
         # Now delete the original playlist so that we can test copied from deleted playlist
         response = self.client.post(

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -635,7 +635,9 @@ class PlaylistAPITestCase(IntegrationTestCase):
               "title": "my stupid playlist",
               "extension": {
                   PLAYLIST_EXTENSION_URI: {
-                      "public": True
+                      "public": True,
+                      "collaborators": [self.user2["musicbrainz_id"],
+                                        self.user3["musicbrainz_id"]]
                   }
               },
            }
@@ -671,7 +673,10 @@ class PlaylistAPITestCase(IntegrationTestCase):
                          [PLAYLIST_EXTENSION_URI]["public"], True)
         self.assertEqual(response.json["playlist"]["title"], "Copy of my stupid playlist")
         self.assertEqual(response.json["playlist"]["creator"], "anothertestuserpleaseignore")
-
+        # Ensure original playlist's collaborators have been scrubbed
+        self.assertEqual(response.json["playlist"]["extension"]
+                         [PLAYLIST_EXTENSION_URI]["collaborators"], [])
+       
 
         # Now delete the original playlist so that we can test copied from deleted playlist
         response = self.client.post(

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -289,7 +289,7 @@ def create_playlist():
     # Don't allow creator to also be a collaborator
     if user["musicbrainz_id"] in collaborators:
         collaborators.remove(user["musicbrainz_id"])
-        
+
     username_lookup = collaborators
     created_for = data["playlist"].get("created_for", None)
     if created_for:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -676,7 +676,7 @@ def copy_playlist(playlist_mbid):
     try:
         new_playlist = db_playlist.copy_playlist(playlist, user["id"])
     except Exception as e:
-        current_app.logger.error("Error deleting playlist: {}".format(e))
-        raise APIInternalServerError("Failed to delete the playlist. Please try again.")
+        current_app.logger.error("Error copying playlist: {}".format(e))
+        raise APIInternalServerError("Failed to copy the playlist. Please try again.")
 
     return jsonify({'status': 'ok', 'playlist_mbid': new_playlist.mbid})

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -285,6 +285,9 @@ def create_playlist():
     collaborators = data.get("playlist", {}).\
         get("extension", {}).get(PLAYLIST_EXTENSION_URI, {}).\
         get("collaborators", [])
+    
+    # Uniquify collaborators list
+    collaborators = list(dict.fromkeys(collaborators))
 
     # Don't allow creator to also be a collaborator
     if user["musicbrainz_id"] in collaborators:
@@ -397,11 +400,13 @@ def edit_playlist(playlist_mbid):
         get("collaborators", [])
     users = {}
 
-    # Don't allow creator to also be a collaborator
-    if collaborators and user["musicbrainz_id"] in collaborators:
-        collaborators.remove(user["musicbrainz_id"])
+    # Uniquify collaborators list
+    collaborators = list(dict.fromkeys(collaborators))
 
     if collaborators:
+        # Don't allow creator to also be a collaborator
+        if user["musicbrainz_id"] in collaborators:
+            collaborators.remove(user["musicbrainz_id"])
         users = db_user.get_many_users_by_mb_id(collaborators)
 
     collaborator_ids = []

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -287,7 +287,7 @@ def create_playlist():
         get("collaborators", [])
     
     # Uniquify collaborators list
-    collaborators = list(dict.fromkeys(collaborators))
+    collaborators = list(set(collaborators))
 
     # Don't allow creator to also be a collaborator
     if user["musicbrainz_id"] in collaborators:
@@ -401,7 +401,7 @@ def edit_playlist(playlist_mbid):
     users = {}
 
     # Uniquify collaborators list
-    collaborators = list(dict.fromkeys(collaborators))
+    collaborators = list(set(collaborators))
 
     if collaborators:
         # Don't allow creator to also be a collaborator

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -286,6 +286,10 @@ def create_playlist():
         get("extension", {}).get(PLAYLIST_EXTENSION_URI, {}).\
         get("collaborators", [])
 
+    # Don't allow creator to also be a collaborator
+    if user["musicbrainz_id"] in collaborators:
+        collaborators.remove(user["musicbrainz_id"])
+        
     username_lookup = collaborators
     created_for = data["playlist"].get("created_for", None)
     if created_for:
@@ -392,6 +396,11 @@ def edit_playlist(playlist_mbid):
         get("extension", {}).get(PLAYLIST_EXTENSION_URI, {}).\
         get("collaborators", [])
     users = {}
+
+    # Don't allow creator to also be a collaborator
+    if collaborators and user["musicbrainz_id"] in collaborators:
+        collaborators.remove(user["musicbrainz_id"])
+
     if collaborators:
         users = db_user.get_many_users_by_mb_id(collaborators)
 


### PR DESCRIPTION
This PR fixes two issues related to having  a playlist owner also be in the collaborators:
[LB-787](https://tickets.metabrainz.org/browse/LB-787) and [LB-788](https://tickets.metabrainz.org/browse/LB-788).

We simply remove the playlist owner if it is in collaborators upon playlist creation, edition and duplication.


# Cleanup

We probably want to run an SQL script to clean up existing playlist where creator_id is in collaborator_ids