### PR TITLE
Don't run coverage if tests fail

### DIFF
--- a/docker/jenkins/unit.sh
+++ b/docker/jenkins/unit.sh
@@ -65,8 +65,8 @@ function run_tests {
 }
 
 function  extract_results {
-    docker cp ${TEST_CONTAINER_REF}:/data/test_report.xml .
-    docker cp ${TEST_CONTAINER_REF}:/data/coverage.xml .
+    docker cp ${TEST_CONTAINER_REF}:/data/test_report.xml . || true
+    docker cp ${TEST_CONTAINER_REF}:/data/coverage.xml . || true
 }
 
 set -e

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=listenbrainz/tests/integration listenbrainz_spark relations listenbrainz/mbid_mapping
-addopts = --cov=listenbrainz
+addopts = --cov=listenbrainz --no-cov-on-fail


### PR DESCRIPTION
# Problem

We compute coverage after pytest runs, but it runs unconditionally. This means that even if a test fails, I have to wait for coverage to run, and then it outputs a whole bunch of statistics. If I want to scroll up to see the test failure I have to scroll past these statistics that I'm not interested in.


# Solution

Add ` --no-cov-on-fail` flag to coverage, this means that there will be no stats output if the tests fail, resulting in a faster debug loop and less scrolling

