### PR TITLE
Only get recommendation feedback for current page of recs

### DIFF
--- a/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
+++ b/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
@@ -75,7 +75,8 @@ export default class Recommendations extends React.Component<
   }
 
   getFeedback = async () => {
-    const { user, recommendations } = this.props;
+    const { user } = this.props;
+    const { recommendations } = this.state;
     const recordings: string[] = [];
 
     if (recommendations) {
@@ -144,7 +145,7 @@ export default class Recommendations extends React.Component<
   handleCurrentRecommendationChange = (
     recommendation: Recommendation | JSPFTrack
   ): void => {
-    this.setState({ currentRecommendation: recommendation as Recommendation});
+    this.setState({ currentRecommendation: recommendation as Recommendation });
   };
 
   newAlert = (
@@ -234,6 +235,10 @@ export default class Recommendations extends React.Component<
   };
 
   afterRecommendationsDisplay() {
+    const { user, currentUser } = this.props;
+    if (currentUser?.name === user?.name) {
+      this.loadFeedback();
+    }
     if (this.recommendationsTable?.current) {
       this.recommendationsTable.current.scrollIntoView({ behavior: "smooth" });
     }


### PR DESCRIPTION
Currently deployed recommendation feedback page on beta doesn't show submitted feedback when a user refreshes the page.
The issue is that we request feedback for all 1000 items, making the URL far too long and the request fails.

This PR changes the mechanism and only fetches feedback for the items in the page the user is on.
