### PR TITLE
LB-806: Importer connection

### DIFF
--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -331,7 +331,6 @@ describe("LastFmImporter Page", () => {
 });
 
 describe("importLoop", () => {
-  const errorMsg: string = "Testing: something went wrong !!!";
   beforeEach(() => {
     const wrapper = shallow<LastFmImporter>(<LastFmImporter {...props} />);
     instance = wrapper.instance();
@@ -376,13 +375,17 @@ describe("importLoop", () => {
     // verify message is success message
     expect(instance.state.msg?.props.children).toContain("Import finished");
     // verify message isn't failure message
-    expect(instance.state.msg?.props.children).not.toContain(errorMsg);
+    expect(instance.state.msg?.props.children).not.toContain(
+      "Something went wrong"
+    );
   });
 
   it("should show error message on unhandled exception / network error", async () => {
+    const errorMsg = "Testing: something went wrong !!!";
     // Mock function for failed importLoop
     instance.importLoop = jest.fn().mockImplementation(async () => {
       const error = new Error();
+      // Changing the error message to make sure it gets reflected in the modal.
       error.message = errorMsg;
       throw error;
     });

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -314,8 +314,8 @@ describe("LastFmImporter Page", () => {
 
   it("should properly convert latest imported timestamp to string", () => {
     // Check getlastImportedString() and formatting
-    const testDate = Number(page.recenttracks.track[0].date.uts);
-    const lastImportedDate = new Date(testDate * 1000);
+    const data = LastFmImporter.encodeScrobbles(page);
+    const lastImportedDate = new Date(data[0].listened_at * 1000);
     const msg = lastImportedDate.toLocaleString("en-US", {
       month: "short",
       day: "2-digit",
@@ -325,7 +325,23 @@ describe("LastFmImporter Page", () => {
       hour12: true,
     });
 
-    expect(LastFmImporter.getlastImportedString(testDate)).toMatch(msg);
-    expect(LastFmImporter.getlastImportedString(testDate)).not.toHaveLength(0);
+    expect(LastFmImporter.getlastImportedString(data[0])).toMatch(msg);
+    expect(LastFmImporter.getlastImportedString(data[0])).not.toHaveLength(0);
+  });
+});
+
+describe("importLoop", () => {
+  beforeEach(() => {
+    const wrapper = shallow<LastFmImporter>(<LastFmImporter {...props} />);
+    instance = wrapper.instance();
+    instance.setState({ lastfmUsername: "dummyUser" });
+  });
+
+  // only uncaught exeptions can cause importLoop to stop processing payloads
+  it("should not contain any uncaught exceptions", async () => {
+    instance.getPage = jest.fn().mockImplementation(() => {
+      return null;
+    });
+    await instance.importLoop();
   });
 });

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -100,19 +100,6 @@ export default class LastFmImporter extends React.Component<
     this.userToken = props.user.auth_token || "";
   }
 
-  static getlastImportedString(listenedAt: number) {
-    // Retrieve first track's timestamp from payload and convert it into string for display
-    const lastImportedDate = new Date(listenedAt * 1000);
-    return lastImportedDate.toLocaleString("en-US", {
-      month: "short",
-      day: "2-digit",
-      year: "numeric",
-      hour: "numeric",
-      minute: "numeric",
-      hour12: true,
-    });
-  }
-
   async getTotalNumberOfScrobbles() {
     /*
      * Get the total play count reported by Last.FM for user
@@ -212,6 +199,19 @@ export default class LastFmImporter extends React.Component<
       retry("Network error");
     }
     return null;
+  }
+
+  static getlastImportedString(listen: Listen) {
+    // Retrieve first track's timestamp from payload and convert it into string for display
+    const lastImportedDate = new Date(listen.listened_at * 1000);
+    return lastImportedDate.toLocaleString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      hour12: true,
+    });
   }
 
   getRateLimitDelay() {

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -158,6 +158,7 @@ export default class LastFmImporter extends React.Component<
     const { lastfmUsername } = this.state;
 
     const retry = (reason: string) => {
+      // eslint-disable-next-line no-console
       console.warn(
         `${reason} while fetching last.fm page=${page}, retrying in 3s`
       );
@@ -334,7 +335,7 @@ export default class LastFmImporter extends React.Component<
           <FontAwesomeIcon icon={faTimes as IconProp} /> Import failed due to a
           network error, please retry.
           <br />
-          Message: "{err.message}."
+          Message: &quot;{err.message}&quot;
           <br />
           <br />
           <span style={{ fontSize: `${10}pt` }}>
@@ -344,7 +345,8 @@ export default class LastFmImporter extends React.Component<
           </span>
         </p>
       );
-      console.warn(err);
+      // eslint-disable-next-line no-console
+      console.debug(err);
       this.setState({ canClose: true, msg: finalMsg });
       return Promise.resolve(null);
     }


### PR DESCRIPTION
Jira ticket [[LB-806]](https://tickets.metabrainz.org/browse/LB-806)

I separated the loop inside startImport to make it easier to test. importLoop will always receive a valid payload from getPage (it's retries are already thoroughly tested). The importer can only fail to recover and stop running if importLoop encounters an unhandled exception, which the new test should take care of. 