### PR TITLE
Fix Webpack build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,9 +98,9 @@ WORKDIR /static
 # Compile static files
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
-COPY package.json package-lock.json webpack.config.js tsconfig.json ./listenbrainz/webserver/static /static/
+COPY package.json package-lock.json webpack.config.js .eslintrc.js tsconfig.json ./listenbrainz/webserver/static /static/
 RUN npm install && npm run build:prod && ./node_modules/less/bin/lessc --clean-css /static/css/main.less > /static/css/main.css && \
-    rm -rf node_modules js/*.jsx *.json webpack.config.js && npm cache clean --force
+    rm -rf node_modules js/*.jsx *.json webpack.config.js .eslintrc.js && npm cache clean --force
 
 # Now install our code, which may change frequently
 COPY . /code/listenbrainz/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -101,6 +101,9 @@ services:
       target: webpack-base
     command: npm run build:dev
     volumes:
+      # Mount source front-end files
       - ../listenbrainz/webserver/static:/code/static:z
+      # We mount this as a sort of shared volume
+      # where we put the compiled output to be served by the service "web"
       - ../listenbrainz/webserver/static:/static:z
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -102,4 +102,5 @@ services:
     command: npm run build:dev
     volumes:
       - ../listenbrainz/webserver/static:/code/static:z
+      - ../listenbrainz/webserver/static:/static:z
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build:prod": "webpack -p --env production --progress --colors",
     "build:types": "tsc --emitDeclarationOnly",
     "build": "npm run build:dev",
-    "postinstall": "npm run build:prod",
     "format": "eslint ./static/js/src --ext .js,jsx,ts,tsx --fix --quiet",
     "format:ci": "eslint ./static/js/src --ext .js,jsx,ts,tsx -o eslint.xml --format checkstyle",
     "test": "jest",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = function (env) {
         mode: "write-references",
       },
       eslint: {
-        files: "./static/js/src/**/*.{ts,tsx,js,jsx}",
+        files: "**/js/src/**/*.{ts,tsx,js,jsx}",
         options: { fix: !isProd },
       },
     }),
@@ -25,19 +25,19 @@ module.exports = function (env) {
   return {
     mode: isProd ? "production" : "development",
     entry: {
-      main: "./static/js/src/RecentListens.tsx",
-      import: "./static/js/src/LastFMImporter.tsx",
-      userEntityChart: "./static/js/src/stats/UserEntityChart.tsx",
-      userReports: "./static/js/src/stats/UserReports.tsx",
-      userPageHeading: "./static/js/src/UserPageHeading.tsx",
-      userFeed: "./static/js/src/UserFeed.tsx",
-      playlist: "./static/js/src/playlists/Playlist.tsx",
-      playlists: "./static/js/src/playlists/Playlists.tsx",
-      recommendations: "./static/js/src/recommendations/Recommendations.tsx",
+      main: "/static/js/src/RecentListens.tsx",
+      import: "/static/js/src/LastFMImporter.tsx",
+      userEntityChart: "/static/js/src/stats/UserEntityChart.tsx",
+      userReports: "/static/js/src/stats/UserReports.tsx",
+      userPageHeading: "/static/js/src/UserPageHeading.tsx",
+      userFeed: "/static/js/src/UserFeed.tsx",
+      playlist: "/static/js/src/playlists/Playlist.tsx",
+      playlists: "/static/js/src/playlists/Playlists.tsx",
+      recommendations: "/static/js/src/recommendations/Recommendations.tsx",
     },
     output: {
       filename: isProd ? "[name].[contenthash].js" : "[name].js",
-      path: path.resolve(__dirname, "static/js/dist"),
+      path: "/static/js/dist",
     },
     devtool: isProd ? false : "inline-source-map",
     module: {
@@ -71,7 +71,7 @@ module.exports = function (env) {
       ],
     },
     resolve: {
-      modules: ["/code/node_modules", "./static/node_modules"],
+      modules: ["/code/node_modules", "/static/node_modules"],
       extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
     },
     plugins,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,9 @@ module.exports = function (env) {
         mode: "write-references",
       },
       eslint: {
+        // Starting the path with "**/" because of current dev/prod path discrepancy
+        // In dev we bind-mount the source code to "/code/static" and in prod to "/static"
+        // The "**/" allows us to ignore the folder structure and find source files in whatever CWD we're in.
         files: "**/js/src/**/*.{ts,tsx,js,jsx}",
         options: { fix: !isProd },
       },


### PR DESCRIPTION
https://github.com/metabrainz/listenbrainz-server/commit/f7dec5 introduced a regression with the build setup.
The static folder is oddly mounted twice for the static_builder service in our docker-compose file.
I tried cleaning that up but consequently broke the production build.
@paramsingh tried to warn me, but I didn't listen ! 😨 

I had to make a couple more adjustments with the Webpack config to work with different code paths between dev and build setup.

While in there I took the opportunity to reduce image build time by removing an unused postinstall script being run in frontend_builder image build.