### PR TITLE
Do not run cron in test. WHY was this there? Dunno, but I am to blame…

### DIFF
--- a/docker/test/uwsgi/uwsgi.service
+++ b/docker/test/uwsgi/uwsgi.service
@@ -2,9 +2,6 @@
 
 if [ "${CONTAINER_NAME}" = "listenbrainz-web-test" ]
 then
-    rm -f /etc/service/cron/down
-    sv restart cron
-
     exec uwsgi /etc/uwsgi/uwsgi.ini
 fi
 


### PR DESCRIPTION
Cron should only ever be running in the cron container!