### PR TITLE
Allow playlist collaborators to access private playlist

### DIFF
--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -79,7 +79,7 @@ class Playlist(BaseModel):
     recordings: List[PlaylistRecording]
     # mbid of the playlist referred to in copied_from_id
     copied_from_mbid: Optional[uuid.UUID]
-    
+
     def is_visible_by(self, user_id: int):
         if self.public:
             return True

--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -97,9 +97,9 @@ class Playlist(BaseModel):
 
     def is_modifiable_by(self, user_id: int):
         """Check if user can modify a playlist
-        
+
         Check if a user is allowed to add/move/delete items in a playlist.
-        
+
         Args:
             user_id : row id of the user.
         """

--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -80,7 +80,12 @@ class Playlist(BaseModel):
     # mbid of the playlist referred to in copied_from_id
     copied_from_mbid: Optional[uuid.UUID]
 
-    def is_visible_by(self, user_id: int):
+    def is_visible_by(self, user_id: Optional[int]):
+         """Check if user is allowed to access a playlist
+        
+        Args:
+            user_id : (Optional) row id of the user.
+        """
         if self.public:
             return True
         if user_id:
@@ -88,8 +93,6 @@ class Playlist(BaseModel):
                 return True
             elif user_id in self.collaborator_ids:
                 return True
-            else:
-                return False
         return False
 
 

--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -94,6 +94,18 @@ class Playlist(BaseModel):
             elif user_id in self.collaborator_ids:
                 return True
         return False
+        
+    def is_modifiable_by(self, user_id: int):
+        """Check if user can modify a playlist
+        
+        Check if a user is allowed to add/move/delete items in a playlist.
+        
+        Args:
+            user_id : row id of the user.
+        """
+        if user_id == self.creator_id or user_id in self.collaborator_ids:
+            return True
+        return False
 
 
 class WritablePlaylist(Playlist):

--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -83,6 +83,8 @@ class Playlist(BaseModel):
     def is_visible_by(self, user_id: Optional[int]):
         """Check if user is allowed to access a playlist
 
+        user_id may be None, for example if the user is not logged in.
+
         Args:
             user_id : (Optional) row id of the user.
         """
@@ -99,6 +101,7 @@ class Playlist(BaseModel):
         """Check if user can modify a playlist
 
         Check if a user is allowed to add/move/delete items in a playlist.
+        user_id is required, since playlist modifications require a logged in user
 
         Args:
             user_id : row id of the user.

--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -79,6 +79,18 @@ class Playlist(BaseModel):
     recordings: List[PlaylistRecording]
     # mbid of the playlist referred to in copied_from_id
     copied_from_mbid: Optional[uuid.UUID]
+    
+    def is_visible_by(self, user_id: int):
+        if self.public:
+            return True
+        if user_id:
+            if user_id == self.creator_id:
+                return True
+            elif user_id in self.collaborator_ids:
+                return True
+            else:
+                return False
+        return False
 
 
 class WritablePlaylist(Playlist):

--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -81,8 +81,8 @@ class Playlist(BaseModel):
     copied_from_mbid: Optional[uuid.UUID]
 
     def is_visible_by(self, user_id: Optional[int]):
-         """Check if user is allowed to access a playlist
-        
+        """Check if user is allowed to access a playlist
+
         Args:
             user_id : (Optional) row id of the user.
         """
@@ -94,7 +94,7 @@ class Playlist(BaseModel):
             elif user_id in self.collaborator_ids:
                 return True
         return False
-        
+
     def is_modifiable_by(self, user_id: int):
         """Check if user can modify a playlist
         

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -797,7 +797,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
         self.assert404(response)
-    
+
     def test_private_playlist_collaborators_access(self):
         """ Test to ensure playlist collaborators can view, copy and add/move/delete tracks """
 
@@ -879,7 +879,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
         self.assert403(response)
-        
+
         # Edit a playlist
         response = self.client.post(
             url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -19,8 +19,8 @@ def load_playlist(playlist_mbid: str):
         raise BadRequest("Provided playlist ID is invalid: %s" % playlist_mbid)
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, True)
-    # TODO: Allow playlist collaborators to access private playlist
-    if playlist is None or not playlist.public and (not current_user.is_authenticated or playlist.creator_id != current_user.id):
+    if playlist is None or not playlist.public and \
+        not current_user.is_authenticated or (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
         raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -19,8 +19,8 @@ def load_playlist(playlist_mbid: str):
         raise BadRequest("Provided playlist ID is invalid: %s" % playlist_mbid)
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, True)
-    if playlist is None or not playlist.public and \
-        not current_user.is_authenticated or (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
+    if playlist is None or not playlist.public and not current_user.is_authenticated or \
+    (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
         raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -19,8 +19,8 @@ def load_playlist(playlist_mbid: str):
         raise BadRequest("Provided playlist ID is invalid: %s" % playlist_mbid)
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, True)
-    if playlist is None or not playlist.public and not current_user.is_authenticated or \
-    (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
+    if playlist is None or not playlist.public and not current_user.is_authenticated \
+        or (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
         raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -21,7 +21,7 @@ def load_playlist(playlist_mbid: str):
     playlist = db_playlist.get_by_mbid(playlist_mbid, True)
     if playlist is None or not playlist.public and not current_user.is_authenticated \
         or (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
-        raise NotFound("Cannot find playlist: %s" % playlist_mbid)
+            raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)
 

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -18,9 +18,12 @@ def load_playlist(playlist_mbid: str):
     if not is_valid_uuid(playlist_mbid):
         raise BadRequest("Provided playlist ID is invalid: %s" % playlist_mbid)
 
+    current_user_id = None
+    if current_user.is_authenticated:
+        current_user_id = current_user.id
+
     playlist = db_playlist.get_by_mbid(playlist_mbid, True)
-    if playlist is None or not playlist.public and not current_user.is_authenticated \
-            or (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
+    if playlist is None or not playlist.is_visible_by(current_user_id):
         raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -20,8 +20,8 @@ def load_playlist(playlist_mbid: str):
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, True)
     if playlist is None or not playlist.public and not current_user.is_authenticated \
-        or (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
-            raise NotFound("Cannot find playlist: %s" % playlist_mbid)
+            or (playlist.creator_id != current_user.id and current_user.id not in playlist.collaborator_ids):
+        raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)
 

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -447,7 +447,7 @@ def get_playlist(playlist_mbid):
     user = validate_auth_header(True)
     user_id = None
     if user:
-        user_id =  user["id"]
+        user_id = user["id"]
     if not playlist.is_visible_by(user_id):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -630,8 +630,7 @@ def delete_playlist(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
-    if playlist is None or \
-       (playlist.creator_id != user["id"] and not playlist.public):
+    if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -371,7 +371,8 @@ def edit_playlist(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, False)
-    if playlist is None or (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
+    if playlist is None or \
+    (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -444,10 +444,12 @@ def get_playlist(playlist_mbid):
     if playlist is None:
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if not playlist.public:
-        user = validate_auth_header()
-        if not playlist.is_visible_by(user["id"]):
-            raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
+    user = validate_auth_header(True)
+    user_id = None
+    if user:
+        user_id =  user["id"]
+    if not playlist.is_visible_by(user_id):
+        raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)
 

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -371,8 +371,8 @@ def edit_playlist(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, False)
-    if playlist is None or \
-    (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
+    if playlist is None \
+        or (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -491,7 +491,7 @@ def add_playlist_item(playlist_mbid, offset):
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
+    if not playlist.is_modifiable_by(user["id"]):
         raise APIForbidden("You are not allowed to add recordings to this playlist.")
 
     data = request.json
@@ -548,7 +548,7 @@ def move_playlist_item(playlist_mbid):
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
+    if not playlist.is_modifiable_by(user["id"]):
         raise APIForbidden("You are not allowed to move recordings in this playlist.")
 
     data = request.json
@@ -593,7 +593,7 @@ def delete_playlist_item(playlist_mbid):
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
+    if not playlist.is_modifiable_by(user["id"]):
         raise APIForbidden("You are not allowed to remove recordings from this playlist.")
 
     data = request.json

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -371,7 +371,7 @@ def edit_playlist(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, False)
-    if playlist is None or (not playlist.public and playlist.creator_id != user["id"]):
+    if playlist is None or (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:
@@ -446,7 +446,7 @@ def get_playlist(playlist_mbid):
 
     if not playlist.public:
         user = validate_auth_header()
-        if playlist.creator_id != user["id"]:
+        if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
             raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)
@@ -487,10 +487,10 @@ def add_playlist_item(playlist_mbid, offset):
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
     if playlist is None or \
-       (playlist.creator_id != user["id"] and not playlist.public):
+       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if playlist.creator_id != user["id"]:
+    if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
         raise APIForbidden("You are not allowed to add recordings to this playlist.")
 
     data = request.json
@@ -545,10 +545,10 @@ def move_playlist_item(playlist_mbid):
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
     if playlist is None or \
-       (playlist.creator_id != user["id"] and not playlist.public):
+       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if playlist.creator_id != user["id"]:
+    if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
         raise APIForbidden("You are not allowed to move recordings in this playlist.")
 
     data = request.json
@@ -591,10 +591,10 @@ def delete_playlist_item(playlist_mbid):
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
     if playlist is None or \
-       (playlist.creator_id != user["id"] and not playlist.public):
+       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if playlist.creator_id != user["id"]:
+    if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
         raise APIForbidden("You are not allowed to remove recordings from this playlist.")
 
     data = request.json
@@ -670,7 +670,7 @@ def copy_playlist(playlist_mbid):
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
     if playlist is None or \
-       (playlist.creator_id != user["id"] and not playlist.public):
+       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     try:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -372,7 +372,7 @@ def edit_playlist(playlist_mbid):
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, False)
     if playlist is None or not playlist.is_visible_by(user["id"]):
-        raise NotFound("Cannot find playlist: %s" % playlist_mbid)
+        raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:
         raise APIForbidden("You are not allowed to edit this playlist.")

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -430,7 +430,8 @@ def get_playlist(playlist_mbid):
     """
     Fetch the given playlist.
 
-    :param playlist_mbid: Optional, The playlist mbid to fetch.
+    :param playlist_mbid: The playlist mbid to fetch.
+    :param fetch_metadata: Optional, pass value 'false' to skip lookup up recording metadata
     :statuscode 200: Yay, you have data!
     :statuscode 404: Playlist not found
     :statuscode 401: Invalid authorization. See error message for details.
@@ -439,6 +440,8 @@ def get_playlist(playlist_mbid):
 
     if not is_valid_uuid(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
+
+    fetch_metadata = _parse_boolean_arg("fetch_metadata", True)
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, True)
     if playlist is None:
@@ -451,7 +454,8 @@ def get_playlist(playlist_mbid):
     if not playlist.is_visible_by(user_id):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    fetch_playlist_recording_metadata(playlist)
+    if fetch_metadata:
+        fetch_playlist_recording_metadata(playlist)
 
     return jsonify(serialize_jspf(playlist))
 

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -372,8 +372,8 @@ def edit_playlist(playlist_mbid):
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, False)
     if playlist is None \
-        or (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
-            raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
+            or (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
+        raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:
         raise APIForbidden("You are not allowed to edit this playlist.")

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -371,9 +371,8 @@ def edit_playlist(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid, False)
-    if playlist is None \
-            or (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
-        raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
+    if playlist is None or not playlist.is_visible_by(user["id"]):
+        raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:
         raise APIForbidden("You are not allowed to edit this playlist.")
@@ -447,7 +446,7 @@ def get_playlist(playlist_mbid):
 
     if not playlist.public:
         user = validate_auth_header()
-        if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
+        if not playlist.is_visible_by(user["id"]):
             raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     fetch_playlist_recording_metadata(playlist)
@@ -487,8 +486,7 @@ def add_playlist_item(playlist_mbid, offset):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
-    if playlist is None or \
-       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
+    if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
@@ -545,8 +543,7 @@ def move_playlist_item(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
-    if playlist is None or \
-       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
+    if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
@@ -591,8 +588,7 @@ def delete_playlist_item(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
-    if playlist is None or \
-       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
+    if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids:
@@ -670,8 +666,7 @@ def copy_playlist(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
     playlist = db_playlist.get_by_mbid(playlist_mbid)
-    if playlist is None or \
-       (playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids and not playlist.public):
+    if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     try:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -373,7 +373,7 @@ def edit_playlist(playlist_mbid):
     playlist = db_playlist.get_by_mbid(playlist_mbid, False)
     if playlist is None \
         or (not playlist.public and playlist.creator_id != user["id"] and user["id"] not in playlist.collaborator_ids):
-        raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
+            raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     if playlist.creator_id != user["id"]:
         raise APIForbidden("You are not allowed to edit this playlist.")


### PR DESCRIPTION
We forgot to implement access to playlist for that playlist's collaborators.

There are a couple of different types of access for collaborators:
- use API endpoints to add/move/delete tracks in the playlist
- use API endpoint to copy the playlist
- view the web page for a playlist

# Left to do
We don't allow collaborators to edit a playlist details (title, private/public, collaborators, etc.), and currently have no provisions to allow a collaborator to remove themselves as collaborator from a playlist. Instead the owner needs to remove them.
A possible avenue for spam?
