### PR TITLE
Improve API error management on front-end

### DIFF
--- a/listenbrainz/webserver/static/js/src/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.ts
@@ -321,7 +321,13 @@ export default class APIService {
     if (response.status >= 200 && response.status < 300) {
       return;
     }
-    const data = response.body || (response.json && (await response.json()));
+    let data;
+    const contentType = response.headers.get("content-type");
+    if (contentType && contentType.indexOf("application/json") !== -1) {
+      data = await response.json();
+    } else {
+      data = response.body;
+    }
     let message;
     if (data?.error) {
       message = data?.error;

--- a/listenbrainz/webserver/static/js/src/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.ts
@@ -321,19 +321,19 @@ export default class APIService {
     if (response.status >= 200 && response.status < 300) {
       return;
     }
-    let data;
-    const contentType = response.headers.get("content-type");
-    if (contentType && contentType.indexOf("application/json") !== -1) {
-      data = await response.json();
-    } else {
-      data = response.body;
-    }
     let message;
-    if (data?.error) {
-      message = data?.error;
-    } else {
+    try {
+      const contentType = response.headers.get("content-type");
+      if (contentType && contentType.indexOf("application/json") !== -1) {
+        const jsonError = await response.json();
+        message = jsonError.error;
+      } else {
+        message = await response.text();
+      }
+    } catch (error) {
       message = `HTTP Error ${response.statusText}`;
     }
+
     const error = new APIError(`HTTP Error ${response.statusText}`);
     error.status = response.statusText;
     error.response = response;


### PR DESCRIPTION
The error messages we are currently getting on the front-end are not very helpful as they swallow the error message.

This small PR does a better job at detecting what sort of response we get from the fetch API and actually parses json content to display the error messages to the user.