### PR TITLE
Sort playlist collaborators

### DIFF
--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -67,6 +67,7 @@ def get_by_mbid(playlist_id: str, load_recordings: bool = True) -> Optional[mode
             user = db_user.get(user_id)
             if user:
                 collaborators.append(user["musicbrainz_id"])
+            collaborators.sort()
             obj['collaborators'] = collaborators
         return model_playlist.Playlist.parse_obj(obj)
 
@@ -180,6 +181,7 @@ def _playlist_resultset_to_model(connection, result, load_recordings):
                 user = db_user.get(user_id)
                 if user:
                     collaborators.append(user["musicbrainz_id"])
+            collaborators.sort()
             p.collaborators = collaborators
 
     return playlists
@@ -436,6 +438,7 @@ def create(playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist
                 user = db_user.get(user_id)
                 if user:
                     collaborators.append(user["musicbrainz_id"])
+            collaborators.sort()
             playlist.collaborators = collaborators
 
         return model_playlist.Playlist.parse_obj(playlist.dict())
@@ -485,6 +488,7 @@ def update_playlist(playlist: model_playlist.Playlist):
             user = db_user.get(user_id)
             if user:
                 collaborators.append(user["musicbrainz_id"])
+        collaborators.sort()
         playlist.collaborators = collaborators
         playlist.last_updated = set_last_updated(connection, playlist.id)
         return playlist

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -437,6 +437,7 @@ def add_playlist_collaborators(connection, playlist_id, collaborator_ids):
     if collaborator_params:
         connection.execute(insert_query, collaborator_params)
 
+
 def get_collaborators_names_from_ids(collaborator_ids: List[int]):
     collaborators = []
     # TODO: Look this up in one query
@@ -446,6 +447,7 @@ def get_collaborators_names_from_ids(collaborator_ids: List[int]):
             collaborators.append(user["musicbrainz_id"])
     collaborators.sort()
     return collaborators
+
 
 def update_playlist(playlist: model_playlist.Playlist):
     """Update playlist metadata (Name, description, public flag)


### PR DESCRIPTION
We are getting random [test failures](https://ci.metabrainz.org/job/listenbrainz-integration/274/console) because we don't sort our lists of playlist collaborators:

```
        self.assertEqual(response.json["playlist"]["extension"]
                         [PLAYLIST_EXTENSION_URI]["collaborators"], [self.user2["musicbrainz_id"],
>                                                                    self.user3["musicbrainz_id"]])
E       AssertionError: Lists differ: ['troi-bot', 'anothertestuserpleaseignore'] != ['anothertestuserpleaseignore', 'troi-bot']
E       
E       First differing element 0:
E       'troi-bot'
E       'anothertestuserpleaseignore'
E       
E       - ['troi-bot', 'anothertestuserpleaseignore']
E       + ['anothertestuserpleaseignore', 'troi-bot']
```


I tried using a getter/setter on the `Playlist` model so as to implement this only once on the model, but that doesn't work because pydantic doesn't serialize `@property` fields: https://github.com/samuelcolvin/pydantic/issues/935
We get errors: `'Playlist' object has no attribute 'collaborators'`

Couldn't find a good way to make it work so I went for sorting everywhere we set collaborators, but I'm open to suggestions.