### PR TITLE
Safely get track metadata in React components

### DIFF
--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -163,13 +163,13 @@ export default class ListenCard extends React.Component<
           <MediaQuery minWidth={768}>
             <div className="col-xs-9">
               <div className="track-details">
-                <p title={listen.track_metadata.track_name}>
+                <p title={listen.track_metadata?.track_name}>
                   {getTrackLink(listen)}
                 </p>
                 <p>
                   <small
                     className="text-muted"
-                    title={listen.track_metadata.artist_name}
+                    title={listen.track_metadata?.artist_name}
                   >
                     {getArtistLink(listen)}
                   </small>
@@ -199,13 +199,13 @@ export default class ListenCard extends React.Component<
           <MediaQuery maxWidth={767}>
             <div className="col-xs-12">
               <div className="track-details">
-                <p title={listen.track_metadata.track_name}>
+                <p title={listen.track_metadata?.track_name}>
                   {getTrackLink(listen)}
                 </p>
                 <p>
                   <small
                     className="text-muted"
-                    title={listen.track_metadata.artist_name}
+                    title={listen.track_metadata?.artist_name}
                   >
                     {listen.playing_now ? (
                       <span className="listen-time text-muted">

--- a/listenbrainz/webserver/static/js/src/playlists/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/utils.tsx
@@ -80,14 +80,14 @@ export function listenToJSPFTrack(listen: Listen): JSPFTrack {
   return {
     identifier:
       PLAYLIST_TRACK_URI_PREFIX +
-      listen.track_metadata.additional_info?.recording_mbid,
-    id: listen.track_metadata.additional_info?.recording_mbid || undefined,
-    title: listen.track_metadata.track_name,
-    creator: listen.track_metadata.artist_name,
-    album: listen.track_metadata.release_name || undefined,
-    duration: listen.track_metadata.additional_info?.duration_ms || undefined,
-    location: listen.track_metadata.additional_info?.origin_url
-      ? [listen.track_metadata.additional_info?.origin_url]
+      listen.track_metadata?.additional_info?.recording_mbid,
+    id: listen.track_metadata?.additional_info?.recording_mbid || undefined,
+    title: listen.track_metadata?.track_name,
+    creator: listen.track_metadata?.artist_name,
+    album: listen.track_metadata?.release_name || undefined,
+    duration: listen.track_metadata?.additional_info?.duration_ms || undefined,
+    location: listen.track_metadata?.additional_info?.origin_url
+      ? [listen.track_metadata?.additional_info?.origin_url]
       : undefined,
   };
 }

--- a/listenbrainz/webserver/static/js/src/recommendations/RecommendationCard.tsx
+++ b/listenbrainz/webserver/static/js/src/recommendations/RecommendationCard.tsx
@@ -171,12 +171,12 @@ export default class RecommendationCard extends React.Component<
         className={`recommendation-card row ${className}`}
       >
         <div className="track-details">
-          <div title={recommendation.track_metadata.track_name}>
+          <div title={recommendation.track_metadata?.track_name}>
             {getTrackLink(recommendation)}
           </div>
           <small
             className="text-muted"
-            title={recommendation.track_metadata.artist_name}
+            title={recommendation.track_metadata?.artist_name}
           >
             {getArtistLink(recommendation)}
           </small>


### PR DESCRIPTION
While using the follow page on LB, the page broke trying to access a property of track_metadata while track_metadata did not exist on that listen (maybe a listening_now type of listen?).

In any case this is a fragile property access and I found a few in the code that we want to fix.