### PR TITLE
Fix websockets data format to avoid breaking listens page

### DIFF
--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -235,9 +235,15 @@ export default class RecentListens extends React.Component<
 
   receiveNewListen = (newListen: string): void => {
     const json = JSON.parse(newListen);
+    // the websocket message received may not contain the expected track_metadata and listened_at fields
+    // therefore, we look for their alias as well.
     if (!("track_metadata" in json)) {
       json.track_metadata = json.data;
       delete json.data;
+    }
+    if (!("listened_at" in json)) {
+      json.listened_at = json.timestamp;
+      delete json.timestamp;
     }
     const listen = json as Listen;
     this.setState((prevState) => {

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -239,25 +239,29 @@ export default class RecentListens extends React.Component<
       json = JSON.parse(newListen);
       // the websocket message received may not contain the expected track_metadata and listened_at fields
       // therefore, we look for their alias as well.
-      if (!("track_metadata" in json) && "data" in json) {
-        json.track_metadata = json.data;
-        delete json.data;
-      } else {
-        // eslint-disable-next-line no-console
-        console.debug(
-          `Could not find track_metadata and data in following json: ${json}`
-        );
-        return;
+      if (!("track_metadata" in json)) {
+        if ("data" in json) {
+          json.track_metadata = json.data;
+          delete json.data;
+        } else {
+          // eslint-disable-next-line no-console
+          console.debug(
+            `Could not find track_metadata and data in following json: ${json}`
+          );
+          return;
+        }
       }
-      if (!("listened_at" in json) && "timestamp" in json) {
-        json.listened_at = json.timestamp;
-        delete json.timestamp;
-      } else {
-        // eslint-disable-next-line no-console
-        console.debug(
-          `Could not find listened_at and timestamp in following json: ${json}`
-        );
-        return;
+      if (!("listened_at" in json)) {
+        if ("timestamp" in json) {
+          json.listened_at = json.timestamp;
+          delete json.timestamp;
+        } else {
+          // eslint-disable-next-line no-console
+          console.debug(
+            `Could not find listened_at and timestamp in following json: ${json}`
+          );
+          return;
+        }
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -234,17 +234,35 @@ export default class RecentListens extends React.Component<
   };
 
   receiveNewListen = (newListen: string): void => {
-    const json = JSON.parse(newListen);
-    // the websocket message received may not contain the expected track_metadata and listened_at fields
-    // therefore, we look for their alias as well.
-    if (!("track_metadata" in json)) {
-      json.track_metadata = json.data;
-      delete json.data;
+    let json;
+    try {
+      json = JSON.parse(newListen);
+      // the websocket message received may not contain the expected track_metadata and listened_at fields
+      // therefore, we look for their alias as well.
+      if (!("track_metadata" in json) && "data" in json) {
+        json.track_metadata = json.data;
+        delete json.data;
+      } else {
+        // eslint-disable-next-line no-console
+        console.debug(
+          `Could not find track_metadata and data in following json: ${json}`
+        );
+      }
+      if (!("listened_at" in json) && "timestamp" in json) {
+        json.listened_at = json.timestamp;
+        delete json.timestamp;
+      } else {
+        // eslint-disable-next-line no-console
+        console.debug(
+          `Could not find listened_at and timestamp in following json: ${json}`
+        );
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      return;
     }
-    if (!("listened_at" in json)) {
-      json.listened_at = json.timestamp;
-      delete json.timestamp;
-    }
+
     const listen = json as Listen;
     this.setState((prevState) => {
       const { listens } = prevState;

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -247,6 +247,7 @@ export default class RecentListens extends React.Component<
         console.debug(
           `Could not find track_metadata and data in following json: ${json}`
         );
+        return;
       }
       if (!("listened_at" in json) && "timestamp" in json) {
         json.listened_at = json.timestamp;
@@ -256,6 +257,7 @@ export default class RecentListens extends React.Component<
         console.debug(
           `Could not find listened_at and timestamp in following json: ${json}`
         );
+        return;
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -234,7 +234,12 @@ export default class RecentListens extends React.Component<
   };
 
   receiveNewListen = (newListen: string): void => {
-    const listen = JSON.parse(newListen) as Listen;
+    const json = JSON.parse(newListen);
+    if (!("track_metadata" in json)) {
+      json.track_metadata = json.data;
+      delete json.data;
+    }
+    const listen = json as Listen;
     this.setState((prevState) => {
       const { listens } = prevState;
       // Crop listens array to 100 max


### PR DESCRIPTION
Currently, the data received from the listenstores is directly sent to clients through websocket messages. This works for `playing_now` listens because their format matches that expected by the frontend. However, this is not the case for the `single` or `import` listens. The `timescale_writer` modifies the format of the inserted listens. In timescale database, we use the `data` column but elsewhere we refer to it as `track_metadata`. This modified data is received by the websockets server and is then sent to the client. The client code is unable to parse this data and causing rendering issues.

The fix is simple to rename the `data` key to `track_metadata` of each listen received from `timescale_listenstore`.
