### PR TITLE
Remove flask and brainzutils dependency from listenbrainz_spark

### DIFF
--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -1,6 +1,10 @@
+import sentry_sdk
+from sentry_sdk.integrations.spark import SparkIntegration
+
 from py4j.protocol import Py4JJavaError
 
 from listenbrainz_spark.exceptions import SparkSessionNotInitializedException
+from listenbrainz_spark import config
 
 from pyspark import SparkContext
 from pyspark.sql import SparkSession, SQLContext
@@ -9,12 +13,14 @@ session = None
 context = None
 sql_context = None
 
+
 def init_spark_session(app_name):
     """ Initializes a Spark Session with the given application name.
 
         Args:
             app_name (str): Name of the Spark application. This will also occur in the Spark UI.
     """
+    sentry_sdk.init(**config.LOG_SENTRY, integrations=[SparkIntegration()])
     global session, context, sql_context
     try:
         session = SparkSession \

--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -20,7 +20,8 @@ def init_spark_session(app_name):
         Args:
             app_name (str): Name of the Spark application. This will also occur in the Spark UI.
     """
-    sentry_sdk.init(**config.LOG_SENTRY, integrations=[SparkIntegration()])
+    if hasattr(config, 'LOG_SENTRY'):  # attempt to initialize sentry_sdk only if configuration available
+        sentry_sdk.init(**config.LOG_SENTRY, integrations=[SparkIntegration()])
     global session, context, sql_context
     try:
         session = SparkSession \

--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -19,10 +19,10 @@ SPARK_RESULT_QUEUE = "spark_result"
 # calculate stats on X months data
 STATS_CALCULATION_WINDOW = 1
 
-LOG_SENTRY = {
-    'dsn':'',
-    'environment': 'development',
-}
+#LOG_SENTRY = {
+#    'dsn':'',
+#    'environment': 'development',
+#}
 SENTRY_DSN_PUBLIC = ''
 
 # Model id is made up of two parts.

--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -1,11 +1,10 @@
 import os
 import ftplib
 import hashlib
+import logging
 
 from listenbrainz_spark import config
 from listenbrainz_spark.exceptions import DumpInvalidException
-
-from flask import current_app
 
 
 class ListenBrainzFTPDownloader:
@@ -20,7 +19,7 @@ class ListenBrainzFTPDownloader:
             self.connection = ftplib.FTP(config.FTP_SERVER_URI)
             self.connection.login()
         except ftplib.error_perm:
-            current_app.logger.critical("Couldn't connect to FTP Server, try again...")
+            logging.critical("Couldn't connect to FTP Server, try again...")
             raise SystemExit
 
     def list_dir(self, path=None, verbose=False):
@@ -52,7 +51,7 @@ class ListenBrainzFTPDownloader:
             try:
                 self.connection.retrbinary('RETR {}'.format(src), f.write)
             except ftplib.error_perm as e:
-                current_app.logger.critical("Could not download file: {}".format(str(e)))
+                logging.critical("Could not download file: {}".format(str(e)))
 
     def download_dump(self, filename, directory):
         """ Download file with `filename` from FTP.
@@ -75,7 +74,7 @@ class ListenBrainzFTPDownloader:
         dest_path = os.path.join(directory, filename)
         self.download_file_binary(filename, dest_path)
 
-        current_app.logger.info("Verifying dump integrity...")
+        logging.info("Verifying dump integrity...")
         calculated_sha = self._calc_sha256(dest_path)
         received_sha = self._read_sha_file(sha_dest_path)
 

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -1,10 +1,10 @@
 import re
 import time
+import logging
 
+from listenbrainz_spark import config
 from listenbrainz_spark.ftp import ListenBrainzFTPDownloader
 from listenbrainz_spark.exceptions import DumpNotFoundException
-
-from flask import current_app
 
 # mbid_msid_mapping_with_matchable is used.
 # refer to: http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/labs/mappings/
@@ -119,17 +119,17 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
                 dest_path (str): Local path where mapping has been downloaded.
                 mapping_file_name (str): file name of downloaded mapping.
         """
-        self.connection.cwd(current_app.config['FTP_MSID_MBID_DIR'])
+        self.connection.cwd(config.FTP_MSID_MBID_DIR)
         dump = self.list_dir()
 
-        mapping = self.get_available_dumps(dump, current_app.config['MAPPING_NAME_PREFIX'])
+        mapping = self.get_available_dumps(dump, config.MAPPING_NAME_PREFIX)
 
         mapping_file_name = self.get_latest_mapping(mapping)
 
         t0 = time.monotonic()
-        current_app.logger.info('Downloading {} from FTP...'.format(mapping_file_name))
+        logging.info('Downloading {} from FTP...'.format(mapping_file_name))
         dest_path = self.download_dump(mapping_file_name, directory)
-        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
+        logging.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
         return dest_path, mapping_file_name
 
     def download_listens(self, directory, listens_dump_id=None, dump_type=FULL):
@@ -145,9 +145,9 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
                 listens_file_name (str): name of downloaded listens dump.
                 dump_id (int): Unique indentifier of downloaded listens dump.
         """
-        ftp_cwd = current_app.config['FTP_LISTENS_DIR'] + 'fullexport/'
+        ftp_cwd = config.FTP_LISTENS_DIR + 'fullexport/'
         if dump_type == INCREMENTAL:
-            ftp_cwd = current_app.config['FTP_LISTENS_DIR'] + 'incremental/'
+            ftp_cwd = config.FTP_LISTENS_DIR + 'incremental/'
         self.connection.cwd(ftp_cwd)
         listens_dump_list = sorted(self.list_dir(), key=lambda x: int(x.split('-')[2]))
         req_listens_dump = self.get_dump_name_to_download(listens_dump_list, listens_dump_id, 2)
@@ -157,9 +157,9 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         listens_file_name = self.get_listens_dump_file_name(req_listens_dump)
 
         t0 = time.monotonic()
-        current_app.logger.info('Downloading {} from FTP...'.format(listens_file_name))
+        logging.info('Downloading {} from FTP...'.format(listens_file_name))
         dest_path = self.download_dump(listens_file_name, directory)
-        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
+        logging.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
         return dest_path, listens_file_name, int(dump_id)
 
     def download_artist_relation(self, directory, artist_relation_dump_id=None):
@@ -174,7 +174,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
                 dest_path (str): Local path where artist relation has been downloaded.
                 artist_relation_file_name (str): file name of downloaded artist relation.
         """
-        self.connection.cwd(current_app.config['FTP_ARTIST_RELATION_DIR'])
+        self.connection.cwd(config.FTP_ARTIST_RELATION_DIR)
         dump = self.list_dir()
         req_dump = self.get_dump_name_to_download(dump, artist_relation_dump_id, ARTIST_RELATION_DUMP_ID_POS)
 
@@ -182,8 +182,8 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         artist_relation_file_name = self.get_dump_archive_name(req_dump)
 
         t0 = time.monotonic()
-        current_app.logger.info('Downloading {} from FTP...'.format(artist_relation_file_name))
+        logging.info('Downloading {} from FTP...'.format(artist_relation_file_name))
         dest_path = self.download_dump(artist_relation_file_name, directory)
-        current_app.logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
+        logging.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
 
         return dest_path, artist_relation_file_name

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -1,24 +1,12 @@
-import os
 import unittest
 from unittest.mock import patch, call
 
-import listenbrainz_spark
-from listenbrainz_spark import config, utils
+from listenbrainz_spark import config
 from listenbrainz_spark.exceptions import DumpNotFoundException
-from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader, ARTIST_RELATION_DUMP_ID_POS
+from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
 
 
 class FTPDownloaderTestCase(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.app = utils.create_app()
-        cls.app_context = cls.app.app_context()
-        cls.app_context.push()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.app_context.pop()
 
     @patch('ftplib.FTP')
     def test_get_dump_name_to_download(self, mock_ftp_cons):

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -1,16 +1,15 @@
 import os
 import pathlib
 import sys
-import shutil
 import subprocess
 import time
+import logging
 from tarfile import TarError
 
 import listenbrainz_spark
 from listenbrainz_spark import utils, config, hdfs_connection
 from listenbrainz_spark.exceptions import SparkSessionNotInitializedException, DumpInvalidException
 
-from flask import current_app
 
 TEMP_DIR_PATH = "/temp"
 
@@ -22,7 +21,7 @@ class ListenbrainzHDFSUploader:
         try:
             listenbrainz_spark.init_spark_session('uploader')
         except SparkSessionNotInitializedException as err:
-            current_app.logger.error(str(err), exc_info=True)
+            logging.error(str(err), exc_info=True)
             sys.exit(-1)
 
     def _is_json_file(self, filename):
@@ -71,16 +70,16 @@ class ListenbrainzHDFSUploader:
         # Copy data from dest_path to TEMP_DIR_PATH to be merged with new data
         if not overwrite and utils.path_exists(dest_path):
             t0 = time.monotonic()
-            current_app.logger.info("Copying old listens into '{}'".format(TEMP_DIR_PATH))
+            logging.info("Copying old listens into '{}'".format(TEMP_DIR_PATH))
             utils.copy(dest_path, TEMP_DIR_PATH, overwrite=True)
-            current_app.logger.info("Done! Time taken: {:.2f}".format(time.monotonic() - t0))
+            logging.info("Done! Time taken: {:.2f}".format(time.monotonic() - t0))
 
-        current_app.logger.info("Uploading listens to temporary directory in HDFS...")
+        logging.info("Uploading listens to temporary directory in HDFS...")
         total_files = 0
         total_time = 0.0
         for member in tar:
             if member.isfile() and self._is_json_file(member.name):
-                current_app.logger.info("Uploading {}...".format(member.name))
+                logging.info("Uploading {}...".format(member.name))
                 t0 = time.monotonic()
 
                 try:
@@ -101,18 +100,18 @@ class ListenbrainzHDFSUploader:
                 time_taken = time.monotonic() - t0
                 total_files += 1
                 total_time += time_taken
-                current_app.logger.info("Done! Current file processed in {:.2f} sec".format(time_taken))
-        current_app.logger.info("Done! Total files processed {}. Average time taken: {:.2f}".format(
+                logging.info("Done! Current file processed in {:.2f} sec".format(time_taken))
+        logging.info("Done! Total files processed {}. Average time taken: {:.2f}".format(
             total_files, total_time / total_files
         ))
 
         # Delete dest_path if present
         if utils.path_exists(dest_path):
-            current_app.logger.info('Removing {} from HDFS...'.format(dest_path))
+            logging.info('Removing {} from HDFS...'.format(dest_path))
             utils.delete_dir(dest_path, recursive=True)
-            current_app.logger.info('Done!')
+            logging.info('Done!')
 
-        current_app.logger.info("Moving the processed files to {}".format(dest_path))
+        logging.info("Moving the processed files to {}".format(dest_path))
         t0 = time.monotonic()
 
         # Check if parent directory exists, if not create a directory
@@ -121,7 +120,7 @@ class ListenbrainzHDFSUploader:
             utils.create_dir(dest_path_parent)
 
         utils.rename(TEMP_DIR_PATH, dest_path)
-        utils.current_app.logger.info("Done! Time taken: {:.2f}".format(time.monotonic() - t0))
+        utils.logging.info("Done! Time taken: {:.2f}".format(time.monotonic() - t0))
 
         # Cleanup
         utils.delete_dir(tmp_dump_dir, recursive=True)

--- a/listenbrainz_spark/hdfs/tests/test_init.py
+++ b/listenbrainz_spark/hdfs/tests/test_init.py
@@ -2,19 +2,16 @@ import os
 import json
 import tarfile
 import tempfile
-import shutil
 import subprocess
 import unittest
 from datetime import datetime
-from unittest.mock import patch, Mock, call, MagicMock
+from unittest.mock import patch, MagicMock
 
-import listenbrainz_spark
 from listenbrainz_spark import config, utils, schema
 from listenbrainz_spark.exceptions import DumpInvalidException
 from listenbrainz_spark.hdfs import ListenbrainzHDFSUploader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
 
-from pyspark.sql.types import StructField, StructType, StringType
 
 test_listen = {
 
@@ -30,17 +27,8 @@ test_listen = {
             'listened_at': str(datetime.utcnow())
         }
 
+
 class HDFSTestCase(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.app = utils.create_app()
-        cls.app_context = cls.app.app_context()
-        cls.app_context.push()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.app_context.pop()
 
     @patch('listenbrainz_spark.hdfs_connection.init_hdfs')
     @patch('listenbrainz_spark.init_spark_session')

--- a/listenbrainz_spark/hdfs/upload.py
+++ b/listenbrainz_spark/hdfs/upload.py
@@ -2,12 +2,10 @@ import os
 import time
 import tarfile
 import tempfile
+import logging
 
-import listenbrainz_spark
-from listenbrainz_spark import schema, path, config, utils
+from listenbrainz_spark import schema, path, utils
 from listenbrainz_spark.hdfs import ListenbrainzHDFSUploader
-
-from flask import current_app
 
 
 class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
@@ -22,11 +20,11 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
         """
         start_time = time.monotonic()
         df = utils.read_json(tmp_hdfs_path, schema=schema)
-        current_app.logger.info("Processing {} rows...".format(df.count()))
+        logging.info("Processing {} rows...".format(df.count()))
 
-        current_app.logger.info("Uploading to {}...".format(dest_path))
+        logging.info("Uploading to {}...".format(dest_path))
         utils.save_parquet(df, dest_path)
-        current_app.logger.info("File processed in {:.2f} seconds!".format(time.monotonic() - start_time))
+        logging.info("File processed in {:.2f} seconds!".format(time.monotonic() - start_time))
 
     def process_json_listens(self, filename, data_dir, tmp_hdfs_path, append, schema):
         """ Process a file containing listens from the ListenBrainz dump and add listens to
@@ -54,8 +52,8 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
         else:
             utils.save_parquet(df, dest_path, mode="overwrite")
 
-        current_app.logger.info("Uploading to {}...".format(dest_path))
-        current_app.logger.info("File processed in {:.2f} seconds!".format(time.monotonic() - start_time))
+        logging.info("Uploading to {}...".format(dest_path))
+        logging.info("File processed in {:.2f} seconds!".format(time.monotonic() - start_time))
 
     def upload_mapping(self, archive: str):
         """ Decompress archive and upload mapping to HDFS.

--- a/listenbrainz_spark/recommendations/dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/dataframe_utils.py
@@ -1,6 +1,6 @@
 import uuid
+import logging
 
-from listenbrainz_spark import path
 import listenbrainz_spark.utils.mapping as mapping_utils
 from listenbrainz_spark.stats import (replace_days,
                                       offset_days)
@@ -9,7 +9,6 @@ from listenbrainz_spark.utils import save_parquet, get_listens
 from listenbrainz_spark.exceptions import (FileNotSavedException,
                                            FileNotFetchedException)
 
-from flask import current_app
 
 def get_dataframe_id(prefix):
     """ Generate dataframe id.
@@ -27,7 +26,7 @@ def save_dataframe(df, dest_path):
     try:
         save_parquet(df, dest_path)
     except FileNotSavedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
 
@@ -94,10 +93,10 @@ def get_listens_for_training_model_window(to_date, from_date, dest_path):
     try:
         training_df = get_listens(from_date, to_date, dest_path)
     except ValueError as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
     except FileNotFetchedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
     partial_listens_df = mapping_utils.convert_text_fields_to_matchable(training_df)

--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -13,27 +13,21 @@ The same process is done for similar artist candidate set.
 
 import logging
 import time
-from datetime import datetime
-from collections import defaultdict
 from py4j.protocol import Py4JJavaError
-from pydantic import ValidationError
 
 import listenbrainz_spark
-from listenbrainz_spark import config, utils, path
+from listenbrainz_spark import utils, path
 
 from listenbrainz_spark.exceptions import (PathNotFoundException,
                                            FileNotFetchedException,
-                                           ViewNotRegisteredException,
                                            SparkSessionNotInitializedException,
                                            RecommendationsNotGeneratedException,
-                                           RatingOutOfRangeException,
                                            EmptyDataframeExcpetion)
 
 from listenbrainz_spark.recommendations.recording.train_models import get_model_path
 from listenbrainz_spark.recommendations.recording.candidate_sets import _is_empty_dataframe
 
 from pyspark.sql import Row
-from flask import current_app
 import pyspark.sql.functions as func
 from pyspark.sql.window import Window
 from pyspark.sql.functions import col, udf, row_number
@@ -62,10 +56,10 @@ def get_most_recent_model_id():
     try:
         model_metadata = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_MODEL_METADATA)
     except PathNotFoundException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
     except FileNotFetchedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
     latest_ts = model_metadata.select(func.max('model_created').alias('model_created')).take(1)[0].model_created
@@ -84,7 +78,7 @@ def load_model():
         model = MatrixFactorizationModel.load(listenbrainz_spark.context, dest_path)
         return model
     except Py4JJavaError as err:
-        current_app.logger.error('Unable to load model "{}"\n{}\nAborting...'.format(model_id, str(err.java_exception)),
+        logging.error('Unable to load model "{}"\n{}\nAborting...'.format(model_id, str(err.java_exception)),
                                  exc_info=True)
         raise
 
@@ -262,10 +256,10 @@ def check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df):
     min_rating = min(similar_artist_rec_df.select(func.min('rating').alias('rating')).take(1)[0].rating, min_rating)
 
     if max_rating > 1.0:
-        current_app.logger.info('Some ratings are greater than 1 \nMax rating: {}'.format(max_rating))
+        logging.info('Some ratings are greater than 1 \nMax rating: {}'.format(max_rating))
 
     if min_rating < -1.0:
-        current_app.logger.info('Some ratings are less than -1 \nMin rating: {}'.format(min_rating))
+        logging.info('Some ratings are less than -1 \nMin rating: {}'.format(min_rating))
 
 
 def create_messages(top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_user_count, total_time,
@@ -363,27 +357,27 @@ def get_recommendations_for_all(params: RecommendationParams, users):
     try:
         top_artist_candidate_set_rdd = get_candidate_set_rdd_for_user(params.top_artist_candidate_set_df, users)
     except EmptyDataframeExcpetion:
-        current_app.logger.error('Top artist candidate set not found for any user.', exc_info=True)
+        logging.error('Top artist candidate set not found for any user.', exc_info=True)
         raise
 
     try:
         similar_artist_candidate_set_rdd = get_candidate_set_rdd_for_user(params.similar_artist_candidate_set_df, users)
     except EmptyDataframeExcpetion:
-        current_app.logger.error('Similar artist candidate set not found for any user.', exc_info=True)
+        logging.error('Similar artist candidate set not found for any user.', exc_info=True)
         raise
 
     try:
         top_artist_rec_df = generate_recommendations(top_artist_candidate_set_rdd, params,
                                                      params.recommendation_top_artist_limit)
     except RecommendationsNotGeneratedException:
-        current_app.logger.error('Top artist recommendations not generated for any user', exc_info=True)
+        logging.error('Top artist recommendations not generated for any user', exc_info=True)
         raise
 
     try:
         similar_artist_rec_df = generate_recommendations(similar_artist_candidate_set_rdd, params,
                                                          params.recommendation_similar_artist_limit)
     except RecommendationsNotGeneratedException:
-        current_app.logger.error('Similar artist recommendations not generated for any user', exc_info=True)
+        logging.error('Similar artist recommendations not generated for any user', exc_info=True)
         raise
 
     return top_artist_rec_df, similar_artist_rec_df
@@ -401,7 +395,7 @@ def main(recommendation_top_artist_limit=None, recommendation_similar_artist_lim
     try:
         listenbrainz_spark.init_spark_session('Recommendations')
     except SparkSessionNotInitializedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
     try:
@@ -409,13 +403,13 @@ def main(recommendation_top_artist_limit=None, recommendation_similar_artist_lim
         top_artist_candidate_set_df = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_TOP_ARTIST_CANDIDATE_SET)
         similar_artist_candidate_set_df = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_SIMILAR_ARTIST_CANDIDATE_SET)
     except PathNotFoundException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
     except FileNotFetchedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
-    current_app.logger.info('Loading model...')
+    logging.info('Loading model...')
     model = load_model()
 
     # an action must be called to persist data in memory
@@ -436,39 +430,39 @@ def main(recommendation_top_artist_limit=None, recommendation_similar_artist_lim
         # active in the last week. Ideally, top_artist_candidate_set should give the active user count.
         active_user_count = users_df.count()
         users_df.persist()
-        current_app.logger.info('Took {:.2f}sec to get active user count'.format(time.monotonic() - ts_initial))
+        logging.info('Took {:.2f}sec to get active user count'.format(time.monotonic() - ts_initial))
     except EmptyDataframeExcpetion as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
-    current_app.logger.info('Generating recommendations...')
+    logging.info('Generating recommendations...')
     ts = time.monotonic()
     top_artist_rec_df, similar_artist_rec_df = get_recommendations_for_all(params, users)
-    current_app.logger.info('Recommendations generated!')
-    current_app.logger.info('Took {:.2f}sec to generate recommendations for all active users'.format(time.monotonic() - ts))
+    logging.info('Recommendations generated!')
+    logging.info('Took {:.2f}sec to generate recommendations for all active users'.format(time.monotonic() - ts))
 
     ts = time.monotonic()
     top_artist_rec_user_count = get_user_count(top_artist_rec_df)
     similar_artist_rec_user_count = get_user_count(similar_artist_rec_df)
-    current_app.logger.info('Took {:.2f}sec to get top artist and similar artist user count'.format(time.monotonic() - ts))
+    logging.info('Took {:.2f}sec to get top artist and similar artist user count'.format(time.monotonic() - ts))
 
     ts = time.monotonic()
     check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df)
 
     top_artist_rec_scaled_df = scale_rating(top_artist_rec_df)
     similar_artist_rec_scaled_df = scale_rating(similar_artist_rec_df)
-    current_app.logger.info('Took {:.2f}sec to scale the ratings'.format(time.monotonic() - ts))
+    logging.info('Took {:.2f}sec to scale the ratings'.format(time.monotonic() - ts))
 
     ts = time.monotonic()
     top_artist_rec_mbid_df = get_recording_mbids(params, top_artist_rec_scaled_df, users_df)
     similar_artist_rec_mbid_df = get_recording_mbids(params, similar_artist_rec_scaled_df, users_df)
-    current_app.logger.info('Took {:.2f}sec to get mbids corresponding to recording ids'.format(time.monotonic() - ts))
+    logging.info('Took {:.2f}sec to get mbids corresponding to recording ids'.format(time.monotonic() - ts))
 
     # persisted data must be cleared from memory after usage to avoid OOM
     recordings_df.unpersist()
 
     total_time = time.monotonic() - ts_initial
-    current_app.logger.info('Total time: {:.2f}sec'.format(total_time))
+    logging.info('Total time: {:.2f}sec'.format(total_time))
 
     result = create_messages(top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_user_count, total_time,
                              top_artist_rec_user_count, similar_artist_rec_user_count)

--- a/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
@@ -1,24 +1,18 @@
-import os
-import time
-from datetime import datetime
-import unittest
-from unittest.mock import patch, call, MagicMock, Mock
+import logging
+from unittest.mock import patch, call, MagicMock
 
 from listenbrainz_spark.tests import SparkTestCase
 from listenbrainz_spark.recommendations.recording import recommend
-from listenbrainz_spark.recommendations.recording import train_models
-from listenbrainz_spark import schema, utils, config, path, stats
+from listenbrainz_spark import schema, utils, path
 from listenbrainz_spark.exceptions import (RecommendationsNotGeneratedException,
-                                           EmptyDataframeExcpetion,
-                                           RatingOutOfRangeException)
+                                           EmptyDataframeExcpetion)
 
 from pyspark.sql import Row
-import pyspark.sql.functions as f
 from pyspark.rdd import RDD
 from pyspark.sql.functions import col
-from pyspark.mllib.recommendation import Rating
 
 # for test data/dataframes refer to listenbrainzspark/tests/__init__.py
+
 
 class RecommendTestClass(SparkTestCase):
 
@@ -400,14 +394,14 @@ class RecommendTestClass(SparkTestCase):
         ))
         return df
 
-    @patch('listenbrainz_spark.recommendations.recording.recommend.current_app')
-    def test_check_for_ratings_beyond_range(self, mock_current_app):
+    @patch('logging.Logger.info')
+    def test_check_for_ratings_beyond_range(self, mock_logger):
         top_artist_rec_df = self.get_top_artist_rec_df()
         similar_artist_rec_df = self.get_similar_artist_rec_df()
 
         recommend.check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df)
 
-        mock_current_app.logger.info.assert_has_calls([
+        mock_logger.assert_has_calls([
             call('Some ratings are greater than 1 \nMax rating: 1.8'),
             call('Some ratings are less than -1 \nMin rating: -2.8')
         ])

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -15,7 +15,6 @@ Since the model is always trained on recently created dataframes, the model_meta
 saved corresponding to recently created dataframe_id. The model metadata also contains the unique identification string for the best model.
 """
 
-import os
 import uuid
 import logging
 import itertools
@@ -41,7 +40,6 @@ from listenbrainz_spark.exceptions import (SparkSessionNotInitializedException,
 import pyspark.sql.functions as func
 from pyspark import RDD
 from pyspark.sql import Row
-from flask import current_app
 from pyspark.mllib.recommendation import ALS, Rating
 
 Model = namedtuple('Model', 'model validation_rmse rank lmbda iteration model_id training_time rmse_time, alpha')
@@ -75,7 +73,7 @@ def compute_rmse(model, data, n, model_id):
                                            .values()
         return sqrt(predictionsAndRatings.map(lambda x: (x[0] - x[1]) ** 2).reduce(add) / float(n))
     except Py4JJavaError as err:
-        current_app.logger.error('Root Mean Squared Error for model "{}" not computed\n{}'.format(
+        logging.error('Root Mean Squared Error for model "{}" not computed\n{}'.format(
                                  model_id, str(err.java_exception)), exc_info=True)
         raise
 
@@ -91,7 +89,7 @@ def preprocess_data(playcounts_df):
             validation_data (rdd): Used for validation.
             test_data (rdd): Used for testing.
     """
-    current_app.logger.info('Splitting dataframe...')
+    logging.info('Splitting dataframe...')
     training_data, validation_data, test_data = playcounts_df.rdd.map(parse_dataset).randomSplit([4, 1, 1], 45)
     return training_data, validation_data, test_data
 
@@ -174,7 +172,7 @@ def train(training_data, rank, iteration, lmbda, alpha, model_id):
         model = ALS.trainImplicit(training_data, rank, iterations=iteration, lambda_=lmbda, alpha=alpha)
         return model
     except Py4JJavaError as err:
-        current_app.logger.error('Unable to train model "{}"\n{}'.format(model_id, str(err.java_exception)), exc_info=True)
+        logging.error('Unable to train model "{}"\n{}'.format(model_id, str(err.java_exception)), exc_info=True)
         raise
 
 
@@ -202,15 +200,15 @@ def get_best_model(training_data, validation_data, num_validation, ranks, lambda
         model_id = generate_model_id()
 
         t0 = time.monotonic()
-        current_app.logger.info("Training model with model id: {}".format(model_id))
+        logging.info("Training model with model id: {}".format(model_id))
         model = train(training_data, rank, iteration, lmbda, alpha, model_id)
-        current_app.logger.info("Model trained!")
+        logging.info("Model trained!")
         mt = '{:.2f}'.format((time.monotonic() - t0) / 60)
 
         t0 = time.monotonic()
-        current_app.logger.info("Calculating validation RMSE for model with model id : {}".format(model_id))
+        logging.info("Calculating validation RMSE for model with model id : {}".format(model_id))
         validation_rmse = compute_rmse(model, validation_data, num_validation, model_id)
-        current_app.logger.info("Validation RMSE calculated!")
+        logging.info("Validation RMSE calculated!")
         vt = '{:.2f}'.format((time.monotonic() - t0) / 60)
 
         model_metadata.append((model_id, mt, rank, '{:.1f}'.format(lmbda), iteration, round(validation_rmse, 2), vt))
@@ -252,11 +250,11 @@ def save_model(model_id, model):
 
     dest_path = get_model_path(model_id)
     try:
-        current_app.logger.info('Saving model...')
+        logging.info('Saving model...')
         model.save(listenbrainz_spark.context, dest_path)
-        current_app.logger.info('Model saved!')
+        logging.info('Model saved!')
     except Py4JJavaError as err:
-        current_app.logger.error('Unable to save model "{}"\n{}. Aborting...'.format(model_id,
+        logging.error('Unable to save model "{}"\n{}. Aborting...'.format(model_id,
                                  str(err.java_exception)), exc_info=True)
         raise
 
@@ -272,16 +270,16 @@ def save_model_metadata_to_hdfs(metadata):
         # Create dataframe from the row object.
         model_metadata_df = utils.create_dataframe(metadata_row, schema.model_metadata_schema)
     except DataFrameNotCreatedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
     try:
-        current_app.logger.info('Saving model metadata...')
+        logging.info('Saving model metadata...')
         # Append the dataframe to existing dataframe if already exist or create a new one.
         utils.append(model_metadata_df, path.RECOMMENDATION_RECORDING_MODEL_METADATA)
-        current_app.logger.info('Model metadata saved...')
+        logging.info('Model metadata saved...')
     except DataFrameNotAppendedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
 
@@ -318,19 +316,19 @@ def save_training_html(time_, num_training, num_validation, num_test, model_meta
 def main(ranks=None, lambdas=None, iterations=None, alpha=None):
 
     if ranks is None:
-        current_app.logger.critical('model param "ranks" missing')
+        logging.critical('model param "ranks" missing')
 
 
     if lambdas is None:
-        current_app.logger.critical('model param "lambdas" missing')
+        logging.critical('model param "lambdas" missing')
         raise
 
     if iterations is None:
-        current_app.logger.critical('model param "iterations" missing')
+        logging.critical('model param "iterations" missing')
         raise
 
     if alpha is None:
-        current_app.logger.critical('model param "alpha" missing')
+        logging.critical('model param "alpha" missing')
         raise
 
     ti = time.monotonic()
@@ -338,7 +336,7 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
     try:
         listenbrainz_spark.init_spark_session('Train Models')
     except SparkSessionNotInitializedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
     # Add checkpoint dir to break and save RDD lineage.
@@ -348,10 +346,10 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
         playcounts_df = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_PLAYCOUNTS_DATAFRAME)
         dataframe_metadata_df = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_DATAFRAME_METADATA)
     except PathNotFoundException as err:
-        current_app.logger.error('{}\nConsider running create_dataframes.py'.format(str(err)), exc_info=True)
+        logging.error('{}\nConsider running create_dataframes.py'.format(str(err)), exc_info=True)
         raise
     except FileNotFetchedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
     time_['load_playcounts'] = '{:.2f}'.format((time.monotonic() - ti) / 60)
@@ -371,9 +369,9 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
     models_training_time = '{:.2f}'.format((time.monotonic() - t0) / 3600)
 
     best_model_metadata = get_best_model_metadata(best_model)
-    current_app.logger.info("Calculating test RMSE for best model with model id: {}".format(best_model.model_id))
+    logging.info("Calculating test RMSE for best model with model id: {}".format(best_model.model_id))
     best_model_metadata['test_rmse'] = compute_rmse(best_model.model, test_data, num_test, best_model.model_id)
-    current_app.logger.info("Test RMSE calculated!")
+    logging.info("Test RMSE calculated!")
 
     best_model_metadata['training_data_count'] = num_training
     best_model_metadata['validation_data_count'] = num_validation
@@ -390,14 +388,14 @@ def main(ranks=None, lambdas=None, iterations=None, alpha=None):
     try:
         utils.delete_dir(path.CHECKPOINT_DIR, recursive=True)
     except HDFSDirectoryNotDeletedException as err:
-        current_app.logger.error(str(err), exc_info=True)
+        logging.error(str(err), exc_info=True)
         raise
 
     if SAVE_TRAINING_HTML:
-        current_app.logger.info('Saving HTML...')
+        logging.info('Saving HTML...')
         save_training_html(time_, num_training, num_validation, num_test, model_metadata, best_model_metadata, ti,
                            models_training_time)
-        current_app.logger.info('Done!')
+        logging.info('Done!')
 
     message = [{
         'type': 'cf_recommendations_recording_model',

--- a/listenbrainz_spark/recommendations/utils.py
+++ b/listenbrainz_spark/recommendations/utils.py
@@ -4,6 +4,7 @@ from jinja2 import Environment, FileSystemLoader
 
 HTML_FILES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'html_files')
 
+
 def save_html(filename, context, template):
     path = os.path.dirname(os.path.abspath(__file__))
     template_environment = Environment(

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -4,10 +4,10 @@
 import shutil
 import tempfile
 import time
+import logging
 from datetime import datetime
 
 import listenbrainz_spark.request_consumer.jobs.utils as utils
-from flask import current_app
 from listenbrainz_spark.exceptions import DumpNotFoundException
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
@@ -49,7 +49,7 @@ def import_newest_incremental_dump_handler():
     if latest_full_dump is None:
         # If no prior full dump is present, just import the lates incremental dump
         imported_dumps.append(import_dump_to_hdfs('incremental', overwrite=False))
-        current_app.logger.warn("No previous full dump found, importing latest incremental dump", exc_info=True)
+        logging.warn("No previous full dump found, importing latest incremental dump", exc_info=True)
     else:
         # Import all missing dumps from last full dump import
         dump_id = latest_full_dump["dump_id"] + 1
@@ -62,7 +62,7 @@ def import_newest_incremental_dump_handler():
                     break
                 except Exception as e:
                     # Exit if any other error occurs during import
-                    current_app.logger.error(f"Error while importing incremental dump with ID {dump_id}: {e}", exc_info=True)
+                    logging.error(f"Error while importing incremental dump with ID {dump_id}: {e}", exc_info=True)
                     break
             dump_id += 1
             request_consumer.rc.ping()

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, call, patch
 

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
@@ -1,7 +1,5 @@
 import json
-import unittest
 from datetime import datetime
-from unittest.mock import MagicMock, patch
 
 import listenbrainz_spark.request_consumer.jobs.utils as import_utils
 from listenbrainz_spark.path import IMPORT_METADATA

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -1,8 +1,8 @@
 """ Bunch of utilility functions needed for import jobs """
+import logging
 from datetime import datetime
 from typing import Optional
 
-from flask import current_app
 from listenbrainz_spark.exceptions import PathNotFoundException
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
@@ -57,7 +57,7 @@ def insert_dump_data(dump_id: int, dump_type: str, imported_at: datetime):
     try:
         import_meta_df = read_files_from_HDFS(IMPORT_METADATA)
     except PathNotFoundException:
-        current_app.logger.info("Import metadata file not found, creating...")
+        logging.info("Import metadata file not found, creating...")
 
     data = create_dataframe(Row(dump_id, dump_type, imported_at), schema=import_metadata_schema)
     if import_meta_df:

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -16,18 +16,15 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import os
 import pika
-import uuid
 import json
-import sys
 import time
+import logging
 
 import listenbrainz_spark
 import listenbrainz_spark.query_map
-from datetime import datetime
+from listenbrainz_spark import config
 from listenbrainz_spark.utils import init_rabbitmq
-from flask import current_app
 
 from py4j.protocol import Py4JJavaError
 
@@ -43,30 +40,30 @@ class RequestConsumer:
             query = request['query']
             params = request.get('params', {})
         except Exception:
-            current_app.logger.error('Bad query sent to spark request consumer: %s', json.dumps(request), exc_info=True)
+            logging.error('Bad query sent to spark request consumer: %s', json.dumps(request), exc_info=True)
             return None
 
         try:
             query_handler = listenbrainz_spark.query_map.get_query_handler(query)
         except KeyError:
-            current_app.logger.error("Bad query sent to spark request consumer: %s", query, exc_info=True)
+            logging.error("Bad query sent to spark request consumer: %s", query, exc_info=True)
             return None
         except Exception as e:
-            current_app.logger.error("Error while mapping query to function: %s", str(e), exc_info=True)
+            logging.error("Error while mapping query to function: %s", str(e), exc_info=True)
             return None
 
         try:
             return query_handler(**params)
         except TypeError as e:
-            current_app.logger.error(
+            logging.error(
                 "TypeError in the query handler for query '%s', maybe bad params. Error: %s", query, str(e), exc_info=True)
             return None
         except Exception as e:
-            current_app.logger.error("Error in the query handler for query '%s': %s", query, str(e), exc_info=True)
+            logging.error("Error in the query handler for query '%s': %s", query, str(e), exc_info=True)
             return None
 
     def push_to_result_queue(self, messages):
-        current_app.logger.debug("Pushing result to RabbitMQ...")
+        logging.debug("Pushing result to RabbitMQ...")
         num_of_messages = 0
         avg_size_of_message = 0
         for message in messages:
@@ -76,14 +73,14 @@ class RequestConsumer:
             while message is not None:
                 try:
                     self.result_channel.basic_publish(
-                        exchange=current_app.config['SPARK_RESULT_EXCHANGE'],
+                        exchange=config.SPARK_RESULT_EXCHANGE,
                         routing_key='',
                         body=body,
                         properties=pika.BasicProperties(delivery_mode=2,),
                     )
                     break
                 except (pika.exceptions.ConnectionClosed, pika.exceptions.ChannelClosed) as e:
-                    current_app.logger.error('RabbitMQ Connection error while publishing results: %s', str(e), exc_info=True)
+                    logging.error('RabbitMQ Connection error while publishing results: %s', str(e), exc_info=True)
                     time.sleep(1)
                     self.rabbitmq.close()
                     self.connect_to_rabbitmq()
@@ -93,15 +90,15 @@ class RequestConsumer:
             avg_size_of_message //= num_of_messages
         except ZeroDivisionError:
             avg_size_of_message = 0
-            current_app.logger.warn("No messages calculated", exc_info=True)
+            logging.warn("No messages calculated", exc_info=True)
 
-        current_app.logger.info("Done!")
-        current_app.logger.info("Number of messages sent: {}".format(num_of_messages))
-        current_app.logger.info("Average size of message: {} bytes".format(avg_size_of_message))
+        logging.info("Done!")
+        logging.info("Number of messages sent: {}".format(num_of_messages))
+        logging.info("Average size of message: {} bytes".format(avg_size_of_message))
 
     def callback(self, channel, method, properties, body):
         request = json.loads(body.decode('utf-8'))
-        current_app.logger.info('Received a request!')
+        logging.info('Received a request!')
         messages = self.get_result(request)
         if messages:
             self.push_to_result_queue(messages)
@@ -110,57 +107,57 @@ class RequestConsumer:
                 self.request_channel.basic_ack(delivery_tag=method.delivery_tag)
                 break
             except (pika.exceptions.ConnectionClosed, pika.exceptions.ChannelClosed) as e:
-                current_app.logger.error('RabbitMQ Connection error when acknowledging request: %s', str(e), exc_info=True)
+                logging.error('RabbitMQ Connection error when acknowledging request: %s', str(e), exc_info=True)
                 time.sleep(1)
                 self.rabbitmq.close()
                 self.connect_to_rabbitmq()
                 self.init_rabbitmq_channels()
-        current_app.logger.info('Request done!')
+        logging.info('Request done!')
 
     def connect_to_rabbitmq(self):
         self.rabbitmq = init_rabbitmq(
-            username=current_app.config['RABBITMQ_USERNAME'],
-            password=current_app.config['RABBITMQ_PASSWORD'],
-            host=current_app.config['RABBITMQ_HOST'],
-            port=current_app.config['RABBITMQ_PORT'],
-            vhost=current_app.config['RABBITMQ_VHOST'],
-            log=current_app.logger.critical,
+            username=config.RABBITMQ_USERNAME,
+            password=config.RABBITMQ_PASSWORD,
+            host=config.RABBITMQ_HOST,
+            port=config.RABBITMQ_PORT,
+            vhost=config.RABBITMQ_VHOST,
+            log=logging.critical,
             heartbeat=RABBITMQ_HEARTBEAT_TIME,
         )
 
     def init_rabbitmq_channels(self):
         self.request_channel = self.rabbitmq.channel()
-        self.request_channel.exchange_declare(exchange=current_app.config['SPARK_REQUEST_EXCHANGE'], exchange_type='fanout')
-        self.request_channel.queue_declare(current_app.config['SPARK_REQUEST_QUEUE'], durable=True)
+        self.request_channel.exchange_declare(exchange=config.SPARK_REQUEST_EXCHANGE, exchange_type='fanout')
+        self.request_channel.queue_declare(config.SPARK_REQUEST_QUEUE, durable=True)
         self.request_channel.queue_bind(
-            exchange=current_app.config['SPARK_REQUEST_EXCHANGE'],
-            queue=current_app.config['SPARK_REQUEST_QUEUE']
+            exchange=config.SPARK_REQUEST_EXCHANGE,
+            queue=config.SPARK_REQUEST_QUEUE
         )
-        self.request_channel.basic_consume(self.callback, queue=current_app.config['SPARK_REQUEST_QUEUE'])
+        self.request_channel.basic_consume(self.callback, queue=config.SPARK_REQUEST_QUEUE)
 
         self.result_channel = self.rabbitmq.channel()
-        self.result_channel.exchange_declare(exchange=current_app.config['SPARK_RESULT_EXCHANGE'], exchange_type='fanout')
+        self.result_channel.exchange_declare(exchange=config.SPARK_RESULT_EXCHANGE, exchange_type='fanout')
 
     def run(self):
         while True:
             try:
                 self.connect_to_rabbitmq()
                 self.init_rabbitmq_channels()
-                current_app.logger.info('Request consumer started!')
+                logging.info('Request consumer started!')
 
                 try:
                     self.request_channel.start_consuming()
                 except pika.exceptions.ConnectionClosed as e:
-                    current_app.logger.error('connection to rabbitmq closed: %s', str(e), exc_info=True)
+                    logging.error('connection to rabbitmq closed: %s', str(e), exc_info=True)
                     self.rabbitmq.close()
                     continue
                 self.rabbitmq.close()
             except Py4JJavaError as e:
-                current_app.logger.critical("Critical: JAVA error in spark-request consumer: %s, message: %s",
+                logging.critical("Critical: JAVA error in spark-request consumer: %s, message: %s",
                                             str(e), str(e.java_exception), exc_info=True)
                 time.sleep(2)
             except Exception as e:
-                current_app.logger.critical("Error in spark-request-consumer: %s", str(e), exc_info=True)
+                logging.critical("Error in spark-request-consumer: %s", str(e), exc_info=True)
                 time.sleep(2)
 
     def ping(self):

--- a/listenbrainz_spark/request_consumer/test_request_consumer.py
+++ b/listenbrainz_spark/request_consumer/test_request_consumer.py
@@ -2,7 +2,6 @@ from unittest.mock import patch, MagicMock
 
 from listenbrainz_spark.request_consumer.request_consumer import RequestConsumer
 from listenbrainz_spark.tests import SparkTestCase
-from listenbrainz_spark.utils import create_app
 
 
 class RequestConsumerTestCase(SparkTestCase):
@@ -13,23 +12,20 @@ class RequestConsumerTestCase(SparkTestCase):
         self.consumer.request_channel = MagicMock()
         self.consumer.result_channel = MagicMock()
 
-    @patch('listenbrainz_spark.request_consumer.request_consumer.current_app')
     @patch('listenbrainz_spark.request_consumer.request_consumer.init_rabbitmq')
-    def test_connect_to_rabbitmq(self, mock_init_rabbitmq, mock_current_app):
-            self.consumer.connect_to_rabbitmq()
-            mock_init_rabbitmq.assert_called_once()
+    def test_connect_to_rabbitmq(self, mock_init_rabbitmq):
+        self.consumer.connect_to_rabbitmq()
+        mock_init_rabbitmq.assert_called_once()
 
-    @patch('listenbrainz_spark.request_consumer.request_consumer.current_app')
-    def test_get_result_if_bad_query(self, mock_current_app):
+    def test_get_result_if_bad_query(self):
         # should return none if no query
         self.assertIsNone(self.consumer.get_result({}))
 
         # should return none if unrecognized query
         self.assertIsNone(self.consumer.get_result({'query': 'idk_what_this_means'}))
 
-    @patch('listenbrainz_spark.request_consumer.request_consumer.current_app')
     @patch('listenbrainz_spark.query_map.get_query_handler')
-    def test_get_result_if_query_recognized(self, mock_get_query_handler, mock_current_app):
+    def test_get_result_if_query_recognized(self, mock_get_query_handler):
         # should call the returned function if query is recognized
         # create the mock query handler
         mock_query_handler = MagicMock()

--- a/listenbrainz_spark/sentry_daemon.py
+++ b/listenbrainz_spark/sentry_daemon.py
@@ -1,0 +1,9 @@
+import sentry_sdk
+from sentry_sdk.integrations.spark import SparkWorkerIntegration
+import pyspark.daemon as original_daemon
+
+import listenbrainz_spark.config as conf
+
+if __name__ == '__main__':
+    sentry_sdk.init(**conf.LOG_SENTRY, integrations=[SparkWorkerIntegration()])
+    original_daemon.manager()

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -1,12 +1,11 @@
 import json
-import calendar
+import logging
 from datetime import datetime
 from typing import List, Optional
 
 import listenbrainz_spark
 from data.model.sitewide_artist_stat import SitewideArtistRecord
 from data.model.sitewide_entity import SitewideEntityStatMessage
-from flask import current_app
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.path import LISTENBRAINZ_DATA_DIRECTORY
 from listenbrainz_spark.stats import (offset_days, offset_months, replace_days,
@@ -30,7 +29,7 @@ time_range_schema = ["time_range", "from_ts", "to_ts"]
 
 def get_entity_week(entity: str, use_mapping: bool = False) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the weekly sitewide top entity """
-    current_app.logger.debug("Calculating sitewide_{}_week...".format(entity))
+    logging.debug("Calculating sitewide_{}_week...".format(entity))
 
     date = get_latest_listen_ts()
 
@@ -59,14 +58,14 @@ def get_entity_week(entity: str, use_mapping: bool = False) -> Optional[List[Sit
     message = create_message(data=data, entity=entity, stats_range='week',
                              from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return message
 
 
 def get_entity_month(entity: str, use_mapping: bool = False) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the montly sitewide top entity """
-    current_app.logger.debug("Calculating sitewide_{}_month...".format(entity))
+    logging.debug("Calculating sitewide_{}_month...".format(entity))
 
     to_date = get_latest_listen_ts()
     # Set time to 00:00
@@ -93,14 +92,14 @@ def get_entity_month(entity: str, use_mapping: bool = False) -> Optional[List[Si
     message = create_message(data=data, entity=entity, stats_range='month',
                              from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return message
 
 
 def get_entity_year(entity: str, use_mapping: bool = False) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the yearly sitewide top entity """
-    current_app.logger.debug("Calculating sitewide_{}_year...".format(entity))
+    logging.debug("Calculating sitewide_{}_year...".format(entity))
 
     to_date = get_latest_listen_ts()
     from_date = datetime(to_date.year-1, 1, 1)
@@ -124,14 +123,14 @@ def get_entity_year(entity: str, use_mapping: bool = False) -> Optional[List[Sit
     message = create_message(data=data, entity=entity, stats_range='year',
                              from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return message
 
 
 def get_entity_all_time(entity: str, use_mapping: bool = False) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the all_time sitewide top entity """
-    current_app.logger.debug("Calculating sitewide_{}_all_time...".format(entity))
+    logging.debug("Calculating sitewide_{}_all_time...".format(entity))
 
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
@@ -153,7 +152,7 @@ def get_entity_all_time(entity: str, use_mapping: bool = False) -> Optional[List
     message = create_message(data=data, entity=entity, stats_range='all_time',
                              from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return message
 
@@ -191,7 +190,7 @@ def create_message(data, entity: str, stats_range: str, from_ts: int, to_ts: int
                 model = entity_model_map[entity](**item)
                 entity_list.append(model.dict())
             except ValidationError:
-                current_app.logger.warning("""Invalid entry present in sitewide {stats_range} top {entity} for
+                logging.warning("""Invalid entry present in sitewide {stats_range} top {entity} for
                                         time_range: {time_range}, skipping""".format(stats_range=stats_range, entity=entity,
                                                                                      time_range=_dict['time_range']))
 
@@ -207,7 +206,7 @@ def create_message(data, entity: str, stats_range: str, from_ts: int, to_ts: int
         result = model.dict(exclude_none=True)
         return [result]
     except ValidationError:
-        current_app.logger.error("""ValidationError while calculating {stats_range} sitewide top {entity}.
+        logging.error("""ValidationError while calculating {stats_range} sitewide top {entity}.
                                  Data: {data}""".format(stats_range=stats_range, entity=entity,
                                                         data=json.dumps(message, indent=4)),
                                  exc_info=True)

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_artist.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_artist.py
@@ -7,7 +7,6 @@ import listenbrainz_spark
 import listenbrainz_spark.stats.sitewide.artist as artist_stats
 from listenbrainz_spark import utils
 from listenbrainz_spark.path import LISTENBRAINZ_DATA_DIRECTORY
-from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.tests import SparkTestCase
 
 

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import listenbrainz_spark.stats.sitewide.entity as entity_stats
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
-from listenbrainz_spark.stats import (offset_days, offset_months, replace_days,
+from listenbrainz_spark.stats import (offset_days, offset_months,
                                       run_query, get_day_end, get_year_end, get_month_end)
 from listenbrainz_spark.path import LISTENBRAINZ_DATA_DIRECTORY
 from listenbrainz_spark.tests import SparkTestCase

--- a/listenbrainz_spark/stats/user/daily_activity.py
+++ b/listenbrainz_spark/stats/user/daily_activity.py
@@ -1,10 +1,10 @@
 import itertools
 import json
 import calendar
+import logging
 from datetime import datetime
 from typing import Iterator, Optional
 
-from flask import current_app
 from pydantic import ValidationError
 
 import listenbrainz_spark
@@ -66,7 +66,7 @@ def get_daily_activity():
 
 def get_daily_activity_week() -> Iterator[Optional[UserDailyActivityStatMessage]]:
     """ Calculate number of listens for an user per hour on each day of the past week. """
-    current_app.logger.debug("Calculating daily_activity_week")
+    logging.debug("Calculating daily_activity_week")
 
     date = get_latest_listen_ts()
     to_date = get_last_monday(date)
@@ -78,14 +78,14 @@ def get_daily_activity_week() -> Iterator[Optional[UserDailyActivityStatMessage]
 
     messages = create_messages(data=data, stats_range='week', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_daily_activity_month() -> Iterator[Optional[UserDailyActivityStatMessage]]:
     """ Calculate number of listens for an user per hour on each day of week of the current month. """
-    current_app.logger.debug("Calculating daily_activity_month")
+    logging.debug("Calculating daily_activity_month")
 
     to_date = get_latest_listen_ts()
     from_date = replace_days(to_date, 1)
@@ -97,14 +97,14 @@ def get_daily_activity_month() -> Iterator[Optional[UserDailyActivityStatMessage
     data = get_daily_activity()
     messages = create_messages(data=data, stats_range='month', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_daily_activity_year() -> Iterator[Optional[UserDailyActivityStatMessage]]:
     """ Calculate number of listens for an user per hour on each day of week of the current year. """
-    current_app.logger.debug("Calculating daily_activity_year")
+    logging.debug("Calculating daily_activity_year")
 
     to_date = get_latest_listen_ts()
     from_date = datetime(to_date.year, 1, 1)
@@ -114,14 +114,14 @@ def get_daily_activity_year() -> Iterator[Optional[UserDailyActivityStatMessage]
     data = get_daily_activity()
     messages = create_messages(data=data, stats_range='year', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_daily_activity_all_time() -> Iterator[Optional[UserDailyActivityStatMessage]]:
     """ Calculate number of listens for an user per hour on each day of week. """
-    current_app.logger.debug("Calculating daily_activity_all_time")
+    logging.debug("Calculating daily_activity_all_time")
 
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
@@ -131,7 +131,7 @@ def get_daily_activity_all_time() -> Iterator[Optional[UserDailyActivityStatMess
     data = get_daily_activity()
     messages = create_messages(data=data, stats_range='all_time', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
@@ -160,7 +160,7 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
             result = model.dict(exclude_none=True)
             yield result
         except ValidationError:
-            current_app.logger.error("""ValidationError while calculating {stats_range} daily_activity for user: {user_name}.
+            logging.error("""ValidationError while calculating {stats_range} daily_activity for user: {user_name}.
                                      Data: {data}""".format(stats_range=stats_range, user_name=_dict['user_name'],
                                                             data=json.dumps(_dict, indent=3)),
                                      exc_info=True)

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -1,8 +1,8 @@
 import json
+import logging
 from datetime import datetime
 from typing import Iterator, Optional
 
-from flask import current_app
 from pydantic import ValidationError
 
 from data.model.user_entity import UserEntityStatMessage
@@ -36,7 +36,7 @@ entity_model_map = {
 
 def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the weekly top entity for all users """
-    current_app.logger.debug("Calculating {}_week...".format(entity))
+    logging.debug("Calculating {}_week...".format(entity))
 
     date = get_latest_listen_ts()
 
@@ -53,14 +53,14 @@ def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     messages = create_messages(data=data, entity=entity, stats_range='week',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the month top entity for all users """
-    current_app.logger.debug("Calculating {}_month...".format(entity))
+    logging.debug("Calculating {}_month...".format(entity))
 
     to_date = get_latest_listen_ts()
     from_date = replace_days(to_date, 1)
@@ -75,14 +75,14 @@ def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     messages = create_messages(data=data, entity=entity, stats_range='month',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the year top entity for all users """
-    current_app.logger.debug("Calculating {}_year...".format(entity))
+    logging.debug("Calculating {}_year...".format(entity))
 
     to_date = get_latest_listen_ts()
     from_date = replace_days(replace_months(to_date, 1), 1)
@@ -96,14 +96,14 @@ def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     messages = create_messages(data=data, entity=entity, stats_range='year',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_entity_all_time(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the all_time top entity for all users """
-    current_app.logger.debug("Calculating {}_all_time...".format(entity))
+    logging.debug("Calculating {}_all_time...".format(entity))
 
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
@@ -117,7 +117,7 @@ def get_entity_all_time(entity: str) -> Iterator[Optional[UserEntityStatMessage]
     messages = create_messages(data=data, entity=entity, stats_range='all_time',
                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
@@ -150,7 +150,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
             try:
                 entity_list.append(entity_model_map[entity](**item))
             except ValidationError:
-                current_app.logger.warning("""Invalid entry present in {stats_range} top {entity} for
+                logging.warning("""Invalid entry present in {stats_range} top {entity} for
                                         user: {user_name}, skipping""".format(stats_range=stats_range, entity=entity,
                                                                               user_name=_dict['user_name']))
         try:
@@ -167,7 +167,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
             result = model.dict(exclude_none=True)
             yield result
         except ValidationError:
-            current_app.logger.error("""ValidationError while calculating {stats_range} top {entity} for user: {user_name}.
+            logging.error("""ValidationError while calculating {stats_range} top {entity} for user: {user_name}.
                                      Data: {data}""".format(stats_range=stats_range, entity=entity, user_name=_dict['user_name'],
                                                             data=json.dumps(_dict, indent=3)),
                                      exc_info=True)

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -1,8 +1,8 @@
 import json
+import logging
 from datetime import datetime
 from typing import Iterator, Optional
 
-from flask import current_app
 from pydantic import ValidationError
 
 import listenbrainz_spark
@@ -67,7 +67,7 @@ def get_listening_activity():
 
 def get_listening_activity_week() -> Iterator[Optional[UserListeningActivityStatMessage]]:
     """ Calculate number of listens for an user on each day of the past and current week. """
-    current_app.logger.debug("Calculating listening_activity_week")
+    logging.debug("Calculating listening_activity_week")
 
     to_date = get_latest_listen_ts()
     from_date = offset_days(get_last_monday(to_date), 7)
@@ -89,14 +89,14 @@ def get_listening_activity_week() -> Iterator[Optional[UserListeningActivityStat
     data = get_listening_activity()
     messages = create_messages(data=data, stats_range='week', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_listening_activity_month() -> Iterator[Optional[UserListeningActivityStatMessage]]:
     """ Calculate number of listens for an user on each day of the past month and current month. """
-    current_app.logger.debug("Calculating listening_activity_month")
+    logging.debug("Calculating listening_activity_month")
 
     to_date = get_latest_listen_ts()
     from_date = offset_months(replace_days(to_date, 1), 1)
@@ -118,14 +118,14 @@ def get_listening_activity_month() -> Iterator[Optional[UserListeningActivitySta
     data = get_listening_activity()
     messages = create_messages(data=data, stats_range='month', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_listening_activity_year() -> Iterator[Optional[UserListeningActivityStatMessage]]:
     """ Calculate the number of listens for an user in each month of the past and current year. """
-    current_app.logger.debug("Calculating listening_activity_year")
+    logging.debug("Calculating listening_activity_year")
 
     to_date = get_latest_listen_ts()
     from_date = datetime(to_date.year-1, 1, 1)
@@ -145,14 +145,14 @@ def get_listening_activity_year() -> Iterator[Optional[UserListeningActivityStat
     data = get_listening_activity()
     messages = create_messages(data=data, stats_range='year', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
 
 def get_listening_activity_all_time() -> Iterator[Optional[UserListeningActivityStatMessage]]:
     """ Calculate the number of listens for an user in each year starting from LAST_FM_FOUNDING_YEAR (2002). """
-    current_app.logger.debug("Calculating listening_activity_all_time")
+    logging.debug("Calculating listening_activity_all_time")
 
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
@@ -185,7 +185,7 @@ def get_listening_activity_all_time() -> Iterator[Optional[UserListeningActivity
 
     messages = create_messages(data=data, stats_range='all_time', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    current_app.logger.debug("Done!")
+    logging.debug("Done!")
 
     return messages
 
@@ -214,7 +214,7 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
             result = model.dict(exclude_none=True)
             yield result
         except ValidationError:
-            current_app.logger.error("""ValidationError while calculating {stats_range} listening_activity for user: {user_name}.
+            logging.error("""ValidationError while calculating {stats_range} listening_activity for user: {user_name}.
                                      Data: {data}""".format(stats_range=stats_range, user_name=_dict['user_name'],
                                                             data=json.dumps(_dict, indent=3)),
                                      exc_info=True)

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -8,12 +8,9 @@ import listenbrainz_spark
 import listenbrainz_spark.utils.mapping as mapping_utils
 from listenbrainz_spark.recommendations import dataframe_utils
 from listenbrainz_spark import hdfs_connection, utils, config, schema
-from listenbrainz_spark.stats.utils import get_latest_listen_ts
-from listenbrainz_spark.recommendations.recording import create_dataframes
 from listenbrainz_spark.recommendations.recording import train_models
 
 from pyspark.sql import Row
-import pyspark.sql.functions as f
 from pyspark.sql.types import StructType, StructField, IntegerType
 
 TEST_PLAYCOUNTS_PATH = '/tests/playcounts.parquet'
@@ -27,14 +24,10 @@ class SparkTestCase(unittest.TestCase):
     def setUpClass(cls):
         listenbrainz_spark.init_test_session('spark-test-run-{}'.format(str(uuid.uuid4())))
         hdfs_connection.init_hdfs(config.HDFS_HTTP_URI)
-        cls.app = utils.create_app()
-        cls.app_context = cls.app.app_context()
         cls.date = datetime(2019, 1, 21)
-        cls.app_context.push()
 
     @classmethod
     def tearDownClass(cls):
-        cls.app_context.pop()
         listenbrainz_spark.context.stop()
 
     @classmethod

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -4,9 +4,6 @@ import os
 from time import sleep
 
 import pika
-from listenbrainz_spark import config
-from brainzutils.flask import CustomFlask
-from flask import current_app
 from py4j.protocol import Py4JJavaError
 from pyspark.sql.utils import AnalysisException
 
@@ -53,30 +50,6 @@ def append(df, dest_path):
         df.write.mode('append').parquet(config.HDFS_CLUSTER_URI + dest_path)
     except Py4JJavaError as err:
         raise DataFrameNotAppendedException(err.java_exception, df.schema)
-
-
-def create_app(debug=None):
-    """ Uses brainzutils (https://github.com/metabrainz/brainzutils-python) to log exceptions to sentry.
-    """
-    # create flask application
-    app = CustomFlask(import_name=__name__)
-    # load config
-    config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'config.py')
-
-    # config must exist to link the file with our flask app.
-    if os.path.exists(config_file):
-        app.config.from_pyfile(config_file)
-    else:
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), config_file)
-
-    if debug is not None:
-        app.debug = debug
-
-    # attach app logs to sentry.
-    app.init_loggers(
-        sentry_config=app.config.get('LOG_SENTRY')
-    )
-    return app
 
 
 def init_rabbitmq(username, password, host, port, vhost, log=logging.error, heartbeat=None):
@@ -170,13 +143,13 @@ def get_listens(from_date, to_date, dest_path):
             month = read_files_from_HDFS('{}/{}/{}.parquet'.format(dest_path, from_date.year, from_date.month))
             df = df.union(month) if df else month
         except PathNotFoundException as err:
-            current_app.logger.debug('{}\nFetching file for next date...'.format(err))
+            logging.debug('{}\nFetching file for next date...'.format(err))
         # go to the next month of from_date
         from_date = stats.offset_months(date=from_date, months=1, shift_backwards=False)
         # shift to the first of the month
         from_date = stats.replace_days(from_date, 1)
     if not df:
-        current_app.logger.error('Listening history missing form HDFS')
+        logging.error('Listening history missing form HDFS')
         raise HDFSException("Listening history missing from HDFS")
     return df
 

--- a/listenbrainz_spark/utils/tests/test_init.py
+++ b/listenbrainz_spark/utils/tests/test_init.py
@@ -3,7 +3,7 @@ import tempfile
 from datetime import datetime
 
 from listenbrainz_spark.tests import SparkTestCase
-from listenbrainz_spark import utils, path, config
+from listenbrainz_spark import utils
 
 from pyspark.sql import Row
 

--- a/listenbrainz_spark/utils/tests/test_mapping.py
+++ b/listenbrainz_spark/utils/tests/test_mapping.py
@@ -1,5 +1,5 @@
 from listenbrainz_spark.tests import SparkTestCase
-from listenbrainz_spark import utils, path, config
+from listenbrainz_spark import utils, path
 import listenbrainz_spark.utils.mapping as mapping_utils
 
 from pyspark.sql import Row

--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -4,21 +4,10 @@ Jinja2 == 2.11.3
 pika==0.13.0
 python-dateutil==2.8.0
 numpy==1.19.4
-git+https://github.com/amCap1712/brainzutils-python.git@sentry
 pytest == 6.2.1
 pytest-cov == 2.10.1
 py4j == 0.10.7
 pyspark == 2.4.5
 pydantic == 1.6.1
 unidecode == 1.1.2
-Flask==1.1.2
-werkzeug==1.0.1
-Flask-DebugToolbar==0.11.0
-Flask-UUID==0.2
-sentry-sdk[flask]==0.20.2
-redis==3.5.3
-msgpack-python==0.5.6
-requests==2.23.0
-SQLAlchemy==1.3.16
-mbdata==25.0.4
-sqlalchemy-dst==1.0.1
+sentry-sdk==0.20.2

--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -4,7 +4,7 @@ Jinja2 == 2.11.3
 pika==0.13.0
 python-dateutil==2.8.0
 numpy==1.19.4
-git+https://github.com/metabrainz/brainzutils-python.git@v1.16.1
+git+https://github.com/amCap1712/brainzutils-python.git@sentry
 pytest == 6.2.1
 pytest-cov == 2.10.1
 py4j == 0.10.7
@@ -15,7 +15,7 @@ Flask==1.1.2
 werkzeug==1.0.1
 Flask-DebugToolbar==0.11.0
 Flask-UUID==0.2
-raven[flask]==6.10.0
+sentry-sdk[flask]==0.20.2
 redis==3.5.3
 msgpack-python==0.5.6
 requests==2.23.0

--- a/spark-submit.sh
+++ b/spark-submit.sh
@@ -14,5 +14,7 @@ time ./run.sh /usr/local/spark/bin/spark-submit \
     --conf "spark.driver.memoryOverhead"=$DRIVER_MEMORY_OVERHEAD \
     --conf "spark.executor.memoryOverhead"=$EXECUTOR_MEMORY_OVERHEAD \
 	--conf "spark.driver.maxResultSize"=$DRIVER_MAX_RESULT_SIZE \
+	--conf "spark.python.use.daemon"=true \
+  --conf "spark.python.daemon.module"=sentry_daemon \
 	--py-files listenbrainz_spark.zip \
 	"$@"

--- a/spark_manage.py
+++ b/spark_manage.py
@@ -13,8 +13,6 @@ from listenbrainz_spark import hdfs_connection
 from hdfs.util import HdfsError
 from py4j.protocol import Py4JJavaError
 
-app = utils.create_app(debug=True)
-
 
 @click.group()
 def cli():
@@ -83,11 +81,10 @@ def upload_mapping():
     """
     from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
     from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
-    with app.app_context():
-        downloader_obj = ListenbrainzDataDownloader()
-        src, _ = downloader_obj.download_msid_mbid_mapping(path.FTP_FILES_PATH)
-        uploader_obj = ListenbrainzDataUploader()
-        uploader_obj.upload_mapping(src)
+    downloader_obj = ListenbrainzDataDownloader()
+    src, _ = downloader_obj.download_msid_mbid_mapping(path.FTP_FILES_PATH)
+    uploader_obj = ListenbrainzDataUploader()
+    uploader_obj.upload_mapping(src)
 
 
 @cli.command(name='upload_listens')
@@ -99,12 +96,11 @@ def upload_listens(overwrite, incremental, id):
     """
     from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
     from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
-    with app.app_context():
-        downloader_obj = ListenbrainzDataDownloader()
-        dump_type = 'incremental' if incremental else 'full'
-        src, _, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, listens_dump_id=id, dump_type=dump_type)
-        uploader_obj = ListenbrainzDataUploader()
-        uploader_obj.upload_listens(src, overwrite=overwrite)
+    downloader_obj = ListenbrainzDataDownloader()
+    dump_type = 'incremental' if incremental else 'full'
+    src, _, _ = downloader_obj.download_listens(directory=path.FTP_FILES_PATH, listens_dump_id=id, dump_type=dump_type)
+    uploader_obj = ListenbrainzDataUploader()
+    uploader_obj.upload_listens(src, overwrite=overwrite)
 
 
 @cli.command(name='upload_artist_relation')
@@ -113,11 +109,10 @@ def upload_artist_relation():
     """
     from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
     from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
-    with app.app_context():
-        downloader_obj = ListenbrainzDataDownloader()
-        src, _ = downloader_obj.download_artist_relation(path.FTP_FILES_PATH)
-        uploader_obj = ListenbrainzDataUploader()
-        uploader_obj.upload_artist_relation(src)
+    downloader_obj = ListenbrainzDataDownloader()
+    src, _ = downloader_obj.download_artist_relation(path.FTP_FILES_PATH)
+    uploader_obj = ListenbrainzDataUploader()
+    uploader_obj.upload_artist_relation(src)
 
 
 @cli.command(name='dataframe')
@@ -126,8 +121,7 @@ def dataframes(days):
     """ Invoke script responsible for pre-processing data.
     """
     from listenbrainz_spark.recommendations.recording import create_dataframes
-    with app.app_context():
-        _ = create_dataframes.main(train_model_window=days)
+    _ = create_dataframes.main(train_model_window=days)
 
 
 def parse_list(ctx, args):
@@ -144,8 +138,7 @@ def model(rank, itr, lmbda, alpha):
         For more details refer to 'https://spark.apache.org/docs/2.1.0/mllib-collaborative-filtering.html'
     """
     from listenbrainz_spark.recommendations.recording import train_models
-    with app.app_context():
-        _ = train_models.main(ranks=rank, lambdas=lmbda, iterations=itr, alpha=alpha)
+    _ = train_models.main(ranks=rank, lambdas=lmbda, iterations=itr, alpha=alpha)
 
 
 @cli.command(name='candidate')
@@ -159,9 +152,8 @@ def candidate(days, top, similar, users, html):
     """ Invoke script responsible for generating candidate sets.
     """
     from listenbrainz_spark.recommendations.recording import candidate_sets
-    with app.app_context():
-        _ = candidate_sets.main(recommendation_generation_window=days, top_artist_limit=top,
-                                similar_artist_limit=similar, users=users, html_flag=html)
+    _ = candidate_sets.main(recommendation_generation_window=days, top_artist_limit=top,
+                            similar_artist_limit=similar, users=users, html_flag=html)
 
 
 @cli.command(name='recommend')
@@ -173,8 +165,7 @@ def recommend(top, similar, users):
     """ Invoke script responsible for generating recommendations.
     """
     from listenbrainz_spark.recommendations.recording import recommend
-    with app.app_context():
-        _ = recommend.main(recommendation_top_artist_limit=top, recommendation_similar_artist_limit=similar, users=users)
+    _ = recommend.main(recommendation_top_artist_limit=top, recommendation_similar_artist_limit=similar, users=users)
 
 
 @cli.command(name='user')
@@ -182,8 +173,7 @@ def user():
     """ Invoke script responsible for calculating user statistics.
     """
     from listenbrainz_spark.stats import user
-    with app.app_context():
-        user.main()
+    user.main()
 
 
 @cli.command(name='request_consumer')
@@ -191,8 +181,7 @@ def request_consumer():
     """ Invoke script responsible for the request consumer
     """
     from listenbrainz_spark.request_consumer.request_consumer import main
-    with app.app_context():
-        main('request-consumer-%s' % str(int(time.time())))
+    main('request-consumer-%s' % str(int(time.time())))
 
 
 @cli.resultcallback()


### PR DESCRIPTION
Flask and in turn brainzutils was being used in listenbrainz_spark only for the purpose of loading configuration values and logging. We instead use the logging module. Further, we add PysparkIntegration and PysparkWorkerIntegraton to the sentry setup in listenbrainz_spark. This may come handy in the production setup.

### TODO before merging
1) #1271 should be merged prior to this
2) The PysparkWorkerIntegration needs to be tested to make sure that at the least it does not break production setup.
