### PR TITLE
LB-821: Fix the position of recording_msid in WS messages

### DIFF
--- a/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
@@ -301,11 +301,24 @@ describe("receiveNewListen", () => {
     track_metadata: {
       artist_name: "Coldplay",
       track_name: "Viva La Vida",
+      additional_info: {
+        recording_msid: "2edee875-55c3-4dad-b3ea-e8741484f4b5",
+      },
     },
     listened_at: 1586580524,
     listened_at_iso: "2020-04-10T10:12:04Z",
   };
 
+  const mockWSListen = {
+    data: {
+      artist_name: "Coldplay",
+      track_name: "Viva La Vida",
+      additional_info: {},
+    },
+    recording_msid: "2edee875-55c3-4dad-b3ea-e8741484f4b5",
+    timestamp: 1586580524,
+    listened_at_iso: "2020-04-10T10:12:04Z",
+  };
   it("crops the listens array if length is more than or equal to 100", () => {
     /* JSON.parse(JSON.stringify(object) is a fast way to deep copy an object,
      * so that it doesn't get passed as a reference.
@@ -385,6 +398,38 @@ describe("receiveNewListen", () => {
     );
     result.unshift(mockListen);
     instance.receiveNewListen(JSON.stringify(mockListen));
+
+    expect(wrapper.state("listens")).toHaveLength(result.length);
+    expect(wrapper.state("listens")).toEqual(result);
+  });
+
+  it("moves the keys in the web socket message to appropriate place to make it identical to a listen", () => {
+    /* JSON.parse(JSON.stringify(object) is a fast way to deep copy an object,
+     * so that it doesn't get passed as a reference.
+     */
+    const wrapper = shallow<RecentListens>(
+      <RecentListens
+        {...(JSON.parse(
+          JSON.stringify(recentListensPropsOneListen)
+        ) as RecentListensProps)}
+      />
+    );
+    const instance = wrapper.instance();
+    wrapper.setState({ mode: "recent" });
+    /* JSON.parse(JSON.stringify(object) is a fast way to deep copy an object,
+     * so that it doesn't get passed as a reference.
+     */
+    const result: Array<Listen> = JSON.parse(
+      JSON.stringify(recentListensPropsOneListen.listens)
+    );
+    /* The mockWSListen has the same keys values as that of the mockListen,
+     * but has different key names or positions. The required keys will be renamed
+     * and moved in the receiveNewListen and it will look identical to mockListen.
+     * So we push the mockListen to expected results and pass the mockWSListen via receiveNewListen
+     * and compare them in the end.
+     */
+    result.unshift(mockListen);
+    instance.receiveNewListen(JSON.stringify(mockWSListen));
 
     expect(wrapper.state("listens")).toHaveLength(result.length);
     expect(wrapper.state("listens")).toEqual(result);

--- a/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
@@ -308,17 +308,6 @@ describe("receiveNewListen", () => {
     listened_at: 1586580524,
     listened_at_iso: "2020-04-10T10:12:04Z",
   };
-
-  const mockWSListen = {
-    data: {
-      artist_name: "Coldplay",
-      track_name: "Viva La Vida",
-      additional_info: {},
-    },
-    recording_msid: "2edee875-55c3-4dad-b3ea-e8741484f4b5",
-    timestamp: 1586580524,
-    listened_at_iso: "2020-04-10T10:12:04Z",
-  };
   it("crops the listens array if length is more than or equal to 100", () => {
     /* JSON.parse(JSON.stringify(object) is a fast way to deep copy an object,
      * so that it doesn't get passed as a reference.
@@ -398,38 +387,6 @@ describe("receiveNewListen", () => {
     );
     result.unshift(mockListen);
     instance.receiveNewListen(JSON.stringify(mockListen));
-
-    expect(wrapper.state("listens")).toHaveLength(result.length);
-    expect(wrapper.state("listens")).toEqual(result);
-  });
-
-  it("moves the keys in the web socket message to appropriate place to make it identical to a listen", () => {
-    /* JSON.parse(JSON.stringify(object) is a fast way to deep copy an object,
-     * so that it doesn't get passed as a reference.
-     */
-    const wrapper = shallow<RecentListens>(
-      <RecentListens
-        {...(JSON.parse(
-          JSON.stringify(recentListensPropsOneListen)
-        ) as RecentListensProps)}
-      />
-    );
-    const instance = wrapper.instance();
-    wrapper.setState({ mode: "recent" });
-    /* JSON.parse(JSON.stringify(object) is a fast way to deep copy an object,
-     * so that it doesn't get passed as a reference.
-     */
-    const result: Array<Listen> = JSON.parse(
-      JSON.stringify(recentListensPropsOneListen.listens)
-    );
-    /* The mockWSListen has the same keys values as that of the mockListen,
-     * but has different key names or positions. The required keys will be renamed
-     * and moved in the receiveNewListen and it will look identical to mockListen.
-     * So we push the mockListen to expected results and pass the mockWSListen via receiveNewListen
-     * and compare them in the end.
-     */
-    result.unshift(mockListen);
-    instance.receiveNewListen(JSON.stringify(mockWSListen));
 
     expect(wrapper.state("listens")).toHaveLength(result.length);
     expect(wrapper.state("listens")).toEqual(result);

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -263,6 +263,23 @@ export default class RecentListens extends React.Component<
           return;
         }
       }
+      // The websocket message received contains the recording_msod as a top level key.
+      // Therefore, we need to shift it json.track_metadata.additional_info.
+      if (!("recording_msid" in json.track_metadata.additional_info)) {
+        if ("recording_msid" in json) {
+          json.track_metadata.additional_info.recording_msid =
+            json.recording_msid;
+          delete json.recording_msid;
+        } else {
+          // eslint-disable-next-line no-console
+          console.debug(
+            `Could not find recording_msid in following json: ${json}`
+          );
+          return;
+        }
+      }
+      // the websocket message received contain some keys which are are either duplicates or are not required in the frontend.
+      // Ideally this should be handled server-side and this will probably be fixed with protobuf move.
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -263,7 +263,7 @@ export default class RecentListens extends React.Component<
           return;
         }
       }
-      // The websocket message received contains the recording_msod as a top level key.
+      // The websocket message received contains the recording_msid as a top level key.
       // Therefore, we need to shift it json.track_metadata.additional_info.
       if (!("recording_msid" in json.track_metadata.additional_info)) {
         if ("recording_msid" in json) {

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -240,7 +240,7 @@ export default class RecentListens extends React.Component<
       json = JSON.parse(newListen);
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error("Coudn't parse the new listen as JSON: ", json);
+      console.error("Coudn't parse the new listen as JSON: ", error);
       return;
     }
     const listen = formatWSMessageToListen(json);

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -235,7 +235,15 @@ export default class RecentListens extends React.Component<
   };
 
   receiveNewListen = (newListen: string): void => {
-    const listen = formatWSMessageToListen(JSON.parse(newListen));
+    let json;
+    try {
+      json = JSON.parse(newListen);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("Coudn't parse the new listen as JSON: ", json);
+      return;
+    }
+    const listen = formatWSMessageToListen(json);
 
     if (listen) {
       this.setState((prevState) => {

--- a/listenbrainz/webserver/static/js/src/utils.test.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.test.tsx
@@ -23,7 +23,7 @@ describe("formatWSMessageToListen", () => {
     timestamp: 1586580524,
     listened_at_iso: "2020-04-10T10:12:04Z",
   };
-  it("renders a link if MBID is provided", () => {
+  it("converts a WS message to Listen properly", () => {
     const result = formatWSMessageToListen(mockWSListen);
     expect(result).toEqual(mockListen);
   });

--- a/listenbrainz/webserver/static/js/src/utils.test.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.test.tsx
@@ -1,0 +1,30 @@
+import { formatWSMessageToListen } from "./utils";
+
+describe("formatWSMessageToListen", () => {
+  const mockListen: Listen = {
+    track_metadata: {
+      artist_name: "Coldplay",
+      track_name: "Viva La Vida",
+      additional_info: {
+        recording_msid: "2edee875-55c3-4dad-b3ea-e8741484f4b5",
+      },
+    },
+    listened_at: 1586580524,
+    listened_at_iso: "2020-04-10T10:12:04Z",
+  };
+
+  const mockWSListen = {
+    data: {
+      artist_name: "Coldplay",
+      track_name: "Viva La Vida",
+      additional_info: {},
+    },
+    recording_msid: "2edee875-55c3-4dad-b3ea-e8741484f4b5",
+    timestamp: 1586580524,
+    listened_at_iso: "2020-04-10T10:12:04Z",
+  };
+  it("renders a link if MBID is provided", () => {
+    const result = formatWSMessageToListen(mockWSListen);
+    expect(result).toEqual(mockListen);
+  });
+});

--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -137,8 +137,11 @@ const formatWSMessageToListen = (wsMsg: any): Listen | null => {
     // Therefore, we need to shift it json.track_metadata.additional_info.
     if (!_.has(json, "track_metadata.additional_info.recording_msid")) {
       if ("recording_msid" in json) {
-        json.track_metadata.additional_info.recording_msid =
-          json.recording_msid;
+        _.merge(json, {
+          track_metadata: {
+            additional_info: { recording_msid: json.recording_msid },
+          },
+        });
         delete json.recording_msid;
       } else {
         // eslint-disable-next-line no-console
@@ -152,6 +155,7 @@ const formatWSMessageToListen = (wsMsg: any): Listen | null => {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
+    return null;
   }
 
   // The websocket message received contain some keys which are are either duplicates or are not required in the frontend.


### PR DESCRIPTION
# Problem

The listens received via web sockets contain the `recording_msid` as a top-level key rather than in `listen.track_metadata.additional_info`. This borks features like listen to feedback as they can't find the `recording_msid` in `additional_info`

# Solution

Moving the `recoding_msid` down into `additional_info` should fix this.
Also added a test to see that the keys in the WS message are replaced/moved as desired.