### PR TITLE
Check if user has revoked authorization if refreshing token fails

### DIFF
--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -84,7 +84,7 @@ class Spotify:
         return "<Spotify(user:%s): %s>" % (self.user_id, self.musicbrainz_id)
 
 
-def refresh_user_token(spotify_user):
+def refresh_user_token(spotify_user: Spotify):
     """ Refreshes the user token for the given spotify user.
 
     Args:
@@ -214,7 +214,7 @@ def update_latest_listened_at(user_id, timestamp):
     db_spotify.update_latest_listened_at(user_id, timestamp)
 
 
-def get_access_token(code):
+def get_access_token(code: str):
     """ Get a valid Spotify Access token given the code.
 
     Returns:
@@ -237,7 +237,17 @@ def get_access_token(code):
     return r.json()
 
 
-def _get_spotify_token(grant_type, token):
+def _get_spotify_token(grant_type: str, token: str) -> requests.Response:
+    """ Fetch access token or refresh token from spotify auth api
+
+    Args:
+        grant_type (str): should be "authorization_code" to retrieve access token and "refresh_token" to refresh tokens
+        token (str): authorization code to retrieve access token first time and refresh token to refresh access tokens
+
+    Returns:
+        response from the spotify authentication endpoint
+    """
+
     client_id = current_app.config['SPOTIFY_CLIENT_ID']
     client_secret = current_app.config['SPOTIFY_CLIENT_SECRET']
     auth_header = base64.b64encode(six.text_type(client_id + ':' + client_secret).encode('ascii'))

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -116,6 +116,8 @@ def refresh_user_token(spotify_user: Spotify):
                 db_spotify.delete_spotify(spotify_user.user_id)
                 return None
 
+            response = None  # some other error during request
+
         retries -= 1
 
     if response is None:

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -3,12 +3,10 @@ import time
 import requests_mock
 
 from flask import current_app
-from requests import Response
 
 from listenbrainz.domain import spotify
 from listenbrainz.webserver.testing import ServerTestCase
 from unittest import mock
-from unittest.mock import MagicMock
 
 
 class SpotifyDomainTestCase(ServerTestCase):
@@ -33,12 +31,13 @@ class SpotifyDomainTestCase(ServerTestCase):
         self.assertIsNone(self.spotify_user.last_updated_iso)
         self.assertIsNone(self.spotify_user.latest_listened_at_iso)
 
+    # apparently, requests_mocker does not follow the usual order in which decorators are applied. :-(
     @requests_mock.Mocker()
     @mock.patch('listenbrainz.domain.spotify.db_spotify.get_user')
     @mock.patch('listenbrainz.domain.spotify.db_spotify.update_token')
-    def test_refresh_user_token(self, mock_update_token, mock_get_user, mock_requests):
+    def test_refresh_user_token(self, mock_requests, mock_update_token, mock_get_user):
         expires_at = int(time.time()) + 3600
-        mock_requests.post("https://accounts.spotify.com/api/token", status_code=200, json={
+        mock_requests.post(spotify.OAUTH_TOKEN_URL, status_code=200, json={
             'access_token': 'tokentoken',
             'refresh_token': 'refreshtokentoken',
             'expires_at': expires_at,
@@ -52,6 +51,26 @@ class SpotifyDomainTestCase(ServerTestCase):
             expires_at,
         )
         mock_get_user.assert_called_with(self.spotify_user.user_id)
+
+    @requests_mock.Mocker()
+    def test_refresh_user_token_bad(self, mock_requests):
+        mock_requests.post(spotify.OAUTH_TOKEN_URL, status_code=400, json={
+            'error': 'invalid request',
+            'error_description': 'invalid refresh token',
+        })
+        with self.assertRaises(spotify.SpotifyAPIError):
+            spotify.refresh_user_token(self.spotify_user)
+
+    # apparently, requests_mocker does not follow the usual order in which decorators are applied. :-(
+    @requests_mock.Mocker()
+    @mock.patch('listenbrainz.db.spotify.delete_spotify')
+    def test_refresh_user_token_bad(self, mock_requests, mock_delete_spotify):
+        mock_requests.post(spotify.OAUTH_TOKEN_URL, status_code=400, json={
+            'error': 'invalid_grant',
+            'error_description': 'Refresh token revoked',
+        })
+        spotify.refresh_user_token(self.spotify_user)
+        mock_delete_spotify.assert_called_with(self.spotify_user.user_id)
 
     def test_get_spotify_oauth(self):
         func_oauth = spotify.get_spotify_oauth()
@@ -167,9 +186,3 @@ class SpotifyDomainTestCase(ServerTestCase):
         t = int(time.time())
         spotify.update_latest_listened_at(1, t)
         mock_update_listened_at.assert_called_once_with(1, t)
-
-    @mock.patch('listenbrainz.domain.spotify._get_spotify_token')
-    def test_refresh_user_token_bad(self, mock_get_spotify_token):
-        mock_get_spotify_token.return_value = None
-        with self.assertRaises(spotify.SpotifyAPIError):
-            spotify.refresh_user_token(self.spotify_user)

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -64,7 +64,7 @@ class SpotifyDomainTestCase(ServerTestCase):
     # apparently, requests_mocker does not follow the usual order in which decorators are applied. :-(
     @requests_mock.Mocker()
     @mock.patch('listenbrainz.db.spotify.delete_spotify')
-    def test_refresh_user_token_bad(self, mock_requests, mock_delete_spotify):
+    def test_refresh_user_token_revoked(self, mock_requests, mock_delete_spotify):
         mock_requests.post(spotify.OAUTH_TOKEN_URL, status_code=400, json={
             'error': 'invalid_grant',
             'error_description': 'Refresh token revoked',

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -173,6 +173,10 @@ def make_api_request(user, spotipy_call, **kwargs):
                         user = spotify.refresh_user_token(user)
                     except SpotifyException as err:
                         raise spotify.SpotifyAPIError('Could not authenticate with Spotify, please unlink and link your account again.')
+                    else:
+                        if user is None:
+                            raise spotify.SpotifyAPIError(
+                                'Could not authenticate with Spotify, please unlink and link your account again.')
 
                     tried_to_refresh_token = True
 
@@ -270,6 +274,9 @@ def process_one_user(user):
         except spotify.SpotifyAPIError:
             current_app.logger.error('Could not refresh user token from spotify', exc_info=True)
             raise
+        else:
+            if user is None:
+                current_app.logger.debug("%s has revoked spotify authorization", str(user))
 
     listenbrainz_user = db_user.get(user.user_id)
 

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -311,11 +311,15 @@ def refresh_spotify_token():
     spotify_user = spotify.get_user(current_user.id)
     if not spotify_user:
         raise APINotFound("User has not authenticated to Spotify")
+
     if spotify_user.token_expired:
         try:
             spotify_user = spotify.refresh_user_token(spotify_user)
         except spotify.SpotifyAPIError:
             raise APIServiceUnavailable("Cannot refresh Spotify token right now")
+        else:
+            if spotify_user is None:
+                raise APINotFound("User has revoked authorization to Spotify")
 
     return jsonify({
         'id': current_user.id,


### PR DESCRIPTION
Sentry is filled with Spotify errors relating to failure if refreshing API tokens. I tried to reproduce the problem locally. It seems that one of the possible causes is that the user revoked LB's authorization to Spotify through Spotify UI but didn't unlink their account from LB. This [official post](https://developer.spotify.com/community/news/2016/07/25/app-ready-token-revoke/) explains how to handle this case. Unfortunately, `spotipy` eats up the error response body in case of any unsuccessful request.

We already fetch the access token manually because of another `spotipy` bug. It makes to modify it to handle refreshing tokens as well.

## TODO:
1) Test by linking a user and revoking authorization from Spotify UI.
2) Log response body for unhandled 400 errors from Spotify.
3) Add a unit/integration test case.