### PR TITLE
Startup dump fixes

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -18,6 +18,15 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+set -e
+
+if [[ "${CONTAINER_NAME}" == "listenbrainz-cron-prod" && "${PROD}" == "prod" ]]
+then
+    echo "Running in listenbrainz-cron-prod container, good!"
+else
+    echo "This container is not the production cron container, exiting..."
+    exit
+fi
 
 function add_rsync_include_rule {
     RULE_FILE=$1/.rsync-filter
@@ -32,20 +41,26 @@ function add_rsync_include_rule {
     echo "$SHA256_FILE_RULE" >> "$RULE_FILE"
 }
 
-if [[ "${CONTAINER_NAME}" = "listenbrainz-cron-prod" && "${PROD}" = "prod" ]]
-then
-    echo "Running in listenbrainz-cron-prod container, good!"
-else
-    echo "This container is not the production cron container, exiting..."
-    exit
-fi
+# all cleanup code should be placed within this function
+function on_exit {
+    echo "Disk space when create-dumps ends:"; df -m
 
+    if [ -n "$TMPDIR" ]; then
+        rm -rf "$TMPDIR"
+    fi
+
+    if [ -n "$START_TIME" ]; then
+        local duration=$(( $(date +%s) - START_TIME ))
+        echo "create-dumps took ${duration}s to run"
+    fi
+}
+
+
+trap on_exit EXIT
+
+START_TIME=$(date +%s)
 echo "This script is being run by the following user: "; whoami
-
-# This is to help with disk space monitoring - run "df" before and after
 echo "Disk space when create-dumps starts:" ; df -m
-trap 'echo "Disk space when create-dumps ends:" ; df -m' 0
-
 
 LB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 cd "$LB_SERVER_ROOT" || exit 1
@@ -57,29 +72,30 @@ DUMP_TYPE="${1:-full}"
 
 if [ "$DUMP_TYPE" == "full" ]; then
     SUB_DIR="fullexport"
-else
+elif [ "$DUMP_TYPE" == "incremental" ]; then
     SUB_DIR="incremental"
+else
+    echo "'$DUMP_TYPE' is not a valid dump type, exiting."
+    exit 1
+fi
+
+if [ -z "${TEMP_DIR:-}" ]; then
+    echo "\$TEMP_DIR not defined, exiting."
+    exit 1
 fi
 
 TMPDIR=$(mktemp --tmpdir="$TEMP_DIR" -d -t "$SUB_DIR.XXXXXXXXXX")
-function finish {
-  rm -rf "$TMPDIR"
-}
-trap finish EXIT
 
 if [ "$DUMP_TYPE" == "full" ]; then
-    if ! /usr/local/bin/python manage.py dump create_full -l "$TMPDIR" -t $DUMP_THREADS --last-dump-id; then
-	echo "Full dump failed, exiting!"
-	exit 1
+    if ! /usr/local/bin/python manage.py dump create_full -l "$TMPDIR" -t "$DUMP_THREADS" --last-dump-id; then
+        echo "Full dump failed, exiting!"
+        exit 1
     fi
 elif [ "$DUMP_TYPE" == "incremental" ]; then
-    if ! /usr/local/bin/python manage.py dump create_incremental -l "$TMPDIR" -t $DUMP_THREADS; then
-	echo "Incremental dump failed, exiting!"
-	exit 1
+    if ! /usr/local/bin/python manage.py dump create_incremental -l "$TMPDIR" -t "$DUMP_THREADS"; then
+        echo "Incremental dump failed, exiting!"
+        exit 1
     fi
-else
-    echo "Not sure what type of dump to create, exiting!"
-    exit 1
 fi
 
 DUMP_ID_FILE=$(find "$TMPDIR" -type f -name 'DUMP_ID.txt')
@@ -89,8 +105,8 @@ if [ -z "$DUMP_ID_FILE" ]; then
 fi
 
 HAS_EMPTY_DIRS_OR_FILES=$(find "$TMPDIR" -empty)
-if [ ! -z "$HAS_EMPTY_DIRS_OR_FILES" ]; then
-    echo "Empty files or dirs, exiting."
+if [ -n "$HAS_EMPTY_DIRS_OR_FILES" ]; then
+    echo "Empty files or dirs found, exiting."
     echo "$HAS_EMPTY_DIRS_OR_FILES"
     exit 1
 fi
@@ -105,8 +121,8 @@ DUMP_NAME=$(basename "$DUMP_DIR")
 # Create backup directories owned by user "listenbrainz"
 echo "Creating Backup directories..."
 mkdir -m "$BACKUP_DIR_MODE" -p \
-         "$BACKUP_DIR"/$SUB_DIR/ \
-         "$BACKUP_DIR"/$SUB_DIR/"$DUMP_NAME"
+         "$BACKUP_DIR/$SUB_DIR/" \
+         "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
 chown "$BACKUP_USER:$BACKUP_GROUP" \
       "$BACKUP_DIR/$SUB_DIR/" \
       "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
@@ -114,8 +130,8 @@ echo "Backup directories created!"
 
 # Copy the files into the backup directory
 echo "Begin copying dumps to backup directory..."
-retry cp -a "$DUMP_DIR"/* "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"/
-chmod "$BACKUP_FILE_MODE" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"/*
+retry rsync -a "$DUMP_DIR/" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME/"
+chmod "$BACKUP_FILE_MODE" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME/"*
 echo "Dumps copied to backup directory!"
 
 
@@ -136,14 +152,16 @@ chown "$FTP_USER:$FTP_GROUP" \
 # make sure all dump files are owned by the correct user
 # and set appropriate mode for files to be uploaded to
 # the FTP server
-retry cp -a "$DUMP_DIR"/* "$FTP_CURRENT_DUMP_DIR"
-chmod "$FTP_FILE_MODE" "$FTP_CURRENT_DUMP_DIR"/*
+retry rsync -a "$DUMP_DIR/" "$FTP_CURRENT_DUMP_DIR/"
+chmod "$FTP_FILE_MODE" "$FTP_CURRENT_DUMP_DIR/"*
 
 # create an explicit rsync filter for the new private dump in the
 # ftp folder
 touch "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
-add_rsync_include_rule "$FTP_CURRENT_DUMP_DIR" "listenbrainz-public-dump-$DUMP_TIMESTAMP.tar.xz"
+add_rsync_include_rule \
+    "$FTP_CURRENT_DUMP_DIR" \
+    "listenbrainz-public-dump-$DUMP_TIMESTAMP.tar.xz"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
     "listenbrainz-listens-dump-$DUMP_ID-$DUMP_TIMESTAMP-$DUMP_TYPE.tar.xz"

--- a/admin/functions.sh
+++ b/admin/functions.sh
@@ -1,22 +1,27 @@
 #!/bin/bash
 
-retry() {
+function retry {
     local attempts_remaining=5
     local delay=15
+    local exit_status=0
+
     while true; do
-        "$@"
-        status=$?
-        if [[ $status -eq 0 ]]; then
-            break
+        if "$@"; then
+            return
+        else
+            exit_status=$?
         fi
-        let 'attempts_remaining -= 1'
-        if [[ $attempts_remaining -gt 0 ]]; then
-            echo "Command failed with exit status $status; retrying in $delay seconds"
+
+        (( attempts_remaining-- )) || :
+        if [ $attempts_remaining -gt 0 ]; then
+            echo "Command failed with exit status $exit_status: retrying in ${delay}s"
             sleep $delay
-            let 'delay *= 2'
+            (( delay *= 2 )) || :
         else
             echo 'Failed to execute command after 5 attempts'
             break
         fi
     done
+
+    return $exit_status
 }


### PR DESCRIPTION
* Enable shell errexit option so that unhandled failures result in
  script termination.
* Consolidate exit traps into a single on_exit function.
* Log how long the script took to run.
* Improve argument and variable validation.
* Quote all arguments to commands to prevent globbing and word
  splitting.
* Use "-n" to check if variables have a value instead of "! -z"
* Use rsync to copy files to the backup and FTP directories to prevent
  truncated files on failure or concurrent runs of the script.

---

The output from shellcheck is as follows:

```
In create-dumps.sh line 60:
source "admin/config.sh"
       ^---------------^ SC1091: Not following: admin/config.sh was not specified as input (see shellcheck -x).


In create-dumps.sh line 61:
source "admin/functions.sh"
       ^------------------^ SC1091: Not following: admin/functions.sh was not specified as input (see shellcheck -x).


In create-dumps.sh line 115:
mkdir -m "$BACKUP_DIR_MODE" -p \
      ^-- SC2174: When used with -p, -m only applies to the deepest directory.


In create-dumps.sh line 136:
mkdir -m "$FTP_DIR_MODE" -p "$FTP_CURRENT_DUMP_DIR"
      ^-- SC2174: When used with -p, -m only applies to the deepest directory.

For more information:
  https://www.shellcheck.net/wiki/SC2174 -- When used with -p, -m only applie...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: admin/config.sh wa...
```

The mkdir warnings are not relevant because the parent directory is specified as a separate argument in both cases.