### PR TITLE
Revert numpy version to 1.19.4

### DIFF
--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -3,7 +3,8 @@ hdfs == 2.5.8
 Jinja2 == 2.11.3
 pika==0.13.0
 python-dateutil==2.8.0
-numpy==1.19.5  # Numpy has dropped support for Python 3.6.x from version 1.20.0. So we use version 1.19.5 till we upgrade Python version in Spark images.
+# Numpy has dropped support for Python 3.6.x from version 1.20.0. So we use version 1.19.5 till we upgrade Python version in Spark images.
+numpy==1.19.5
 git+https://github.com/metabrainz/brainzutils-python.git@v1.16.1
 pytest == 6.2.2
 pytest-cov == 2.10.1

--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -3,7 +3,7 @@ hdfs == 2.5.8
 Jinja2 == 2.11.3
 pika==0.13.0
 python-dateutil==2.8.0
-numpy==1.20.1
+numpy==1.19.5  # Numpy has dropped support for Python 3.6.x from version 1.20.0. So we use version 1.19.5 till we upgrade Python version in Spark images.
 git+https://github.com/metabrainz/brainzutils-python.git@v1.16.1
 pytest == 6.2.2
 pytest-cov == 2.10.1


### PR DESCRIPTION
# Problem
Numpy has dropped support for Python 3.6.x from version 1.20.0. [(reference).](https://github.com/numpy/numpy/blob/v1.20.0/setup.py#L29)
This is failing the Spark builds after #1303 was merged.

# Solution

Using version 1.19.5 fixes the problem. It still supports Python 3.6.x [(reference).](https://github.com/numpy/numpy/blob/v1.19.5/setup.py#L31)
