### PR TITLE
Spotify reader do not process deleted users

### DIFF
--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -280,6 +280,8 @@ def get_user_dict(user_id):
 
 
 class SpotifyInvalidGrantError(Exception):
+    """ Raised if spotify API returns invalid_grant during authorization. This usually means that the user has revoked
+    authorization to the ListenBrainz application through Spotify UI."""
     pass
 
 

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -111,9 +111,6 @@ def refresh_user_token(spotify_user: Spotify):
         elif response.status_code == 400:
             error_body = response.json()
             if "error" in error_body and error_body["error"] == "invalid_grant":
-                # user has revoked authorization through spotify ui or deleted their spotify account etc.
-                # in any of these cases, we should delete user from our spotify db as well.
-                db_spotify.delete_spotify(spotify_user.user_id)
                 raise SpotifyInvalidGrantError(error_body)
 
         response = None  # some other error occurred

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -92,10 +92,10 @@ def refresh_user_token(spotify_user: Spotify):
 
     Returns:
         user (domain.spotify.Spotify): the same user with updated tokens
-        None: if the user has revoked authorization to spotify
 
     Raises:
         SpotifyAPIError: if unable to refresh spotify user token
+        SpotifyInvalidGrantError: if the user has revoked authorization to spotify
 
     Note: spotipy eats up the json body in case of error but we need it for checking
     whether the user has revoked our authorization. hence, we use our own
@@ -114,10 +114,9 @@ def refresh_user_token(spotify_user: Spotify):
                 # user has revoked authorization through spotify ui or deleted their spotify account etc.
                 # in any of these cases, we should delete user from our spotify db as well.
                 db_spotify.delete_spotify(spotify_user.user_id)
-                return None
+                raise SpotifyInvalidGrantError(error_body)
 
-            response = None  # some other error during request
-
+        response = None  # some other error occurred
         retries -= 1
 
     if response is None:
@@ -281,6 +280,10 @@ def get_user_dict(user_id):
         'access_token': user.user_token,
         'permission': user.permission,
     }
+
+
+class SpotifyInvalidGrantError(Exception):
+    pass
 
 
 class SpotifyImporterException(Exception):

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -82,15 +82,13 @@ class SpotifyDomainTestCase(ServerTestCase):
 
     # apparently, requests_mocker does not follow the usual order in which decorators are applied. :-(
     @requests_mock.Mocker()
-    @mock.patch('listenbrainz.db.spotify.delete_spotify')
-    def test_refresh_user_token_revoked(self, mock_requests, mock_delete_spotify):
+    def test_refresh_user_token_revoked(self, mock_requests):
         mock_requests.post(spotify.OAUTH_TOKEN_URL, status_code=400, json={
             'error': 'invalid_grant',
             'error_description': 'Refresh token revoked',
         })
         with self.assertRaises(spotify.SpotifyInvalidGrantError):
             spotify.refresh_user_token(self.spotify_user)
-        mock_delete_spotify.assert_called_with(self.spotify_user.user_id)
 
     def test_get_spotify_oauth(self):
         func_oauth = spotify.get_spotify_oauth()

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -277,6 +277,7 @@ def process_one_user(user):
         else:
             if user is None:
                 current_app.logger.debug("%s has revoked spotify authorization", str(user))
+                return
 
     listenbrainz_user = db_user.get(user.user_id)
 

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -146,7 +146,7 @@ def make_api_request(user, spotipy_call, **kwargs):
                 # Rate Limit Problems -- the client handles these, but it can still give up
                 # after a certain number of retries, so we look at the header and try the
                 # request again, if the error is raised
-                time_to_sleep = e.headers.get('Retry-After', delay)
+                time_to_sleep = int(e.headers.get('Retry-After', delay))
                 current_app.logger.warn('Encountered a rate limit, sleeping %d seconds and trying again...', time_to_sleep)
                 time.sleep(time_to_sleep)
                 delay += 1

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -108,13 +108,12 @@ class ConvertListensTestCase(DatabaseTestCase):
         mock_send_mail.assert_called_once()
         self.assertListEqual(mock_send_mail.call_args[1]['recipients'], ['example@listenbrainz.org'])
 
-
     @patch('listenbrainz.spotify_updater.spotify_read_listens.spotify.update_last_updated')
     @patch('listenbrainz.spotify_updater.spotify_read_listens.notify_error')
-    @patch('listenbrainz.spotify_updater.spotify_read_listens.process_one_user')
+    @patch('listenbrainz.spotify_updater.spotify_read_listens.make_api_request')
     @patch('listenbrainz.domain.spotify.get_active_users_to_process')
-    def test_notification_on_api_error(self, mock_get_active_users, mock_process_one_user, mock_notify_error, mock_update):
-        mock_process_one_user.side_effect = SpotifyAPIError('api borked')
+    def test_notification_on_api_error(self, mock_get_active_users, mock_make_api_request, mock_notify_error, mock_update):
+        mock_make_api_request.side_effect = SpotifyAPIError('api borked')
         mock_get_active_users.return_value = [self.spotify_user]
         app = listenbrainz.webserver.create_app()
         app.config['TESTING'] = False

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -317,9 +317,8 @@ def refresh_spotify_token():
             spotify_user = spotify.refresh_user_token(spotify_user)
         except spotify.SpotifyAPIError:
             raise APIServiceUnavailable("Cannot refresh Spotify token right now")
-        else:
-            if spotify_user is None:
-                raise APINotFound("User has revoked authorization to Spotify")
+        except spotify.SpotifyInvalidGrantError:
+            raise APINotFound("User has revoked authorization to Spotify")
 
     return jsonify({
         'id': current_user.id,

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -249,7 +249,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
             permission='user-read-recently-played',
         )
         mock_get_user.return_value = spotify_user
-        mock_refresh_user_token.return_value = None
+        mock_refresh_user_token.side_effect = spotify.SpotifyInvalidGrantError
         response = self.client.post(url_for('profile.refresh_spotify_token'))
         self.assertEqual(response.json, {'code': 404, 'error': 'User has revoked authorization to Spotify'})
 


### PR DESCRIPTION
At one place, the code does not whether the user is `None` before trying to process a user. Instead of returning None, raise an Exception in case of invalid grant received from Spotify API. An exception will stop the execution before and we can also know the reason why it happened.