### PR TITLE
Fix order of getting listens for feed endpoint

### DIFF
--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -240,7 +240,7 @@ class TimescaleListenStore(ListenStore):
             from_ts: seconds since epoch, in float
             to_ts: seconds since epoch, in float
             limit: the maximum number of items to return
-            order: 0 for ASCending order, 1 for DESCending order
+            order: 0 for DESCending order, 1 for ASCending order
             time_range: the time range (in units of 5 days) to search for listens. If none is given
                         3 ranges (15 days) are searched. If -1 is given then all listens are searched
                         which is slow and should be avoided if at all possible.

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -192,7 +192,7 @@ def get_listen_events(
         from_ts=min_ts,
         to_ts=max_ts,
         time_range=time_range,
-        order=1,  # descending
+        order=0,  # descending
     )
 
     user_listens_map = defaultdict(list)

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -206,12 +206,12 @@ def get_listen_events(
             try:
                 listen_dict = listen.to_api()
                 listen_dict['inserted_at'] = listen_dict['inserted_at'].timestamp()
-                listen = APIListen(**listen_dict)
+                api_listen = APIListen(**listen_dict)
                 events.append(APITimelineEvent(
                     event_type=UserTimelineEventType.LISTEN,
-                    user_name=listen.user_name,
-                    created=listen.listened_at,
-                    metadata=listen,
+                    user_name=api_listen.user_name,
+                    created=api_listen.listened_at,
+                    metadata=api_listen,
                 ))
             except pydantic.ValidationError as e:
                 current_app.logger.error('Validation error: ' + str(e), exc_info=True)


### PR DESCRIPTION
The docstring of the timescale listenstore get listens was incorrect about the order param. This PR changes the feed endpoint to get the latest listens, and fixes the docstring.

I also fixed a bug where listen data was being overwritten due to variable names.

I'll add a test for the correct ordering in the feed endpoint in a follow up PR, I'd like to merge this quickly.