### PR TITLE
LB-830: Make all buttons on listen page equal width

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -246,6 +246,7 @@
         stroke-width: 40px;
         font-size: 18px;
         margin: 0% 7%;
+        width: 1em;
       }
 
       .fa-heart, .fa-heart-broken {


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

The three dots icon on the listens page is very narrow, making it hard to click. It is even difficult with a mouse, and trying to hit this on my mobile completely drives me nuts

The clickable area on those icons should be expanded. The three dots is exactly as wide as the dots, making it wider would solve the issue.

See LB-830


# Solution
This fixes the three dots button to be very narrow and hard to hit. 1em is the height and the width of the other rectangular buttons. The three dots button ends up centered in this width.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

