### PR TITLE
Temporarily disable LastFM importer

### DIFF
--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -292,7 +292,7 @@ describe("LastFmImporter Page", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("modal renders when button clicked", () => {
+  xit("modal renders when button clicked", () => {
     const wrapper = shallow(<LastFmImporter {...props} />);
     // Simulate submiting the form
     wrapper.find("form").simulate("submit", {
@@ -303,7 +303,7 @@ describe("LastFmImporter Page", () => {
     expect(wrapper.exists("LastFMImporterModal")).toBe(true);
   });
 
-  it("submit button is disabled when input is empty", () => {
+  xit("submit button is disabled when input is empty", () => {
     const wrapper = shallow(<LastFmImporter {...props} />);
     // Make sure that the input is empty
     wrapper.setState({ lastfmUsername: "" });

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -422,35 +422,40 @@ export default class LastFmImporter extends React.Component<
 
   render() {
     const { show, canClose, lastfmUsername, msg } = this.state;
-
     return (
-      <div className="Importer">
-        <form onSubmit={this.handleSubmit}>
-          <input
-            type="text"
-            onChange={this.handleChange}
-            value={lastfmUsername}
-            placeholder="Last.fm Username"
-            size={30}
-          />
-          <input type="submit" value="Import Now!" disabled={!lastfmUsername} />
-        </form>
-        {show && (
-          <LastFMImporterModal onClose={this.toggleModal} disable={!canClose}>
-            <img
-              src="/static/img/listenbrainz-logo.svg"
-              height="75"
-              className="img-responsive"
-              alt=""
-            />
-            <br />
-            <br />
-            <div>{msg}</div>
-            <br />
-          </LastFMImporterModal>
-        )}
+      <div className="alert alert-danger">
+        We are having some issues with the LastFM importer, but we are working
+        on fixing it. Please try again later. Our apologies for the delay!
       </div>
     );
+    // return (
+    //   <div className="Importer">
+    //     <form onSubmit={this.handleSubmit}>
+    //       <input
+    //         type="text"
+    //         onChange={this.handleChange}
+    //         value={lastfmUsername}
+    //         placeholder="Last.fm Username"
+    //         size={30}
+    //       />
+    //       <input type="submit" value="Import Now!" disabled={!lastfmUsername} />
+    //     </form>
+    //     {show && (
+    //       <LastFMImporterModal onClose={this.toggleModal} disable={!canClose}>
+    //         <img
+    //           src="/static/img/listenbrainz-logo.svg"
+    //           height="75"
+    //           className="img-responsive"
+    //           alt=""
+    //         />
+    //         <br />
+    //         <br />
+    //         <div>{msg}</div>
+    //         <br />
+    //       </LastFMImporterModal>
+    //     )}
+    //   </div>
+    // );
   }
 }
 

--- a/listenbrainz/webserver/static/js/src/__snapshots__/LastFMImporter.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/__snapshots__/LastFMImporter.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LastFmImporter Page renders 1`] = `"<div class=\\"Importer\\"><form><input type=\\"text\\" placeholder=\\"Last.fm Username\\" size=\\"30\\" value=\\"\\"><input type=\\"submit\\" disabled=\\"\\" value=\\"Import Now!\\"></form></div>"`;
+exports[`LastFmImporter Page renders 1`] = `"<div class=\\"alert alert-danger\\">We are having some issues with the LastFM importer, but we are working on fixing it. Please try again later. Our apologies for the delay!</div>"`;


### PR DESCRIPTION
LastFM importer is currently not working. Pending resolution let's disable it and show the user a message instead.

When this is reverted, the two disabled tests need to be re-enabled and the snapshot updated.