### PR TITLE
Fix removing playlist collaborators

### DIFF
--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
@@ -569,20 +569,17 @@ export default class PlaylistPage extends React.Component<
       return;
     }
     try {
-      // Replace keys that have changed but keep all other attributres
-      const editedPlaylist: JSPFPlaylist = defaultsDeep(
-        {
-          annotation: description,
-          title: name,
-          extension: {
-            [MUSICBRAINZ_JSPF_PLAYLIST_EXTENSION]: {
-              public: isPublic,
-              collaborators,
-            },
+      const editedPlaylist: JSPFPlaylist = {
+        ...playlist,
+        annotation: description,
+        title: name,
+        extension: {
+          [MUSICBRAINZ_JSPF_PLAYLIST_EXTENSION]: {
+            public: isPublic,
+            collaborators,
           },
         },
-        playlist
-      );
+      };
 
       await this.APIService.editPlaylist(currentUser.auth_token, id, {
         playlist: omit(editedPlaylist, "track") as JSPFPlaylist,

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -403,10 +403,11 @@ def edit_playlist(playlist_mbid):
     # Uniquify collaborators list
     collaborators = list(set(collaborators))
 
+    # Don't allow creator to also be a collaborator
+    if user["musicbrainz_id"] in collaborators:
+        collaborators.remove(user["musicbrainz_id"])
+
     if collaborators:
-        # Don't allow creator to also be a collaborator
-        if user["musicbrainz_id"] in collaborators:
-            collaborators.remove(user["musicbrainz_id"])
         users = db_user.get_many_users_by_mb_id(collaborators)
 
     collaborator_ids = []


### PR DESCRIPTION
The current playlist page does not allow to delete collaborators properly because of these two problems:

1. On the front-end a utility is used to duplicate a playlist before sending it to be saved, but that utility merges the existing collaborators array rather than replacing it. That means if you remove all the collaborators and save, the playlist will still have the original collaborators sent to be saved.

I copied the working code we use for the Playlists.tsx page. Ironically that object destructuring method is what was used in Playlist.tsx before being replaced with `defaultsDeep`.

2. When the playlist owner is the only collaborator added to a playlist, we do a check for the length of that list *before*  removing the owner from the list of collaborators, leaving us to fetch an empty list of user IDs which throws an error.