### PR TITLE
LB-773: Remove pytz dependency

### DIFF
--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -2,7 +2,6 @@ from listenbrainz import db, utils
 import sqlalchemy
 from listenbrainz.db.exceptions import DatabaseException
 from datetime import datetime
-import pytz
 from flask import current_app, url_for
 import spotipy.oauth2
 

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -1,5 +1,4 @@
 import base64
-import pytz
 import requests
 import six
 import time
@@ -7,7 +6,7 @@ from flask import current_app
 import spotipy.oauth2
 
 from listenbrainz.db import spotify as db_spotify
-import datetime
+from datetime import datetime, timezone
 
 SPOTIFY_API_RETRIES = 5
 
@@ -60,8 +59,8 @@ class Spotify:
 
     @property
     def token_expired(self):
-        now = datetime.datetime.utcnow()
-        now = now.replace(tzinfo=pytz.UTC)
+        now = datetime.utcnow()
+        now = now.replace(tzinfo=timezone.utc)
         return now >= self.token_expires
 
     @staticmethod

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -1,8 +1,7 @@
 import os
 import json
 import listenbrainz.webserver
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 
 import listenbrainz.db.user as db_user
 from listenbrainz.domain.spotify import Spotify, SpotifyAPIError, SpotifyListenBrainzError
@@ -25,7 +24,7 @@ class ConvertListensTestCase(DatabaseTestCase):
                     musicbrainz_id='jude',
                     musicbrainz_row_id=312,
                     user_token='token',
-                    token_expires=datetime.max.replace(tzinfo=pytz.UTC),
+                    token_expires=datetime.max.replace(tzinfo=timezone.utc),
                     refresh_token='refresh',
                     last_updated=None,
                     record_listens=True,

--- a/listenbrainz/tests/utils.py
+++ b/listenbrainz/tests/utils.py
@@ -7,7 +7,6 @@ import os
 
 from listenbrainz.listen import Listen
 import uuid
-import pytz
 import listenbrainz.db.user as db_user
 
 

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -1,10 +1,9 @@
 import errno
 import os
 import pika
-import pytz
 import time
 
-from datetime import datetime
+from datetime import datetime, timezone
 from redis import Redis
 
 def escape(value):
@@ -139,6 +138,6 @@ def unix_timestamp_to_datetime(timestamp):
     Returns:
         A datetime object with timezone UTC corresponding to the provided timestamp
     """
-    return datetime.utcfromtimestamp(timestamp).replace(tzinfo=pytz.UTC)
+    return datetime.utcfromtimestamp(timestamp).replace(tzinfo=timezone.utc)
 
 

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -1,11 +1,10 @@
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 import listenbrainz.db.spotify as db_spotify
-import pytz
 import time
 import ujson
 
-from datetime import datetime
+from datetime import datetime, timezone
 from flask import url_for
 from listenbrainz.domain import spotify
 from listenbrainz.db.testing import DatabaseTestCase
@@ -173,7 +172,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
     def test_spotify_refresh_token_which_has_expired(self, mock_refresh_user_token, mock_get_user):
         self.temporary_login(self.user['login_id'])
         # token hasn't expired
-        expires = datetime.utcfromtimestamp(int(time.time()) + 10).replace(tzinfo=pytz.UTC)
+        expires = datetime.utcfromtimestamp(int(time.time()) + 10).replace(tzinfo=timezone.utc)
         mock_get_user.return_value = spotify.Spotify(
             user_id=self.user['id'],
             musicbrainz_id=self.user['musicbrainz_id'],
@@ -202,7 +201,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
     def test_spotify_refresh_token_which_has_not_expired(self, mock_refresh_user_token, mock_get_user):
         self.temporary_login(self.user['login_id'])
         # token hasn't expired
-        expires = datetime.utcfromtimestamp(int(time.time()) - 10).replace(tzinfo=pytz.UTC)
+        expires = datetime.utcfromtimestamp(int(time.time()) - 10).replace(tzinfo=timezone.utc)
         spotify_user = spotify.Spotify(
             user_id=self.user['id'],
             musicbrainz_id=self.user['musicbrainz_id'],
@@ -234,7 +233,7 @@ class ProfileViewsTestCase(ServerTestCase, DatabaseTestCase):
     def test_spotify_refresh_token_which_has_been_revoked(self, mock_refresh_user_token, mock_get_user):
         self.temporary_login(self.user['login_id'])
         # token hasn't expired
-        expires = datetime.utcfromtimestamp(int(time.time()) - 10).replace(tzinfo=pytz.UTC)
+        expires = datetime.utcfromtimestamp(int(time.time()) - 10).replace(tzinfo=timezone.utc)
         spotify_user = spotify.Spotify(
             user_id=self.user['id'],
             musicbrainz_id=self.user['musicbrainz_id'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ rauth == 0.7.3
 setproctitle == 1.2.2
 markupsafe == 1.1.1
 blist == 1.3.6
-pytz==2021.1
 psycopg2-binary == 2.8.6
 python-dateutil == 2.8.1
 ujson == 1.35


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
ListenBrainz uses pytz for pytz.UTC function whereas in new python datetime has timezone.utc which should be used instead.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Removed pytz dependency from the project and used timezone.UTC wherever needed.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->




<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


