### PR TITLE
Set retry limit for LastFMImporter

### DIFF
--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { mount, shallow } from "enzyme";
-import LastFmImporter from "./LastFMImporter";
+import LastFmImporter, {LASTFM_RETRIES} from "./LastFMImporter";
 // Mock data to test functions
 import * as page from "./__mocks__/page.json";
 import * as getInfo from "./__mocks__/getInfo.json";
@@ -133,7 +133,6 @@ describe("getTotalNumberOfScrobbles", () => {
 });
 
 describe("getPage", () => {
-  const RETRIES = 3;
   beforeEach(() => {
     const wrapper = shallow<LastFmImporter>(<LastFmImporter {...props} />);
     instance = wrapper.instance();
@@ -148,7 +147,7 @@ describe("getPage", () => {
   });
 
   it("should call with the correct url", () => {
-    instance.getPage(1, RETRIES);
+    instance.getPage(1, LASTFM_RETRIES);
 
     expect(window.fetch).toHaveBeenCalledWith(
       `${props.lastfmApiUrl}?method=user.getrecenttracks&user=${instance.state.lastfmUsername}&api_key=${props.lastfmApiKey}&from=1&page=1&format=json`
@@ -159,7 +158,7 @@ describe("getPage", () => {
     // Mock function for encodeScrobbles
     LastFmImporter.encodeScrobbles = jest.fn(() => ["foo", "bar"]);
 
-    const data = await instance.getPage(1, RETRIES);
+    const data = await instance.getPage(1, LASTFM_RETRIES);
     expect(LastFmImporter.encodeScrobbles).toHaveBeenCalledTimes(1);
     expect(data).toEqual(["foo", "bar"]);
   });
@@ -174,10 +173,10 @@ describe("getPage", () => {
     });
 
     const getPageSpy = jest.spyOn(instance, "getPage");
-    await instance.getPage(1, RETRIES);
+    await instance.getPage(1, LASTFM_RETRIES);
 
-    // we run the timer sufficient number of timers to ensure retries are not exceeded or undetected due to timeouts
-    for (let i = 0; i < 10; i += 1) {
+    // we run the timer sufficient number of times to ensure retries are not exceeded or undetected due to timeouts
+    for (let i = 0; i < LASTFM_RETRIES + 2; i += 1) {
       jest.runAllTimers();
       // make timers and promises play well with jest
       // eslint-disable-next-line no-await-in-loop
@@ -196,10 +195,10 @@ describe("getPage", () => {
       });
     });
     const getPageSpy = jest.spyOn(instance, "getPage");
-    await instance.getPage(1, RETRIES);
+    await instance.getPage(1, LASTFM_RETRIES);
 
-    // we run the timer sufficient number of timers to ensure retries are not exceeded or undetected due to timeouts
-    for (let i = 0; i < 10; i += 1) {
+    // we run the timer sufficient number of times to ensure retries are not exceeded or undetected due to timeouts
+    for (let i = 0; i < LASTFM_RETRIES + 2; i += 1) {
       jest.runAllTimers();
       // make timers and promises play well with jest
       // eslint-disable-next-line no-await-in-loop
@@ -220,9 +219,9 @@ describe("getPage", () => {
 
     const getPageSpy = jest.spyOn(instance, "getPage");
 
-    await instance.getPage(1, RETRIES);
-    // we run the timer sufficient number of timers to ensure retries are not exceeded or undetected due to timeouts
-    for (let i = 0; i < 10; i += 1) {
+    await instance.getPage(1, LASTFM_RETRIES);
+    // we run the timer sufficient number of times to ensure retries are not exceeded or undetected due to timeouts
+    for (let i = 0; i < LASTFM_RETRIES + 2; i += 1) {
       jest.runAllTimers();
       // make timers and promises play well with jest
       // eslint-disable-next-line no-await-in-loop

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -183,7 +183,7 @@ describe("getPage", () => {
       await Promise.resolve();
     }
 
-    expect(getPageSpy).toHaveBeenCalledTimes(4);
+    expect(getPageSpy).toHaveBeenCalledTimes(1 + LASTFM_RETRIES);
   });
 
   it("should skip the page if 40x is recieved", async () => {
@@ -228,7 +228,7 @@ describe("getPage", () => {
       await Promise.resolve();
     }
 
-    expect(getPageSpy).toHaveBeenCalledTimes(4);
+    expect(getPageSpy).toHaveBeenCalledTimes(1 + LASTFM_RETRIES);
   });
 });
 

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -133,19 +133,20 @@ describe("getTotalNumberOfScrobbles", () => {
 });
 
 describe("getPage", () => {
+  const originalTimeout = window.setTimeout;
   beforeAll(() => {
-    // The timeout we use in getPage's implementation does not work with Jest fake timers
-    // so we disable fake timers for this section
-    // and give enough time for the real timeouts to run
-    // see https://stackoverflow.com/questions/50783013/how-to-timeout-promises-in-jest
-    jest.useRealTimers();
-    jest.setTimeout(3000 * (LASTFM_RETRIES + 2));
+    // Ugly hack: Jest fake timers don't play well with promises and setTimeout
+    // so we replace the setTimeout function.
+    // see https://github.com/facebook/jest/issues/7151
+    // @ts-ignore
+    window.setTimeout = (fn: () => void, _timeout: number): number => {
+      fn();
+      return _timeout;
+    };
   });
 
   afterAll(() => {
-    // Back to default
-    jest.setTimeout(5000);
-    jest.useFakeTimers();
+    window.setTimeout = originalTimeout;
   });
 
   beforeEach(() => {

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.test.tsx
@@ -232,6 +232,21 @@ describe("getPage", () => {
     expect(finalValue).toEqual(undefined);
   });
 
+  it("should skip the page if 30x is recieved", async () => {
+    // Mock function for failed fetch
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: false,
+        status: 301,
+      });
+    });
+    const getPageSpy = jest.spyOn(instance, "getPage");
+    const finalValue = await instance.getPage(1, LASTFM_RETRIES);
+
+    expect(getPageSpy).toHaveBeenCalledTimes(1);
+    expect(finalValue).toEqual(undefined);
+  });
+
   it("should retry if there is any other error", async () => {
     // Mock function for fetch
     window.fetch = jest
@@ -239,13 +254,7 @@ describe("getPage", () => {
       .mockImplementationOnce(() => {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.reject(),
-        });
-      })
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          ok: false,
-          status: 600,
+          json: () => Promise.reject(new Error("Error")),
         });
       })
       .mockImplementationOnce(() => {
@@ -258,7 +267,7 @@ describe("getPage", () => {
     const getPageSpy = jest.spyOn(instance, "getPage");
     const finalValue = await instance.getPage(1, LASTFM_RETRIES);
 
-    expect(getPageSpy).toHaveBeenCalledTimes(3);
+    expect(getPageSpy).toHaveBeenCalledTimes(2);
     expect(finalValue).toEqual(encodeScrobbleOutput);
   });
 

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -150,19 +150,23 @@ export default class LastFmImporter extends React.Component<
     }
   }
 
+  /*
+   * @param {number} page - the page to fetch from Last.fm
+   * @param {number} retries - number times to retry in case of errors other than 40x
+   * Fetch page from Last.fm
+   */
   async getPage(page: number, retries: number) {
-    /*
-     * Fetch page from Last.fm
-     */
     const { lastfmUsername } = this.state;
 
     const retry = (reason: string) => {
       // eslint-disable-next-line no-console
+      const timeout = 3000;
       console.warn(
-        `${reason} while fetching last.fm page=${page}, retrying in 3s`
+        `${reason} while fetching last.fm page=${page}, retrying in 
+        ${timeout / 1000}s`
       );
       if (retries > 0) {
-        setTimeout(() => this.getPage(page, retries - 1), 3000);
+        setTimeout(() => this.getPage(page, retries - 1), timeout);
       }
     };
 

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -6,7 +6,7 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import APIService from "./APIService";
 import Scrobble from "./Scrobble";
 
-
+export const LASTFM_RETRIES = 3;
 export type ImporterProps = {
   user: {
     id?: string;
@@ -77,7 +77,6 @@ export default class LastFmImporter extends React.Component<
   private rlReset = -1;
 
   private rlOrigin = -1;
-  private LASTFM_RETRIES = 3;
 
   constructor(props: ImporterProps) {
     super(props);
@@ -278,7 +277,7 @@ export default class LastFmImporter extends React.Component<
     while (this.page > 0) {
       // Fixing no-await-in-loop will require significant changes to the code, ignoring for now
       this.lastImportedString = "...";
-      const payload = await this.getPage(this.page, this.LASTFM_RETRIES); // eslint-disable-line
+      const payload = await this.getPage(this.page, LASTFM_RETRIES); // eslint-disable-line
       if (payload) {
         // Submit only if response is valid
         this.submitPage(payload);

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -188,31 +188,28 @@ export default class LastFmImporter extends React.Component<
         this.countReceived += payload.length;
         return payload;
       }
-      // ignore 40x errors
-      if (!/^4/.test(response.status.toString())) {
+      // Retry if we receive a 5xx server error
+      if (/^5/.test(response.status.toString())) {
         // eslint-disable-next-line no-console
         console.warn(
-          `Got ${
-            response.status
-          } while fetching last.fm page=${page}, retrying in
-          ${timeout / 1000}s`
+          `Got ${response.status} while fetching last.fm page ${page}`
         );
         if (retries <= 0) {
           return null;
         }
+        // eslint-disable-next-line no-console
+        console.warn(`Retrying in ${timeout / 1000}s, ${retries} retries left`);
         await new Promise((resolve) => setTimeout(resolve, timeout));
         return await this.getPage(page, retries - 1);
       }
     } catch {
       // Retry if there is a network error
       // eslint-disable-next-line no-console
-      console.warn(
-        `Network error while fetching last.fm page=${page}, retrying in
-        ${timeout / 1000}s`
-      );
+      console.warn(`Network error while fetching last.fm page ${page}`);
       if (retries <= 0) {
         return null;
       }
+      console.warn(`Retrying in ${timeout / 1000}s, ${retries} retries left`);
       await new Promise((resolve) => setTimeout(resolve, timeout));
       // eslint-disable-next-line no-return-await
       return await this.getPage(page, retries - 1);

--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -6,7 +6,6 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import APIService from "./APIService";
 import Scrobble from "./Scrobble";
 
-import LastFMImporterModal from "./LastFMImporterModal";
 
 export type ImporterProps = {
   user: {
@@ -78,6 +77,7 @@ export default class LastFmImporter extends React.Component<
   private rlReset = -1;
 
   private rlOrigin = -1;
+  private LASTFM_RETRIES = 3;
 
   constructor(props: ImporterProps) {
     super(props);
@@ -151,7 +151,7 @@ export default class LastFmImporter extends React.Component<
     }
   }
 
-  async getPage(page: number) {
+  async getPage(page: number, retries: number) {
     /*
      * Fetch page from Last.fm
      */
@@ -162,7 +162,9 @@ export default class LastFmImporter extends React.Component<
       console.warn(
         `${reason} while fetching last.fm page=${page}, retrying in 3s`
       );
-      setTimeout(() => this.getPage(page), 3000);
+      if (retries > 0) {
+        setTimeout(() => this.getPage(page, retries - 1), 3000);
+      }
     };
 
     const url = `${
@@ -276,7 +278,7 @@ export default class LastFmImporter extends React.Component<
     while (this.page > 0) {
       // Fixing no-await-in-loop will require significant changes to the code, ignoring for now
       this.lastImportedString = "...";
-      const payload = await this.getPage(this.page); // eslint-disable-line
+      const payload = await this.getPage(this.page, this.LASTFM_RETRIES); // eslint-disable-line
       if (payload) {
         // Submit only if response is valid
         this.submitPage(payload);


### PR DESCRIPTION
The `LastFMImporter` _used to retry_ indefinitely in case of errors (e.g. _50x_). Further, when a page import failed, we _used to_ move to the next page, while the previous pages continued to retry.

We are now restricting the number of retries to _3_. We also _do not_ move to the next page while we are still retrying the current page.

A few tests have also been added to ensure that the retry logic works as expected.