### PR TITLE
Add a notification that similar users imported or failed

### DIFF
--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -15,10 +15,10 @@ ROWS_PER_BATCH = 1000
 
 def import_user_similarities(data):
     """ Import the user similarities into the DB by inserting the data into a new table
-        and then rotating the table into place atomically. 
+        and then rotating the table into place atomically.
 
         Returns a tuple of three values:
-            (user_count, avr_similar_users_per_user, error) 
+            (user_count, avr_similar_users_per_user, error)
         If an error occurs rotating the tables in place, error will be a non-empty
         string and the user count values will be 0. Upon success error will be empty
         and the user count values will be set accordingly.
@@ -66,7 +66,7 @@ def import_user_similarities(data):
             curs.execute("""INSERT INTO recommendation.tmp_similar_user
                                         SELECT id AS user_id, similar_users
                                           FROM recommendation.similar_user_import
-                                          JOIN "user" 
+                                          JOIN "user"
                                             ON user_name = musicbrainz_id""")
 
             curs.execute("""DROP TABLE recommendation.similar_user_import""")

--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -15,7 +15,13 @@ ROWS_PER_BATCH = 1000
 
 def import_user_similarities(data):
     """ Import the user similarities into the DB by inserting the data into a new table
-        and then rotating the table into place atomically.
+        and then rotating the table into place atomically. 
+
+        Returns a tuple of three values:
+            (user_count, avr_similar_users_per_user, error) 
+        If an error occurs rotating the tables in place, error will be a non-empty
+        string and the user count values will be 0. Upon success error will be empty
+        and the user count values will be set accordingly.
     """
 
     user_count = 0

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -392,4 +392,20 @@ def handle_similar_users(message):
     if current_app.config['TESTING']:
         return
 
-    import_user_similarities(message['data'])
+    user_count, avg_similar_users, error = import_user_similarities(message['data'])
+    if error:
+        send_mail(
+            subject='Similar User data failed to be calculated',
+            text=render_template('emails/similar_users_failed_notification.txt', error=error),
+            recipients=['listenbrainz-observability@metabrainz.org'],
+            from_name='ListenBrainz',
+            from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
+        )
+    else:
+        send_mail(
+            subject='Similar User data has been calculated',
+            text=render_template('emails/similar_users_updated_notification.txt', user_count=str(user_count), avg_similar_users="%.1f" % avg_similar_users),
+            recipients=['listenbrainz-observability@metabrainz.org'],
+            from_name='ListenBrainz',
+            from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
+        )

--- a/listenbrainz/webserver/templates/emails/similar_users_failed_notification.txt
+++ b/listenbrainz/webserver/templates/emails/similar_users_failed_notification.txt
@@ -1,0 +1,7 @@
+Hey! 👋
+
+Similar users were not able to be written to the database, due to:
+
+{{ error }}
+
+Your Friendly Neighbourhood Brainzbot 🤖

--- a/listenbrainz/webserver/templates/emails/similar_users_updated_notification.txt
+++ b/listenbrainz/webserver/templates/emails/similar_users_updated_notification.txt
@@ -1,0 +1,9 @@
+Hey! 👋
+
+Similar users were received by the spark consumer
+and are being written into the database.
+
+{{ user_count }} users had similar users calculated with an average
+of {{ avg_similar_users }} being generated per user.
+
+Your Friendly Neighbourhood Brainzbot 🤖


### PR DESCRIPTION
Add a simple email letting the folks on the LB observability email about similar users being imported or the import having failed. Output should look like:

Similar users were received by the spark consumer
and are being written into the database.

6511 users had similar users calculated with an average
of 48.4 being generated per user.