### PR TITLE
LB-838: Limit Error Messages

### DIFF
--- a/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
@@ -362,11 +362,31 @@ describe("newAlert", () => {
     expect(wrapper.state().alerts).toEqual([
       { id: 0, type: "warning", headline: "Test", message: "foobar" },
     ]);
-
+    instance.newAlert("warning", "Test", "foobar");
+    expect(wrapper.state().alerts).toEqual([
+      {
+        id: 0,
+        type: "warning",
+        headline: "Test (2)",
+        message: "foobar",
+        count: 2,
+      },
+    ]);
     instance.newAlert("danger", "test", <p>foobar</p>);
     expect(wrapper.state().alerts).toEqual([
-      { id: 0, type: "warning", headline: "Test", message: "foobar" },
-      { id: 0, type: "danger", headline: "test", message: <p>foobar</p> },
+      {
+        id: 0,
+        type: "warning",
+        headline: "Test (2)",
+        message: "foobar",
+        count: 2,
+      },
+      {
+        id: 0,
+        type: "danger",
+        headline: "test",
+        message: <p>foobar</p>,
+      },
     ]);
   });
 });

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -225,16 +225,37 @@ export default class RecentListens extends React.Component<
   newAlert = (
     type: AlertType,
     title: string,
-    message: string | JSX.Element
+    message: string | JSX.Element,
+    count?: number
   ): void => {
     const newAlert: Alert = {
       id: new Date().getTime(),
       type,
       headline: title,
       message,
+      count,
     };
 
     this.setState((prevState) => {
+      const alertsList = prevState.alerts;
+      for (let i = 0; i < alertsList.length; i += 1) {
+        const item = alertsList[i];
+        if (
+          item.type === newAlert.type &&
+          item.headline.includes(newAlert.headline) &&
+          item.message === newAlert.message
+        ) {
+          if (!alertsList[i].count) {
+            // If the count attribute is undefined, then Initializing it as 2
+            alertsList[i].count = 2;
+          } else {
+            alertsList[i].count! += 1;
+          }
+          alertsList[i].headline = `${newAlert.headline} (${alertsList[i]
+            .count!})`;
+          return { alerts: alertsList };
+        }
+      }
       return {
         alerts: [...prevState.alerts, newAlert],
       };

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -242,7 +242,7 @@ export default class RecentListens extends React.Component<
         const item = alertsList[i];
         if (
           item.type === newAlert.type &&
-          item.headline.includes(newAlert.headline) &&
+          item.headline.startsWith(newAlert.headline) &&
           item.message === newAlert.message
         ) {
           if (!alertsList[i].count) {

--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
@@ -340,16 +340,37 @@ export default class PlaylistPage extends React.Component<
   newAlert = (
     type: AlertType,
     title: string,
-    message: string | JSX.Element
+    message: string | JSX.Element,
+    count?: number
   ): void => {
     const newAlert: Alert = {
       id: new Date().getTime(),
       type,
       headline: title,
       message,
+      count,
     };
 
     this.setState((prevState) => {
+      const alertsList = prevState.alerts;
+      for (let i = 0; i < alertsList.length; i += 1) {
+        const item = alertsList[i];
+        if (
+          item.type === newAlert.type &&
+          item.headline.includes(newAlert.headline) &&
+          item.message === newAlert.message
+        ) {
+          if (!alertsList[i].count) {
+            // If the count attribute is undefined, then Initializing it as 2
+            alertsList[i].count = 2;
+          } else {
+            alertsList[i].count! += 1;
+          }
+          alertsList[i].headline = `${newAlert.headline} (${alertsList[i]
+            .count!})`;
+          return { alerts: alertsList };
+        }
+      }
       return {
         alerts: [...prevState.alerts, newAlert],
       };

--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
@@ -357,7 +357,7 @@ export default class PlaylistPage extends React.Component<
         const item = alertsList[i];
         if (
           item.type === newAlert.type &&
-          item.headline.includes(newAlert.headline) &&
+          item.headline.startsWith(newAlert.headline) &&
           item.message === newAlert.message
         ) {
           if (!alertsList[i].count) {

--- a/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
@@ -364,16 +364,37 @@ export default class UserPlaylists extends React.Component<
   newAlert = (
     type: AlertType,
     title: string,
-    message: string | JSX.Element
+    message: string | JSX.Element,
+    count?: number
   ): void => {
     const newAlert: Alert = {
       id: new Date().getTime(),
       type,
       headline: title,
       message,
+      count,
     };
 
     this.setState((prevState) => {
+      const alertsList = prevState.alerts;
+      for (let i = 0; i < alertsList.length; i += 1) {
+        const item = alertsList[i];
+        if (
+          item.type === newAlert.type &&
+          item.headline.includes(newAlert.headline) &&
+          item.message === newAlert.message
+        ) {
+          if (!alertsList[i].count) {
+            // If the count attribute is undefined, then Initializing it as 2
+            alertsList[i].count = 2;
+          } else {
+            alertsList[i].count! += 1;
+          }
+          alertsList[i].headline = `${newAlert.headline} (${alertsList[i]
+            .count!})`;
+          return { alerts: alertsList };
+        }
+      }
       return {
         alerts: [...prevState.alerts, newAlert],
       };

--- a/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
@@ -381,7 +381,7 @@ export default class UserPlaylists extends React.Component<
         const item = alertsList[i];
         if (
           item.type === newAlert.type &&
-          item.headline.includes(newAlert.headline) &&
+          item.headline.startsWith(newAlert.headline) &&
           item.message === newAlert.message
         ) {
           if (!alertsList[i].count) {

--- a/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
+++ b/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
@@ -151,16 +151,37 @@ export default class Recommendations extends React.Component<
   newAlert = (
     type: AlertType,
     headline: string,
-    message?: string | JSX.Element
+    message?: string | JSX.Element,
+    count?: number
   ): void => {
     const newAlert = {
       id: new Date().getTime(),
       type,
       headline,
       message,
+      count,
     } as Alert;
 
     this.setState((prevState) => {
+      const alertsList = prevState.alerts;
+      for (let i = 0; i < alertsList.length; i += 1) {
+        const item = alertsList[i];
+        if (
+          item.type === newAlert.type &&
+          item.headline.includes(newAlert.headline) &&
+          item.message === newAlert.message
+        ) {
+          if (!alertsList[i].count) {
+            // If the count attribute is undefined, then Initializing it as 2
+            alertsList[i].count = 2;
+          } else {
+            alertsList[i].count! += 1;
+          }
+          alertsList[i].headline = `${newAlert.headline} (${alertsList[i]
+            .count!})`;
+          return { alerts: alertsList };
+        }
+      }
       return {
         alerts: [...prevState.alerts, newAlert],
       };

--- a/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
+++ b/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
@@ -168,7 +168,7 @@ export default class Recommendations extends React.Component<
         const item = alertsList[i];
         if (
           item.type === newAlert.type &&
-          item.headline.includes(newAlert.headline) &&
+          item.headline.startsWith(newAlert.headline) &&
           item.message === newAlert.message
         ) {
           if (!alertsList[i].count) {

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -12,6 +12,7 @@ declare type Alert = {
   type: AlertType;
   headline: string;
   message: string | JSX.Element;
+  count?: number;
 };
 
 // TODO: Remove "| null" when backend stops sending fields with null

--- a/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
+++ b/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
@@ -236,16 +236,37 @@ export default class UserFeedPage extends React.Component<
   newAlert = (
     type: AlertType,
     title: string,
-    message: string | JSX.Element
+    message: string | JSX.Element,
+    count?: number
   ): void => {
     const newAlert: Alert = {
       id: new Date().getTime(),
       type,
       headline: title,
       message,
+      count,
     };
 
     this.setState((prevState) => {
+      const alertsList = prevState.alerts;
+      for (let i = 0; i < alertsList.length; i += 1) {
+        const item = alertsList[i];
+        if (
+          item.type === newAlert.type &&
+          item.headline.includes(newAlert.headline) &&
+          item.message === newAlert.message
+        ) {
+          if (!alertsList[i].count) {
+            // If the count attribute is undefined, then Initializing it as 2
+            alertsList[i].count = 2;
+          } else {
+            alertsList[i].count! += 1;
+          }
+          alertsList[i].headline = `${newAlert.headline} (${alertsList[i]
+            .count!})`;
+          return { alerts: alertsList };
+        }
+      }
       return {
         alerts: [...prevState.alerts, newAlert],
       };

--- a/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
+++ b/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
@@ -253,7 +253,7 @@ export default class UserFeedPage extends React.Component<
         const item = alertsList[i];
         if (
           item.type === newAlert.type &&
-          item.headline.includes(newAlert.headline) &&
+          item.headline.startsWith(newAlert.headline) &&
           item.message === newAlert.message
         ) {
           if (!alertsList[i].count) {


### PR DESCRIPTION
# Problem
Presently there are issues with YouTube playback and that generates a series of errors. This spams the user with error messages. These messages can be limited. [LB838 - Ticket link](https://tickets.metabrainz.org/projects/LB/issues/LB-838?filter=myopenissues)


# Solution
After discussing with others over IRC, I have implemented a basic change. If another error message with same type, title and message is encountered, the original error message is concatenated with the count of the error message. 

### Screen Recording:

[Screen Recording](https://user-images.githubusercontent.com/56514792/111285255-f4fdec00-8666-11eb-982c-cfa8e413b2a0.mp4)


# Some Clarifications
- I maintain count to be an optional argument. So that existing code at many places wouldn't have to be changed (The places where we trigger errors). Would this be fine?
- What I wanted to implement is that if it times out, then decrease error count by 1, if dismissed by user then close entire message but this seemed complex to implement because we are using a library for this notification. 
- I was not sure if variable name 'alertsList' is appropriate. The list temporarily stores the lists of alerts, I edit this array and use this to set the state. If there are any suggestions for this variable name, I'll implement it.


