### PR TITLE
Fix charts and reports pages for old browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4247,9 +4247,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
     },
     "core-js-compat": {
       "version": "3.6.4",
@@ -5985,6 +5985,13 @@
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
       }
     },
     "figgy-pudding": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nivo/legends": "^0.62.0",
     "@nivo/tooltip": "^0.62.0",
     "clean-css": "^4.2.1",
+    "core-js": "^3.9.1",
     "d3-format": "^1.4.4",
     "d3-scale": "^3.2.1",
     "d3-scale-chromatic": "^1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,8 @@ module.exports = function (env) {
                 [
                   "@babel/preset-env",
                   {
+                    useBuiltIns: "usage",
+                    corejs: { version: "3.9", proposals: true },
                     targets: {
                       node: "10",
                       browsers: ["> 0.2% and not dead", "firefox >= 44"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,8 @@ module.exports = function (env) {
       rules: [
         {
           test: /\.(js|ts)x?$/,
-          exclude: /node_modules/,
+          // some nivo/D3 dependencies need to be transpiled, we include them with the following regex
+          exclude: /node_modules\/(?!(d3-array|d3-scale|internmap)\/).*/,
           use: {
             loader: "babel-loader",
             options: {


### PR DESCRIPTION
Some of our dependencies of our graph libraries do not generate ES2015 code, therefore breaking the page completely on older versions of Firefox (< v.45) and IE.
Reference:
https://github.com/d3/d3-scale/releases/tag/v3.0.0
https://github.com/d3/d3-scale/issues/225
(related, although from another library altogether) https://github.com/swimlane/ngx-charts/issues/1369

This commit adds those libraries I found that need to be transpiled (there may be others) to our babel workflow in Webpack.
Dependencies are usually expected to be ES2015 and the node_modules folder is ignored by babel by default.

One other option was to use this utility that automatically detects libraries that are compiled to ES2015 and adds them to the workflow, but that didn't work so well for me when I tried: https://andersdjohnson.github.io/webpack-babel-env-deps/

I also added core-js as a dependency and set it up to transpile other parts of our code that were breaking on older browsers. A recent version of core-js fixes a specific issue with iterators on FF<45: https://github.com/zloirock/core-js/releases/tag/v3.8.3



This only affects the compiled javascript output, nothing in the codebase itself.