### PR TITLE
Delete items from .gitignore from previous tech stacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,10 @@
-.kitchen
-.vagrant
 .DS_Store
 *.pyc
 *.swp
 config.py
-custom_config.py
 *.log
 .cache
 env
-bigquery-credentials.json
 *.bak
 
 # tmp folder


### PR DESCRIPTION
We've removed vagrant, kitchen, and bigquery so remove their config
files from gitignore


