### PR TITLE
LB-793: validate-token endpoint takes token as an argument instead of header

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -605,6 +605,19 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json['user_name'],
                          self.user['musicbrainz_id'])
 
+    def test_token_validation_auth_header(self):
+        """Sends a valid token to api.validate_token in the Authorization header"""
+        url = url_for('api_v1.validate_token')
+        response = self.client.get(url, headers={
+            "Authorization": "Token {}".format(self.user['auth_token'])
+        })
+        self.assert200(response)
+        self.assertEqual(response.json['code'], 200)
+        self.assertEqual('Token valid.', response.json['message'])
+        self.assertTrue(response.json['valid'])
+        self.assertEqual(response.json['user_name'], self.user['musicbrainz_id'])
+
+
     def test_get_playing_now(self):
         """ Test for valid submission and retrieval of listen_type 'playing_now'
         """

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -414,7 +414,8 @@ def validate_token():
     header = request.headers.get('Authorization')
     if header:
         auth_token = header.split(" ")[1]
-    else:  # for backward compatibility, check for auth token in query parameters as well
+    else:
+        # for backwards compatibility, check for auth token in query parameters as well
         auth_token = request.args.get('token', '')
 
     if not auth_token:


### PR DESCRIPTION
LB-793

In all our other endpoints, we accept the token as a part of the `Authorization` header. However, the `validate-token` endpoint accepts it as a query parameter. To remove this inconsistency, the `validate-token` endpoint is now updated to accept the token as in the `Authorization` Header. If the header is missing, the query parameters are checked for the token for backward compatibility.