### PR TITLE
Reorganize Dockerfile sequence of events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,19 +64,26 @@ RUN groupadd --gid 901 listenbrainz_stats_cron
 RUN useradd --create-home --shell /bin/bash --uid 901 --gid 901 listenbrainz_stats_cron
 RUN mkdir /logs && chown lbdumps:lbdumps /logs
 
+# Create directories for backups and FTP syncs
+RUN mkdir /home/lbdumps/backup /home/lbdumps/ftp
+RUN chown -R lbdumps:lbdumps /home/lbdumps/backup /home/lbdumps/ftp
 
-COPY ./docker/run-lb-command /usr/local/bin
+# Install NodeJS and front-end dependencies
+RUN mkdir /static
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
+COPY package.json package-lock.json /static/
+WORKDIR /static
+RUN npm install
 
 # runit service files
 # All services are created with a `down` file, preventing them from starting
 # rc.local removes the down file for the specific service we want to run in a container
 # http://smarden.org/runit/runsv.8.html
 
+COPY ./docker/run-lb-command /usr/local/bin
+
 # cron
-COPY ./docker/services/cron/stats-crontab /etc/cron.d/stats-crontab
-RUN chmod 0644 /etc/cron.d/stats-crontab
-COPY ./docker/services/cron/dump-crontab /etc/cron.d/dump-crontab
-RUN chmod 0644 /etc/cron.d/dump-crontab
 COPY ./docker/services/cron/consul-template-cron-config.conf /etc/consul-template-cron-config.conf
 COPY ./docker/services/cron/cron-config.service /etc/service/cron-config/run
 RUN touch /etc/service/cron/down
@@ -122,23 +129,20 @@ RUN touch /etc/service/uwsgi/down
 
 COPY ./docker/rc.local /etc/rc.local
 
-# Create directories for backups and FTP syncs
-RUN mkdir /home/lbdumps/backup /home/lbdumps/ftp
-RUN chown -R lbdumps:lbdumps /home/lbdumps/backup /home/lbdumps/ftp
+# crontabs
+COPY ./docker/services/cron/stats-crontab /etc/cron.d/stats-crontab
+RUN chmod 0644 /etc/cron.d/stats-crontab
+COPY ./docker/services/cron/dump-crontab /etc/cron.d/dump-crontab
+RUN chmod 0644 /etc/cron.d/dump-crontab
 
-RUN mkdir /static
-WORKDIR /static
-
-# Compile static files
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
-COPY package.json package-lock.json webpack.config.js .eslintrc.js tsconfig.json ./listenbrainz/webserver/static /static/
-RUN npm install && npm run build:prod && ./node_modules/less/bin/lessc --clean-css /static/css/main.less > /static/css/main.css && \
-    rm -rf node_modules js/*.jsx *.json webpack.config.js .eslintrc.js && npm cache clean --force
+# Compile front-end (static) files
+COPY webpack.config.js .eslintrc.js tsconfig.json ./listenbrainz/webserver/static /static/
+RUN npm run build:prod
 
 # Now install our code, which may change frequently
 COPY . /code/listenbrainz/
 
 WORKDIR /code/listenbrainz
+# Ensure we use the right files and folders by removing duplicates
 RUN rm -rf ./listenbrainz/webserver/static/
 RUN rm -f /code/listenbrainz/listenbrainz/config.py /code/listenbrainz/listenbrainz/config.pyc

--- a/docker/Dockerfile.webpack
+++ b/docker/Dockerfile.webpack
@@ -3,8 +3,9 @@ FROM node:10.15-alpine AS webpack-base
 RUN mkdir /code
 WORKDIR /code
 
-COPY package.json package-lock.json webpack.config.js babel.config.js enzyme.config.ts jest.config.js tsconfig.json .eslintrc.js /code/
+COPY package.json package-lock.json /code/
 RUN npm install
+COPY webpack.config.js babel.config.js enzyme.config.ts jest.config.js tsconfig.json .eslintrc.js /code/
 
 # When running in metabrainz CI, we can't mount source into a container at runtime,
 # so we have a target here to add source to the image at build-time

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build:dev": "webpack --progress --colors",
-    "build:prod": "webpack -p --env production --progress --colors",
+    "build:prod": "webpack -p --env production --progress --colors & npm run build:prod:less",
+    "build:prod:less": "lessc /static/css/main.less > /static/css/main.css",
     "build:types": "tsc --emitDeclarationOnly",
     "build": "npm run build:dev",
     "format": "eslint ./static/js/src --ext .js,jsx,ts,tsx --fix --quiet",


### PR DESCRIPTION
We currently optimize our build for image size rather than build time.
After some discussion ruaok alastair and I agreed that we would rather optimize for build time by changing the order in which we run or Dockerfile operations.
In particular, installing NodeJS, copying and building front-end code was done in one command and we would remove the JS dependencies (node_modules) at the end of the command, saving the space of these dependencies in the final image, at the cost of having to reinstall Node and all the dependencies every time we build for prod, regardless of whether they have changed.

Instead, we move the installation of Node and of the dependencies much sooner in the image to have better caching and thus faster build times.