### PR TITLE
Upgrade brainzutils and integrate metrics endpoints

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -4,6 +4,7 @@ import sys
 from time import sleep
 from shutil import copyfile
 
+from brainzutils import metrics
 from brainzutils.flask import CustomFlask
 from flask import request, url_for, redirect
 from flask_login import current_user
@@ -101,6 +102,9 @@ def gen_app(config_path=None, debug=None):
 
     # Timescale connection
     create_timescale(app)
+
+    # Metrics
+    metrics.init('listenbrainz')
 
     # RabbitMQ connection
     try:
@@ -240,6 +244,9 @@ def _register_blueprints(app):
 
     from listenbrainz.webserver.views.api import api_bp
     app.register_blueprint(api_bp, url_prefix=API_PREFIX)
+
+    from listenbrainz.webserver.views.api_internal import api_internal
+    app.register_blueprint(api_internal, url_prefix='/internal')
 
     from listenbrainz.webserver.views.api_compat import api_bp as api_bp_compat
     app.register_blueprint(api_bp_compat)

--- a/listenbrainz/webserver/views/api_internal.py
+++ b/listenbrainz/webserver/views/api_internal.py
@@ -1,0 +1,18 @@
+from brainzutils import metrics
+from flask import Blueprint, jsonify
+
+# These views expose internal statistics for use in the MetaBrainz logging sytem
+# you're welcome to look at them youselves, but they are not supported outside
+# of our infrastructure
+
+api_internal = Blueprint('api_internal', __name__)
+
+
+@api_internal.route('/statistics')
+def statistics():
+    return jsonify(metrics.stats())
+
+
+@api_internal.route('/counter/<metric_name>')
+def statistics_counter(metric_name):
+    return jsonify(metrics.stats_count(metric_name))

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ yattag == 1.14.0
 xmltodict == 0.12.0
 oauth2client == 4.1.3
 pika == 0.13.0
-git+https://github.com/metabrainz/brainzutils-python.git@v1.16.1
+git+https://github.com/metabrainz/brainzutils-python.git@v1.17.0
 spotipy == 2.16.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster
 pyyaml == 5.4.1


### PR DESCRIPTION
# Problem

We sometimes want to count things

# Solution

Integrate the BU metrics module to let us count things!

In code, we can use these two methods to make metrics:
for things that count up:

    from brainzutils import metrics
    metrics.increment('foo')

for things that you want to set a value:

    metrics.set_count('messybrainz_match', artists=200, recordings=4432)


Then there are API endpoints available: 
`/internal/statistics` for _all_ metrics created by `increment`
![Screenshot 2021-03-24 at 6 18 00 PM](https://user-images.githubusercontent.com/19217/112355454-f31ed300-8ccd-11eb-939f-80f37cdb0b7e.png)

`/internal/counter/[counter_name]` for metrics created by `set_count`
![Screenshot 2021-03-24 at 6 19 11 PM](https://user-images.githubusercontent.com/19217/112355571-147fbf00-8cce-11eb-9476-1ba0ffd4d7b4.png)

# Action

Set up telegraf/logging/monitoring/etc to show these stats somewhere
