### PR TITLE
User Timeline: send notification events and potential bugfix

### DIFF
--- a/data/model/user_timeline_event.py
+++ b/data/model/user_timeline_event.py
@@ -42,7 +42,7 @@ class RecordingRecommendationMetadata(pydantic.BaseModel):
 
 
 class NotificationMetadata(pydantic.BaseModel):
-    creator_id: int
+    creator: str
     message: str
 
 
@@ -57,6 +57,10 @@ class UserTimelineEvent(pydantic.BaseModel):
     created: Optional[datetime]
 
 
+class APINotificationEvent(pydantic.BaseModel):
+    message: str
+
+
 class APIFollowEvent(pydantic.BaseModel):
     user_name_0: str
     user_name_1: str
@@ -64,7 +68,7 @@ class APIFollowEvent(pydantic.BaseModel):
     created: int
 
 
-APIEventMetadata = Union[APIListen, APIFollowEvent]
+APIEventMetadata = Union[APIListen, APIFollowEvent, APINotificationEvent]
 
 
 class APITimelineEvent(pydantic.BaseModel):

--- a/listenbrainz/db/tests/test_user_timeline_event.py
+++ b/listenbrainz/db/tests/test_user_timeline_event.py
@@ -91,13 +91,13 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
         event = db_user_timeline_event.create_user_notification_event(
             user_id=self.user['id'],
             metadata=NotificationMetadata(
-                creator_id=self.user['id'],
+                creator=self.user['musicbrainz_id'],
                 message=message,
             )
         )
         self.assertEqual(self.user['id'], event.user_id)
         self.assertEqual(message, event.metadata.message)
-        self.assertEqual(self.user['id'], event.metadata.creator_id)
+        self.assertEqual(self.user['musicbrainz_id'], event.metadata.creator)
         self.assertEqual(UserTimelineEventType.NOTIFICATION, event.event_type)
 
     def test_get_events_only_gets_events_for_the_specified_user(self):

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -138,3 +138,15 @@ def get_recording_recommendation_events_for_feed(user_ids: List[int], min_ts: in
         })
 
         return [UserTimelineEvent(**row) for row in result.fetchall()]
+
+
+def get_user_notification_events(user_id: int, count: int = 50) -> List[UserTimelineEvent]:
+    """ Gets notification posted on the user's timeline.
+
+    The optional `count` parameter can be used to control the number of events being returned.
+    """
+    return get_user_timeline_events(
+        user_id=user_id,
+        event_type=UserTimelineEventType.NOTIFICATION,
+        count=count
+    )

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -172,20 +172,12 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
             url_for('user_timeline_event_api_bp.user_feed', user_name=self.user['musicbrainz_id']),
             headers={'Authorization': 'Token {}'.format(self.user['auth_token'])}
         )
-        expected_json = {
-            'payload': {
-                'count': 1,
-                'events': [
-                    {
-                        'created': 1616745110,
-                        'event_type': 'notification',
-                        'metadata': {
-                            'message': 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'
-                        },
-                        'user_name': approved_user['musicbrainz_id']
-                    }
-                ],
-                'user_id': self.user['musicbrainz_id']
-            }
-        }
-        self.assertEqual(expected_json, r.json)
+
+        payload = r.json['payload']
+        self.assertEqual(1, payload['count'])
+        self.assertEqual(self.user['musicbrainz_id'], payload['user_id'])
+
+        event = payload['events'][0]
+        self.assertEqual('notification', event['event_type'])
+        self.assertEqual('You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>',event['metadata']['message'])
+        self.assertEqual(approved_user['musicbrainz_id'], event['user_name'])

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -179,5 +179,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         event = payload['events'][0]
         self.assertEqual('notification', event['event_type'])
-        self.assertEqual('You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>',event['metadata']['message'])
+        self.assertEqual('You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>',
+                         event['metadata']['message'])
         self.assertEqual(approved_user['musicbrainz_id'], event['user_name'])

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -180,16 +180,13 @@ def user_feed(user_name: str):
         max_ts = int(time.time())
 
     users_following = db_user_relationship.get_following_for_user(user['id'])
-    if len(users_following) == 0:
-        return jsonify({'payload': {
-            'count': 0,
-            'user_id': user_name,
-            'events': [],
-        }})
 
     # get all listen events
     musicbrainz_ids = [user['musicbrainz_id'] for user in users_following]
-    listen_events = get_listen_events(db_conn, musicbrainz_ids, min_ts, max_ts, count, time_range)
+    if len(users_following) == 0:
+        listen_events = []
+    else:
+        listen_events = get_listen_events(db_conn, musicbrainz_ids, min_ts, max_ts, count, time_range)
 
     # for events like "follow" and "recording recommendations", we want to show the user
     # their own events as well


### PR DESCRIPTION
In #1342, I had forgotten to update the `user_feed` endpoint to send notification events as well to the frontend. I realised this while testing #1359 locally. This PR in conjunction with the other two successfully displays the notification events in the feed.

![Screenshot from 2021-03-26 13-41-12](https://user-images.githubusercontent.com/27751938/112602757-1797be00-8e3a-11eb-8fed-d276c43de3e0.png)

During testing, I also found a potential bug. If I do not follow a user, no events are sent for my timeline. For example, I do not follow anyone and recommend a track to my followers, this event does not show up in my timeline.

(In the attached image, it does because it was taken after the fix but the problem is easily reproducible in production just unfollow all users and open your timeline.)