### PR TITLE
Pass API URL to FollowButton component

### DIFF
--- a/listenbrainz/webserver/static/js/src/FollowButton.test.tsx
+++ b/listenbrainz/webserver/static/js/src/FollowButton.test.tsx
@@ -39,6 +39,7 @@ describe("<FollowButton />", () => {
       <FollowButton
         type="icon-only"
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={loggedInUser}
         loggedInUserFollowsUser
       />
@@ -50,6 +51,7 @@ describe("<FollowButton />", () => {
       <FollowButton
         type="block"
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={loggedInUser}
         loggedInUserFollowsUser={false}
       />
@@ -63,6 +65,7 @@ describe("<FollowButton />", () => {
       <FollowButton
         type="icon-only"
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={loggedInUser}
         loggedInUserFollowsUser
       />
@@ -74,6 +77,7 @@ describe("<FollowButton />", () => {
       <FollowButton
         type="icon-only"
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={loggedInUser}
         loggedInUserFollowsUser={false}
       />
@@ -109,6 +113,7 @@ describe("<FollowButton />", () => {
         <FollowButton
           type="icon-only"
           user={user}
+          apiUrl="http://0.0.0.0"
           loggedInUser={loggedInUser}
           loggedInUserFollowsUser={false}
         />
@@ -125,6 +130,7 @@ describe("<FollowButton />", () => {
         <FollowButton
           type="icon-only"
           user={user}
+          apiUrl="http://0.0.0.0"
           loggedInUser={loggedInUser}
           loggedInUserFollowsUser
         />

--- a/listenbrainz/webserver/static/js/src/FollowButton.tsx
+++ b/listenbrainz/webserver/static/js/src/FollowButton.tsx
@@ -65,7 +65,9 @@ class FollowButton extends React.Component<
 
     const { apiUrl } = this.props;
 
-    this.APIService = new APIService(apiUrl);
+    this.APIService = new APIService(
+      props.apiUrl || `${window.location.origin}/1`
+    );
   }
 
   componentDidUpdate(prevProps: FollowButtonProps) {

--- a/listenbrainz/webserver/static/js/src/FollowButton.tsx
+++ b/listenbrainz/webserver/static/js/src/FollowButton.tsx
@@ -38,6 +38,7 @@ type FollowButtonProps = {
     user: ListenBrainzUser,
     action: "follow" | "unfollow"
   ) => void;
+  apiUrl: string;
 };
 
 type FollowButtonState = {
@@ -62,7 +63,9 @@ class FollowButton extends React.Component<
       error: false,
     };
 
-    this.APIService = new APIService(`${window.location.origin}/1`);
+    const { apiUrl } = this.props;
+
+    this.APIService = new APIService(apiUrl);
   }
 
   componentDidUpdate(prevProps: FollowButtonProps) {

--- a/listenbrainz/webserver/static/js/src/UserPageHeading.test.tsx
+++ b/listenbrainz/webserver/static/js/src/UserPageHeading.test.tsx
@@ -38,6 +38,7 @@ describe("<UserPageHeading />", () => {
     const wrapper = shallow(
       <UserPageHeading
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={loggedInUser}
         loggedInUserFollowsUser
       />
@@ -49,6 +50,7 @@ describe("<UserPageHeading />", () => {
     const wrapper = shallow(
       <UserPageHeading
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={null}
         loggedInUserFollowsUser={false}
       />
@@ -60,6 +62,7 @@ describe("<UserPageHeading />", () => {
     const wrapper = shallow(
       <UserPageHeading
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={user}
         loggedInUserFollowsUser={false}
       />
@@ -71,6 +74,7 @@ describe("<UserPageHeading />", () => {
     const wrapper = shallow(
       <UserPageHeading
         user={user}
+        apiUrl="http://0.0.0.0"
         loggedInUser={loggedInUser}
         loggedInUserFollowsUser={false}
       />
@@ -79,6 +83,7 @@ describe("<UserPageHeading />", () => {
     expect(followButton.props()).toEqual({
       type: "icon-only",
       user: { id: 1, name: "followed_user" },
+      apiUrl: "http://0.0.0.0",
       loggedInUser: { id: 2, name: "iliekcomputers" },
       loggedInUserFollowsUser: false,
     });

--- a/listenbrainz/webserver/static/js/src/UserPageHeading.tsx
+++ b/listenbrainz/webserver/static/js/src/UserPageHeading.tsx
@@ -24,10 +24,12 @@ import FollowButton from "./FollowButton";
 
 const UserPageHeading = ({
   user,
+  apiUrl,
   loggedInUser,
   loggedInUserFollowsUser = false,
 }: {
   user: ListenBrainzUser;
+  apiUrl: string;
   loggedInUser: ListenBrainzUser | null;
   loggedInUserFollowsUser: boolean;
 }) => {
@@ -38,6 +40,7 @@ const UserPageHeading = ({
         <FollowButton
           type="icon-only"
           user={user}
+          apiUrl={apiUrl}
           loggedInUser={loggedInUser}
           loggedInUserFollowsUser={loggedInUserFollowsUser}
         />
@@ -53,10 +56,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const propsElement = document.getElementById("react-props");
   const reactProps = JSON.parse(propsElement!.innerHTML);
-  const { user, current_user, logged_in_user_follows_user } = reactProps;
+  const {
+    user,
+    current_user,
+    logged_in_user_follows_user,
+    api_url,
+  } = reactProps;
   ReactDOM.render(
     <UserPageHeading
       user={user}
+      apiUrl={api_url}
       loggedInUser={current_user || null}
       loggedInUserFollowsUser={logged_in_user_follows_user}
     />,

--- a/listenbrainz/webserver/static/js/src/follow/FollowerFollowingModal.test.tsx
+++ b/listenbrainz/webserver/static/js/src/follow/FollowerFollowingModal.test.tsx
@@ -24,6 +24,7 @@ import FollowerFollowingModal from "./FollowerFollowingModal";
 
 const props = {
   user: { name: "foobar" },
+  apiUrl: "http://0.0.0.0",
   loggedInUser: null,
   followerList: ["foo"],
   followingList: ["bar"],

--- a/listenbrainz/webserver/static/js/src/follow/FollowerFollowingModal.tsx
+++ b/listenbrainz/webserver/static/js/src/follow/FollowerFollowingModal.tsx
@@ -5,6 +5,7 @@ import Pill from "../components/Pill";
 import UserListModalEntry from "./UserListModalEntry";
 
 export type FollowerFollowingModalProps = {
+  apiUrl: string;
   user: ListenBrainzUser;
   loggedInUser: ListenBrainzUser | null;
   followerList: Array<string>;
@@ -42,6 +43,7 @@ export default class FollowerFollowingModal extends React.Component<
       updateFollowingList,
       followerList,
       followingList,
+      apiUrl,
     } = this.props;
     const { activeMode } = this.state;
 
@@ -76,6 +78,7 @@ export default class FollowerFollowingModal extends React.Component<
               <UserListModalEntry
                 mode="follow-following"
                 key={listEntry}
+                apiUrl={apiUrl}
                 user={formattedAsUser}
                 loggedInUser={loggedInUser}
                 loggedInUserFollowsUser={loggedInUserFollowsUser(

--- a/listenbrainz/webserver/static/js/src/follow/SimilarUsersModal.test.tsx
+++ b/listenbrainz/webserver/static/js/src/follow/SimilarUsersModal.test.tsx
@@ -4,6 +4,7 @@ import SimilarUsersModal from "./SimilarUsersModal";
 
 const props = {
   user: { name: "shivam-kapila" },
+  apiUrl: "http://0.0.0.0",
   loggedInUser: null,
   List: [{ name: "mr_monkey" }],
   similarUsersList: [{ name: "mr_monkey", similarityScore: 0.567 }],

--- a/listenbrainz/webserver/static/js/src/follow/SimilarUsersModal.tsx
+++ b/listenbrainz/webserver/static/js/src/follow/SimilarUsersModal.tsx
@@ -5,6 +5,7 @@ import UserListModalEntry from "./UserListModalEntry";
 
 export type SimilarUsersModalProps = {
   user: ListenBrainzUser;
+  apiUrl: string;
   loggedInUser: ListenBrainzUser | null;
   similarUsersList: Array<SimilarUser>;
   loggedInUserFollowsUser: (user: ListenBrainzUser | SimilarUser) => boolean;
@@ -21,6 +22,7 @@ const SimilarUsersModal = (props: SimilarUsersModalProps) => {
     loggedInUserFollowsUser,
     updateFollowingList,
     similarUsersList,
+    apiUrl,
   } = props;
 
   return (
@@ -35,6 +37,7 @@ const SimilarUsersModal = (props: SimilarUsersModalProps) => {
               mode="similar-users"
               key={listEntry.name}
               user={listEntry}
+              apiUrl={apiUrl}
               loggedInUser={loggedInUser}
               loggedInUserFollowsUser={loggedInUserFollowsUser(listEntry)}
               updateFollowingList={updateFollowingList}

--- a/listenbrainz/webserver/static/js/src/follow/UserListModalEntry.tsx
+++ b/listenbrainz/webserver/static/js/src/follow/UserListModalEntry.tsx
@@ -7,6 +7,7 @@ export type UserListModalEntryProps = {
   mode: "follow-following" | "similar-users";
   user: ListenBrainzUser | SimilarUser;
   loggedInUser: ListenBrainzUser | null;
+  apiUrl: string;
   loggedInUserFollowsUser: boolean;
   updateFollowingList: (
     user: ListenBrainzUser,
@@ -21,6 +22,7 @@ const UserListModalEntry = (props: UserListModalEntryProps) => {
     loggedInUserFollowsUser,
     loggedInUser,
     updateFollowingList,
+    apiUrl,
   } = props;
   return (
     <>
@@ -45,6 +47,7 @@ const UserListModalEntry = (props: UserListModalEntryProps) => {
           <FollowButton
             type="block"
             user={user}
+            apiUrl={apiUrl}
             loggedInUser={loggedInUser}
             loggedInUserFollowsUser={loggedInUserFollowsUser}
             updateFollowingList={updateFollowingList}

--- a/listenbrainz/webserver/static/js/src/follow/UserSocialNetwork.tsx
+++ b/listenbrainz/webserver/static/js/src/follow/UserSocialNetwork.tsx
@@ -121,7 +121,7 @@ export default class UserSocialNetwork extends React.Component<
   };
 
   render() {
-    const { user, loggedInUser } = this.props;
+    const { user, loggedInUser, apiUrl } = this.props;
     const { followerList, followingList, similarUsersList } = this.state;
     return (
       <>
@@ -130,6 +130,7 @@ export default class UserSocialNetwork extends React.Component<
           loggedInUser={loggedInUser}
           followerList={followerList}
           followingList={followingList}
+          apiUrl={apiUrl}
           loggedInUserFollowsUser={this.loggedInUserFollowsUser}
           updateFollowingList={this.updateFollowingList}
         />
@@ -137,6 +138,7 @@ export default class UserSocialNetwork extends React.Component<
           user={user}
           loggedInUser={loggedInUser}
           similarUsersList={similarUsersList}
+          apiUrl={apiUrl}
           loggedInUserFollowsUser={this.loggedInUserFollowsUser}
           updateFollowingList={this.updateFollowingList}
         />


### PR DESCRIPTION
FollowButton is not using the API URL to call follow and unfollow endpoints. As we have moved those endpoints to API now, we need to modify it to use the API URL. Instead of reading the props again in the FollowButton component, we pass it down the hierarchy of components.