### PR TITLE
Add not None checks at a few places

### DIFF
--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -31,6 +31,9 @@ def notify_error(musicbrainz_row_id, error):
         error (str): a description of the error encountered.
     """
     user_email = mb_editor.get_editor_by_id(musicbrainz_row_id)['email']
+    if not user_email:
+        return
+
     spotify_url = current_app.config['SERVER_ROOT_URL'] + '/profile/connect-spotify'
     text = render_template('emails/spotify_import_error.txt', error=error, link=spotify_url)
     send_mail(

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -5,9 +5,9 @@ import json
 
 from datetime import datetime
 from listenbrainz.utils import safely_import_config
-from listenbrainz.webserver.errors import APIBadRequest
-
 safely_import_config()
+
+from listenbrainz.webserver.errors import APIBadRequest
 
 from dateutil import parser
 from flask import current_app, render_template
@@ -275,11 +275,13 @@ def process_one_user(user):
         listenbrainz_user = db_user.get(user.user_id)
 
         currently_playing = get_user_currently_playing(user)
-        if currently_playing is not None and 'item' in currently_playing and currently_playing['item'] is not None:
-            current_app.logger.debug('Received a currently playing track for %s', str(user))
-            listens = parse_and_validate_spotify_plays([currently_playing['item']], LISTEN_TYPE_PLAYING_NOW)
-            if listens:
-                submit_listens_to_listenbrainz(listenbrainz_user, listens, listen_type=LISTEN_TYPE_PLAYING_NOW)
+        if currently_playing is not None:
+            currently_playing_item = currently_playing.get('item', None)
+            if currently_playing_item is not None:
+                current_app.logger.debug('Received a currently playing track for %s', str(user))
+                listens = parse_and_validate_spotify_plays([currently_playing_item], LISTEN_TYPE_PLAYING_NOW)
+                if listens:
+                    submit_listens_to_listenbrainz(listenbrainz_user, listens, listen_type=LISTEN_TYPE_PLAYING_NOW)
 
         recently_played = get_user_recently_played(user)
         if recently_played is not None and 'items' in recently_played:

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -274,10 +274,13 @@ def process_one_user(user):
 
         listenbrainz_user = db_user.get(user.user_id)
 
+        # If there is no playback, currently_playing will be None.
+        # There are two playing types, track and episode. We use only the
+        # track type. Therefore, when the user's playback type is not a track,
+        # Spotify will set the item field to null which becomes None after
+        # parsing the JSON. Due to these reasons, we cannot simplify the
+        # checks below.
         currently_playing = get_user_currently_playing(user)
-        # There are two playing types, track and episode. We use only track.
-        # When the user's playback type is an episode, Spotify will set the
-        # field to null which becomes None after parsing the JSON.
         if currently_playing is not None:
             currently_playing_item = currently_playing.get('item', None)
             if currently_playing_item is not None:

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -275,6 +275,9 @@ def process_one_user(user):
         listenbrainz_user = db_user.get(user.user_id)
 
         currently_playing = get_user_currently_playing(user)
+        # There are two playing types, track and episode. We use only track.
+        # When the user's playback type is an episode, Spotify will set the
+        # field to null which becomes None after parsing the JSON.
         if currently_playing is not None:
             currently_playing_item = currently_playing.get('item', None)
             if currently_playing_item is not None:

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -272,7 +272,7 @@ def process_one_user(user):
         listenbrainz_user = db_user.get(user.user_id)
 
         currently_playing = get_user_currently_playing(user)
-        if currently_playing is not None and 'item' in currently_playing:
+        if currently_playing is not None and 'item' in currently_playing and currently_playing['item'] is not None:
             current_app.logger.debug('Received a currently playing track for %s', str(user))
             listens = parse_and_validate_spotify_plays([currently_playing['item']], LISTEN_TYPE_PLAYING_NOW)
             if listens:

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -124,6 +124,7 @@ class ConvertListensTestCase(DatabaseTestCase):
     @patch('listenbrainz.domain.spotify.get_active_users_to_process')
     def test_spotipy_methods_are_called_with_correct_params(self, mock_get_active_users):
         self.spotify_user.get_spotipy_client = MagicMock()
+        self.spotify_user.get_spotipy_client.return_value.current_user_playing_track.return_value = None
         mock_get_active_users.return_value = [self.spotify_user]
 
         with listenbrainz.webserver.create_app().app_context():
@@ -136,6 +137,7 @@ class ConvertListensTestCase(DatabaseTestCase):
     def test_spotipy_methods_are_called_with_correct_params_with_no_latest_listened_at(self, mock_get_active_users):
         self.spotify_user.latest_listened_at = None
         self.spotify_user.get_spotipy_client = MagicMock()
+        self.spotify_user.get_spotipy_client.return_value.current_user_playing_track.return_value = None
         mock_get_active_users.return_value = [self.spotify_user]
 
         with listenbrainz.webserver.create_app().app_context():

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -268,7 +268,10 @@ def get_similar_users(user_name):
     user = db_user.get_by_mb_id(user_name)
     if not user:
         raise APINotFound("User %s not found" % user_name)
+
     similar_users = db_user.get_similar_users(user['id'])
+    if not similar_users:
+        return jsonify({'payload': []})
 
     response = []
     for user_name in similar_users.similar_users:


### PR DESCRIPTION
Sentry has multiple different errors that occur due to performing some operation on `None`. This can easily be mitigated by adding checks for None as required.