### PR TITLE
Add artist credit recording lookup to labs api & MBID mapping improvements

### DIFF
--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import psycopg2
+import psycopg2.extras
+from datasethoster import Query
+from unidecode import unidecode
+
+import config
+
+
+class ArtistCreditRecordingLookupQuery(Query):
+
+    def names(self):
+        return ("acr-lookup", "MusicBrainz Artist Credit Recording lookup")
+
+    def inputs(self):
+        return ['artist_credit_name', 'recording_name']
+
+    def introduction(self):
+        return """This lookup performs an semi-exact string match on Artist Credit and Recording. The given parameters will have non-word
+                  characters removed, unaccted and lower cased before being looked up in the database."""
+
+    def outputs(self):
+        return ['artist_credit_name', 'release_name', 'recording_name', 
+                'artist_credit_id', 'release_mbid', 'recording_mbid']
+
+    def fetch(self, params, offset=-1, count=-1):
+        artists = []
+        recordings = []
+        for param in params:
+            artists.append("".join(unidecode(param['artist_credit_name'].lower()).split()))
+            recordings.append("".join(unidecode(param['recording_name'].lower()).split()))
+        artists = tuple(artists)
+        recordings = tuple(recordings)
+
+        with psycopg2.connect(config.DB_CONNECT_MB) as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+                curs.execute("""SELECT DISTINCT ac.name AS artist_credit_name, 
+                                       rl.name AS release_name, 
+                                       r.name AS recording_name,
+                                       rl.gid AS release_mbid,
+                                       r.gid AS recording_mbid,
+                                       artist_credit_id
+                                  FROM mapping.recording_artist_credit_pairs
+                                  JOIN recording r
+                                    ON r.id = recording_id
+                                  JOIN release rl
+                                    ON rl.id = release_id
+                                  JOIN artist_credit ac
+                                    ON r.artist_credit = ac.id
+                                 WHERE artist_credit_name IN %s
+                                   AND recording_name IN %s""", (artists, recordings))
+
+                results = []
+                while True:
+                    data = curs.fetchone()
+                    if not data:
+                        break
+
+                    results.append(dict(data))
+
+                return results

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -8,6 +8,7 @@ from listenbrainz.labs_api.labs.api.recording_from_recording_mbid import Recordi
 from listenbrainz.labs_api.labs.api.mbid_mapping import MBIDMappingQuery
 from listenbrainz.labs_api.labs.api.year_from_artist_credit_recording import YearFromArtistCreditRecordingQuery
 from listenbrainz.labs_api.labs.api.recording_search import RecordingSearchQuery
+from listenbrainz.labs_api.labs.api.artist_credit_recording_lookup import ArtistCreditRecordingLookupQuery
 from listenbrainz.webserver import load_config
 
 register_query(ArtistCountryFromArtistMBIDQuery())
@@ -17,6 +18,7 @@ register_query(RecordingFromRecordingMBIDQuery())
 register_query(MBIDMappingQuery())
 register_query(YearFromArtistCreditRecordingQuery())
 register_query(RecordingSearchQuery())
+register_query(ArtistCreditRecordingLookupQuery())
 
 app = create_app()
 load_config(app)

--- a/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
+++ b/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
@@ -27,11 +27,11 @@ def create_tables(mb_conn):
             curs.execute("DROP TABLE IF EXISTS mapping.tmp_mbid_mapping")
             curs.execute("""CREATE TABLE mapping.tmp_mbid_mapping (
                                          recording_name            TEXT NOT NULL,
-                                         recording_id              INTEGER NOT NULL,
+                                         recording_mbid            UUID NOT NULL,
                                          artist_credit_name        TEXT NOT NULL,
                                          artist_credit_id          INTEGER NOT NULL,
                                          release_name              TEXT NOT NULL,
-                                         release_id                INTEGER NOT NULL,
+                                         release_mbid              UUID NOT NULL,
                                          combined_lookup           TEXT NOT NULL,
                                          score                     INTEGER NOT NULL)""")
             curs.execute("DROP TABLE IF EXISTS mapping.tmp_mbid_mapping_releases")
@@ -192,11 +192,11 @@ def create_mbid_mapping():
                 batch_count = 0
                 log("mbid mapping: fetch recordings")
                 mb_curs.execute("""SELECT r.name AS recording_name,
-                                          r.id AS recording_id,
+                                          r.gid AS recording_mbid,
                                           ac.name AS artist_credit_name,
                                           ac.id AS artist_credit_id,
                                           rl.name AS release_name,
-                                          rl.id AS release_id,
+                                          rl.gid AS release_mbid,
                                           rpr.id AS score
                                      FROM recording r
                                      JOIN artist_credit ac
@@ -213,7 +213,7 @@ def create_mbid_mapping():
                                        ON rl.id = rpr.release
                                 LEFT JOIN release_country rc
                                        ON rc.release = rl.id
-                                    GROUP BY rpr.id, ac.id, rl.id, artist_credit_name, r.id, r.name, release_name
+                                    GROUP BY rpr.id, ac.id, rl.gid, artist_credit_name, r.gid, r.name, release_name
                                     ORDER BY ac.id, rpr.id""")
                 while True:
                     row = mb_curs.fetchone()
@@ -244,9 +244,9 @@ def create_mbid_mapping():
                         release_name = row['release_name']
                         combined_lookup = unidecode(re.sub(r'[^\w]+', '', artist_credit_name + recording_name).lower())
                         if recording_name not in artist_recordings:
-                            artist_recordings[recording_name] = (recording_name, row['recording_id'],
+                            artist_recordings[recording_name] = (recording_name, row['recording_mbid'],
                                                                  artist_credit_name, row['artist_credit_id'],
-                                                                 release_name, row['release_id'], combined_lookup,
+                                                                 release_name, row['release_mbid'], combined_lookup,
                                                                  row['score'])
                     except TypeError:
                         log(row)

--- a/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
+++ b/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
@@ -1,3 +1,5 @@
+import re
+
 import psycopg2
 from psycopg2.errors import OperationalError
 from unidecode import unidecode
@@ -53,7 +55,7 @@ def create_indexes(conn):
         with conn.cursor() as curs:
             curs.execute("""CREATE INDEX tmp_mbid_mapping_idx_artist_credit_recording_name
                                       ON mapping.tmp_mbid_mapping(artist_credit_name, recording_name)""")
-            curs.execute("""CREATE UNIQUE INDEX tmp_mbid_mapping_idx_combined_lookup
+            curs.execute("""CREATE INDEX tmp_mbid_mapping_idx_combined_lookup
                                       ON mapping.tmp_mbid_mapping(combined_lookup)""")
         conn.commit()
     except OperationalError as err:
@@ -176,8 +178,9 @@ def create_mbid_mapping():
         with mb_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as mb_curs:
 
             # Create the dest table (perhaps dropping the old one first)
-            log("mbid mapping: drop old tables, create new tables")
+            log("mbid mapping: create schema")
             create_schema(mb_conn)
+            log("mbid mapping: drop old tables, create new tables")
             create_tables(mb_conn)
 
             create_temp_release_table(mb_conn)

--- a/listenbrainz/mbid_mapping/mapping/typesense_index.py
+++ b/listenbrainz/mbid_mapping/mapping/typesense_index.py
@@ -92,18 +92,14 @@ def build(client, collection_name):
             curs.execute("SELECT max(score) FROM mapping.mbid_mapping")
             max_score = curs.fetchone()[0]
 
-            query = ("""SELECT recording_name AS recording_name,
-                               r.gid AS recording_mbid,
-                               release_name AS release_name,
-                               rl.gid AS release_mbid,
-                               artist_credit_name AS artist_credit_name,
+            query = ("""SELECT recording_name,
+                               recording_mbid,
+                               release_name,
+                               release_mbid,
+                               artist_credit_name,
                                artist_credit_id,
                                score
-                          FROM mapping.mbid_mapping
-                          JOIN recording r
-                            ON r.id = recording_id
-                          JOIN release rl
-                            ON rl.id = release_id""")
+                          FROM mapping.mbid_mapping""")
 
             if config.USE_MINIMAL_DATASET:
                 query += " WHERE artist_credit_id = 1160983"


### PR DESCRIPTION
While working on the MBID mapping writer it became clear that we're getting a lot more exact matches than I expected now and that the artist credit recording dataset is perfect for this. Postgres can handle these queries much faster than typesense, so this new endpoint allows me to send the majority of traffic to postgres and not to typesense.