### PR TITLE
Automatically build and push image to Docker Hub when new tag is pushed

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,7 @@ name: Build image and publish to Docker Hub
 on:
   push:
     tags:
-      - '*'
+      - 'v-[0-9]{4}-[0-9]{2}-[0-9]{1,2}.[0-9]+'
 
 jobs:
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,23 @@
+name: Build image and publish to Docker Hub
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  deploy:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Login to Docker Hub
+      run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+    
+    - name: Build and push image
+      # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME. 
+      # Using shell parameter expansion, we extract the TAG_NAME.
+      run: ./docker/push.sh 'prod' "${GITHUB_REF/refs\/tags\//}"


### PR DESCRIPTION
Our deployment workflow is a bit convoluted. One step in simplifying the deployment is to automate building of docker images. Hence, adding an actions workflow for it.