### PR TITLE
Fix user similarity thresholding

### DIFF
--- a/docker/services/cron/stats-crontab
+++ b/docker/services/cron/stats-crontab
@@ -61,7 +61,7 @@ MAILTO=""
 10 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=all_time
 
 # user similarity dataframes
-20 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_dataframes --job-type="similar_users" --days=730 --listens-threshold=200
+20 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_dataframes --job-type="similar_users" --days=365 --listens-threshold=50
 
 # user similarity
 30 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_similar_users 

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -259,12 +259,12 @@ def request_import_artist_relation():
 
 
 @cli.command(name='request_similar_users')
-@click.option("--threshold", type=float, default=.075, help="Threshold for minimum relationship strenth between two users.")
-def request_similar_users(threshold):
+@click.option("--max-num-users", type=int, default=25, help="The maxiumum number of similar users to return for any given user.")
+def request_similar_users(max_num_users):
     """ Send the cluster a request to generate similar users.
     """
     params = {
-        'threshold': threshold
+        'max_num_users': max_num_users
     }
     send_request_to_spark_cluster(_prepare_query_message(
         'similarity.similar_users', params=params))

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -147,7 +147,7 @@
     "name": "similarity.similar_users",
     "description": "Generate similar user correlation",
     "params": [
-      "threshold"
+      "max_num_users"
     ]
   }
 }

--- a/listenbrainz/spark/test_request_manage.py
+++ b/listenbrainz/spark/test_request_manage.py
@@ -199,7 +199,7 @@ class RequestManageTestCase(unittest.TestCase):
         message = {
             'query': 'similarity.similar_users',
             'params': {
-                'threshold': .3
+                'max_num_users': 25 
             }
         }
         expected_message = ujson.dumps(message)

--- a/listenbrainz_spark/user_similarity/user_similarity.py
+++ b/listenbrainz_spark/user_similarity/user_similarity.py
@@ -80,7 +80,9 @@ def threshold_similar_users(matrix: ndarray, max_user_count: int) -> List[Tuple[
 
             row.append((x, y, (float(matrix[x, y]) - min_similarity) / similarity_range))
 
-        similar_users.extend(sorted(row, itemgetter(2), reverse=True)[:max_user_count])
+        row = sorted(row, key=itemgetter(2), reverse=True)[:max_user_count]
+        current_app.logger.info(row)
+        similar_users.extend(row)
 
     return similar_users
 

--- a/listenbrainz_spark/user_similarity/user_similarity.py
+++ b/listenbrainz_spark/user_similarity/user_similarity.py
@@ -79,7 +79,7 @@ def threshold_similar_users(matrix: ndarray, max_user_count: int) -> List[Tuple[
             if x == y or math.isnan(value):
                 continue
 
-            row.append((x, y, value - min_similarity) / similarity_range))
+            row.append((x, y, (value - min_similarity) / similarity_range))
 
         row = sorted(row, key=itemgetter(2), reverse=True)[:max_user_count]
         current_app.logger.info(row)

--- a/listenbrainz_spark/user_similarity/user_similarity.py
+++ b/listenbrainz_spark/user_similarity/user_similarity.py
@@ -75,10 +75,11 @@ def threshold_similar_users(matrix: ndarray, max_user_count: int) -> List[Tuple[
     for x in range(rows):
         row = []
         for y in range(cols):
-            if x == y:
+            value = float(matrix[x, y])
+            if x == y or math.isnan(value):
                 continue
 
-            row.append((x, y, (float(matrix[x, y]) - min_similarity) / similarity_range))
+            row.append((x, y, value - min_similarity) / similarity_range))
 
         row = sorted(row, key=itemgetter(2), reverse=True)[:max_user_count]
         current_app.logger.info(row)


### PR DESCRIPTION
The absolute threshold method of limiting max number of similar users wasn't working well. Changing it from an absolute value threshold to a max number of users per user threshold works much better and is more future proof.

This PR also commits a number of tweaked settings (reduce dataframe days to 1 year and minimum listens to 50) that give good results for a broad number of users.