### PR TITLE
Setup request consumer for new cluster

### DIFF
--- a/Dockerfile.spark.newcluster
+++ b/Dockerfile.spark.newcluster
@@ -1,5 +1,17 @@
 FROM metabrainz/python:3.7-20210115
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    wget \
+    git \
+    net-tools \
+    dnsutils \
+    bsdmainutils \
+    xz-utils \
+    pxz \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip3 install pip==21.0.1
 
 RUN mkdir /rec

--- a/Dockerfile.spark.newcluster
+++ b/Dockerfile.spark.newcluster
@@ -1,0 +1,10 @@
+FROM metabrainz/python:3.7-20210115
+
+RUN pip3 install pip==21.0.1
+
+RUN mkdir /rec
+WORKDIR /rec
+COPY requirements_spark.txt /rec/requirements_spark.txt
+RUN pip3 install -r requirements_spark.txt
+
+COPY . /rec

--- a/Dockerfile.spark.newcluster
+++ b/Dockerfile.spark.newcluster
@@ -1,4 +1,4 @@
-FROM metabrainz/python:3.7-20210115
+FROM metabrainz/python:3.8-20210115
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/spark-new-cluster/push-request-consumer.sh
+++ b/docker/spark-new-cluster/push-request-consumer.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../"
+
+docker build -t metabrainz/listenbrainz-spark-new-cluster -f Dockerfile.spark.newcluster .
+docker push metabrainz/listenbrainz-spark-new-cluster

--- a/docker/spark-new-cluster/start-request-consumer-container.sh
+++ b/docker/spark-new-cluster/start-request-consumer-container.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../"
+
+source spark_config.sh
+
+CONTAINER_NAME="spark-request-consumer"
+
+docker pull metabrainz/listenbrainz-spark-new-cluster:latest
+
+zip -rq listenbrainz_spark_request_consumer.zip listenbrainz_spark/
+docker run \
+    -d \
+    -v /spark:/spark
+    -v `pwd`:/rec \
+    --network host \
+    --name $CONTAINER_NAME \
+    metabrainz/listenbrainz-spark-request-consumer:latest \
+    spark/bin/spark-submit \
+        --packages org.apache.spark:spark-avro_2.11:2.4.1 \
+        --master yarn \
+        --conf "spark.scheduler.listenerbus.eventqueue.capacity"=$LISTENERBUS_CAPACITY \
+        --conf "spark.cores.max"=$MAX_CORES \
+        --conf "spark.executor.cores"=$EXECUTOR_CORES \
+        --conf "spark.executor.memory"=$EXECUTOR_MEMORY \
+        --conf "spark.driver.memory"=$DRIVER_MEMORY \
+        --py-files listenbrainz_spark_request_consumer.zip \
+	spark_manage.py request_consumer

--- a/docker/spark-new-cluster/start-request-consumer-container.sh
+++ b/docker/spark-new-cluster/start-request-consumer-container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../"
+cd "$(dirname "${BASH_SOURCE[0]}")/../../"
 
 source spark_config.sh
 
@@ -13,6 +13,7 @@ docker run \
     -d \
     -v /spark:/spark \
     -v /hadoop:/hadoop \
+    -v /usr/lib/jvm/adoptopenjdk-11-hotspot-amd64:/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64 \
     -v `pwd`:/rec \
     --network host \
     --name $CONTAINER_NAME \
@@ -20,6 +21,7 @@ docker run \
     /spark/bin/spark-submit \
         --packages org.apache.spark:spark-avro_2.11:2.4.1 \
         --master yarn \
+        --deploy-mode cluster \
         --conf "spark.scheduler.listenerbus.eventqueue.capacity"=$LISTENERBUS_CAPACITY \
         --conf "spark.cores.max"=$MAX_CORES \
         --conf "spark.executor.cores"=$EXECUTOR_CORES \

--- a/docker/spark-new-cluster/start-request-consumer-container.sh
+++ b/docker/spark-new-cluster/start-request-consumer-container.sh
@@ -11,12 +11,13 @@ docker pull metabrainz/listenbrainz-spark-new-cluster:latest
 zip -rq listenbrainz_spark_request_consumer.zip listenbrainz_spark/
 docker run \
     -d \
-    -v /spark:/spark
+    -v /spark:/spark \
+    -v /hadoop:/hadoop \
     -v `pwd`:/rec \
     --network host \
     --name $CONTAINER_NAME \
-    metabrainz/listenbrainz-spark-request-consumer:latest \
-    spark/bin/spark-submit \
+    metabrainz/listenbrainz-spark-new-cluster:latest \
+    /spark/bin/spark-submit \
         --packages org.apache.spark:spark-avro_2.11:2.4.1 \
         --master yarn \
         --conf "spark.scheduler.listenerbus.eventqueue.capacity"=$LISTENERBUS_CAPACITY \

--- a/docker/spark-new-cluster/start-request-consumer-container.sh
+++ b/docker/spark-new-cluster/start-request-consumer-container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../"
 
@@ -8,10 +9,11 @@ CONTAINER_NAME="spark-request-consumer"
 
 docker pull metabrainz/listenbrainz-spark-new-cluster:latest
 
-python -m venv pyspark_venv
+python3 -m venv pyspark_venv
 source pyspark_venv/bin/activate
 pip install -r requirements_spark.txt
-pip uninstall pyspark py4j
+pip uninstall pyspark py4j -y
+pip install venv-pack
 venv-pack -o pyspark_venv.tar.gz
 
 export PYSPARK_DRIVER_PYTHON=python

--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -1,13 +1,12 @@
 from py4j.protocol import Py4JJavaError
+from pyspark.sql import SparkSession, SQLContext
 
 from listenbrainz_spark.exceptions import SparkSessionNotInitializedException
-
-from pyspark import SparkContext
-from pyspark.sql import SparkSession, SQLContext
 
 session = None
 context = None
 sql_context = None
+
 
 def init_spark_session(app_name):
     """ Initializes a Spark Session with the given application name.

--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -19,8 +19,6 @@ def init_spark_session(app_name):
         session = SparkSession \
                 .builder \
                 .appName(app_name) \
-                .config("spark.hadoop.dfs.client.use.datanode.hostname", "true") \
-                .config("spark.hadoop.dfs.datanode.use.datanode.hostname", "true") \
                 .config("spark.driver.maxResultSize", "4g") \
                 .getOrCreate()
         context = session.sparkContext

--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -19,7 +19,6 @@ def init_spark_session(app_name):
         session = SparkSession \
                 .builder \
                 .appName(app_name) \
-                .config("spark.driver.maxResultSize", "4g") \
                 .getOrCreate()
         context = session.sparkContext
         context.setLogLevel("ERROR")

--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -1,6 +1,6 @@
-HDFS_HTTP_URI = 'http://hadoop-master:9870' # the URI of the http webclient for HDFS
+HDFS_HTTP_URI = 'http://leader:9870' # the URI of the http webclient for HDFS
 
-HDFS_CLUSTER_URI = 'hdfs://hadoop-master:9000' # the URI to be used with Spark
+HDFS_CLUSTER_URI = 'hdfs://leader:9000' # the URI to be used with Spark
 
 # rabbitmq
 RABBITMQ_HOST = "rabbitmq"

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -24,8 +24,8 @@ listen_schema = [
 # schema to contain model parameters.
 model_param_schema = [
     StructField('alpha', FloatType(), nullable=True),  # Baseline level of confidence weighting applied.
-    StructField('lmbda', FloatType(), nullable=True),  # Controls over fitting.
     StructField('iteration', IntegerType(), nullable=True),  # Number of iterations to run.
+    StructField('lmbda', FloatType(), nullable=True),  # Controls over fitting.
     StructField('rank', IntegerType(), nullable=True),  # Number of hidden features in our low-rank approximation matrices.
 ]
 model_param_schema = StructType(sorted(model_param_schema, key=lambda field: field.name))
@@ -144,8 +144,8 @@ def convert_model_metadata_to_row(meta):
         model_id=meta.get('model_id'),
         model_param=Row(
             alpha=meta.get('alpha'),
-            lmbda=meta.get('lmbda'),
             iteration=meta.get('iteration'),
+            lmbda=meta.get('lmbda'),
             rank=meta.get('rank'),
         ),
         test_data_count=meta.get('test_data_count'),

--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -8,8 +8,8 @@ numpy==1.19.5
 git+https://github.com/metabrainz/brainzutils-python.git@v1.16.1
 pytest == 6.2.2
 pytest-cov == 2.10.1
-py4j == 0.10.7
-pyspark == 2.4.5
+py4j==0.10.9
+pyspark == 3.1.1
 pydantic == 1.8.1
 unidecode == 1.2.0
 Flask==1.1.2


### PR DESCRIPTION
Modify the request consumer setup to work with the new cluster setup. Since we have now installed spark on the host directly, we do not need to include it in the docker image. 

We'll also need to change the configuration parameters according to the resources available on the host and yarn cluster manager.