### PR TITLE
When writing a batch of listens, skip any which have null characters

### DIFF
--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -116,7 +116,6 @@ class ListenTestCase(unittest.TestCase):
         self.assertEqual(json_data['user_id'], listen.user_id)
         self.assertEqual(json_data['track_metadata']['artist_name'], listen.data['artist_name'])
 
-
     def test_from_json(self):
         json_row = {
                     "track_metadata": {
@@ -134,3 +133,16 @@ class ListenTestCase(unittest.TestCase):
         listen = Listen.from_json(json_row)
 
         self.assertEqual(listen.timestamp, None)
+
+    def test_from_json_null_values(self):
+        data = {
+            "listened_at": 1618353413, "track_metadata": {
+                "additional_info": {"recording_mbid": "99e087e1-5649-4e8c-b84f-eea05b8e143a",
+                                    "release_mbid": "4b6ca48c-f7db-439d-ba57-6104b5fec61e",
+                                    "artist_mbid": "e1564e98-978b-4947-8698-f6fd6f8b0181\u0000\ufeff9ad10546-b081-4cc8-a487-3d2eece82d9e\u0000\ufeff5245e5cd-4408-4d9e-a037-c71a53edce83",
+                                    "artist_msid": "392f2883-724f-4c63-b155-81a7cc89a499",
+                                    "release_msid": "632207f8-150f-4342-99ad-0fd5a6687e63"},
+                "artist_name": "Fort Minor Feat. Holly Brook & Jonah Matranga", "track_name": "some name"}
+            }
+        with self.assertRaises(ValueError):
+            Listen.from_json(data)

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -34,7 +34,10 @@ class TimescaleWriterSubscriber(ListenWriter):
 
         submit = []
         for listen in listens:
-            submit.append(Listen.from_json(listen))
+            try:
+                submit.append(Listen.from_json(listen))
+            except ValueError:
+                pass
 
         ret = self.insert_to_listenstore(submit)
         if not ret:


### PR DESCRIPTION
# Problem

postgres/timescale doens't like null values in json.
If we roll back an entire batch due to one listen being bad, we'll skip all items from the batch


# Solution
while processing each item in the batch, validate text data to see if there are nulls in it and if so don't add them to the batch


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


