### PR TITLE
Check for CI env variable

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -26,10 +26,10 @@ jobs:
       continue-on-error: true
 
     - name: Run frontend tests
-      run: ./test.sh fe -ci
+      run: ./test.sh fe
 
     - name: Run linter
-      run: ./test.sh fe -f -ci
+      run: ./test.sh fe -f
       if: ${{ always() }}
 
     - name: Run type checker

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -47,6 +47,7 @@ class DumpTestCase(DatabaseTestCase):
         shutil.rmtree(self.tempdir)
 
     def test_create_private_dump(self):
+        assert False
         time_now = datetime.today()
         dump_location = db_dump.create_private_dump(self.tempdir, time_now)
         self.assertTrue(os.path.isfile(dump_location))

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -47,7 +47,6 @@ class DumpTestCase(DatabaseTestCase):
         shutil.rmtree(self.tempdir)
 
     def test_create_private_dump(self):
-        assert False
         time_now = datetime.today()
         dump_location = db_dump.create_private_dump(self.tempdir, time_now)
         self.assertTrue(os.path.isfile(dump_location))

--- a/test.sh
+++ b/test.sh
@@ -116,26 +116,25 @@ function update_snapshots {
 
 function run_lint_check {
     if [ "$CI" == "true" ] ; then
-        docker-compose -f $COMPOSE_FILE_LOC \
-                       -p $COMPOSE_PROJECT_NAME \
-                    run --rm frontend_tester npm run format:ci
+        command="format:ci"
     else
-        docker-compose -f $COMPOSE_FILE_LOC \
-                       -p $COMPOSE_PROJECT_NAME \
-                    run --rm frontend_tester npm run format
+        command="format"
     fi
+
+    docker-compose -f $COMPOSE_FILE_LOC \
+                   -p $COMPOSE_PROJECT_NAME \
+                run --rm frontend_tester npm run $command
 }
 
 function run_frontend_tests {
     if [ "$CI" == "true" ] ; then
-        docker-compose -f $COMPOSE_FILE_LOC \
-                       -p $COMPOSE_PROJECT_NAME \
-                    run --rm frontend_tester npm run test:ci
+        command="test:ci"
     else
-        docker-compose -f $COMPOSE_FILE_LOC \
-                       -p $COMPOSE_PROJECT_NAME \
-                    run --rm frontend_tester npm test
+        command="test"
     fi
+    docker-compose -f $COMPOSE_FILE_LOC \
+                   -p $COMPOSE_PROJECT_NAME \
+                run --rm frontend_tester npm run $command
 }
 
 function run_type_check {

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if [ "$CI" == "true" ]; then
-    set -e
-fi
-
 # UNIT TESTS
 # ./test.sh                build unit test containers, bring up, make database, test, bring down
 # for development:
@@ -211,8 +207,9 @@ if [ "$1" == "spark" ]; then
     docker-compose -f $SPARK_COMPOSE_FILE_LOC \
                    -p $SPARK_COMPOSE_PROJECT_NAME \
                 up test
+    RET=$?
     spark_dcdown
-    exit 0
+    exit $RET
 fi
 
 if [ "$1" == "int" ]; then
@@ -245,9 +242,10 @@ if [ "$1" == "int" ]; then
                   -wait tcp://redis:6379 -timeout 60s \
                   -wait tcp://rabbitmq:5672 -timeout 60s \
                 bash -c "pytest $TESTS_TO_RUN"
+    RET=$?
     echo "Taking containers down"
     int_dcdown
-    exit 0
+    exit $RET
 fi
 
 # Project name is sanitized by Compose, so we need to do the same thing.
@@ -272,18 +270,18 @@ if [ "$1" == "fe" ]; then
     if [ "$2" == "-t" ]; then
         echo "Running type checker"
         run_type_check
-        exit 0
+        exit $?
     fi
 
     if [ "$2" == "-f" ]; then
         echo "Running linter"
         run_lint_check
-        exit 0
+        exit $?
     fi
 
     echo "Running tests"
     run_frontend_tests
-    exit 0
+    exit $?
 fi
 
 if [ "$1" == "-s" ]; then
@@ -329,11 +327,14 @@ if [ $DB_EXISTS -eq 1 -a $DB_RUNNING -eq 1 ]; then
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
                 run --rm listenbrainz pytest "$@"
+    RET=$?
     unit_dcdown
+    exit $RET
 else
     # Else, we have containers, just run tests
     echo "Running tests"
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
                 run --rm listenbrainz pytest "$@"
+    exit $?
 fi

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$CI" ]; then
+if [ "$CI" == "true" ]; then
     set -e
 fi
 
@@ -119,7 +119,7 @@ function update_snapshots {
 }
 
 function run_lint_check {
-    if [ -z "$CI" ] ; then
+    if [ "$CI" == "true" ] ; then
         docker-compose -f $COMPOSE_FILE_LOC \
                        -p $COMPOSE_PROJECT_NAME \
                     run --rm frontend_tester npm run format:ci
@@ -131,7 +131,7 @@ function run_lint_check {
 }
 
 function run_frontend_tests {
-    if [ -z "$CI" ] ; then
+    if [ "$CI" == "true" ] ; then
         docker-compose -f $COMPOSE_FILE_LOC \
                        -p $COMPOSE_PROJECT_NAME \
                     run --rm frontend_tester npm run test:ci

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -z "$CI" ]; then
+    set -e
+fi
+
 # UNIT TESTS
 # ./test.sh                build unit test containers, bring up, make database, test, bring down
 # for development:
@@ -14,9 +18,6 @@
 # ./test.sh fe -b          build frontend test containers
 # ./test.sh fe -t          run type-checker
 # ./test.sh fe -f          run linter
-
-# ./test.sh fe -ci         run frontend tests in ci mode
-# ./test.sh fe -f -ci      run linter in ci mode
 
 # SPARK TESTS
 # ./test.sh spark          run spark tests
@@ -118,7 +119,7 @@ function update_snapshots {
 }
 
 function run_lint_check {
-    if [ "$1" == "-ci" ] ; then
+    if [ -z "$CI" ] ; then
         docker-compose -f $COMPOSE_FILE_LOC \
                        -p $COMPOSE_PROJECT_NAME \
                     run --rm frontend_tester npm run format:ci
@@ -130,7 +131,7 @@ function run_lint_check {
 }
 
 function run_frontend_tests {
-    if [ "$1" == "-ci" ] ; then
+    if [ -z "$CI" ] ; then
         docker-compose -f $COMPOSE_FILE_LOC \
                        -p $COMPOSE_PROJECT_NAME \
                     run --rm frontend_tester npm run test:ci
@@ -276,12 +277,12 @@ if [ "$1" == "fe" ]; then
 
     if [ "$2" == "-f" ]; then
         echo "Running linter"
-        run_lint_check "$3"
+        run_lint_check
         exit 0
     fi
 
     echo "Running tests"
-    run_frontend_tests "$2"
+    run_frontend_tests
     exit 0
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Github Actions automatically sets the CI environment variable. We use this variable to detect if the script is running
+# inside a CI environment and modify its execution as needed.
+if [ "$CI" == "true" ] ; then
+    echo "Running in CI mode"
+fi
+
 # UNIT TESTS
 # ./test.sh                build unit test containers, bring up, make database, test, bring down
 # for development:


### PR DESCRIPTION
GH Actions is reporting passed workflow even when tests fail. This is probably because the script continues running even when the tests fail. And then the final status reported by the script is due to  the `exit 0`. Therefore, store the exit code returned by the command executing the tests and return that at the end of the script. 

Unrelated change, instead of using `-ci` check if the CI environment variable is set to `true`. This environment variable is automatically set by GH Actions when running the workflows.