### PR TITLE
Recalculate all user data

### DIFF
--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -19,7 +19,6 @@ import sqlalchemy
 from brainzutils import cache
 
 import listenbrainz.db.user as db_user
-from listenbrainz import db
 from listenbrainz.db import timescale
 from listenbrainz import DUMP_LICENSE_FILE_PATH
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
@@ -186,88 +185,6 @@ class TimescaleListenStore(ListenStore):
             self.log.error("Cannot fetch min/max timestamp: %s" %
                            str(e), exc_info=True)
             raise
-
-    def recalculate_all_user_data(self):
-
-        # Find the created timestamp of the last listen
-        query = "SELECT max(created) FROM listen WHERE created > :date"
-        try:
-            with timescale.engine.connect() as connection:
-                result = connection.execute(sqlalchemy.text(query), date=datetime.now() - timedelta(weeks=4))
-                row = result.fetchone()
-                last_created_ts = row[0]
-        except psycopg2.OperationalError as e:
-            self.log.error("Cannot query ts to fetch latest listen." % str(e), exc_info=True)
-            raise
-
-        self.log.info("Last created timestamp: " + str(last_created_ts))
-
-        # Select a list of users
-        user_list = []
-        query = 'SELECT musicbrainz_id FROM "user"'
-        try:
-            with db.engine.connect() as connection:
-                result = connection.execute(sqlalchemy.text(query))
-                for row in result:
-                    user_list.append(row[0])
-        except psycopg2.OperationalError as e:
-            self.log.error("Cannot query db to fetch user list." % str(e), exc_info=True)
-            raise
-
-        self.log.info("Fetched %d users. Setting empty cache entries." % len(user_list))
-
-        # Reset the timestamps and listen counts to 0 for all users
-        for user_name in user_list:
-            cache.set(REDIS_USER_LISTEN_COUNT + user_name, 0, time=0, encode=False)
-            cache.set(REDIS_USER_LISTEN_COUNT + user_name, 0, time=0, encode=False)
-            cache.set(REDIS_USER_TIMESTAMPS + user_name, "0,0", time=0)
-
-        # Tabulate all of the listen counts/timestamps for all users
-        self.log.info("Scan the whole listen table...")
-        listen_counts = defaultdict(int)
-        user_timestamps = {}
-        query = "SELECT listened_at, user_name FROM listen where created <= :ts" 
-        try:
-            with timescale.engine.connect() as connection:
-                result = connection.execute(sqlalchemy.text(query), ts=last_created_ts)
-                for row in result:
-                    ts = row[0]
-                    user_name = row[1]
-                    if user_name not in user_timestamps:
-                        user_timestamps[user_name] = [ts, ts]
-                    else:
-                        if ts > user_timestamps[user_name][1]:
-                            user_timestamps[user_name][1] = ts
-                        if ts < user_timestamps[user_name][0]:
-                            user_timestamps[user_name][0] = ts
-
-                    listen_counts[user_name] += 1
-
-        except psycopg2.OperationalError as e:
-            self.log.error("Cannot query db to fetch user list." % str(e), exc_info=True)
-            raise
-
-        self.log.info("Setting updated cache entries.")
-        # Set the timestamps and listen counts for all users
-        for user_name in user_list:
-            try:
-                cache._r.incrby(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name), listen_counts[user_name])
-            except KeyError:
-                pass
-
-            try:
-                tss = cache.get(REDIS_USER_TIMESTAMPS + user_name)
-                (min_ts, max_ts) = tss.split(",")
-                min_ts = int(min_ts)
-                max_ts = int(max_ts)
-                if min_ts and min_ts < user_timestamps[user_name][0]:
-                    user_timestamps[user_name][0] = min_ts
-                if max_ts and max_ts > user_timestamps[user_name][1]:
-                    user_timestamps[user_name][1] = max_ts
-                cache.set(REDIS_USER_TIMESTAMPS + user_name, "%d,%d" % (user_timestamps[user_name][0], user_timestamps[user_name][1]), time=0)
-            except KeyError:
-                pass
-
 
     def get_total_listen_count(self, cache_value=True):
         """ Returns the total number of listens stored in the ListenStore.

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -19,6 +19,7 @@ import sqlalchemy
 from brainzutils import cache
 
 import listenbrainz.db.user as db_user
+from listenbrainz import db
 from listenbrainz.db import timescale
 from listenbrainz import DUMP_LICENSE_FILE_PATH
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
@@ -185,6 +186,81 @@ class TimescaleListenStore(ListenStore):
             self.log.error("Cannot fetch min/max timestamp: %s" %
                            str(e), exc_info=True)
             raise
+
+    def recalculate_all_user_data(self):
+
+        # Find the created timestamp of the last listen
+        query = "SELECT max(created) FROM listen WHERE created > :date"
+        try:
+            with timescale.engine.connect() as connection:
+                result = connection.execute(sqlalchemy.text(query), date=datetime.now() - timedelta(weeks=4))
+                row = result.fetchone()
+                last_created_ts = row[0]
+        except psycopg2.OperationalError as e:
+            self.log.error("Cannot query ts to fetch latest listen." % str(e), exc_info=True)
+            raise
+
+        self.log.info("Last created timestamp: " + str(last_created_ts))
+
+        # Select a list of users
+        user_list = []
+        query = 'SELECT musicbrainz_id FROM "user"'
+        try:
+            with db.engine.connect() as connection:
+                result = connection.execute(sqlalchemy.text(query))
+                for row in result:
+                    user_list.append(row[0])
+        except psycopg2.OperationalError as e:
+            self.log.error("Cannot query db to fetch user list." % str(e), exc_info=True)
+            raise
+
+        self.log.info("Fetched %d users. Setting empty cache entries." % len(user_list))
+
+        # Reset the timestamps and listen counts to 0 for all users
+        for user_name in user_list:
+            cache.set(REDIS_USER_LISTEN_COUNT + user_name, 0, time=0, encode=False)
+            cache.set(REDIS_USER_LISTEN_COUNT + user_name, 0, time=0, encode=False)
+            cache.set(REDIS_USER_TIMESTAMPS + user_name, "0,0", time=0)
+
+        # Tabulate all of the listen counts/timestamps for all users
+        self.log.info("Scan the whole listen table...")
+        listen_counts = defaultdict(int)
+        user_timestamps = {}
+        query = "SELECT listened_at, user_name FROM listen where created <= :ts" 
+        try:
+            with timescale.engine.connect() as connection:
+                result = connection.execute(sqlalchemy.text(query), ts=last_created_ts)
+                for row in result:
+                    ts = row[0]
+                    user_name = row[1]
+                    if user_name not in user_timestamps:
+                        user_timestamps[user_name] = [ts, ts]
+                    else:
+                        if ts > user_timestamps[user_name][1]:
+                            user_timestamps[user_name][1] = ts
+                        if ts < user_timestamps[user_name][0]:
+                            user_timestamps[user_name][0] = ts
+
+                    listen_counts[user_name] += 1
+
+        except psycopg2.OperationalError as e:
+            self.log.error("Cannot query db to fetch user list." % str(e), exc_info=True)
+            raise
+
+        self.log.info("Setting updated cache entries.")
+        # Set the timestamps and listen counts for all users
+        for user_name in user_list:
+            cache._r.incrby(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name), listen_counts[user_name])
+            tss = cache.get(REDIS_USER_TIMESTAMPS + user_name)
+            (min_ts, max_ts) = tss.split(",")
+            min_ts = int(min_ts)
+            max_ts = int(max_ts)
+            if min_ts and min_ts < user_timestamps[user_name][0]:
+                user_timestamps[user_name][0] = min_ts
+            if max_ts and max_ts > user_timestamps[user_name][1]:
+                user_timestamps[user_name][1] = max_ts
+            cache.set(REDIS_USER_TIMESTAMPS + user_name, "%d,%d" % (user_timestamps[user_name][0], user_timestamps[user_name][1]), time=0)
+
 
     def get_total_listen_count(self, cache_value=True):
         """ Returns the total number of listens stored in the ListenStore.

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -1,0 +1,104 @@
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta
+import psycopg2
+from psycopg2.errors import UntranslatableCharacter
+import sqlalchemy
+import logging
+
+from brainzutils import cache
+from listenbrainz.utils import init_cache
+from listenbrainz import db
+from listenbrainz.db import timescale
+from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT, REDIS_USER_TIMESTAMPS
+from listenbrainz import config
+
+
+logger = logging.getLogger(__name__)
+
+
+def recalculate_all_user_data():
+
+    timescale.init_db_connection(config.SQLALCHEMY_TIMESCALE_URI)
+    db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
+    init_cache(host=config.REDIS_HOST, port=config.REDIS_PORT, namespace=config.REDIS_NAMESPACE)
+
+
+    # Find the created timestamp of the last listen
+    query = "SELECT max(created) FROM listen WHERE created > :date"
+    try:
+        with timescale.engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text(query), date=datetime.now() - timedelta(weeks=4))
+            row = result.fetchone()
+            last_created_ts = row[0]
+    except psycopg2.OperationalError as e:
+        logger.error("Cannot query ts to fetch latest listen." % str(e), exc_info=True)
+        raise
+
+    logger.info("Last created timestamp: " + str(last_created_ts))
+
+    # Select a list of users
+    user_list = []
+    query = 'SELECT musicbrainz_id FROM "user"'
+    try:
+        with db.engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text(query))
+            for row in result:
+                user_list.append(row[0])
+    except psycopg2.OperationalError as e:
+        logger.error("Cannot query db to fetch user list." % str(e), exc_info=True)
+        raise
+
+    logger.info("Fetched %d users. Setting empty cache entries." % len(user_list))
+
+    # Reset the timestamps and listen counts to 0 for all users
+    for user_name in user_list:
+        cache.set(REDIS_USER_LISTEN_COUNT + user_name, 0, time=0, encode=False)
+        cache.set(REDIS_USER_LISTEN_COUNT + user_name, 0, time=0, encode=False)
+        cache.set(REDIS_USER_TIMESTAMPS + user_name, "0,0", time=0)
+
+    # Tabulate all of the listen counts/timestamps for all users
+    logger.info("Scan the whole listen table...")
+    listen_counts = defaultdict(int)
+    user_timestamps = {}
+    query = "SELECT listened_at, user_name FROM listen where created <= :ts" 
+    try:
+        with timescale.engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text(query), ts=last_created_ts)
+            for row in result:
+                ts = row[0]
+                user_name = row[1]
+                if user_name not in user_timestamps:
+                    user_timestamps[user_name] = [ts, ts]
+                else:
+                    if ts > user_timestamps[user_name][1]:
+                        user_timestamps[user_name][1] = ts
+                    if ts < user_timestamps[user_name][0]:
+                        user_timestamps[user_name][0] = ts
+
+                listen_counts[user_name] += 1
+
+    except psycopg2.OperationalError as e:
+        logger.error("Cannot query db to fetch user list." % str(e), exc_info=True)
+        raise
+
+    logger.info("Setting updated cache entries.")
+    # Set the timestamps and listen counts for all users
+    for user_name in user_list:
+        try:
+            cache._r.incrby(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name), listen_counts[user_name])
+        except KeyError:
+            pass
+
+        try:
+            tss = cache.get(REDIS_USER_TIMESTAMPS + user_name)
+            (min_ts, max_ts) = tss.split(",")
+            min_ts = int(min_ts)
+            max_ts = int(max_ts)
+            if min_ts and min_ts < user_timestamps[user_name][0]:
+                user_timestamps[user_name][0] = min_ts
+            if max_ts and max_ts > user_timestamps[user_name][1]:
+                user_timestamps[user_name][1] = max_ts
+            cache.set(REDIS_USER_TIMESTAMPS + user_name, "%d,%d" % (user_timestamps[user_name][0], user_timestamps[user_name][1]), time=0)
+        except KeyError:
+            pass

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 import listenbrainz.db.dump_manager as dump_manager
 import listenbrainz.spark.request_manage as spark_request_manage
+from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data as ts_recalculate_all_user_data
 from listenbrainz import db
 from listenbrainz.db import timescale as ts
 from listenbrainz import webserver
@@ -252,18 +253,7 @@ def calculate_user_similarity():
 
 @cli.command(name="recalculate_all_user_data")
 def recalculate_all_user_data():
-    from listenbrainz import config
-    from listenbrainz.listenstore.timescale_listenstore import TimescaleListenStore
-    import logging
-    ts = TimescaleListenStore({
-            'REDIS_HOST': config.REDIS_HOST,
-            'REDIS_PORT': config.REDIS_PORT,
-            'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
-            'SQLALCHEMY_TIMESCALE_URI': config.SQLALCHEMY_TIMESCALE_URI,
-        },  logging.getLogger(__name__))
-    application = webserver.create_app()
-    with application.app_context():
-        ts.recalculate_all_user_data()
+    ts_recalculate_all_user_data()
 
 # Add other commands here
 cli.add_command(spark_request_manage.cli, name="spark")

--- a/manage.py
+++ b/manage.py
@@ -250,6 +250,20 @@ def calculate_user_similarity():
     with application.app_context():
         user_similarity.calculate_similar_users()
 
+@cli.command(name="recalculate_all_user_data")
+def recalculate_all_user_data():
+    from listenbrainz import config
+    from listenbrainz.listenstore.timescale_listenstore import TimescaleListenStore
+    import logging
+    ts = TimescaleListenStore({
+            'REDIS_HOST': config.REDIS_HOST,
+            'REDIS_PORT': config.REDIS_PORT,
+            'REDIS_NAMESPACE': config.REDIS_NAMESPACE,
+            'SQLALCHEMY_TIMESCALE_URI': config.SQLALCHEMY_TIMESCALE_URI,
+        },  logging.getLogger(__name__))
+    application = webserver.create_app()
+    with application.app_context():
+        ts.recalculate_all_user_data()
 
 # Add other commands here
 cli.add_command(spark_request_manage.cli, name="spark")


### PR DESCRIPTION
DO NOT MERGE UNTIL AFTER #1390 IS MERGED!

NB: This branch is off another feature branch, NOT MASTER.

This function implements the "tabulation" of all user data by:
1. Fixing a point in time.
2. Zeroing user data (ts & count)
3. Scanning all listens
4. Updating user data using increments so it will not disturb a running timescale writer.

This branch should be deployed in the following manner:
1. Deploy this branch to timescale_writer prod & to web-beta
2. Run recalculate all user data from manage.py on beta.
3. Deploy web and other containers.