### PR TITLE
Improve the Spotify Integration code

### DIFF
--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -1,7 +1,5 @@
-from data.model.external_service import ExternalService
 from listenbrainz import db, utils
 import sqlalchemy
-import listenbrainz.db.external_service_oauth as db_oauth
 
 
 def add_update_error(user_id, error_message):
@@ -92,14 +90,16 @@ def get_active_users_to_process():
 def get_user_import_details(user_id):
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT user_id
-                 , external_service_oauth_id
-                 , last_updated
+            SELECT external_service_oauth.user_id
+                 , listens_importer.id
+                 , listens_importer.last_updated
                  , latest_listened_at
                  , error_message
-              FROM listens_importer
-              WHERE user_id = :user_id
-                AND service = 'spotify'
+              FROM external_service_oauth
+   LEFT OUTER JOIN listens_importer
+                ON listens_importer.external_service_oauth_id = external_service_oauth.id
+             WHERE external_service_oauth.user_id = :user_id
+               AND external_service_oauth.service = 'spotify'
             """), {
                 'user_id': user_id,
             })

--- a/listenbrainz/db/tests/test_oauth.py
+++ b/listenbrainz/db/tests/test_oauth.py
@@ -1,0 +1,61 @@
+import time
+
+from data.model.external_service import ExternalService
+from listenbrainz.db.testing import DatabaseTestCase
+
+import listenbrainz.db.user as db_user
+import listenbrainz.db.external_service_oauth as db_oauth
+
+
+class OAuthDatabaseTestCase(DatabaseTestCase):
+
+    def setUp(self):
+        super(OAuthDatabaseTestCase, self).setUp()
+        db_user.create(1, 'testspotifyuser')
+        self.user = db_user.get(1)
+        db_oauth.save_token(
+            user_id=self.user['id'],
+            service=ExternalService.SPOTIFY,
+            access_token='token',
+            refresh_token='refresh_token',
+            token_expires_ts=int(time.time()),
+            record_listens=True,
+            scopes=['user-read-recently-played']
+        )
+
+    def test_create_oauth(self):
+        db_user.create(2, 'spotify')
+        db_oauth.save_token(
+            user_id=2,
+            service=ExternalService.SPOTIFY,
+            access_token='token',
+            refresh_token='refresh_token',
+            token_expires_ts=int(time.time()),
+            record_listens=True,
+            scopes=['user-read-recently-played']
+        )
+        user = db_oauth.get_token(2, ExternalService.SPOTIFY)
+        self.assertEqual('token', user['access_token'])
+
+    def test_update_token(self):
+        db_oauth.update_token(
+            user_id=self.user['id'],
+            service=ExternalService.SPOTIFY,
+            access_token='testtoken',
+            refresh_token='refreshtesttoken',
+            expires_at=int(time.time()),
+        )
+        spotify_user = db_oauth.get_token(self.user['id'], ExternalService.SPOTIFY)
+        self.assertEqual(spotify_user['access_token'], 'testtoken')
+        self.assertEqual(spotify_user['refresh_token'], 'refreshtesttoken')
+
+    def test_get_oauth(self):
+        user = db_oauth.get_token(self.user['id'])
+        self.assertEqual(user['user_id'], self.user['id'])
+        self.assertEqual(user['musicbrainz_id'], self.user['musicbrainz_id'])
+        self.assertEqual(user['musicbrainz_row_id'], self.user['musicbrainz_row_id'])
+        self.assertEqual(user['access_token'], 'token')
+        self.assertEqual(user['refresh_token'], 'refresh_token')
+        self.assertIn('token_expires', user)
+        self.assertIn('token_expired', user)
+

--- a/listenbrainz/db/tests/test_oauth.py
+++ b/listenbrainz/db/tests/test_oauth.py
@@ -50,7 +50,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(spotify_user['refresh_token'], 'refreshtesttoken')
 
     def test_get_oauth(self):
-        user = db_oauth.get_token(self.user['id'])
+        user = db_oauth.get_token(self.user['id'], ExternalService.SPOTIFY)
         self.assertEqual(user['user_id'], self.user['id'])
         self.assertEqual(user['musicbrainz_id'], self.user['musicbrainz_id'])
         self.assertEqual(user['musicbrainz_row_id'], self.user['musicbrainz_row_id'])

--- a/listenbrainz/db/tests/test_spotify.py
+++ b/listenbrainz/db/tests/test_spotify.py
@@ -93,7 +93,6 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
     def test_get_user_import_details(self):
         user = db_spotify.get_user_import_details(self.user['id'])
         self.assertEqual(user['user_id'], self.user['id'])
-        self.assertIn('external_service_oauth_id', user)
         self.assertIn('last_updated', user)
         self.assertIn('latest_listened_at', user)
         self.assertIn('error_message', user)

--- a/listenbrainz/db/tests/test_spotify.py
+++ b/listenbrainz/db/tests/test_spotify.py
@@ -16,6 +16,15 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         super(SpotifyDatabaseTestCase, self).setUp()
         db_user.create(1, 'testspotifyuser')
         self.user = db_user.get(1)
+        db_oauth.save_token(
+            user_id=1,
+            service=ExternalService.SPOTIFY,
+            access_token='token',
+            refresh_token='refresh_token',
+            token_expires_ts=int(time.time()),
+            record_listens=True,
+            scopes=['user-read-recently-played']
+        )
 
     def test_add_update_error(self):
         db_spotify.add_update_error(self.user['id'], 'test error message')

--- a/listenbrainz/db/tests/test_spotify.py
+++ b/listenbrainz/db/tests/test_spotify.py
@@ -2,15 +2,12 @@
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.spotify as db_spotify
-import spotipy.oauth2
-import sqlalchemy
+import listenbrainz.db.external_service_oauth as db_oauth
+
 import time
 
-from datetime import datetime
-from listenbrainz import db
+from data.model.external_service import ExternalService
 from listenbrainz.db.testing import DatabaseTestCase
-from unittest import mock
-from unittest.mock import MagicMock
 
 
 class SpotifyDatabaseTestCase(DatabaseTestCase):
@@ -19,34 +16,6 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         super(SpotifyDatabaseTestCase, self).setUp()
         db_user.create(1, 'testspotifyuser')
         self.user = db_user.get(1)
-        db_spotify.create_spotify(
-            user_id=self.user['id'],
-            access_token='token',
-            refresh_token='refresh_token',
-            token_expires_ts=int(time.time()),
-            record_listens=True,
-            scopes=['user-read-recently-played']
-        )
-
-    def test_create_spotify(self):
-        db_user.create(2, 'spotify')
-        db_spotify.create_spotify(
-            user_id=2,
-            access_token='token',
-            refresh_token='refresh_token',
-            token_expires_ts=int(time.time()),
-            record_listens=True,
-            scopes=['user-read-recently-played']
-        )
-        token = db_spotify.get_token_for_user(2)
-        self.assertEqual(token, 'token')
-
-    def test_delete_spotify(self):
-        token = db_spotify.get_token_for_user(self.user['id'])
-        self.assertIsNotNone(token)
-        db_spotify.delete_spotify(self.user['id'])
-        token = db_spotify.get_token_for_user(self.user['id'])
-        self.assertIsNone(token)
 
     def test_add_update_error(self):
         db_spotify.add_update_error(self.user['id'], 'test error message')
@@ -60,18 +29,6 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         self.assertIsNone(spotify_user['error_message'])
         self.assertIsNotNone(spotify_user['last_updated'])
 
-    def test_update_token(self):
-        old_spotify_user = db_spotify.get_user(self.user['id'])
-        db_spotify.update_token(
-            user_id=self.user['id'],
-            access_token='testtoken',
-            refresh_token='refreshtesttoken',
-            expires_at=int(time.time()),
-        )
-        spotify_user = db_spotify.get_user(self.user['id'])
-        self.assertEqual(spotify_user['access_token'], 'testtoken')
-        self.assertEqual(spotify_user['refresh_token'], 'refreshtesttoken')
-
     def test_update_latest_listened_at(self):
         old_spotify_user = db_spotify.get_user_import_details(self.user['id'])
         self.assertIsNone(old_spotify_user['latest_listened_at'])
@@ -82,8 +39,9 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
 
     def test_get_active_users_to_process(self):
         db_user.create(2, 'newspotifyuser')
-        db_spotify.create_spotify(
+        db_oauth.save_token(
             user_id=2,
+            service=ExternalService.SPOTIFY,
             access_token='token',
             refresh_token='refresh_token',
             token_expires_ts=int(time.time()),
@@ -99,8 +57,9 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
 
         # check order, the users should be sorted by latest_listened_at timestamp
         db_user.create(3, 'newnewspotifyuser')
-        db_spotify.create_spotify(
+        db_oauth.save_token(
             user_id=3,
+            service=ExternalService.SPOTIFY,
             access_token='tokentoken',
             refresh_token='newrefresh_token',
             token_expires_ts=int(time.time()),
@@ -121,16 +80,6 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         users = db_spotify.get_active_users_to_process()
         self.assertEqual(len(users), 1)
         self.assertEqual(users[0]['user_id'], 1)
-
-    def test_get_user(self):
-        user = db_spotify.get_user(self.user['id'])
-        self.assertEqual(user['user_id'], self.user['id'])
-        self.assertEqual(user['musicbrainz_id'], self.user['musicbrainz_id'])
-        self.assertEqual(user['musicbrainz_row_id'], self.user['musicbrainz_row_id'])
-        self.assertEqual(user['access_token'], 'token')
-        self.assertEqual(user['refresh_token'], 'refresh_token')
-        self.assertIn('token_expires', user)
-        self.assertIn('token_expired', user)
 
     def test_get_user_import_details(self):
         user = db_spotify.get_user_import_details(self.user['id'])

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import listenbrainz.db.user as db_user
-import listenbrainz.db.spotify as db_spotify
+import listenbrainz.db.external_service_oauth as db_oauth
 import listenbrainz.db.stats as db_stats
 import sqlalchemy
 import time
 import ujson
 
+from data.model.external_service import ExternalService
 from listenbrainz import db
 from listenbrainz.db.similar_users import import_user_similarities
 from listenbrainz.db.testing import DatabaseTestCase
@@ -150,12 +151,13 @@ class UserTestCase(DatabaseTestCase):
         user_id = db_user.create(11, 'kishore')
         user = db_user.get(user_id)
         self.assertIsNotNone(user)
-        db_spotify.create_spotify(user_id, 'user token', 'refresh token', 0, True, ['user-read-recently-played'])
+        db_oauth.save_token(user_id, ExternalService.SPOTIFY, 'user token',
+                            'refresh token', 0, True, ['user-read-recently-played'])
 
         db_user.delete(user_id)
         user = db_user.get(user_id)
         self.assertIsNone(user)
-        token = db_spotify.get_token_for_user(user_id)
+        token = db_oauth.get_token(user_id, ExternalService.SPOTIFY)
         self.assertIsNone(token)
 
     def test_validate_usernames(self):

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -197,8 +197,13 @@ def get_user_import_details(user_id):
     if user:
         if user['latest_listened_at']:
             user['latest_listened_at_iso'] = user['latest_listened_at'].isoformat() + "Z"
+        else:
+            user['latest_listened_at_iso'] = None
+
         if user['last_updated']:
             user['last_updated_iso'] = user['last_updated'].isoformat() + "Z"
+        else:
+            user['last_updated_iso'] = None
 
     return user
 

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -58,6 +58,8 @@ class Spotify:
 
     @property
     def token_expired(self):
+        if not self.token_expires:
+            return False
         now = datetime.utcnow()
         now = now.replace(tzinfo=timezone.utc)
         return now >= self.token_expires

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -6,11 +6,11 @@ from flask import current_app
 
 from data.model.external_service import ExternalService
 from listenbrainz.domain import spotify
-from listenbrainz.webserver.testing import ServerTestCase
+from listenbrainz.tests.integration import IntegrationTestCase
 from unittest import mock
 
 
-class SpotifyDomainTestCase(ServerTestCase):
+class SpotifyDomainTestCase(IntegrationTestCase):
 
     def setUp(self):
         super(SpotifyDomainTestCase, self).setUp()

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -22,6 +22,21 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
 
+
+class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):
+    def setUp(self):
+        IntegrationTestCase.setUp(self)
+        TimescaleTestCase.setUp(self)
+        self.user = db_user.get_or_create(1, 'testuserpleaseignore')
+        db_user.agree_to_gdpr(self.user['musicbrainz_id'])
+        self.user2 = db_user.get_or_create(2, 'all_muppets_all_of_them')
+
+    def tearDown(self):
+        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
+        r.flushall()
+        IntegrationTestCase.tearDown(self)
+        TimescaleTestCase.tearDown(self)
+
     def wait_for_query_to_have_items(self, url, num_items, **kwargs):
         """Try the provided query in a loop until the required number of returned listens is available.
         In integration tests, we send data through a number of services before it hits the database,
@@ -45,21 +60,6 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
             if data['count'] == num_items:
                 break
         return response
-
-
-class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):
-    def setUp(self):
-        IntegrationTestCase.setUp(self)
-        TimescaleTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, 'testuserpleaseignore')
-        db_user.agree_to_gdpr(self.user['musicbrainz_id'])
-        self.user2 = db_user.get_or_create(2, 'all_muppets_all_of_them')
-
-    def tearDown(self):
-        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
-        r.flushall()
-        IntegrationTestCase.tearDown(self)
-        TimescaleTestCase.tearDown(self)
 
     def send_data(self, payload, user=None):
         """ Sends payload to api.submit_listen and return the response

--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
@@ -103,7 +103,11 @@ describe("BrainzPlayer", () => {
       ...props,
       spotifyUser: {
         access_token: "haveyouseenthefnords",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as Array<SpotifyPermission>,
       },
     };
     const wrapper = mount<BrainzPlayer>(<BrainzPlayer {...mockProps} />);
@@ -129,7 +133,11 @@ describe("BrainzPlayer", () => {
       ...props,
       spotifyUser: {
         access_token: "haveyouseenthefnords",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as Array<SpotifyPermission>,
       },
     };
     const wrapper = mount<BrainzPlayer>(<BrainzPlayer {...mockProps} />);
@@ -154,7 +162,11 @@ describe("BrainzPlayer", () => {
       ...props,
       spotifyUser: {
         access_token: "haveyouseenthefnords",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as Array<SpotifyPermission>,
       },
     };
     const wrapper = mount<BrainzPlayer>(<BrainzPlayer {...mockProps} />);
@@ -179,7 +191,11 @@ describe("BrainzPlayer", () => {
       ...props,
       spotifyUser: {
         access_token: "haveyouseenthefnords",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as Array<SpotifyPermission>,
       },
     };
     const wrapper = mount<BrainzPlayer>(<BrainzPlayer {...mockProps} />);

--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
@@ -9,7 +9,7 @@ import APIService from "./APIService";
 const props = {
   spotifyUser: {
     access_token: "heyo",
-    permission: "read" as SpotifyPermission,
+    permission: ["user-read-currently-playing"] as Array<SpotifyPermission>,
   },
   direction: "up" as BrainzPlayDirection,
   onCurrentListenChange: (listen: Listen | JSPFTrack) => {},
@@ -55,7 +55,11 @@ describe("BrainzPlayer", () => {
       ...props,
       spotifyUser: {
         access_token: "haveyouseenthefnords",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as Array<SpotifyPermission>,
       },
     };
     const wrapper = mount<BrainzPlayer>(<BrainzPlayer {...mockProps} />);
@@ -68,7 +72,11 @@ describe("BrainzPlayer", () => {
       ...props,
       spotifyUser: {
         access_token: "haveyouseenthefnords",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as Array<SpotifyPermission>,
       },
     };
     const wrapper = mount<BrainzPlayer>(<BrainzPlayer {...mockProps} />);

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.test.tsx
@@ -8,7 +8,7 @@ import { DataSourceTypes } from "./BrainzPlayer";
 const props = {
   spotifyUser: {
     access_token: "heyo",
-    permission: "read" as SpotifyPermission,
+    permission: ["user-read-currently-playing"] as SpotifyPermission[],
   },
   refreshSpotifyToken: new APIService("base-uri").refreshSpotifyToken,
   show: true,
@@ -112,7 +112,11 @@ describe("SpotifyPlayer", () => {
       const onInvalidateDataSource = jest.fn();
       const spotifyUser = {
         access_token: "FNORD",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as SpotifyPermission[],
       };
       expect(SpotifyPlayer.hasPermissions(spotifyUser)).toEqual(true);
       const mockProps = {
@@ -134,7 +138,11 @@ describe("SpotifyPlayer", () => {
       const checkSpotifyToken = jest.fn();
       const spotifyUser = {
         access_token: "FNORD",
-        permission: "streaming user-read-email user-read-private" as SpotifyPermission,
+        permission: [
+          "streaming",
+          "user-read-email",
+          "user-read-private",
+        ] as SpotifyPermission[],
       };
       const mockProps = {
         ...props,

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -212,7 +212,7 @@ export default class SpotifyPlayer
         }
       })
       .catch((error) => {
-        handleError(error.message);
+        handleError(error);
       });
   };
 

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -46,7 +46,6 @@ type SpotifyPlayerProps = DataSourceProps & {
 
 type SpotifyPlayerState = {
   accessToken: string;
-  permission: Array<SpotifyPermission>;
   currentSpotifyTrack?: SpotifyTrack;
   durationMs: number;
   trackWindow?: SpotifyPlayerTrackWindow;
@@ -55,6 +54,25 @@ type SpotifyPlayerState = {
 export default class SpotifyPlayer
   extends React.Component<SpotifyPlayerProps, SpotifyPlayerState>
   implements DataSourceType {
+  static hasPermissions = (spotifyUser: SpotifyUser) => {
+    const { access_token: accessToken, permission } = spotifyUser;
+    if (!accessToken || !permission) {
+      return false;
+    }
+    const scopes = permission;
+    const requiredScopes = [
+      "streaming",
+      "user-read-email",
+      "user-read-private",
+    ] as Array<SpotifyPermission>;
+    for (let i = 0; i < requiredScopes.length; i += 1) {
+      if (!scopes.includes(requiredScopes[i])) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   spotifyPlayer?: SpotifyPlayerType;
   debouncedOnTrackEnd: () => void;
 
@@ -62,7 +80,6 @@ export default class SpotifyPlayer
     super(props);
     this.state = {
       accessToken: props.spotifyUser.access_token || "",
-      permission: props.spotifyUser.permission || [],
       durationMs: 0,
     };
 
@@ -197,34 +214,6 @@ export default class SpotifyPlayer
       .catch((error) => {
         handleError(error.message);
       });
-  };
-
-  checkSpotifyToken = async (
-    accessToken?: string,
-    permission?: Array<SpotifyPermission>
-  ): Promise<boolean> => {
-    const { onInvalidateDataSource, handleError } = this.props;
-    if (!accessToken || !permission || !permission.length) {
-      this.handleAccountError();
-      return false;
-    }
-    try {
-      const requiredScopes: Array<SpotifyPermission> = [
-        "streaming",
-        "user-read-email",
-        "user-read-private",
-      ];
-      for (let i = 0; i < requiredScopes.length; i += 1) {
-        if (!permission.includes(requiredScopes[i])) {
-          onInvalidateDataSource(this, "Permission to play songs not granted");
-          return false;
-        }
-      }
-      return true;
-    } catch (error) {
-      handleError(error);
-      return false;
-    }
   };
 
   playListen = (listen: Listen | JSPFTrack): void => {

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensProps.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensProps.json
@@ -2199,7 +2199,7 @@
     "mode": "listens",
     "spotify": {
         "access_token": "access token",
-        "permission": ["streaming user-read-email", "user-read-private"]
+        "permission": ["streaming", "user-read-email", "user-read-private"]
     },
     "webSocketsServerUrl": "http://localhost:8082",
     "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensProps.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensProps.json
@@ -2199,7 +2199,7 @@
     "mode": "listens",
     "spotify": {
         "access_token": "access token",
-        "permission": "streaming user-read-email user-read-private"
+        "permission": ["streaming user-read-email", "user-read-private"]
     },
     "webSocketsServerUrl": "http://localhost:8082",
     "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsOneListen.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsOneListen.json
@@ -30,7 +30,7 @@
   "mode": "listens",
   "spotify": {
     "access_token": "access token",
-    "permission": ["streaming user-read-email", "user-read-private"]
+    "permission": ["streaming", "user-read-email", "user-read-private"]
   },
   "webSocketsServerUrl": "http://localhost:8082",
   "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsOneListen.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsOneListen.json
@@ -30,7 +30,7 @@
   "mode": "listens",
   "spotify": {
     "access_token": "access token",
-    "permission": "streaming user-read-email user-read-private"
+    "permission": ["streaming user-read-email", "user-read-private"]
   },
   "webSocketsServerUrl": "http://localhost:8082",
   "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsPlayingNow.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsPlayingNow.json
@@ -40,7 +40,7 @@
   "mode": "listens",
   "spotify": {
     "access_token": "access token",
-    "permission": ["streaming user-read-email", "user-read-private"]
+    "permission": ["streaming", "user-read-email", "user-read-private"]
   },
   "webSocketsServerUrl": "http://localhost:8082",
   "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsPlayingNow.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsPlayingNow.json
@@ -40,7 +40,7 @@
   "mode": "listens",
   "spotify": {
     "access_token": "access token",
-    "permission": "streaming user-read-email user-read-private"
+    "permission": ["streaming user-read-email", "user-read-private"]
   },
   "webSocketsServerUrl": "http://localhost:8082",
   "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsTooManyListens.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsTooManyListens.json
@@ -839,7 +839,7 @@
   "mode": "listens",
   "spotify": {
     "access_token": "access token",
-    "permission": "streaming user-read-email user-read-private"
+    "permission": ["streaming user-read-email", "user-read-private"]
   },
   "webSocketsServerUrl": "http://localhost:8082",
   "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsTooManyListens.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsTooManyListens.json
@@ -839,7 +839,7 @@
   "mode": "listens",
   "spotify": {
     "access_token": "access token",
-    "permission": ["streaming user-read-email", "user-read-private"]
+    "permission": ["streaming", "user-read-email", "user-read-private"]
   },
   "webSocketsServerUrl": "http://localhost:8082",
   "apiUrl": "http://0.0.0.0",

--- a/listenbrainz/webserver/static/js/src/__mocks__/recommendationPropsOne.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recommendationPropsOne.json
@@ -29,7 +29,7 @@
     "apiUrl": "http://0.0.0.0",
     "spotify": {
       "access_token": "access token",
-      "permission": "streaming user-read-email user-read-private"
+      "permission": ["streaming", "user-read-email", "user-read-private"]
     },
     "profileUrl": "/user/vansika"
   }

--- a/listenbrainz/webserver/static/js/src/__mocks__/recommendations.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recommendations.json
@@ -729,7 +729,7 @@
   "apiUrl": "http://0.0.0.0",
   "spotify": {
     "access_token": "access token",
-    "permission": "streaming user-read-email user-read-private"
+    "permission": ["streaming", "user-read-email", "user-read-private"]
   },
   "profileUrl": "/user/vansika"
 }

--- a/listenbrainz/webserver/static/js/src/__snapshots__/SpotifyPlayer.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/__snapshots__/SpotifyPlayer.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`SpotifyPlayer renders 1`] = `
   spotifyUser={
     Object {
       "access_token": "heyo",
-      "permission": "read",
+      "permission": Array [
+        "user-read-currently-playing",
+      ],
     }
   }
 >

--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.test.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.test.tsx
@@ -26,7 +26,7 @@ const props = {
   playlist: playlist as JSPFObject,
   spotify: {
     access_token: "heyo",
-    permission: "streaming" as SpotifyPermission,
+    permission: ["streaming"] as Array<SpotifyPermission>,
   },
   currentUser,
   webSocketsServerUrl,

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -77,7 +77,7 @@ declare type SubmitListensPayload = {
 
 declare type SpotifyUser = {
   access_token?: string;
-  permission?: SpotifyPermission;
+  permission?: Array<SpotifyPermission>;
 };
 
 declare type SpotifyPermission =

--- a/listenbrainz/webserver/static/js/src/user-feed/__mocks__/timelineProps.json
+++ b/listenbrainz/webserver/static/js/src/user-feed/__mocks__/timelineProps.json
@@ -6,7 +6,7 @@
     },
     "spotify": {
         "access_token": "access token",
-        "permission": "streaming user-read-email user-read-private"
+        "permission": ["streaming", "user-read-email", "user-read-private"]
     },
     "apiUrl": "http://0.0.0.0",
 	"events": [


### PR DESCRIPTION
Now that we are moving to new schema structure which supports integrating multiple services, it makes sense to use this opportunity to rewrite existing code to promote reuse between different services and make adding new integrations easier.