### PR TITLE
Add source maps to Webpack production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = function (env) {
       filename: isProd ? "[name].[contenthash].js" : "[name].js",
       path: "/static/js/dist",
     },
-    devtool: isProd ? false : "inline-source-map",
+    devtool: isProd ? "source-map" : "eval-source-map",
     module: {
       rules: [
         {


### PR DESCRIPTION
Publishing these source maps will give Sentry access to them to be able to display error in an un-minified context.

This is the easy solution, and since all our code is publicly hosted anyway… 🤷 

Reference: https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/hosting-publicly/
and https://webpack.js.org/configuration/devtool/