### PR TITLE
Youtube player bug

### DIFF
--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -139,10 +139,9 @@ export default class YoutubePlayer
     const { onTrackNotFound } = this.props;
     // We use cueVideoById("") as a means to clear any playlist.
     // If search or loadVideoByID yield no results we can detect that nothing was found
-    if (
-      this.youtubePlayer.getVideoData &&
-      !this.youtubePlayer.getVideoData().video_id
-    ) {
+    const videoData =
+      this.youtubePlayer.getVideoData && this.youtubePlayer.getVideoData();
+    if (videoData && !videoData.video_id) {
       onTrackNotFound();
     }
   };

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -205,7 +205,7 @@ export default class YoutubePlayer
         iv_load_policy: 3,
         modestbranding: 1,
         rel: 0,
-        origin: window.location.origin.toString(),
+        origin: window.location.origin,
       },
       width: "100%",
       height: "100%",
@@ -215,6 +215,7 @@ export default class YoutubePlayer
         <YouTube
           opts={options}
           onStateChange={this.handlePlayerStateChanged}
+          onError={this.onError}
           onReady={this.onReady}
         />
       </div>

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -23,7 +23,7 @@ export default class YoutubePlayer
   extends React.Component<DataSourceProps, YoutubePlayerState>
   implements DataSourceType {
   youtubePlayer?: ExtendedYoutubePlayer;
-  youtubePlayerStateTimerID = null;
+  checkVideoLoadedTimerId?: NodeJS.Timeout;
 
   componentDidUpdate(prevProps: DataSourceProps) {
     const { show } = this.props;
@@ -129,7 +129,10 @@ export default class YoutubePlayer
     } else {
       this.searchAndPlayTrack(listen);
     }
-    setTimeout(this.checkVideoLoaded.bind(this), 1500);
+    this.checkVideoLoadedTimerId = setTimeout(
+      this.checkVideoLoaded.bind(this),
+      1500
+    );
   };
 
   checkVideoLoaded = () => {
@@ -171,6 +174,9 @@ export default class YoutubePlayer
   onError = (event: YT.OnErrorEvent): void => {
     const { data: errorNumber } = event;
     const { handleError, onTrackNotFound } = this.props;
+    if (this.checkVideoLoadedTimerId) {
+      clearTimeout(this.checkVideoLoadedTimerId);
+    }
     let message = "Something went wrong";
     switch (errorNumber) {
       case 101:

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -141,11 +141,13 @@ export default class YoutubePlayer
     }
     const { onTrackNotFound } = this.props;
     // We use cueVideoById("") as a means to clear any playlist.
-    // If search or loadVideoByID yield no results we can detect that nothing was found
-    const videoData =
-      this.youtubePlayer.getVideoData && this.youtubePlayer.getVideoData();
-    if (videoData && !videoData.video_id) {
-      onTrackNotFound();
+    // If there was an undetected error loading a video, the getVideoData method won't exist
+    // or getVideoData.video_id will be null and we should go to the next track
+    if (this.youtubePlayer?.getVideoData) {
+      const videoData = this.youtubePlayer.getVideoData();
+      if (videoData?.video_id === null) {
+        onTrackNotFound();
+      }
     }
   };
 


### PR DESCRIPTION
Sentry reported issue with the Youtube player: `Cannot read property 'video_id' of undefined`
https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/115090

We have some unsafe property access, easy to fix.

It also turns out the `onError` handler wasn't tied to the youtube player.
Fixing this, along with canceling the (admitedly hacky) `checkVideoLoaded` function we run with a timeout, should fix some of the issues with the player and at the very least let users know something went wrong.