### PR TITLE
Fix bugs in stats pages

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.test.tsx
@@ -192,7 +192,7 @@ describe("processData", () => {
     // When stats haven't been calculated, processData is called with an empty object
     const result = instance.processData({} as UserArtistMapResponse, "listen");
 
-    expect(result).toEqual(userArtistMapProcessedDataListen);
+    expect(result).toEqual([]);
   });
 });
 

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.test.tsx
@@ -183,6 +183,17 @@ describe("processData", () => {
 
     expect(result).toEqual(userArtistMapProcessedDataListen);
   });
+  it("returns an empty array if no payload", () => {
+    const wrapper = shallow<UserArtistMap>(
+      <UserArtistMap {...{ ...props, range: "all_time" }} />
+    );
+    const instance = wrapper.instance();
+
+    // When stats haven't been calculated, processData is called with an empty object
+    const result = instance.processData({} as UserArtistMapResponse, "listen");
+
+    expect(result).toEqual(userArtistMapProcessedDataListen);
+  });
 });
 
 describe("changeSelectedMetric", () => {

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -131,6 +131,9 @@ export default class UserArtistMap extends React.Component<
     data: UserArtistMapResponse,
     selectedMetric: "artist" | "listen"
   ): UserArtistMapData => {
+    if (!data?.payload) {
+      return [];
+    }
     return data.payload.artist_map.map((country) => {
       return {
         id: country.country,

--- a/listenbrainz/webserver/static/js/src/stats/UserDailyActivity.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserDailyActivity.test.tsx
@@ -186,6 +186,17 @@ describe("processData", () => {
 
     expect(result).toEqual(userDailyActivityProcessedData);
   });
+  it("returns an empty array if no payload", () => {
+    const wrapper = shallow<UserDailyActivity>(
+      <UserDailyActivity {...{ ...props, range: "all_time" }} />
+    );
+    const instance = wrapper.instance();
+
+    // When stats haven't been calculated, processData is called with an empty object
+    const result = instance.processData({} as UserDailyActivityResponse);
+
+    expect(result).toEqual([]);
+  });
 });
 
 describe("loadData", () => {

--- a/listenbrainz/webserver/static/js/src/stats/UserDailyActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserDailyActivity.tsx
@@ -118,6 +118,9 @@ export default class UserDailyActivity extends React.Component<
     ];
 
     const result: UserDailyActivityData = [];
+    if (!data?.payload) {
+      return result;
+    }
 
     const tzOffset = -Math.floor(new Date().getTimezoneOffset() / 60);
 

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.test.tsx
@@ -400,6 +400,15 @@ describe("processData", () => {
       instance.processData(userRecordingsResponse as UserRecordingsResponse, 1)
     ).toEqual(userRecordingsProcessDataOutput);
   });
+  it("returns an empty array if no payload", () => {
+    const wrapper = shallow<UserEntityChart>(<UserEntityChart {...props} />);
+    const instance = wrapper.instance();
+
+    // When stats haven't been calculated, processData is called with an empty object
+    const result = instance.processData({} as UserRecordingsResponse, 1);
+
+    expect(result).toEqual([]);
+  });
 });
 
 describe("syncStateWithURL", () => {

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -207,7 +207,7 @@ export default class UserEntityChart extends React.Component<
     }
     const offset = (page - 1) * this.ROWS_PER_PAGE;
 
-    let result = {} as UserEntityData;
+    let result = [] as UserEntityData;
     if (!data?.payload) {
       return result;
     }

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -208,6 +208,9 @@ export default class UserEntityChart extends React.Component<
     const offset = (page - 1) * this.ROWS_PER_PAGE;
 
     let result = {} as UserEntityData;
+    if (!data?.payload) {
+      return result;
+    }
     if (entity === "artist") {
       result = (data as UserArtistsResponse).payload.artists
         .map((elem, idx: number) => {

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.test.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.test.tsx
@@ -286,6 +286,17 @@ describe("processData", () => {
 
     expect(result).toEqual(userListeningActivityProcessedDataAllTime);
   });
+  it("returns an empty array if no payload", () => {
+    const wrapper = shallow<UserListeningActivity>(
+      <UserListeningActivity {...{ ...props, range: "year" }} />
+    );
+    const instance = wrapper.instance();
+
+    // When stats haven't been calculated, processData is called with an empty object
+    const result = instance.processData({} as UserListeningActivityResponse);
+
+    expect(result).toEqual([]);
+  });
 });
 
 describe("loadData", () => {

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -144,16 +144,16 @@ export default class UserListeningActivity extends React.Component<
     if (!data?.payload) {
       return result;
     }
-    if (range === "week") {
+    else if (range === "week") {
       result = this.processWeek(data);
     }
-    if (range === "month") {
+    else if (range === "month") {
       result = this.processMonth(data);
     }
-    if (range === "year") {
+    else if (range === "year") {
       result = this.processYear(data);
     }
-    if (range === "all_time") {
+    else if (range === "all_time") {
       result = this.processAllTime(data);
     }
     return result;

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -140,7 +140,7 @@ export default class UserListeningActivity extends React.Component<
     data: UserListeningActivityResponse
   ): UserListeningActivityData => {
     const { range } = this.props;
-    let result = {} as UserListeningActivityData;
+    let result = [] as UserListeningActivityData;
     if (!data?.payload) {
       return result;
     }

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -144,7 +144,7 @@ export default class UserListeningActivity extends React.Component<
     if (!data?.payload) {
       return result;
     }
-    else if (range === "week") {
+    if (range === "week") {
       result = this.processWeek(data);
     }
     else if (range === "month") {

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -140,19 +140,23 @@ export default class UserListeningActivity extends React.Component<
     data: UserListeningActivityResponse
   ): UserListeningActivityData => {
     const { range } = this.props;
+    let result = {} as UserListeningActivityData;
+    if (!data?.payload) {
+      return result;
+    }
     if (range === "week") {
-      return this.processWeek(data);
+      result = this.processWeek(data);
     }
     if (range === "month") {
-      return this.processMonth(data);
+      result = this.processMonth(data);
     }
     if (range === "year") {
-      return this.processYear(data);
+      result = this.processYear(data);
     }
     if (range === "all_time") {
-      return this.processAllTime(data);
+      result = this.processAllTime(data);
     }
-    return {} as UserListeningActivityData;
+    return result;
   };
 
   processWeek = (


### PR DESCRIPTION
If user stats have not been calculated, API will return 204 and an empty response.
The code that then processes the response currently tries to access a non-existing payload and throws an error.
I added some checks to abort early if there is no payload and return an appropriate empty  array.
Added some tests for this behavior.

Errors reported in Sentry:
https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/115123
and
https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/115127