### PR TITLE
Catch unhandled promise rejections in ErrorBoundary

### DIFF
--- a/listenbrainz/webserver/static/js/src/ErrorBoundary.tsx
+++ b/listenbrainz/webserver/static/js/src/ErrorBoundary.tsx
@@ -15,9 +15,31 @@ export default class ErrorBoundary extends React.Component<
     this.state = { hasError: false, error: null };
   }
 
+  componentDidMount() {
+    // Add an event listener to the window to catch unhandled promise rejections & stash the error in the state
+    window.addEventListener(
+      "unhandledrejection",
+      this.promiseRejectionHandler.bind(this)
+    );
+  }
+
   componentDidCatch(error: Error) {
     // Update state so the next render will show the fallback UI.
     this.setState({ hasError: true, error });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener(
+      "unhandledrejection",
+      this.promiseRejectionHandler
+    );
+  }
+
+  promiseRejectionHandler(event: PromiseRejectionEvent) {
+    this.setState({
+      error: event.reason,
+      hasError: true,
+    });
   }
 
   render() {

--- a/listenbrainz/webserver/static/js/src/ErrorBoundary.tsx
+++ b/listenbrainz/webserver/static/js/src/ErrorBoundary.tsx
@@ -17,10 +17,7 @@ export default class ErrorBoundary extends React.Component<
 
   componentDidMount() {
     // Add an event listener to the window to catch unhandled promise rejections & stash the error in the state
-    window.addEventListener(
-      "unhandledrejection",
-      this.promiseRejectionHandler.bind(this)
-    );
+    window.addEventListener("unhandledrejection", this.promiseRejectionHandler);
   }
 
   componentDidCatch(error: Error) {
@@ -35,12 +32,12 @@ export default class ErrorBoundary extends React.Component<
     );
   }
 
-  promiseRejectionHandler(event: PromiseRejectionEvent) {
+  promiseRejectionHandler = (event: PromiseRejectionEvent) => {
     this.setState({
       error: event.reason,
       hasError: true,
     });
-  }
+  };
 
   render() {
     const { children } = this.props;

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -119,9 +119,7 @@ export default class UserArtistMap extends React.Component<
           errorMessage: "Statistics for the user have not been calculated",
         });
       } else {
-        this.setState(() => {
-          throw error;
-        });
+        throw error;
       }
     }
     return {} as UserArtistMapResponse;

--- a/listenbrainz/webserver/static/js/src/stats/UserDailyActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserDailyActivity.tsx
@@ -86,9 +86,7 @@ export default class UserDailyActivity extends React.Component<
           errorMessage: "Statistics for the user have not been calculated",
         });
       } else {
-        this.setState(() => {
-          throw error;
-        });
+        throw error;
       }
     }
     return {} as UserDailyActivityResponse;

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -328,12 +328,7 @@ export default class UserEntityChart extends React.Component<
           entity,
         });
       } else {
-        // Error Boundaries don't catch errors in async code.
-        // Throwing an error in setState fixes this.
-        // This is a hacky solution but should be fixed with upcoming concurrent mode in React.
-        this.setState(() => {
-          throw error;
-        });
+        throw error;
       }
     }
   };

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -120,9 +120,7 @@ export default class UserListeningActivity extends React.Component<
           errorMessage: "Statistics for the user have not been calculated",
         });
       } else {
-        this.setState(() => {
-          throw error;
-        });
+        throw error;
       }
     }
     return {} as UserListeningActivityResponse;

--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -87,9 +87,7 @@ export default class UserTopEntity extends React.Component<
           errorMessage: "Statistics for the user have not been calculated",
         });
       } else {
-        this.setState(() => {
-          throw error;
-        });
+        throw error;
       }
     }
     return {} as UserEntityResponse;


### PR DESCRIPTION
React ErrorBoundaries do not catch errors thrown in async code (such as event listeners and promises).
That's…not great.
With this PR, we add a listener in ErrorBoundary listening to [the unhandledrejection event](https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event), and setting the error to be displayed in the rendered component.

This allows us to get rid of some ugly hack (suggested in the React ticket[1]) we have peppered in the code, for example:
https://github.com/metabrainz/listenbrainz-server/blob/22c365c82fb75d692dbd8cafb91fd4c54462e868/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx#L331-L336

This nifty unhandledrejection trick is courtesy of https://eddiewould.com/2021/28/28/handling-rejected-promises-error-boundary-react/

[1]: Some extra context: https://github.com/facebook/react/issues/11409
