### PR TITLE
Fix unique queue

### DIFF
--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -167,6 +167,9 @@ class TimescaleWriterSubscriber(ListenWriter):
 
                     self.unique_ch = self.connection.channel()
                     self.unique_ch.exchange_declare(exchange=current_app.config['UNIQUE_EXCHANGE'], exchange_type='fanout')
+                    self.unique_ch.queue_declare(current_app.config['UNIQUE_QUEUE'], durable=True)
+                    self.unique_ch.queue_bind(exchange=current_app.config['UNIQUE_EXCHANGE'],
+                                              queue=current_app.config['UNIQUE_QUEUE'])
 
                     try:
                         self.incoming_ch.start_consuming()


### PR DESCRIPTION
For some reason the code to properly configure the unique exchange/queue was never added to the timescale_writer, but instead it was on the consuming side, which feels a bit odd. This fixes that, at least in theory. :)