### PR TITLE
Change tag pattern to trigger build image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,7 @@ name: Build image and publish to Docker Hub
 on:
   push:
     tags:
-      - v-[0-9]{4}-[0-9]{2}-[0-9]{1,2}.[0-9]+
+      - v-[0-9]+-[0-9]+-[0-9]+.[0-9]+
 
 jobs:
 


### PR DESCRIPTION
Turns out @alastair was right all along, Github Actions indeed does not support `{}` in the tag pattern.