### PR TITLE
Timescale offline support

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -32,6 +32,10 @@ MB_DATABASE_URI = 'postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrain
 {{end}}
 {{end}}
 
+SQLALCHEMY_TIMESCALE_URI = ""
+TIMESCALE_ADMIN_URI=""
+TIMESCALE_ADMIN_LB_URI=""
+
 {{if service "timescale-listenbrainz"}}
 {{with index (service "timescale-listenbrainz") 0}}
 SQLALCHEMY_TIMESCALE_URI = "postgresql://listenbrainz_ts:listenbrainz_ts@{{.Address}}:{{.Port}}/listenbrainz_ts"
@@ -39,7 +43,6 @@ TIMESCALE_ADMIN_URI="postgresql://postgres:postgres@{{.Address}}:{{.Port}}/postg
 TIMESCALE_ADMIN_LB_URI="postgresql://postgres:postgres@{{.Address}}:{{.Port}}/listenbrainz_ts"
 {{end}}
 {{end}}
-SQLALCHEMY_TIMESCALE_URI = ""
 
 {{if service "pgbouncer-williams"}}
 {{with index (service "pgbouncer-williams") 0}}

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -39,6 +39,7 @@ TIMESCALE_ADMIN_URI="postgresql://postgres:postgres@{{.Address}}:{{.Port}}/postg
 TIMESCALE_ADMIN_LB_URI="postgresql://postgres:postgres@{{.Address}}:{{.Port}}/listenbrainz_ts"
 {{end}}
 {{end}}
+SQLALCHEMY_TIMESCALE_URI = ""
 
 {{if service "pgbouncer-williams"}}
 {{with index (service "pgbouncer-williams") 0}}

--- a/listenbrainz/db/timescale.py
+++ b/listenbrainz/db/timescale.py
@@ -21,6 +21,9 @@ def init_db_connection(connect_str):
     for more info.
     """
     global engine
+    if not connect_str:
+        return
+
     while True:
         try:
             engine = create_engine(connect_str, poolclass=NullPool)

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -8,6 +8,7 @@ import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 from listenbrainz import db
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
+from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
 
@@ -33,6 +34,15 @@ class APITestCase(ListenAPIIntegrationTestCase):
         response = self.client.get(
             url, query_string={'max_ts': '1400000000', 'min_ts': '1500000000'})
         self.assert400(response)
+
+    def test_get_listens_ts_unavailable(self):
+        """Check that an error message is returned if the listenstore is unavailable"""
+        timescale_connection._ts = None
+
+        url = url_for('api_v1.get_listens',
+                      user_name=self.user['musicbrainz_id'])
+        response = self.client.get(url)
+        self.assertStatus(response, 503)
 
     def test_get_listens(self):
         """ Test to make sure that the api sends valid listens on get requests.

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -19,20 +19,20 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 
-import json
 import time
 import logging
 import xmltodict
 
 import listenbrainz.db.user as db_user
-from flask import url_for, current_app
+from flask import url_for
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.db.lastfm_token import Token
 from listenbrainz.db.lastfm_user import User
 from listenbrainz import config
-from listenbrainz.listenstore import TimescaleListenStore
+from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.timescale_connection import init_timescale_connection
 from listenbrainz.tests.integration import APICompatIntegrationTestCase
+
 
 
 class APICompatTestCase(APICompatIntegrationTestCase):
@@ -135,6 +135,31 @@ class APICompatTestCase(APICompatIntegrationTestCase):
         response = xmltodict.parse(r.data)
         self.assertEqual(response['lfm']['@status'], 'failed')
         self.assertEqual(response['lfm']['error']['@code'], '4')
+
+    def test_user_getinfo_no_listenstore(self):
+        """If this listenstore is unavailable, performing a query that gets user information
+           (touches the listenstore for user count) should return an error message in the
+           requested format"""
+        timescale_connection._ts = None
+
+        token = Token.generate(self.lfm_user.api_key)
+        token.approve(self.lfm_user.name)
+        session = Session.create(token)
+
+        data = {
+            'method': 'user.getInfo',
+            'api_key': self.lfm_user.api_key,
+            'sk': session.sid
+        }
+
+        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        self.assert200(r)
+
+        expected_message = b"""<?xml version="1.0" encoding="utf-8"?>
+<lfm status="failed">
+  <error code="16">The service is temporarily unavailable, please try again.</error>
+</lfm>"""
+        assert r.data == expected_message
 
     def test_record_listen(self):
         """ Tests if listen is recorded correctly if valid information is provided. """

--- a/listenbrainz/webserver/decorators.py
+++ b/listenbrainz/webserver/decorators.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from flask import request, current_app, make_response, redirect, url_for
 from six import string_types
 
+from listenbrainz.webserver import timescale_connection
 
 
 def crossdomain(origin='*', methods=None, headers=None,
@@ -56,7 +57,7 @@ def api_listenstore_needed(func):
     @wraps(func)
     def decorator(*args, **kwargs):
         from listenbrainz.webserver.errors import APIServiceUnavailable
-        if not current_app.config["SQLALCHEMY_TIMESCALE_URI"]:
+        if timescale_connection._ts is None:
             raise APIServiceUnavailable("The listen database is momentarily offline. " +
                                         "Please wait a few minutes and try again.")
         return func(*args, **kwargs)
@@ -72,7 +73,7 @@ def web_listenstore_needed(func):
     """
     @wraps(func)
     def decorator(*args, **kwargs):
-        if not current_app.config["SQLALCHEMY_TIMESCALE_URI"]:
+        if timescale_connection._ts is None:
             return redirect(url_for("index.listens_offline"))
         return func(*args, **kwargs)
 

--- a/listenbrainz/webserver/decorators.py
+++ b/listenbrainz/webserver/decorators.py
@@ -1,7 +1,8 @@
 from functools import update_wrapper
 from datetime import timedelta
-from flask import request, current_app, make_response
+from flask import request, current_app, make_response, redirect, url_for
 from six import string_types
+
 
 
 def crossdomain(origin='*', methods=None, headers=None,
@@ -44,4 +45,37 @@ def crossdomain(origin='*', methods=None, headers=None,
 
         f.provide_automatic_options = False
         return update_wrapper(wrapped_function, f)
+    return decorator
+
+def api_listenstore_needed():
+    """
+        This API decorator checks to see if timescale is online (by having
+        a DB URI) and if not, it raises APIServiceUnavailable.
+    """
+    def decorator(f):
+        def wrapped_function(*args, **kwargs):
+            from listenbrainz.webserver.errors import APIServiceUnavailable
+            if not current_app.config["SQLALCHEMY_TIMESCALE_URI"]:
+                raise APIServiceUnavailable("The listen database is momentarily offline. " +
+                                            "Please wait a few minutes and try again.")
+            return f(*args, **kwargs)
+
+        return update_wrapper(wrapped_function, f)
+
+    return decorator
+
+def web_listenstore_needed():
+    """
+        This web decorator checks to see if timescale is online (by having
+        a DB URI) and if not, it redirects to an error page telling the user
+        that the listenstore is offline.
+    """
+    def decorator(f):
+        def wrapped_function(*args, **kwargs):
+            if not current_app.config["SQLALCHEMY_TIMESCALE_URI"]:
+                return redirect(url_for("index.listens_offline"))
+            return f(*args, **kwargs)
+
+        return update_wrapper(wrapped_function, f)
+
     return decorator

--- a/listenbrainz/webserver/decorators.py
+++ b/listenbrainz/webserver/decorators.py
@@ -47,6 +47,7 @@ def crossdomain(origin='*', methods=None, headers=None,
         return update_wrapper(wrapped_function, f)
     return decorator
 
+
 def api_listenstore_needed(func):
     """
         This API decorator checks to see if timescale is online (by having
@@ -61,6 +62,7 @@ def api_listenstore_needed(func):
         return func(*args, **kwargs)
 
     return decorator
+
 
 def web_listenstore_needed(func):
     """

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -208,10 +208,11 @@ class InvalidAPIUsage(Exception):
         self.output_format = output_format
 
     def render_error(self):
-        return {
-            "json": self.to_json,
-            "xml": self.to_xml
-        }.get(self.output_format, self.to_xml)()
+        if self.output_format == "json":
+            return self.to_json()
+        else:
+            # default to xml if the output format isn't known or is missing
+            return self.to_xml()
 
     def to_json(self):
         return ujson.dumps({

--- a/listenbrainz/webserver/templates/index/listens_offline.html
+++ b/listenbrainz/webserver/templates/index/listens_offline.html
@@ -1,0 +1,17 @@
+{%- extends 'base.html' -%}
+{%- block title -%}Listens currently unavailable - ListenBrainz{%- endblock -%}
+{%- block content -%}
+  <h2 class="page-title">Listens currently unavailable</h2>
+
+  <p>
+     The database that contains listens for our users is currently offline
+     for maintenance. Please try again in a few minutes.
+  </p>
+
+  <p>
+     You may find out more about the current status of our services by
+     checking our <a href="https://twitter.com/ListenBrainz">Twitter
+     feed</a>.
+  </p>
+
+{%- endblock -%}

--- a/listenbrainz/webserver/templates/index/listens_offline.html
+++ b/listenbrainz/webserver/templates/index/listens_offline.html
@@ -9,6 +9,11 @@
   </p>
 
   <p>
+     Please note: You may continue to submit listens during this time. We'll
+     save them once our database is available again.
+  </p>
+
+  <p>
      You may find out more about the current status of our services by
      checking our <a href="https://twitter.com/ListenBrainz">Twitter
      feed</a>.

--- a/listenbrainz/webserver/templates/index/listens_offline.html
+++ b/listenbrainz/webserver/templates/index/listens_offline.html
@@ -18,5 +18,9 @@
      checking our <a href="https://twitter.com/ListenBrainz">Twitter
      feed</a>.
   </p>
+  <div id="twitter-block">
+    <a class="twitter-timeline" data-dnt="true" data-lang="en" href="https://twitter.com/ListenBrainz" data-widget-id="640261552604643328" data-height="450px">Tweets by @ListenBrainz</a>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+  </div>
 
 {%- endblock -%}

--- a/listenbrainz/webserver/timescale_connection.py
+++ b/listenbrainz/webserver/timescale_connection.py
@@ -8,7 +8,7 @@ def init_timescale_connection(logger, conf):
     global _ts
 
     if not conf["SQLALCHEMY_TIMESCALE_URI"]:
-        return None
+        return
 
     while True:
         try:

--- a/listenbrainz/webserver/timescale_connection.py
+++ b/listenbrainz/webserver/timescale_connection.py
@@ -6,6 +6,10 @@ _ts = None
 
 def init_timescale_connection(logger, conf):
     global _ts
+
+    if not conf["SQLALCHEMY_TIMESCALE_URI"]:
+        return None
+
     while True:
         try:
             _ts = TimescaleListenStore(conf, logger)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -7,6 +7,7 @@ from flask import Blueprint, request, jsonify, current_app
 
 from listenbrainz.listenstore import TimescaleListenStore
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIServiceUnavailable
+from listenbrainz.webserver.decorators import api_listenstore_needed
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz import webserver
@@ -97,6 +98,7 @@ def submit_listen():
 @api_bp.route("/user/<user_name>/listens")
 @crossdomain()
 @ratelimit()
+@api_listenstore_needed()
 def get_listens(user_name):
     """
     Get listens for user ``user_name``. The format for the JSON returned is defined in our :ref:`json-doc`.

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -98,7 +98,7 @@ def submit_listen():
 @api_bp.route("/user/<user_name>/listens")
 @crossdomain()
 @ratelimit()
-@api_listenstore_needed()
+@api_listenstore_needed
 def get_listens(user_name):
     """
     Get listens for user ``user_name``. The format for the JSON returned is defined in our :ref:`json-doc`.
@@ -147,6 +147,7 @@ def get_listens(user_name):
 @api_bp.route("/user/<user_name>/listen-count")
 @crossdomain()
 @ratelimit()
+@api_listenstore_needed
 def get_listen_count(user_name):
     """
         Get the number of listens for a user ``user_name``.
@@ -215,6 +216,7 @@ def get_playing_now(user_name):
 @api_bp.route("/users/<user_list>/recent-listens")
 @crossdomain(headers='Authorization, Content-Type')
 @ratelimit()
+@api_listenstore_needed
 def get_recent_listens_for_user_list(user_list):
     """
     Fetch the most recent listens for a comma separated list of users. Take care to properly HTTP escape
@@ -446,6 +448,7 @@ def validate_token():
 @api_bp.route('/delete-listen', methods=['POST', 'OPTIONS'])
 @crossdomain(headers="Authorization, Content-Type")
 @ratelimit()
+@api_listenstore_needed
 def delete_listen():
     """
     Delete a particular listen from a user's listen history.

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -80,7 +80,6 @@ def api_auth_approve():
 
 @api_bp.route('/2.0/', methods=['POST', 'GET'])
 @ratelimit()
-@api_listenstore_needed
 def api_methods():
     """ Receives both (GET & POST)-API calls and redirects them to appropriate methods.
     """

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -11,6 +11,7 @@ from flask_login import login_required, current_user
 from listenbrainz.webserver.external import messybrainz
 from listenbrainz.webserver.rate_limiter import ratelimit
 from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError
+from listenbrainz.webserver.decorators import api_listenstore_needed
 import xmltodict
 from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen
 from listenbrainz.db.lastfm_user import User
@@ -79,6 +80,7 @@ def api_auth_approve():
 
 @api_bp.route('/2.0/', methods=['POST', 'GET'])
 @ratelimit()
+@api_listenstore_needed
 def api_methods():
     """ Receives both (GET & POST)-API calls and redirects them to appropriate methods.
     """

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -293,7 +293,7 @@ def similar_users():
 
 @index_bp.route("/listens-offline")
 def listens_offline():
-    """ 
+    """
         Show the "listenstore offline" message.
     """
 

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -285,3 +285,12 @@ def similar_users():
         "index/similar-users.html",
         similar_users=similar_users
     )
+
+
+@index_bp.route("/listens-offline")
+def listens_offline():
+    """ 
+        Show the "listenstore offline" message.
+    """
+
+    return render_template("index/listens_offline.html")

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -170,6 +170,7 @@ def recent_listens():
 
 @index_bp.route('/feed', methods=['GET', 'OPTIONS'])
 @login_required
+@web_listenstore_needed
 def feed():
 
     spotify_user = {}

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -17,6 +17,7 @@ import listenbrainz.db.user as db_user
 from listenbrainz.db.similar_users import get_top_similar_users
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.domain import spotify
+from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz import webserver
 from listenbrainz.webserver import flash
 from listenbrainz.webserver.timescale_connection import _ts
@@ -34,13 +35,15 @@ NUMBER_OF_RECENT_LISTENS = 50
 @index_bp.route("/")
 def index():
 
-    # get total listen count
-    try:
-        listen_count = _ts.get_total_listen_count()
-    except Exception as e:
-        current_app.logger.error('Error while trying to get total listen count: %s', str(e))
+    if _ts:
+        # get total listen count
+        try:
+            listen_count = _ts.get_total_listen_count()
+        except Exception as e:
+            current_app.logger.error('Error while trying to get total listen count: %s', str(e))
+            listen_count = None
+    else:
         listen_count = None
-
 
     return render_template(
         "index/index.html",
@@ -102,6 +105,7 @@ def roadmap():
 
 
 @index_bp.route("/current-status")
+@web_listenstore_needed
 def current_status():
 
     load = "%.2f %.2f %.2f" % os.getloadavg()

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -2,7 +2,7 @@ import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 import listenbrainz.webserver.rabbitmq_connection as rabbitmq_connection
-from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver.decorators import crossdomain, web_listenstore_needed
 import os
 import re
 import ujson
@@ -163,6 +163,7 @@ def stream_json_array(elements):
 
 @profile_bp.route("/export", methods=["GET", "POST"])
 @login_required
+@web_listenstore_needed
 def export_data():
     """ Exporting the data to json """
     if request.method == "POST":
@@ -206,6 +207,7 @@ def export_feedback():
 
 @profile_bp.route('/delete', methods=['GET', 'POST'])
 @login_required
+@web_listenstore_needed
 def delete():
     """ Delete currently logged-in user from ListenBrainz.
 
@@ -236,6 +238,7 @@ def delete():
 
 @profile_bp.route('/delete-listens', methods=['GET', 'POST'])
 @login_required
+@web_listenstore_needed
 def delete_listens():
     """ Delete all the listens for the currently logged-in user from ListenBrainz.
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -51,7 +51,7 @@ redirect_bp.add_url_rule("/recommendations",
                          redirect_user_page("user.recommendation_playlists"))
 
 @user_bp.route("/<user_name>")
-@web_listenstore_needed()
+@web_listenstore_needed
 def profile(user_name):
     # Which database to use to showing user listens.
     db_conn = webserver.timescale_connection._ts

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -9,6 +9,7 @@ from flask_login import current_user, login_required
 from listenbrainz import webserver
 from listenbrainz.db.playlist import get_playlists_for_user, get_playlists_created_for_user, get_playlists_collaborated_on
 from listenbrainz.domain import spotify
+from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.login import User
 from listenbrainz.webserver import timescale_connection
@@ -49,8 +50,8 @@ redirect_bp.add_url_rule("/recommendations",
                          "redirect_recommendations",
                          redirect_user_page("user.recommendation_playlists"))
 
-
 @user_bp.route("/<user_name>")
+@web_listenstore_needed()
 def profile(user_name):
     # Which database to use to showing user listens.
     db_conn = webserver.timescale_connection._ts

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -35,7 +35,7 @@ from listenbrainz import webserver
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.listenstore import TimescaleListenStore
 from listenbrainz.webserver.views.api import _validate_get_endpoint_params
-from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver.decorators import crossdomain, api_listenstore_needed
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APIUnauthorized, APINotFound, \
     APIForbidden
 from listenbrainz.webserver.views.api_tools import validate_auth_header, _filter_description_html
@@ -157,6 +157,7 @@ def create_user_notification_event(user_name):
 @user_timeline_event_api_bp.route('/user/<user_name>/feed/events', methods=['OPTIONS', 'GET'])
 @crossdomain(headers="Authorization, Content-Type")
 @ratelimit()
+@api_listenstore_needed
 def user_feed(user_name: str):
     """ Get feed events for a user's timeline.
 


### PR DESCRIPTION
Gaga's fan is failing and we will need to replace it. This will take at least 15 minutes, so this PR adds support for having timescale be offline for while the remainder of the services remain up. In theory our web-containers should start up without having the DB connect string defined and give correct error messages. 

API calls will get a 503 error with the correct error message. Web users will be redirected to this error page if they attempt to load a page that requires the timescale listenstore:

<img width="550" alt="Screen Shot 2021-05-03 at 4 30 41 PM" src="https://user-images.githubusercontent.com/49745/116889550-fbebb880-ac2c-11eb-9f93-7c2111da3e14.png">
