### PR TITLE
Don't add GIT_COMMIT_SHA build to the label at the beginning of the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ARG PYTHON_BASE_IMAGE_VERSION=3.7-20210115
 FROM metabrainz/python:$PYTHON_BASE_IMAGE_VERSION as listenbrainz-base
 
+ARG PYTHON_BASE_IMAGE_VERSION
 ARG deploy_env
-ARG GIT_COMMIT_SHA
 
 LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-server.git" \
-      org.label-schema.vcs-ref=$GIT_COMMIT_SHA \
+      org.label-schema.vcs-ref= \
       org.label-schema.schema-version="1.0.0-rc1" \
       org.label-schema.vendor="MetaBrainz Foundation" \
       org.label-schema.name="ListenBrainz" \
@@ -160,4 +160,5 @@ RUN rm -rf ./listenbrainz/webserver/static/
 RUN rm -f /code/listenbrainz/listenbrainz/config.py /code/listenbrainz/listenbrainz/config.pyc
 
 ARG GIT_COMMIT_SHA
+LABEL org.label-schema.vcs-ref=$GIT_COMMIT_SHA
 ENV GIT_SHA ${GIT_COMMIT_SHA}


### PR DESCRIPTION
# Problem

This causes all build to invalidate the entire cache as the
GIT_COMMIT_SHA changes every time that we make a new image. 

# Solution

Add the version label at the end after all other items have changed


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


