### PR TITLE
Update timescale image used in local development

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -7,7 +7,7 @@ version: "3.4"
 services:
 
   db:
-    image: timescale/timescaledb:1.7.4-pg12
+    image: timescale/timescaledb:2.2.0-pg11
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -7,7 +7,7 @@ version: "3.4"
 services:
 
   db:
-    image: timescale/timescaledb:1.7.4-pg12
+    image: timescale/timescaledb:2.2.0-pg11
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'


### PR DESCRIPTION
The prod image is running 2.2. Updating the local image to match the one used in prod.