### PR TITLE
Fix typescript compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ COPY ./docker/services/cron/dump-crontab /etc/cron.d/dump-crontab
 RUN chmod 0644 /etc/cron.d/dump-crontab
 
 # Compile front-end (static) files
-COPY webpack.config.js .eslintrc.js tsconfig.json ./listenbrainz/webserver/static /static/
+COPY webpack.config.js babel.config.js .eslintrc.js tsconfig.json ./listenbrainz/webserver/static /static/
 RUN npm run build:prod
 
 # Now install our code, which may change frequently

--- a/babel.config.js
+++ b/babel.config.js
@@ -19,5 +19,8 @@ module.exports = {
     ],
     "@babel/preset-react",
   ],
-  plugins: ["@babel/plugin-transform-runtime"],
+  plugins: [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-runtime",
+  ],
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,13 @@
 module.exports = {
   presets: [
     [
+      "@babel/preset-typescript",
+      {
+        allowDeclareFields: true,
+      },
+    ],
+    "@babel/preset-react",
+    [
       "@babel/preset-env",
       {
         useBuiltIns: "usage",
@@ -11,15 +18,14 @@ module.exports = {
         },
       },
     ],
+  ],
+  plugins: [
     [
-      "@babel/preset-typescript",
+      "@babel/plugin-transform-typescript",
       {
         allowDeclareFields: true,
       },
     ],
-    "@babel/preset-react",
-  ],
-  plugins: [
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-runtime",
   ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,23 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-react'],
-  plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-transform-runtime']
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        useBuiltIns: "usage",
+        corejs: { version: "3.9", proposals: true },
+        targets: {
+          node: "10",
+          browsers: ["> 0.2% and not dead", "firefox >= 44"],
+        },
+      },
+    ],
+    [
+      "@babel/preset-typescript",
+      {
+        allowDeclareFields: true,
+      },
+    ],
+    "@babel/preset-react",
+  ],
+  plugins: ["@babel/plugin-transform-runtime"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4550,9 +4550,9 @@
       "dev": true
     },
     "d3-array": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.5.0.tgz",
-      "integrity": "sha512-U+CrYn19GmiKeI9qU1RLV1p5ZodBKXw64k9Z3Id6d11LLuZ4JdyCnMT6W/2b84bvqEMFU15zg/JC3/oRYTanVg=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.3.3.tgz",
+      "integrity": "sha512-syv3wp0U5aB6toP2zb2OdBkhTy1MWDsCAaYk6OXJZv+G4u7bSWEmYgxLoFyc88RQUhZYGCebW9a9UD1gFi5+MQ=="
     },
     "d3-color": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@sentry/react": "^6.2.2",
     "clean-css": "^4.2.1",
     "core-js": "^3.9.1",
+    "d3-array": "~2.3.3",
     "d3-format": "^1.4.4",
     "d3-scale": "^3.2.1",
     "d3-scale-chromatic": "^1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,30 +49,9 @@ module.exports = function (env) {
           test: /\.(js|ts)x?$/,
           // some nivo/D3 dependencies need to be transpiled, we include them with the following regex
           exclude: /node_modules\/(?!(d3-array|d3-scale|internmap)\/).*/,
-          use: {
-            loader: "babel-loader",
-            options: {
-              presets: [
-                [
-                  "@babel/preset-env",
-                  {
-                    useBuiltIns: "usage",
-                    corejs: { version: "3.9", proposals: true },
-                    targets: {
-                      node: "10",
-                      browsers: ["> 0.2% and not dead", "firefox >= 44"],
-                    },
-                  },
-                ],
-                "@babel/preset-typescript",
-                "@babel/preset-react",
-              ],
-              plugins: [
-                "@babel/plugin-proposal-class-properties",
-                "@babel/plugin-transform-runtime",
-              ],
-            },
-          },
+          // Don't specify the babel configuration here
+          // Configuration can be found in ./babel.config.js
+          use: "babel-loader",
         },
       ],
     },


### PR DESCRIPTION
My previous PR #1402 inadvertently broke production build due to a missing configuration option for Typescript transpilation.

Not exactly 100% sure why this didn't show up during dev builds at all, but I have some theories (post processing steps like minification or sourcemaps generation).


I also moved the babel configuration to `babel.config.js` (which already existed) to avoid confusion of having two separate configs.