### PR TITLE
LB-882: Build production image in Github actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,3 +30,22 @@ jobs:
 
     - name: Run tests
       run: ./test.sh
+      
+  prod:
+      
+      runs-on: ubuntu-latest
+      
+      needs: test
+      
+      steps:
+      - uses: actions/checkout@v2
+      
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+        continue-on-error: true
+
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+        
+      - name: Build production image
+        run: docker build --target listenbrainz-prod --build-arg deploy_env=test --build-arg GIT_COMMIT_SHA=test .

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,4 +48,4 @@ jobs:
         continue-on-error: true
         
       - name: Build production image
-        run: docker build --target listenbrainz-prod --build-arg deploy_env=test --build-arg GIT_COMMIT_SHA=test .
+        run: docker build --target listenbrainz-prod --build-arg GIT_COMMIT_SHA=HEAD .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ ARG PYTHON_BASE_IMAGE_VERSION=3.7-20210115
 FROM metabrainz/python:$PYTHON_BASE_IMAGE_VERSION as listenbrainz-base
 
 ARG PYTHON_BASE_IMAGE_VERSION
-ARG deploy_env
 
 LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-server.git" \
       org.label-schema.vcs-ref= \

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -2,11 +2,12 @@
 #
 # Build production image from the currently checked out version
 # of ListenBrainz and push it to Docker Hub, with an optional
-# tag (which defaults to "latest")
+# tag (which defaults to "beta")
 #
 # Usage:
 #   $ ./push.sh [tag]
 
+set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../"
 
@@ -14,7 +15,7 @@ git describe --tags --dirty --always > .git-version
 
 TAG=${1:-beta}
 echo "building for env $ENV tag $TAG"
-docker build -t metabrainz/listenbrainz:$TAG \
+docker build -t metabrainz/listenbrainz:"$TAG" \
         --target listenbrainz-prod \
-        --build-arg GIT_COMMIT_SHA=$(git describe --tags --dirty --always) . && \
-    docker push metabrainz/listenbrainz:$TAG
+        --build-arg GIT_COMMIT_SHA="$(git describe --tags --dirty --always)" . && \
+    docker push metabrainz/listenbrainz:"$TAG"

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -12,11 +12,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../"
 
 git describe --tags --dirty --always > .git-version
 
-ENV=${1:-beta}
-TAG=${2:-beta}
+TAG=${1:-beta}
 echo "building for env $ENV tag $TAG"
 docker build -t metabrainz/listenbrainz:$TAG \
         --target listenbrainz-prod \
-        --build-arg deploy_env=$ENV \
         --build-arg GIT_COMMIT_SHA=$(git describe --tags --dirty --always) . && \
     docker push metabrainz/listenbrainz:$TAG


### PR DESCRIPTION
Sometimes a change may break the prod image but not the development workflow. We won't know about before merging the change and attempting to deploy from it. Hence, build the image in CI to catch such issues beforehand.