### PR TITLE
Add ftp dump date check

### DIFF
--- a/docker/services/cron/dump-crontab
+++ b/docker/services/cron/dump-crontab
@@ -6,9 +6,12 @@ MAILTO=""
 0 0 2,16 * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full >> /logs/dumps.log 2>&1
 
 ## Trigger an incremental dump everyday, near noon, far away from whole dump times, again do not block for the lock.
-0 12 * * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1
+0 6 * * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1
 ## Around 1 hour later, trigger an incremental import into the spark cluster, blocking for the lock in case the dump was not complete
-0 13 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental >> /logs/dumps.log 2>&1
+0 7 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental >> /logs/dumps.log 2>&1
+
+# After the daily dumping is done, make sure everything turned out ok, otherwise mail the observability list.
+0 8 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py dump check_dump_ages >> /logs/dumps.log 2>&1
 
 # Dump user feedback every monday before we generate recommendations
 0 4 * * 1 lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feeedback >> /logs/dumps.log 2>&1

--- a/docker/services/cron/dump-crontab
+++ b/docker/services/cron/dump-crontab
@@ -1,17 +1,26 @@
 MAILTO=""
 
-## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
-0 0 1,15 * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/dumps.log 2>&1
-## Around 24 hours later, trigger a full import into the spark cluster, and this time wait for the lock, in case the dump hasn't finished.
-0 0 2,16 * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full >> /logs/dumps.log 2>&1
+# NOTE: This file is organized in chronological order of the start hour of each job, keeping jobs spread over the night and not overlapping.
 
 ## Trigger an incremental dump everyday, near noon, far away from whole dump times, again do not block for the lock.
-0 6 * * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1
+0 0 * * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1
 ## Around 1 hour later, trigger an incremental import into the spark cluster, blocking for the lock in case the dump was not complete
-0 7 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental >> /logs/dumps.log 2>&1
+0 1 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental >> /logs/dumps.log 2>&1
 
 # After the daily dumping is done, make sure everything turned out ok, otherwise mail the observability list.
-0 8 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py dump check_dump_ages >> /logs/dumps.log 2>&1
+0 2 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py dump check_dump_ages >> /logs/dumps.log 2>&1
 
 # Dump user feedback every monday before we generate recommendations
-0 4 * * 1 lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feeedback >> /logs/dumps.log 2>&1
+10 2 * * 1 lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feeedback >> /logs/dumps.log 2>&1
+
+# Calculate user similarity
+30 05 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_similar_users 
+
+# Request recommendations every Monday after dump and mapping has been imported into the spark cluster
+30 06 * * 1 listenbrainz_stats_cron /code/listenbrainz/docker/cf_recommendation.sh cf
+
+## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
+0 4 1,15 * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/dumps.log 2>&1
+## Around 24 hours later, trigger a full import into the spark cluster, and this time wait for the lock, in case the dump hasn't finished.
+0 4 2,16 * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full >> /logs/dumps.log 2>&1
+

--- a/docker/services/cron/stats-crontab
+++ b/docker/services/cron/stats-crontab
@@ -1,70 +1,64 @@
 MAILTO=""
 
-# Request user weekly artists every day at 12:00
-00 00 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=week --entity=artists
+# Request user weekly artists
+00 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=week --entity=artists
 
-# Request user monthly artists every day at 12:10
-10 00 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=month --entity=artists
+# Request user monthly artists
+10 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=month --entity=artists
 
-# Request user yearly artists every day at 12:20
-20 00 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=year --entity=artists
+# Request user yearly artists
+20 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=year --entity=artists
 
-# Request user all_time artists every day at 12:30
-30 00 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=all_time --entity=artists
+# Request user all_time artists
+30 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=all_time --entity=artists
 
-# Request user weekly releases every day at 13:00
-40 00 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=week --entity=releases
+# Request user weekly releases
+40 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=week --entity=releases
 
-# Request user monthly releases every day at 13:10
-50 00 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=month --entity=releases
+# Request user monthly releases
+50 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=month --entity=releases
 
-# Request user yearly releases every day at 13:20
-00 01 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=year --entity=releases
+# Request user yearly releases
+00 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=year --entity=releases
 
-# Request user all_time releases every day at 13:30
-10 01 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=all_time --entity=releases
+# Request user all_time releases
+10 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=all_time --entity=releases
 
-# Request user weekly recordings every day at 14:00
-20 01 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=week --entity=recordings
+# Request user weekly recordings
+20 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=week --entity=recordings
 
-# Request user monthly recordings every day at 14:10
-30 01 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=month --entity=recordings
+# Request user monthly recordings
+30 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=month --entity=recordings
 
-# Request user yearly recordings every day at 14:20
-40 01 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=year --entity=recordings
+# Request user yearly recordings
+40 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=year --entity=recordings
 
-# Request user all_time recordings every day at 14:30
-50 01 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=all_time --entity=recordings
+# Request user all_time recordings
+50 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=entity --range=all_time --entity=recordings
 
-# Request user weekly listening_activity every day at 15:00
-00 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=week
+# Request user weekly listening_activity
+00 04 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=week
 
-# Request user monthly listening_activity every day at 15:10
-10 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=month
+# Request user monthly listening_activity
+10 04 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=month
 
-# Request user yearly listening_activity every day at 15:20
-20 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=year
+# Request user yearly listening_activity
+20 04 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=year
 
-# Request user all_time listening_activity every day at 15:30
-30 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=all_time
+# Request user all_time listening_activity
+30 04 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=listening_activity --range=all_time
 
 # user weekly daily_activity
-40 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=week
+40 04 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=week
 
 # user monthly daily_activity
-50 02 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=month
+50 04 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=month
 
 # user weekly daily_activity
-00 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=year
+00 05 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=year
 
 # user weekly daily_activity
-10 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=all_time
+10 05 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_user_stats --type=daily_activity --range=all_time
 
 # user similarity dataframes
-20 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_dataframes --job-type="similar_users" --days=365 --listens-threshold=50
-
-# user similarity
-30 03 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_similar_users 
-
-# Request recommendations every Monday after dump and mapping has been imported into the spark cluster
-30 4 * * 1 listenbrainz_stats_cron /code/listenbrainz/docker/cf_recommendation.sh cf
+20 05 * * * listenbrainz_stats_cron /usr/local/bin/python /code/listenbrainz/manage.py spark request_dataframes --job-type="similar_users" --days=365 --listens-threshold=50

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -552,7 +552,7 @@ def _check_ftp_dump_ages():
             send_mail(
                 subject="ListenBrainz outdated dumps!",
                 text=render_template('emails/data_dump_outdated.txt', msg=msg),
-                recipients=['listenbrainz-observability@metabrainz.org'],
+                recipients=['listenbrainz-exceptions@metabrainz.org'],
                 from_name='ListenBrainz',
                 from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN']
             )

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -530,12 +530,13 @@ def _check_ftp_dump_ages():
     except Exception as err:
         msg = "Cannot fetch full dump age: %s" % str(err)
 
-    if not current_app.config['TESTING'] and msg:
-        send_mail(
-            subject="ListenBrainz outdated dumps!".format(
-                dump_type, dump_name),
-            text=render_template('emails/data_dump_outdated.txt', msg=msg)
-            recipients=['listenbrainz-observability@metabrainz.org'],
-            from_name='ListenBrainz',
-            from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN']
-        )
+    app = create_app()
+    with app.app_context():
+        if not current_app.config['TESTING'] and msg:
+            send_mail(
+                subject="ListenBrainz outdated dumps!",
+                text=render_template('emails/data_dump_outdated.txt', msg=msg),
+                recipients=['listenbrainz-observability@metabrainz.org'],
+                from_name='ListenBrainz',
+                from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN']
+            )

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -530,5 +530,12 @@ def _check_ftp_dump_ages():
     except Exception as err:
         msg = "Cannot fetch full dump age: %s" % str(err)
 
-    if msg:
-        print(msg)
+    if not current_app.config['TESTING'] and msg:
+        send_mail(
+            subject="ListenBrainz outdated dumps!".format(
+                dump_type, dump_name),
+            text=render_template('emails/data_dump_outdated.txt', msg=msg)
+            recipients=['listenbrainz-observability@metabrainz.org'],
+            from_name='ListenBrainz',
+            from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN']
+        )

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -43,11 +43,9 @@ from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
 from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app
 from listenbrainz.webserver.timescale_connection import init_timescale_connection
+from listenbrainz.db.dump import check_ftp_dump_ages
 
 
-MAIN_FTP_SERVER_URL = "ftp.eu.metabrainz.org"
-FULLEXPORT_MAX_AGE = 16  # days
-INCREMENTAL_MAX_AGE = 26  # hours
 NUMBER_OF_FULL_DUMPS_TO_KEEP = 2
 NUMBER_OF_INCREMENTAL_DUMPS_TO_KEEP = 30
 NUMBER_OF_FEEDBACK_DUMPS_TO_KEEP = 2
@@ -315,7 +313,7 @@ def delete_old_dumps(location):
 @cli.command(name="check_dump_ages")
 def check_dump_ages():
     """Check to make sure that data dumps are sufficiently fresh. Send mail if they are not."""
-    _check_ftp_dump_ages()
+    check_ftp_dump_ages()
     sys.exit(0)
 
 
@@ -488,71 +486,3 @@ def transmogrify_dump_file_to_spark_import_format(in_file, out_file, threads):
         current_app.logger.error('IOError while trying to mogrify spark dump file for file %s -> %s: %s',
                                  in_file, out_file, str(e), exc_info=True)
         raise
-
-
-def fetch_latest_file_info_from_ftp_dir(server, dir):
-    """
-        Given a FTP server and dir, fetch the latst dump file info, parse it and
-        return a tuple containing (dump_id, datetime_of_dump_file).
-    """
-
-    line = ""
-
-    def add_line(l):
-        nonlocal line
-        l = l.strip()
-        if l:
-            line = l
-
-    ftp = FTP(server)
-    ftp.login()
-    ftp.cwd(dir)
-    ftp.retrlines('LIST', add_line)
-    _, _, id, d, t, _ = line[56:].strip().split("-")
-
-    return int(id), datetime.strptime(d + t, "%Y%m%d%H%M%S")
-
-
-def _check_ftp_dump_ages():
-    """
-        Fetch the FTP dir listing of the full and incremental dumps and check their ages. Send mail
-        to the observability list in case the dumps are too old.
-    """
-
-    msg = ""
-    try:
-        id, dt = fetch_latest_file_info_from_ftp_dir(
-            MAIN_FTP_SERVER_URL, '/pub/musicbrainz/listenbrainz/fullexport')
-        age = datetime.now() - dt
-        if age > timedelta(days=FULLEXPORT_MAX_AGE):
-            msg = "Full dump %d is more than %d days old: %s\n" % (
-                id, FULLEXPORT_MAX_AGE, str(age))
-            print(msg, end="")
-        else:
-            print("Full dump %s is %s old, good!" % (id, str(age)))
-    except Exception as err:
-        msg = "Cannot fetch full dump age: %s" % str(err)
-
-    try:
-        id, dt = fetch_latest_file_info_from_ftp_dir(
-            MAIN_FTP_SERVER_URL, '/pub/musicbrainz/listenbrainz/incremental')
-        age = datetime.now() - dt
-        if age > timedelta(hours=INCREMENTAL_MAX_AGE):
-            msg = "Incremental dump %s is more than %s hours old: %s\n" % (
-                id, INCREMENTAL_MAX_AGE, str(age))
-            print(msg, end="")
-        else:
-            print("Incremental dump %s is %s old, good!" % (id, str(age)))
-    except Exception as err:
-        msg = "Cannot fetch full dump age: %s" % str(err)
-
-    app = create_app()
-    with app.app_context():
-        if not current_app.config['TESTING'] and msg:
-            send_mail(
-                subject="ListenBrainz outdated dumps!",
-                text=render_template('emails/data_dump_outdated.txt', msg=msg),
-                recipients=['listenbrainz-exceptions@metabrainz.org'],
-                from_name='ListenBrainz',
-                from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN']
-            )

--- a/listenbrainz/webserver/templates/emails/data_dump_outdated.txt
+++ b/listenbrainz/webserver/templates/emails/data_dump_outdated.txt
@@ -1,0 +1,11 @@
+Bon dia! 👋
+
+Sorry, but I come bearing bad news -- your shit is broken again. Surprise!
+
+Some data dumps are outdated:
+
+{{msg}}
+
+Go fix your shit!
+
+Your Grouchy Neighbourhood Brainzbot 🤖


### PR DESCRIPTION
I've moved the daily incremental dump creation to the morning (from mid-day) EU and added a check to ensure that full dumps at at most 16 days old and incremental dumps at most 26 hours old. If they are older than that, send mail to the observability list.
