### PR TITLE
Upgrade spotipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ werkzeug==1.0.1
 Flask-DebugToolbar==0.11.0
 Flask-UUID==0.2
 msgpack-python==0.5.6
-requests==2.23.0
+requests==2.25.1
 SQLAlchemy==1.3.23
 mbdata==25.0.4
 sqlalchemy-dst==1.0.1


### PR DESCRIPTION

# Problem

dependabot is sleeping on the job and not rebasing https://github.com/metabrainz/listenbrainz-server/pull/1304 properly.

New version of spotipy is out. It depends on a newer version of requests than the one that we have.



# Solution

Upgrade spotipy and requests


# Action

I tested spotify integration on my local environment. Now playing, playback history, and the player work as expected.

I had a look at the release notes for requests and there doesn't seem to be any major things that would affect our few uses.


