### PR TITLE
Run build image action on publishing release

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,9 +1,8 @@
 name: Build image and publish to Docker Hub
 
 on:
-  push:
-    tags:
-      - v-[0-9]+-[0-9]+-[0-9]+.[0-9]+
+  release:
+    types: [published]
 
 jobs:
 


### PR DESCRIPTION
We are having some issues with action triggering on pushing a tag. Now attempting, to trigger the action on publishing a release.