### PR TITLE
Handle listen deletion correctly.

### DIFF
--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -462,3 +462,9 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
         self.assertEqual(listens[2].ts_since_epoch, 1400000100)
         self.assertEqual(listens[3].ts_since_epoch, 1400000000)
+
+        self.assertEqual(self.logstore.get_listen_count_for_user(testuser_name), 4)
+        min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser_name)
+        self.assertEqual(min_ts, 1400000000)
+        self.assertEqual(max_ts, 1400000200)
+       

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -441,3 +441,24 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.logstore.delete(testuser_name)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=testuser_name, to_ts=1400000300)
         self.assertEqual(len(listens), 0)
+
+    def test_000_delete_single_listen(self):
+        uid = random.randint(2000, 1 << 31)
+        testuser = db_user.get_or_create(uid, "user_%d" % uid)
+        testuser_name = testuser['musicbrainz_id']
+        self._create_test_data(testuser_name)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=testuser_name, to_ts=1400000300)
+        self.assertEqual(len(listens), 5)
+        self.assertEqual(listens[0].ts_since_epoch, 1400000200)
+        self.assertEqual(listens[1].ts_since_epoch, 1400000150)
+        self.assertEqual(listens[2].ts_since_epoch, 1400000100)
+        self.assertEqual(listens[3].ts_since_epoch, 1400000050)
+        self.assertEqual(listens[4].ts_since_epoch, 1400000000)
+
+        self.logstore.delete_listen(1400000050, testuser_name, "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=testuser_name, to_ts=1400000300)
+        self.assertEqual(len(listens), 4)
+        self.assertEqual(listens[0].ts_since_epoch, 1400000200)
+        self.assertEqual(listens[1].ts_since_epoch, 1400000150)
+        self.assertEqual(listens[2].ts_since_epoch, 1400000100)
+        self.assertEqual(listens[3].ts_since_epoch, 1400000000)

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -766,7 +766,7 @@ class TimescaleListenStore(ListenStore):
             with timescale.engine.connect() as connection:
                 connection.execute(sqlalchemy.text(query), args)
 
-            cache._r.decby(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name))
+            cache._r.decrby(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name))
         except psycopg2.OperationalError as e:
             self.log.error("Cannot delete listen for user: %s" % str(e))
             raise TimescaleListenStoreException

--- a/listenbrainz/testdata/timescale_listenstore_test_listens.json
+++ b/listenbrainz/testdata/timescale_listenstore_test_listens.json
@@ -27,7 +27,7 @@
             },
             "user_id": 1,
             "listened_at": "1400000050",
-            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+            "recording_msid": "c7a41965-9f1e-456c-8b1d-27c0f0dde280"
 	},
 	{
             "track_metadata": {


### PR DESCRIPTION
Deleting all listens did the wrong thing to delete the cache key, when they should've been NULLed. Deleting single listen was also doing stupid shit. This is worth a hot fix.