### PR TITLE
Add management command to see when next cron job is going to be

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask-UUID == 0.2
 flask-socketio == 4.3.2
 bleach==3.3.0
 click == 7.1.2
+croniter == 1.0.13
 jsonschema == 3.2.0
 rauth == 0.7.3
 setproctitle == 1.2.2


### PR DESCRIPTION
# Problem

When we make a deployment, we don't always know if it's safe to update cron, because something might be running or about to run


# Solution

Make a management command that tells us when the next cron job will run


# Action

A few things still to check:

1. read both cron files
2. not sure if we should run this directly in the cron container using the _installed_ crontabs, or just the ones in the build tree. Theoretically they should be the same so I don't think that's a problem
3. double-check the timezone of the container that is running cron to make sure that we're using timezones/UTC correctly
4. add a "Most recently run" list - for example we don't want to restart if dumps just started 5 minutes ago
5. consider looking for the cron process and checking if it has any child processes, this is a clear indication that something is running


