### PR TITLE
Delete listens as well when user is deleted using admin console

### DIFF
--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -1,4 +1,7 @@
 from datetime import datetime
+
+from flask import current_app
+from psycopg2 import OperationalError, DatabaseError
 from listenbrainz.model import db
 from listenbrainz.webserver.admin import AdminModelView
 from listenbrainz.webserver.views.user import delete_user
@@ -51,4 +54,9 @@ class UserAdminView(AdminModelView):
     ]
 
     def delete_model(self, model):
-        delete_user(model.musicbrainz_id)
+        try:
+            delete_user(model.musicbrainz_id)
+            return True
+        except OperationalError or DatabaseError as err:
+            current_app.logger.error(err, exc_info=True)
+            return False

--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from listenbrainz.model import db
 from listenbrainz.webserver.admin import AdminModelView
+from listenbrainz.webserver.views.user import delete_user
 
 
 class User(db.Model):
@@ -15,6 +16,7 @@ class User(db.Model):
     gdpr_agreed = db.Column(db.DateTime(timezone=True))
     musicbrainz_row_id = db.Column(db.Integer, nullable=False)
     login_id = db.Column(db.String)
+
 
 class UserAdminView(AdminModelView):
     form_columns = [
@@ -47,3 +49,6 @@ class UserAdminView(AdminModelView):
         'musicbrainz_id',
         'musicbrainz_row_id',
     ]
+
+    def delete_model(self, model):
+        delete_user(model.musicbrainz_id)


### PR DESCRIPTION
When a user is deleted using the admin console, the current and default mechanism is to delete it from the users table. However, we also want the the listens of the deleted user to go away. Hence, override the default behaviour. We already have a `delete_user` method used when a user deletes their account, we can reuse the same here.