### PR TITLE
Use docker cache-from to use caching in building production image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,7 +17,7 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
 
     - name: Pull latest docker image
-      uses: docker pull kartik1712/listenbrainz:latest
+      run: docker pull kartik1712/listenbrainz:latest
       continue-on-error: true
 
     - name: Build and push image

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,7 +17,7 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
 
     - name: Pull latest docker image
-      run: docker pull kartik1712/listenbrainz:latest
+      run: docker pull metabrainz/listenbrainz:latest
       continue-on-error: true
 
     - name: Build and push image

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,7 +17,7 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
 
     - name: Pull latest docker image
-      uses: docker pull metabrainz/listenbrainz:latest
+      uses: docker pull kartik1712/listenbrainz:latest
       continue-on-error: true
 
     - name: Build and push image

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
 
-    - uses: satackey/action-docker-layer-caching@v0.0.11
+    - name: Pull latest docker image
+      uses: docker pull metabrainz/listenbrainz:latest
       continue-on-error: true
 
     - name: Build and push image

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -11,15 +11,23 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../"
 
-git describe --tags --dirty --always > .git-version
+GIT_COMMIT_SHA="$(git describe --tags --dirty --always)"
+echo "$GIT_COMMIT_SHA" > .git-version
 
 TAG=${1:-beta}
-echo "building for tag $TAG"
-docker build \
+
+function build_and_push_image {
+    echo "building for tag $1"
+    docker build \
         --cache-from metabrainz/listenbrainz:latest \
-        --tag metabrainz/listenbrainz:"$TAG" \
-        --tag metabrainz/listenbrainz:latest \
+        --tag metabrainz/listenbrainz:"$1" \
         --target listenbrainz-prod \
-        --build-arg GIT_COMMIT_SHA="$(git describe --tags --dirty --always)" . && \
-    docker push metabrainz/listenbrainz:"$TAG" && \
-    docker push metabrainz/listenbrainz:latest
+        --build-arg GIT_COMMIT_SHA="$GIT_COMMIT_SHA" . && \
+    docker push metabrainz/listenbrainz:"$1"
+}
+
+build_and_push_image "$TAG"
+
+if [[ $TAG =~ v-[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]+  ]]; then
+    build_and_push_image "latest"
+fi

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -28,6 +28,8 @@ function build_and_push_image {
 
 build_and_push_image "$TAG"
 
+# Only build and push the latest image if the TAG matches the date
+# pattern (v-YYYY-MM-DD.N) we use for production releases.
 if [[ $TAG =~ v-[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]+  ]]; then
     build_and_push_image "latest"
 fi

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -30,6 +30,6 @@ build_and_push_image "$TAG"
 
 # Only build and push the latest image if the TAG matches the date
 # pattern (v-YYYY-MM-DD.N) we use for production releases.
-if [[ $TAG =~ v-[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]+  ]]; then
+if [[ $TAG =~ ^v-[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]+$  ]]; then
     build_and_push_image "latest"
 fi

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -16,10 +16,10 @@ git describe --tags --dirty --always > .git-version
 TAG=${1:-beta}
 echo "building for tag $TAG"
 docker build \
-        --cache-from kartik1712/listenbrainz:latest \
-        --tag kartik1712/listenbrainz:"$TAG" \
-        --tag kartik1712/listenbrainz:latest \
+        --cache-from metabrainz/listenbrainz:latest \
+        --tag metabrainz/listenbrainz:"$TAG" \
+        --tag metabrainz/listenbrainz:latest \
         --target listenbrainz-prod \
         --build-arg GIT_COMMIT_SHA="$(git describe --tags --dirty --always)" . && \
-    docker push kartik1712/listenbrainz:"$TAG" && \
-    docker push kartik1712/listenbrainz:latest
+    docker push metabrainz/listenbrainz:"$TAG" && \
+    docker push metabrainz/listenbrainz:latest

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -15,9 +15,9 @@ git describe --tags --dirty --always > .git-version
 
 TAG=${1:-beta}
 echo "building for tag $TAG"
-docker build --tag metabrainz/listenbrainz:"$TAG" \
-        --tag metabrainz/listenbrainz:latest \
+docker build --tag kartik1712/listenbrainz:"$TAG" \
+        --tag kartik1712/listenbrainz:latest \
         --target listenbrainz-prod \
         --build-arg GIT_COMMIT_SHA="$(git describe --tags --dirty --always)" . && \
-    docker push metabrainz/listenbrainz:"$TAG" && \
-    docker push metabrainz/listenbrainz:latest
+    docker push kartik1712/listenbrainz:"$TAG" && \
+    docker push kartik1712/listenbrainz:latest

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -15,7 +15,9 @@ git describe --tags --dirty --always > .git-version
 
 TAG=${1:-beta}
 echo "building for tag $TAG"
-docker build --tag kartik1712/listenbrainz:"$TAG" \
+docker build \
+        --cache-from kartik1712/listenbrainz:latest \
+        --tag kartik1712/listenbrainz:"$TAG" \
         --tag kartik1712/listenbrainz:latest \
         --target listenbrainz-prod \
         --build-arg GIT_COMMIT_SHA="$(git describe --tags --dirty --always)" . && \

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -15,7 +15,9 @@ git describe --tags --dirty --always > .git-version
 
 TAG=${1:-beta}
 echo "building for tag $TAG"
-docker build -t metabrainz/listenbrainz:"$TAG" \
+docker build --tag metabrainz/listenbrainz:"$TAG" \
+        --tag metabrainz/listenbrainz:latest \
         --target listenbrainz-prod \
         --build-arg GIT_COMMIT_SHA="$(git describe --tags --dirty --always)" . && \
-    docker push metabrainz/listenbrainz:"$TAG"
+    docker push metabrainz/listenbrainz:"$TAG" && \
+    docker push metabrainz/listenbrainz:latest


### PR DESCRIPTION
Github Actions caching does not seem to work for tagged revisions due to cache scoping. Long story short, we workaround this by pulling the latest built image from docker hub and using that as a source of cache for next build.