### PR TITLE
If a user does a bulk-import set a 4 hour expiry time on their listen…

### DIFF
--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -32,6 +32,7 @@ from listenbrainz.utils import create_path, init_cache
 REDIS_USER_LISTEN_COUNT = "lc."
 REDIS_USER_TIMESTAMPS = "ts."
 REDIS_TOTAL_LISTEN_COUNT = "lc-total"
+REDIS_POST_IMPORT_LISTEN_COUNT_EXPIRY = 14400
 
 DUMP_CHUNK_SIZE = 100000
 NUMBER_OF_USERS_PER_DIRECTORY = 1000
@@ -112,6 +113,17 @@ class TimescaleListenStore(ListenStore):
         cache.set(REDIS_USER_LISTEN_COUNT + user_name,
                   count, time=0, encode=False)
         return count
+
+    def set_listen_count_expiry_for_user(self, user_name):
+        """ Set an expire time for the listen count cache item. This is called after
+            a bulk import which allows for timescale continuous aggregates to catch up
+            to listen counts. Once the key expires, the correct value can be calculated
+            from the aggregate.
+
+            Args:
+                user_name: the musicbrainz id of user whose listen count needs an expiry time
+        """
+        cache._r.expire(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name), REDIS_POST_IMPORT_LISTEN_COUNT_EXPIRY)
 
     def update_timestamps_for_user(self, user_name, min_ts, max_ts):
         """

--- a/listenbrainz/tests/integration/test_profile_views.py
+++ b/listenbrainz/tests/integration/test_profile_views.py
@@ -3,9 +3,12 @@ import time
 
 from flask import url_for, current_app
 from redis import Redis
+from brainzutils import cache
 
 import listenbrainz.db.user as db_user
 from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT
+from listenbrainz.utils import init_cache
 
 
 class ProfileViewsTestCase(IntegrationTestCase):
@@ -14,9 +17,14 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.user = db_user.get_or_create(1, 'iliekcomputers')
         db_user.agree_to_gdpr(self.user['musicbrainz_id'])
 
+        # Initialize brainzutils cache
+        init_cache(host=current_app.config['REDIS_HOST'],
+                   port=current_app.config['REDIS_PORT'],
+                   namespace=current_app.config['REDIS_NAMESPACE'])
+        self.redis = cache._r
+
     def tearDown(self):
-        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
-        r.flushall()
+        self.redis.flushall()
         super(ProfileViewsTestCase, self).tearDown()
 
     def send_listens(self):
@@ -89,6 +97,8 @@ class ProfileViewsTestCase(IntegrationTestCase):
         resp = self.client.get(url_for('api_v1.latest_import', user_name=self.user['musicbrainz_id']))
         self.assert200(resp)
         self.assertEqual(resp.json['latest_import'], val)
+
+        self.assertNotEqual(self.redis.ttl(cache._prep_key(REDIS_USER_LISTEN_COUNT + self.user['musicbrainz_id'])), 0)
 
         # check that listens have been successfully submitted
         resp = self.client.get(url_for('api_v1.get_listen_count', user_name=self.user['musicbrainz_id']))

--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -24,6 +24,10 @@
         Clicking the "Import now!" button will import your profile now without the need to open lastfm.<br/>
         You need to keep this page open for the tool to work, it might take a while to complete. Though, you can continue doing your work. :)
       </p>
+      <p>
+        <em>NOTE</em>: Please note that your listen counts may not be accurate for up to 4 hours after
+        you import your data!
+      </p>
       We need to know your Last.fm username:
       <div class="well">
         <div id="react-container">

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -367,7 +367,10 @@ def latest_import():
             raise APIInternalServerError(
                 'Could not update latest_import, try again')
 
-        _ts.set_listen_count_expiry_for_user(user['musicbrainz_id'])
+        # During unrelated tests _ts may be None -- improving this would be a great headache. 
+        # However, during the test of this code and while serving requests _ts is set.
+        if _ts:
+            _ts.set_listen_count_expiry_for_user(user['musicbrainz_id'])
 
         return jsonify({'status': 'ok'})
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -367,6 +367,8 @@ def latest_import():
             raise APIInternalServerError(
                 'Could not update latest_import, try again')
 
+        _ts.set_listen_count_expiry_for_user(user['musicbrainz_id'])
+
         return jsonify({'status': 'ok'})
 
 


### PR DESCRIPTION
As per our discussion in the officer earlier -- when a user does a bulk import their listen_counts may be inaccurate. To solve this we show a note on the last.fm import screen notifying the user that the listen_counts will be out of date for a few hours and then we set an expiry on the listen count cache item. This should cause the listen counts to be fixed for the user.