### PR TITLE
Fix bugs after Youtube Player release

### DIFF
--- a/admin/sql/util/restart_spotify_imports.sql
+++ b/admin/sql/util/restart_spotify_imports.sql
@@ -3,8 +3,8 @@
 
 BEGIN;
 
-UPDATE spotify_auth
-   SET record_listens = 't',
-       error_message = NULL;
+UPDATE listens_importer
+   SET error_message = NULL
+ WHERE service = 'spotify';
 
 COMMIT;

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -121,7 +121,6 @@ def get_token(user_id: int, service: ExternalServiceType) -> Union[dict, None]:
                  , refresh_token
                  , last_updated
                  , token_expires
-                 , token_expires < now() as token_expired
                  , scopes
               FROM external_service_oauth
               JOIN "user"

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -16,7 +16,6 @@ def get_active_users_to_process() -> List[dict]:
                  , refresh_token
                  , listens_importer.last_updated
                  , token_expires
-                 , token_expires < now() as token_expired
                  , scopes
                  , latest_listened_at
                  , error_message
@@ -72,7 +71,6 @@ def get_user(user_id: int) -> Optional[dict]:
                  , refresh_token
                  , external_service_oauth.last_updated
                  , token_expires
-                 , token_expires < now() as token_expired
                  , scopes
                  , latest_listened_at
                  , error_message

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from listenbrainz import db
 import sqlalchemy
@@ -32,7 +32,7 @@ def get_active_users_to_process() -> List[dict]:
         return [dict(row) for row in result.fetchall()]
 
 
-def get_user_import_details(user_id: int):
+def get_user_import_details(user_id: int) -> Optional[dict]:
     """ Return user's spotify linking details to display on connect services page
 
     Args:
@@ -53,6 +53,36 @@ def get_user_import_details(user_id: int):
             """), {
                 'user_id': user_id,
             })
+        if result.rowcount > 0:
+            return dict(result.fetchone())
+    return None
+
+
+def get_user(user_id: int) -> Optional[dict]:
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT external_service_oauth.user_id
+                 , "user".musicbrainz_id
+                 , "user".musicbrainz_row_id
+                 , external_service_oauth.service
+                 , access_token
+                 , refresh_token
+                 , external_service_oauth.last_updated
+                 , token_expires
+                 , token_expires < now() as token_expired
+                 , scopes
+                 , latest_listened_at
+                 , error_message
+              FROM external_service_oauth
+              JOIN "user"
+                ON "user".id = external_service_oauth.user_id
+              JOIN listens_importer
+                ON listens_importer.external_service_oauth_id = external_service_oauth.id
+              WHERE external_service_oauth.service = 'spotify'
+                AND "user".id = :user_id
+        """), {
+            'user_id': user_id
+        })
         if result.rowcount > 0:
             return dict(result.fetchone())
     return None

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -59,6 +59,9 @@ def get_user_import_details(user_id: int) -> Optional[dict]:
 
 
 def get_user(user_id: int) -> Optional[dict]:
+    """ This get_user method is different from the one in external_service_oauth.py because
+     here we join against the listens_importer table to fetch the latest_listened_at column.
+     We need latest_listened_at column for using in the spotify_reader."""
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT external_service_oauth.user_id

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -79,10 +79,10 @@ def get_user(user_id: int) -> Optional[dict]:
               FROM external_service_oauth
               JOIN "user"
                 ON "user".id = external_service_oauth.user_id
-              JOIN listens_importer
+         LEFT JOIN listens_importer
                 ON listens_importer.external_service_oauth_id = external_service_oauth.id
-              WHERE external_service_oauth.service = 'spotify'
-                AND "user".id = :user_id
+             WHERE external_service_oauth.service = 'spotify'
+               AND "user".id = :user_id
         """), {
             'user_id': user_id
         })

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -58,7 +58,6 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(user['access_token'], 'token')
         self.assertEqual(user['refresh_token'], 'refresh_token')
         self.assertIn('token_expires', user)
-        self.assertIn('token_expired', user)
 
     def test_delete_token_unlink(self):
         db_oauth.delete_token(self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=True)

--- a/listenbrainz/domain/external_service.py
+++ b/listenbrainz/domain/external_service.py
@@ -1,3 +1,4 @@
+import datetime
 from abc import ABC
 from typing import Union, Sequence
 
@@ -30,6 +31,23 @@ class ExternalService(ABC):
 
     def get_user(self, user_id: int) -> Union[dict, None]:
         return external_service_oauth.get_token(user_id=user_id, service=self.service)
+
+    def user_oauth_token_has_expired(self, user: dict, within_minutes: int = 5) -> bool:
+        """Check if a user's oauth token has expired (within a threshold)
+
+        Args:
+            user: the result of :py:meth:`~ExternalService.get_user`
+            within_minutes: say that the token has expired if it will expire within this
+               many minutes
+
+        Returns:
+            True if ``user['token_expires']`` is after the current time
+        """
+        if within_minutes < 0:
+            raise ValueError("within_minutes must be 0 or greater")
+        now = datetime.datetime.now(datetime.timezone.utc)
+        return user['token_expires'] < (now - datetime.timedelta(minutes=within_minutes))
+
 
     def get_authorize_url(self, scopes: Sequence[str]):
         raise NotImplementedError()

--- a/listenbrainz/domain/external_service.py
+++ b/listenbrainz/domain/external_service.py
@@ -46,8 +46,7 @@ class ExternalService(ABC):
         if within_minutes < 0:
             raise ValueError("within_minutes must be 0 or greater")
         now = datetime.datetime.now(datetime.timezone.utc)
-        return user['token_expires'] < (now - datetime.timedelta(minutes=within_minutes))
-
+        return user['token_expires'] < (now + datetime.timedelta(minutes=within_minutes))
 
     def get_authorize_url(self, scopes: Sequence[str]):
         raise NotImplementedError()

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -1,6 +1,6 @@
 import time
 import base64
-from typing import Sequence
+from typing import Sequence, Optional
 
 import requests
 
@@ -66,6 +66,9 @@ class SpotifyService(ImporterService):
         self.client_id = current_app.config['SPOTIFY_CLIENT_ID']
         self.client_secret = current_app.config['SPOTIFY_CLIENT_SECRET']
         self.redirect_url = current_app.config['SPOTIFY_CALLBACK_URL']
+
+    def get_user(self, user_id: int) -> Optional[dict]:
+        return spotify.get_user(user_id)
 
     def add_new_user(self, user_id: int, token: dict):
         """Create a spotify row for a user based on OAuth access tokens

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -153,8 +153,6 @@ class SpotifyService(ImporterService):
         access_token = response['access_token']
         if "refresh_token" in response:
             refresh_token = response['refresh_token']
-        else:
-            refresh_token = refresh_token
         expires_at = int(time.time()) + response['expires_in']
         external_service_oauth.update_token(user_id=user_id, service=self.service,
                                             access_token=access_token, refresh_token=refresh_token,

--- a/listenbrainz/domain/tests/test_external_service.py
+++ b/listenbrainz/domain/tests/test_external_service.py
@@ -17,8 +17,8 @@ class ExternalServiceTestCase(ServerTestCase):
         assert service.user_oauth_token_has_expired(user) is True
 
         # expires within the 5 minute threshold
-        user = {'token_expires': datetime.datetime(2021, 5, 12, 3, 18, 40, tzinfo=datetime.timezone.utc)}
-        assert service.user_oauth_token_has_expired(user) is False
+        user = {'token_expires': datetime.datetime(2021, 5, 12, 3, 24, 40, tzinfo=datetime.timezone.utc)}
+        assert service.user_oauth_token_has_expired(user) is True
 
         # hasn't expired
         user = {'token_expires': datetime.datetime(2021, 5, 12, 4, 1, 40, tzinfo=datetime.timezone.utc)}

--- a/listenbrainz/domain/tests/test_external_service.py
+++ b/listenbrainz/domain/tests/test_external_service.py
@@ -1,0 +1,25 @@
+import datetime
+
+from freezegun import freeze_time
+
+from listenbrainz.domain.spotify import SpotifyService
+from listenbrainz.webserver.testing import ServerTestCase
+
+
+class ExternalServiceTestCase(ServerTestCase):
+
+    @freeze_time("2021-05-12 03:21:34", tz_offset=0)
+    def test_user_oauth_token_has_expired(self):
+        service = SpotifyService()
+
+        # hasn't expired
+        user = {'token_expires': datetime.datetime(2021, 5, 12, 3, 0, 40, tzinfo=datetime.timezone.utc)}
+        assert service.user_oauth_token_has_expired(user) is True
+
+        # expires within the 5 minute threshold
+        user = {'token_expires': datetime.datetime(2021, 5, 12, 3, 18, 40, tzinfo=datetime.timezone.utc)}
+        assert service.user_oauth_token_has_expired(user) is False
+
+        # has expired
+        user = {'token_expires': datetime.datetime(2021, 5, 12, 4, 1, 40, tzinfo=datetime.timezone.utc)}
+        assert service.user_oauth_token_has_expired(user) is False

--- a/listenbrainz/domain/tests/test_external_service.py
+++ b/listenbrainz/domain/tests/test_external_service.py
@@ -12,7 +12,7 @@ class ExternalServiceTestCase(ServerTestCase):
     def test_user_oauth_token_has_expired(self):
         service = SpotifyService()
 
-        # hasn't expired
+        # has expired
         user = {'token_expires': datetime.datetime(2021, 5, 12, 3, 0, 40, tzinfo=datetime.timezone.utc)}
         assert service.user_oauth_token_has_expired(user) is True
 
@@ -20,6 +20,6 @@ class ExternalServiceTestCase(ServerTestCase):
         user = {'token_expires': datetime.datetime(2021, 5, 12, 3, 18, 40, tzinfo=datetime.timezone.utc)}
         assert service.user_oauth_token_has_expired(user) is False
 
-        # has expired
+        # hasn't expired
         user = {'token_expires': datetime.datetime(2021, 5, 12, 4, 1, 40, tzinfo=datetime.timezone.utc)}
         assert service.user_oauth_token_has_expired(user) is False

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -35,7 +35,7 @@ def notify_error(musicbrainz_row_id, error):
     if not user_email:
         return
 
-    spotify_url = url_for("profile.music_services_details")
+    spotify_url = current_app.config['SERVER_ROOT_URL'] + '/profile/music-services/details/'
     text = render_template('emails/spotify_import_error.txt', error=error, link=spotify_url)
     send_mail(
         subject='ListenBrainz Spotify Importer Error',

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -149,8 +149,8 @@ def make_api_request(user: dict, endpoint: str, **kwargs):
             spotipy_call = getattr(spotipy_client, endpoint)
             recently_played = spotipy_call(**kwargs)
             break
-        except (AttributeError, TypeError) as err:
-            current_app.logger.critical("Invalid spotipy endpoint or arguments:", err, exc_info=True)
+        except (AttributeError, TypeError):
+            current_app.logger.critical("Invalid spotipy endpoint or arguments:", exc_info=True)
             return None
         except SpotifyException as e:
             retries -= 1

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -311,13 +311,6 @@ def process_one_user(user: dict, service: SpotifyService):
 
         current_app.logger.info('imported %d listens for %s' % (len(listens), str(user['musicbrainz_id'])))
 
-    except ExternalServiceAPIError as e:
-        # if it is an error from the Spotify API, show the error message to the user
-        service.update_user_import_status(user_id=user['user_id'], error=str(e))
-        if not current_app.config['TESTING']:
-            notify_error(user['musicbrainz_row_id'], str(e))
-        raise ExternalServiceError("Could not refresh user token from spotify")
-
     except ExternalServiceInvalidGrantError:
         error_message = "It seems like you've revoked permission for us to read your spotify account"
         service.update_user_import_status(user_id=user['user_id'], error=error_message)
@@ -327,6 +320,13 @@ def process_one_user(user: dict, service: SpotifyService):
         # in any of these cases, we should delete the user's token from.
         service.revoke_user(user['user_id'])
         raise ExternalServiceError("User has revoked spotify authorization")
+
+    except ExternalServiceAPIError as e:
+        # if it is an error from the Spotify API, show the error message to the user
+        service.update_user_import_status(user_id=user['user_id'], error=str(e))
+        if not current_app.config['TESTING']:
+            notify_error(user['musicbrainz_row_id'], str(e))
+        raise ExternalServiceError("Could not refresh user token from spotify")
 
 
 def process_all_spotify_users():

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -273,7 +273,7 @@ def process_one_user(user: dict, service: SpotifyService):
 
     """
     try:
-        if user['token_expired']:
+        if service.user_oauth_token_has_expired(user):
             user = service.refresh_access_token(user['user_id'], user['refresh_token'])
 
         listenbrainz_user = db_user.get(user['user_id'])

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -149,6 +149,9 @@ def make_api_request(user: dict, endpoint: str, **kwargs):
             spotipy_call = getattr(spotipy_client, endpoint)
             recently_played = spotipy_call(**kwargs)
             break
+        except (AttributeError, TypeError) as err:
+            current_app.logger.critical("Invalid spotipy endpoint or arguments:", err, exc_info=True)
+            return None
         except SpotifyException as e:
             retries -= 1
             if e.http_status == 429:

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -14,7 +14,7 @@ from listenbrainz.domain.spotify import SpotifyService
 from listenbrainz.webserver.errors import APIBadRequest
 
 from dateutil import parser
-from flask import current_app, render_template, url_for
+from flask import current_app, render_template
 from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
 from listenbrainz.db import user as db_user
 from listenbrainz.db.exceptions import DatabaseException

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -150,13 +150,13 @@ def recent_listens():
             })
 
     spotify_user = get_current_spotify_user()
-    youtuber_user = get_current_youtube_user()
+    youtube_user = get_current_youtube_user()
 
     props = {
         "listens": recent,
         "mode": "recent",
         "spotify": spotify_user,
-        "youtube": youtuber_user,
+        "youtube": youtube_user,
         "api_url": current_app.config["API_URL"],
         "sentry_dsn": current_app.config.get("LOG_SENTRY", {}).get("dsn")
     }
@@ -172,6 +172,7 @@ def recent_listens():
 def feed():
 
     spotify_user = get_current_spotify_user()
+    youtube_user = get_current_youtube_user()
 
     current_user_data = {
         "id": current_user.id,
@@ -182,6 +183,7 @@ def feed():
     props = {
         "current_user": current_user_data,
         "spotify": spotify_user,
+        "youtube": youtube_user,
         "api_url": current_app.config["API_URL"],
     }
     return render_template('index/feed.html', props=ujson.dumps(props))

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -347,7 +347,12 @@ def refresh_service_token(service_name: str):
 @api_login_required
 def music_services_disconnect(service_name: str):
     service = _get_service_or_raise_404(service_name)
-    service.remove_user(current_user.id)
+    user = service.get_user(current_user.id)
+    # this is to support the workflow of changing permissions in a single step
+    # we delete the current permissions and then try to authenticate with new ones
+    # we should try to delete the current permissions only if the user has connected previously
+    if user:
+        service.remove_user(current_user.id)
 
     action = request.form.get(service_name)
     if not action or action == 'disable':

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -331,7 +331,7 @@ def refresh_service_token(service_name: str):
     if not user:
         raise APINotFound("User has not authenticated to %s" % service_name.capitalize())
 
-    if user["token_expired"]:
+    if service.user_oauth_token_has_expired(user):
         try:
             user = service.refresh_access_token(current_user.id, user["refresh_token"])
         except ExternalServiceInvalidGrantError:

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -166,7 +166,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assert404(r)
 
     def _create_spotify_user(self, expired):
-        offset = -100 if expired else 100
+        offset = -1000 if expired else 1000
         expires = int(time.time()) + offset
         db_oauth.save_token(user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
                             access_token='old-token', refresh_token='old-refresh-token',

--- a/requirements_development.txt
+++ b/requirements_development.txt
@@ -1,6 +1,7 @@
+coverage==5.4
 flask-shell-ipython==0.4.1
-nose == 1.3.7
-coverage == 5.4
+freezegun==1.1.0
+nose==1.3.7
 pytest==6.2.2
 pytest-cov==2.10.1
 requests-mock==1.8.0


### PR DESCRIPTION
I have found two bugs that were introduced by the Youtube Player PR. One was trying to delete a user that doesn't exist. Added some context in the code comment. Second was that after refresh expired token in spotify updater, we didn't get the latest_listened_ts field for the user. I have added another method to fetch that field as well.