### PR TITLE
Fix "/artist-map" parameters types declaration

### DIFF
--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -565,7 +565,7 @@ def get_artist_map(user_name: str):
         ``month``, ``year``, ``all_time``, defaults to ``all_time``
     :type range: ``str``
     :param force_recalculate: Optional, recalculate the data instead of returning the cached result.
-    :type range: ``bool``
+    :type force_recalculate: ``bool``
     :statuscode 200: Successful query, you have data!
     :statuscode 204: Statistics for the user haven't been calculated, empty response will be returned
     :statuscode 400: Bad request, check ``response['error']`` for more details


### PR DESCRIPTION
# Problem

Parameters types declaration is wrong for ``GET /1/stats/user/(user_name)/artist-map`` (https://listenbrainz.readthedocs.io/en/latest/dev/api/#get--1-stats-user-(user_name)-artist-map)

![image](https://user-images.githubusercontent.com/4103719/118518794-c7055880-b738-11eb-95e9-f83af3eb43d1.png)

# Solution

Fix api "docblock"

# Action

~

