### PR TITLE
Use xz instead of pxz

### DIFF
--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -47,7 +47,7 @@ class ListenbrainzHDFSUploader:
             Returns:
                 pxz: Return pipe to pxz command.
         """
-        pxz_command = ['pxz', '--decompress', '--stdout', archive, '-T{}'.format(threads)]
+        pxz_command = ['xz', '--decompress', '--stdout', archive, '-T{}'.format(threads)]
         pxz = subprocess.Popen(pxz_command, stdout=subprocess.PIPE)
         return pxz
 

--- a/listenbrainz_spark/hdfs/tests/test_init.py
+++ b/listenbrainz_spark/hdfs/tests/test_init.py
@@ -59,7 +59,7 @@ class HDFSTestCase(unittest.TestCase):
         temp_archive = os.path.join(tempfile.mkdtemp(), 'temp_tar.tar.xz')
         temp_dir = tempfile.mkdtemp()
         with open(temp_archive, 'w') as archive:
-            pxz_command = ['pxz', '--compress']
+            pxz_command = ['xz', '--compress']
             pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
 
             with tarfile.open(fileobj=pxz.stdin, mode='w|') as tar:


### PR DESCRIPTION
Ubuntu 20.04 has removed `pxz` from its repo because `xz` now supports parallelism. As the spark cluster is now running directly on Ubuntu 20.04, we have two options installing `pxz` or using `xz`. Going with latter.