### PR TITLE
Another shot at Actions + Buildx + Deployment

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -31,5 +31,5 @@ jobs:
         push: true
         # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME.
         # Using shell parameter expansion, we extract the TAG_NAME.
-        tags: kartik1712/listenbrainz:${GITHUB_REF/refs\/tags\//}
+        tags: kartik1712/listenbrainz:"${GITHUB_REF/refs\/tags\//}"
         target: listenbrainz-prod

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
+      # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME.
+      # Using shell parameter expansion, we extract the TAG_NAME. Also, it seems we cannot use shell tricks
+      # directly in the with block, so doing it in a separate step and then fetching its output when needed.
+    - name: Get the tag name
+      id: get_tag
+      run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+    
     - name: Docker Setup Buildx
       uses: docker/setup-buildx-action@v1.3.0
       
@@ -29,7 +36,5 @@ jobs:
         cache-from: kartik1712/listenbrainz:cache
         cache-to: kartik1712/listenbrainz:cache
         push: true
-        # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME.
-        # Using shell parameter expansion, we extract the TAG_NAME.
-        tags: kartik1712/listenbrainz:"${GITHUB_REF/refs\/tags\//}"
+        tags: kartik1712/listenbrainz:${{ steps.get_tag.outputs.TAG }}
         target: listenbrainz-prod

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -31,8 +31,8 @@ jobs:
       uses: docker/build-push-action@v2.4.0
       with:
         build-args: GIT_COMMIT_SHA=${{ github.sha }}
-        cache-from: kartik1712/listenbrainz:cache
-        cache-to: kartik1712/listenbrainz:cache
+        cache-from: metabrainz/listenbrainz:cache
+        cache-to: metabrainz/listenbrainz:cache
         push: true
-        tags: kartik1712/listenbrainz:${{ steps.get_tag.outputs.TAG }}
+        tags: metabrainz/listenbrainz:${{ steps.get_tag.outputs.TAG }}
         target: listenbrainz-prod

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -12,15 +12,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Login to Docker Hub
-      run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-
-    - name: Pull latest docker image
-      run: docker pull metabrainz/listenbrainz:latest
-      continue-on-error: true
-
-    - name: Build and push image
-      # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME.
-      # Using shell parameter expansion, we extract the TAG_NAME.
-      run: ./docker/push.sh "${GITHUB_REF/refs\/tags\//}"
+    
+    - name: Docker Setup Buildx
+      uses: docker/setup-buildx-action@v1.3.0
+      
+    - name: Docker Login
+      uses: docker/login-action@v1.9.0
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.4.0
+      with:
+        build-args: GIT_COMMIT_SHA=${{ github.sha }}
+        cache-from: kartik1712/listenbrainz:cache
+        cache-to: kartik1712/listenbrainz:cache
+        push: true
+        # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME.
+        # Using shell parameter expansion, we extract the TAG_NAME.
+        tags: kartik1712/listenbrainz:${GITHUB_REF/refs\/tags\//}
+        target: listenbrainz-prod

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -10,9 +10,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
-    
+    steps:    
       # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME.
       # Using shell parameter expansion, we extract the TAG_NAME. Also, it seems we cannot use shell tricks
       # directly in the with block, so doing it in a separate step and then fetching its output when needed.


### PR DESCRIPTION
Use docker actions to build and push the image. The push.sh script is intentionally left unmodified to use as a backup in case the action misbehaves.