### PR TITLE
Set permission of FTP dumps directory after copying into it

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -161,8 +161,8 @@ FTP_CURRENT_DUMP_DIR="$FTP_DIR/$SUB_DIR/$DUMP_NAME"
 
 # create the dir in which to copy the dumps before
 # changing their permissions to the FTP_FILE_MODE
-echo "Creating FTP directories and setting permissions..."
-mkdir -m "$FTP_DIR_MODE" -p "$FTP_CURRENT_DUMP_DIR"
+echo "Creating FTP directories..."
+mkdir -p "$FTP_CURRENT_DUMP_DIR"
 
 # make sure these dirs are owned by the correct user
 chown "$FTP_USER:$FTP_GROUP" \
@@ -174,6 +174,8 @@ chown "$FTP_USER:$FTP_GROUP" \
 # and set appropriate mode for files to be uploaded to
 # the FTP server
 retry rsync -a "$DUMP_DIR/" "$FTP_CURRENT_DUMP_DIR/"
+echo "Fixing FTP permissions"
+chmod "$FTP_DIR_MODE" "$FTP_CURRENT_DUMP_DIR"
 chmod "$FTP_FILE_MODE" "$FTP_CURRENT_DUMP_DIR/"*
 
 # create an explicit rsync filter for the new private dump in the


### PR DESCRIPTION
In f5ed0b7f we changed from copying the contents of the FTP directory
with cp to using rsync, which also copies the permissions of the
source directory. This means that the permissions of $FTP_CURRENT_DUMP_DIR
were set to the permissions of $DUMP_DIR (700) instead of 755,
preventing world-read permissions and breaking ftp/http download.
In order to be explicit about what permissions are required, manually
chmod the directory at the same time that the files are chmod'd

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


