### PR TITLE
Log recommendations without users to debug only

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -299,8 +299,7 @@ def handle_recommendations(data):
     musicbrainz_id = data['musicbrainz_id']
     user = db_user.get_by_mb_id(musicbrainz_id)
     if not user:
-        current_app.logger.debug("Generated recommendations for a user that doesn't exist in the "
-                                 "Postgres database: {}".format(musicbrainz_id))
+        current_app.logger.info("Generated recommendations for a user that doesn't exist in the Postgres database: %s", musicbrainz_id)
         return
 
     current_app.logger.debug("inserting recommendation for {}".format(musicbrainz_id))

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -299,8 +299,8 @@ def handle_recommendations(data):
     musicbrainz_id = data['musicbrainz_id']
     user = db_user.get_by_mb_id(musicbrainz_id)
     if not user:
-        current_app.logger.critical("Generated recommendations for a user that doesn't exist in the Postgres database: {}"
-                                    .format(musicbrainz_id))
+        current_app.logger.debug("Generated recommendations for a user that doesn't exist in the "
+                                 "Postgres database: {}".format(musicbrainz_id))
         return
 
     current_app.logger.debug("inserting recommendation for {}".format(musicbrainz_id))


### PR DESCRIPTION
We cannot do anything about this. It can take upto a month for the deleted user to be removed from the dumps. Hence, lowering the log level to debug only to reduce noise in sentry.
