### PR TITLE
Make user reports JS component more robust

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -188,14 +188,14 @@ export default class UserListeningActivity extends React.Component<
     });
 
     this.setState({
-      avgListens: Math.ceil(totalListens / totalDays),
+      avgListens: totalListens > 0 ? Math.ceil(totalListens / totalDays) : 0,
       lastRangePeriod: {
-        start: lastWeek[0].from_ts,
-        end: lastWeek[6].from_ts,
+        start: lastWeek?.[0]?.from_ts,
+        end: lastWeek?.[6]?.from_ts,
       },
       thisRangePeriod: {
-        start: thisWeek[0].from_ts,
-        end: thisWeek[totalDays - 1].from_ts,
+        start: thisWeek?.[0]?.from_ts,
+        end: thisWeek?.[totalDays - 1]?.from_ts,
       },
       totalListens,
     });
@@ -248,12 +248,12 @@ export default class UserListeningActivity extends React.Component<
     });
 
     this.setState({
-      avgListens: Math.ceil(totalListens / totalDays),
+      avgListens: totalListens > 0 ? Math.ceil(totalListens / totalDays) : 0,
       lastRangePeriod: {
-        start: lastMonth[0].from_ts,
+        start: lastMonth?.[0]?.from_ts,
       },
       thisRangePeriod: {
-        start: thisMonth[0].from_ts,
+        start: thisMonth?.[0]?.from_ts,
       },
       totalListens,
     });
@@ -295,12 +295,12 @@ export default class UserListeningActivity extends React.Component<
     });
 
     this.setState({
-      avgListens: Math.ceil(totalListens / totalMonths),
+      avgListens: totalListens > 0 ? Math.ceil(totalListens / totalMonths) : 0,
       lastRangePeriod: {
-        start: lastYear[0].from_ts,
+        start: lastYear?.[0]?.from_ts,
       },
       thisRangePeriod: {
-        start: thisYear[0].from_ts,
+        start: thisYear?.[0]?.from_ts,
       },
       totalListens,
     });
@@ -345,7 +345,7 @@ export default class UserListeningActivity extends React.Component<
     }
 
     this.setState({
-      avgListens: Math.ceil(totalListens / totalYears),
+      avgListens: totalListens > 0 ? Math.ceil(totalListens / totalYears) : 0,
       totalListens,
     });
 


### PR DESCRIPTION
Currently, if we don't have any data for the current time range (let's say the dafault 'week' range), the API will return data for the past week only.
The reports React component expects some data for the current week, and will throw an error trying to access a property of an non-existing object:
https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/119844

With this PR, we make sure that we can safely access those nested properties, and default to `undefined` otherwise.
This means that the chart legend will show a colour square for the current week (see top right in screenshot), but with no information next to it (where we would expect a time range for the current week), and the listen count and per day count will be 0 (which might not be true information: I might have listens this week but the stats haven't been calculated):

#### After:
![image](https://user-images.githubusercontent.com/6179856/119479285-c67c4b80-bd50-11eb-92d9-838438e79b7e.png)
#### Before:
![image](https://user-images.githubusercontent.com/6179856/119479409-e3188380-bd50-11eb-9e24-0f6aee4f44ef.png)
