### PR TITLE
Fixed date in RecentListens snapshot test

### DIFF
--- a/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
@@ -67,12 +67,20 @@ fetchMock.mockIf(
 
 describe("Recentlistens", () => {
   it("renders correctly on the profile page", () => {
+    // Datepicker component uses current time at load as max date,
+    // so we have to mock the Date constructor otherwise snapshots will be different every day
+    const mockDate = new Date("2021-05-19");
+    const fakeDateNow = jest
+      .spyOn(global.Date, "now")
+      .mockImplementation(() => mockDate.getTime());
+
     timeago.ago = jest.fn().mockImplementation(() => "1 day ago");
     const wrapper = mount<RecentListens>(
       <RecentListens {...props} />,
       mountOptions
     );
     expect(wrapper.html()).toMatchSnapshot();
+    fakeDateNow.mockRestore();
   });
 });
 

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -85,7 +85,7 @@ export default class RecentListens extends React.Component<
       recordingFeedbackMap: {},
       dateTimePickerValue: nextListenTs
         ? new Date(nextListenTs * 1000)
-        : new Date(),
+        : new Date(Date.now()),
     };
 
     this.listensTable = React.createRef();
@@ -675,7 +675,7 @@ export default class RecentListens extends React.Component<
                         onChange={this.onChangeDateTimePicker}
                         value={dateTimePickerValue}
                         clearIcon={null}
-                        maxDate={new Date()}
+                        maxDate={new Date(Date.now())}
                         minDate={
                           oldestListenTs
                             ? new Date(oldestListenTs * 1000)


### PR DESCRIPTION
After merging #1381 , we're ending up with one test regularly failing. 
This is because I added a datepicker that has a date limit set to today's date. Obviously, that date will change every time you run the test on a different date.
The snapshot for that component is thus considered different, and the test fails.

The quick fix is to mock parts of the Date class, specifically `Date.now()` is really easy to mock (rather than mocking the whole Date class).
Combined with the use of `new Date(Date.now())` in the code instead of `new Date()`, that allows us to set a fixed date when running the snapshot test.

A better but more involved fix would be to update Jest version to version 27+ to be able to use their built-in Date mocking [as describe in their docs](https://jestjs.io/docs/jest-object#jestsetsystemtimenow-number--date)