### PR TITLE
Simplify importing the latest incremental dump into spark

### DIFF
--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -2,9 +2,8 @@ import os
 import ftplib
 import hashlib
 import logging
-from collections import namedtuple
-from dataclasses import dataclass
 from enum import Enum
+from typing import NamedTuple
 
 from listenbrainz_spark import config
 from listenbrainz_spark.exceptions import DumpInvalidException
@@ -18,8 +17,7 @@ class DumpType(Enum):
     FULL = 'full'
 
 
-@dataclass
-class ListensDump:
+class ListensDump(NamedTuple):
     dump_id: int
     dump_date: str
     dump_tod: str
@@ -32,6 +30,10 @@ class ListensDump:
                            dump_date=parts[3],
                            dump_tod=parts[4],
                            dump_type=DumpType.INCREMENTAL if parts[5] == 'incremental' else DumpType.FULL)
+
+    def get_dump_file(self):
+        return f'listenbrainz-listens-dump-{self.dump_id}-{self.dump_date}' \
+               f'-{self.dump_tod}-spark-{self.dump_type.value}.tar.xz'
 
 
 class ListenBrainzFTPDownloader:

--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -25,7 +25,8 @@ class ListensDump(NamedTuple):
 
     @staticmethod
     def from_ftp_dir(dir_name: str) -> 'ListensDump':
-        parts = dir_name.split('-')
+        # Remove / if any from the end of dir name before splitting so the dump_type is correct
+        parts = dir_name.replace('/', '').split('-')
         return ListensDump(dump_id=int(parts[2]),
                            dump_date=parts[3],
                            dump_tod=parts[4],

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -127,22 +127,24 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
         return dest_path, mapping_file_name
 
-    def download_listens(self, directory, listens_dump_id=None, dump_type=FULL):
+    def download_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
         """ Download listens to dir passed as an argument.
 
             Args:
                 directory (str): Dir to save listens locally.
                 listens_dump_id (int): Unique identifier of listens to be downloaded.
                     If not provided, most recent listens will be downloaded.
+                dump_type: type of dump, full or incremental
 
             Returns:
                 dest_path (str): Local path where listens have been downloaded.
                 listens_file_name (str): name of downloaded listens dump.
                 dump_id (int): Unique indentifier of downloaded listens dump.
         """
-        ftp_cwd = os.path.join(config.FTP_LISTENS_DIR, 'fullexport/')
-        if dump_type == INCREMENTAL:
+        if dump_type == DumpType.INCREMENTAL:
             ftp_cwd = os.path.join(config.FTP_LISTENS_DIR, 'incremental/')
+        else:
+            ftp_cwd = os.path.join(config.FTP_LISTENS_DIR, 'fullexport/')
         self.connection.cwd(ftp_cwd)
         listens_dump_list = sorted(self.list_dir(), key=lambda x: int(x.split('-')[2]))
         req_listens_dump = self.get_dump_name_to_download(listens_dump_list, listens_dump_id, 2)

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -61,16 +61,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
             Returns:
                 str : Spark listens dump archive name.
         """
-        dump_id = dump_name.split('-')[2]
-        dump_date = dump_name.split('-')[3]
-        dump_time_of_day = dump_name.split('-')[4]
-        dump_type = 'full' if 'full' in dump_name.split('-')[5] else 'incremental'
-        return 'listenbrainz-listens-dump-{dump_id}-{date}-{tod}-spark-{dump_type}.tar.xz'.format(
-            dump_id=dump_id,
-            date=dump_date,
-            tod=dump_time_of_day,
-            dump_type=dump_type,
-        )
+        return ListensDump.from_ftp_dir(dump_name).get_dump_file()
 
     def get_available_dumps(self, dump, mapping_name_prefix):
         """ Get list of available mapping dumps.

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, call
 
 from listenbrainz_spark import config
 from listenbrainz_spark.exceptions import DumpNotFoundException
+from listenbrainz_spark.ftp import DumpType
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
 
 
@@ -115,7 +116,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_full_dump(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-123-20190101-000000-spark-full.tar.xz'
-        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='full')
+        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type=DumpType.FULL)
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls(
             [call(config.FTP_LISTENS_DIR + 'fullexport/'), call('listenbrainz-dump-123-20190101-000000/')])
@@ -134,7 +135,8 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-45-20190201-000000-spark-full.tar.xz'
         dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir',
-                                                                                     listens_dump_id=45, dump_type='full')
+                                                                                     listens_dump_id=45,
+                                                                                     dump_type=DumpType.FULL)
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls([
             call(config.FTP_LISTENS_DIR + 'fullexport/'),
@@ -154,7 +156,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
     def test_download_listens_incremental_dump(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-123-20190101-000000-spark-incremental.tar.xz'
-        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type='incremental')
+        dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', None, dump_type=DumpType.INCREMENTAL)
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls(
             [call(config.FTP_LISTENS_DIR + 'incremental/'), call('listenbrainz-dump-123-20190101-000000/')])
@@ -173,7 +175,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
         mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-listens-dump-45-20190201-000000-spark-incremental.tar.xz'
         dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45,
-                                                                                     dump_type='incremental')
+                                                                                     dump_type=DumpType.INCREMENTAL)
         mock_list_dir.assert_called_once()
         mock_ftp.return_value.cwd.assert_has_calls([
             call(config.FTP_LISTENS_DIR + 'incremental/'),

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 def import_dump_to_hdfs(dump_type, overwrite, dump_id=None):
     temp_dir = tempfile.mkdtemp()
-    dump_type = 'incremental' if dump_type == 'incremental' else 'full'
     src, dump_name, dump_id = ListenbrainzDataDownloader().download_listens(directory=temp_dir, dump_type=dump_type,
                                                                             listens_dump_id=dump_id)
     ListenbrainzDataUploader().upload_listens(src, overwrite=overwrite)
@@ -30,7 +29,7 @@ def import_dump_to_hdfs(dump_type, overwrite, dump_id=None):
 
 
 def import_newest_full_dump_handler():
-    dump_name = import_dump_to_hdfs('full', overwrite=True)
+    dump_name = import_dump_to_hdfs(DumpType.FULL, overwrite=True)
     return [{
         'type': 'import_full_dump',
         'imported_dump': [dump_name],
@@ -39,7 +38,7 @@ def import_newest_full_dump_handler():
 
 
 def import_full_dump_by_id_handler(id: int):
-    dump_name = import_dump_to_hdfs('full', overwrite=True, dump_id=id)
+    dump_name = import_dump_to_hdfs(DumpType.FULL, overwrite=True, dump_id=id)
     return [{
         'type': 'import_full_dump',
         'imported_dump': [dump_name],
@@ -52,7 +51,7 @@ def import_newest_incremental_dump_handler():
     latest_full_dump = utils.get_latest_full_dump()
     if latest_full_dump is None:
         # If no prior full dump is present, just import the latest incremental dump
-        imported_dumps.append(import_dump_to_hdfs('incremental', overwrite=False))
+        imported_dumps.append(import_dump_to_hdfs(DumpType.INCREMENTAL, overwrite=False))
         logger.warning("No previous full dump found, importing latest incremental dump", exc_info=True)
     else:
         # Import all missing dumps from last full dump import
@@ -61,9 +60,9 @@ def import_newest_incremental_dump_handler():
         end_id = ListenbrainzDataDownloader().get_latest_dump_id(DumpType.INCREMENTAL) + 1
 
         for dump_id in range(start_id, end_id, 1):
-            if not utils.search_dump(dump_id, 'incremental', imported_at):
+            if not utils.search_dump(dump_id, DumpType.INCREMENTAL, imported_at):
                 try:
-                    imported_dumps.append(import_dump_to_hdfs('incremental', False, dump_id))
+                    imported_dumps.append(import_dump_to_hdfs(DumpType.INCREMENTAL, False, dump_id))
                 except DumpNotFoundException:
                     continue
                 except Exception as e:
@@ -80,7 +79,7 @@ def import_newest_incremental_dump_handler():
 
 
 def import_incremental_dump_by_id_handler(id: int):
-    dump_name = import_dump_to_hdfs('incremental', overwrite=False, dump_id=id)
+    dump_name = import_dump_to_hdfs(DumpType.INCREMENTAL, overwrite=False, dump_id=id)
     return [{
         'type': 'import_incremental_dump',
         'imported_dump': [dump_name],

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -47,31 +47,9 @@ def import_full_dump_by_id_handler(id: int):
 
 
 def import_newest_incremental_dump_handler():
-    imported_dumps = []
-    latest_full_dump = utils.get_latest_full_dump()
-    if latest_full_dump is None:
-        # If no prior full dump is present, just import the lates incremental dump
-        imported_dumps.append(import_dump_to_hdfs('incremental', overwrite=False))
-        logger.warning("No previous full dump found, importing latest incremental dump", exc_info=True)
-    else:
-        # Import all missing dumps from last full dump import
-        dump_id = latest_full_dump["dump_id"] + 1
-        imported_at = latest_full_dump["imported_at"]
-        while True:
-            if not utils.search_dump(dump_id, 'incremental', imported_at):
-                try:
-                    imported_dumps.append(import_dump_to_hdfs('incremental', False, dump_id))
-                except DumpNotFoundException:
-                    break
-                except Exception as e:
-                    # Exit if any other error occurs during import
-                    logger.error(f"Error while importing incremental dump with ID {dump_id}: {e}", exc_info=True)
-                    break
-            dump_id += 1
-            request_consumer.rc.ping()
     return [{
         'type': 'import_incremental_dump',
-        'imported_dump': imported_dumps,
+        'imported_dump': [import_dump_to_hdfs('incremental', overwrite=False)],
         'time': str(datetime.utcnow()),
     }]
 

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -74,7 +74,7 @@ def import_newest_incremental_dump_handler():
             request_consumer.rc.ping()
     return [{
         'type': 'import_incremental_dump',
-        'imported_dump': [import_dump_to_hdfs('incremental', overwrite=False)],
+        'imported_dump': imported_dumps,
         'time': str(datetime.utcnow()),
     }]
 

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest.mock import MagicMock, call, patch
 
+from listenbrainz_spark.ftp import DumpType
 from listenbrainz_spark.request_consumer.jobs import import_dump
 from listenbrainz_spark.exceptions import (DumpInvalidException,
                                            DumpNotFoundException)
@@ -15,7 +16,7 @@ def mock_import_dump_to_hdfs(dump_type: str, overwrite: bool, dump_id: int):
     if (dump_id < 210):
         return f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz"
     else:
-        raise DumpNotFoundException
+        raise DumpNotFoundException("Dump Not Found")
 
 
 def mock_import_dump_to_hdfs_error(dump_type: str, overwrite: bool, dump_id: int):
@@ -56,7 +57,7 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
 
         messages = import_dump.import_newest_full_dump_handler()
-        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type='full',  listens_dump_id=None)
+        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type=DumpType.FULL, listens_dump_id=None)
         mock_upload.assert_called_once_with(mock_src, overwrite=True)
         mock_rmtree.assert_called_once_with('best_dir_ever')
 
@@ -85,7 +86,7 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
 
         messages = import_dump.import_full_dump_by_id_handler(202)
-        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type='full',  listens_dump_id=202)
+        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type=DumpType.FULL,  listens_dump_id=202)
         mock_upload.assert_called_once_with(mock_src, overwrite=True)
         mock_rmtree.assert_called_once_with('best_dir_ever')
 
@@ -114,7 +115,7 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_import_calls = []
         expected_import_list = []
         for dump_id in range(204, 210, 3):
-            mock_import_calls.append(call('incremental', False, dump_id))
+            mock_import_calls.append(call(DumpType.INCREMENTAL, False, dump_id))
             expected_import_list.append(f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz")
 
         messages = import_dump.import_newest_incremental_dump_handler()
@@ -122,12 +123,15 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_import_dump.assert_has_calls(mock_import_calls)
         self.assertListEqual(expected_import_list, messages[0]['imported_dump'])
 
+    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.get_latest_dump_id')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.import_dump_to_hdfs', side_effect=mock_import_dump_to_hdfs_error)
     @patch('listenbrainz_spark.request_consumer.jobs.utils.search_dump', side_effect=mock_search_dump)
     @patch('listenbrainz_spark.request_consumer.jobs.utils.get_latest_full_dump')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.request_consumer')
-    def test_import_newest_incremental_dump_handler_error(self, mock_rc, mock_latest_full_dump, mock_search, mock_import_dump):
-        """ Test to make sure import is aborted if there is a fatal error. """
+    def test_import_newest_incremental_dump_handler_error(self, mock_rc, mock_latest_full_dump, mock_search,
+                                                          mock_import_dump, mock_latest_dump_id):
+        """ Test to make sure import continues if there is a fatal error. """
+        mock_latest_dump_id.return_value = 210
         mock_latest_full_dump.return_value = {
             "dump_id": 202,
             "imported_at": datetime(2020, 9, 29),
@@ -136,7 +140,7 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_import_calls = []
         expected_import_list = []
         for dump_id in range(204, 210, 3):
-            mock_import_calls.append(call('incremental', False, dump_id))
+            mock_import_calls.append(call(DumpType.INCREMENTAL, False, dump_id))
             expected_import_list.append(f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz")
 
         messages = import_dump.import_newest_incremental_dump_handler()
@@ -154,7 +158,7 @@ class DumpImporterJobTestCase(SparkTestCase):
 
         messages = import_dump.import_newest_incremental_dump_handler()
 
-        mock_import_dump.assert_called_once_with('incremental', overwrite=False)
+        mock_import_dump.assert_called_once_with(DumpType.INCREMENTAL, overwrite=False)
         self.assertEqual(len(messages), 1)
         self.assertListEqual(['listenbrainz-listens-dump-202-20200915-180002-spark-incremental.tar.xz'],
                              messages[0]['imported_dump'])
@@ -173,7 +177,7 @@ class DumpImporterJobTestCase(SparkTestCase):
         mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
 
         messages = import_dump.import_incremental_dump_by_id_handler(202)
-        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type='incremental',  listens_dump_id=202)
+        mock_download.assert_called_once_with(directory='best_dir_ever', dump_type=DumpType.INCREMENTAL,  listens_dump_id=202)
         mock_upload.assert_called_once_with(mock_src, overwrite=False)
         mock_rmtree.assert_called_once_with('best_dir_ever')
 

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -23,9 +23,9 @@ def mock_import_dump_to_hdfs_error(dump_type: str, overwrite: bool, dump_id: int
     if (dump_id < 210) or (dump_id > 210 and dump_id < 213):
         return f"listenbrainz-listens-dump-{dump_id}-spark-incremental.tar.xz"
     elif dump_id == 210:
-        raise DumpInvalidException
+        raise DumpInvalidException("Invalid Dump")
     else:
-        raise DumpNotFoundException
+        raise DumpNotFoundException("Dump not found")
 
 
 def mock_search_dump(dump_id: int, dump_type: str, imported_at: datetime):

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 
 import listenbrainz_spark.request_consumer.jobs.utils as import_utils
+from listenbrainz_spark.ftp import DumpType
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.tests import SparkTestCase
@@ -70,12 +71,12 @@ class ImporterUtilsTestCase(SparkTestCase):
 
     def test_search_dump(self):
         """ Test to ensure 'True' is returned if appropriate dump is found and 'False' if it isn't found. """
-        self.assertTrue(import_utils.search_dump(4, "full", datetime.fromtimestamp(3)))
-        self.assertFalse(import_utils.search_dump(4, "full", datetime.fromtimestamp(5)))
-        self.assertFalse(import_utils.search_dump(5, "full", datetime.fromtimestamp(5)))
+        self.assertTrue(import_utils.search_dump(4, DumpType.FULL, datetime.fromtimestamp(3)))
+        self.assertFalse(import_utils.search_dump(4, DumpType.FULL, datetime.fromtimestamp(5)))
+        self.assertFalse(import_utils.search_dump(5, DumpType.FULL, datetime.fromtimestamp(5)))
 
-        self.assertTrue(import_utils.search_dump(4, "incremental", datetime.fromtimestamp(4)))
-        self.assertFalse(import_utils.search_dump(4, "incremental", datetime.fromtimestamp(5)))
+        self.assertTrue(import_utils.search_dump(4, DumpType.INCREMENTAL, datetime.fromtimestamp(4)))
+        self.assertFalse(import_utils.search_dump(4, DumpType.INCREMENTAL, datetime.fromtimestamp(5)))
 
     def test_search_dump_file_missing(self):
         """ Test to ensure 'False' is returned if metadata file is missing. """
@@ -83,19 +84,19 @@ class ImporterUtilsTestCase(SparkTestCase):
         if path_found:
             delete_dir(self.path_, recursive=True)
 
-        self.assertFalse(import_utils.search_dump(1, "full", datetime.fromtimestamp(1)))
+        self.assertFalse(import_utils.search_dump(1, DumpType.FULL, datetime.fromtimestamp(1)))
 
     def test_insert_dump_data(self):
         """ Test to ensure that data is inserted correctly. """
-        import_utils.insert_dump_data(9, "full", datetime.fromtimestamp(9))
-        self.assertTrue(import_utils.search_dump(9, "full", datetime.fromtimestamp(9)))
+        import_utils.insert_dump_data(9, DumpType.FULL, datetime.fromtimestamp(9))
+        self.assertTrue(import_utils.search_dump(9, DumpType.FULL, datetime.fromtimestamp(9)))
 
     def test_insert_dump_data_update_date(self):
         """ Test to ensure date is updated if entry already exists. """
-        self.assertFalse(import_utils.search_dump(7, "incremental", datetime.fromtimestamp(9)))
-        import_utils.insert_dump_data(7, "incremental", datetime.fromtimestamp(9))
-        self.assertTrue(import_utils.search_dump(7, "incremental", datetime.fromtimestamp(9)))
-        self.assertTrue(import_utils.search_dump(2, "incremental", datetime.fromtimestamp(2)))
+        self.assertFalse(import_utils.search_dump(7, DumpType.INCREMENTAL, datetime.fromtimestamp(9)))
+        import_utils.insert_dump_data(7, DumpType.INCREMENTAL, datetime.fromtimestamp(9))
+        self.assertTrue(import_utils.search_dump(7, DumpType.INCREMENTAL, datetime.fromtimestamp(9)))
+        self.assertTrue(import_utils.search_dump(2, DumpType.INCREMENTAL, datetime.fromtimestamp(2)))
 
     def test_insert_dump_data_file_missing(self):
         """ Test to ensure a file is created if it is missing. """
@@ -103,6 +104,6 @@ class ImporterUtilsTestCase(SparkTestCase):
         if path_found:
             delete_dir(self.path_, recursive=True)
 
-        self.assertFalse(import_utils.search_dump(1, "full", datetime.fromtimestamp(1)))
-        import_utils.insert_dump_data(1, "full", datetime.fromtimestamp(1))
-        self.assertTrue(import_utils.search_dump(1, "full", datetime.fromtimestamp(1)))
+        self.assertFalse(import_utils.search_dump(1, DumpType.FULL, datetime.fromtimestamp(1)))
+        import_utils.insert_dump_data(1, DumpType.FULL, datetime.fromtimestamp(1))
+        self.assertTrue(import_utils.search_dump(1, DumpType.FULL, datetime.fromtimestamp(1)))


### PR DESCRIPTION
The current code to import incremental dumps into spark is non-trivial. I do not see the need for us to maintain it, given we can always import using the id. The current code tries to import all incremental dumps since the last full dump. When it does not find a dump, it assumes there are no further dumps and stops importing. Its possible to maintain the current functionality in the current state but it will increase the complexity further. I suggest we just import the latest dump. In case, there are dumps missing we can always import them manually by id. I'll open tickets to simplify the import code and add back this functionality at that point if it makes sense.