### PR TITLE
Remove check for mounted dumps location

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -76,11 +76,6 @@ if [ -z $DUMP_BASE_DIR ]; then
     exit 1
 fi
 
-if ! findmnt -n --type cifs --target $DUMP_BASE_DIR; then
-    echo "DUMP_BASE_DIR ($DUMP_BASE_DIR) isn't mounted using CIFS as expected"
-    exit 1
-fi
-
 DUMP_TYPE="${1:-full}"
 
 if [ "$DUMP_TYPE" == "full" ]; then


### PR DESCRIPTION


# Problem

Dumps are no longer on a cifs mount, so we don't need this check



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


