### PR TITLE
Remove lbdumps user from Dockerfile and crontab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,11 @@ COPY . /code/listenbrainz
 ###########################################
 FROM listenbrainz-base as listenbrainz-prod
 
-# Create directories for cron logs, dump backups and FTP syncs
-RUN mkdir /logs /mnt/backup /mnt/ftp
+# Create directories for cron logs and dumps
+# /mnt/dumps: Temporary working space for dumps
+# /mnt/backup: All dumps
+# /mnt/ftp: Subset of all dumps that are uploaded to
+RUN mkdir /logs /mnt/dumps /mnt/backup /mnt/ftp
 
 # Install NodeJS and front-end dependencies
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,18 +70,8 @@ COPY . /code/listenbrainz
 ###########################################
 FROM listenbrainz-base as listenbrainz-prod
 
-
-# production sidenote: We create a `lbdumps` user to create data dumps because
-# the ListenBrainz servers on prod (etc. lemmy) use storage boxes [0] which
-# are owned by lbdumps on the host too.
-# [0]: https://github.com/metabrainz/syswiki/blob/master/ListenBrainzStorageBox.md
-RUN groupadd --gid 900 lbdumps
-RUN useradd --create-home --shell /bin/bash --uid 900 --gid 900 lbdumps
-RUN mkdir /logs && chown lbdumps:lbdumps /logs
-
-# Create directories for backups and FTP syncs
-RUN mkdir /home/lbdumps/backup /home/lbdumps/ftp
-RUN chown -R lbdumps:lbdumps /home/lbdumps/backup /home/lbdumps/ftp
+# Create directories for cron logs, dump backups and FTP syncs
+RUN mkdir /logs /mnt/backup /mnt/ftp
 
 # Install NodeJS and front-end dependencies
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \

--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -29,9 +29,9 @@ RSYNC_FULLEXPORT_PORT="{{template "KEY" "rsync_fullexport_port"}}"
 RSYNC_FULLEXPORT_DIR="$FTP_DIR/fullexport"
 RSYNC_INCREMENTAL_DIR="$FTP_DIR/incremental"
 RSYNC_SPARK_DIR="$FTP_DIR/spark"
-RSYNC_FULLEXPORT_KEY='/home/{{template "KEY" "user"}}/.ssh/rsync-listenbrainz-dumps-full'
-RSYNC_INCREMENTAL_KEY='/home/{{template "KEY" "user"}}/.ssh/rsync-listenbrainz-dumps-incremental'
-RSYNC_SPARK_KEY='/home/{{template "KEY" "user"}}/.ssh/rsync-listenbrainz-dumps-spark'
+RSYNC_FULLEXPORT_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-full'
+RSYNC_INCREMENTAL_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-incremental'
+RSYNC_SPARK_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-spark'
 
 # Check to make sure that this container is the prod cron container, otherwise never rsync anything!
 PROD="{{ (env "DEPLOY_ENV") }}"

--- a/admin/config.sh.sample
+++ b/admin/config.sh.sample
@@ -1,22 +1,22 @@
 #!/bin/bash
 
 DUMP_THREADS=4
-DUMP_BASE_DIR='/home/listenbrainz/data/dumps'
+DUMP_BASE_DIR='/mnt/dumps'
 
 # Where to back things up to, who should own the backup files, and what mode
 # those files should have.
 # The backups include a full database export, and all replication data.
-BACKUP_DIR=/home/listenbrainz/backup
-BACKUP_USER=listenbrainz
-BACKUP_GROUP=listenbrainz
+BACKUP_DIR=/mnt/backup
+BACKUP_USER=root
+BACKUP_GROUP=root
 BACKUP_DIR_MODE=700
 BACKUP_FILE_MODE=600
 
 # Same but for the files that need to copied to the FTP server,
 # for public consumption
-FTP_DIR='/home/listenbrainz/ftp/'
-FTP_USER=listenbrainz
-FTP_GROUP=listenbrainz
+FTP_DIR='/mnt/ftp/'
+FTP_USER=root
+FTP_GROUP=root
 FTP_DIR_MODE=755
 FTP_FILE_MODE=644
 

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -134,7 +134,6 @@ DUMP_DIR=$(dirname "$DUMP_ID_FILE")
 DUMP_NAME=$(basename "$DUMP_DIR")
 
 # Backup dumps to the backup volume
-# Create backup directories owned by user "listenbrainz"
 echo "Creating Backup directories..."
 mkdir -m "$BACKUP_DIR_MODE" -p \
     "$BACKUP_DIR/$SUB_DIR" \

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -136,7 +136,9 @@ DUMP_NAME=$(basename "$DUMP_DIR")
 # Backup dumps to the backup volume
 # Create backup directories owned by user "listenbrainz"
 echo "Creating Backup directories..."
-mkdir -p "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
+mkdir -m "$BACKUP_DIR_MODE" -p \
+    "$BACKUP_DIR/$SUB_DIR" \
+    "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
 echo "Backup directories created!"
 
 # Copy the files into the backup directory
@@ -152,7 +154,9 @@ FTP_CURRENT_DUMP_DIR="$FTP_DIR/$SUB_DIR/$DUMP_NAME"
 # create the dir in which to copy the dumps before
 # changing their permissions to the FTP_FILE_MODE
 echo "Creating FTP directories..."
-mkdir -p "$FTP_CURRENT_DUMP_DIR"
+mkdir  -m "$FTP_DIR_MODE" -p \
+    "$FTP_DIR/$SUB_DIR" \
+    "$FTP_CURRENT_DUMP_DIR"
 
 # make sure all dump files are owned by the correct user
 # and set appropriate mode for files to be uploaded to
@@ -186,7 +190,6 @@ cat "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
 /usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR/$SUB_DIR"
 /usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"
-/usr/local/bin/python manage.py dump delete_old_dumps "$DUMP_BASE_DIR/$SUB_DIR"
 
 # rsync to ftp folder taking care of the rules
 ./admin/rsync-dump-files.sh "$DUMP_TYPE"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -136,12 +136,7 @@ DUMP_NAME=$(basename "$DUMP_DIR")
 # Backup dumps to the backup volume
 # Create backup directories owned by user "listenbrainz"
 echo "Creating Backup directories..."
-mkdir -m "$BACKUP_DIR_MODE" -p \
-         "$BACKUP_DIR/$SUB_DIR/" \
-         "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
-chown "$BACKUP_USER:$BACKUP_GROUP" \
-      "$BACKUP_DIR/$SUB_DIR/" \
-      "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
+mkdir -p "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
 echo "Backup directories created!"
 
 # Copy the files into the backup directory
@@ -158,12 +153,6 @@ FTP_CURRENT_DUMP_DIR="$FTP_DIR/$SUB_DIR/$DUMP_NAME"
 # changing their permissions to the FTP_FILE_MODE
 echo "Creating FTP directories..."
 mkdir -p "$FTP_CURRENT_DUMP_DIR"
-
-# make sure these dirs are owned by the correct user
-chown "$FTP_USER:$FTP_GROUP" \
-      "$FTP_DIR" \
-      "$FTP_DIR/$SUB_DIR" \
-      "$FTP_CURRENT_DUMP_DIR"
 
 # make sure all dump files are owned by the correct user
 # and set appropriate mode for files to be uploaded to

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -3,29 +3,29 @@ MAILTO=""
 # NOTE: This file is organized in chronological order of the start hour of each job, keeping jobs spread over the night and not overlapping.
 
 ## Trigger an incremental dump everyday, near noon, far away from whole dump times, again do not block for the lock.
-0 0 * * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1
+0 0 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1
 ## Around 1 hour later, trigger an incremental import into the spark cluster, blocking for the lock in case the dump was not complete
-0 1 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental >> /logs/dumps.log 2>&1
+0 1 * * * root flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_incremental >> /logs/dumps.log 2>&1
 
 # After the daily dumping is done, make sure everything turned out ok, otherwise mail the observability list.
-0 2 * * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py dump check_dump_ages >> /logs/dumps.log 2>&1
+0 2 * * * root flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py dump check_dump_ages >> /logs/dumps.log 2>&1
 
 # Request all statistics
-00 2 * * * lbdumps /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_all_stats >> /logs/stats.log 2>&1
+00 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_all_stats >> /logs/stats.log 2>&1
 
 ## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
-0 4 1,15 * * lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/dumps.log 2>&1
+0 4 1,15 * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/dumps.log 2>&1
 ## Around 24 hours later, trigger a full import into the spark cluster, and this time wait for the lock, in case the dump hasn't finished.
-0 4 2,16 * * lbdumps flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full >> /logs/dumps.log 2>&1
+0 4 2,16 * * root flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full >> /logs/dumps.log 2>&1
 
 # Update our continuous aggregates for listens older than 1 year
-0 5 * * * lbdumps /usr/local/bin/python /code/listenbrainz/manage.py refresh_continuous_aggregates >> /logs/continuous_aggregates.log 2>&1
+0 5 * * * root /usr/local/bin/python /code/listenbrainz/manage.py refresh_continuous_aggregates >> /logs/continuous_aggregates.log 2>&1
 
 # Calculate user similarity
-30 5 * * * lbdumps /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_similar_users >> /logs/stats.log 2>&1
+30 5 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_similar_users >> /logs/stats.log 2>&1
 
 # Dump user feedback every monday before we generate recommendations
-00 6 * * 1 lbdumps flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feeedback >> /logs/dumps.log 2>&1
+00 6 * * 1 root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feeedback >> /logs/dumps.log 2>&1
 
 # Request recommendations every Monday after dump and mapping has been imported into the spark cluster
-30 6 * * 1 lbdumps /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_recommendations >> /logs/stats.log 2>&1
+30 6 * * 1 root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_recommendations >> /logs/stats.log 2>&1


### PR DESCRIPTION
The lbdumps user was only needed because we used a storage box in production. With the server upgrade, we know have enough disk space on the server itself and do not need the storage box. Hence, we are getting rid of the storage box and related workarounds.