### PR TITLE
Add retrying to revoking Youtube access tokens

### DIFF
--- a/listenbrainz/domain/external_service.py
+++ b/listenbrainz/domain/external_service.py
@@ -18,7 +18,14 @@ class ExternalService(ABC):
         """
         self.service = service
 
-    def add_new_user(self, user_id: int, token: dict):
+    def add_new_user(self, user_id: int, token: dict) -> bool:
+        """ Inserts a user for the specific service in the database
+        Args:
+            user_id: the ListenBrainz row ID of the user
+            token: the response from the OAuth API of the services
+        Returns:
+            whether the user was inserted in the database
+        """
         raise NotImplementedError()
 
     def remove_user(self, user_id: int):

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -70,7 +70,7 @@ class SpotifyService(ImporterService):
     def get_user(self, user_id: int) -> Optional[dict]:
         return spotify.get_user(user_id)
 
-    def add_new_user(self, user_id: int, token: dict):
+    def add_new_user(self, user_id: int, token: dict) -> bool:
         """Create a spotify row for a user based on OAuth access tokens
 
         Args:
@@ -86,6 +86,7 @@ class SpotifyService(ImporterService):
         external_service_oauth.save_token(user_id=user_id, service=self.service, access_token=access_token,
                                           refresh_token=refresh_token, token_expires_ts=expires_at,
                                           record_listens=active, scopes=scopes)
+        return True
 
     def get_authorize_url(self, permissions: Sequence[str]):
         """ Returns a spotipy OAuth instance that can be used to authenticate with spotify.

--- a/listenbrainz/domain/tests/test_youtube.py
+++ b/listenbrainz/domain/tests/test_youtube.py
@@ -79,6 +79,18 @@ class YoutubeServiceTestCase(IntegrationTestCase):
         self.assertEqual(YOUTUBE_SCOPES, token["scope"])
 
     @requests_mock.Mocker()
+    def test_add_user_without_refresh_token(self, mock_requests):
+        mock_requests.post(OAUTH_REVOKE_URL, status_code=200, json={'status': 'ok'})
+        token = {
+            "access_token": "new-access-token",
+            "expires_in": 3920,
+            "scope": YOUTUBE_SCOPES[0],
+            "token_type": "Bearer"
+        }
+        self.assertFalse(self.service.add_new_user(self.user_id, token))
+        self.assertTrue(mock_requests.called)
+
+    @requests_mock.Mocker()
     def test_remove_user(self, mock_requests):
         mock_requests.post(OAUTH_REVOKE_URL, status_code=200, json={})
         self.service.remove_user(self.user_id)

--- a/listenbrainz/domain/youtube.py
+++ b/listenbrainz/domain/youtube.py
@@ -36,7 +36,7 @@ class YoutubeService(ExternalService):
         # previous time. We try to revoke the new issued token and ask the user to
         # authenticate again so that we receive the refresh token as well.
         if "refresh_token" not in token:
-            self._revoke_token(token["access_token"])
+            self._revoke_token(user_id, token["access_token"])
             return False
         else:
             external_service_oauth.save_token(user_id=user_id,
@@ -93,10 +93,10 @@ class YoutubeService(ExternalService):
         # try to revoke token with Google Auth API otherwise Google will consider the account
         # be still connected and will not send a refresh_token next time the user tries to
         # connect again. if it doesn't succeed proceed normally and just delete from our database
-        self._revoke_token(user["access_token"])
+        self._revoke_token(user_id, user["access_token"])
         super(YoutubeService, self).remove_user(user_id)
 
-    def _revoke_token(self, access_token):
+    def _revoke_token(self, user_id: int, access_token: str):
         """ Revoke the given access_token using Google OAuth Revoke endpoint.
         Args:
             access_token: the token to be revoked
@@ -112,7 +112,8 @@ class YoutubeService(ExternalService):
             response.raise_for_status()
         except RequestException:
             error_msg = response.text if response else None
-            current_app.logger.error("Error while trying to revoke token: %s", error_msg, exc_info=True)
+            current_app.logger.error("Error while trying to revoke token for user_id %d : %s",
+                                     user_id, error_msg, exc_info=True)
 
     def get_user_connection_details(self, user_id: int):
         pass

--- a/listenbrainz/domain/youtube.py
+++ b/listenbrainz/domain/youtube.py
@@ -2,6 +2,8 @@ from datetime import timezone
 
 import requests
 from requests import RequestException
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.db import external_service_oauth
@@ -79,15 +81,29 @@ class YoutubeService(ExternalService):
 
     def remove_user(self, user_id: int):
         user = self.get_user(user_id)
-        # try to revoke token with Google Auth API on a best effort basis, even if it doesn't succeed proceed normally
-        # and delete from our database
-        try:
-            requests.post(OAUTH_REVOKE_URL,
-                          params={'token': user["access_token"]},
-                          headers={'content-type': 'application/x-www-form-urlencoded'})
-        except RequestException as e:
-            current_app.logger.error(e, exc_info=True)
+        # try to revoke token with Google Auth API otherwise Google will consider the account
+        # be still connected and will not send a refresh_token next time the user tries to
+        # connect again. if it doesn't succeed proceed normally and just delete from our database
+        self._revoke_token(user["access_token"])
         super(YoutubeService, self).remove_user(user_id)
+
+    def _revoke_token(self, access_token):
+        """ Revoke the given access_token using Google OAuth Revoke endpoint.
+        Args:
+            access_token: the token to be revoked
+        """
+        response = None
+        try:
+            session = requests.Session()
+            session.mount("https://",
+                          HTTPAdapter(max_retries=Retry(total=3, backoff_factor=1, method_whitelist=["POST"])))
+            response = session.post(OAUTH_REVOKE_URL,
+                                    params={'token': access_token},
+                                    headers={'content-type': 'application/x-www-form-urlencoded'})
+            response.raise_for_status()
+        except RequestException:
+            error_msg = response.text if response else None
+            current_app.logger.error("Error while trying to revoke token: %s", error_msg, exc_info=True)
 
     def get_user_connection_details(self, user_id: int):
         pass

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -317,8 +317,10 @@ def music_services_callback(service_name: str):
     if not code:
         raise BadRequest('missing code')
     token = service.fetch_access_token(code)
-    service.add_new_user(current_user.id, token)
-    flash.success('Successfully authenticated with %s!' % service_name.capitalize())
+    if service.add_new_user(current_user.id, token):
+        flash.success('Successfully authenticated with %s!' % service_name.capitalize())
+    else:
+        flash.error('Unable to connect to %s! Please try again.' % service_name.capitalize())
     return redirect(url_for('profile.music_services_details'))
 
 


### PR DESCRIPTION
Try to revoke token with Google Auth API otherwise Google will consider the account to be still connected and will not send a refresh_token next time the user tries to connect again. We retry multiple times to reduce chances of failure. If it doesn't succeed proceed normally and just delete from our database.

Further, when a user connects again and the response from Google OAuth API is missing the refresh_token, we try to invalidate the access_token received in that response and ask the user to authenticate again.