### PR TITLE
Use base-react.html template in LastFM importer page

### DIFF
--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'base-react.html' %}
 
 {% block title %}Import for "{{ user.musicbrainz_id }}" - ListenBrainz{% endblock %}
 
@@ -39,5 +39,4 @@
 {% block scripts %}
   {{ super() }}
   <script src="{{ get_static_path('import.js') }}" type="text/javascript"></script>
-  <script id="page-react-props" type="application/json">{{ props|safe }}</script>
 {% endblock %}


### PR DESCRIPTION
With #1420 we forgot one page that was using the wrong base template (base.html instead of base-react.html) and as a result didn't have global props, which completely broke the LFM importer page :/