### PR TITLE
Use tag to set GIT_COMMIT_SHA

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build and push Docker images
       uses: docker/build-push-action@v2.4.0
       with:
-        build-args: GIT_COMMIT_SHA=${{ github.sha }}
+        build-args: GIT_COMMIT_SHA=${{ steps.get_tag.outputs.TAG }}
         cache-from: metabrainz/listenbrainz:cache
         cache-to: metabrainz/listenbrainz:cache
         push: true


### PR DESCRIPTION
Instead of using `GIT_COMMIT_SHA`, use `GITHUB_REF` for human readable release name in sentry.