### PR TITLE
Fix acking listens in timescale_writer

### DIFF
--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -20,6 +20,7 @@ from listenbrainz.utils import init_cache
 from brainzutils import metrics, cache
 
 METRIC_UPDATE_INTERVAL = 60  # seconds
+LISTEN_INSERT_ERROR_SENTINEL = -1  #
 
 class TimescaleWriterSubscriber(ListenWriter):
 
@@ -48,7 +49,9 @@ class TimescaleWriterSubscriber(ListenWriter):
                 pass
 
         ret = self.insert_to_listenstore(submit)
-        if not ret:
+
+        # If there is an error, we do not ack the message so that rabbitmq redelivers it later.
+        if ret == LISTEN_INSERT_ERROR_SENTINEL:
             return ret
 
         while True:
@@ -70,7 +73,8 @@ class TimescaleWriterSubscriber(ListenWriter):
             data: the data to be inserted into the ListenStore
             retries: the number of retries to make before deciding that we've failed
 
-        Returns: number of listens successfully sent
+        Returns: number of listens successfully sent or LISTEN_INSERT_ERROR_SENTINEL
+        if there was an error in inserting listens
         """
 
         if not data:
@@ -82,7 +86,7 @@ class TimescaleWriterSubscriber(ListenWriter):
         except psycopg2.OperationalError as err:
             current_app.logger.error("Cannot write data to listenstore: %s. Sleep." % str(err), exc_info=True)
             sleep(self.ERROR_RETRY_DELAY)
-            return 0
+            return LISTEN_INSERT_ERROR_SENTINEL
 
         if not rows_inserted:
             return len(data)


### PR DESCRIPTION
rabbitmq 3.8.15 onwards, the rabbitmq server disconnects connections which have not acked a message for over 15 mins. In timescale_writer we do not ack messages, if insert_to_listenstore method returns 0. This can happen in two cases, if there was an error during inserting listens or if the entire batch of listens was duplicates. We want to ack the message in the second case but not in the first. Hence, we now return different values in the errors and duplicates case.