### PR TITLE
Upgrade pika to 1.2.0

### DIFF
--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -113,7 +113,7 @@ class SparkReader:
                     exchange=current_app.config['SPARK_RESULT_EXCHANGE'],
                     queue=current_app.config['SPARK_RESULT_QUEUE'],
                     callback_function=self.callback,
-                    no_ack=True,
+                    auto_ack=True,
                 )
                 self.incoming_ch.basic_qos(prefetch_count=1)
                 current_app.logger.info('Spark consumer attempt to start consuming!')

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -178,8 +178,8 @@ class TimescaleWriterSubscriber(ListenWriter):
                     self.incoming_ch.queue_bind(exchange=current_app.config['INCOMING_EXCHANGE'],
                                                 queue=current_app.config['INCOMING_QUEUE'])
                     self.incoming_ch.basic_consume(
-                        lambda ch, method, properties, body: self.static_callback(ch, method, properties, body, obj=self),
                         queue=current_app.config['INCOMING_QUEUE'],
+                        on_message_callback=lambda ch, method, properties, body: self.static_callback(ch, method, properties, body, obj=self)
                     )
 
                     self.unique_ch = self.connection.channel()

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -72,14 +72,15 @@ def init_cache(host, port, namespace):
     cache.init(host=host, port=port, namespace=namespace)
 
 
-def create_channel_to_consume(connection, exchange, queue, callback_function, no_ack=False):
+def create_channel_to_consume(connection, exchange: str, queue: str, callback_function, auto_ack: bool = False):
     """ Returns a newly created channel that can consume from the specified queue.
 
     Args:
         connection: a RabbitMQ connection
-        exchange (str): the name of the exchange
-        queue (str): the name of the queue
+        exchange: the name of the exchange
+        queue: the name of the queue
         callback_function: the callback function to be called on message reception
+        auto_ack: should messages be automatically ack'ed when received
 
     Returns:
         a RabbitMQ channel
@@ -88,7 +89,7 @@ def create_channel_to_consume(connection, exchange, queue, callback_function, no
     ch.exchange_declare(exchange=exchange, exchange_type='fanout')
     ch.queue_declare(queue, durable=True)
     ch.queue_bind(exchange=exchange, queue=queue)
-    ch.basic_consume(callback_function, queue=queue, no_ack=no_ack)
+    ch.basic_consume(queue=queue, on_message_callback=callback_function, auto_ack=auto_ack)
     return ch
 
 

--- a/listenbrainz/webserver/test_rabbitmq_connection.py
+++ b/listenbrainz/webserver/test_rabbitmq_connection.py
@@ -17,7 +17,7 @@ class RabbitMQConnectionPoolTestCase(TestCase):
     @patch('listenbrainz.webserver.rabbitmq_connection.pika.BlockingConnection')
     @patch('listenbrainz.webserver.rabbitmq_connection.sleep')
     def test_connection_closed_while_creating(self, mock_sleep, mock_blocking_connection):
-        mock_blocking_connection.side_effect = ConnectionClosed
+        mock_blocking_connection.side_effect = ConnectionClosed(reply_code=200, reply_text='Normal Shutdown')
         with self.assertRaises(ConnectionClosed):
             connection = self.pool.create()
             self.pool.log.critical.assert_called_once()

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -45,7 +45,7 @@ class ListensDispatcher(threading.Thread):
         channel.basic_consume(queue=current_app.config['PLAYING_NOW_QUEUE'], on_message_callback=self.callback_playing_now)
 
     def on_open(self, connection):
-        connection.channel(self.on_open_callback)
+        connection.channel(on_open_callbak=self.on_open_callback)
 
     def init_rabbitmq_connection(self):
         while True:

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -39,10 +39,10 @@ class ListensDispatcher(threading.Thread):
 
     def on_open_callback(self, channel):
         self.create_and_bind_exchange_and_queue(channel, current_app.config['UNIQUE_EXCHANGE'], current_app.config['WEBSOCKETS_QUEUE'])
-        channel.basic_consume(self.callback_listen, queue=current_app.config['WEBSOCKETS_QUEUE'])
+        channel.basic_consume(queue=current_app.config['WEBSOCKETS_QUEUE'], on_message_callback=self.callback_listen)
 
         self.create_and_bind_exchange_and_queue(channel, current_app.config['PLAYING_NOW_EXCHANGE'], current_app.config['PLAYING_NOW_QUEUE'])
-        channel.basic_consume(self.callback_playing_now, queue=current_app.config['PLAYING_NOW_QUEUE'])
+        channel.basic_consume(queue=current_app.config['PLAYING_NOW_QUEUE'], on_message_callback=self.callback_playing_now)
 
     def on_open(self, connection):
         connection.channel(self.on_open_callback)

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -45,7 +45,7 @@ class ListensDispatcher(threading.Thread):
         channel.basic_consume(queue=current_app.config['PLAYING_NOW_QUEUE'], on_message_callback=self.callback_playing_now)
 
     def on_open(self, connection):
-        connection.channel(on_open_callbak=self.on_open_callback)
+        connection.channel(on_open_callback=self.on_open_callback)
 
     def init_rabbitmq_connection(self):
         while True:

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -140,7 +140,7 @@ class RequestConsumer:
             exchange=config.SPARK_REQUEST_EXCHANGE,
             queue=config.SPARK_REQUEST_QUEUE
         )
-        self.request_channel.basic_consume(self.callback, queue=config.SPARK_REQUEST_QUEUE)
+        self.request_channel.basic_consume(queue=config.SPARK_REQUEST_QUEUE, on_message_callback=self.callback)
 
         self.result_channel = self.rabbitmq.channel()
         self.result_channel.exchange_declare(exchange=config.SPARK_RESULT_EXCHANGE, exchange_type='fanout')

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ redis == 3.5.3
 yattag == 1.14.0
 xmltodict == 0.12.0
 oauth2client == 4.1.3
-pika == 0.13.0
+pika == 1.2.0
 git+https://github.com/metabrainz/brainzutils-python.git@v2.0.3
 spotipy == 2.17.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster

--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -1,7 +1,7 @@
 click==7.1.2
 hdfs == 2.5.8
 Jinja2 == 2.11.3
-pika==0.13.0
+pika==1.2.0
 python-dateutil==2.8.0
 # Numpy has dropped support for Python 3.6.x from version 1.20.0. So we use version 1.19.5 till we upgrade Python version in Spark images.
 numpy==1.19.5


### PR DESCRIPTION
no_ack has been renamed to auto_ack. The callback argument we used has now been renamed to on_message_callback, the basic_consume method still has a callback argument but that is different and currently not useful to us. I don't think other incompatible changes affect us. Release notes available [here](https://pika.readthedocs.io/en/stable/version_history.html)