### PR TITLE
Set GIT_SHA env variable so that sentry tags release correctly

### DIFF
--- a/docker/start-spark-request-consumer.sh
+++ b/docker/start-spark-request-consumer.sh
@@ -14,6 +14,9 @@ venv-pack -o pyspark_venv.tar.gz
 export PYSPARK_DRIVER_PYTHON=python
 export PYSPARK_PYTHON=./environment/bin/python
 
+GIT_COMMIT_SHA="$(git describe --tags --dirty --always)"
+echo "$GIT_COMMIT_SHA" > .git-version
+
 zip -rq listenbrainz_spark_request_consumer.zip listenbrainz_spark/
 
 source spark_config.sh
@@ -26,5 +29,6 @@ spark-submit \
         --conf "spark.executor.cores"=$EXECUTOR_CORES \
         --conf "spark.executor.memory"=$EXECUTOR_MEMORY \
         --conf "spark.driver.memory"=$DRIVER_MEMORY \
+        --conf "spark.yarn.appMasterEnv.GIT_SHA"=$GIT_COMMIT_SHA \
        --py-files listenbrainz_spark_request_consumer.zip \
     spark_manage.py request_consumer

--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -22,6 +22,7 @@ STATS_CALCULATION_WINDOW = 1
 # LOG_SENTRY = {
 #    'dsn':'',
 #    'environment': 'development',
+#    'release': ''
 # }
 
 # Model id is made up of two parts.


### PR DESCRIPTION
We already do this in consul config but spark uses does not use consul and has a different config file so need to do it again. Changes to config.py in spark here https://github.com/metabrainz/docker-server-configs/commit/f095343d898f7a78222604d36b424e04bad1f963