### PR TITLE
Improve pinnedRecording database queries + models

### DIFF
--- a/listenbrainz/db/model/pinned_recording.py
+++ b/listenbrainz/db/model/pinned_recording.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from typing import Optional
 from pydantic import BaseModel, validator
-from listenbrainz.db.model.utils import check_rec_mbid_msid_is_valid_uuid, check_datetime_has_tzinfo_or_set_now
+from listenbrainz.db.model.utils import check_rec_mbid_msid_is_valid_uuid, check_datetime_has_tzinfo
 
 DAYS_UNTIL_UNPIN = 7  # default = unpin after one week
 
@@ -9,26 +10,68 @@ class PinnedRecording(BaseModel):
     """Represents a pinned recording object.
     Args:
         user_id: the row id of the user in the DB
-        row_id: (Optional) the row id of the pinned_recording in the DB
+        row_id: the row id of the pinned_recording in the DB
         recording_mbid: the MusicBrainz ID of the recording
         blurb_content: (Optional) the custom text content of the pinned recording
-        created: (Optional) the timestamp when the pinned recording record was inserted into DB
-        pinned_until: (Optional) the timestamp when the pinned recording is set to expire/unpin
+        created: the timestamp when the pinned recording record was inserted into DB
+        pinned_until: the timestamp when the pinned recording is set to expire/unpin
 
-        Created is set to now() by default. Pinned_until is set to created + _daysUntilUnpin (7 days) by default.
-        If arguments are provided but either is invalid, the object will not be created.
+        Validates that pinned_until contains tzinfo() and is greater than created.
     """
 
     user_id: int
-    row_id: int = None
+    user_name: Optional[str]
+    row_id: int
+    recording_mbid: str
+    blurb_content: str = None
+    created: datetime
+    pinned_until: datetime
+
+    _validate_recording_mbid: classmethod = validator("recording_mbid", allow_reuse=True)(check_rec_mbid_msid_is_valid_uuid)
+
+    _validate_created_tzinfo: classmethod = validator("created", always=True, allow_reuse=True)(check_datetime_has_tzinfo)
+
+    # need to validate tzinfo and greater than created
+    _validate_pin_until_tzinfo: classmethod = validator("pinned_until", always=True, allow_reuse=True)(check_datetime_has_tzinfo)
+
+    @validator("pinned_until", always=True)
+    def check_pin_until_greater_than_created(cls, pin_until, values):
+        try:
+            if pin_until <= values["created"]:
+                raise ValueError
+            return pin_until
+        except (ValueError, AttributeError):
+            raise ValueError(
+                """Pinned_until of returned PinnedRecording must be greater than created.
+                        See https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for acceptable formats."""
+            )
+
+
+class PinnedRecordingSubmit(BaseModel):
+    """Represents a pinned recording object to pin/submit to the DB. Created is initialized to now().
+
+    Args:
+        user_id: the row id of the user in the DB
+        recording_mbid: the MusicBrainz ID of the recording
+        blurb_content: (Optional) the custom text content of the pinned recording
+        pinned_until: (Optional) the timestamp when the pinned recording is set to expire/unpin
+
+        Pinned_until is set to created + _daysUntilUnpin (7 days) by default.
+        If pinned_until is provided, the model validates that it contains tzinfo() and is greater than created.
+
+    """
+
+    user_id: int
     recording_mbid: str
     blurb_content: str = None
     created: datetime = None
     pinned_until: datetime = None
 
-    _is_recording_mbid_valid: classmethod = validator("recording_mbid", allow_reuse=True)(check_rec_mbid_msid_is_valid_uuid)
+    _validate_recording_mbid: classmethod = validator("recording_mbid", allow_reuse=True)(check_rec_mbid_msid_is_valid_uuid)
 
-    _is_created_valid: classmethod = validator("created", always=True, allow_reuse=True)(check_datetime_has_tzinfo_or_set_now)
+    @validator("created", pre=True, always=True)
+    def set_created_now(cls, created):
+        return datetime.now(timezone.utc)
 
     @validator("pinned_until", always=True)
     def check_valid_pinned_until_or_set(cls, pin_until, values):
@@ -39,11 +82,8 @@ class PinnedRecording(BaseModel):
                 return pin_until
             except (ValueError, AttributeError):
                 raise ValueError(
-                    """Pinned until must be a valid datetime, contain tzinfo, and be greater than created.
+                    """Pinned until must be a valid datetime, contain tzinfo, and be greater than now().
                             See https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for acceptable formats."""
                 )
         else:
-            if "created" in values:
-                return values["created"] + timedelta(days=DAYS_UNTIL_UNPIN)  # set default value
-            else:
-                raise ValueError("Cannot set default pinned_until until created is valid.")
+            return values["created"] + timedelta(days=DAYS_UNTIL_UNPIN)  # set default value

--- a/listenbrainz/db/model/utils.py
+++ b/listenbrainz/db/model/utils.py
@@ -18,7 +18,7 @@ def check_rec_mbid_msid_is_valid_uuid(rec_id: str):
         raise ValueError("Recording MBID/MSID must be a valid UUID.")
 
 
-def check_datetime_has_tzinfo_or_set_now(date_time: datetime = None):
+def check_datetime_has_tzinfo(date_time: datetime):
     """Validates that the provided datetime object contains tzinfo. Otherwise, raises a ValueError.
 
     Args:
@@ -26,17 +26,13 @@ def check_datetime_has_tzinfo_or_set_now(date_time: datetime = None):
 
     Returns:
         The provided datetime object containing tzinfo if it was valid.
-        If no object was provided, returns now() as a datetime containing tzinfo.
     """
-    if date_time:  # validate if argument provided
-        try:  # validate that datetime contains tzinfo
-            if date_time.tzinfo is None or date_time.tzinfo.utcoffset(date_time) is None:
-                raise ValueError
-            return date_time
-        except (AttributeError, ValueError):  # timestamp.tzinfo throws AttributeError if invalid datetime
-            raise ValueError(
-                """Datetime provided must be a valid datetime and contain tzinfo.
-                       See https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for acceptable formats."""
-            )
-    else:
-        return datetime.now(timezone.utc)  # set default value
+    try:  # validate that datetime contains tzinfo
+        if date_time.tzinfo is None or date_time.tzinfo.utcoffset(date_time) is None:
+            raise ValueError
+        return date_time
+    except (AttributeError, ValueError):  # timestamp.tzinfo throws AttributeError if invalid datetime
+        raise ValueError(
+            """Datetime provided must be a valid datetime and contain tzinfo.
+                    See https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for acceptable formats."""
+        )

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -2,7 +2,7 @@ import sqlalchemy
 import json
 
 from listenbrainz import db
-from listenbrainz.db.model.pinned_recording import PinnedRecording, PinnedRecordingSubmit
+from listenbrainz.db.model.pinned_recording import PinnedRecording, WritablePinnedRecording
 from typing import List
 
 
@@ -10,12 +10,12 @@ PINNED_REC_GET_COLUMNS = ['user_id', 'pin.id AS row_id', 'recording_mbid::text',
                           'pin.created as created']
 
 
-def pin(pinnedRecording: PinnedRecordingSubmit):
+def pin(pinnedRecording: WritablePinnedRecording):
     """ Inserts a pinned recording record into the database for the user.
         If the user already has an active pinned recording, it will be unpinned before the new one is pinned.
 
         Args:
-            pinnedRecording: An object of class PinnedRecordingSubmit
+            pinnedRecording: An object of class WritablePinnedRecording
     """
     args = {
         'user_id': pinnedRecording.user_id,

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -43,7 +43,7 @@ def unpin(user_id: int):
             user_id: the row ID of the user in the DB
 
         Returns:
-            True if an active pinned recording was unpinned, 
+            True if an active pinned recording was unpinned,
             False if no pinned recording belonging to the given user_id was currently pinned.
     """
 
@@ -64,10 +64,10 @@ def delete(row_id: int, user_id: int):
 
         Args:
             row_id: The row id of the pinned_recording to delete from the DB's 'pinned_recording' table
-    
+
         Returns:
-            True if a pinned recording for the given row_id and user_id was deleted. 
-            False if the pinned recording for the given row_id and user_id did not exist. 
+            True if a pinned recording for the given row_id and user_id was deleted.
+            False if the pinned recording for the given row_id and user_id did not exist.
     """
 
     with db.engine.connect() as connection:
@@ -131,8 +131,10 @@ def get_pin_history_for_user(user_id: int, count: int, offset: int) -> List[Pinn
         })
         return [PinnedRecording(**dict(row)) for row in result.fetchall()]
 
+
 def get_pins_for_user_following(user_id: int, count: int, offset: int) -> List[PinnedRecording]:
-    """ Get a list of currently active pinned recordings for users in the user's following list in descending order of their created date.
+    """ Get a list of currently active pinned recordings for users 
+        in the user's following list in descending order of their created date.
 
         Args:
             user_id: the row ID of the main user in the DB

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -133,7 +133,7 @@ def get_pin_history_for_user(user_id: int, count: int, offset: int) -> List[Pinn
 
 
 def get_pins_for_user_following(user_id: int, count: int, offset: int) -> List[PinnedRecording]:
-    """ Get a list of currently active pinned recordings for users 
+    """ Get a list of currently active pinned recordings for users
         in the user's following list in descending order of their created date.
 
         Args:

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -2,19 +2,20 @@ import sqlalchemy
 import json
 
 from listenbrainz import db
-from listenbrainz.db.model.pinned_recording import PinnedRecording
+from listenbrainz.db.model.pinned_recording import PinnedRecording, PinnedRecordingSubmit
 from typing import List
 
-PINNED_REC_GET_COLUMNS = ['user_id', 'id AS row_id', 'recording_mbid::text', 'blurb_content', 'pinned_until',
-                          'created']
+
+PINNED_REC_GET_COLUMNS = ['user_id', 'pin.id AS row_id', 'recording_mbid::text', 'blurb_content', 'pinned_until',
+                          'pin.created as created']
 
 
-def pin(pinnedRecording: PinnedRecording):
+def pin(pinnedRecording: PinnedRecordingSubmit):
     """ Inserts a pinned recording record into the database for the user.
         If the user already has an active pinned recording, it will be unpinned before the new one is pinned.
 
         Args:
-            pinnedRecording: An object of class PinnedRecording
+            pinnedRecording: An object of class PinnedRecordingSubmit
     """
     args = {
         'user_id': pinnedRecording.user_id,
@@ -40,10 +41,14 @@ def unpin(user_id: int):
 
         Args:
             user_id: the row ID of the user in the DB
+
+        Returns:
+            True if an active pinned recording was unpinned, 
+            False if no pinned recording belonging to the given user_id was currently pinned.
     """
 
     with db.engine.connect() as connection:
-        connection.execute(sqlalchemy.text("""
+        result = connection.execute(sqlalchemy.text("""
             UPDATE pinned_recording
                SET pinned_until = NOW()
              WHERE (user_id = :user_id AND pinned_until >= NOW())
@@ -51,6 +56,7 @@ def unpin(user_id: int):
             'user_id': user_id,
             }
         )
+        return result.rowcount == 1
 
 
 def delete(row_id: int, user_id: int):
@@ -58,10 +64,14 @@ def delete(row_id: int, user_id: int):
 
         Args:
             row_id: The row id of the pinned_recording to delete from the DB's 'pinned_recording' table
+    
+        Returns:
+            True if a pinned recording for the given row_id and user_id was deleted. 
+            False if the pinned recording for the given row_id and user_id did not exist. 
     """
 
     with db.engine.connect() as connection:
-        connection.execute(sqlalchemy.text("""
+        result = connection.execute(sqlalchemy.text("""
             DELETE FROM pinned_recording
              WHERE id = :row_id
                AND user_id = :user_id
@@ -70,6 +80,7 @@ def delete(row_id: int, user_id: int):
             'user_id': user_id
             }
         )
+        return result.rowcount == 1
 
 
 def get_current_pin_for_user(user_id: int) -> PinnedRecording:
@@ -85,7 +96,7 @@ def get_current_pin_for_user(user_id: int) -> PinnedRecording:
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT {columns}
-              FROM pinned_recording
+              FROM pinned_recording as pin
              WHERE (user_id = :user_id
                AND pinned_until >= NOW())
             """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {'user_id': user_id})
@@ -94,11 +105,11 @@ def get_current_pin_for_user(user_id: int) -> PinnedRecording:
 
 
 def get_pin_history_for_user(user_id: int, count: int, offset: int) -> List[PinnedRecording]:
-    """ Get a list of pinned recording records for the user in descending order of their created date
+    """ Get a list of pinned recordings for the user in descending order of their created date
 
         Args:
             user_id: the row ID of the user in the DB
-            count: number of rows to be returned
+            count: number of pinned recordings to be returned
             offset: number of pinned recordings to skip from the beginning
 
         Returns:
@@ -108,7 +119,7 @@ def get_pin_history_for_user(user_id: int, count: int, offset: int) -> List[Pinn
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT {columns}
-              FROM pinned_recording
+              FROM pinned_recording as pin
              WHERE user_id = :user_id
              ORDER BY created DESC
              LIMIT :count
@@ -120,6 +131,39 @@ def get_pin_history_for_user(user_id: int, count: int, offset: int) -> List[Pinn
         })
         return [PinnedRecording(**dict(row)) for row in result.fetchall()]
 
+def get_pins_for_user_following(user_id: int, count: int, offset: int) -> List[PinnedRecording]:
+    """ Get a list of currently active pinned recordings for users in the user's following list in descending order of their created date.
+
+        Args:
+            user_id: the row ID of the main user in the DB
+            count: number of pinned recordings to be returned
+            offset: number of pinned recordings to skip from the beginning
+
+        Returns:
+            A list of PinnedRecording objects sorted by newest to oldest creation date.
+    """
+    COLUMNS_WITH_USERNAME = PINNED_REC_GET_COLUMNS + ['"user".musicbrainz_id as user_name']
+
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT {columns}
+              FROM user_relationship
+              JOIN "user"
+                ON user_1 = "user".id
+              JOIN pinned_recording as pin
+                ON user_1 = pin.user_id
+             WHERE user_0 = :user_id
+               AND relationship_type = 'follow'
+               AND pinned_until >= NOW()
+             ORDER BY created DESC
+             LIMIT :count
+            OFFSET :offset
+            """.format(columns=','.join(COLUMNS_WITH_USERNAME))), {
+            'user_id': user_id,
+            'count': count,
+            'offset': offset
+        })
+        return [PinnedRecording(**dict(row)) for row in result.fetchall()]
 
 def get_pin_count_for_user(user_id: int) -> int:
     """ Get the total number pinned_recordings for the user.

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from pydantic import ValidationError
 
-from listenbrainz.db.model.pinned_recording import PinnedRecording, PinnedRecordingSubmit, DAYS_UNTIL_UNPIN
+from listenbrainz.db.model.pinned_recording import PinnedRecording, WritablePinnedRecording, DAYS_UNTIL_UNPIN
 import listenbrainz.db.pinned_recording as db_pinned_rec
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
@@ -38,7 +38,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
 
         for data in self.pinned_rec_samples[:limit]:
             db_pinned_rec.pin(
-                PinnedRecordingSubmit(
+                WritablePinnedRecording(
                     user_id=user_id,
                     recording_mbid=data["recording_mbid"],
                     blurb_content=data["blurb_content"],
@@ -46,7 +46,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
             )
         return min(limit, len(self.pinned_rec_samples))
 
-    def pin_single_sample(self, user_id: int, index: int = 0) -> PinnedRecordingSubmit:
+    def pin_single_sample(self, user_id: int, index: int = 0) -> WritablePinnedRecording:
         """Inserts one recording from pinned_rec_samples into the database.
 
         Args:
@@ -56,7 +56,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
         Returns:
             The PinnedRecording object that was pinned
         """
-        recording_to_pin = PinnedRecordingSubmit(
+        recording_to_pin = WritablePinnedRecording(
             user_id=user_id,
             recording_mbid=self.pinned_rec_samples[index]["recording_mbid"],
             blurb_content=self.pinned_rec_samples[index]["blurb_content"],
@@ -68,20 +68,20 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
     def test_Pinned_Recording_model(self):
         # test missing required arguments error
         with self.assertRaises(ValidationError):
-            PinnedRecordingSubmit(
+            WritablePinnedRecording(
                 user_id=self.user["id"],
             )
 
         # test recording_mbid = invalid uuid format
         with self.assertRaises(ValidationError):
-            PinnedRecordingSubmit(
+            WritablePinnedRecording(
                 user_id=self.user["id"],
                 recording_mbid="7f3-38-43-9e-f3",
                 blurb_content=self.pinned_rec_samples[0]["blurb_content"],
             )
 
         # test created = invalid datetime error doesn't raise error
-        PinnedRecordingSubmit(
+        WritablePinnedRecording(
             user_id=self.user["id"],
             recording_mbid=self.pinned_rec_samples[0]["recording_mbid"],
             blurb_content=self.pinned_rec_samples[0]["blurb_content"],
@@ -90,7 +90,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
 
         # test pinned_until = datetime with missing tzinfo error
         with self.assertRaises(ValidationError):
-            PinnedRecordingSubmit(
+            WritablePinnedRecording(
                 user_id=self.user["id"],
                 recording_mbid=self.pinned_rec_samples[0]["recording_mbid"],
                 blurb_content=self.pinned_rec_samples[0]["blurb_content"],
@@ -99,7 +99,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
 
         # test pinned_until = invalid datetime error
         with self.assertRaises(ValidationError):
-            PinnedRecordingSubmit(
+            WritablePinnedRecording(
                 user_id=self.user["id"],
                 recording_mbid=self.pinned_rec_samples[0]["recording_mbid"],
                 blurb_content=self.pinned_rec_samples[0]["blurb_content"],
@@ -108,7 +108,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
 
         # test pinned_until < created error
         with self.assertRaises(ValidationError):
-            PinnedRecordingSubmit(
+            WritablePinnedRecording(
                 user_id=self.user["id"],
                 recording_mbid=self.pinned_rec_samples[0]["recording_mbid"],
                 blurb_content=self.pinned_rec_samples[0]["blurb_content"],


### PR DESCRIPTION
This PR aims to make several improvements to the database models and queries in [PR 1503:](https://github.com/metabrainz/listenbrainz-server/pull/1503)

**1) Separate PinnedRecording and WritablePinnedRecording models**
  
  - When pinning a recording there wouldn't be a reason to set 'created' to anything other than the current datetime, but the query functions return a validated object and we wouldn't want the 'created' value to be replaced in the validator. 
  - From now on all pinned recordings would have a 'created' time set automatically to now(). (WritablePinnedRecording model)

**2) Unpin and Delete queries return True/False**: improves the responses and error messages at the API level when unpinning and deleting tracks.

**3) Get_pins_for_user_following()**
