### PR TITLE
Validate mbids of listens submitted through AudioScrobbler 1.2 API

### DIFF
--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -31,7 +31,7 @@ from time import time
 from flask import current_app, Blueprint, request, render_template, redirect
 from werkzeug.exceptions import BadRequest
 from listenbrainz.db.lastfm_session import Session
-from listenbrainz.webserver.views.api_tools import insert_payload, is_valid_timestamp, LISTEN_TYPE_PLAYING_NOW
+from listenbrainz.webserver.views.api_tools import insert_payload, is_valid_timestamp, LISTEN_TYPE_PLAYING_NOW, is_valid_uuid
 
 
 api_compat_old_bp = Blueprint('api_compat_old', __name__)
@@ -175,7 +175,9 @@ def _to_native_api(data, append_key):
         listen['track_metadata']['additional_info']['track_number'] = data['n{}'.format(append_key)]
 
     if 'm{}'.format(append_key) in data:
-        listen['track_metadata']['additional_info']['recording_mbid'] = data['m{}'.format(append_key)]
+        mbid = data['m{}'.format(append_key)]
+        if is_valid_uuid(mbid):
+            listen['track_metadata']['additional_info']['recording_mbid'] = mbid
 
     if 'l{}'.format(append_key) in data:
         listen['track_metadata']['additional_info']['track_length'] = data['l{}'.format(append_key)]


### PR DESCRIPTION
We discovered that some of the clients using AudioScrobbler 1.2 API are submitting invalid values as mbids. In the AudioScrobbler 2.0 and ListenBrainz API, we reject such listens but AS 1.2 is a legacy api and many clients out there are probably unmaintained. Considering this, we have decided to drop the invalid mbid fields but accept the listens.