### PR TITLE
Remove --last-dump-id flag to simplify dumps code

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -77,6 +77,9 @@ if [ -z $DUMP_BASE_DIR ]; then
 fi
 
 DUMP_TYPE="${1:-full}"
+# consume dump type argument so that we can pass the remaining arguments to
+# the python dump manager script
+shift
 
 if [ "$DUMP_TYPE" == "full" ]; then
     SUB_DIR="fullexport"
@@ -95,17 +98,17 @@ echo "creating DUMP_TEMP_DIR $DUMP_TEMP_DIR"
 mkdir -p "$DUMP_TEMP_DIR"
 
 if [ "$DUMP_TYPE" == "full" ]; then
-    if ! /usr/local/bin/python manage.py dump create_full -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS"; then
+    if ! /usr/local/bin/python manage.py dump create_full -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS" "$@"; then
         echo "Full dump failed, exiting!"
         exit 1
     fi
 elif [ "$DUMP_TYPE" == "incremental" ]; then
-    if ! /usr/local/bin/python manage.py dump create_incremental -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS"; then
+    if ! /usr/local/bin/python manage.py dump create_incremental -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS" "$@"; then
         echo "Incremental dump failed, exiting!"
         exit 1
     fi
 elif [ "$DUMP_TYPE" == "feedback" ]; then
-    if ! /usr/local/bin/python manage.py dump create_feedback -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS"; then
+    if ! /usr/local/bin/python manage.py dump create_feedback -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS" "$@"; then
         echo "Feedback dump failed, exiting!"
         exit 1
     fi

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -18,6 +18,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+# usage
+# the first argument to this script is the dump type, it can be either
+# full, incremental or feedback. the remaining arguments are forwarded
+# the python dump_manager script. this can be useful in scenarios where
+# we want to pass in the --dump-id manually for recreating a failed dump.
+
 set -e
 
 LB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -95,7 +95,7 @@ echo "creating DUMP_TEMP_DIR $DUMP_TEMP_DIR"
 mkdir -p "$DUMP_TEMP_DIR"
 
 if [ "$DUMP_TYPE" == "full" ]; then
-    if ! /usr/local/bin/python manage.py dump create_full -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS" --last-dump-id; then
+    if ! /usr/local/bin/python manage.py dump create_full -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS"; then
         echo "Full dump failed, exiting!"
         exit 1
     fi

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -72,8 +72,7 @@ def send_dump_creation_notification(dump_name, dump_type):
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'))
 @click.option('--threads', '-t', type=int, default=DUMP_DEFAULT_THREAD_COUNT)
 @click.option('--dump-id', type=int, default=None)
-@click.option('--last-dump-id', is_flag=True)
-def create_full(location, threads, dump_id, last_dump_id):
+def create_full(location, threads, dump_id):
     """ Create a ListenBrainz data dump which includes a private dump, a statistics dump
         and a dump of the actual listens from the listenstore
 
@@ -81,19 +80,10 @@ def create_full(location, threads, dump_id, last_dump_id):
             location (str): path to the directory where the dump should be made
             threads (int): the number of threads to be used while compression
             dump_id (int): the ID of the ListenBrainz data dump
-            last_dump_id (bool): flag indicating whether to create a full dump from the last entry in the dump table
     """
     app = create_app()
     with app.app_context():
         from listenbrainz.webserver.timescale_connection import _ts as ls
-        if last_dump_id:
-            all_dumps = db_dump.get_dump_entries()
-            if len(all_dumps) == 0:
-                current_app.logger.error(
-                    "Cannot create full dump with last dump's ID, no dump exists!")
-                sys.exit(-1)
-            dump_id = all_dumps[0]['id']
-
         if dump_id is None:
             end_time = datetime.now()
             dump_id = db_dump.add_dump_entry(int(end_time.strftime('%s')))

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -212,23 +212,6 @@ class DumpManagerTestCase(DatabaseTestCase):
                 archive_count += 1
         self.assertEqual(archive_count, 4)
 
-        # now, remove the old dump and create a new one with the same id
-        shutil.rmtree(os.path.join(self.tempdir, dump_name))
-        self.runner.invoke(dump_manager.create_full, [
-                           '--location', self.tempdir, '--last-dump-id'])
-        self.assertEqual(len(os.listdir(self.tempdir)), 1)
-        recreated_dump_name = os.listdir(self.tempdir)[0]
-
-        # dump names should be the exact same
-        self.assertEqual(dump_name, recreated_dump_name)
-
-        # dump should contain the 4 archives
-        archive_count = 0
-        for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
-            if file_name.endswith('.tar.xz'):
-                archive_count += 1
-        self.assertEqual(archive_count, 4)
-
     def test_create_full_dump_with_id(self):
 
         self.listenstore.insert(generate_data(


### PR DESCRIPTION
We have decided to simplify the dumps code, by default a dump will always add an entry to data_dump table. In case something goes wrong, we will pass in the `--dump-id` manually.