### PR TITLE
Silently drop empty or null mbids in listen submissions

### DIFF
--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -260,8 +260,7 @@ def parse_and_validate_spotify_plays(plays, listen_type):
     for play in plays:
         listen = _convert_spotify_play_to_listen(play, listen_type=listen_type)
         try:
-            validate_listen(listen, listen_type)
-            listens.append(listen)
+            listens.append(validate_listen(listen, listen_type))
         except APIBadRequest:
             pass
     return listens

--- a/listenbrainz/testdata/invalid_mbid_listens.json
+++ b/listenbrainz/testdata/invalid_mbid_listens.json
@@ -1,0 +1,31 @@
+{
+    "listen_type": "import",
+    "payload": [
+        {
+            "track_metadata": {
+                "track_name": "Fade",
+                "artist_name": "Kanye West",
+                "release_name": "The Life of Pablo",
+                "additional_info": {
+                    "recording_mbid": null,
+                    "release_mbid": "",
+                    "release_group_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+                    "artist_mbids": [],
+                    "work_mbids": null
+                }
+            },
+            "listened_at": 1486466946
+        },
+        {
+            "track_metadata": {
+                "track_name": "Sister",
+                "artist_name": "The Black Keys",
+                "release_name": "El Camino",
+                "additional_info": {
+                    "artist_mbids": [null, "", "ac4f356f-23e5-40ab-990e-da7e34b65d6e"]
+                }
+            },
+            "listened_at": 1486466992
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -2,7 +2,7 @@ import json
 import time
 
 import pytest
-from flask import url_for
+from flask import url_for, current_app
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
@@ -503,6 +503,28 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertNotIn('track_name', sent_additional_info)
         self.assertNotIn('artist_name', sent_additional_info)
         self.assertNotIn('release_name', sent_additional_info)
+
+    def test_additional_info_invalid_mbids(self):
+        """ Test mbid fields with [], "", null values are dropped without error """
+        with open(self.path_to_data_file('invalid_mbid_listens.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
+
+        url = url_for('api_v1.get_listens', user_name=self.user['musicbrainz_id'])
+        response = self.wait_for_query_to_have_items(url, num_items=2, query_string={'count': '2'})
+        listens = json.loads(response.data)['payload']['listens']
+
+        additional_info = listens[0]['track_metadata']['additional_info']
+        self.assertEqual(["ac4f356f-23e5-40ab-990e-da7e34b65d6e"], additional_info["artist_mbids"])
+
+        additional_info = listens[1]['track_metadata']['additional_info']
+        self.assertNotIn("recording_mbid", additional_info)
+        self.assertNotIn("artist_mbids", additional_info)
+        self.assertNotIn("release_mbid", additional_info)
+        self.assertNotIn("work_mbids", additional_info)
+        self.assertEqual("2cfad207-3f55-4aec-8120-86cf66e34d59", additional_info["release_group_mbid"])
 
     def test_000_similar_users(self):
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -79,8 +79,7 @@ def submit_listen():
         log_raise_400("Invalid JSON document submitted.", raw_data)
 
     # validate listens to make sure json is okay
-    for listen in payload:
-        validate_listen(listen, listen_type)
+    payload = map(lambda x: validate_listen(x, listen_type), payload)
 
     try:
         insert_payload(

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -79,9 +79,7 @@ def submit_listen():
         log_raise_400("Invalid JSON document submitted.", raw_data)
 
     # validate listens to make sure json is okay
-    validated_payload = []
-    for listen in payload:
-        validated_payload.append(validate_listen(listen, listen_type))
+    validated_payload = [validate_listen(listen, listen_type) for listen in payload]
 
     try:
         insert_payload(validated_payload, user, listen_type)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -79,11 +79,12 @@ def submit_listen():
         log_raise_400("Invalid JSON document submitted.", raw_data)
 
     # validate listens to make sure json is okay
-    payload = map(lambda x: validate_listen(x, listen_type), payload)
+    validated_payload = []
+    for listen in payload:
+        validated_payload.append(validate_listen(listen, listen_type))
 
     try:
-        insert_payload(
-            payload, user, listen_type=_get_listen_type(data['listen_type']))
+        insert_payload(validated_payload, user, listen_type)
     except APIServiceUnavailable as e:
         raise
     except Exception as e:

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -271,8 +271,7 @@ def record_listens(request, data):
 
     # Convert to native payload then submit 'em after validation.
     listen_type, native_payload = _to_native_api(lookup, data['method'], output_format)
-    for listen in native_payload:
-        validate_listen(listen, listen_type)
+    native_payload = map(lambda x: validate_listen(x, listen_type), native_payload)
 
     user = db_user.get(session.user_id)
     augmented_listens = insert_payload(native_payload, user, listen_type=listen_type)

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -271,10 +271,12 @@ def record_listens(request, data):
 
     # Convert to native payload then submit 'em after validation.
     listen_type, native_payload = _to_native_api(lookup, data['method'], output_format)
-    native_payload = map(lambda x: validate_listen(x, listen_type), native_payload)
+    validated_payload = []
+    for listen in native_payload:
+        validated_payload.append(validate_listen(listen, listen_type))
 
     user = db_user.get(session.user_id)
-    augmented_listens = insert_payload(native_payload, user, listen_type=listen_type)
+    augmented_listens = insert_payload(validated_payload, user, listen_type=listen_type)
 
     # With corrections than the original submitted listen.
     doc, tag, text = Doc().tagtext()

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -271,9 +271,7 @@ def record_listens(request, data):
 
     # Convert to native payload then submit 'em after validation.
     listen_type, native_payload = _to_native_api(lookup, data['method'], output_format)
-    validated_payload = []
-    for listen in native_payload:
-        validated_payload.append(validate_listen(listen, listen_type))
+    validated_payload = [validate_listen(listen, listen_type) for listen in native_payload]
 
     user = db_user.get(session.user_id)
     augmented_listens = insert_payload(validated_payload, user, listen_type=listen_type)

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -186,13 +186,13 @@ def validate_listen(listen, listen_type):
                 if len(tag) > MAX_TAG_SIZE:
                     raise APIBadRequest("JSON document may not contain track_metadata.additional_info.tags "
                                         "longer than %d characters." % MAX_TAG_SIZE, listen)
-        # MBIDs
+        # MBIDs, both of the mbid validation methods mutate the listen payload if needed.
         single_mbid_keys = ['release_mbid', 'recording_mbid', 'release_group_mbid', 'track_mbid']
         for key in single_mbid_keys:
-            verify_mbid_validity(listen, key, multi = False)
+            validate_single_mbid_field(listen, key)
         multiple_mbid_keys = ['artist_mbids', 'work_mbids']
         for key in multiple_mbid_keys:
-            verify_mbid_validity(listen, key, multi = True)
+            validate_multiple_mbids_field(listen, key)
 
 
 # lifted from AcousticBrainz
@@ -309,23 +309,53 @@ def log_raise_400(msg, data=""):
     raise APIBadRequest(msg)
 
 
-def verify_mbid_validity(listen, key, multi):
-    """ Verify that mbid(s) present in listen with key `key` is valid.
+def validate_single_mbid_field(listen, key):
+    """ Verify that mbid if present in the listen with given key is valid.
+    An APIBadRequest error is raised for invalid values of mbids.
 
-        Args:
-            listen: listen data
-            key: the key whose mbids is to be validated
-            multi: boolean value signifying if the key contains multiple mbids
+    NOTE: If the mbid at the key is None or "", the key is dropped without
+     raising an error.
+
+    Args:
+        listen: listen data
+        key: the key whose mbid is to be validated
     """
-    if not multi:
-        items = listen['track_metadata']['additional_info'].get(key)
-        items = [items] if items else []
-    else:
-        items = listen['track_metadata']['additional_info'].get(key, [])
-    for item in items:
-        if not is_valid_uuid(item):
+    if key in listen['track_metadata']['additional_info']:
+        mbid = listen['track_metadata']['additional_info'][key]
+        if not mbid:  # the mbid field is None or "", hence drop the field and return
+            del listen['track_metadata']['additional_info'][key]
+            return
+
+        if not is_valid_uuid(mbid):  # if the mbid is invalid raise an error
             log_raise_400("%s MBID format invalid." % (key, ), listen)
 
+
+def validate_multiple_mbids_field(listen, key):
+    """ Verify that all the mbids in the list if present in the listen with
+    given key are valid. An APIBadRequest error is raised for if any mbid is
+    invalid.
+
+    NOTE: If an mbid in the list is None or "", it is dropped from the list
+    without an error. If the key is an empty list or None, it is dropped
+    without raising an error.
+
+    Args:
+        listen: listen data
+        key: the key whose mbids is to be validated
+    """
+    if key in listen['track_metadata']['additional_info']:
+        mbids = listen['track_metadata']['additional_info'][key]
+        if not mbids:  # empty list or None, drop the field and return
+            del listen['track_metadata']['additional_info'][key]
+            return
+
+        mbids = [x for x in mbids if x]  # drop None and "" from list of mbids if any
+
+        for mbid in mbids:
+            if not is_valid_uuid(mbid):   # if the mbid is invalid raise an error
+                log_raise_400("%s MBID format invalid." % (key,), listen)
+
+        listen['track_metadata']['additional_info'][key] = mbids  # set the filtered in the listen payload
 
 def is_valid_timestamp(ts):
     """ Returns True if the timestamp passed is in the API's

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from urllib.parse import urlparse
 
 import bleach
@@ -118,8 +119,9 @@ def _send_listens_to_queue(listen_type, listens):
         )
 
 
-def validate_listen(listen, listen_type):
-    """Make sure that required keys are present, filled out and not too large."""
+def validate_listen(listen: Dict, listen_type) -> Dict:
+    """Make sure that required keys are present, filled out and not too large.
+    The function may also mutate listens in place if needed."""
 
     if listen is None:
         raise APIBadRequest("Listen is empty and cannot be validated.")
@@ -193,6 +195,7 @@ def validate_listen(listen, listen_type):
         multiple_mbid_keys = ['artist_mbids', 'work_mbids']
         for key in multiple_mbid_keys:
             validate_multiple_mbids_field(listen, key)
+    return listen
 
 
 # lifted from AcousticBrainz


### PR DESCRIPTION
The existing checks are insufficient as they allow "", null, [] values for various mbid fields to pass through. We have decided to silently drop such empty fields without erroring.
