### PR TITLE
Speed up python tests in CI with sharding and tmpfs mounts

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,9 @@ on:
 jobs:
 
   test:
+    strategy:
+      matrix:
+        shard: [ 0, 1 ]
 
     runs-on: ubuntu-latest
 
@@ -42,4 +45,4 @@ jobs:
       continue-on-error: true
 
     - name: Run tests
-      run: ./test.sh int
+      run: ./test.sh int --shard-id=${{ matrix.shard }} --num-shards=2

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -16,11 +16,17 @@ on:
 jobs:
 
   test:
+    strategy:
+      matrix:
+        shard: [ 0, 1 ]
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Create configuration file
+      run: cp listenbrainz_spark/config.py.sample listenbrainz_spark/config.py
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
@@ -33,4 +39,4 @@ jobs:
       run: ./test.sh spark -b
 
     - name: Run tests
-      run: ./test.sh spark
+      run: ./test.sh spark --shard-id=${{ matrix.shard }} --num-shards=2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        shard: [ 0, 1 ]
+
     steps:
     - uses: actions/checkout@v2
 
@@ -39,4 +43,4 @@ jobs:
       continue-on-error: true
 
     - name: Run tests
-      run: ./test.sh
+      run: ./test.sh --shard-id=${{ matrix.shard }} --num-shards=2

--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -9,6 +9,8 @@ services:
   db:
     image: timescale/timescaledb:2.2.0-pg11
     command: postgres -F
+    tmpfs:
+      - /var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: 'postgres'
 
@@ -20,7 +22,7 @@ services:
       context: ..
       dockerfile: Dockerfile
       target: listenbrainz-dev
-    command: py.test listenbrainz/tests/integration
+    command: pytest listenbrainz/tests/integration
     image: listenbrainz
     volumes:
       - ..:/code/listenbrainz:z

--- a/docker/docker-compose.spark.yml
+++ b/docker/docker-compose.spark.yml
@@ -29,6 +29,5 @@ services:
     depends_on:
       - namenode
       - datanode
-    command: dockerize -wait tcp://namenode:9000 -timeout 60s bash -c "cp listenbrainz_spark/config.py.sample listenbrainz_spark/config.py; PYTHONDONTWRITEBYTECODE=1 python -m pytest -c pytest.spark.ini"
     volumes:
       - ..:/rec

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -9,6 +9,8 @@ services:
   db:
     image: timescale/timescaledb:2.2.0-pg11
     command: postgres -F
+    tmpfs:
+      - /var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: 'postgres'
 

--- a/requirements_development.txt
+++ b/requirements_development.txt
@@ -5,3 +5,4 @@ nose==1.3.7
 pytest==6.2.2
 pytest-cov==2.10.1
 requests-mock==1.8.0
+pytest-shard

--- a/test.sh
+++ b/test.sh
@@ -210,8 +210,9 @@ if [ "$1" == "spark" ]; then
     echo "Running tests"
     docker-compose -f $SPARK_COMPOSE_FILE_LOC \
                    -p $SPARK_COMPOSE_PROJECT_NAME \
-                   -e PYTHONDONTWRITEBYTECODE=1 \
-                run --rm request_consumer \
+                run \
+                -e PYTHONDONTWRITEBYTECODE=1 \
+                --rm request_consumer \
                 dockerize -wait tcp://namenode:9000 -timeout 60s \
                 python -m pytest -c pytest.spark.ini "$@"
     RET=$?

--- a/test.sh
+++ b/test.sh
@@ -210,9 +210,10 @@ if [ "$1" == "spark" ]; then
     echo "Running tests"
     docker-compose -f $SPARK_COMPOSE_FILE_LOC \
                    -p $SPARK_COMPOSE_PROJECT_NAME \
+                   -e PYTHONDONTWRITEBYTECODE=1 \
                 run --rm request_consumer \
                 dockerize -wait tcp://namenode:9000 -timeout 60s \
-                PYTHONDONTWRITEBYTECODE=1 python -m pytest -c pytest.spark.ini "$@"
+                python -m pytest -c pytest.spark.ini "$@"
     RET=$?
     spark_dcdown
     exit $RET

--- a/test.sh
+++ b/test.sh
@@ -205,11 +205,14 @@ if [ "$1" == "spark" ]; then
         exit 0
     fi
 
+    shift
     spark_setup
     echo "Running tests"
     docker-compose -f $SPARK_COMPOSE_FILE_LOC \
                    -p $SPARK_COMPOSE_PROJECT_NAME \
-                run --rm request_consumer
+                run --rm request_consumer \
+                dockerize -wait tcp://namenode:9000 -timeout 60s \
+                PYTHONDONTWRITEBYTECODE=1 python -m pytest -c pytest.spark.ini "$@"
     RET=$?
     spark_dcdown
     exit $RET


### PR DESCRIPTION
The python tests take about 8-10 mins to execute usually. Using sharding, we spilt the tests into batches and run them parallelly using Github Actions' strategy matrix. One issue with the current approach is that the image is built for each batch. It would nice if we could split the image building and test running into different steps but that requires us to upload the image somewhere.

Another thing I was looking into is mounting a `tmpfs` volume in the database image. I tried that but didn't get noticeable performance gains, further that is only supported on Linux according to my understanding. I do not know if that means it will error on Docker Mac or just ignored. @alastair can you try running tests with this PR locally? If it just gets ignored, we can add it anyways.