### PR TITLE
Modify spark test configuration to make test execution faster

### DIFF
--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -50,6 +50,14 @@ def init_test_session(app_name):
                 .builder \
                 .master('local') \
                 .appName(app_name) \
+                .config("spark.sql.shuffle.partitions", "1") \
+                .config("spark.default.parallelism", "1") \
+                .config("spark.executor.cores", "1") \
+                .config("spark.executor.instances", "1") \
+                .config("spark.shuffle.compress", "false") \
+                .config("spark.rdd.compress", "false") \
+                .config("spark.dynamicAllocation.enabled", "false") \
+                .config("spark.io.compression.codec", "lz4") \
                 .getOrCreate()
         context = session.sparkContext
         context.setLogLevel("ERROR")

--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -44,6 +44,11 @@ def init_spark_session(app_name):
 
 
 def init_test_session(app_name):
+    """Create a spark session suitable for running tests.
+    This sets some config items in order to make tests faster,
+    the list of settings is taken from
+    https://github.com/malexer/pytest-spark#overriding-default-parameters-of-the-spark_session-fixture
+    """
     global session, context, sql_context
     try:
         session = SparkSession \

--- a/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
@@ -87,6 +87,7 @@ class RecommendTestClass(SparkTestCase):
         return recommendation_df
 
     def test_get_recording_mbids(self):
+        self.maxDiff = None
         params = self.get_recommendation_params()
         recommendation_df = self.get_recommendation_df()
         users = []
@@ -94,9 +95,27 @@ class RecommendTestClass(SparkTestCase):
 
         df = recommend.get_recording_mbids(params, recommendation_df, users_df)
         self.assertEqual(df.count(), 4)
-        row = df.collect()
-        received_data = [row[0], row[1], row[2], row[3]]
-        expected_data = [
+        # Each user's rows are ordered by ratings but the order of users is not
+        # fixed so need to test each user's recommendations separately.
+        rows_rob = df.where(df.user_name == "rob").collect()
+        self.assertEqual(rows_rob, [
+            Row(
+                mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
+                rank=1,
+                rating=7.999,
+                user_id=2,
+                user_name='rob'
+            ),
+            Row(
+                mb_recording_mbid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
+                rank=2,
+                rating=-2.4587,
+                user_id=2,
+                user_name='rob'
+            )
+        ])
+        rows_vansika = df.where(df.user_name == "vansika").collect()
+        self.assertEqual(rows_vansika, [
             Row(mb_recording_mbid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
                 rank=1,
                 rating=6.994590001,
@@ -109,22 +128,7 @@ class RecommendTestClass(SparkTestCase):
                 user_id=1,
                 user_name='vansika'
                 ),
-            Row(
-                mb_recording_mbid="3acb406f-c716-45f8-a8bd-96ca3939c2e5",
-                rank=1,
-                rating=7.999,
-                user_id=2,
-                user_name='rob'
-                ),
-            Row(
-                mb_recording_mbid="2acb406f-c716-45f8-a8bd-96ca3939c2e5",
-                rank=2,
-                rating=-2.4587,
-                user_id=2,
-                user_name='rob'
-                )
-        ]
-        self.assertEqual(received_data, expected_data)
+        ])
 
     def test_filter_recommendations_on_rating(self):
         df = self.get_recommendation_df()


### PR DESCRIPTION
Spark's defaults are optimized for large distributed datasets. Our test datasets are small and therefore altering the configuration to make test execution faster. This reduces the test execution time from ~9 mins to ~3 mins.