### PR TITLE
Adhoc fix for thresholding listens

### DIFF
--- a/listenbrainz_spark/recommendations/dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/dataframe_utils.py
@@ -50,14 +50,13 @@ def get_dates_to_train_data(train_model_window):
     return to_date, from_date
 
 
-def get_mapped_artist_and_recording_mbids(partial_listens_df, msid_mbid_mapping_df, mapped_listens_path):
+def get_mapped_artist_and_recording_mbids(partial_listens_df, msid_mbid_mapping_df):
     """ Map recording msid->mbid and artist msid->mbids so that every listen has an mbid.
 
         Args:
             partial_listens_df (dataframe): listens without artist mbid and recording mbid.
             msid_mbid_mapping_df (dataframe): msid->mbid mapping. For columns refer to
                                               msid_mbid_mapping_schema in listenbrainz_spark/schema.py
-            mapped_listens_path (str): Path to store mapped listens.
         Returns:
             mapped_listens_df (dataframe): listens mapped with msid_mbid_mapping.
     """
@@ -78,7 +77,6 @@ def get_mapped_artist_and_recording_mbids(partial_listens_df, msid_mbid_mapping_
                                   'msb_recording_name_matchable',
                                   'user_name')
 
-    save_dataframe(mapped_listens_df, mapped_listens_path)
     return mapped_listens_df
 
 

--- a/listenbrainz_spark/recommendations/recording/tests/test_dataframe.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_dataframe.py
@@ -71,8 +71,7 @@ class CreateDataframeTestCase(SparkTestCase):
         recordings_df = create_dataframes.get_recordings_df(mapped_listens, {}, self.recordings_path)
         listens_df = create_dataframes.get_listens_df(mapped_listens, {})
 
-        threshold = 0
-        create_dataframes.save_playcounts_df(listens_df, recordings_df, users_df, threshold, metadata, self.playcounts_path)
+        create_dataframes.save_playcounts_df(listens_df, recordings_df, users_df, metadata, self.playcounts_path)
         playcounts_df = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_PLAYCOUNTS_DATAFRAME)
         self.assertEqual(playcounts_df.count(), 5)
 

--- a/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
@@ -57,7 +57,7 @@ class DataframeUtilsTestCase(SparkTestCase):
         mapping_df = mapping_utils.get_unique_rows_from_mapping(df)
         mapped_listens_path = '/mapped_listens.parquet'
 
-        mapped_listens = dataframe_utils.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df, mapped_listens_path)
+        mapped_listens = dataframe_utils.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df)
         self.assertEqual(mapped_listens.count(), 8)
 
         cols = [
@@ -72,8 +72,6 @@ class DataframeUtilsTestCase(SparkTestCase):
         ]
 
         self.assertListEqual(sorted(cols), sorted(mapped_listens.columns))
-        status = utils.path_exists(mapped_listens_path)
-        self.assertTrue(status)
 
     def test_save_dataframe(self):
         path_ = '/test_df.parquet'

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -8,6 +8,7 @@ import listenbrainz_spark
 import listenbrainz_spark.utils.mapping as mapping_utils
 from listenbrainz_spark.recommendations import dataframe_utils
 from listenbrainz_spark import hdfs_connection, utils, config, schema
+from listenbrainz_spark.recommendations.dataframe_utils import save_dataframe
 from listenbrainz_spark.recommendations.recording import train_models
 
 from pyspark.sql import Row
@@ -198,4 +199,5 @@ class SparkTestCase(unittest.TestCase):
         df = utils.read_files_from_HDFS(mapping_path)
         mapping_df = mapping_utils.get_unique_rows_from_mapping(df)
 
-        _ = dataframe_utils.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df, mapped_listens_path)
+        mapped_listens_df = dataframe_utils.get_mapped_artist_and_recording_mbids(partial_listen_df, mapping_df)
+        save_dataframe(mapped_listens_df, mapped_listens_path)


### PR DESCRIPTION
There are two issues with the current thresholding code:
1) threshold is applied on individual (recording mbid, user_id) pairs.
This is wrong because the threshold is for total listens of the user.
2) threshold is applied after assigning ranks to recordings and users.
This means if the thresholding removes a user or recording from the
listens, the matrix for generated during later processing will have
rows and columns filled with 0s.

This patch fixes both of these issues by performing thresholding on
total listen count for user just after mapping listens. The current
fix is not the best possible but the quickest one I could come up with.
