### PR TITLE
LB-865: Move messybrainz lookup to after listen data is added to the queue

### DIFF
--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -5,7 +5,7 @@ import redis
 from typing import Optional
 import ujson
 
-from listenbrainz.listen import Listen
+from listenbrainz.listen import Listen, NowPlayingListen
 from listenbrainz.listenstore import ListenStore
 from brainzutils import cache
 from listenbrainz.utils import create_path, init_cache
@@ -43,8 +43,7 @@ class RedisListenStore(ListenStore):
         if not data:
             return None
         data = ujson.loads(data)
-        data.update({'playing_now': True})
-        return Listen.from_json(data)
+        return NowPlayingListen(user_id=data['user_id'], user_name=data['user_name'], data=data['track_metadata'])
 
     def put_playing_now(self, user_id, listen, expire_time):
         """ Save a listen as `playing_now` for a particular time in Redis.

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -12,7 +12,7 @@ from brainzutils import cache
 import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz import config
-from listenbrainz.listen import Listen
+from listenbrainz.listen import Listen, NowPlayingListen
 from listenbrainz.webserver.redis_connection import init_redis_connection
 from listenbrainz.listenstore.redis_listenstore import RedisListenStore
 
@@ -46,7 +46,7 @@ class RedisListenStoreTestCase(DatabaseTestCase):
 
         playing_now = self._redis.get_playing_now(listen['user_id'])
         self.assertIsNotNone(playing_now)
-        self.assertIsInstance(playing_now, Listen)
+        self.assertIsInstance(playing_now, NowPlayingListen)
         self.assertEqual(playing_now.data['artist_name'], 'The Strokes')
         self.assertEqual(playing_now.data['track_name'], 'Call It Fate, Call It Karma')
 

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -128,11 +128,6 @@ class ListenTestCase(unittest.TestCase):
 
         self.assertEqual(listen.timestamp, json_row['listened_at'])
 
-        del json_row['listened_at']
-        json_row.update({'playing_now': True})
-        listen = Listen.from_json(json_row)
-
-        self.assertEqual(listen.timestamp, None)
 
     def test_from_json_null_values(self):
         data = {

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import pika
 import ujson
 from flask import current_app
+from more_itertools import chunked
 from redis import Redis
 import psycopg2
 
@@ -18,6 +19,9 @@ from listenbrainz.listenstore import TimescaleListenStore
 from listenbrainz.webserver import create_app
 from listenbrainz.utils import init_cache
 from brainzutils import metrics, cache
+
+from listenbrainz.webserver.external import messybrainz
+from listenbrainz.webserver.views.api_tools import MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP
 
 METRIC_UPDATE_INTERVAL = 60  # seconds
 LISTEN_INSERT_ERROR_SENTINEL = -1  #
@@ -36,13 +40,16 @@ class TimescaleWriterSubscriber(ListenWriter):
         self.unique_listens = 0
         self.metric_submission_time = monotonic() + METRIC_UPDATE_INTERVAL
 
-
     def callback(self, ch, method, properties, body):
 
         listens = ujson.loads(body)
 
+        msb_listens = []
+        for chunk in chunked(listens, MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP):
+            msb_listens.extend(self.messybrainz_lookup(chunk))
+
         submit = []
-        for listen in listens:
+        for listen in msb_listens:
             try:
                 submit.append(Listen.from_json(listen))
             except ValueError:
@@ -62,6 +69,73 @@ class TimescaleWriterSubscriber(ListenWriter):
                 self.connect_to_rabbitmq()
 
         return ret
+
+    def messybrainz_lookup(self, listens):
+        msb_listens = []
+        for listen in listens:
+            messy_dict = {
+                'artist': listen['track_metadata']['artist_name'],
+                'title': listen['track_metadata']['track_name'],
+            }
+            if 'release_name' in listen['track_metadata']:
+                messy_dict['release'] = listen['track_metadata']['release_name']
+
+            if 'additional_info' in listen['track_metadata']:
+                ai = listen['track_metadata']['additional_info']
+                if 'artist_mbids' in ai and isinstance(ai['artist_mbids'], list):
+                    messy_dict['artist_mbids'] = ai['artist_mbids']
+                if 'release_mbid' in ai:
+                    messy_dict['release_mbid'] = ai['release_mbid']
+                if 'recording_mbid' in ai:
+                    messy_dict['recording_mbid'] = ai['recording_mbid']
+                if 'track_number' in ai:
+                    messy_dict['track_number'] = ai['track_number']
+                if 'spotify_id' in ai:
+                    messy_dict['spotify_id'] = ai['spotify_id']
+            msb_listens.append(messy_dict)
+
+        try:
+            msb_responses = messybrainz.submit_listens(msb_listens)
+        except (messybrainz.exceptions.BadDataException, messybrainz.exceptions.ErrorAddingException):
+            current_app.logger.error("MessyBrainz lookup for listens failed: ", exc_info=True)
+            return []
+        except messybrainz.exceptions.NoDataFoundException:
+            return []
+
+        augmented_listens = []
+        for listen, messybrainz_resp in zip(listens, msb_responses['payload']):
+            messybrainz_resp = messybrainz_resp['ids']
+
+            if 'additional_info' not in listen['track_metadata']:
+                listen['track_metadata']['additional_info'] = {}
+
+            try:
+                listen['recording_msid'] = messybrainz_resp['recording_msid']
+                listen['track_metadata']['additional_info']['artist_msid'] = messybrainz_resp['artist_msid']
+            except KeyError:
+                current_app.logger.error("MessyBrainz did not return a proper set of ids")
+                return []
+
+            try:
+                listen['track_metadata']['additional_info']['release_msid'] = messybrainz_resp['release_msid']
+            except KeyError:
+                pass
+
+            artist_mbids = messybrainz_resp.get('artist_mbids', [])
+            release_mbid = messybrainz_resp.get('release_mbid', None)
+            recording_mbid = messybrainz_resp.get('recording_mbid', None)
+
+            if 'artist_mbids' not in listen['track_metadata']['additional_info'] and \
+                    'release_mbid' not in listen['track_metadata']['additional_info'] and \
+                    'recording_mbid' not in listen['track_metadata']['additional_info']:
+
+                if len(artist_mbids) > 0 and release_mbid and recording_mbid:
+                    listen['track_metadata']['additional_info']['artist_mbids'] = artist_mbids
+                    listen['track_metadata']['additional_info']['release_mbid'] = release_mbid
+                    listen['track_metadata']['additional_info']['recording_mbid'] = recording_mbid
+
+            augmented_listens.append(listen)
+        return augmented_listens
 
     def insert_to_listenstore(self, data):
         """

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -7,18 +7,13 @@ import listenbrainz.webserver.redis_connection as redis_connection
 import listenbrainz.db.user as db_user
 import pika
 import pika.exceptions
-import sys
 import time
 import ujson
 import uuid
-from more_itertools import chunked
 
 from flask import current_app, request
-from sqlalchemy.exc import DataError
 
-from listenbrainz.listen import Listen
 from listenbrainz.webserver import API_LISTENED_AT_ALLOWED_SKEW
-from listenbrainz.webserver.external import messybrainz
 from listenbrainz.webserver.errors import APIInternalServerError, APIServiceUnavailable, APIBadRequest, APIUnauthorized
 #: Maximum overall listen size in bytes, to prevent egregious spamming.
 MAX_LISTEN_SIZE = 10240
@@ -53,8 +48,6 @@ def insert_payload(payload, user, listen_type=LISTEN_TYPE_IMPORT):
         _send_listens_to_queue(listen_type, augmented_listens)
     except (APIInternalServerError, APIServiceUnavailable):
         raise
-    except DataError:
-        raise APIBadRequest("Listen submission contains invalid characters.")
     except Exception as e:
         current_app.logger.error("Error while inserting payload: %s", str(e), exc_info=True)
         raise APIInternalServerError("Something went wrong. Please try again.")

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -49,7 +49,7 @@ def insert_payload(payload, user, listen_type=LISTEN_TYPE_IMPORT):
         Returns: augmented_listens
     """
     try:
-        augmented_listens = _get_augmented_listens(payload, user, listen_type)
+        augmented_listens = _get_augmented_listens(payload, user)
         _send_listens_to_queue(listen_type, augmented_listens)
     except (APIInternalServerError, APIServiceUnavailable):
         raise
@@ -213,94 +213,12 @@ def is_valid_uuid(u):
         return False
 
 
-def _get_augmented_listens(payload, user, listen_type):
-    """ Converts the payload to augmented list after lookup
-        in the MessyBrainz database
-    """
-
-    augmented_listens = []
-    msb_listens = []
-    for l in payload:
-        listen = l.copy()   # Create a local object to prevent the mutation of the passed object
+def _get_augmented_listens(payload, user):
+    """ Converts the payload to augmented list after adding user_id and user_name attributes """
+    for listen in payload:
         listen['user_id'] = user['id']
         listen['user_name'] = user['musicbrainz_id']
-
-        msb_listens.append(listen)
-
-    for chunk in chunked(msb_listens, MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP):
-        augmented_listens.extend(_messybrainz_lookup(chunk))
-
-    return augmented_listens
-
-
-def _messybrainz_lookup(listens):
-
-    msb_listens = []
-    for listen in listens:
-        messy_dict = {
-            'artist': listen['track_metadata']['artist_name'],
-            'title': listen['track_metadata']['track_name'],
-        }
-        if 'release_name' in listen['track_metadata']:
-            messy_dict['release'] = listen['track_metadata']['release_name']
-
-        if 'additional_info' in listen['track_metadata']:
-            ai = listen['track_metadata']['additional_info']
-            if 'artist_mbids' in ai and isinstance(ai['artist_mbids'], list):
-                messy_dict['artist_mbids'] = ai['artist_mbids']
-            if 'release_mbid' in ai:
-                messy_dict['release_mbid'] = ai['release_mbid']
-            if 'recording_mbid' in ai:
-                messy_dict['recording_mbid'] = ai['recording_mbid']
-            if 'track_number' in ai:
-                messy_dict['track_number'] = ai['track_number']
-            if 'spotify_id' in ai:
-                messy_dict['spotify_id'] = ai['spotify_id']
-        msb_listens.append(messy_dict)
-
-    try:
-        msb_responses = messybrainz.submit_listens(msb_listens)
-    except messybrainz.exceptions.BadDataException as e:
-        log_raise_400(str(e))
-    except messybrainz.exceptions.NoDataFoundException:
-        return []
-    except messybrainz.exceptions.ErrorAddingException as e:
-        raise APIServiceUnavailable(str(e))
-
-    augmented_listens = []
-    for listen, messybrainz_resp in zip(listens, msb_responses['payload']):
-        messybrainz_resp = messybrainz_resp['ids']
-
-        if 'additional_info' not in listen['track_metadata']:
-            listen['track_metadata']['additional_info'] = {}
-
-        try:
-            listen['recording_msid'] = messybrainz_resp['recording_msid']
-            listen['track_metadata']['additional_info']['artist_msid'] = messybrainz_resp['artist_msid']
-        except KeyError:
-            current_app.logger.error("MessyBrainz did not return a proper set of ids")
-            raise APIInternalServerError
-
-        try:
-            listen['track_metadata']['additional_info']['release_msid'] = messybrainz_resp['release_msid']
-        except KeyError:
-            pass
-
-        artist_mbids = messybrainz_resp.get('artist_mbids', [])
-        release_mbid = messybrainz_resp.get('release_mbid', None)
-        recording_mbid = messybrainz_resp.get('recording_mbid', None)
-
-        if 'artist_mbids'   not in listen['track_metadata']['additional_info'] and \
-           'release_mbid'   not in listen['track_metadata']['additional_info'] and \
-           'recording_mbid' not in listen['track_metadata']['additional_info']:
-
-            if len(artist_mbids) > 0 and release_mbid and recording_mbid:
-                listen['track_metadata']['additional_info']['artist_mbids'] = artist_mbids
-                listen['track_metadata']['additional_info']['release_mbid'] = release_mbid
-                listen['track_metadata']['additional_info']['recording_mbid'] = recording_mbid
-
-        augmented_listens.append(listen)
-    return augmented_listens
+    return payload
 
 
 def log_raise_400(msg, data=""):

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -11,6 +11,7 @@ import sys
 import time
 import ujson
 import uuid
+from more_itertools import chunked
 
 from flask import current_app, request
 from sqlalchemy.exc import DataError
@@ -217,12 +218,10 @@ def _get_augmented_listens(payload, user, listen_type):
         listen['user_name'] = user['musicbrainz_id']
 
         msb_listens.append(listen)
-        if len(msb_listens) >= MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP:
-            augmented_listens.extend(_messybrainz_lookup(msb_listens))
-            msb_listens = []
 
-    if msb_listens:
-        augmented_listens.extend(_messybrainz_lookup(msb_listens))
+    for chunk in chunked(msb_listens, MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP):
+        augmented_listens.extend(_messybrainz_lookup(chunk))
+
     return augmented_listens
 
 

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -51,7 +51,7 @@ def insert_payload(payload, user, listen_type=LISTEN_TYPE_IMPORT):
     try:
         augmented_listens = _get_augmented_listens(payload, user, listen_type)
         _send_listens_to_queue(listen_type, augmented_listens)
-    except (APIInternalServerError, APIServiceUnavailable) as e:
+    except (APIInternalServerError, APIServiceUnavailable):
         raise
     except DataError:
         raise APIBadRequest("Listen submission contains invalid characters.")
@@ -97,8 +97,8 @@ def _send_listens_to_queue(listen_type, listens):
                 listen = handle_playing_now(listen)
                 if listen:
                     submit.append(listen)
-            except Exception as e:
-                current_app.logger.error("Redis rpush playing_now write error: " + str(e))
+            except Exception:
+                current_app.logger.error("Redis rpush playing_now write error: ", exc_info=True)
                 raise APIServiceUnavailable("Cannot record playing_now at this time.")
         else:
             submit.append(listen)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ unidecode==1.2.0
 Levenshtein==0.12.0
 google_auth_oauthlib==0.4.4
 google-auth==1.30.0
+more-itertools==8.8.0


### PR DESCRIPTION
LB-865 describes the rationale to do so.  This means either we add another queue to do messybrainz lookup for now playing
listens or stop doing msb lookup for them. Since, the now playing listens are only transient and not stored in the database, we have believe it is safe to stop doing msb lookups for now playing listens. This creates some differences between the now playing Listens and submit listens, hence creating a separate class.
