### PR TITLE
Add socketio libraries to babel transpilation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,20 @@ const jsDir = path.join(baseDir, "js");
 const distDir = path.join(baseDir, "dist");
 const cssDir = path.join(baseDir, "css");
 
+const es5LibrariesToTranspile = [
+  "d3-array",
+  "d3-scale",
+  "internmap",
+  "react-date-picker",
+  "react-calendar",
+  "socket.io-client",
+  "socket.io-parser",
+  "engine.io-client",
+];
+const babelExcludeLibrariesRegexp = new RegExp(
+  `node_modules/(?!(${es5LibrariesToTranspile.join("|")})/).*`,
+  ""
+);
 module.exports = function (env, argv) {
   const isProd = argv.mode === "production";
   const plugins = [
@@ -61,8 +75,8 @@ module.exports = function (env, argv) {
       rules: [
         {
           test: /\.(js|ts)x?$/,
-          // some nivo/D3 dependencies need to be transpiled, we include them with the following regex
-          exclude: /node_modules\/(?!(d3-array|d3-scale|internmap|react-date-picker|react-calendar)\/).*/,
+          // some third-party libraries need to be transpiled to ES5, we include them with the following regex
+          exclude: babelExcludeLibrariesRegexp,
           // Don't specify the babel configuration here
           // Configuration can be found in ./babel.config.js
           use: "babel-loader",


### PR DESCRIPTION
Transpile new socket.io packages to ES5 for older browsers support.

I also did some refactoring because that list of libraries was getting messy.


I tried to automate the process (i.e. automatically detect ES6 libraries and transpile them) but my efforts were in vain. None of the options I tried ([are-you-es5](https://github.com/obahareth/are-you-es5), [ecma-version-validator-webpack-plugin](https://github.com/koba04/ecma-version-validator-webpack-plugin), [webpack-babel-env-deps](https://github.com/andersdjohnson/webpack-babel-env-deps)) worked any better than this manual list, and made the build significantly slower.
