### PR TITLE
Do not block startup if typesense is down

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -72,8 +72,8 @@ TYPESENSE_HOST = "{{.Address}}"
 TYPESENSE_PORT = {{.Port}}
 {{end}}
 {{else}}
-TYPESENSE_HOST = "SERVICEDOESNOTEXIST_typesense-listenbrainz"
-TYPESENSE_PORT = "SERVICEDOESNOTEXIST_typesense-listenbrainz"
+TYPESENSE_HOST = "localhost"
+TYPESENSE_PORT = 80
 {{end}}
 TYPESENSE_API_KEY = '''{{template "KEY" "typesense_api_key"}}'''
 


### PR DESCRIPTION
Typesense was acting up today and needed to be shutdown. This brought down LB along with it. In case we need to shutdown typesense again, disabling startup improvements for it. The SERVICEDOESNOTEXIST sentinel is grepped by the startup script to detect issues and prevent container from starting. Setting it to any other value so that container starts even in absence of typesense.