### PR TITLE
Use REJECT_NEW_USERS_WITHOUT_EMAIL to warn existing users regarding email

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -208,5 +208,5 @@ LISTEN_DUMP_TEMP_DIR_ROOT = '''{{template "KEY" "listen_dump_temp_dir"}}'''
 # If set to True, reject listens from users who do not have an email
 REJECT_LISTENS_WITHOUT_USER_EMAIL = {{template "KEY_JSON" "reject_listens_without_email"}}
 
-# If set to True, do not allow new users without email to register
+# If set to True, do not allow new users without email to register and warn existing without email
 REJECT_NEW_USERS_WITHOUT_EMAIL = {{template "KEY_JSON" "reject_new_users_without_email"}}

--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -37,7 +37,7 @@ def musicbrainz_post():
             flash.error(no_email_warning + 'before creating a ListenBrainz account. ' + blog_link)
             return redirect(url_for('index.index'))
 
-        if current_app.config["REJECT_LISTENS_WITHOUT_USER_EMAIL"] and not user["email"]:
+        if current_app.config["REJECT_NEW_USERS_WITHOUT_EMAIL"] and not user["email"]:
             # existing user without email, show a warning
             flash.warning(no_email_warning + 'before 1 November 2021, or you will be unable to submit '
                                              'listens. ' + blog_link)


### PR DESCRIPTION
We cannot  use `REJECT_LISTENS_WITHOUT_USER_EMAIL` because that will be set to False till 1 November in prod. We however want to show users warnings before during this period. `REJECT_NEW_USERS_WITHOUT_EMAIL` fits the bill. It will on prevent new users without email from signing up and warn existing users without email when they log in. Documented this in comments as well.