### PR TITLE
Fix missing email bug in sign up process preventing new users from signing up

### DIFF
--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -47,7 +47,7 @@ def get_user():
             # if flag is set to True and the user does not have an email do not allow to sign up
             return None
         db_user.create(musicbrainz_row_id, musicbrainz_id, email=user_email)
-        user = db_user.get_by_mb_row_id(musicbrainz_row_id, musicbrainz_id)
+        user = db_user.get_by_mb_id(musicbrainz_id, fetch_email=True)
         ts.set_empty_cache_values_for_user(musicbrainz_id)
     else:  # an existing user is trying to log in
         # Other option is to change the return type of get_by_mb_row_id to a dict


### PR DESCRIPTION
The musicbrainz_post method in login view checks for the user's email to determine whether a warning should be shown. Add email in new user's dict so that the check can happen but they are not shown the warning. Currently, we get a NoSuchColumnError preventing new users from signing up.