### PR TITLE
Query Youtube API using api key only

### DIFF
--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
@@ -32,7 +32,6 @@ const GlobalContextMock = {
       permission: ["user-read-currently-playing"] as Array<SpotifyPermission>,
     },
     youtubeAuth: {
-      access_token: "frontend-test",
       api_key: "fake-api-key",
     },
     currentUser: { name: "" },

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.test.tsx
@@ -9,7 +9,6 @@ const props = {
   show: true,
   playerPaused: false,
   youtubeUser: {
-    access_token: "frontend-test",
     api_key: "fake-api-key",
   } as YoutubeUser,
   refreshYoutubeToken: new APIService("base-uri").refreshYoutubeToken,

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -128,10 +128,9 @@ export default class YoutubePlayer
     }
 
     try {
-      const { api_key, access_token } = youtubeUser;
+      const { api_key } = youtubeUser;
       const videoIds = await searchForYoutubeTrack(
         api_key,
-        access_token,
         trackName,
         artistName,
         releaseName,

--- a/listenbrainz/webserver/static/js/src/__snapshots__/YoutubePlayer.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/__snapshots__/YoutubePlayer.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`YoutubePlayer renders 1`] = `
   show={true}
   youtubeUser={
     Object {
-      "access_token": "frontend-test",
       "api_key": "fake-api-key",
     }
   }

--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.test.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.test.tsx
@@ -28,7 +28,6 @@ const props = {
 const GlobalContextMock: GlobalAppContextT = {
   APIService: new APIService("foo"),
   youtubeAuth: {
-    access_token: "frontend-test",
     api_key: "fake-api-key",
   },
   spotifyAuth: {

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -82,7 +82,6 @@ declare type SpotifyUser = {
 
 declare type YoutubeUser = {
   api_key?: string;
-  access_token?: string;
 };
 
 declare type SpotifyPermission =

--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -56,7 +56,6 @@ const searchForSpotifyTrack = async (
 
 const searchForYoutubeTrack = async (
   apiKey?: string,
-  accessToken?: string,
   trackName?: string,
   artistName?: string,
   releaseName?: string,
@@ -64,7 +63,6 @@ const searchForYoutubeTrack = async (
   onAccountError?: () => void
 ): Promise<Array<string> | null> => {
   if (!apiKey) return null;
-  if (!accessToken) return null;
   let query = trackName;
   if (artistName) {
     query += ` ${artistName}`;
@@ -80,7 +78,6 @@ const searchForYoutubeTrack = async (
       method: "GET",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
       },
     }
   );
@@ -88,10 +85,8 @@ const searchForYoutubeTrack = async (
   if (response.status === 401) {
     if (refreshToken) {
       try {
-        const newAccessToken = await refreshToken();
         return searchForYoutubeTrack(
           apiKey,
-          newAccessToken,
           trackName,
           artistName,
           releaseName,

--- a/listenbrainz/webserver/templates/user/music_services.html
+++ b/listenbrainz/webserver/templates/user/music_services.html
@@ -72,32 +72,9 @@
             <div class="panel-body">
                 <p>
                     ListenBrainz integrates with Youtube to let you play music tracks from ListenBrainz pages.
-                    ListenBrainz has a number of music discovery features that require authentication to search
-                    and play tracks from Youtube.
+                    You do not need to do anything to enable this. ListenBrainz will automatically search for
+                    tracks on Youtube and play one if it finds a match.
                 </p>
-                <p>
-                    You can revoke these permissions whenever you want by unlinking your Youtube account.
-                </p>
-
-                <p>
-                    <b>
-                        Our Youtube OAuth integration is currently undergoing verification. Till then, you may see a
-                        warning screen while trying to enable it.
-                    </b>
-                </p>
-                <div class="music-service-selection">
-                    <form action="{{ url_for('profile.music_services_disconnect', service_name='youtube') }}"
-                          method="post">
-                        {{ service_permission_button("youtube", current_youtube_permissions, "listen",
-                    "Play music on ListenBrainz",
-                    "Discover and play songs directly on ListenBrainz") }}
-
-                        {{ service_permission_button("youtube", current_youtube_permissions, "disable",
-                    "Disable",
-                    "Youtube integration will be disabled. You won't be able to listen to music on "
-                    "ListenBrainz using Youtube.") }}
-                    </form>
-                </div>
             </div>
         </div>
     </div>

--- a/listenbrainz/webserver/views/views_utils.py
+++ b/listenbrainz/webserver/views/views_utils.py
@@ -24,13 +24,6 @@ def get_current_youtube_user():
     """Returns the youtube access token for the current authenticated
     user and the youtube api key. If the user is not authenticated or
     has not linked to a Youtube account, returns empty dict."""
-    if not current_user.is_authenticated:
-        return {}
-    user = YoutubeService().get_user(current_user.id)
-    if user is None:
-        return {}
     return {
-        "access_token": user["access_token"],
         "api_key": current_app.config["YOUTUBE_API_KEY"]
     }
-


### PR DESCRIPTION
Found that this works by hit and try and some chance. All documentation points to need of Oauth to access the Youtube but somehow this works 😄 . We tested this on beta. This also renders most of the Youtube Oauth stuff we wrote useless 😭 , will remove that in a subsequent PR. 