### PR TITLE
LB-662: Fix public dump import

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -54,7 +54,7 @@ INCREMENTAL_MAX_AGE = 26  # hours
 
 # this dict contains the tables dumped in public dump as keys
 # and a tuple of columns that should be dumped as values
-PUBLIC_TABLES = {
+PUBLIC_TABLES_DUMP = {
     '"user"': (
         'id',
         'created',
@@ -62,7 +62,7 @@ PUBLIC_TABLES = {
         'musicbrainz_row_id',
         # the following are dummy values for columns that we do not want to
         # dump in the public dump
-        '\'\'',  # auth token
+        'null',  # auth token
         'to_timestamp(0)',  # last_login
         'to_timestamp(0)',  # latest_import
     ),
@@ -108,6 +108,19 @@ PUBLIC_TABLES = {
         'created'
     ),
 }
+
+PUBLIC_TABLES_IMPORT = PUBLIC_TABLES_DUMP.copy()
+# When importing fields with COPY we need to use the names of the fields, rather
+# than the placeholders that we set for the export
+PUBLIC_TABLES_IMPORT['"user"'] = (
+        'id',
+        'created',
+        'musicbrainz_id',
+        'musicbrainz_row_id',
+        'auth_token',
+        'last_login',
+        'latest_import',
+    )
 
 # this dict contains the tables dumped in the private dump as keys
 # and a tuple of columns that should be dumped as values
@@ -353,7 +366,7 @@ def create_public_dump(location, dump_time, threads=DUMP_DEFAULT_THREAD_COUNT):
     return _create_dump(
         location=location,
         dump_type='public',
-        tables=PUBLIC_TABLES,
+        tables=PUBLIC_TABLES_DUMP,
         dump_time=dump_time,
         threads=threads,
     )
@@ -552,7 +565,7 @@ def import_postgres_dump(private_dump_archive_path=None, public_dump_archive_pat
         current_app.logger.info(
             'Importing public dump %s...', public_dump_archive_path)
 
-        tables_to_import = PUBLIC_TABLES.copy()
+        tables_to_import = PUBLIC_TABLES_IMPORT.copy()
         if private_dump_archive_path:
             # if the private dump exists and has been imported, we need to
             # ignore the sanitized user table in the public dump

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -247,7 +247,7 @@ def create_feedback(location, threads):
 
 
 @cli.command(name="import_dump")
-@click.option('--private-archive', '-pr', default=None, required=True)
+@click.option('--private-archive', '-pr', default=None, required=False)
 @click.option('--public-archive', '-pu', default=None, required=True)
 @click.option('--listen-archive', '-l', default=None, required=True)
 @click.option('--threads', '-t', type=int, default=DUMP_DEFAULT_THREAD_COUNT)

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -122,15 +122,15 @@ def create_full(location, threads, dump_id):
         except OSError as e:
             sys.exit(-1)
 
-        # if in production, send an email to interested people for observability
-        send_dump_creation_notification(dump_name, 'fullexport')
-
         current_app.logger.info(
             'Dumps created and hashes written at %s' % dump_path)
 
         # Write the DUMP_ID file so that the FTP sync scripts can be more robust
         with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
             f.write("%s %s full\n" % (ts, dump_id))
+
+        # if in production, send an email to interested people for observability
+        send_dump_creation_notification(dump_name, 'fullexport')
 
         sys.exit(0)
 


### PR DESCRIPTION
LB-662

# Problem
Performing an import of just public dump + listen data would fail, due to `PUBLIC_TABLES['"user"']` contain constant values that were dumped into the file. When we used this list to import the dump file, it failed because it should only contain column names and not constant values. 

# Solution
Make a copy of the `PUBLIC_TABLES` dictionary which is used for importing, and set the `"user"` key to a list of column names.

The resulting public dump files are slightly different (they contain the string `\N` to represent null, instead of an empty string `''`), but we decided that we wouldn't increase the schema value, because the public dumps never worked anyway.

Update the import method to allow the private dump file to be optional.

Change the dump method to send an email after all dump steps have finished (writing DUMP_ID.txt) so that in the case that sending an email fails, we still have all of the outputs of the dump created.
