### PR TITLE
Deduplicate listens submitted by spotify reader

### DIFF
--- a/listenbrainz/db/listens_importer.py
+++ b/listenbrainz/db/listens_importer.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from data.model.external_service import ExternalServiceType
 from listenbrainz import db, utils
 import sqlalchemy
@@ -25,7 +27,7 @@ def update_import_status(user_id: int, service: ExternalServiceType, error_messa
         })
 
 
-def update_latest_listened_at(user_id: int, service: ExternalServiceType, timestamp: int):
+def update_latest_listened_at(user_id: int, service: ExternalServiceType, timestamp: Union[int, float]):
     """ Update the timestamp of the last listen imported for the user with
     specified LB user ID.
 

--- a/listenbrainz/domain/importer_service.py
+++ b/listenbrainz/domain/importer_service.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List
+from typing import List, Union
 
 from listenbrainz.domain.external_service import ExternalService, ExternalServiceError
 from listenbrainz.db import listens_importer
@@ -24,12 +24,12 @@ class ImporterService(ExternalService, ABC):
         """
         listens_importer.update_import_status(user_id, self.service, error)
 
-    def update_latest_listen_ts(self, user_id: int, timestamp: int):
+    def update_latest_listen_ts(self, user_id: int, timestamp: Union[int, float]):
         """ Update the latest_listened_at field for user with specified ListenBrainz user ID.
 
         Args:
-            user_id (int): the ListenBrainz row ID of the user
-            timestamp (int): the unix timestamp of the latest listen imported for the user
+            user_id: the ListenBrainz row ID of the user
+            timestamp: the unix timestamp of the latest listen imported for the user
         """
         listens_importer.update_latest_listened_at(user_id, self.service, timestamp)
 

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -35,7 +35,7 @@ class ConvertListensTestCase(DatabaseTestCase):
         listen = spotify_read_listens._convert_spotify_play_to_listen(data, LISTEN_TYPE_IMPORT)
 
         expected_listen = {
-            'listened_at': 1519241031,
+            'listened_at': 1519241031.761,
             'track_metadata': {
                 'artist_name': 'The Hollies',
                 'track_name': "Draggin' My Heels - Special Disco Version",
@@ -67,7 +67,7 @@ class ConvertListensTestCase(DatabaseTestCase):
         listen = spotify_read_listens._convert_spotify_play_to_listen(data, LISTEN_TYPE_IMPORT)
 
         expected_listen = {
-            'listened_at': 1519240503,
+            'listened_at': 1519240503.665,
             'track_metadata': {
                 'artist_name': 'Robert Plant, Alison Krauss',
                 'track_name': 'Rich Woman',


### PR DESCRIPTION
Spotify provides the "played_at" time in resolution of milliseconds but during parsing we round it off to the nearest lower second because in LB we use  timestamps having resolution of seconds. However when querying spotify we again  have to convert seconds to milliseconds, this actually makes us fetch the last listen again.

Following example demonstrates how this happens:
 
We receive a listen a played_at of `2021-07-09T17:09:00.381Z` from spotify.  This is equal to a milliseconds timestamp of `1625850540381,` we round this off to nearest lower seconds timestamp. So we put latest_listened_at as `1625850540` in our database. Now when we query spotify again, we need to convert this back into milliseconds which becomes `1625850540000`. This is lower than the actual timestamp we received hence spotify sends us the last listen again.

To solve this issue, we store the `latest_listened_at` timestamp in listens_importer table with precision of milliseconds.