### PR TITLE
Migrate lastfm import timestamps from users table to listens_importer table

### DIFF
--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -8,4 +8,4 @@ CREATE TYPE recommendation_feedback_type_enum AS ENUM('like', 'love', 'dislike',
 
 CREATE TYPE user_timeline_event_type_enum AS ENUM('recording_recommendation', 'notification');
 
-CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz');
+CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm');

--- a/admin/sql/updates/2021-07-10-add-lastfm-external-service-type.sql
+++ b/admin/sql/updates/2021-07-10-add-lastfm-external-service-type.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TYPE external_service_oauth_type ADD VALUE 'lastfm';
+COMMIT;

--- a/admin/sql/updates/2021-07-10-add-lastfm-external-service-type.sql
+++ b/admin/sql/updates/2021-07-10-add-lastfm-external-service-type.sql
@@ -1,3 +1,1 @@
-BEGIN;
 ALTER TYPE external_service_oauth_type ADD VALUE 'lastfm';
-COMMIT;

--- a/admin/sql/updates/2021-07-14-migrate-import-ts-from-users-to-listens-importer.sql
+++ b/admin/sql/updates/2021-07-14-migrate-import-ts-from-users-to-listens-importer.sql
@@ -1,0 +1,6 @@
+BEGIN;
+INSERT INTO listens_importer(user_id, service, latest_listened_at)
+SELECT id, 'lastfm', now()
+FROM "user"
+WHERE latest_import > 'epoch';
+COMMIT;

--- a/admin/sql/updates/2021-07-14-migrate-import-ts-from-users-to-listens-importer.sql
+++ b/admin/sql/updates/2021-07-14-migrate-import-ts-from-users-to-listens-importer.sql
@@ -1,6 +1,6 @@
 BEGIN;
 INSERT INTO listens_importer(user_id, service, latest_listened_at)
-SELECT id, 'lastfm', now()
+SELECT id, 'lastfm', latest_import
 FROM "user"
 WHERE latest_import > 'epoch';
 COMMIT;

--- a/data/model/external_service.py
+++ b/data/model/external_service.py
@@ -5,3 +5,4 @@ class ExternalServiceType(Enum):
     SPOTIFY = 'spotify'
     YOUTUBE = 'youtube'
     CRITIQUEBRAINZ = 'critiquebrainz'
+    LASTFM = 'lastfm'

--- a/docs/dev/api_usage_examples/get_latest_import.py
+++ b/docs/dev/api_usage_examples/get_latest_import.py
@@ -7,11 +7,12 @@ AUTH_HEADER = {
     "Authorization": "Token {0}".format(TOKEN)
 }
 
-def get_latest_import(username):
+def get_latest_import(username, service="lastfm"):
     """Gets the latest import timestamp of a given user.
 
     Args:
         username: User to get latest import time of.
+        service: service to get latest import time of.
 
     Returns:
         A Unix timestamp if there's an OK status.
@@ -25,6 +26,7 @@ def get_latest_import(username):
         url="http://{0}/1/latest-import".format(ROOT),
         params={
             "user_name": username,
+            "service": service
         },
         headers=AUTH_HEADER,
     )

--- a/docs/dev/api_usage_examples/set_latest_import.py
+++ b/docs/dev/api_usage_examples/set_latest_import.py
@@ -3,12 +3,13 @@ import requests
 
 ROOT = '127.0.0.1'
 
-def set_latest_import(timestamp, token):
+def set_latest_import(timestamp, token, service="lastfm"):
     """Sets the time of the latest import.
 
     Args:
         timestamp: Unix epoch to set latest import to.
         token: the auth token of the user you're setting latest_import of
+        service: service to set latest import time of.
 
     Returns:
         The JSON response if there's an OK status.
@@ -20,7 +21,8 @@ def set_latest_import(timestamp, token):
     response = requests.post(
         url="http://{0}/1/latest-import".format(ROOT),
         json={
-            "ts": timestamp
+            "ts": timestamp,
+            "service": service
         },
         headers={
             "Authorization": "Token {0}".format(token),

--- a/listenbrainz/db/listens_importer.py
+++ b/listenbrainz/db/listens_importer.py
@@ -1,4 +1,5 @@
-from typing import Union
+import datetime
+from typing import Optional, Union
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz import db, utils
@@ -38,13 +39,38 @@ def update_latest_listened_at(user_id: int, service: ExternalServiceType, timest
     """
     with db.engine.connect() as connection:
         connection.execute(sqlalchemy.text("""
-            UPDATE listens_importer
-               SET last_updated = now()
-                 , latest_listened_at = :timestamp
-             WHERE user_id = :user_id
-               AND service = :service
+            INSERT INTO listens_importer (user_id, service, last_updated, latest_listened_at)
+                 VALUES (:user_id, :service, now(), :timestamp)
+            ON CONFLICT (user_id, service)
+              DO UPDATE 
+                    SET last_updated = now()
+                      , latest_listened_at = :timestamp
             """), {
                 'user_id': user_id,
                 'service': service.value,
                 'timestamp': utils.unix_timestamp_to_datetime(timestamp),
             })
+
+
+def get_latest_listened_at(user_id: int, service: ExternalServiceType) -> Optional[datetime.datetime]:
+    """ Returns the timestamp of the last listen imported for the user with
+    specified LB user ID from the given service.
+
+    Args:
+        user_id: the ListenBrainz row ID of the user
+        service: service to update latest listen timestamp for
+    Returns:
+        timestamp: the unix timestamp of the latest listen imported for the user
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT latest_listened_at
+              FROM listens_importer
+             WHERE user_id = :user_id
+               AND service = :service
+            """), {
+                'user_id': user_id,
+                'service': service.value,
+            })
+        row = result.fetchone()
+        return row["latest_listened_at"] if row else None

--- a/listenbrainz/db/tests/test_listens_importer.py
+++ b/listenbrainz/db/tests/test_listens_importer.py
@@ -8,6 +8,7 @@ import listenbrainz.db.external_service_oauth as db_oauth
 import time
 
 from data.model.external_service import ExternalServiceType
+from listenbrainz.db import listens_importer
 from listenbrainz.db.testing import DatabaseTestCase
 
 
@@ -47,3 +48,15 @@ class ListensImporterDatabaseTestCase(DatabaseTestCase):
         spotify_user = db_spotify.get_user_import_details(self.user_id)
         self.assertEqual(t, int(spotify_user['latest_listened_at'].strftime('%s')))
         self.assertIsNotNone(spotify_user['last_updated'])
+
+    def test_update_latest_import(self):
+        user = db_user.get_or_create(3, 'updatelatestimportuser')
+
+        val = int(time.time())
+        listens_importer.update_latest_listened_at(user['id'], ExternalServiceType.LASTFM, val)
+        ts = listens_importer.get_latest_listened_at(user['id'], ExternalServiceType.LASTFM)
+        self.assertEqual(int(ts.strftime('%s')), val)
+
+        listens_importer.update_latest_listened_at(user['id'], ExternalServiceType.LASTFM, 0)
+        ts = listens_importer.get_latest_listened_at(user['id'], ExternalServiceType.LASTFM)
+        self.assertEqual(int(ts.strftime('%s')), 0)

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -57,45 +57,6 @@ class UserTestCase(DatabaseTestCase):
         # after update_last_login, the val should be greater than the old value i.e 0
         self.assertGreater(int(user['last_login'].strftime('%s')), 0)
 
-    def test_update_latest_import(self):
-        user = db_user.get_or_create(3, 'updatelatestimportuser')
-        self.assertEqual(int(user['latest_import'].strftime('%s')), 0)
-
-        val = int(time.time())
-        db_user.update_latest_import(user['musicbrainz_id'], val)
-        user = db_user.get_by_mb_id(user['musicbrainz_id'])
-        self.assertEqual(int(user['latest_import'].strftime('%s')), val)
-
-    def test_increase_latest_import(self):
-        user = db_user.get_or_create(4, 'testlatestimportuser')
-
-        val = int(time.time())
-        db_user.increase_latest_import(user['musicbrainz_id'], val)
-        user = db_user.get_by_mb_id(user['musicbrainz_id'])
-        self.assertEqual(val, int(user['latest_import'].strftime('%s')))
-
-        db_user.increase_latest_import(user['musicbrainz_id'], val - 10)
-        user = db_user.get_by_mb_id(user['musicbrainz_id'])
-        self.assertEqual(val, int(user['latest_import'].strftime('%s')))
-
-        val += 10
-        db_user.increase_latest_import(user['musicbrainz_id'], val)
-        user = db_user.get_by_mb_id(user['musicbrainz_id'])
-        self.assertEqual(val, int(user['latest_import'].strftime('%s')))
-
-    def test_reset_latest_import(self):
-        user = db_user.get_or_create(7, 'resetlatestimportuser')
-        self.assertEqual(int(user['latest_import'].strftime('%s')), 0)
-
-        val = int(time.time())
-        db_user.update_latest_import(user['musicbrainz_id'], val)
-        user = db_user.get_by_mb_id(user['musicbrainz_id'])
-        self.assertEqual(int(user['latest_import'].strftime('%s')), val)
-
-        db_user.reset_latest_import(user['musicbrainz_id'])
-        user = db_user.get_by_mb_id(user['musicbrainz_id'])
-        self.assertEqual(int(user['latest_import'].strftime('%s')), 0)
-
     def test_get_all_users(self):
         """ Tests that get_all_users returns ALL users in the db """
 

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -272,41 +272,6 @@ def update_last_login(musicbrainz_id):
                 "Couldn't update last_login: %s" % str(err))
 
 
-def update_latest_import(musicbrainz_id, ts):
-    """ Update the value of latest_import field for user with specified MusicBrainz ID
-
-    Args:
-        musicbrainz_id (str): MusicBrainz username of user
-        ts (int): Timestamp value with which to update the database
-    """
-
-    with db.engine.connect() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET latest_import = to_timestamp(:ts)
-                 WHERE musicbrainz_id = :musicbrainz_id
-                """), {
-                'ts': ts,
-                'musicbrainz_id': musicbrainz_id
-            })
-        except sqlalchemy.exc.ProgrammingError as e:
-            logger.error(e)
-            raise DatabaseException
-
-
-def increase_latest_import(musicbrainz_id, ts):
-    """Increases the latest_import field for user with specified MusicBrainz ID"""
-    user = get_by_mb_id(musicbrainz_id)
-    if ts > int(user['latest_import'].strftime('%s')):
-        update_latest_import(musicbrainz_id, ts)
-
-
-def reset_latest_import(musicbrainz_id):
-    """Resets the latest_import field for user with specified MusicBrainz ID to 0"""
-    update_latest_import(musicbrainz_id, 0)
-
-
 def get_all_users(created_before=None, columns=None):
     """ Returns a list of all users in the database
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -346,6 +346,7 @@ def latest_import():
     :statuscode 200: latest import timestamp updated
     :statuscode 400: invalid JSON sent, see error message for details.
     :statuscode 401: invalid authorization. See error message for details.
+    :statuscode 404: user or service not found. See error message for details.
     """
     if request.method == 'GET':
         user_name = request.args.get('user_name', '')
@@ -355,9 +356,9 @@ def latest_import():
         except KeyError:
             raise APINotFound("Service does not exist: {}".format(service_name))
         user = db_user.get_by_mb_id(user_name)
-        latest_import_ts = listens_importer.get_latest_listened_at(user["id"], service)
         if user is None:
             raise APINotFound("Cannot find user: {user_name}".format(user_name=user_name))
+        latest_import_ts = listens_importer.get_latest_listened_at(user["id"], service)
         return jsonify({
             'musicbrainz_id': user['musicbrainz_id'],
             'latest_import': 0 if not latest_import_ts else int(latest_import_ts.strftime('%s'))

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -3,6 +3,7 @@ from flask_wtf import FlaskForm
 
 import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.user as db_user
+from listenbrainz.db import listens_importer
 from listenbrainz.domain.critiquebrainz import CritiqueBrainzService, CRITIQUEBRAINZ_SCOPES
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from data.model.external_service import ExternalServiceType
@@ -61,7 +62,7 @@ def reset_latest_import_timestamp():
     form = FlaskForm()
     if form.validate_on_submit():
         try:
-            db_user.reset_latest_import(current_user.musicbrainz_id)
+            listens_importer.update_latest_listened_at(current_user.id, ExternalServiceType.LASTFM, 0)
             flash.info("Latest import time reset, we'll now import all your data instead of stopping at your last imported listen.")
         except DatabaseException:
             flash.error("Something went wrong! Unable to reset latest import timestamp right now.")

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -4,7 +4,7 @@ import listenbrainz.db.user as db_user
 import time
 import ujson
 
-from flask import url_for, current_app, g
+from flask import url_for, g
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.domain.external_service import ExternalServiceInvalidGrantError
@@ -13,7 +13,7 @@ from listenbrainz.listen import Listen
 from listenbrainz.tests.integration import IntegrationTestCase
 from unittest.mock import patch
 from listenbrainz.db.model.feedback import Feedback
-from listenbrainz.db import external_service_oauth as db_oauth
+from listenbrainz.db import external_service_oauth as db_oauth, listens_importer
 
 
 class ProfileViewsTestCase(IntegrationTestCase):
@@ -38,7 +38,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         # we do a get request first to put the CSRF token in the flask global context
         # so that we can access it for using in the post request in the next step
         val = int(time.time())
-        db_user.update_latest_import(self.user['musicbrainz_id'], val)
+        listens_importer.update_latest_listened_at(self.user['id'], ExternalServiceType.LASTFM, val)
         self.temporary_login(self.user['login_id'])
         response = self.client.get(url_for('profile.reset_latest_import_timestamp'))
         self.assertTemplateUsed('profile/resetlatestimportts.html')
@@ -50,8 +50,8 @@ class ProfileViewsTestCase(IntegrationTestCase):
         )
         self.assertStatus(response, 302)  # should have redirected to the info page
         self.assertRedirects(response, url_for('profile.info'))
-        ts = db_user.get(self.user['id'])['latest_import'].strftime('%s')
-        self.assertEqual(int(ts), 0)
+        ts = listens_importer.get_latest_listened_at(self.user['id'], ExternalServiceType.LASTFM)
+        self.assertEqual(int(ts.strftime('%s')), 0)
 
     def test_user_info_not_logged_in(self):
         """Tests user info view when not logged in"""

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -8,7 +8,10 @@ import ujson
 
 from flask import Blueprint, render_template, request, url_for, redirect, current_app, jsonify
 from flask_login import current_user, login_required
+
+from data.model.external_service import ExternalServiceType
 from listenbrainz import webserver
+from listenbrainz.db import listens_importer
 from listenbrainz.db.playlist import get_playlists_for_user, get_playlists_created_for_user, get_playlists_collaborated_on
 from listenbrainz.db.model.pinned_recording import fetch_track_metadata_for_pins
 from listenbrainz.db.pinned_recording import get_current_pin_for_user, get_pin_count_for_user, get_pin_history_for_user
@@ -453,5 +456,5 @@ def delete_listens_history(musicbrainz_id):
     user = _get_user(musicbrainz_id)
     timescale_connection._ts.delete(user.musicbrainz_id)
     timescale_connection._ts.reset_listen_count(user.musicbrainz_id)
-    db_user.reset_latest_import(user.musicbrainz_id)
+    listens_importer.update_latest_listened_at(user.id, ExternalServiceType.LASTFM, 0)
     db_stats.delete_user_stats(user.id)


### PR DESCRIPTION
This aligns storing Last.FM timestamps with Spotify and makes adding future services easier (for eg: libre.fm).