### PR TITLE
LB-571: Add trailing slash to all user endpoints

### DIFF
--- a/listenbrainz/webserver/test/test_routes.py
+++ b/listenbrainz/webserver/test/test_routes.py
@@ -1,0 +1,28 @@
+import flask
+
+from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.webserver import API_PREFIX
+from listenbrainz.webserver.testing import ServerTestCase
+
+
+class RoutesTestCase(DatabaseTestCase, ServerTestCase):
+
+    def setUp(self):
+        ServerTestCase.setUp(self)
+        DatabaseTestCase.setUp(self)
+
+    def test_routes_have_trailing_slash(self):
+        """Check that all user-facing routes have a trailing /"""
+
+        # We don't check some rules.
+        # Don't add a / to API endpoints, because a redirect on a POST from an external client
+        #  may result in unexpected results
+        # Admin endpoints are maintained by flask-admin
+        ignored_prefixes = (API_PREFIX, '/admin', '/static')
+        # Specific endpoint for deleting accounts from musicbrainz-server (MBS-9680)
+        ignored_endpoints = {'index.mb_user_deleter'}
+
+        for rule in flask.current_app.url_map.iter_rules():
+            if not rule.rule.startswith(ignored_prefixes) and rule.endpoint not in ignored_endpoints:
+                if not rule.rule.endswith('/'):
+                    self.fail(f"Rule doesn't end with a trailing slash: {rule.rule} ({rule.endpoint})")

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -1,5 +1,4 @@
 import flask_testing
-import os
 
 from listenbrainz.webserver import create_app, create_api_compat_app
 
@@ -7,7 +6,7 @@ from listenbrainz.webserver import create_app, create_api_compat_app
 class ServerTestCase(flask_testing.TestCase):
 
     def create_app(self):
-        app = create_app()
+        app = create_app(debug=False)
         app.config['TESTING'] = True
         return app
 

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 feedback_api_bp = Blueprint('feedback_api_v1', __name__)
 
 
-@feedback_api_bp.route("recording-feedback", methods=["POST", "OPTIONS"])
+@feedback_api_bp.route("/recording-feedback", methods=["POST", "OPTIONS"])
 @crossdomain(headers="Authorization, Content-Type")
 @ratelimit()
 def recording_feedback():

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -48,7 +48,7 @@ def index():
     )
 
 
-@index_bp.route("/import")
+@index_bp.route("/import/")
 def import_data():
     if current_user.is_authenticated:
         return redirect(url_for("profile.import_data"))
@@ -56,52 +56,57 @@ def import_data():
         return current_app.login_manager.unauthorized()
 
 
-@index_bp.route("/download")
+@index_bp.route("/download/")
 def downloads():
     return redirect(url_for('index.data'))
 
 
-@index_bp.route("/data")
+@index_bp.route("/data/")
 def data():
     return render_template("index/data.html")
 
 
-@index_bp.route("/contribute")
+@index_bp.route("/contribute/")
 def contribute():
     return render_template("index/contribute.html")
 
 
-@index_bp.route("/add-data")
+@index_bp.route("/add-data/")
 def add_data_info():
     return render_template("index/add-data.html")
 
 
-@index_bp.route("/import-data")
+@index_bp.route("/import-data/")
 def import_data_info():
     return render_template("index/import-data.html")
 
 
-@index_bp.route("/goals")
+@index_bp.route("/goals/")
 def goals():
     return render_template("index/goals.html")
 
 
-@index_bp.route("/faq")
+@index_bp.route("/faq/")
 def faq():
     return render_template("index/faq.html")
 
 
-@index_bp.route("/lastfm-proxy")
+@index_bp.route("/lastfm-proxy/")
 def proxy():
     return render_template("index/lastfm-proxy.html")
 
 
-@index_bp.route("/roadmap")
+@index_bp.route("/roadmap/")
 def roadmap():
     return render_template("index/roadmap.html")
 
 
-@index_bp.route("/current-status")
+@index_bp.route("/privacy/")
+def privacy_policy():
+    return render_template("index/privacy-policy.html")
+
+
+@index_bp.route("/current-status/")
 @web_listenstore_needed
 def current_status():
 
@@ -136,7 +141,7 @@ def current_status():
     )
 
 
-@index_bp.route("/recent")
+@index_bp.route("/recent/")
 def recent_listens():
 
     recent = []
@@ -158,16 +163,15 @@ def recent_listens():
         mode='recent',
         active_section='listens')
 
-@index_bp.route('/feed', methods=['GET', 'OPTIONS'])
+
+@index_bp.route('/feed/', methods=['GET', 'OPTIONS'])
 @login_required
 @web_listenstore_needed
 def feed():
-
     return render_template('index/feed.html')
 
 
-
-@index_bp.route('/agree-to-terms', methods=['GET', 'POST'])
+@index_bp.route('/agree-to-terms/', methods=['GET', 'POST'])
 @login_required
 def gdpr_notice():
     if request.method == 'GET':
@@ -253,7 +257,7 @@ def _get_user_count():
         return user_count
 
 
-@index_bp.route("/similar-users")
+@index_bp.route("/similar-users/")
 def similar_users():
     """ Show all of the users with the highest similarity in order to make
         them visible to all of our users. This view can show bugs in the algorithm
@@ -267,7 +271,7 @@ def similar_users():
     )
 
 
-@index_bp.route("/listens-offline")
+@index_bp.route("/listens-offline/")
 def listens_offline():
     """
         Show the "listenstore offline" message.

--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -15,14 +15,14 @@ def index():
     return render_template('login/login.html')
 
 
-@login_bp.route('/musicbrainz')
+@login_bp.route('/musicbrainz/')
 @login_forbidden
 def musicbrainz():
     session['next'] = request.args.get('next')
     return redirect(provider.get_authentication_uri())
 
 
-@login_bp.route('/musicbrainz/post')
+@login_bp.route('/musicbrainz/post/')
 @login_forbidden
 def musicbrainz_post():
     """Callback endpoint."""

--- a/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
+++ b/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
@@ -32,7 +32,7 @@ from brainzutils.ratelimit import ratelimit
 missing_musicbrainz_data_api_bp = Blueprint('missing_musicbrainz_data_v1', __name__)
 
 
-@missing_musicbrainz_data_api_bp.route("/user/<user_name>")
+@missing_musicbrainz_data_api_bp.route("/user/<user_name>/")
 @crossdomain()
 @ratelimit()
 def get_missing_musicbrainz_data(user_name):

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -11,7 +11,7 @@ import listenbrainz.db.playlist as db_playlist
 playlist_bp = Blueprint("playlist", __name__)
 
 
-@playlist_bp.route("/<playlist_mbid>", methods=["GET"])
+@playlist_bp.route("/<playlist_mbid>/", methods=["GET"])
 @web_listenstore_needed
 def load_playlist(playlist_mbid: str):
     """Load a single playlist by id

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -31,7 +31,7 @@ profile_bp = Blueprint("profile", __name__)
 EXPORT_FETCH_COUNT = 5000
 
 
-@profile_bp.route("/resettoken", methods=["GET", "POST"])
+@profile_bp.route("/resettoken/", methods=["GET", "POST"])
 @login_required
 def reset_token():
     if request.method == "POST":
@@ -54,7 +54,7 @@ def reset_token():
         )
 
 
-@profile_bp.route("/resetlatestimportts", methods=["GET", "POST"])
+@profile_bp.route("/resetlatestimportts/", methods=["GET", "POST"])
 @login_required
 def reset_latest_import_timestamp():
     if request.method == "POST":
@@ -87,7 +87,7 @@ def info():
     )
 
 
-@profile_bp.route("/import")
+@profile_bp.route("/import/")
 @login_required
 def import_data():
     """ Displays the import page to user, giving various options """
@@ -154,7 +154,7 @@ def stream_json_array(elements):
     yield ']'
 
 
-@profile_bp.route("/export", methods=["GET", "POST"])
+@profile_bp.route("/export/", methods=["GET", "POST"])
 @login_required
 @web_listenstore_needed
 def export_data():
@@ -179,7 +179,7 @@ def export_data():
         return render_template("user/export.html", user=current_user)
 
 
-@profile_bp.route("/export-feedback", methods=["POST"])
+@profile_bp.route("/export-feedback/", methods=["POST"])
 @login_required
 def export_feedback():
     """ Exporting the feedback data to json """
@@ -198,7 +198,7 @@ def export_feedback():
     return response
 
 
-@profile_bp.route('/delete', methods=['GET', 'POST'])
+@profile_bp.route('/delete/', methods=['GET', 'POST'])
 @login_required
 @web_listenstore_needed
 def delete():
@@ -230,7 +230,7 @@ def delete():
         )
 
 
-@profile_bp.route('/delete-listens', methods=['GET', 'POST'])
+@profile_bp.route('/delete-listens/', methods=['GET', 'POST'])
 @login_required
 @web_listenstore_needed
 def delete_listens():

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -13,7 +13,7 @@ recommendations_cf_recording_bp = Blueprint('recommendations_cf_recording', __na
 SERVER_URL = "https://labs.api.listenbrainz.org/recording-mbid-lookup/json"
 
 
-@recommendations_cf_recording_bp.route("/<user_name>")
+@recommendations_cf_recording_bp.route("/<user_name>/")
 def info(user_name):
     """ Show info about the recommended tracks
     """
@@ -27,7 +27,7 @@ def info(user_name):
     )
 
 
-@recommendations_cf_recording_bp.route("/<user_name>/top_artist")
+@recommendations_cf_recording_bp.route("/<user_name>/top_artist/")
 def top_artist(user_name: str):
     """ Show top artist user recommendations """
     user = _get_user(user_name)
@@ -37,7 +37,7 @@ def top_artist(user_name: str):
     return template
 
 
-@recommendations_cf_recording_bp.route("/<user_name>/similar_artist")
+@recommendations_cf_recording_bp.route("/<user_name>/similar_artist/")
 def similar_artist(user_name: str):
     """ Show similar artist user recommendations """
     user = _get_user(user_name)

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -75,7 +75,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         """
         app = create_app(debug=True)
         client = app.test_client()
-        resp = client.get('/data')
+        resp = client.get('/data/')
         self.assert200(resp)
         self.assertIn('flDebug', str(resp.data))
 
@@ -301,7 +301,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         user = db_user.get_or_create(1, 'iliekcomputers')
         db_user.agree_to_gdpr(user['musicbrainz_id'])
         self.temporary_login(user['login_id'])
-        r = self.client.get('/feed')
+        r = self.client.get('/feed/')
         self.assert200(r)
 
     def test_similar_users(self):

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -45,23 +45,60 @@ class UserViewsTestCase(IntegrationTestCase):
         self.logstore = None
 
     def test_redirects(self):
+        """Test the /my/[something]/ endponts which redirect to the /user/ namespace"""
         # Not logged in
         response = self.client.get(url_for("redirect.redirect_listens"))
         self.assertEqual(response.status_code, 302)
-        assert response.location.endswith("/login/?next=%2Fmy%2Flistens")
+        assert response.location.endswith("/login/?next=%2Fmy%2Flistens%2F")
 
+        # Logged in
         self.temporary_login(self.user.login_id)
         response = self.client.get(url_for("redirect.redirect_listens"))
         self.assertEqual(response.status_code, 302)
-        assert response.location.endswith("/user/iliekcomputers")
+        assert response.location.endswith("/user/iliekcomputers/")
 
         response = self.client.get(url_for("redirect.redirect_charts"))
         self.assertEqual(response.status_code, 302)
-        assert response.location.endswith("/user/iliekcomputers/charts")
+        assert response.location.endswith("/user/iliekcomputers/charts/")
 
         response = self.client.get(url_for("redirect.redirect_charts") + "?foo=bar")
         self.assertEqual(response.status_code, 302)
-        assert response.location.endswith("/user/iliekcomputers/charts?foo=bar")
+        assert response.location.endswith("/user/iliekcomputers/charts/?foo=bar")
+
+    def test_user_redirects(self):
+        response = self.client.get('/user/iliekcomputers/')
+        self.assert200(response)
+        response = self.client.get('/user/iliekcomputers')
+        self.assertEqual(response.status_code, 308)
+        assert response.location.endswith('/user/iliekcomputers/')
+
+        response = self.client.get('/user/iliekcomputers/charts/')
+        self.assert200(response)
+        response = self.client.get('/user/iliekcomputers/charts')
+        self.assertEqual(response.status_code, 308)
+        assert response.location.endswith('/user/iliekcomputers/charts/')
+
+        response = self.client.get('/user/iliekcomputers/reports/')
+        self.assert200(response)
+        response = self.client.get('/user/iliekcomputers/reports')
+        self.assertEqual(response.status_code, 308)
+        assert response.location.endswith('/user/iliekcomputers/reports/')
+
+        # these are permanent redirects to user/<username>/charts
+
+        response = self.client.get('/user/iliekcomputers/history/')
+        self.assertEqual(response.status_code, 301)
+        assert response.location.endswith('/user/iliekcomputers/charts/?entity=artist&page=1&range=all_time')
+        response = self.client.get('/user/iliekcomputers/history')
+        self.assertEqual(response.status_code, 308)
+        assert response.location.endswith('/user/iliekcomputers/history/')
+
+        response = self.client.get('/user/iliekcomputers/artists/')
+        self.assertEqual(response.status_code, 301)
+        assert response.location.endswith('/user/iliekcomputers/charts/?entity=artist&page=1&range=all_time')
+        response = self.client.get('/user/iliekcomputers/artists')
+        self.assertEqual(response.status_code, 308)
+        assert response.location.endswith('/user/iliekcomputers/artists/')
 
     def test_user_page(self):
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -35,7 +35,6 @@ def redirect_user_page(target):
     the user to this specific page in their namespace if they are logged in."""
     def inner():
         if current_user.is_authenticated:
-            print(url_for(target, user_name=current_user.musicbrainz_id, **request.args))
             return redirect(url_for(target, user_name=current_user.musicbrainz_id, **request.args))
         else:
             return current_app.login_manager.unauthorized()
@@ -43,16 +42,16 @@ def redirect_user_page(target):
     return inner
 
 
-redirect_bp.add_url_rule("/listens", "redirect_listens", redirect_user_page("user.profile"))
-redirect_bp.add_url_rule("/charts", "redirect_charts", redirect_user_page("user.charts"))
-redirect_bp.add_url_rule("/reports", "redirect_reports", redirect_user_page("user.reports"))
-redirect_bp.add_url_rule("/playlists", "redirect_playlists", redirect_user_page("user.playlists"))
-redirect_bp.add_url_rule("/collaborations", "redirect_collaborations", redirect_user_page("user.collaborations"))
-redirect_bp.add_url_rule("/recommendations",
+redirect_bp.add_url_rule("/listens/", "redirect_listens", redirect_user_page("user.profile"))
+redirect_bp.add_url_rule("/charts/", "redirect_charts", redirect_user_page("user.charts"))
+redirect_bp.add_url_rule("/reports/", "redirect_reports", redirect_user_page("user.reports"))
+redirect_bp.add_url_rule("/playlists/", "redirect_playlists", redirect_user_page("user.playlists"))
+redirect_bp.add_url_rule("/collaborations/", "redirect_collaborations", redirect_user_page("user.collaborations"))
+redirect_bp.add_url_rule("/recommendations/",
                          "redirect_recommendations",
                          redirect_user_page("user.recommendation_playlists"))
 
-@user_bp.route("/<user_name>")
+@user_bp.route("/<user_name>/")
 @web_listenstore_needed
 def profile(user_name):
     # Which database to use to showing user listens.
@@ -140,7 +139,7 @@ def profile(user_name):
                            active_section='listens')
 
 
-@user_bp.route("/<user_name>/artists")
+@user_bp.route("/<user_name>/artists/")
 def artists(user_name):
     """ Redirect to charts page """
     page = request.args.get('page', default=1)
@@ -148,7 +147,7 @@ def artists(user_name):
     return redirect(url_for('user.charts', user_name=user_name, entity='artist', page=page, range=stats_range), code=301)
 
 
-@user_bp.route("/<user_name>/history")
+@user_bp.route("/<user_name>/history/")
 def history(user_name):
     """ Redirect to charts page """
     entity = request.args.get('entity', default="artist")
@@ -157,7 +156,7 @@ def history(user_name):
     return redirect(url_for('user.charts', user_name=user_name, entity=entity, page=page, range=stats_range), code=301)
 
 
-@user_bp.route("/<user_name>/charts")
+@user_bp.route("/<user_name>/charts/")
 def charts(user_name):
     """ Show the top entitys for the user. """
     user = _get_user(user_name)
@@ -179,7 +178,7 @@ def charts(user_name):
     )
 
 
-@user_bp.route("/<user_name>/reports")
+@user_bp.route("/<user_name>/reports/")
 def reports(user_name: str):
     """ Show user reports """
     user = _get_user(user_name)
@@ -200,7 +199,7 @@ def reports(user_name: str):
         user=user
     )
 
-@user_bp.route("/<user_name>/playlists")
+@user_bp.route("/<user_name>/playlists/")
 @web_listenstore_needed
 def playlists(user_name: str):
     """ Show user playlists """
@@ -251,7 +250,7 @@ def playlists(user_name: str):
     )
 
 
-@user_bp.route("/<user_name>/recommendations")
+@user_bp.route("/<user_name>/recommendations/")
 @web_listenstore_needed
 def recommendation_playlists(user_name: str):
     """ Show playlists created for user """
@@ -293,7 +292,8 @@ def recommendation_playlists(user_name: str):
         user=user
     )
 
-@user_bp.route("/<user_name>/collaborations")
+
+@user_bp.route("/<user_name>/collaborations/")
 @web_listenstore_needed
 def collaborations(user_name: str):
     """ Show playlists a user collaborates on """


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
LB-571

URLs such as https://listenbrainz.org/user/alastairp/ currently result in a 404 page.


# Solution
Add a trailing / to `@route` definitions in our views. This configures flask so that a redirect is added for the same route without a / which then redirects to this specific route (with HTTP 308), and then the redirected URL serves the view.

This means that https://listenbrainz.org/user/alastairp -> 308 -> https://listenbrainz.org/user/alastairp/ , and https://listenbrainz.org/user/alastairp/  will load normally.

I made a specific decision not to add this to any API endpoints, because:
* I don't know how many API clients support 307/308 redirects instead of 301/302 (a POST on 301/2 will retry as GET, which is something that we don't want, but maybe a 308 is ignored as unknown, which is just as bad)
* We explicitly document the API endpoints in readthedocs, and they don't have any trailing slashes, so I don't think that there are any clients which are erroneously adding a trailing /

I had a look into how we could support both trailing / and no / in the API endpoints with no redirect, and the only way I could find was to define each `@route` twice. To me this feels like additional work that isn't really necessary, so I'm recommending that we leave it for now.

