### PR TITLE
LB-921 (I): A treasure trove of rabbitmq nuances

### DIFF
--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -9,6 +9,8 @@ _logger = logging.getLogger("listenbrainz_spark")
 _logger.setLevel(logging.DEBUG)
 _logger.addHandler(_handler)
 
+logging.getLogger("pika").setLevel(logging.DEBUG)
+
 import sentry_sdk
 
 from py4j.protocol import Py4JJavaError

--- a/listenbrainz_spark/__init__.py
+++ b/listenbrainz_spark/__init__.py
@@ -1,12 +1,12 @@
 import logging
 
 _handler = logging.StreamHandler()
-_handler.setLevel(logging.INFO)
+_handler.setLevel(logging.DEBUG)
 _formatter = logging.Formatter("%(asctime)s %(name)-20s %(levelname)-8s %(message)s")
 _handler.setFormatter(_formatter)
 
 _logger = logging.getLogger("listenbrainz_spark")
-_logger.setLevel(logging.INFO)
+_logger.setLevel(logging.DEBUG)
 _logger.addHandler(_handler)
 
 import sentry_sdk

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -57,20 +57,6 @@ class RequestConsumer:
             logger.error("Error while mapping query to function:", exc_info=True)
             return None
 
-        try:
-            # initialize connection to HDFS, the request consumer is a long running process
-            # so we try to create a connection everytime before executing a query to avoid
-            # affecting subsequent queries in case there's an intermittent connection issue
-            hdfs_connection.init_hdfs(config.HDFS_HTTP_URI)
-            return query_handler(**params)
-        except TypeError as e:
-            logger.error(
-                "TypeError in the query handler for query '%s', maybe bad params. Error: %s", query, str(e), exc_info=True)
-            return None
-        except Exception as e:
-            logger.error("Error in the query handler for query '%s': %s", query, str(e), exc_info=True)
-            return None
-
         return query_handler, params
 
     def callback(self, channel, method, properties, body):

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -152,7 +152,7 @@ class RequestConsumer:
             try:
                 self.connect_to_rabbitmq()
                 self.init_request_channel()
-                self.init_request_channel()
+                self.init_result_channel()
                 logger.info('Request consumer started!')
 
                 try:

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -108,10 +108,6 @@ class RequestConsumer:
         request = json.loads(body.decode('utf-8'))
         logger.info('Received a request!')
 
-        messages = self.get_result(request)
-        if messages:
-            self.push_to_result_queue(messages)
-
         while True:
             try:
                 self.request_channel.basic_ack(delivery_tag=method.delivery_tag)
@@ -125,6 +121,10 @@ class RequestConsumer:
                 self.rabbitmq.close()
                 self.connect_to_rabbitmq()
                 self.init_rabbitmq_channels()
+
+        messages = self.get_result(request)
+        if messages:
+            self.push_to_result_queue(messages)
 
         logger.info('Request done!')
 

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -110,6 +110,10 @@ class RequestConsumer:
         request = json.loads(body.decode('utf-8'))
         logger.info('Received a request!')
 
+        messages = self.get_result(request)
+        if messages:
+            self.push_to_result_queue(messages)
+
         # We do not retry ack'ing because rabbitmq requires the ack be sent
         # from same channel that received the message. If we an error during
         # nothing can be done, the request will be resent again later. We just
@@ -124,10 +128,6 @@ class RequestConsumer:
             self.connect_to_rabbitmq()
             self.init_request_channel()
             self.init_result_channel()
-
-        messages = self.get_result(request)
-        if messages:
-            self.push_to_result_queue(messages)
 
         logger.info('Request done!')
 

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -28,7 +28,6 @@ from listenbrainz_spark.utils import init_rabbitmq
 
 from py4j.protocol import Py4JJavaError
 
-RABBITMQ_HEARTBEAT_TIME = 2 * 60 * 60  # 2 hours -- a full dump import takes 40 minutes right now
 
 rc = None
 logger = logging.getLogger(__name__)
@@ -136,7 +135,6 @@ class RequestConsumer:
             port=config.RABBITMQ_PORT,
             vhost=config.RABBITMQ_VHOST,
             log=logger.critical,
-            heartbeat=RABBITMQ_HEARTBEAT_TIME,
         )
 
     def init_rabbitmq_channels(self):

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -82,7 +82,6 @@ class RequestConsumer:
         Thread(target=invoke_query, args=(
             self.rabbitmq,
             self.request_channel,
-            self.result_channel,
             method.delivery_tag,
             *query
         )).start()
@@ -117,16 +116,11 @@ class RequestConsumer:
         # basic_consume should be called after basic_qos otherwise basic_qos doesn't eork
         self.request_channel.basic_consume(queue=config.SPARK_REQUEST_QUEUE, on_message_callback=self.callback)
 
-    def init_result_channel(self):
-        self.result_channel = self.rabbitmq.channel()
-        self.result_channel.exchange_declare(exchange=config.SPARK_RESULT_EXCHANGE, exchange_type='fanout')
-
     def run(self):
         while True:
             try:
                 self.connect_to_rabbitmq()
                 self.init_request_channel()
-                self.init_result_channel()
                 logger.info('Request consumer started!')
 
                 try:

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -166,11 +166,9 @@ class RequestConsumer:
                 logger.critical("Critical: JAVA error in spark-request consumer: %s, message: %s",
                                             str(e), str(e.java_exception), exc_info=True)
                 time.sleep(2)
-                self.publisher.shutdown()
             except Exception as e:
                 logger.critical("Error in spark-request-consumer: %s", str(e), exc_info=True)
                 time.sleep(2)
-                self.publisher.shutdown()
 
     def ping(self):
         """ Sends a heartbeat to rabbitmq to avoid closing the connection during long processes """

--- a/listenbrainz_spark/request_consumer/result_publisher.py
+++ b/listenbrainz_spark/request_consumer/result_publisher.py
@@ -105,6 +105,8 @@ class ResultPublisher(threading.Thread):
 
     def run(self):
         logger.info("Starting result publisher")
+        self.init_connection()
+        self.init_channel()
         while not self.done:
             try:
                 connection, channel, delivery_tag, query = self.queue.get(timeout=600)

--- a/listenbrainz_spark/request_consumer/result_publisher.py
+++ b/listenbrainz_spark/request_consumer/result_publisher.py
@@ -1,87 +1,125 @@
 import functools
 import json
 import logging
+import threading
 import time
+from queue import Queue, Empty
 
 import pika
 
 from listenbrainz_spark import config
+from listenbrainz_spark.utils import init_rabbitmq
 
 logger = logging.getLogger(__name__)
 
-def get_results(query_handler, params):
-    try:
-        return query_handler(**params)
-    except TypeError:
-        logger.error("TypeError in the query handler for query '%s', "
-                     "maybe bad params: ", query_handler, exc_info=True)
-        return None
-    except Exception:
-        logger.error("Error in the query handler for query '%s':",
-                     query_handler, exc_info=True)
-        return None
 
+class ResultPublisher(threading.Thread):
 
-def get_result_channel(connection):
-    result_channel = connection.channel()
-    result_channel.exchange_declare(
-        exchange=config.SPARK_RESULT_EXCHANGE,
-        exchange_type='fanout'
-    )
-    return result_channel
+    def __init__(self):
+        super().__init__()
+        self.queue = Queue(maxsize=2)
+        self.connection = None
+        self.result_channel = None
+        self.done = False
 
+    def add_query(self, connection, channel, delivery_tag, query):
+        logger.info("Added a task to internal queue")
+        self.queue.put((connection, channel, delivery_tag, query))
 
-def invoke_query(
-        connection,
-        request_channel,
-        delivery_tag,
-        query_handler,
-        params
-    ):
-    t0 = time.monotonic()
-    messages = get_results(query_handler, params)
-    if messages is None:
-        return
+    def init_connection(self):
+        self.connection = init_rabbitmq(
+            username=config.RABBITMQ_USERNAME,
+            password=config.RABBITMQ_PASSWORD,
+            host=config.RABBITMQ_HOST,
+            port=config.RABBITMQ_PORT,
+            vhost=config.RABBITMQ_VHOST,
+            connection_name="listenbrainz-spark-result-publisher"
+        )
 
-    result_channel = get_result_channel(connection)
+    def init_channel(self):
+        self.result_channel = self.connection.channel()
+        self.result_channel.exchange_declare(
+            exchange=config.SPARK_RESULT_EXCHANGE,
+            exchange_type='fanout'
+        )
 
-    logger.info("Pushing result to RabbitMQ...")
-    num_of_messages = 0
-    avg_size_of_message = 0
+    def get_results(self, query_handler, params):
+        try:
+            return query_handler(**params)
+        except TypeError:
+            logger.error("TypeError in the query handler for query '%s', "
+                         "maybe bad params: ", query_handler, exc_info=True)
+            return None
+        except Exception:
+            logger.error("Error in the query handler for query '%s':",
+                         query_handler, exc_info=True)
+            return None
 
-    for message in messages:
-        num_of_messages += 1
-        body = json.dumps(message)
-        avg_size_of_message += len(body)
-        while message is not None:
-            try:
-                result_channel.basic_publish(
-                    exchange=config.SPARK_RESULT_EXCHANGE,
-                    routing_key='',
-                    body=body,
-                    properties=pika.BasicProperties(delivery_mode=2, ),
-                )
-                break
-            # we do not catch ConnectionClosed exception here because when
-            # a connection closes so do all of the channels on it. so if the
-            # connection is closed, we have lost the request channel. hence,
-            # we'll be unable to ack the request later and receive it again
-            # for processing anyways.
-            except pika.exceptions.ChannelClosed:
-                logger.error('RabbitMQ Connection error while publishing results:', exc_info=True)
-                time.sleep(1)
-                result_channel = get_result_channel(connection)
+    def invoke_query(self, query_handler, params):
+        t0 = time.monotonic()
+        messages = self.get_results(query_handler, params)
+        if messages is None:
+            return
 
-    try:
-        avg_size_of_message //= num_of_messages
-    except ZeroDivisionError:
+        logger.info("Pushing result to RabbitMQ...")
+        num_of_messages = 0
         avg_size_of_message = 0
-        logger.warning("No messages calculated", exc_info=True)
 
-    logger.info("Done!")
-    logger.info("Number of messages sent: {}".format(num_of_messages))
-    logger.info("Average size of message: {} bytes".format(avg_size_of_message))
+        for message in messages:
+            num_of_messages += 1
+            body = json.dumps(message)
+            avg_size_of_message += len(body)
+            while message is not None:
+                try:
+                    self.result_channel.basic_publish(
+                        exchange=config.SPARK_RESULT_EXCHANGE,
+                        routing_key='',
+                        body=body,
+                        properties=pika.BasicProperties(delivery_mode=2, ),
+                    )
+                    break
+                # we do not catch ConnectionClosed exception here because when
+                # a connection closes so do all of the channels on it. so if the
+                # connection is closed, we have lost the request channel. hence,
+                # we'll be unable to ack the request later and receive it again
+                # for processing anyways.
+                except (pika.exceptions.ChannelClosed, pika.exceptions.ConnectionClosed):
+                    logger.error('RabbitMQ Connection error while publishing results:', exc_info=True)
+                    time.sleep(1)
+                    self.connection.close()
+                    self.init_connection()
+                    self.init_channel()
 
-    logger.info("Time Taken: %d s", time.monotonic() - t0)
-    callback = functools.partial(request_channel.basic_ack, delivery_tag)
-    connection.add_callback_threadsafe(callback)
+        try:
+            avg_size_of_message //= num_of_messages
+        except ZeroDivisionError:
+            avg_size_of_message = 0
+            logger.warning("No messages calculated", exc_info=True)
+
+        logger.info("Done!")
+        logger.info("Number of messages sent: {}".format(num_of_messages))
+        logger.info("Average size of message: {} bytes".format(avg_size_of_message))
+
+        logger.info("Time Taken: %d s", time.monotonic() - t0)
+        logger.info('Request done!')
+
+    def run(self):
+        logger.info("Starting result publisher")
+        while not self.done:
+            try:
+                connection, channel, delivery_tag, query = self.queue.get(timeout=600)
+                self.invoke_query(*query)
+                self.queue.task_done()
+                callback = functools.partial(channel.basic_ack, delivery_tag)
+                connection.add_callback_threadsafe(callback)
+            except Empty:
+                logger.info("No query received in last 10 minutes")
+            except Exception:
+                logger.error("Error in result publisher:", exc_info=True)
+                self.queue.task_done()
+        logger.info("Stopping result publisher")
+
+    def shutdown(self):
+        self.done = True
+        if self.queue.empty():
+            self.queue.put(None)

--- a/listenbrainz_spark/request_consumer/result_publisher.py
+++ b/listenbrainz_spark/request_consumer/result_publisher.py
@@ -1,0 +1,81 @@
+import functools
+import json
+import logging
+import time
+
+import pika
+
+from listenbrainz_spark import config
+
+logger = logging.getLogger(__name__)
+
+def get_results(query_handler, params):
+    try:
+        return query_handler(**params)
+    except TypeError:
+        logger.error("TypeError in the query handler for query '%s', "
+                     "maybe bad params: ", query_handler, exc_info=True)
+        return None
+    except Exception:
+        logger.error("Error in the query handler for query '%s':",
+                     query_handler, exc_info=True)
+        return None
+
+
+def invoke_query(
+        connection,
+        request_channel,
+        result_channel,
+        delivery_tag,
+        query_handler,
+        params
+    ):
+    t0 = time.monotonic()
+    messages = get_results(query_handler, params)
+    if messages is None:
+        return
+
+    logger.info("Pushing result to RabbitMQ...")
+    num_of_messages = 0
+    avg_size_of_message = 0
+
+    for message in messages:
+        num_of_messages += 1
+        body = json.dumps(message)
+        avg_size_of_message += len(body)
+        while message is not None:
+            try:
+                result_channel.basic_publish(
+                    exchange=config.SPARK_RESULT_EXCHANGE,
+                    routing_key='',
+                    body=body,
+                    properties=pika.BasicProperties(delivery_mode=2, ),
+                )
+                break
+            # we do not catch ConnectionClosed exception here because when
+            # a connection closes so do all of the channels on it. so if the
+            # connection is closed, we have lost the request channel. hence,
+            # we'll be unable to ack the request later and receive it again
+            # for processing anyways.
+            except pika.exceptions.ChannelClosed:
+                logger.error('RabbitMQ Connection error while publishing results:', exc_info=True)
+                time.sleep(1)
+                result_channel = connection.channel()
+                result_channel.exchange_declare(
+                    exchange=config.SPARK_RESULT_EXCHANGE,
+                    exchange_type='fanout'
+                )
+
+    try:
+        avg_size_of_message //= num_of_messages
+    except ZeroDivisionError:
+        avg_size_of_message = 0
+        logger.warning("No messages calculated", exc_info=True)
+
+    logger.info("Done!")
+    logger.info("Number of messages sent: {}".format(num_of_messages))
+    logger.info("Average size of message: {} bytes".format(avg_size_of_message))
+
+    logger.info("Time Taken: %d s", time.monotonic() - t0)
+    callback = functools.partial(request_channel.basic_ack, delivery_tag)
+    connection.add_callback_threadsafe(callback)

--- a/listenbrainz_spark/request_consumer/result_publisher.py
+++ b/listenbrainz_spark/request_consumer/result_publisher.py
@@ -1,127 +1,59 @@
 import functools
 import json
 import logging
-import threading
 import time
-from queue import Queue, Empty
-
-import pika
-
-from listenbrainz_spark import config
-from listenbrainz_spark.utils import init_rabbitmq
 
 logger = logging.getLogger(__name__)
 
 
-class ResultPublisher(threading.Thread):
+def get_results(query_handler, params):
+    try:
+        return query_handler(**params)
+    except TypeError:
+        logger.error("TypeError in the query handler for query '%s', "
+                     "maybe bad params: ", query_handler, exc_info=True)
+        return None
+    except Exception:
+        logger.error("Error in the query handler for query '%s':",
+                     query_handler, exc_info=True)
+        return None
 
-    def __init__(self):
-        super().__init__()
-        self.queue = Queue(maxsize=2)
-        self.connection = None
-        self.result_channel = None
-        self.done = False
 
-    def add_query(self, connection, channel, delivery_tag, query):
-        logger.info("Added a task to internal queue")
-        self.queue.put((connection, channel, delivery_tag, query))
+def invoke_query(connection, channel, delivery_tag,
+                 query_handler, params, method_to_callback):
+    t0 = time.monotonic()
+    messages = get_results(query_handler, params)
+    if messages is None:
+        ack_callback = functools.partial(channel.basic_ack, delivery_tag)
+        connection.add_callback_threadsafe(ack_callback)
+        return
 
-    def init_connection(self):
-        self.connection = init_rabbitmq(
-            username=config.RABBITMQ_USERNAME,
-            password=config.RABBITMQ_PASSWORD,
-            host=config.RABBITMQ_HOST,
-            port=config.RABBITMQ_PORT,
-            vhost=config.RABBITMQ_VHOST,
-            connection_name="listenbrainz-spark-result-publisher"
-        )
+    logger.info("Pushing result to RabbitMQ...")
+    num_of_messages = 0
+    avg_size_of_message = 0
+    list_of_messages = list()
 
-    def init_channel(self):
-        self.result_channel = self.connection.channel()
-        self.result_channel.exchange_declare(
-            exchange=config.SPARK_RESULT_EXCHANGE,
-            exchange_type='fanout'
-        )
+    for message in messages:
+        if message is None:
+            continue
+        num_of_messages += 1
+        body = json.dumps(message)
+        avg_size_of_message += len(body)
+        list_of_messages.append(body)
 
-    def get_results(self, query_handler, params):
-        try:
-            return query_handler(**params)
-        except TypeError:
-            logger.error("TypeError in the query handler for query '%s', "
-                         "maybe bad params: ", query_handler, exc_info=True)
-            return None
-        except Exception:
-            logger.error("Error in the query handler for query '%s':",
-                         query_handler, exc_info=True)
-            return None
+    callback = functools.partial(method_to_callback, list_of_messages)
+    connection.add_callback_threadsafe(callback)
 
-    def invoke_query(self, query_handler, params):
-        t0 = time.monotonic()
-        messages = self.get_results(query_handler, params)
-        if messages is None:
-            return
+    ack_callback = functools.partial(channel.basic_ack, delivery_tag)
+    connection.add_callback_threadsafe(ack_callback)
 
-        logger.info("Pushing result to RabbitMQ...")
-        num_of_messages = 0
+    try:
+        avg_size_of_message //= num_of_messages
+    except ZeroDivisionError:
         avg_size_of_message = 0
+        logger.warning("No messages calculated", exc_info=True)
 
-        for message in messages:
-            num_of_messages += 1
-            body = json.dumps(message)
-            avg_size_of_message += len(body)
-            while message is not None:
-                try:
-                    self.result_channel.basic_publish(
-                        exchange=config.SPARK_RESULT_EXCHANGE,
-                        routing_key='',
-                        body=body,
-                        properties=pika.BasicProperties(delivery_mode=2, ),
-                    )
-                    break
-                # we do not catch ConnectionClosed exception here because when
-                # a connection closes so do all of the channels on it. so if the
-                # connection is closed, we have lost the request channel. hence,
-                # we'll be unable to ack the request later and receive it again
-                # for processing anyways.
-                except (pika.exceptions.ChannelClosed, pika.exceptions.ConnectionClosed):
-                    logger.error('RabbitMQ Connection error while publishing results:', exc_info=True)
-                    time.sleep(1)
-                    self.connection.close()
-                    self.init_connection()
-                    self.init_channel()
-
-        try:
-            avg_size_of_message //= num_of_messages
-        except ZeroDivisionError:
-            avg_size_of_message = 0
-            logger.warning("No messages calculated", exc_info=True)
-
-        logger.info("Done!")
-        logger.info("Number of messages sent: {}".format(num_of_messages))
-        logger.info("Average size of message: {} bytes".format(avg_size_of_message))
-
-        logger.info("Time Taken: %d s", time.monotonic() - t0)
-        logger.info('Request done!')
-
-    def run(self):
-        logger.info("Starting result publisher")
-        self.init_connection()
-        self.init_channel()
-        while not self.done:
-            try:
-                connection, channel, delivery_tag, query = self.queue.get(timeout=600)
-                self.invoke_query(*query)
-                self.queue.task_done()
-                callback = functools.partial(channel.basic_ack, delivery_tag)
-                connection.add_callback_threadsafe(callback)
-            except Empty:
-                logger.info("No query received in last 10 minutes")
-            except Exception:
-                logger.error("Error in result publisher:", exc_info=True)
-                self.queue.task_done()
-        logger.info("Stopping result publisher")
-
-    def shutdown(self):
-        self.done = True
-        if self.queue.empty():
-            self.queue.put(None)
+    logger.info("Number of messages sent: {}".format(num_of_messages))
+    logger.info("Average size of message: {} bytes".format(avg_size_of_message))
+    logger.info("Time Taken: %d s", time.monotonic() - t0)
+    logger.info('Request done!')

--- a/listenbrainz_spark/request_consumer/result_publisher.py
+++ b/listenbrainz_spark/request_consumer/result_publisher.py
@@ -3,11 +3,17 @@ import json
 import logging
 import time
 
+from listenbrainz_spark import hdfs_connection, config
+
 logger = logging.getLogger(__name__)
 
 
 def get_results(query_handler, params):
     try:
+        # initialize connection to HDFS, the request consumer is a long running process
+        # so we try to create a connection everytime before executing a query to avoid
+        # affecting subsequent queries in case there's an intermittent connection issue
+        hdfs_connection.init_hdfs(config.HDFS_HTTP_URI)
         return query_handler(**params)
     except TypeError:
         logger.error("TypeError in the query handler for query '%s', "

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -59,7 +59,7 @@ def append(df, dest_path):
 
 
 def init_rabbitmq(username, password, host, port, vhost, log=logger.error,
-                  heartbeat=None, connection_name="listenbrainz-spark-request-consumer"):
+                  connection_name="listenbrainz-spark-request-consumer"):
     while True:
         try:
             credentials = pika.PlainCredentials(username, password)
@@ -68,7 +68,6 @@ def init_rabbitmq(username, password, host, port, vhost, log=logger.error,
                 port=port,
                 virtual_host=vhost,
                 credentials=credentials,
-                heartbeat=heartbeat,
                 client_properties={"connection_name": connection_name}
             )
             return pika.BlockingConnection(connection_parameters)

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -58,8 +58,8 @@ def append(df, dest_path):
         raise DataFrameNotAppendedException(err.java_exception, df.schema)
 
 
-def init_rabbitmq(username, password, host, port, vhost, log=logger.error,
-                  connection_name="listenbrainz-spark-request-consumer"):
+def init_rabbitmq(username, password, host,
+                  port, vhost, connection_name):
     while True:
         try:
             credentials = pika.PlainCredentials(username, password)
@@ -71,8 +71,8 @@ def init_rabbitmq(username, password, host, port, vhost, log=logger.error,
                 client_properties={"connection_name": connection_name}
             )
             return pika.BlockingConnection(connection_parameters)
-        except Exception as e:
-            log('Error while connecting to RabbitMQ', exc_info=True)
+        except Exception:
+            logger.error('Error while connecting to RabbitMQ', exc_info=True)
             sleep(1)
 
 


### PR DESCRIPTION
### Fix consumer ack timeouts in spark request consumer

We originally tried to fix this in c13b9f0114ad93ec21ec2a2ce42891c453c4b102. The fix worked fine and we did not recompute requests again and again in spark. However, we continued to get a consumer ack timeout daily during the cron job runs.

It turns out that rabbitmq tries to send as many messages possible at a time by default. All of these messages are delivered and marked as unacked. The callback is called on first message. We ack it right away and then execute the spark request. Once the request has finished the method returns and the callback is executed on the next message. Now if the first request took a considerable amount of time to execute, we have already hit a timeout on the remaining messages before we reach them. This is probably why we have been seeing the consumer ack timeouts till now.

To fix this, we request rabbitmq to send only one message at a time and ack the message after it has been processed. (If we ack'ed right away, rabbitmq would send another message and we are back at the above described problem.) The next message is not sent until the current one has been ack'ed so the issue of timeout is mitigated. 

*Before applying this fix*
|name|messages|messages_ready|messages_unacknowledged|
|------|-----------|------------------|------------------------------|
|spark_request|10|0|10|

*After applying this fix*
|name|messages|messages_ready|messages_unacknowledged|
|------|-----------|------------------|------------------------------|
|spark_request|10|9 |1|