### PR TITLE
Fix invalid parameter passed to get_top_similar_users

### DIFF
--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -118,7 +118,7 @@ def import_user_similarities(data):
     return (user_count, target_user_count / user_count, "")
 
 
-def get_top_similar_users(count=200, global_similarity=False):
+def get_top_similar_users(count: int = 200, global_similarity: bool = False):
     """
         Fetch the count top similar users and return a tuple(user1, user2, score(0.0-1.0))
         If global_similarity is True, the return the user similarity on a global (not

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -260,7 +260,7 @@ def similar_users():
         and spammers as well.
     """
 
-    similar_users = get_top_similar_users(True)
+    similar_users = get_top_similar_users(global_similarity=True)
     return render_template(
         "index/similar-users.html",
         similar_users=similar_users


### PR DESCRIPTION
The global_similarity flag was being passed without keyword name, hence the True flag was going to the value of count parameter instead. This was causing us to display only one result on the top similar users page.