### PR TITLE
LB-867: Add unicode null checking to api endpoints

### DIFF
--- a/listenbrainz/testdata/listen_having_unicode_null.json
+++ b/listenbrainz/testdata/listen_having_unicode_null.json
@@ -1,0 +1,13 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": 1486449409,
+            "track_metadata": {
+                "artist_name": "Kanye West",
+                "track_name": "\u0000Fade",
+                "release_name": "The Life of Pablo"
+            }
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -450,6 +450,14 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
 
+    def test_unicode_null_error(self):
+        with open(self.path_to_data_file('listen_having_unicode_null.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+        self.assertEqual(response.json['error'], '\x00Fade contains a unicode null')
+
     def test_additional_info(self):
         """ Test to make sure that user generated data present in additional_info field
             of listens is preserved

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -32,9 +32,10 @@ from time import time
 from flask import current_app, Blueprint, request, render_template, redirect
 from werkzeug.exceptions import BadRequest
 from listenbrainz.db.lastfm_session import Session
+from listenbrainz.webserver.errors import APIBadRequest
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
-from listenbrainz.webserver.views.api_tools import insert_payload, is_valid_timestamp, LISTEN_TYPE_PLAYING_NOW, is_valid_uuid
-
+from listenbrainz.webserver.views.api_tools import insert_payload, is_valid_timestamp, LISTEN_TYPE_PLAYING_NOW, \
+    is_valid_uuid, check_for_unicode_null_recursively
 
 api_compat_old_bp = Blueprint('api_compat_old', __name__)
 
@@ -190,6 +191,11 @@ def _to_native_api(data, append_key):
     # if there is nothing in the additional info field of the track, remove it
     if listen['track_metadata']['additional_info'] == {}:
         del listen['track_metadata']['additional_info']
+
+    try:
+        check_for_unicode_null_recursively(listen)
+    except APIBadRequest:
+        return None
 
     return listen
 


### PR DESCRIPTION
Postgres does not allow `\u0000` character. This has brought down the TS Writer down twice before. Also, added a couple of tests so that we don't regress this in future. 