### PR TITLE
Refactor load recording from UUID functions

### DIFF
--- a/listenbrainz/db/model/pinned_recording.py
+++ b/listenbrainz/db/model/pinned_recording.py
@@ -104,7 +104,7 @@ def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRec
         fetch_msids = [pin.recording_msid for pin in msid_pins]   # retrieves list of msid's to fetch with
         metadatas.extend(load_recordings_from_msids(fetch_msids))
 
-    # assign track metadata to every pin in correct order 
+    # assign track metadata to every pin in correct order
     for pin in pins:
         # find matching metadata from query results
         metadata = list(filter(lambda x: x["ids"]["recording_msid"] == pin.recording_msid, metadatas))[0]

--- a/listenbrainz/db/model/pinned_recording.py
+++ b/listenbrainz/db/model/pinned_recording.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Optional, List
 from pydantic import BaseModel, validator, constr
 from listenbrainz.db.model.validators import check_rec_mbid_msid_is_valid_uuid, check_datetime_has_tzinfo
-from messybrainz import load_recording_from_msid, load_recording_from_mbid
+from messybrainz import load_recordings_from_msids, load_recordings_from_mbids
 
 DAYS_UNTIL_UNPIN = 7  # default = unpin after one week
 MAX_BLURB_CONTENT_LENGTH = 280  # maximum length of blurb content
@@ -82,18 +82,35 @@ class WritablePinnedRecording(PinnedRecording):
         return pin_until or values["created"] + timedelta(days=DAYS_UNTIL_UNPIN)
 
 
-def fetch_track_metadata_for_pin(pin: PinnedRecording) -> PinnedRecording:
-    """ Fetches track_metadata (track_name, artist_name, release_name...) for a given PinnedRecording.
+def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRecording]:
+    """ Fetches track_metadata for every object in a list of PinnedRecordings.
 
         Args:
-            pin (PinnedRecording): the PinnedRecording to fetch track_metadata for.
+            pins (List of PinnedRecordings): the PinnedRecordings to fetch track_metadata for.
         Returns:
-            The given pin with track_metadata.
+            The given list of PinnedRecording objects with updated track_metadata.
     """
-    if pin.recording_mbid:
-        metadata = load_recording_from_mbid(pin.recording_mbid)['payload']
-    else:
-        metadata = load_recording_from_msid(pin.recording_msid)['payload']
 
-    pin.track_metadata = {"track_name": metadata["title"], "artist_name": metadata["artist"]}
-    return pin
+    # seperate pins containing mbid's from those without
+    mbid_pins = list(filter(lambda pin: pin.recording_mbid, pins))
+    msid_pins = list(filter(lambda pin: not pin.recording_mbid, pins))
+
+    metadatas = []
+
+    if mbid_pins:
+        fetch_mbids = [pin.recording_mbid for pin in mbid_pins]  # retrieves list of mbid's to fetch with
+        metadatas.extend(load_recordings_from_mbids(fetch_mbids))
+    if msid_pins:
+        fetch_msids = [pin.recording_msid for pin in msid_pins]   # retrieves list of msid's to fetch with
+        metadatas.extend(load_recordings_from_msids(fetch_msids))
+
+    # assign track metadata to every pin in correct order 
+    for pin in pins:
+        # find matching metadata from query results
+        metadata = list(filter(lambda x: x["ids"]["recording_msid"] == pin.recording_msid, metadatas))[0]
+        pin.track_metadata = {
+            "track_name": metadata["payload"]["title"],
+            "artist_name": metadata["payload"]["artist"],
+            "artist_msid": metadata["ids"]["artist_msid"],
+        }
+    return pins

--- a/listenbrainz/db/model/pinned_recording.py
+++ b/listenbrainz/db/model/pinned_recording.py
@@ -106,7 +106,7 @@ def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRec
 
     # assign track metadata to every pin in correct order
     for pin in pins:
-        # find matching metadata from query results
+        # find matching metadata in list from query results
         metadata = list(filter(lambda x: x["ids"]["recording_msid"] == pin.recording_msid, metadatas))[0]
         pin.track_metadata = {
             "track_name": metadata["payload"]["title"],

--- a/messybrainz/__init__.py
+++ b/messybrainz/__init__.py
@@ -36,7 +36,7 @@ def submit_listens_and_sing_me_a_sweet_song(recordings):
         raise exceptions.ErrorAddingException("Failed to add data")
 
 
-def load_recording_from_msid(msid):
+def load_recordings_from_msids(msids):
     """ Returns data for a recording with specified MessyBrainz ID.
 
     Args:
@@ -46,10 +46,10 @@ def load_recording_from_msid(msid):
     """
 
     with db.engine.begin() as connection:
-        return data.load_recording_from_msid(connection, msid)
+        return data.load_recordings_from_msids(connection, msids)
 
 
-def load_recording_from_mbid(mbid):
+def load_recordings_from_mbids(mbids):
     """ Returns data for a recording with specified MusicBrainz ID.
 
     Args:
@@ -59,7 +59,7 @@ def load_recording_from_mbid(mbid):
     """
 
     with db.engine.begin() as connection:
-        return data.load_recording_from_mbid(connection, mbid)
+        return data.load_recordings_from_mbids(connection, mbids)
 
 def insert_single(connection, recording):
     """ Inserts a single recording into MessyBrainz.
@@ -74,7 +74,7 @@ def insert_single(connection, recording):
     gid = data.get_id_from_recording(connection, recording)
     if not gid:
         gid = data.submit_recording(connection, recording)
-    loaded = data.load_recording_from_msid(connection, gid)
+    loaded = data.load_recordings_from_msids(connection, [gid])[0]
     return loaded
 
 def insert_all_in_transaction(recordings):

--- a/messybrainz/db/data.py
+++ b/messybrainz/db/data.py
@@ -182,71 +182,98 @@ def submit_recording(connection, data):
     return gid
 
 
-def load_recording_from_msid(connection, messybrainz_id):
-    """ Return data for a recording with specified MessyBrainz ID.
+def load_recordings_from_msids(connection, messybrainz_ids):
+    """ Returns data for a recordings corresponding to a given list of MessyBrainz IDs.
 
     Args:
         connection: sqlalchemy connection to execute db queries with
-        messybrainz_id (uuid): the MessyBrainz ID of the recording
+        messybrainz_id (list [uuid]): the MessyBrainz IDs of the recordings to fetch data for
 
     Returns:
-        dict: the recording data for the recording with specified MessyBrainz ID
+        list [dict]: a list of the recording data for the recordings in the order of the given MSIDs.
     """
 
-    query = text("""SELECT rj.data
+    if not messybrainz_ids:
+        return {}
+
+    query = text("""SELECT DISTINCT rj.data
                          , r.artist
                          , r.release
                          , r.gid
                       FROM recording_json AS rj
                  LEFT JOIN recording AS r
                         ON rj.id = r.data
-                     WHERE r.gid = :gid""")
-    result = connection.execute(query, {"gid": str(messybrainz_id)})
+                     WHERE r.gid IN :msids""")
+    result = connection.execute(query, {"msids": tuple(map(str, messybrainz_ids))})
 
-    row = result.fetchone()
-    if not row:
+    rows = result.fetchall()
+    if not rows:
         raise exceptions.NoDataFoundException
-    result = {}
-    result["payload"] = row["data"]
-    result["ids"] = {"artist_mbids": [], "release_mbid": ""}
-    result["ids"]["recording_mbid"] = str(row["data"]["recording_mbid"]) if "recording_mbid" in row["data"] else ''
-    result["ids"]["artist_msid"] = str(row["artist"])
-    result["ids"]["release_msid"] = str(row["release"]) if row["release"] else None
-    result["ids"]["recording_msid"] = str(row["gid"])
-    return result
+    
+    # match results to every given mbid so list is returned in the same order
+    results = []
+    for msid in messybrainz_ids:
+        row = list(filter(lambda x: str(x["gid"]) == str(msid), rows))[0]
+        if not row:
+            raise exceptions.NoDataFoundException
+
+        result = {}
+        result["payload"] = row["data"]
+        result["ids"] = {"artist_mbids": [], "release_mbid": ""}
+        result["ids"]["recording_mbid"] = str(row["data"]["recording_mbid"]) if "recording_mbid" in row["data"] else ''
+        result["ids"]["artist_msid"] = str(row["artist"])
+        result["ids"]["release_msid"] = str(row["release"]) if row["release"] else None
+        result["ids"]["recording_msid"] = str(row["gid"])
+        results.append(result)
+
+    return results
 
 
-def load_recording_from_mbid(connection, musicbrainz_id):
-    """ Return data for a recording with specified MusicBrainz ID.
+def load_recordings_from_mbids(connection, musicbrainz_ids):
+    """ Returns data for a recordings corresponding to a given list of MusicBrainz IDs.
 
     Args:
         connection: sqlalchemy connection to execute db queries with
-        messybrainz_id (uuid): the MusicBrainz ID of the recording
+        messybrainz_id (list [uuid]): the MusicBrainz IDs of the recordings to fetch data for
 
     Returns:
-        dict: the recording data for the recording with specified MusicBrainz ID
+        list [dict]: a list of the recording data for the recordings in the order of the given MBIDs.
     """
-    query = text("""SELECT rj.data
+
+    if not musicbrainz_ids:
+        return {}
+    
+    query = text("""SELECT DISTINCT rj.data
                          , r.artist
                          , r.release
                          , r.gid
                       FROM recording_json AS rj
                  LEFT JOIN recording AS r
                         ON rj.id = r.data
-                     WHERE rj.data ->> 'recording_mbid' = :recording_mbid""")
-    result = connection.execute(query, {"recording_mbid": str(musicbrainz_id)})
+                     WHERE rj.data ->> 'recording_mbid' IN :mbids""")
+    result = connection.execute(query, {"mbids": tuple(map(str, musicbrainz_ids))})
 
-    row = result.fetchone()
-    if not row:
+    rows = result.fetchall()
+    if not rows:
         raise exceptions.NoDataFoundException
-    result = {}
-    result["payload"] = row["data"]
-    result["ids"] = {"artist_mbids": [], "release_mbid": ""}
-    result["ids"]["recording_mbid"] = str(row["data"]["recording_mbid"])
-    result["ids"]["artist_msid"] = str(row["artist"])
-    result["ids"]["release_msid"] = str(row["release"]) if row["release"] else None
-    result["ids"]["recording_msid"] = str(row["gid"])
-    return result
+
+    # match results to every given mbid so list is returned in the same order
+    results = []
+    for mbid in musicbrainz_ids:
+        row = list(filter(lambda x: str(x["data"]["recording_mbid"]) == str(mbid), rows))[0]
+        if not row:
+            raise exceptions.NoDataFoundException
+
+        result = {}
+        result["payload"] = row["data"]
+        result["ids"] = {"artist_mbids": [], "release_mbid": ""}
+        result["ids"]["recording_mbid"] = str(row["data"]["recording_mbid"])
+        result["ids"]["artist_msid"] = str(row["artist"])
+        result["ids"]["release_msid"] = str(row["release"]) if row["release"] else None
+        result["ids"]["recording_msid"] = str(row["gid"])
+        results.append(result)
+
+    return results
 
 def link_recording_to_recording_id(connection, msid, mbid):
     """ Link a MessyBrainz recording to specified MusicBrainz Recording ID.

--- a/messybrainz/db/data.py
+++ b/messybrainz/db/data.py
@@ -209,7 +209,7 @@ def load_recordings_from_msids(connection, messybrainz_ids):
     rows = result.fetchall()
     if not rows:
         raise exceptions.NoDataFoundException
-    
+
     # match results to every given mbid so list is returned in the same order
     results = []
     for msid in messybrainz_ids:
@@ -242,7 +242,7 @@ def load_recordings_from_mbids(connection, musicbrainz_ids):
 
     if not musicbrainz_ids:
         return {}
-    
+
     query = text("""SELECT DISTINCT rj.data
                          , r.artist
                          , r.release

--- a/messybrainz/db/tests/test_data.py
+++ b/messybrainz/db/tests/test_data.py
@@ -61,7 +61,7 @@ class DataTestCase(DatabaseTestCase):
         with db.engine.connect() as connection:
             recording_msid = data.submit_recording(connection, recording)
             artist_msid = data.get_artist_credit(connection, recording['artist'])
-            recording_data = data.load_recording_from_msid(connection, recording_msid)
+            recording_data = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertEqual(artist_msid, recording_data['ids']['artist_msid'])
 
 
@@ -69,7 +69,7 @@ class DataTestCase(DatabaseTestCase):
         with db.engine.connect() as connection:
             recording_msid = data.submit_recording(connection, recording)
             release_msid = data.get_release(connection, recording['release'])
-            recording_data = data.load_recording_from_msid(connection, recording_msid)
+            recording_data = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertEqual(release_msid, recording_data['ids']['release_msid'])
 
 
@@ -92,16 +92,16 @@ class DataTestCase(DatabaseTestCase):
             msid2 = str(data.get_id_from_recording(connection, recording_diff_case))
             self.assertEqual(msid1, msid2)
 
-    def test_load_recording_from_msid(self):
+    def test_load_recordings_from_msids(self):
         with db.engine.connect() as connection:
             recording_msid = data.submit_recording(connection, recording)
-            result = data.load_recording_from_msid(connection, recording_msid)
+            result = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertDictEqual(result['payload'], recording)
 
-    def test_load_recording_from_mbid(self):
+    def test_load_recordings_from_mbids(self):
         with db.engine.connect() as connection:
             data.submit_recording(connection, recording)
-            result = data.load_recording_from_mbid(connection, recording["recording_mbid"])
+            result = data.load_recordings_from_mbids(connection, [recording["recording_mbid"]])[0]
             self.assertDictEqual(result['payload'], recording)
 
     def test_convert_to_messybrainz_json(self):

--- a/messybrainz/webserver/views/api.py
+++ b/messybrainz/webserver/views/api.py
@@ -41,7 +41,7 @@ def submit():
 @crossdomain()
 def get(messybrainz_id):
     try:
-        data = messybrainz.load_recording_from_msid(messybrainz_id)
+        data = messybrainz.load_recordings_from_msids([messybrainz_id])[0]
     except messybrainz.exceptions.NoDataFoundException:
         raise NotFound
 


### PR DESCRIPTION
This PR refactors the helper functions added in #1547 (load_recording_from_msid(), load_recording_from_mbid(), to support doing lookups in one query. 

Both functions were renamed and changed so that they take in a list of UUID's instead of just one, and return a list of dicts in the same order instead of just one dict. 