### PR TITLE
Improve artist credit recording pairs query

### DIFF
--- a/listenbrainz/mbid_mapping/README.md
+++ b/listenbrainz/mbid_mapping/README.md
@@ -49,8 +49,7 @@ If you plan to create a typesense index, you'll need typesense installed. First 
 then run:
 
 ```
-docker run -p 8108:8108 -d -v <some_data_dir_for_typesense>/data --name=typesense
-       --network=musicbrainzdocker_default typesense/typesense:0.17.0 --data-dir /data --api-key=<the api key>
+docker run -p 8108:8108 -d -v typesense:/data --name=typesense --network=musicbrainzdocker_default typesense/typesense:0.19.0 --data-dir /data --api-key=<the api key>
 ```
 
 To create the typesense index:

--- a/listenbrainz/mbid_mapping/mapping/mapping_test/mapping_test.py
+++ b/listenbrainz/mbid_mapping/mapping/mapping_test/mapping_test.py
@@ -34,8 +34,8 @@ def test_mapping():
     for row in data:
         hits = search(row[1] + " " + row[0])
         if row[2] != hits[0]['release_mbid']:
-            print("Q %-30s %-30s %-25 %s" % (row[0][:29], "", row[1][:29], row[2]))
-            print("H %-30s %-30s %-25 %s" % (hits[0]['recording_name'][:29], hits[0]['release_name'][:29],
+            print("Q %-30s %-30s %-25s %s" % (row[0][:29], "", row[1][:29], row[2]))
+            print("H %-30s %-30s %-25s %s" % (hits[0]['recording_name'][:29], hits[0]['release_name'][:29],
                   hits[0]['artist_credit_name'][:29], hits[0]['release_mbid']))
             print()
             failed += 1

--- a/listenbrainz/mbid_mapping/mapping/mapping_test/mapping_test_cases.csv
+++ b/listenbrainz/mbid_mapping/mapping/mapping_test/mapping_test_cases.csv
@@ -12,12 +12,11 @@ horizon,daft punk,79215cdf-4764-4dee-b0b9-fec1643df7c5
 reconsider,the xx,c58f53f5-a071-48fd-bb6b-8f344b2eca34
 bird song,florence + the machine,f4a3ef7e-ad82-3eba-8f20-425536925309
 seda,foo fighters,9bb88ca5-583a-4e21-96e8-994a5fc900e5
-dreaming,beyonce,7c08b5f8-2d6f-4d72-a829-3175528ef25f
+dreaming,beyonce,7e5d3746-210d-439c-8711-d8d700ac7ae3
 cyclops,the libertines,d224298c-82a1-4668-a3d3-c3bd40c8fbb1
 bravado (fffrrannno remix),lorde,491dd8ee-2b66-4510-b457-919b39058fe6
-teo torriatte (let us cling together),queen,762cb62a-e91d-402d-8a2e-3d1068ca53d5
+teo torriatte (let us cling together),queen,2183a8fd-569e-440d-9a8d-c6eeaa589c71
 flipside,lana del rey,abc92375-0d33-4479-aba0-97abd12f579e
-god bless the girl,david bowie,378576dc-1eb1-48d1-aff6-fdb933b16cbf
+god bless the girl,david bowie,6241d76e-45d9-4f7e-b9fc-24ad33e4955a
 2013,arctic monkeys,a432408f-335e-4d64-b33a-c1fb809af58f
 verdict for worst dictator,void,5941ccda-d6b5-4d5e-8a1a-5ca755321482
-think,void,450148b3-997d-4c04-a121-2d158a689ba2

--- a/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
+++ b/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
@@ -108,7 +108,7 @@ def create_temp_release_table(conn):
                                           to_date(date_year::TEXT || '-' ||
                                                   COALESCE(date_month,12)::TEXT || '-' ||
                                                   COALESCE(date_day,28)::TEXT, 'YYYY-MM-DD'),
-                                          country, rg.artist_credit, rg.name"""
+                                          country, rg.artist_credit, rg.name, r.id"""
 
         if config.USE_MINIMAL_DATASET:
             log("mbid mapping temp tables: Using a minimal dataset for artist credit pairs")

--- a/listenbrainz/mbid_mapping/mapping/search.py
+++ b/listenbrainz/mbid_mapping/mapping/search.py
@@ -25,7 +25,7 @@ def search(query):
         'num_typos': 5
     }
 
-    hits = client.collections['recording_artist_credit_mapping'].documents.search(search_parameters)
+    hits = client.collections['mbid_mapping_latest'].documents.search(search_parameters)
 
     output = []
     for hit in hits['hits']:


### PR DESCRIPTION
Improve artist credit recording pairs query to be more stable, which should improve stability of tracks being matched to releases that are identical for all of our criteria. 

Update tests for the new sort order created above.

Improve docs/indexes to reflect current reality.