### PR TITLE
Fix invalid parameters on charts page, fix charts navigation links

### DIFF
--- a/listenbrainz/webserver/static/css/theme/boostrap/pager.less
+++ b/listenbrainz/webserver/static/css/theme/boostrap/pager.less
@@ -50,6 +50,7 @@
       color: @pager-disabled-color;
       background-color: @pager-bg;
       cursor: @cursor-disabled;
+	  pointer-events: none;
     }
   }
 }

--- a/listenbrainz/webserver/static/css/theme/boostrap/pager.less
+++ b/listenbrainz/webserver/static/css/theme/boostrap/pager.less
@@ -45,6 +45,7 @@
     > a,
     > a:hover,
     > a:focus,
+    > a:visited,
     > span {
       color: @pager-disabled-color;
       background-color: @pager-bg;

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -78,7 +78,7 @@ export default class UserEntityChart extends React.Component<
     window.history.replaceState(
       null,
       "",
-      `?page=${page}&range=${range}&entity=${entity}`
+      this.buildURLParams(page, range, entity)
     );
     this.syncStateWithURL();
     this.handleResize();
@@ -89,27 +89,13 @@ export default class UserEntityChart extends React.Component<
     window.removeEventListener("resize", this.handleResize);
   }
 
-  changePage = (
-    newPage: number,
-    event?: React.MouseEvent<HTMLElement>
-  ): void => {
-    if (event) {
-      event.preventDefault();
-    }
-
+  changePage = (newPage: number): void => {
     const { entity, range } = this.state;
     this.setURLParams(newPage, range, entity);
     this.syncStateWithURL();
   };
 
-  changeRange = (
-    newRange: UserStatsAPIRange,
-    event?: React.MouseEvent<HTMLElement>
-  ): void => {
-    if (event) {
-      event.preventDefault();
-    }
-
+  changeRange = (newRange: UserStatsAPIRange): void => {
     const { entity } = this.state;
     this.setURLParams(1, newRange, entity);
     this.syncStateWithURL();
@@ -378,23 +364,38 @@ export default class UserEntityChart extends React.Component<
     );
   };
 
+  /*
+  Build a url querystring (including the ?) for a page, range, and entity
+   */
   buildURLParams = (
     page: number,
     range: UserStatsAPIRange,
     entity: Entity
   ): string => {
-    const params = new URLSearchParams({
-      page: page.toString(),
-      range: range as string,
-      entity: entity as string,
-    }).toString();
-    return `?${params}`;
+    return `?page=${page}&range=${range}&entity=${entity}`;
   };
 
   handleResize = () => {
     this.setState({
       graphContainerWidth: this.graphContainer.current?.offsetWidth,
     });
+  };
+
+  /*
+  Handle a click on a link that will perform an action
+   - if control is held down, don't prevent the event from firing
+     this will allow ctrl/cmd-click to open links in a new tab
+   - otherwise, prevent the event from happening and call a callback
+     that performs some action (e.g. load a new page)
+   */
+  handleClickEvent = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    callback: () => any
+  ) => {
+    if (!e.ctrlKey) {
+      e.preventDefault();
+      callback();
+    }
   };
 
   render() {
@@ -466,7 +467,11 @@ export default class UserEntityChart extends React.Component<
                       <a
                         href={this.buildURLParams(1, "week", entity)}
                         role="button"
-                        onClick={(event) => this.changeRange("week", event)}
+                        onClick={(e) => {
+                          this.handleClickEvent(e, () => {
+                            this.changeRange("week");
+                          });
+                        }}
                       >
                         Week
                       </a>
@@ -475,7 +480,11 @@ export default class UserEntityChart extends React.Component<
                       <a
                         href={this.buildURLParams(1, "month", entity)}
                         role="button"
-                        onClick={(event) => this.changeRange("month", event)}
+                        onClick={(e) => {
+                          this.handleClickEvent(e, () => {
+                            this.changeRange("month");
+                          });
+                        }}
                       >
                         Month
                       </a>
@@ -484,7 +493,11 @@ export default class UserEntityChart extends React.Component<
                       <a
                         href={this.buildURLParams(1, "year", entity)}
                         role="button"
-                        onClick={(event) => this.changeRange("year", event)}
+                        onClick={(e) => {
+                          this.handleClickEvent(e, () => {
+                            this.changeRange("year");
+                          });
+                        }}
                       >
                         Year
                       </a>
@@ -493,7 +506,11 @@ export default class UserEntityChart extends React.Component<
                       <a
                         href={this.buildURLParams(1, "all_time", entity)}
                         role="button"
-                        onClick={(event) => this.changeRange("all_time", event)}
+                        onClick={(e) => {
+                          this.handleClickEvent(e, () => {
+                            this.changeRange("all_time");
+                          });
+                        }}
                       >
                         All Time
                       </a>
@@ -567,9 +584,13 @@ export default class UserEntityChart extends React.Component<
                       }`}
                     >
                       <a
-                        href={this.buildURLParams(prevPage, range, entity)}
+                        href=""
                         role="button"
-                        onClick={(event) => this.changePage(prevPage, event)}
+                        onClick={(e) => {
+                          this.handleClickEvent(e, () => {
+                            this.changePage(prevPage);
+                          });
+                        }}
                       >
                         &larr; Previous
                       </a>
@@ -582,7 +603,11 @@ export default class UserEntityChart extends React.Component<
                       <a
                         href={this.buildURLParams(nextPage, range, entity)}
                         role="button"
-                        onClick={(event) => this.changePage(nextPage, event)}
+                        onClick={(e) => {
+                          this.handleClickEvent(e, () => {
+                            this.changePage(nextPage);
+                          });
+                        }}
                       >
                         Next &rarr;
                       </a>

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -374,8 +374,21 @@ export default class UserEntityChart extends React.Component<
     window.history.pushState(
       null,
       "",
-      `?page=${page}&range=${range}&entity=${entity}`
+      this.buildURLParams(page, range, entity)
     );
+  };
+
+  buildURLParams = (
+    page: number,
+    range: UserStatsAPIRange,
+    entity: Entity
+  ): string => {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      range: range as string,
+      entity: entity as string,
+    }).toString();
+    return `?${params}`;
   };
 
   handleResize = () => {
@@ -451,7 +464,7 @@ export default class UserEntityChart extends React.Component<
                   <ul className="dropdown-menu" role="menu">
                     <li>
                       <a
-                        href=""
+                        href={this.buildURLParams(1, "week", entity)}
                         role="button"
                         onClick={(event) => this.changeRange("week", event)}
                       >
@@ -460,7 +473,7 @@ export default class UserEntityChart extends React.Component<
                     </li>
                     <li>
                       <a
-                        href=""
+                        href={this.buildURLParams(1, "month", entity)}
                         role="button"
                         onClick={(event) => this.changeRange("month", event)}
                       >
@@ -469,7 +482,7 @@ export default class UserEntityChart extends React.Component<
                     </li>
                     <li>
                       <a
-                        href=""
+                        href={this.buildURLParams(1, "year", entity)}
                         role="button"
                         onClick={(event) => this.changeRange("year", event)}
                       >
@@ -478,7 +491,7 @@ export default class UserEntityChart extends React.Component<
                     </li>
                     <li>
                       <a
-                        href=""
+                        href={this.buildURLParams(1, "all_time", entity)}
                         role="button"
                         onClick={(event) => this.changeRange("all_time", event)}
                       >
@@ -554,7 +567,7 @@ export default class UserEntityChart extends React.Component<
                       }`}
                     >
                       <a
-                        href=""
+                        href={this.buildURLParams(prevPage, range, entity)}
                         role="button"
                         onClick={(event) => this.changePage(prevPage, event)}
                       >
@@ -567,7 +580,7 @@ export default class UserEntityChart extends React.Component<
                       }`}
                     >
                       <a
-                        href=""
+                        href={this.buildURLParams(nextPage, range, entity)}
                         role="button"
                         onClick={(event) => this.changePage(nextPage, event)}
                       >

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -348,6 +348,7 @@ export default class UserEntityChart extends React.Component<
     let page = 1;
     if (url.searchParams.get("page")) {
       page = Number(url.searchParams.get("page"));
+      page = Math.max(page, 1);
     }
 
     // Get range from URL

--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserEntityChart.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserEntityChart.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
               >
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=week&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -152,7 +152,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=month&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -161,7 +161,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=year&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -170,7 +170,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=all_time&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -677,7 +677,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
               className="next disabled"
             >
               <a
-                href=""
+                href="?page=2&range=&entity="
                 onClick={[Function]}
                 role="button"
               >
@@ -835,7 +835,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
               >
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=week&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -844,7 +844,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=month&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -853,7 +853,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=year&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -862,7 +862,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=all_time&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -1619,7 +1619,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
               className="next disabled"
             >
               <a
-                href=""
+                href="?page=2&range=&entity="
                 onClick={[Function]}
                 role="button"
               >
@@ -1777,7 +1777,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
               >
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=week&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -1786,7 +1786,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=month&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -1795,7 +1795,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=year&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -1804,7 +1804,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=all_time&entity="
                     onClick={[Function]}
                     role="button"
                   >
@@ -2461,7 +2461,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
               className="next disabled"
             >
               <a
-                href=""
+                href="?page=2&range=&entity="
                 onClick={[Function]}
                 role="button"
               >
@@ -2622,7 +2622,7 @@ exports[`UserEntityChart Page renders correctly if stats are not calculated 1`] 
               >
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=week&entity=artist"
                     onClick={[Function]}
                     role="button"
                   >
@@ -2631,7 +2631,7 @@ exports[`UserEntityChart Page renders correctly if stats are not calculated 1`] 
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=month&entity=artist"
                     onClick={[Function]}
                     role="button"
                   >
@@ -2640,7 +2640,7 @@ exports[`UserEntityChart Page renders correctly if stats are not calculated 1`] 
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=year&entity=artist"
                     onClick={[Function]}
                     role="button"
                   >
@@ -2649,7 +2649,7 @@ exports[`UserEntityChart Page renders correctly if stats are not calculated 1`] 
                 </li>
                 <li>
                   <a
-                    href=""
+                    href="?page=1&range=all_time&entity=artist"
                     onClick={[Function]}
                     role="button"
                   >


### PR DESCRIPTION
# Problems
When being passed a `?page=0` query parameter, the charts page subtracts 1 from this in order to compute an offset, resulting in a negative offset and an error from the server (https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/126368/)
-> Update the page parsing to not allow it to go below 1.

The next/previous links in the charts page had an empty a href. This means that the hover value of the link was invalid, and the pages were unable to be copied or opened in a new tab (LB-864)
-> Add values to the href property

