### PR TITLE
Return JSON in the API in responses to a ratelimit limit

### DIFF
--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -162,6 +162,10 @@ def init_error_handlers(app):
     def file_size_too_large(error):
         return handle_error(error, 413)
 
+    @app.errorhandler(429)
+    def too_many_requests(error):
+        return handle_error(error, 429)
+
     @app.errorhandler(500)
     def internal_server_error(error):
         # This error handler gets triggered on any uncaught exception.

--- a/manage.py
+++ b/manage.py
@@ -264,7 +264,9 @@ def update_user_emails():
 @click.argument("window_size", type=click.IntRange(1, None))
 def set_rate_limits(per_token_limit, per_ip_limit, window_size):
     from brainzutils.ratelimit import set_rate_limits
-    set_rate_limits(per_token_limit, per_ip_limit, window_size)
+    application = webserver.create_app()
+    with application.app_context():
+        set_rate_limits(per_token_limit, per_ip_limit, window_size)
 
 
 @cli.command(name="recalculate_all_user_data")

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ yattag == 1.14.0
 xmltodict == 0.12.0
 oauth2client == 4.1.3
 pika == 1.2.0
-git+https://github.com/metabrainz/brainzutils-python.git@v2.0.4
+git+https://github.com/metabrainz/brainzutils-python.git@v2.1.0
 spotipy == 2.17.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster
 pyyaml == 5.4.1


### PR DESCRIPTION
# Problem
Ratelimit messages were being returned as plain text even in API responses

# Solution
This is the LB side of https://github.com/metabrainz/brainzutils-python/pull/72. It catches the werkzeug exception and uses LB's error handler to return either JSON or HTML depending on what view is being called.

# Action

Still need to update BU dependency once a new version has been released

example response:
```
alastair@alastairpc:~/work/listenbrainz-server$ curl --silent -D -  http://localhost/1/user/alastairp/listens 
HTTP/1.0 429 TOO MANY REQUESTS
Content-Type: application/json
Content-Length: 156
Access-Control-Expose-Headers: X-RateLimit-Remaining,X-RateLimit-Limit,X-RateLimit-Reset,X-RateLimit-Reset-In
X-RateLimit-Remaining: 0
X-RateLimit-Limit: 3
X-RateLimit-Reset: 1628678940
X-RateLimit-Reset-In: 1
Server: Werkzeug/1.0.1 Python/3.7.9
Date: Wed, 11 Aug 2021 10:48:59 GMT

{
  "code": 429, 
  "error": "You have exceeded your rate limit. See the X-RateLimit-* response headers for more information on your current rate limit."
}

```

