### PR TITLE
Minor PinnedRecording backend changes

### DIFF
--- a/listenbrainz/tests/integration/test_pinned_recording_api.py
+++ b/listenbrainz/tests/integration/test_pinned_recording_api.py
@@ -238,7 +238,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         pin_to_delete = db_pinned_rec.get_current_pin_for_user(self.user["id"])
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", pinned_id=pin_to_delete.row_id),
+            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=pin_to_delete.row_id),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
         )
 
@@ -259,14 +259,14 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         pin_to_delete = db_pinned_rec.get_current_pin_for_user(self.user["id"])
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", pinned_id=pin_to_delete.row_id),
+            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=pin_to_delete.row_id),
             headers={"Authorization": "Token {}".format("-- This is an invalid auth token --")},
         )
         self.assert401(response)
         self.assertEqual(response.json["code"], 401)
 
-    def test_delete_no_pinned_id_found(self):
-        """Tests that delete endpoint returns 404 when no pin with pinned_id is found to delete"""
+    def test_delete_no_row_id_found(self):
+        """Tests that delete endpoint returns 404 when no pin with row_id is found to delete"""
         self.client.post(
             url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(self.pinned_rec_samples[0]),
@@ -275,7 +275,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         )
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", pinned_id=98764),
+            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=98764),
             headers={"Authorization": "Token {}".format(self.followed_user_1["auth_token"])},
         )
 
@@ -297,7 +297,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # check that data is sorted in descending order of created date
         self.assertGreaterEqual(pins[0]["created"], pins[1]["created"])
-        self.assertGreater(pins[0]["pinned_id"], pins[1]["pinned_id"])
+        self.assertGreater(pins[0]["row_id"], pins[1]["row_id"])
 
         self.assertEqual(pins[0]["recording_msid"], self.pinned_rec_samples[1]["recording_msid"])
         self.assertEqual(pins[0]["recording_mbid"], self.pinned_rec_samples[1]["recording_mbid"])

--- a/listenbrainz/tests/integration/test_pinned_recording_api.py
+++ b/listenbrainz/tests/integration/test_pinned_recording_api.py
@@ -1,4 +1,6 @@
 from flask import url_for
+from typing import List
+from unittest.mock import patch
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.pinned_recording as db_pinned_rec
@@ -8,13 +10,17 @@ from listenbrainz.tests.integration import IntegrationTestCase
 from listenbrainz.db.model.pinned_recording import (
     PinnedRecording,
     WritablePinnedRecording,
+    fetch_track_metadata_for_pins,
     DAYS_UNTIL_UNPIN,
     MAX_BLURB_CONTENT_LENGTH,
 )
 import json
 
 
+def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRecording]:
+    return pins
 class PinnedRecAPITestCase(IntegrationTestCase):
+
     def setUp(self):
         super(PinnedRecAPITestCase, self).setUp()
         self.user = db_user.get_or_create(1, "test_user_1")
@@ -282,8 +288,10 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assert404(response)
         self.assertEqual(response.json["code"], 404)
 
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_pins', fetch_track_metadata_for_pins)
     def test_get_pins_for_user(self):
         """Test that valid response is received with 200 code"""
+
         count = self.insert_test_data(self.user["id"], 2)  # pin 2 recordings
         response = self.client.get(url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"]))
         self.assert200(response)
@@ -315,6 +323,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assert404(response)
         self.assertEqual(response.json["code"], 404)
 
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_pins', fetch_track_metadata_for_pins)
     def test_get_pins_for_user_count_param(self):
         """Tests that valid response is received honoring count parameter"""
         limit = 2
@@ -359,6 +368,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_pins', fetch_track_metadata_for_pins)
     def test_get_pins_for_user_offset_param(self):
         """Tests that valid response is received honoring offset parameter"""
         offset = 2
@@ -405,6 +415,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_pins', fetch_track_metadata_for_pins)
     def test_get_pins_for_user_following(self):
         """Test that valid response is received with 200 code"""
         # user follows followed_user_1 and followed_user_2
@@ -445,6 +456,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assert404(response)
         self.assertEqual(response.json["code"], 404)
 
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_pins', fetch_track_metadata_for_pins)
     def test_get_pins_for_user_count_param(self):
         """Tests that valid response is received honoring count parameter"""
         # user follows followed_user_1 and followed_user_2
@@ -491,6 +503,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_pins', fetch_track_metadata_for_pins)
     def test_get_pins_for_user_following_offset_param(self):
         """Tests that valid response is received honoring offset parameter"""
         # user follows followed_user_1 and followed_user_2

--- a/listenbrainz/webserver/static/js/src/PinnedRecordingCard.tsx
+++ b/listenbrainz/webserver/static/js/src/PinnedRecordingCard.tsx
@@ -37,9 +37,8 @@ export default class PinnedRecordingCard extends React.Component<
 
   constructor(props: PinnedRecordingCardProps) {
     super(props);
-    const currentlyPinned = this.determineIfCurrentlyPinned();
     this.state = {
-      currentlyPinned,
+      currentlyPinned: this.determineIfCurrentlyPinned(),
       isDeleted: false,
     };
   }

--- a/listenbrainz/webserver/static/js/src/__snapshots__/PinnedRecordingCard.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/__snapshots__/PinnedRecordingCard.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`PinnedRecordingCard renders correctly 1`] = `
     Object {
       "blurb_content": "I LOVE",
       "created": 1111111111,
+      "row_id": 1,
       "pinned_until": 9999999999,
       "recording_mbid": "98255a8c-017a-4bc7-8dd6-1fa36124572b",
-      "row_id": 1,
       "track_metadata": Object {
         "artist_name": "Rick Astley",
         "track_name": "Never Gonna Give You Up",

--- a/listenbrainz/webserver/static/js/src/__snapshots__/PinnedRecordingCard.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/__snapshots__/PinnedRecordingCard.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`PinnedRecordingCard renders correctly 1`] = `
     Object {
       "blurb_content": "I LOVE",
       "created": 1111111111,
-      "row_id": 1,
       "pinned_until": 9999999999,
       "recording_mbid": "98255a8c-017a-4bc7-8dd6-1fa36124572b",
+      "row_id": 1,
       "track_metadata": Object {
         "artist_name": "Rick Astley",
         "track_name": "Never Gonna Give You Up",

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -464,6 +464,7 @@ declare type PinnedRecording = {
   pinned_until: number;
   row_id: number;
   recording_mbid: string;
+  recording_msid?: string;
   track_metadata: {
     artist_name: string;
     release_name?: string | null;

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -13,7 +13,7 @@ from listenbrainz.webserver.views.api_tools import (
     get_non_negative_param,
     validate_auth_header,
 )
-from listenbrainz.db.model.pinned_recording import PinnedRecording, WritablePinnedRecording
+from listenbrainz.db.model.pinned_recording import PinnedRecording, WritablePinnedRecording, fetch_track_metadata_for_pins
 from pydantic import ValidationError
 
 pinned_recording_api_bp = Blueprint("pinned_rec_api_bp_v1", __name__)
@@ -99,32 +99,32 @@ def unpin_recording_for_user():
     return jsonify({"status": "ok"})
 
 
-@pinned_recording_api_bp.route("/pin/delete/<pinned_id>", methods=["POST"])
+@pinned_recording_api_bp.route("/pin/delete/<row_id>", methods=["POST"])
 @crossdomain(headers="Authorization, Content-Type")
 @ratelimit()
-def delete_pin_for_user(pinned_id):
+def delete_pin_for_user(row_id):
     """
-    Deletes the pinned recording with given ``pinned_id`` from the server.
+    Deletes the pinned recording with given ``row_id`` from the server.
     A user token (found on  https://listenbrainz.org/profile/) must be provided in the Authorization header!
 
     :reqheader Authorization: Token <user token>
-    :param pinned_id: the pinned_id of the pinned recording that should be deleted.
-    :type pinned_id: ``int``
+    :param row_id: the row_id of the pinned recording that should be deleted.
+    :type row_id: ``int``
     :statuscode 200: recording unpinned.
     :statuscode 401: invalid authorization. See error message for details.
-    :statuscode 404: the requested pinned_id for the user was not found.
+    :statuscode 404: the requested row_id for the user was not found.
     :resheader Content-Type: *application/json*
     """
     user = validate_auth_header()
 
     try:
-        recording_deleted = db_pinned_rec.delete(pinned_id, user["id"])
+        recording_deleted = db_pinned_rec.delete(row_id, user["id"])
     except Exception as e:
         current_app.logger.error("Error while unpinning recording for user: {}".format(e))
         raise APIInternalServerError("Something went wrong. Please try again.")
 
     if recording_deleted is False:
-        raise APINotFound("Cannot find pin with pinned_id '%s' for user '%s'" % (pinned_id, user["musicbrainz_id"]))
+        raise APINotFound("Cannot find pin with row_id '%s' for user '%s'" % (row_id, user["musicbrainz_id"]))
 
     return jsonify({"status": "ok"})
 
@@ -144,10 +144,15 @@ def get_pins_for_user(user_name):
                 {
                     "blurb_content": "Awesome recording!",
                     "created": 1623997168,
-                    "pinned_id": 10,
+                    "row_id": 10,
                     "pinned_until": 1623997485,
                     "recording_mbid": null,
                     "recording_msid": "fd7d9162-a284-4a10-906c-faae4f1e166b"
+                    "track_metadata": {
+                        "artist_msid": "8c7b4641-e363-4598-ae70-7709840fb934",
+                        "artist_name": "Rick Astley",
+                        "track_name": "Never Gonna Give You Up"
+                        }
                 },
                 "-- more pinned recording items here ---"
             ],
@@ -184,6 +189,7 @@ def get_pins_for_user(user_name):
         current_app.logger.error("Error while retrieving pins for user: {}".format(e))
         raise APIInternalServerError("Something went wrong. Please try again.")
 
+    pinned_recordings = fetch_track_metadata_for_pins(pinned_recordings)
     pinned_recordings = [_pinned_recording_to_api(pin) for pin in pinned_recordings]
     total_count = db_pinned_rec.get_pin_count_for_user(user_id=user["id"])
 
@@ -214,10 +220,15 @@ def get_pins_for_user_following(user_name):
                 {
                 "blurb_content": "Spectacular recording!",
                 "created": 1624000841,
-                "pinned_id": 1,
+                "row_id": 1,
                 "pinned_until": 1624605641,
                 "recording_mbid": null,
                 "recording_msid": "40ef0ae1-5626-43eb-838f-1b34187519bf",
+                "track_metadata": {
+                        "artist_msid": "8c7b4641-e363-4598-ae70-7709840fb934",
+                        "artist_name": "Rick Astley",
+                        "track_name": "Never Gonna Give You Up"
+                },
                 "user_name": "-- the MusicBrainz ID of the user who pinned this recording --"
                 },
                 "-- more pinned recordings from different users here ---"
@@ -250,6 +261,7 @@ def get_pins_for_user_following(user_name):
         raise APINotFound("Cannot find user: %s" % user_name)
 
     pinned_recordings = db_pinned_rec.get_pins_for_user_following(user_id=user["id"], count=count, offset=offset)
+    pinned_recordings = fetch_track_metadata_for_pins(pinned_recordings)
     pinned_recordings = [_pinned_recording_to_api(pin) for pin in pinned_recordings]
 
     return jsonify(
@@ -266,8 +278,6 @@ def _pinned_recording_to_api(pinnedRecording: PinnedRecording) -> dict:
     pin = pinnedRecording.dict()
     pin["created"] = int(pin["created"].timestamp())
     pin["pinned_until"] = int(pin["pinned_until"].timestamp())
-    pin["pinned_id"] = pin["row_id"]
-    del pin["row_id"]
     del pin["user_id"]
     if pin["user_name"] is None:
         del pin["user_name"]


### PR DESCRIPTION
(this PR doesn't depend on any others to be merged)

This PR mainly makes 2 changes to pins:
1) renaming `pinned_id `attribute to `row_id` everywhere: Pinned_id's were being returned by the API while row_id was used in front-end, so I'm renaming it to avoid confusion.
2)  `track_metadata` is now returned by the API when fetching pins. This way, we don't have to make additional API calls from the frontend to obtain the track name and artist name.