### PR TITLE
Add getPins/getPinCount functions to APIService 

### DIFF
--- a/listenbrainz/webserver/static/js/src/APIService.test.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.test.ts
@@ -883,9 +883,12 @@ describe("getPinsForUser", () => {
 
   it("calls fetch with correct parameters", async () => {
     await apiService.getPinsForUser("jdaok", 25, 25);
-    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins?offset=25&count=25", {
-      method: "GET",
-    });
+    expect(window.fetch).toHaveBeenCalledWith(
+      "foobar/1/jdaok/pins?offset=25&count=25",
+      {
+        method: "GET",
+      }
+    );
   });
 
   it("returns the correct data objects", async () => {

--- a/listenbrainz/webserver/static/js/src/APIService.test.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.test.ts
@@ -1,6 +1,7 @@
 import APIService from "./APIService";
 
 const feedProps = require("./__mocks__/feedProps.json");
+const pinProps = require("./__mocks__/pinProps.json");
 
 const apiService = new APIService("foobar");
 
@@ -861,5 +862,92 @@ describe("recommendTrackToFollowers", () => {
     it("returns the response code if successful", async () => {
       await expect(apiService.deletePin("foobar", 1337)).resolves.toEqual(200);
     });
+  });
+});
+
+describe("getPinsForUser", () => {
+  const payload = { ...pinProps };
+  beforeEach(() => {
+    // Mock function for fetch
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => payload,
+      });
+    });
+
+    // Mock function for checkStatus
+    apiService.checkStatus = jest.fn();
+  });
+
+  it("calls fetch correctly with offset parameter", async () => {
+    await apiService.getPinsForUser("jdaok");
+    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins", {
+      method: "GET",
+    });
+
+    await apiService.getPinsForUser("jdaok", 25);
+    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins?offset=25", {
+      method: "GET",
+    });
+  });
+
+  it("returns the correct PinnedRecording objects", async () => {
+    const result = await apiService.getPinsForUser("jdaok");
+    expect(result).toEqual(payload.pinned_recordings);
+  });
+
+  it("throws appropriate error if username is missing", async () => {
+    await expect(apiService.getPinsForUser("")).rejects.toThrow(
+      SyntaxError("Username missing")
+    );
+  });
+
+  it("calls checkStatus once", async () => {
+    apiService.checkStatus = jest.fn();
+    await apiService.getPinsForUser("jdaok");
+    expect(apiService.checkStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getPinCountForUser", () => {
+  const payload = { ...pinProps };
+  beforeEach(() => {
+    // Mock function for fetch
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => payload,
+      });
+    });
+
+    // Mock function for checkStatus
+    apiService.checkStatus = jest.fn();
+  });
+
+  it("calls fetch correctly", async () => {
+    await apiService.getPinCountForUser("jdaok");
+    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins", {
+      method: "GET",
+    });
+  });
+
+  it("returns a number", async () => {
+    const result = await apiService.getPinCountForUser("jdaok");
+    expect(result).toEqual(41);
+  });
+
+  it("throws appropriate error if username is missing", async () => {
+    await expect(apiService.getPinCountForUser("")).rejects.toThrow(
+      SyntaxError("Username missing")
+    );
+  });
+
+  it("calls checkStatus once", async () => {
+    apiService.checkStatus = jest.fn();
+    await apiService.getPinCountForUser("jdaok");
+    expect(apiService.checkStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/listenbrainz/webserver/static/js/src/APIService.test.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.test.ts
@@ -881,73 +881,27 @@ describe("getPinsForUser", () => {
     apiService.checkStatus = jest.fn();
   });
 
-  it("calls fetch correctly with offset parameter", async () => {
-    await apiService.getPinsForUser("jdaok");
-    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins", {
-      method: "GET",
-    });
-
-    await apiService.getPinsForUser("jdaok", 25);
-    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins?offset=25", {
+  it("calls fetch with correct parameters", async () => {
+    await apiService.getPinsForUser("jdaok", 25, 25);
+    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins?offset=25&count=25", {
       method: "GET",
     });
   });
 
-  it("returns the correct PinnedRecording objects", async () => {
-    const result = await apiService.getPinsForUser("jdaok");
-    expect(result).toEqual(payload.pinned_recordings);
+  it("returns the correct data objects", async () => {
+    const result = await apiService.getPinsForUser("jdaok", 25, 25);
+    expect(result).toEqual(payload);
   });
 
   it("throws appropriate error if username is missing", async () => {
-    await expect(apiService.getPinsForUser("")).rejects.toThrow(
+    await expect(apiService.getPinsForUser("", 25, 25)).rejects.toThrow(
       SyntaxError("Username missing")
     );
   });
 
   it("calls checkStatus once", async () => {
     apiService.checkStatus = jest.fn();
-    await apiService.getPinsForUser("jdaok");
-    expect(apiService.checkStatus).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("getPinCountForUser", () => {
-  const payload = { ...pinProps };
-  beforeEach(() => {
-    // Mock function for fetch
-    window.fetch = jest.fn().mockImplementation(() => {
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => payload,
-      });
-    });
-
-    // Mock function for checkStatus
-    apiService.checkStatus = jest.fn();
-  });
-
-  it("calls fetch correctly", async () => {
-    await apiService.getPinCountForUser("jdaok");
-    expect(window.fetch).toHaveBeenCalledWith("foobar/1/jdaok/pins", {
-      method: "GET",
-    });
-  });
-
-  it("returns correct number", async () => {
-    const result = await apiService.getPinCountForUser("jdaok");
-    expect(result).toEqual(41);
-  });
-
-  it("throws appropriate error if username is missing", async () => {
-    await expect(apiService.getPinCountForUser("")).rejects.toThrow(
-      SyntaxError("Username missing")
-    );
-  });
-
-  it("calls checkStatus once", async () => {
-    apiService.checkStatus = jest.fn();
-    await apiService.getPinCountForUser("jdaok");
+    await apiService.getPinsForUser("jdaok", 25, 25);
     expect(apiService.checkStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/listenbrainz/webserver/static/js/src/APIService.test.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.test.ts
@@ -934,7 +934,7 @@ describe("getPinCountForUser", () => {
     });
   });
 
-  it("returns a number", async () => {
+  it("returns correct number", async () => {
     const result = await apiService.getPinCountForUser("jdaok");
     expect(result).toEqual(41);
   });

--- a/listenbrainz/webserver/static/js/src/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.ts
@@ -843,18 +843,12 @@ export default class APIService {
     return response.status;
   };
 
-  getPinsForUser = async (
-    userName: string,
-    offset?: number
-  ): Promise<Array<PinnedRecording>> => {
+  getPinsForUser = async (userName: string, offset: number, count: number) => {
     if (!userName) {
       throw new SyntaxError("Username missing");
     }
 
-    let query = `${this.APIBaseURI}/${userName}/pins`;
-    if (offset) {
-      query += `?offset=${offset}`;
-    }
+    const query = `${this.APIBaseURI}/${userName}/pins?offset=${offset}&count=${count}`;
 
     const response = await fetch(query, {
       method: "GET",
@@ -862,22 +856,6 @@ export default class APIService {
 
     await this.checkStatus(response);
     const data = await response.json();
-    return data.pinned_recordings;
-  };
-
-  getPinCountForUser = async (userName: string): Promise<number> => {
-    if (!userName) {
-      throw new SyntaxError("Username missing");
-    }
-    const query = `${this.APIBaseURI}/${userName}/pins`;
-
-    const response = await fetch(query, {
-      method: "GET",
-    });
-
-    await this.checkStatus(response);
-    const data = await response.json();
-
-    return data.total_count;
+    return data;
   };
 }

--- a/listenbrainz/webserver/static/js/src/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.ts
@@ -842,4 +842,42 @@ export default class APIService {
     await this.checkStatus(response);
     return response.status;
   };
+
+  getPinsForUser = async (
+    userName: string,
+    offset?: number
+  ): Promise<Array<PinnedRecording>> => {
+    if (!userName) {
+      throw new SyntaxError("Username missing");
+    }
+
+    let query = `${this.APIBaseURI}/${userName}/pins`;
+    if (offset) {
+      query += `?offset=${offset}`;
+    }
+
+    const response = await fetch(query, {
+      method: "GET",
+    });
+
+    await this.checkStatus(response);
+    const data = await response.json();
+    return data.pinned_recordings;
+  };
+
+  getPinCountForUser = async (userName: string): Promise<number> => {
+    if (!userName) {
+      throw new SyntaxError("Username missing");
+    }
+    const query = `${this.APIBaseURI}/${userName}/pins`;
+
+    const response = await fetch(query, {
+      method: "GET",
+    });
+
+    await this.checkStatus(response);
+    const data = await response.json();
+
+    return data.total_count;
+  };
 }

--- a/listenbrainz/webserver/static/js/src/__mocks__/pinProps.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/pinProps.json
@@ -1,0 +1,333 @@
+{
+    "count": 25,
+    "offset": 0,
+    "pinned_recordings": [
+        {
+            "blurb_content": null,
+            "created": 1628753018,
+            "pinned_until": 1629357818,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 53,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719732,
+            "pinned_until": 1628719735,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 44,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719729,
+            "pinned_until": 1628719732,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 43,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719727,
+            "pinned_until": 1628719729,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 42,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719724,
+            "pinned_until": 1628719727,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 41,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719721,
+            "pinned_until": 1628719724,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 40,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719718,
+            "pinned_until": 1628719721,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 39,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719716,
+            "pinned_until": 1628719718,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 38,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719712,
+            "pinned_until": 1628719716,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 37,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719709,
+            "pinned_until": 1628719712,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 36,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719693,
+            "pinned_until": 1628719709,
+            "recording_mbid": null,
+            "recording_msid": "07e7cb6a-5a96-4d6e-a126-cc8b896a077c",
+            "row_id": 35,
+            "track_metadata": {
+                "artist_msid": "c4f169e8-ce2d-4901-9450-31b5f1a8ccbb",
+                "artist_name": "Nicki Minaj, Drake & Lil Wayne",
+                "track_name": "Seeing Green"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719690,
+            "pinned_until": 1628719693,
+            "recording_mbid": null,
+            "recording_msid": "0fe0ab88-0501-4575-8971-edf05ee5c944",
+            "row_id": 34,
+            "track_metadata": {
+                "artist_msid": "794da5ac-27e7-4483-8e05-29b269e90063",
+                "artist_name": "Imogen Heap",
+                "track_name": "The Walk"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719687,
+            "pinned_until": 1628719690,
+            "recording_mbid": null,
+            "recording_msid": "a539519f-e99e-4a6a-acc8-b80f6cd38476",
+            "row_id": 33,
+            "track_metadata": {
+                "artist_msid": "edbb5ff8-ebd3-42e1-96c2-e22d4e4c080a",
+                "artist_name": "Lorde",
+                "track_name": "400 Lux"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628719683,
+            "pinned_until": 1628719687,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 32,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": "asdasd",
+            "created": 1628711786,
+            "pinned_until": 1628719683,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 31,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": null,
+            "created": 1628711647,
+            "pinned_until": 1628711786,
+            "recording_mbid": null,
+            "recording_msid": "a539519f-e99e-4a6a-acc8-b80f6cd38476",
+            "row_id": 30,
+            "track_metadata": {
+                "artist_msid": "edbb5ff8-ebd3-42e1-96c2-e22d4e4c080a",
+                "artist_name": "Lorde",
+                "track_name": "400 Lux"
+            }
+        },
+        {
+            "blurb_content": "dsasdasdasda",
+            "created": 1628711334,
+            "pinned_until": 1628711647,
+            "recording_mbid": null,
+            "recording_msid": "90dab040-f0a5-4984-ab33-6c8729f102b9",
+            "row_id": 29,
+            "track_metadata": {
+                "artist_msid": "7c7b4641-e363-4598-ae70-7709840fb934",
+                "artist_name": "Cascada",
+                "track_name": "Bad Boy (Nightcore) - Single"
+            }
+        },
+        {
+            "blurb_content": "7",
+            "created": 1628708857,
+            "pinned_until": 1628711316,
+            "recording_mbid": null,
+            "recording_msid": "109c237d-c94a-4630-a83c-c022024ce22d",
+            "row_id": 28,
+            "track_metadata": {
+                "artist_msid": "ffec1dfc-96e0-4db7-b7a5-ebda8ff1d18c",
+                "artist_name": "Chairlift",
+                "track_name": "Crying in Public"
+            }
+        },
+        {
+            "blurb_content": "6",
+            "created": 1628708841,
+            "pinned_until": 1628708857,
+            "recording_mbid": null,
+            "recording_msid": "388ba2f8-d5df-4f11-b36b-2348675f6ac7",
+            "row_id": 27,
+            "track_metadata": {
+                "artist_msid": "ced786c1-ebda-4fa2-99e2-649a16091e48",
+                "artist_name": "Carly Rae Jepsen",
+                "track_name": "Emotion"
+            }
+        },
+        {
+            "blurb_content": "5",
+            "created": 1628708833,
+            "pinned_until": 1628708841,
+            "recording_mbid": null,
+            "recording_msid": "46e2aa24-2e46-456a-a449-56c4a6f97364",
+            "row_id": 26,
+            "track_metadata": {
+                "artist_msid": "a0443fc9-0cf5-4689-88e6-cc53c9cf2c05",
+                "artist_name": "Kelela",
+                "track_name": "Blue Light"
+            }
+        },
+        {
+            "blurb_content": "3",
+            "created": 1628708821,
+            "pinned_until": 1628708826,
+            "recording_mbid": null,
+            "recording_msid": "23697e32-0770-49d6-a894-ea7de4568791",
+            "row_id": 24,
+            "track_metadata": {
+                "artist_msid": "0b172d06-0fc9-4c2d-9db9-e254bd626c58",
+                "artist_name": "Marina & the Diamonds",
+                "track_name": "I'm a Ruin"
+            }
+        },
+        {
+            "blurb_content": "2",
+            "created": 1628708815,
+            "pinned_until": 1628708821,
+            "recording_mbid": null,
+            "recording_msid": "0f425bf6-42b5-4df9-ab87-2280980caed0",
+            "row_id": 23,
+            "track_metadata": {
+                "artist_msid": "41ebe526-6952-4520-ac12-3e8fd8d2535e",
+                "artist_name": "Caroline Polachek",
+                "track_name": "Bunny is a Rider"
+            }
+        },
+        {
+            "blurb_content": "1",
+            "created": 1628708807,
+            "pinned_until": 1628708815,
+            "recording_mbid": null,
+            "recording_msid": "21f18f6f-768c-40fb-a45d-fa769c002362",
+            "row_id": 22,
+            "track_metadata": {
+                "artist_msid": "ffec1dfc-96e0-4db7-b7a5-ebda8ff1d18c",
+                "artist_name": "Chairlift",
+                "track_name": "Amanaemonesia"
+            }
+        },
+        {
+            "blurb_content": "3",
+            "created": 1628708794,
+            "pinned_until": 1628708807,
+            "recording_mbid": null,
+            "recording_msid": "67cebe1f-debf-423e-89cb-f2710f1f63d3",
+            "row_id": 21,
+            "track_metadata": {
+                "artist_msid": "dd755d47-87af-4779-8651-e87d4e423447",
+                "artist_name": "宇多田ヒカル",
+                "track_name": "Simple and Clean (PLANiTb Remix)"
+            }
+        },
+        {
+            "blurb_content": "asf",
+            "created": 1628708784,
+            "pinned_until": 1628708788,
+            "recording_mbid": null,
+            "recording_msid": "4b2aa0c6-e29e-458e-a3f0-a4c08b5a57f9",
+            "row_id": 19,
+            "track_metadata": {
+                "artist_msid": "a95616a0-808b-4e1f-9816-eff6d511a426",
+                "artist_name": "Hannah Diamond",
+                "track_name": "Make Believe"
+            }
+        }
+    ],
+    "total_count": 41,
+    "user_name": "jdaok"
+}

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -464,6 +464,7 @@ declare type PinnedRecording = {
   pinned_until: number;
   row_id: number;
   recording_mbid: string;
+  recording_msid?: string;
   track_metadata: {
     artist_name: string;
     release_name?: string | null;


### PR DESCRIPTION
(this PR doesn't depend on any others to be merged)

This PR adds `getPinsForUser()` and `getPinCountForUser()` to APIService. These functions will be used for the pin history tab, for pagination / fetching pins.

**Next: #1581** 
