### PR TITLE
LB-940: Modify the fields in Stats API response to maintain compatibility

### DIFF
--- a/data/model/sitewide_artist_stat.py
+++ b/data/model/sitewide_artist_stat.py
@@ -13,6 +13,8 @@ class SitewideArtistRecord(pydantic.BaseModel):
     artist_mbids: List[str] = []
     listen_count: int
     artist_name: str
+    # to add an empty field to stats API response, for compatibility
+    artist_msid: Optional[str]
 
 
 class SitewideArtistStatRange(pydantic.BaseModel):

--- a/data/model/user_artist_stat.py
+++ b/data/model/user_artist_stat.py
@@ -12,6 +12,8 @@ class UserArtistRecord(pydantic.BaseModel):
     artist_mbids: List[str] = []
     listen_count: int
     artist_name: str
+    # to add an empty field to stats API response, for compatibility
+    artist_msid: Optional[str]
 
 
 class UserArtistStatRange(pydantic.BaseModel):

--- a/data/model/user_recording_stat.py
+++ b/data/model/user_recording_stat.py
@@ -14,6 +14,10 @@ class UserRecordingRecord(pydantic.BaseModel):
     release_mbid: Optional[str]
     recording_name: str
     listen_count: int
+    # to add empty fields to stats API response, for compatibility
+    artist_msid: Optional[str]
+    recording_msid: Optional[str]
+    release_msid: Optional[str]
 
 
 class UserRecordingStatRange(pydantic.BaseModel):

--- a/data/model/user_recording_stat.py
+++ b/data/model/user_recording_stat.py
@@ -12,7 +12,7 @@ class UserRecordingRecord(pydantic.BaseModel):
     recording_mbid: Optional[str]
     release_name: Optional[str]
     release_mbid: Optional[str]
-    recording_name: str
+    track_name: str
     listen_count: int
     # to add empty fields to stats API response, for compatibility
     artist_msid: Optional[str]

--- a/data/model/user_release_stat.py
+++ b/data/model/user_release_stat.py
@@ -12,6 +12,9 @@ class UserReleaseRecord(pydantic.BaseModel):
     release_name: str
     listen_count: int
     artist_name: str
+    # to add empty fields to stats API response, for compatibility
+    artist_msid: Optional[str]
+    release_msid: Optional[str]
 
 
 class UserReleaseStatRange(pydantic.BaseModel):

--- a/listenbrainz/testdata/sitewide_top_artists_db.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db.json
@@ -1,30 +1,36 @@
 {
-  "from_ts": 1009843200,
-  "time_ranges": [
-    {
-      "artists": [
+    "from_ts": 1009843200,
+    "time_ranges": [
         {
-          "artist_mbids": ["cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"],
-          "artist_name": "Judas Priest",
-          "listen_count": 2521
-        }
-      ],
-      "from_ts": 1104537600,
-      "time_range": "2005",
-      "to_ts": 1136073599
-    },
-    {
-      "artists": [
+            "artists": [
+                {
+                    "artist_mbids": [
+                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
+                    ],
+                    "listen_count": 2521,
+                    "artist_name": "Judas Priest",
+                    "artist_msid": null
+                }
+            ],
+            "from_ts": 1104537600,
+            "time_range": "2005",
+            "to_ts": 1136073599
+        },
         {
-          "artist_mbids": ["cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"],
-          "artist_name": "Judas Priest",
-          "listen_count": 1354
+            "artists": [
+                {
+                    "artist_mbids": [
+                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
+                    ],
+                    "listen_count": 1354,
+                    "artist_name": "Judas Priest",
+                    "artist_msid": null
+                }
+            ],
+            "from_ts": 1136073600,
+            "time_range": "2006",
+            "to_ts": 1167609599
         }
-      ],
-      "from_ts": 1136073600,
-      "time_range": "2006",
-      "to_ts": 1167609599
-    }
-  ],
-  "to_ts": 1593043183
+    ],
+    "to_ts": 1593043183
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test.json
@@ -8,211 +8,241 @@
                     "artist_mbids": [
                         "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
                     ],
+                    "listen_count": 2521,
                     "artist_name": "Judas Priest",
-                    "listen_count": 2521
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
                     ],
+                    "listen_count": 813,
                     "artist_name": "Slayer",
-                    "listen_count": 813
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2f13b1cb-32e3-45c6-8b87-25629490ac44"
                     ],
+                    "listen_count": 770,
                     "artist_name": "Iron Maiden",
-                    "listen_count": 770
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
                     ],
+                    "listen_count": 726,
                     "artist_name": "Black Label Society",
-                    "listen_count": 726
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
                     ],
+                    "listen_count": 667,
                     "artist_name": "Arch Enemy",
-                    "listen_count": 667
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e6a8399-a625-4151-9bba-3994b033957e"
                     ],
+                    "listen_count": 608,
                     "artist_name": "Black Sabbath",
-                    "listen_count": 608
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "87e396ef-3ee0-4ff2-853c-6174c4243df6"
                     ],
+                    "listen_count": 592,
                     "artist_name": "Foo Fighters",
-                    "listen_count": 592
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f6804334-5021-4e52-9f71-3ea924e6abc6"
                     ],
+                    "listen_count": 569,
                     "artist_name": "Evergrey",
-                    "listen_count": 569
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
                     ],
+                    "listen_count": 558,
                     "artist_name": "Alanis Morissette",
-                    "listen_count": 558
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "61746abb-76a5-465d-aee7-c4c42d61b7c4"
                     ],
+                    "listen_count": 501,
                     "artist_name": "Massive Attack",
-                    "listen_count": 501
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "79f83982-a0a1-4907-b12e-dc974868e219"
                     ],
+                    "listen_count": 475,
                     "artist_name": "Audioslave",
-                    "listen_count": 475
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "38742bd1-2ceb-4854-a138-206d095cdcc0"
                     ],
+                    "listen_count": 473,
                     "artist_name": "Opeth",
-                    "listen_count": 473
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
                     ],
+                    "listen_count": 466,
                     "artist_name": "Tiamat",
-                    "listen_count": 466
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c707783d-53b6-47fc-8c94-4d5323489209"
                     ],
+                    "listen_count": 457,
                     "artist_name": "Avril Lavigne",
-                    "listen_count": 457
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "58914eb6-0518-45eb-a917-9985aa1cd374"
                     ],
+                    "listen_count": 453,
                     "artist_name": "Emperor",
-                    "listen_count": 453
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "69ab35a3-c877-484a-8db9-4569010e72ed"
                     ],
+                    "listen_count": 451,
                     "artist_name": "Nine Inch Nails",
-                    "listen_count": 451
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "844c13e8-9264-41f1-acc1-a59be2af611e"
                     ],
+                    "listen_count": 440,
                     "artist_name": "In Flames",
-                    "listen_count": 440
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
                     ],
+                    "listen_count": 414,
                     "artist_name": "Megadeth",
-                    "listen_count": 414
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a3c5dedf-13bb-4df2-be11-285972577112"
                     ],
+                    "listen_count": 406,
                     "artist_name": "Metallica",
-                    "listen_count": 406
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
                     ],
+                    "listen_count": 371,
                     "artist_name": "Katatonia",
-                    "listen_count": 371
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "94f867bb-3542-4675-858e-86dafdd7a647"
                     ],
+                    "listen_count": 366,
                     "artist_name": "Ayreon",
-                    "listen_count": 366
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
                     ],
+                    "listen_count": 357,
                     "artist_name": "Darkthrone",
-                    "listen_count": 357
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f5b259cb-2323-41f7-9d19-32e69e79a87e"
                     ],
+                    "listen_count": 313,
                     "artist_name": "Kitaro",
-                    "listen_count": 313
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "114378b9-019b-48ab-a6af-0e122cf6c056"
                     ],
+                    "listen_count": 312,
                     "artist_name": "Bathory",
-                    "listen_count": 312
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8d0f8872-4527-4604-8e35-705afc9f50e6"
                     ],
+                    "listen_count": 299,
                     "artist_name": "Dream Theater",
-                    "listen_count": 299
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "12379346-99d9-4941-b4a2-f04144a39863"
                     ],
+                    "listen_count": 294,
                     "artist_name": "Iced Earth",
-                    "listen_count": 294
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
                     ],
+                    "listen_count": 269,
                     "artist_name": "System of a Down",
-                    "listen_count": 269
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "662105c0-9830-4ea7-9637-1aa5cedc9650"
                     ],
+                    "listen_count": 269,
                     "artist_name": "Paradise Lost",
-                    "listen_count": 269
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f0aa3926-f243-4c5d-9162-6fee7f811934"
                     ],
+                    "listen_count": 269,
                     "artist_name": "Cradle of Filth",
-                    "listen_count": 269
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
                     ],
+                    "listen_count": 268,
                     "artist_name": "Sentenced",
-                    "listen_count": 268
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1104537600,
@@ -225,211 +255,241 @@
                     "artist_mbids": [
                         "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
                     ],
+                    "listen_count": 1354,
                     "artist_name": "Judas Priest",
-                    "listen_count": 1354
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f6804334-5021-4e52-9f71-3ea924e6abc6"
                     ],
+                    "listen_count": 691,
                     "artist_name": "Evergrey",
-                    "listen_count": 691
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "431cc9fb-ef90-4819-9c7b-2229c298727c"
                     ],
+                    "listen_count": 641,
                     "artist_name": "Danko Jones",
-                    "listen_count": 641
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "87e396ef-3ee0-4ff2-853c-6174c4243df6"
                     ],
+                    "listen_count": 606,
                     "artist_name": "Foo Fighters",
-                    "listen_count": 606
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
                     ],
+                    "listen_count": 584,
                     "artist_name": "Katatonia",
-                    "listen_count": 584
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4b321558-10b1-4d93-9bed-7c9048e28ecb"
                     ],
+                    "listen_count": 556,
                     "artist_name": "The Hellacopters",
-                    "listen_count": 556
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fcee89d2-70a6-4149-afd3-90806ddc650d"
                     ],
+                    "listen_count": 504,
                     "artist_name": "Death Cab for Cutie",
-                    "listen_count": 504
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "645129c1-9b76-48c0-a3af-c87b284265a3"
                     ],
+                    "listen_count": 470,
                     "artist_name": "The Darkness",
-                    "listen_count": 470
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e9e619a9-5170-4ef7-bfeb-29ef64ed3f5d"
                     ],
+                    "listen_count": 461,
                     "artist_name": "Turbonegro",
-                    "listen_count": 461
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
                     ],
+                    "listen_count": 415,
                     "artist_name": "Black Label Society",
-                    "listen_count": 415
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "79f83982-a0a1-4907-b12e-dc974868e219"
                     ],
+                    "listen_count": 405,
                     "artist_name": "Audioslave",
-                    "listen_count": 405
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "94f867bb-3542-4675-858e-86dafdd7a647"
                     ],
+                    "listen_count": 402,
                     "artist_name": "Ayreon",
-                    "listen_count": 402
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ceff4c9-fe82-444a-ba9d-20e724e04190"
                     ],
+                    "listen_count": 394,
                     "artist_name": "Strapping Young Lad",
-                    "listen_count": 394
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
                     ],
+                    "listen_count": 385,
                     "artist_name": "Slayer",
-                    "listen_count": 385
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
                     ],
+                    "listen_count": 347,
                     "artist_name": "The Cardigans",
-                    "listen_count": 347
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
                     ],
+                    "listen_count": 342,
                     "artist_name": "The Offspring",
-                    "listen_count": 342
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
                     ],
+                    "listen_count": 329,
                     "artist_name": "Arch Enemy",
-                    "listen_count": 329
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "574dfe13-97aa-4318-8e4a-0ec79e05db24"
                     ],
+                    "listen_count": 324,
                     "artist_name": "Hoobastank",
-                    "listen_count": 324
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "540eebc9-0fc6-41df-8372-2c1a534e92e3"
                     ],
+                    "listen_count": 316,
                     "artist_name": "Depeche Mode",
-                    "listen_count": 316
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99eec84e-42cb-4f47-b80f-ce46ca65735b"
                     ],
+                    "listen_count": 305,
                     "artist_name": "Panic! at the Disco",
-                    "listen_count": 305
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
                     ],
+                    "listen_count": 297,
                     "artist_name": "Mot\u00f6rhead",
-                    "listen_count": 297
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dbed7c10-e68c-4805-9295-09c48c06b897"
                     ],
+                    "listen_count": 292,
                     "artist_name": "W.A.S.P.",
-                    "listen_count": 292
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "38742bd1-2ceb-4854-a138-206d095cdcc0"
                     ],
+                    "listen_count": 275,
                     "artist_name": "Opeth",
-                    "listen_count": 275
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
                     ],
+                    "listen_count": 268,
                     "artist_name": "The Postal Service",
-                    "listen_count": 268
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2f13b1cb-32e3-45c6-8b87-25629490ac44"
                     ],
+                    "listen_count": 264,
                     "artist_name": "Iron Maiden",
-                    "listen_count": 264
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d3e64ede-3456-4f67-952c-fa0b7d05231a"
                     ],
+                    "listen_count": 262,
                     "artist_name": "Wizo",
-                    "listen_count": 262
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e6a8399-a625-4151-9bba-3994b033957e"
                     ],
+                    "listen_count": 249,
                     "artist_name": "Black Sabbath",
-                    "listen_count": 249
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6599e41e-390c-4855-a2ac-68ee798538b4"
                     ],
+                    "listen_count": 246,
                     "artist_name": "Coldplay",
-                    "listen_count": 246
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
                     ],
+                    "listen_count": 244,
                     "artist_name": "D-A-D",
-                    "listen_count": 244
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "12379346-99d9-4941-b4a2-f04144a39863"
                     ],
+                    "listen_count": 238,
                     "artist_name": "Iced Earth",
-                    "listen_count": 238
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1136073600,

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_month.json
@@ -8,211 +8,241 @@
                     "artist_mbids": [
                         "a200b8a0-2248-4abb-9454-5f99750be117"
                     ],
+                    "listen_count": 90,
                     "artist_name": "Dance Gavin Dance",
-                    "listen_count": 90
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b9956564-f7fd-4c97-a3fa-b88b157affa1"
                     ],
+                    "listen_count": 42,
                     "artist_name": "Vader",
-                    "listen_count": 42
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b5e3b53e-34e1-4dd3-bb39-6ffcf61e0855"
                     ],
+                    "listen_count": 31,
                     "artist_name": "The Clash",
-                    "listen_count": 31
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "000a993a-03af-48f4-a810-e0524fda111a"
                     ],
+                    "listen_count": 25,
                     "artist_name": "Webb Pierce",
-                    "listen_count": 25
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b6082729-fc87-4a0f-b874-00ae560c6f29"
                     ],
+                    "listen_count": 24,
                     "artist_name": "Citizen Bravo & Raymond MacDonald",
-                    "listen_count": 24
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e29fd013-45c0-4edd-abe2-8635fdd0502a"
                     ],
+                    "listen_count": 20,
                     "artist_name": "Lana Del Rey",
-                    "listen_count": 20
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "517ac5e2-0a9f-4974-8233-44be9bec9c42"
                     ],
+                    "listen_count": 20,
                     "artist_name": "Grinderman",
-                    "listen_count": 20
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "52758846-744f-4295-8dbc-6a4caf77459c"
                     ],
+                    "listen_count": 18,
                     "artist_name": "Pink Floyd",
-                    "listen_count": 18
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "aa5bc83f-70a7-4f21-8b00-60309b7fa1d1"
                     ],
+                    "listen_count": 17,
                     "artist_name": "The Colorist & Emil\u00edana Torrini",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3f4ed551-99ce-422a-aaee-04829c60cbb9"
                     ],
+                    "listen_count": 17,
                     "artist_name": "David Thomas Broughton",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "bf4cb1ee-7a93-44d6-9463-c46063506a20"
                     ],
+                    "listen_count": 16,
                     "artist_name": "Portishead",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "50789a5a-0fcf-4427-b105-2270cd9baf0b"
                     ],
+                    "listen_count": 15,
                     "artist_name": "Witchcraft",
-                    "listen_count": 15
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "abe14328-4e15-413c-8ad6-ac8a174aedcd"
                     ],
+                    "listen_count": 15,
                     "artist_name": "Sampa The Great",
-                    "listen_count": 15
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "92867b62-c838-4bbd-97dc-07681b3b0439"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Moacir Santos",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8bf0a378-f5e9-4029-9733-debf6bbf75f8"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Crash Test Dummies",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "bfff03a0-bb31-4225-a12b-fc11df420cc6"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Code Orange",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Bring Me the Horizon",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f7c2b580-1935-4bbb-8f3b-476cc6215ef2"
                     ],
+                    "listen_count": 13,
                     "artist_name": "The Warlocks",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c8fee4af-cf1c-4676-809b-930251b57289"
                     ],
+                    "listen_count": 13,
                     "artist_name": "Solange",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "aebd2c50-9eed-447d-b8b0-dbdbe5850ba8"
                     ],
+                    "listen_count": 13,
                     "artist_name": "Snow Patrol",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c613a9c8-9b8d-4cf6-89a8-fd40afe62e59"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Suzanne Vega",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "38ff2a96-ef90-42ef-b4f7-ef6afc9de0b7"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Jace Everett",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0a93648a-7c2f-4346-b117-f6eeb4395fa9"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Inka",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6f5db00a-3ddc-47cf-aa90-0fffc4fb6d58"
                     ],
+                    "listen_count": 12,
                     "artist_name": "EL VY",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f7422d0f-6dd6-4c16-97b9-8c8500a0567a"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Alex Rex",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b55293d2-87eb-4ca3-93bd-72d1529e21ae"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Rokia Traor\u00e9",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "bba02547-375b-46cb-b5e4-c94bdfc29693"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Havok",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "feff5fdb-cfba-40b7-af26-541445a15ef9"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Bonny Light Horseman",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "24a56abe-bcbc-4408-835e-739124e9f818"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Westside Gunn",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "92423ebd-10d7-478d-85db-920b1fb94ead"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Voivod",
-                    "listen_count": 10
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1588291200,
@@ -225,211 +255,241 @@
                     "artist_mbids": [
                         "a200b8a0-2248-4abb-9454-5f99750be117"
                     ],
+                    "listen_count": 95,
                     "artist_name": "Dance Gavin Dance",
-                    "listen_count": 95
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e29fd013-45c0-4edd-abe2-8635fdd0502a"
                     ],
+                    "listen_count": 52,
                     "artist_name": "Lana Del Rey",
-                    "listen_count": 52
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1fd33ffc-d262-4fbd-9d8a-0cc28795cec1"
                     ],
+                    "listen_count": 34,
                     "artist_name": "Vel the Wonder",
-                    "listen_count": 34
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "97d4de44-fd69-4865-b25c-2f93a5110046"
                     ],
+                    "listen_count": 30,
                     "artist_name": "Fu Manchu",
-                    "listen_count": 30
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fcee89d2-70a6-4149-afd3-90806ddc650d"
                     ],
+                    "listen_count": 28,
                     "artist_name": "Death Cab for Cutie",
-                    "listen_count": 28
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "61b56aa7-6b17-4a12-987d-f6e3027d1a3c"
                     ],
+                    "listen_count": 26,
                     "artist_name": "Karnivool",
-                    "listen_count": 26
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
                     ],
+                    "listen_count": 19,
                     "artist_name": "Bring Me the Horizon",
-                    "listen_count": 19
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ff73b406-2a9f-430a-9ea3-eebd241ae0b3"
                     ],
+                    "listen_count": 16,
                     "artist_name": "R.E.M.",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "bb89657c-c0c6-4c2d-9233-619823a3b043"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Seth Lakeman",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "32150f6d-5ad6-4913-83fc-7b15bd847588"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Mastodon",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "00a2e257-eccc-466e-9c3f-c424281e20d3"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Torgeir Waldemar",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "732032de-66d9-44d0-8db8-eb139db32824"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Rita Marley",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "afa1780e-1194-476e-aa3a-31466ce62f2c"
                     ],
+                    "listen_count": 8,
                     "artist_name": "New Order",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9f5e9335-ca47-4f2d-979b-1890076ededc"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Silverstein",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "093b9f69-79bc-4e9c-bd00-040e926b0bf3"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Kaukasus",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b63ad51b-f30e-405a-abb3-75c57f4bc2f7"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Bones",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "be444ee2-0c08-4b49-9f7c-cf848ea27c69"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Trevor Daniel",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e9e1e99c-7439-4152-a170-d52d607b90b1"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Doja Cat",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cb43ab86-25c7-49b4-a086-83af74393978"
                     ],
+                    "listen_count": 5,
                     "artist_name": "The fin.",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "42b34077-464d-4e09-877e-077db701469d"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Jaira Burns",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4ffe7e89-a6f2-449a-92be-4ce0a62d9257"
                     ],
+                    "listen_count": 5,
                     "artist_name": "IAMDDB",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0006cb8e-897f-43a0-bdc4-b56b62d6ec29"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Black Veil Brides",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "54a3ad2a-a98e-436f-b0bf-8e48c4b79106"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Yorkston/Thorne/Khan",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b8e44f2e-3e42-4f0d-b7ef-6f874b882bad"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Whitechapel",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "139e13e9-1ebc-48fb-af90-97cf9909e632"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Vulfpeck",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9820da6d-66d9-424d-9f67-2654ed2f31e4"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Tame Impala",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
                     ],
+                    "listen_count": 4,
                     "artist_name": "System of a Down",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "50fa106f-e40d-49ec-bca1-9802fb2157e7"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Radiohead",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4aa12451-67b1-413e-86e4-71416e913aa6"
                     ],
+                    "listen_count": 4,
                     "artist_name": "New Hope Club",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "78df245f-0fe0-4a21-b1d4-e79f695354fd"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Gorillaz",
-                    "listen_count": 4
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1588377600,

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_too_many.json
@@ -8,708 +8,809 @@
                     "artist_mbids": [
                         "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
                     ],
+                    "listen_count": 2521,
                     "artist_name": "Judas Priest",
-                    "listen_count": 2521
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
                     ],
+                    "listen_count": 813,
                     "artist_name": "Slayer",
-                    "listen_count": 813
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2f13b1cb-32e3-45c6-8b87-25629490ac44"
                     ],
+                    "listen_count": 770,
                     "artist_name": "Iron Maiden",
-                    "listen_count": 770
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
                     ],
+                    "listen_count": 726,
                     "artist_name": "Black Label Society",
-                    "listen_count": 726
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
                     ],
+                    "listen_count": 667,
                     "artist_name": "Arch Enemy",
-                    "listen_count": 667
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e6a8399-a625-4151-9bba-3994b033957e"
                     ],
+                    "listen_count": 608,
                     "artist_name": "Black Sabbath",
-                    "listen_count": 608
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "87e396ef-3ee0-4ff2-853c-6174c4243df6"
                     ],
+                    "listen_count": 592,
                     "artist_name": "Foo Fighters",
-                    "listen_count": 592
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f6804334-5021-4e52-9f71-3ea924e6abc6"
                     ],
+                    "listen_count": 569,
                     "artist_name": "Evergrey",
-                    "listen_count": 569
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
                     ],
+                    "listen_count": 558,
                     "artist_name": "Alanis Morissette",
-                    "listen_count": 558
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "61746abb-76a5-465d-aee7-c4c42d61b7c4"
                     ],
+                    "listen_count": 501,
                     "artist_name": "Massive Attack",
-                    "listen_count": 501
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "79f83982-a0a1-4907-b12e-dc974868e219"
                     ],
+                    "listen_count": 475,
                     "artist_name": "Audioslave",
-                    "listen_count": 475
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "38742bd1-2ceb-4854-a138-206d095cdcc0"
                     ],
+                    "listen_count": 473,
                     "artist_name": "Opeth",
-                    "listen_count": 473
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
                     ],
+                    "listen_count": 466,
                     "artist_name": "Tiamat",
-                    "listen_count": 466
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c707783d-53b6-47fc-8c94-4d5323489209"
                     ],
+                    "listen_count": 457,
                     "artist_name": "Avril Lavigne",
-                    "listen_count": 457
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "58914eb6-0518-45eb-a917-9985aa1cd374"
                     ],
+                    "listen_count": 453,
                     "artist_name": "Emperor",
-                    "listen_count": 453
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "69ab35a3-c877-484a-8db9-4569010e72ed"
                     ],
+                    "listen_count": 451,
                     "artist_name": "Nine Inch Nails",
-                    "listen_count": 451
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "844c13e8-9264-41f1-acc1-a59be2af611e"
                     ],
+                    "listen_count": 440,
                     "artist_name": "In Flames",
-                    "listen_count": 440
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
                     ],
+                    "listen_count": 414,
                     "artist_name": "Megadeth",
-                    "listen_count": 414
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a3c5dedf-13bb-4df2-be11-285972577112"
                     ],
+                    "listen_count": 406,
                     "artist_name": "Metallica",
-                    "listen_count": 406
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
                     ],
+                    "listen_count": 371,
                     "artist_name": "Katatonia",
-                    "listen_count": 371
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "94f867bb-3542-4675-858e-86dafdd7a647"
                     ],
+                    "listen_count": 366,
                     "artist_name": "Ayreon",
-                    "listen_count": 366
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
                     ],
+                    "listen_count": 357,
                     "artist_name": "Darkthrone",
-                    "listen_count": 357
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f5b259cb-2323-41f7-9d19-32e69e79a87e"
                     ],
+                    "listen_count": 313,
                     "artist_name": "Kitaro",
-                    "listen_count": 313
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "114378b9-019b-48ab-a6af-0e122cf6c056"
                     ],
+                    "listen_count": 312,
                     "artist_name": "Bathory",
-                    "listen_count": 312
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8d0f8872-4527-4604-8e35-705afc9f50e6"
                     ],
+                    "listen_count": 299,
                     "artist_name": "Dream Theater",
-                    "listen_count": 299
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "12379346-99d9-4941-b4a2-f04144a39863"
                     ],
+                    "listen_count": 294,
                     "artist_name": "Iced Earth",
-                    "listen_count": 294
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
                     ],
+                    "listen_count": 269,
                     "artist_name": "System of a Down",
-                    "listen_count": 269
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "662105c0-9830-4ea7-9637-1aa5cedc9650"
                     ],
+                    "listen_count": 269,
                     "artist_name": "Paradise Lost",
-                    "listen_count": 269
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f0aa3926-f243-4c5d-9162-6fee7f811934"
                     ],
+                    "listen_count": 269,
                     "artist_name": "Cradle of Filth",
-                    "listen_count": 269
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
                     ],
+                    "listen_count": 268,
                     "artist_name": "Sentenced",
-                    "listen_count": 268
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7ef97e12-5648-4261-89ed-982da0eed624"
                     ],
+                    "listen_count": 266,
                     "artist_name": "Green Day",
-                    "listen_count": 266
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b2451d61-1e02-45e9-970e-bb122048c4f1"
                     ],
+                    "listen_count": 264,
                     "artist_name": "Pain of Salvation",
-                    "listen_count": 264
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fc9bf307-4b19-42fa-a1f1-f445e5d79bf2"
                     ],
+                    "listen_count": 252,
                     "artist_name": "Entombed",
-                    "listen_count": 252
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3d6d2533-f3f9-4859-a3c9-5c3a8db9b628"
                     ],
+                    "listen_count": 250,
                     "artist_name": "Bj\u00f6rk",
-                    "listen_count": 250
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0279d8a2-a1bc-4255-9e48-8abf9e2854e0"
                     ],
+                    "listen_count": 247,
                     "artist_name": "Dimmu Borgir",
-                    "listen_count": 247
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cba89705-8c5d-4a47-8bad-fd5d0dcc353e"
                     ],
+                    "listen_count": 246,
                     "artist_name": "Dark Tranquillity",
-                    "listen_count": 246
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1a21143a-ce09-40b1-95ef-8c2b97eb5170"
                     ],
+                    "listen_count": 234,
                     "artist_name": "Lamb",
-                    "listen_count": 234
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cf0654b0-14c1-400b-a1f5-58b03ededca3"
                     ],
+                    "listen_count": 215,
                     "artist_name": "Bruce Dickinson",
-                    "listen_count": 215
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "645129c1-9b76-48c0-a3af-c87b284265a3"
                     ],
+                    "listen_count": 213,
                     "artist_name": "The Darkness",
-                    "listen_count": 213
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "70b2e0d6-2c39-4044-bd88-1c1ad31fd21a"
                     ],
+                    "listen_count": 208,
                     "artist_name": "HammerFall",
-                    "listen_count": 208
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ceff4c9-fe82-444a-ba9d-20e724e04190"
                     ],
+                    "listen_count": 203,
                     "artist_name": "Strapping Young Lad",
-                    "listen_count": 203
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99a7dfc9-ace3-4fbe-b502-4894c21d59af"
                     ],
+                    "listen_count": 200,
                     "artist_name": "Welle:Erdball",
-                    "listen_count": 200
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "93648a14-2239-42ff-8339-944038c78a5b"
                     ],
+                    "listen_count": 200,
                     "artist_name": "Garbage",
-                    "listen_count": 200
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9cf2d25e-948f-4be3-8e52-d34221faaeec"
                     ],
+                    "listen_count": 189,
                     "artist_name": "Helloween",
-                    "listen_count": 189
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ff73b406-2a9f-430a-9ea3-eebd241ae0b3"
                     ],
+                    "listen_count": 185,
                     "artist_name": "R.E.M.",
-                    "listen_count": 185
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0ff71cac-a18a-4472-b3e0-d58219081544"
                     ],
+                    "listen_count": 183,
                     "artist_name": "Gluecifer",
-                    "listen_count": 183
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7fc48e0d-36bd-479e-928e-87dcf610a782"
                     ],
+                    "listen_count": 177,
                     "artist_name": "The Killers",
-                    "listen_count": 177
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a66d6e61-f261-4a07-8bdb-abb122b2e284"
                     ],
+                    "listen_count": 167,
                     "artist_name": "In Strict Confidence",
-                    "listen_count": 167
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3105cdac-628b-4a55-bcdd-e2bd11e21288"
                     ],
+                    "listen_count": 159,
                     "artist_name": "The Project Hate MCMXCIX",
-                    "listen_count": 159
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4a35fa46-b647-422b-bf66-0650ad3091ef"
                     ],
+                    "listen_count": 158,
                     "artist_name": "Rage Against the Machine",
-                    "listen_count": 158
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
                     ],
+                    "listen_count": 154,
                     "artist_name": "The Cardigans",
-                    "listen_count": 154
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3711919c-c8d3-459d-b753-48b7117d0e21"
                     ],
+                    "listen_count": 153,
                     "artist_name": "Hypocrisy",
-                    "listen_count": 153
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3d851dd4-4c5b-411c-af24-11aa44bdc26f"
                     ],
+                    "listen_count": 151,
                     "artist_name": "R\u00f6yksopp",
-                    "listen_count": 151
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e6456dc5-3519-4547-993a-4e87e91a85df"
                     ],
+                    "listen_count": 151,
                     "artist_name": "Kent",
-                    "listen_count": 151
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
                     ],
+                    "listen_count": 149,
                     "artist_name": "The Offspring",
-                    "listen_count": 149
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "540eebc9-0fc6-41df-8372-2c1a534e92e3"
                     ],
+                    "listen_count": 145,
                     "artist_name": "Depeche Mode",
-                    "listen_count": 145
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fe7912cc-3102-4277-9df8-c20ed3b1499d"
                     ],
+                    "listen_count": 144,
                     "artist_name": "The Soundtrack of Our Lives",
-                    "listen_count": 144
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6599e41e-390c-4855-a2ac-68ee798538b4"
                     ],
+                    "listen_count": 143,
                     "artist_name": "Coldplay",
-                    "listen_count": 143
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ff67daaa-dc6c-4e29-a1d1-f40b2457489d"
                     ],
+                    "listen_count": 134,
                     "artist_name": "Nationalteatern",
-                    "listen_count": 134
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ff2404ad-86ea-499e-8c09-127f487fa06e"
                     ],
+                    "listen_count": 134,
                     "artist_name": "A Perfect Circle",
-                    "listen_count": 134
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f64cb322-70ba-4d70-9107-449c007414a5"
                     ],
+                    "listen_count": 132,
                     "artist_name": "The Devin Townsend Band",
-                    "listen_count": 132
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4b321558-10b1-4d93-9bed-7c9048e28ecb"
                     ],
+                    "listen_count": 131,
                     "artist_name": "The Hellacopters",
-                    "listen_count": 131
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e7c27081-e80d-4641-aed3-356e28320f6f"
                     ],
+                    "listen_count": 131,
                     "artist_name": "Red Hot Chili Peppers",
-                    "listen_count": 131
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c7f68e27-4e43-4b70-8aae-39e0f9397914"
                     ],
+                    "listen_count": 131,
                     "artist_name": "Queens of the Stone Age",
-                    "listen_count": 131
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "775f251e-7635-405c-89bc-4d985c44f92c"
                     ],
+                    "listen_count": 130,
                     "artist_name": "Sahara Hotnights",
-                    "listen_count": 130
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d290cd3b-40a4-47c8-a476-7dfc2f8b3895"
                     ],
+                    "listen_count": 127,
                     "artist_name": "The Cure",
-                    "listen_count": 127
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4e735f68-1b0c-481d-b1c4-1449f7d14550"
                     ],
+                    "listen_count": 124,
                     "artist_name": "The Donnas",
-                    "listen_count": 124
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "805b29f9-07c9-4d1d-98fa-e326e58363d9"
                     ],
+                    "listen_count": 121,
                     "artist_name": "Pearl Jam",
-                    "listen_count": 121
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b0346a81-4a99-461d-870a-de5d086ea1c3"
                     ],
+                    "listen_count": 118,
                     "artist_name": "Apocalyptica",
-                    "listen_count": 118
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "aee14ac9-e46d-4867-8425-8476b63fb767"
                     ],
+                    "listen_count": 116,
                     "artist_name": "The Crown",
-                    "listen_count": 116
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "05953c3e-c5c4-4410-9877-18e85132629c"
                     ],
+                    "listen_count": 114,
                     "artist_name": "Satyricon",
-                    "listen_count": 114
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "519b9bed-e6d5-4b8b-b65e-88a8d219c85d"
                     ],
+                    "listen_count": 113,
                     "artist_name": "Testament",
-                    "listen_count": 113
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8d41e541-9edd-4de8-961a-e30f847f54a7"
                     ],
+                    "listen_count": 109,
                     "artist_name": "At the Gates",
-                    "listen_count": 109
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7cc9d360-061f-4ada-999c-52ccda412795"
                     ],
+                    "listen_count": 108,
                     "artist_name": "Marit Bergman",
-                    "listen_count": 108
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6797b29b-a94c-4f99-b602-ab606a0bf4e6"
                     ],
+                    "listen_count": 108,
                     "artist_name": "Karunesh",
-                    "listen_count": 108
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6bf52c09-6b35-4d7c-af51-6a47245f21a7"
                     ],
+                    "listen_count": 104,
                     "artist_name": "No Doubt",
-                    "listen_count": 104
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "765fba92-fae2-498b-b04a-327690869e15"
                     ],
+                    "listen_count": 102,
                     "artist_name": "Nickelback",
-                    "listen_count": 102
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "de5825a7-9b41-4e8d-9e64-ac6f0617ed83"
                     ],
+                    "listen_count": 102,
                     "artist_name": "Epica",
-                    "listen_count": 102
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
                     ],
+                    "listen_count": 99,
                     "artist_name": "The Postal Service",
-                    "listen_count": 99
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e2fe00d2-810b-4a91-a3b4-ba9b7406c6c1"
                     ],
+                    "listen_count": 99,
                     "artist_name": "Borknagar",
-                    "listen_count": 99
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b648c557-dd92-4bfd-a0d4-569e903b8666"
                     ],
+                    "listen_count": 98,
                     "artist_name": "Middleman",
-                    "listen_count": 98
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dbed7c10-e68c-4805-9295-09c48c06b897"
                     ],
+                    "listen_count": 97,
                     "artist_name": "W.A.S.P.",
-                    "listen_count": 97
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2f68b232-a2fa-4f35-9eba-f2f3ab956e87"
                     ],
+                    "listen_count": 95,
                     "artist_name": "Velvet Revolver",
-                    "listen_count": 95
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ee182ec-fda1-491b-8f13-c19e2da34c82"
                     ],
+                    "listen_count": 95,
                     "artist_name": "Dire Straits",
-                    "listen_count": 95
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "af4fa0d4-a060-4171-84cf-f40a20600cac"
                     ],
+                    "listen_count": 94,
                     "artist_name": "Progg",
-                    "listen_count": 94
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "093d1c46-f28c-427c-a521-c5abe25fa75d"
                     ],
+                    "listen_count": 94,
                     "artist_name": "Apoptygma Berzerk",
-                    "listen_count": 94
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0739cfee-131b-41c8-8caa-fc846d6ae9be"
                     ],
+                    "listen_count": 93,
                     "artist_name": "Front 242",
-                    "listen_count": 93
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "361ce71c-80b1-4717-b91f-3b0d9fccf906"
                     ],
+                    "listen_count": 91,
                     "artist_name": "M\u00f6rk Gryning",
-                    "listen_count": 91
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
                     ],
+                    "listen_count": 87,
                     "artist_name": "D-A-D",
-                    "listen_count": 87
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "addd9cc5-1964-49cd-b607-431349991084"
                     ],
+                    "listen_count": 86,
                     "artist_name": "Cemetary",
-                    "listen_count": 86
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "85d4d644-822b-4596-a83d-a0373158027a"
                     ],
+                    "listen_count": 85,
                     "artist_name": "Front Line Assembly",
-                    "listen_count": 85
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "87b24ec1-b811-422a-bf9f-a52d4e6bb249"
                     ],
+                    "listen_count": 83,
                     "artist_name": "Sonata Arctica",
-                    "listen_count": 83
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4f7ac8db-ccb1-4411-af5d-395c785b2566"
                     ],
+                    "listen_count": 83,
                     "artist_name": "Queen",
-                    "listen_count": 83
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "13da5ac3-039a-4a29-b2d8-18b287de7d4e"
                     ],
+                    "listen_count": 81,
                     "artist_name": "They Might Be Giants",
-                    "listen_count": 81
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99fa93b3-796a-45a0-855e-6fe0e1b1a0b0"
                     ],
+                    "listen_count": 81,
                     "artist_name": "Tale",
-                    "listen_count": 81
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2d6e3002-fbf7-4fa5-a38f-c58ba12349b2"
                     ],
+                    "listen_count": 81,
                     "artist_name": "Dream Evil",
-                    "listen_count": 81
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
                     ],
+                    "listen_count": 77,
                     "artist_name": "Mot\u00f6rhead",
-                    "listen_count": 77
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4ed8e056-d7da-442f-8699-75d638041ca3"
                     ],
+                    "listen_count": 77,
                     "artist_name": "Grip Inc.",
-                    "listen_count": 77
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "78301a87-32ce-4857-b64d-97b4a08850ef"
                     ],
+                    "listen_count": 76,
                     "artist_name": "Abramis Brama",
-                    "listen_count": 76
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1738561e-cdcb-454a-98c0-58bfa7b54796"
                     ],
+                    "listen_count": 75,
                     "artist_name": "Pain",
-                    "listen_count": 75
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1738561e-cdca-454a-98c0-58bfa7b54796"
                     ],
+                    "listen_count": 73,
                     "artist_name": "Ellie Goulding",
-                    "listen_count": 73
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1104537600,
@@ -722,708 +823,809 @@
                     "artist_mbids": [
                         "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
                     ],
+                    "listen_count": 1354,
                     "artist_name": "Judas Priest",
-                    "listen_count": 1354
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f6804334-5021-4e52-9f71-3ea924e6abc6"
                     ],
+                    "listen_count": 691,
                     "artist_name": "Evergrey",
-                    "listen_count": 691
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "431cc9fb-ef90-4819-9c7b-2229c298727c"
                     ],
+                    "listen_count": 641,
                     "artist_name": "Danko Jones",
-                    "listen_count": 641
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "87e396ef-3ee0-4ff2-853c-6174c4243df6"
                     ],
+                    "listen_count": 606,
                     "artist_name": "Foo Fighters",
-                    "listen_count": 606
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
                     ],
+                    "listen_count": 584,
                     "artist_name": "Katatonia",
-                    "listen_count": 584
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4b321558-10b1-4d93-9bed-7c9048e28ecb"
                     ],
+                    "listen_count": 556,
                     "artist_name": "The Hellacopters",
-                    "listen_count": 556
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fcee89d2-70a6-4149-afd3-90806ddc650d"
                     ],
+                    "listen_count": 504,
                     "artist_name": "Death Cab for Cutie",
-                    "listen_count": 504
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "645129c1-9b76-48c0-a3af-c87b284265a3"
                     ],
+                    "listen_count": 470,
                     "artist_name": "The Darkness",
-                    "listen_count": 470
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e9e619a9-5170-4ef7-bfeb-29ef64ed3f5d"
                     ],
+                    "listen_count": 461,
                     "artist_name": "Turbonegro",
-                    "listen_count": 461
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
                     ],
+                    "listen_count": 415,
                     "artist_name": "Black Label Society",
-                    "listen_count": 415
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "79f83982-a0a1-4907-b12e-dc974868e219"
                     ],
+                    "listen_count": 405,
                     "artist_name": "Audioslave",
-                    "listen_count": 405
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "94f867bb-3542-4675-858e-86dafdd7a647"
                     ],
+                    "listen_count": 402,
                     "artist_name": "Ayreon",
-                    "listen_count": 402
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ceff4c9-fe82-444a-ba9d-20e724e04190"
                     ],
+                    "listen_count": 394,
                     "artist_name": "Strapping Young Lad",
-                    "listen_count": 394
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
                     ],
+                    "listen_count": 385,
                     "artist_name": "Slayer",
-                    "listen_count": 385
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
                     ],
+                    "listen_count": 347,
                     "artist_name": "The Cardigans",
-                    "listen_count": 347
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
                     ],
+                    "listen_count": 342,
                     "artist_name": "The Offspring",
-                    "listen_count": 342
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
                     ],
+                    "listen_count": 329,
                     "artist_name": "Arch Enemy",
-                    "listen_count": 329
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "574dfe13-97aa-4318-8e4a-0ec79e05db24"
                     ],
+                    "listen_count": 324,
                     "artist_name": "Hoobastank",
-                    "listen_count": 324
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "540eebc9-0fc6-41df-8372-2c1a534e92e3"
                     ],
+                    "listen_count": 316,
                     "artist_name": "Depeche Mode",
-                    "listen_count": 316
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99eec84e-42cb-4f47-b80f-ce46ca65735b"
                     ],
+                    "listen_count": 305,
                     "artist_name": "Panic! at the Disco",
-                    "listen_count": 305
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
                     ],
+                    "listen_count": 297,
                     "artist_name": "Mot\u00f6rhead",
-                    "listen_count": 297
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dbed7c10-e68c-4805-9295-09c48c06b897"
                     ],
+                    "listen_count": 292,
                     "artist_name": "W.A.S.P.",
-                    "listen_count": 292
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "38742bd1-2ceb-4854-a138-206d095cdcc0"
                     ],
+                    "listen_count": 275,
                     "artist_name": "Opeth",
-                    "listen_count": 275
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
                     ],
+                    "listen_count": 268,
                     "artist_name": "The Postal Service",
-                    "listen_count": 268
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2f13b1cb-32e3-45c6-8b87-25629490ac44"
                     ],
+                    "listen_count": 264,
                     "artist_name": "Iron Maiden",
-                    "listen_count": 264
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d3e64ede-3456-4f67-952c-fa0b7d05231a"
                     ],
+                    "listen_count": 262,
                     "artist_name": "Wizo",
-                    "listen_count": 262
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e6a8399-a625-4151-9bba-3994b033957e"
                     ],
+                    "listen_count": 249,
                     "artist_name": "Black Sabbath",
-                    "listen_count": 249
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6599e41e-390c-4855-a2ac-68ee798538b4"
                     ],
+                    "listen_count": 246,
                     "artist_name": "Coldplay",
-                    "listen_count": 246
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
                     ],
+                    "listen_count": 244,
                     "artist_name": "D-A-D",
-                    "listen_count": 244
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "12379346-99d9-4941-b4a2-f04144a39863"
                     ],
+                    "listen_count": 238,
                     "artist_name": "Iced Earth",
-                    "listen_count": 238
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4f7ac8db-ccb1-4411-af5d-395c785b2566"
                     ],
+                    "listen_count": 235,
                     "artist_name": "Queen",
-                    "listen_count": 235
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d01b7459-4a8e-4c00-a0d5-0a373634eb47"
                     ],
+                    "listen_count": 219,
                     "artist_name": "The Knife",
-                    "listen_count": 219
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "92133235-e98d-48cf-be8c-85693bec10fa"
                     ],
+                    "listen_count": 218,
                     "artist_name": "Alkaline Trio",
-                    "listen_count": 218
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "765fba92-fae2-498b-b04a-327690869e15"
                     ],
+                    "listen_count": 215,
                     "artist_name": "Nickelback",
-                    "listen_count": 215
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b0346a81-4a99-461d-870a-de5d086ea1c3"
                     ],
+                    "listen_count": 214,
                     "artist_name": "Apocalyptica",
-                    "listen_count": 214
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
                     ],
+                    "listen_count": 206,
                     "artist_name": "Sentenced",
-                    "listen_count": 206
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
                     ],
+                    "listen_count": 203,
                     "artist_name": "System of a Down",
-                    "listen_count": 203
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "162be21e-3e55-43ef-95f4-2f741c6e58b1"
                     ],
+                    "listen_count": 201,
                     "artist_name": "Symphony X",
-                    "listen_count": 201
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a3c5dedf-13bb-4df2-be11-285972577112"
                     ],
+                    "listen_count": 201,
                     "artist_name": "Metallica",
-                    "listen_count": 201
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "30f8806c-e6b2-4a5a-92d5-454cdd41bbcc"
                     ],
+                    "listen_count": 201,
                     "artist_name": "Green Carnation",
-                    "listen_count": 201
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fe7912cc-3102-4277-9df8-c20ed3b1499d"
                     ],
+                    "listen_count": 198,
                     "artist_name": "The Soundtrack of Our Lives",
-                    "listen_count": 198
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2f3568d9-9ac0-4936-9712-a95302ca51a3"
                     ],
+                    "listen_count": 198,
                     "artist_name": "The Kristet Utseende",
-                    "listen_count": 198
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8716eb48-0079-4a90-b561-2fa5bbd03862"
                     ],
+                    "listen_count": 178,
                     "artist_name": "Amorphis",
-                    "listen_count": 178
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "5627d327-7d81-43ae-ae7c-bb5c7d4f0d24"
                     ],
+                    "listen_count": 172,
                     "artist_name": "Nevermore",
-                    "listen_count": 172
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
                     ],
+                    "listen_count": 171,
                     "artist_name": "Tiamat",
-                    "listen_count": 171
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7fc48e0d-36bd-479e-928e-87dcf610a782"
                     ],
+                    "listen_count": 167,
                     "artist_name": "The Killers",
-                    "listen_count": 167
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3d6d2533-f3f9-4859-a3c9-5c3a8db9b628"
                     ],
+                    "listen_count": 167,
                     "artist_name": "Bj\u00f6rk",
-                    "listen_count": 167
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c707783d-53b6-47fc-8c94-4d5323489209"
                     ],
+                    "listen_count": 158,
                     "artist_name": "Avril Lavigne",
-                    "listen_count": 158
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4920ba92-d2bb-4826-ba31-c82dae4a633b"
                     ],
+                    "listen_count": 147,
                     "artist_name": "Queensr\u00ffche",
-                    "listen_count": 147
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "58914eb6-0518-45eb-a917-9985aa1cd374"
                     ],
+                    "listen_count": 144,
                     "artist_name": "Emperor",
-                    "listen_count": 144
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "599e16ce-3705-450d-8014-1d9292b69dd9"
                     ],
+                    "listen_count": 137,
                     "artist_name": "Type O Negative",
-                    "listen_count": 137
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99fa93b3-796a-45a0-855e-6fe0e1b1a0b0"
                     ],
+                    "listen_count": 136,
                     "artist_name": "Tale",
-                    "listen_count": 136
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "114378b9-019b-48ab-a6af-0e122cf6c056"
                     ],
+                    "listen_count": 136,
                     "artist_name": "Bathory",
-                    "listen_count": 136
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8a75931e-2a0e-4f39-9fe1-7233b344efaf"
                     ],
+                    "listen_count": 127,
                     "artist_name": "Prince",
-                    "listen_count": 127
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "70b2e0d6-2c39-4044-bd88-1c1ad31fd21a"
                     ],
+                    "listen_count": 122,
                     "artist_name": "HammerFall",
-                    "listen_count": 122
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
                     ],
+                    "listen_count": 121,
                     "artist_name": "Alanis Morissette",
-                    "listen_count": 121
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f9c8e154-2986-4dec-96ce-345ff327a271"
                     ],
+                    "listen_count": 120,
                     "artist_name": "Wise Guys",
-                    "listen_count": 120
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "78df245f-0fe0-4a21-b1d4-e79f695354fd"
                     ],
+                    "listen_count": 118,
                     "artist_name": "Gorillaz",
-                    "listen_count": 118
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fc9bf307-4b19-42fa-a1f1-f445e5d79bf2"
                     ],
+                    "listen_count": 113,
                     "artist_name": "Entombed",
-                    "listen_count": 113
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
                     ],
+                    "listen_count": 112,
                     "artist_name": "Megadeth",
-                    "listen_count": 112
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "93648a14-2239-42ff-8339-944038c78a5b"
                     ],
+                    "listen_count": 112,
                     "artist_name": "Garbage",
-                    "listen_count": 112
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4e735f68-1b0c-481d-b1c4-1449f7d14550"
                     ],
+                    "listen_count": 111,
                     "artist_name": "The Donnas",
-                    "listen_count": 111
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "72ee05f0-bed3-41be-ab77-e5523332e3b6"
                     ],
+                    "listen_count": 110,
                     "artist_name": "Stream of Passion",
-                    "listen_count": 110
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "844c13e8-9264-41f1-acc1-a59be2af611e"
                     ],
+                    "listen_count": 109,
                     "artist_name": "In Flames",
-                    "listen_count": 109
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3d851dd4-4c5b-411c-af24-11aa44bdc26f"
                     ],
+                    "listen_count": 108,
                     "artist_name": "R\u00f6yksopp",
-                    "listen_count": 108
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e7c27081-e80d-4641-aed3-356e28320f6f"
                     ],
+                    "listen_count": 106,
                     "artist_name": "Red Hot Chili Peppers",
-                    "listen_count": 106
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "13da5ac3-039a-4a29-b2d8-18b287de7d4e"
                     ],
+                    "listen_count": 104,
                     "artist_name": "They Might Be Giants",
-                    "listen_count": 104
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "31e65ed7-cb97-482f-93a5-6dae925761e4"
                     ],
+                    "listen_count": 104,
                     "artist_name": "Porcupine Tree",
-                    "listen_count": 104
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4155b1d3-5b20-402c-9117-b7d1d0ee6204"
                     ],
+                    "listen_count": 104,
                     "artist_name": "Ice-T",
-                    "listen_count": 104
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3105cdac-628b-4a55-bcdd-e2bd11e21288"
                     ],
+                    "listen_count": 103,
                     "artist_name": "The Project Hate MCMXCIX",
-                    "listen_count": 103
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "32150f6d-5ad6-4913-83fc-7b15bd847588"
                     ],
+                    "listen_count": 100,
                     "artist_name": "Mastodon",
-                    "listen_count": 100
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0e3ebeae-9b2c-4a1e-aa2e-e99aab0cdc5c"
                     ],
+                    "listen_count": 98,
                     "artist_name": "Fight",
-                    "listen_count": 98
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "723245dd-68c3-42c6-ab02-095e30e3dca9"
                     ],
+                    "listen_count": 93,
                     "artist_name": "J.B.O.",
-                    "listen_count": 93
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "136cb38f-3cd6-4a97-8031-e5c8d0cc6eb9"
                     ],
+                    "listen_count": 92,
                     "artist_name": "Wolfmother",
-                    "listen_count": 92
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e82bddba-140d-418b-bde9-8e6ee9e9aa5c"
                     ],
+                    "listen_count": 91,
                     "artist_name": "Falconer",
-                    "listen_count": 91
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "841f458f-a940-4220-8120-5e2f719c771e"
                     ],
+                    "listen_count": 90,
                     "artist_name": "The Haunted",
-                    "listen_count": 90
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "02264268-7813-455b-b97a-9437b4a048cd"
                     ],
+                    "listen_count": 89,
                     "artist_name": "LOK",
-                    "listen_count": 89
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ff67daaa-dc6c-4e29-a1d1-f40b2457489d"
                     ],
+                    "listen_count": 88,
                     "artist_name": "Nationalteatern",
-                    "listen_count": 88
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f31223bf-43e7-4565-9d5b-34f4e7897d71"
                     ],
+                    "listen_count": 88,
                     "artist_name": "Anathema",
-                    "listen_count": 88
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b958833f-4d74-4f94-8402-7cd1a6e6fb21"
                     ],
+                    "listen_count": 84,
                     "artist_name": "U2",
-                    "listen_count": 84
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
                     ],
+                    "listen_count": 84,
                     "artist_name": "David Bowie",
-                    "listen_count": 84
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d834dd3d-653f-496e-895b-1885ee6b0d68"
                     ],
+                    "listen_count": 81,
                     "artist_name": "The Doors",
-                    "listen_count": 81
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "be15b50e-8df8-481b-b0af-3991db5e3ee9"
                     ],
+                    "listen_count": 81,
                     "artist_name": "LCD Soundsystem",
-                    "listen_count": 81
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "52758846-744f-4295-8dbc-6a4caf77459c"
                     ],
+                    "listen_count": 80,
                     "artist_name": "Pink Floyd",
-                    "listen_count": 80
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
                     ],
+                    "listen_count": 80,
                     "artist_name": "Darkthrone",
-                    "listen_count": 80
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0ebbb014-d2f4-4588-a1a2-dafc1c777b22"
                     ],
+                    "listen_count": 78,
                     "artist_name": "Tenacious D",
-                    "listen_count": 78
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "171f623b-5ca6-4081-ae7b-faf92724500a"
                     ],
+                    "listen_count": 78,
                     "artist_name": "Magnatune Compilation (PREVIEW: buy it at www.magnatune.com)",
-                    "listen_count": 78
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9b11fcf9-8282-418c-bc8c-c4003aa16963"
                     ],
+                    "listen_count": 76,
                     "artist_name": "Witchery",
-                    "listen_count": 76
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cfc09e6a-5d59-4c07-b14d-3a55bd7a8c1b"
                     ],
+                    "listen_count": 75,
                     "artist_name": "Combustible Edison",
-                    "listen_count": 75
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0ce6d420-1273-46a5-98ed-faee68c3d269"
                     ],
+                    "listen_count": 74,
                     "artist_name": "Zyklon",
-                    "listen_count": 74
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "183a545e-416b-49c5-ba35-08497fbf732b"
                     ],
+                    "listen_count": 72,
                     "artist_name": "Kaizers Orchestra",
-                    "listen_count": 72
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7ffc4fc1-b158-4e8c-9b88-bac95af3225b"
                     ],
+                    "listen_count": 71,
                     "artist_name": "Raise Hell",
-                    "listen_count": 71
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "addd9cc5-1964-49cd-b607-431349991084"
                     ],
+                    "listen_count": 68,
                     "artist_name": "Cemetary",
-                    "listen_count": 68
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4dd5aff8-49f4-4f37-b412-ca0227f4534f"
                     ],
+                    "listen_count": 67,
                     "artist_name": "Jan Delay",
-                    "listen_count": 67
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e6456dc5-3519-4547-993a-4e87e91a85df"
                     ],
+                    "listen_count": 66,
                     "artist_name": "Kent",
-                    "listen_count": 66
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "51a562cf-9515-4c63-8d7d-80eca213c30b"
                     ],
+                    "listen_count": 65,
                     "artist_name": "Khoma",
-                    "listen_count": 65
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8d0f8872-4527-4604-8e35-705afc9f50e6"
                     ],
+                    "listen_count": 65,
                     "artist_name": "Dream Theater",
-                    "listen_count": 65
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "704872ad-8327-4b72-8cf2-53b2fb6977f1"
                     ],
+                    "listen_count": 65,
                     "artist_name": "Astrud Gilberto",
-                    "listen_count": 65
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "59812ffc-6782-4427-878b-1116ff5c769c"
                     ],
+                    "listen_count": 64,
                     "artist_name": "Tool",
-                    "listen_count": 64
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "775f251e-7635-405c-89bc-4d985c44f92c"
                     ],
+                    "listen_count": 64,
                     "artist_name": "Sahara Hotnights",
-                    "listen_count": 64
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8r5f251e-7635-405c-89bc-4d985c44f92c"
                     ],
+                    "listen_count": 63,
                     "artist_name": "Hotnights Sahara",
-                    "listen_count": 63
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1136073600,

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_week.json
@@ -8,701 +8,801 @@
                     "artist_mbids": [
                         "3e58ced5-c379-4b6f-92b8-492f909d53ef"
                     ],
+                    "listen_count": 139,
                     "artist_name": "Clarence Clarity",
-                    "listen_count": 139
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "45515fc0-28b4-4e9c-b530-47b0fc256ead"
                     ],
+                    "listen_count": 86,
                     "artist_name": "Bomba Est\u00e9reo",
-                    "listen_count": 86
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "92274620-f425-4d74-af9f-49a8ea3a0fb6"
                     ],
+                    "listen_count": 72,
                     "artist_name": "John Carpenter, Cody Carpenter & Daniel Davies",
-                    "listen_count": 72
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8c0fe262-b4c0-4835-bf56-cb1597ca8306"
                     ],
+                    "listen_count": 72,
                     "artist_name": "Flying Lotus",
-                    "listen_count": 72
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99a3f584-0c1f-422d-9581-daa935892166"
                     ],
+                    "listen_count": 48,
                     "artist_name": "MNEK",
-                    "listen_count": 48
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4bba65ae-b6bc-49b4-a6de-2b18a357797c"
                     ],
+                    "listen_count": 48,
                     "artist_name": "Janet Jackson",
-                    "listen_count": 48
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "bb89657c-c0c6-4c2d-9233-619823a3b043"
                     ],
+                    "listen_count": 46,
                     "artist_name": "Seth Lakeman",
-                    "listen_count": 46
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ff5c0560-a3c4-45b7-81de-56a56f14a899"
                     ],
+                    "listen_count": 46,
                     "artist_name": "100 gecs",
-                    "listen_count": 46
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c8910ef9-c8b6-434c-95e0-be44c3c4a47e"
                     ],
+                    "listen_count": 41,
                     "artist_name": "John Carpenter",
-                    "listen_count": 41
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "180fcf80-8de9-4efa-889e-3bb545cc5252"
                     ],
+                    "listen_count": 36,
                     "artist_name": "Metaform",
-                    "listen_count": 36
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "052fef56-cfea-41de-b07d-72ecf607e5be"
                     ],
+                    "listen_count": 32,
                     "artist_name": "Calexico",
-                    "listen_count": 32
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a200b8a0-2248-4abb-9454-5f99750be117"
                     ],
+                    "listen_count": 31,
                     "artist_name": "Dance Gavin Dance",
-                    "listen_count": 31
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8fd0aeee-23f9-4cb7-8801-2566cf116607"
                     ],
+                    "listen_count": 30,
                     "artist_name": "Exmag",
-                    "listen_count": 30
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9820da6d-66d9-424d-9f67-2654ed2f31e4"
                     ],
+                    "listen_count": 27,
                     "artist_name": "Tame Impala",
-                    "listen_count": 27
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cbb9a699-457c-4082-9ee7-46238d95b76a"
                     ],
+                    "listen_count": 24,
                     "artist_name": "Zayn",
-                    "listen_count": 24
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ac24a1a7-3ef5-4adc-8438-1f8bcce70f43"
                     ],
+                    "listen_count": 24,
                     "artist_name": "Rina Sawayama",
-                    "listen_count": 24
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9720fd77-fe48-41ba-a7a2-b4795718dd97"
                     ],
+                    "listen_count": 23,
                     "artist_name": "Drake",
-                    "listen_count": 23
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c8fee4af-cf1c-4676-809b-930251b57289"
                     ],
+                    "listen_count": 20,
                     "artist_name": "Solange",
-                    "listen_count": 20
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3b2f4fcd-6305-44cb-9312-b7d1fbc91b4c"
                     ],
+                    "listen_count": 19,
                     "artist_name": "The 1975",
-                    "listen_count": 19
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a97e8d2b-73dc-46f6-9e6b-26e9eac7b574"
                     ],
+                    "listen_count": 18,
                     "artist_name": "Pentangle",
-                    "listen_count": 18
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "503ea1d1-92d6-4b68-9019-99a53ed45348"
                     ],
+                    "listen_count": 17,
                     "artist_name": "Yabby You & Prophets",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "13ad5913-a409-4b6d-b7ab-f853d3a84007"
                     ],
+                    "listen_count": 17,
                     "artist_name": "TomppaBeats",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b558a0d1-6f28-4134-8110-e625a30389a2"
                     ],
+                    "listen_count": 17,
                     "artist_name": "Redman",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0b2aab1a-7ec2-4b8e-87c7-80c1313f9398"
                     ],
+                    "listen_count": 17,
                     "artist_name": "Emarosa",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "288235cb-1187-4d24-8f73-cbeece34dee2"
                     ],
+                    "listen_count": 16,
                     "artist_name": "Vikingur Olafsson",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "025a1214-9225-40ea-b32a-fa1da63f9a5f"
                     ],
+                    "listen_count": 16,
                     "artist_name": "The Damned",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ad11bf90-ed19-438e-b661-8e3a8f922124"
                     ],
+                    "listen_count": 16,
                     "artist_name": "Stray Kids",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b50d094d-a722-40b9-83ef-74d5c1de2866"
                     ],
+                    "listen_count": 16,
                     "artist_name": "Showbiz & A.G.",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b4ae3356-b8a7-471a-a23a-e471a69ad454"
                     ],
+                    "listen_count": 16,
                     "artist_name": "Ariana Grande",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "543f38fd-2126-4924-8d69-fb753f281dbb"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Zuco 103",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "428b6e4c-795e-4a08-8d0b-7bef7aaf8582"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Kanye West",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4f409234-d8d3-4a4a-a664-7186614a9c09"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Big Sean",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0a3cacb2-f1f6-4426-a758-e41e395caf9f"
                     ],
+                    "listen_count": 13,
                     "artist_name": "Onyx",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "98168481-f215-4115-bd5e-a603b0b33280"
                     ],
+                    "listen_count": 13,
                     "artist_name": "Odetta",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6599e41e-390c-4855-a2ac-68ee798538b4"
                     ],
+                    "listen_count": 13,
                     "artist_name": "Coldplay",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "560271d1-cea8-4a39-92c4-ac9e448c20f4"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Tom Odell",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fef3595e-cfaa-4dbc-ba8f-55ba76305c64"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Tinashe",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "47ba76ad-dcd2-41e8-8d8a-91c3ba0e73eb"
                     ],
+                    "listen_count": 12,
                     "artist_name": "The Mountain Goats",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "34314f1c-de56-4556-b6c5-78bbf15590f1"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Sleep Token",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fe2cbb92-9164-40d2-a4fd-76fdd20ecf08"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Sam Gellaitry",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d51d9a4a-1cf9-4ce3-aba8-33d8958e7845"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Nuclear Assault",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "270bca08-33f6-40ce-9508-869f484d20fe"
                     ],
+                    "listen_count": 12,
                     "artist_name": "LoFi Hip Hop",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "50fbeb99-f068-41f7-beaf-cf18daf19124"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Justin Bieber",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "74985888-541e-4992-9290-7149e5919270"
                     ],
+                    "listen_count": 11,
                     "artist_name": "William Orbit",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a84bc968-c327-4f84-baca-01aad2e508b5"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Thrice",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cb620508-f737-4348-aad1-27bab9bc3f02"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Organectomy",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dc9a749f-f1fa-4acc-9f6e-12c411ed301b"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Instra:mental",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7d22f0c5-7f70-4d97-8a9c-c381d8ebbf3a"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Ahtme",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0f85c13d-cb10-4ade-b69c-ee159ba09a1c"
                     ],
+                    "listen_count": 10,
                     "artist_name": "tmantz625",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4f7ac8db-ccb1-4411-af5d-395c785b2566"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Queen",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2040ef57-13b6-4c0c-a3be-470a1a6edc2e"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Osunlade",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c66f95c3-8e7f-4286-b1c6-1d52f078cc70"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Martin O'Donnell",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f883661c-de05-4050-b62b-88474a7223d2"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Black Honey",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4e279c33-5f70-4f06-a9d8-9e8ab5ba0166"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Andy Stott",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "17fa7925-eca7-4edb-b5fe-e68843139a25"
                     ],
+                    "listen_count": 9,
                     "artist_name": "The Night Game",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "5201944d-b08d-4cd6-a580-9cda7b7c9b60"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Seether",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8a19ab32-a2f8-4b64-9b1c-6deb297a1587"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Recondite",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3eb81b8a-7cae-4fff-bed8-4c4f036e4a69"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Emancipator",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7167a53b-536a-4b15-9e93-babfed0888fe"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Candlemass",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "410bd3e3-49d4-4417-b3af-7493bdcf00c7"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Bleed from Within",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "78048022-8412-4658-8fa2-e77398cc3d4f"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Yann Tiersen",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8b64f68f-e56e-4681-80f6-5f83e12b03a7"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Shinedown",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "008657f2-43ae-41d5-937d-36e5439b0944"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Richard Henshall",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9235923c-1c5b-467f-964d-5841c38797f4"
                     ],
+                    "listen_count": 8,
                     "artist_name": "RZA",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "260a4dc3-19c5-4fae-9f2f-d495a8baa13d"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Lady Gaga",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3e9567ef-1549-4196-9241-c8b8c9330a8f"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Eidola",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "5ff10afa-6f42-442f-8883-ea6169542f7f"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Abra",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d1a03708-1cc0-4134-9577-c1382b322d83"
                     ],
+                    "listen_count": 8,
                     "artist_name": "16",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "59812ffc-6782-4427-878b-1116ff5c769c"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Tool",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
                     ],
+                    "listen_count": 7,
                     "artist_name": "The Weeknd",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "83c6f015-ea59-43ac-a1a7-8ac2ca20ce14"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Sianvar",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dcd4245a-0ad2-47f2-a217-06d0c78c108b"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Pontiac Streator & Ulla Straus",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "40dc813f-3336-49ab-80aa-e8fce8ae6935"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Missy Elliott",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "53e4814d-705e-4768-979f-9cf918d9c6bd"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Mansionair",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "11009d8b-8206-46d1-b1fd-e3cfca7b507e"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Jupiter One",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "38c3e14d-e614-48dc-9395-860e68619385"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Jim White",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c9f2dede-fc69-4b2f-af51-346bf506d113"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Hannes Grossmann",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8669e61f-d379-4ee9-b51c-66bc83777aae"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Dog Eat Dog",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ee182ec-fda1-491b-8f13-c19e2da34c82"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Dire Straits",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f5592c17-0b2f-4f58-8a2e-923e3cd8da93"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Charli XCX",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8d05c31c-78b1-4bb6-b80a-8ef6bc6f2b58"
                     ],
+                    "listen_count": 6,
                     "artist_name": "dgoHn",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3f00c1e3-17ce-423f-a35c-0037a4c172f0"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Three Days Grace",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7fa344b3-258a-4bd2-b321-db9297b249ed"
                     ],
+                    "listen_count": 6,
                     "artist_name": "The Pretty Reckless",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7a7abbe4-ab1b-49c1-9276-9bc4cee66661"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Special Request",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8d9dce0a-4aca-4273-916c-612fc481c783"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Rosie Carney",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "5c330293-3c1d-4ddb-a8e9-6b647cb0db85"
                     ],
+                    "listen_count": 6,
                     "artist_name": "PARK RD",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "76f85521-163f-427f-a3e8-27fa23b3d602"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Little Brother",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "bf57daba-fc3a-4d32-9e8f-4a02ebdff84d"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Fjord",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7165726f-7b7e-4c65-a222-df1b95ef4199"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Eve",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7eeeae6a-30b9-401d-9f37-c3d23dad8f98"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Circa Survive",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7a4756b9-e47a-407c-85c0-667514d2ffed"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Bridgit Mendler",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2eb58555-10ac-422b-b0ff-9d17367f91ad"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Atlus Sound Team",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e2e65849-a5f0-441b-b6a7-0948a0bde559"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Aim",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "83df9d14-ba3b-4ab1-bf4c-21dcbb92e324"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Wormed",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a2503d0a-4dde-4848-8fff-a4352cdb3384"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Wax Tailor",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a5dcf727-2234-4ddb-a743-808e18a4cd3f"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Waajeed",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ea42c685-2b12-4f68-b8e0-e3bb9b207102"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Tierra Whack",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fcdf75e0-5eaf-47a0-9dcc-04784514f5ca"
                     ],
+                    "listen_count": 5,
                     "artist_name": "The Maine",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0d5aad58-2e55-4e84-870b-99edbf958fe6"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Sum 41",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6a3996f1-c0a5-447a-a434-a41812f09f3d"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Sam Martin",
-                    "listen_count": 5
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1591574400,
@@ -715,701 +815,801 @@
                     "artist_mbids": [
                         "a200b8a0-2248-4abb-9454-5f99750be117"
                     ],
+                    "listen_count": 119,
                     "artist_name": "Dance Gavin Dance",
-                    "listen_count": 119
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3e58ced5-c379-4b6f-92b8-492f909d53ef"
                     ],
+                    "listen_count": 88,
                     "artist_name": "Clarence Clarity",
-                    "listen_count": 88
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "45515fc0-28b4-4e9c-b530-47b0fc256ead"
                     ],
+                    "listen_count": 58,
                     "artist_name": "Bomba Est\u00e9reo",
-                    "listen_count": 58
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "92274620-f425-4d74-af9f-49a8ea3a0fb6"
                     ],
+                    "listen_count": 55,
                     "artist_name": "John Carpenter, Cody Carpenter & Daniel Davies",
-                    "listen_count": 55
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ac24a1a7-3ef5-4adc-8438-1f8bcce70f43"
                     ],
+                    "listen_count": 41,
                     "artist_name": "Rina Sawayama",
-                    "listen_count": 41
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4f2da2f8-22c5-4d6d-989f-c6899d7e683e"
                     ],
+                    "listen_count": 38,
                     "artist_name": "Richard Thompson Band",
-                    "listen_count": 38
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "288235cb-1187-4d24-8f73-cbeece34dee2"
                     ],
+                    "listen_count": 33,
                     "artist_name": "Vikingur Olafsson",
-                    "listen_count": 33
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3f513bed-50e1-4890-b666-0f45d726043c"
                     ],
+                    "listen_count": 31,
                     "artist_name": "Pyre",
-                    "listen_count": 31
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e29fd013-45c0-4edd-abe2-8635fdd0502a"
                     ],
+                    "listen_count": 25,
                     "artist_name": "Lana Del Rey",
-                    "listen_count": 25
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "94c767b1-0068-483b-b233-a3c56776bea8"
                     ],
+                    "listen_count": 23,
                     "artist_name": "SZA",
-                    "listen_count": 23
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "73c6dfb8-9a66-4967-a965-46532d412693"
                     ],
+                    "listen_count": 23,
                     "artist_name": "Caligula's Horse",
-                    "listen_count": 23
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cbb9a699-457c-4082-9ee7-46238d95b76a"
                     ],
+                    "listen_count": 22,
                     "artist_name": "Zayn",
-                    "listen_count": 22
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ae5c875b-3f76-4ab2-935e-6c6f11be6d0e"
                     ],
+                    "listen_count": 20,
                     "artist_name": "wavvyboi",
-                    "listen_count": 20
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "74985888-541e-4992-9290-7149e5919270"
                     ],
+                    "listen_count": 20,
                     "artist_name": "William Orbit",
-                    "listen_count": 20
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a84bc968-c327-4f84-baca-01aad2e508b5"
                     ],
+                    "listen_count": 20,
                     "artist_name": "Thrice",
-                    "listen_count": 20
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ce675bb2-5424-4936-9424-30a98f81b059"
                     ],
+                    "listen_count": 18,
                     "artist_name": "Miguel",
-                    "listen_count": 18
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "42b34077-464d-4e09-877e-077db701469d"
                     ],
+                    "listen_count": 18,
                     "artist_name": "Jaira Burns",
-                    "listen_count": 18
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b650167d-3f75-4a39-a0b5-7cf4e65b7205"
                     ],
+                    "listen_count": 17,
                     "artist_name": "Katy Perry",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ad541512-7c48-4c7c-91a0-0dc68b2e4c85"
                     ],
+                    "listen_count": 17,
                     "artist_name": "Insomnium",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d1d1189c-9842-4d87-949e-0cfe7093da2c"
                     ],
+                    "listen_count": 17,
                     "artist_name": "Amon Tobin",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ff5c0560-a3c4-45b7-81de-56a56f14a899"
                     ],
+                    "listen_count": 17,
                     "artist_name": "100 gecs",
-                    "listen_count": 17
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99a3f584-0c1f-422d-9581-daa935892166"
                     ],
+                    "listen_count": 16,
                     "artist_name": "MNEK",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "19a802c6-9b4e-4128-b291-0893077b3d31"
                     ],
+                    "listen_count": 16,
                     "artist_name": "Anelis Assump\u00e7\u00e3o",
-                    "listen_count": 16
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "30fd3091-0127-4746-89cd-493b35ad0112"
                     ],
+                    "listen_count": 15,
                     "artist_name": "Riverside",
-                    "listen_count": 15
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
                     ],
+                    "listen_count": 15,
                     "artist_name": "David Bowie",
-                    "listen_count": 15
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dcb5740f-949d-4ccf-9e9e-40755da0a336"
                     ],
+                    "listen_count": 14,
                     "artist_name": "Bilmuri",
-                    "listen_count": 14
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9092d3a9-a24d-490f-a758-7537905ddfb2"
                     ],
+                    "listen_count": 13,
                     "artist_name": "Thank You Scientist",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
                     ],
+                    "listen_count": 13,
                     "artist_name": "Shawn Mendes",
-                    "listen_count": 13
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a76a3ee6-8a46-468f-a24f-2fe5f3be77b2"
                     ],
+                    "listen_count": 12,
                     "artist_name": "The Tourist Company",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "46ceff00-4f51-4d47-b49b-cae6420eeb63"
                     ],
+                    "listen_count": 12,
                     "artist_name": "Abstract Void",
-                    "listen_count": 12
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b9956564-f7fd-4c97-a3fa-b88b157affa1"
                     ],
+                    "listen_count": 11,
                     "artist_name": "Vader",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2090ff2e-6657-4997-9d4f-2d3baa0017f0"
                     ],
+                    "listen_count": 11,
                     "artist_name": "The Strokes",
-                    "listen_count": 11
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a1328477-0e85-4bb6-8913-7f472e0e736e"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Shaka Ponk",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "84d50322-0713-4461-aaf0-18a7c0eaabc6"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Sade",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d1d0b7db-4b6c-4032-9c20-ab4fa862f62c"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Red Vox",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "53056a48-242c-4fa4-a7df-1ce749acf4be"
                     ],
+                    "listen_count": 10,
                     "artist_name": "NeuroWulf",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6599e41e-390c-4855-a2ac-68ee798538b4"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Coldplay",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "991c78a3-9242-4354-b48b-276b2563e2cf"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Between the Buried and Me",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "89d99f49-e6c5-4f33-a497-364f00443250"
                     ],
+                    "listen_count": 10,
                     "artist_name": "Baco Exu do Blues",
-                    "listen_count": 10
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b100da12-be6b-43c2-a0a6-91d6dfa31d2d"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Ms Nina",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4c267f9f-95b7-4a77-9ba8-275695bb5c77"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Kosheen",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "46f46533-0545-4204-a3a0-3460025e9bc8"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Kelsea Ballerini",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "961bfa0a-407d-4a23-a0dd-b8e458fb7278"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Kari Faux",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0130abed-3ff5-407a-a814-581ab1b13c65"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Jessie J",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f1993b30-8616-4de2-bb7d-93dc0ba45521"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Harry Styles",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "78180459-0eac-4664-87d6-2a729ac0f5af"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Camila Cabello",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fcaef907-0ed4-43b7-bb98-b0b8afe9df5c"
                     ],
+                    "listen_count": 9,
                     "artist_name": "Caligula\u2019s Horse",
-                    "listen_count": 9
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7ba181fe-0133-4ba3-8628-e4a3961194d1"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Lola Marsh",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4f409234-d8d3-4a4a-a664-7186614a9c09"
                     ],
+                    "listen_count": 8,
                     "artist_name": "Big Sean",
-                    "listen_count": 8
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3f00c1e3-17ce-423f-a35c-0037a4c172f0"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Three Days Grace",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "48037460-0837-460f-b2c8-2794f4bc1406"
                     ],
+                    "listen_count": 7,
                     "artist_name": "The Wanted",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c8fee4af-cf1c-4676-809b-930251b57289"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Solange",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "5b7f6101-c781-4664-8c4b-48192fed83eb"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Snakehips",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ac6f4804-6215-4e1b-bb47-3672f085dde6"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Sia",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "254069ee-0bcd-49bf-b4a0-ece111ae541b"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Robert Francis",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8c69c8e8-c42d-4ba5-82f2-f687934c9e13"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Piano",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d501dda5-2735-4b7d-a2c9-a20f2e78b418"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Mac Miller",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ea88d5da-63b0-4410-a893-294d61d07033"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Lu\u00edsa Sonza",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "db5f18d9-0319-4a0d-bc75-08354b92bff5"
                     ],
+                    "listen_count": 7,
                     "artist_name": "Amy Winehouse",
-                    "listen_count": 7
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7f103972-1ade-4b78-bb74-c0a70731097a"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Zero 7",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
                     ],
+                    "listen_count": 6,
                     "artist_name": "The Weeknd",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "44985283-048c-4fd4-8817-4bf278104d49"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Sid Sriram",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "070844c0-d715-471d-9141-ac02aaeb1896"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Rick Wakeman",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "37733b1f-e682-45ef-a509-51b7ee61f9e0"
                     ],
+                    "listen_count": 6,
                     "artist_name": "October Tide",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "865022b8-09bf-4cc6-9a2a-db9b679e137f"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Jorja Smith",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7ef97e12-5648-4261-89ed-982da0eed624"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Green Day",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d09497af-2736-44f1-832a-e796201d89a4"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Freddie Gibbs & The Alchemist",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "01304329-2423-4ad7-b2ff-d4d9b796b2c6"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Death in Vegas",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c8009cbf-fffe-476e-a94c-27c2199d68af"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Bamao Yend\u00e9",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "3239a1ee-2405-477d-a296-e2a82324af79"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Alice Phoebe Lou",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "78301a87-32ce-4857-b64d-97b4a08850ef"
                     ],
+                    "listen_count": 6,
                     "artist_name": "Abramis Brama",
-                    "listen_count": 6
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "00a2e257-eccc-466e-9c3f-c424281e20d3"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Torgeir Waldemar",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "87fc6bdb-50ba-4fcc-9819-24e2b78053ec"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Team Sleep",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7db97ead-5341-466a-8436-1d14bf25a6ec"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Papa Roach",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "000efb44-525a-4f95-a717-a2503ce66adf"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Morrissey",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a6347ef8-b6bf-4eec-87fb-6a366090f1b3"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Lucky Daye",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "68b03150-d13f-4d85-bf51-ddfb2a06b028"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Ling Tosite Sigure",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b0b5b781-fca0-4152-a500-8f9c00d7d1a0"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Janelle Mon\u00e1e",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "97d4de44-fd69-4865-b25c-2f93a5110046"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Fu Manchu",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "811158af-6dd8-49eb-a3ae-a73fa16a4ca6"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Elder",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ee182ec-fda1-491b-8f13-c19e2da34c82"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Dire Straits",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7309f023-a3f8-45cf-83f8-ac898b588220"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Danna Paola",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "97913071-2c2e-4669-b7ab-ad48f89a8e92"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Bibi",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8be7c18f-70e6-4e26-985c-769a45d3b64a"
                     ],
+                    "listen_count": 5,
                     "artist_name": "Bebe Rexha",
-                    "listen_count": 5
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1e7a13d0-c053-47b6-9c06-2a0fafe33009"
                     ],
+                    "listen_count": 4,
                     "artist_name": "bomb the bass feat. bim sherman",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1910e8be-1950-4b32-aeda-3f86b6adac1e"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Zendaya",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4ae89ac4-67f3-4ec8-bc0e-484dcb2b4183"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Wolfman",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "29d92749-b0a0-42de-ba68-6fa8b0c45dc9"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Theme",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "5f6d94d6-072f-4a3a-8e3d-e2c0b7d0a254"
                     ],
+                    "listen_count": 4,
                     "artist_name": "The Sword",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0d5aad58-2e55-4e84-870b-99edbf958fe6"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Sum 41",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "4522e59f-1250-485f-aa6e-403c4aecdb30"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Special D.",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "30e74976-ab8e-4cf8-a44e-5a123f04eb3a"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Royal Republic",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8e170cec-b5f2-4dc2-8599-c097165a5ffc"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Princess Nokia",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "edd660e7-70a5-4385-ac87-1a773b806891"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Pop Will Eat Itself",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "8a253b0f-4a3a-4557-a293-7a99e9d5fad5"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Peter Andre",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "21416da1-b660-4376-a7c5-2324499277cb"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Pennywise",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cc8d1b77-14b3-42e4-83ec-802c3a1427fa"
                     ],
+                    "listen_count": 4,
                     "artist_name": "OutKast",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "ab24f28b-6b72-42ed-8086-aeb738427e58"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Nu Era",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0d915677-5f4c-4101-99c6-8108729ce9aa"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Mike Posner",
-                    "listen_count": 4
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a2c1ed01-991f-4a9d-81e0-9b04c8df1c80"
                     ],
+                    "listen_count": 4,
                     "artist_name": "Michelle McManus",
-                    "listen_count": 4
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1591660800,

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_year.json
@@ -8,211 +8,241 @@
                     "artist_mbids": [
                         "75c5f0fe-ff02-4f36-bd79-9db14041b6d2"
                     ],
+                    "listen_count": 424,
                     "artist_name": "Bob Dylan",
-                    "listen_count": 424
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "50fa106f-e40d-49ec-bca1-9802fb2157e7"
                     ],
+                    "listen_count": 363,
                     "artist_name": "Radiohead",
-                    "listen_count": 363
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e12b120c-9b69-49ac-9d22-6a904edff32b"
                     ],
+                    "listen_count": 286,
                     "artist_name": "The Rolling Stones",
-                    "listen_count": 286
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b4ae3356-b8a7-471a-a23a-e471a69ad454"
                     ],
+                    "listen_count": 286,
                     "artist_name": "Ariana Grande",
-                    "listen_count": 286
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "27f6c4f6-f7a3-4fe0-b02c-7f3ed494e9fb"
                     ],
+                    "listen_count": 207,
                     "artist_name": "Rosal\u00eda",
-                    "listen_count": 207
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "62cc4b55-7b65-4676-909c-e3f221a40dfb"
                     ],
+                    "listen_count": 194,
                     "artist_name": "The Beatles",
-                    "listen_count": 194
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d290cd3b-40a4-47c8-a476-7dfc2f8b3895"
                     ],
+                    "listen_count": 187,
                     "artist_name": "The Cure",
-                    "listen_count": 187
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e98b10b6-0208-4157-9544-36041e303f07"
                     ],
+                    "listen_count": 166,
                     "artist_name": "Lauv",
-                    "listen_count": 166
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1d743e65-7850-4aed-b248-650c1e8ccfc1"
                     ],
+                    "listen_count": 151,
                     "artist_name": "Theophilus London",
-                    "listen_count": 151
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
                     ],
+                    "listen_count": 133,
                     "artist_name": "Bring Me the Horizon",
-                    "listen_count": 133
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e03b3c0c-f1b1-4647-aa87-c6a9a05da72e"
                     ],
+                    "listen_count": 132,
                     "artist_name": "Kedr Livanskiy",
-                    "listen_count": 132
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "34dcee7e-347d-42fa-9326-1e2ba1a3023b"
                     ],
+                    "listen_count": 132,
                     "artist_name": "Arctic Monkeys",
-                    "listen_count": 132
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "416bd396-6859-4c6a-94bd-36271a9113fc"
                     ],
+                    "listen_count": 114,
                     "artist_name": "Kehlani",
-                    "listen_count": 114
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2e7243ec-b05c-40ff-8e89-200a1b0b8474"
                     ],
+                    "listen_count": 113,
                     "artist_name": "Broken Social Scene",
-                    "listen_count": 113
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ee182ec-fda1-491b-8f13-c19e2da34c82"
                     ],
+                    "listen_count": 107,
                     "artist_name": "Dire Straits",
-                    "listen_count": 107
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "c1c80ec1-9153-482f-b0f9-2d3b94645920"
                     ],
+                    "listen_count": 107,
                     "artist_name": "Beyonc\u00e9",
-                    "listen_count": 107
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "7388fe00-a3bd-4c03-a242-02fcd92a867e"
                     ],
+                    "listen_count": 106,
                     "artist_name": "Kamasi Washington",
-                    "listen_count": 106
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b18756d6-bb73-4233-8715-1b46a9e7b904"
                     ],
+                    "listen_count": 106,
                     "artist_name": "James Blake",
-                    "listen_count": 106
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "089c6d19-4157-4d57-9859-2c57e3d7ccf1"
                     ],
+                    "listen_count": 105,
                     "artist_name": "Led Zeppelin",
-                    "listen_count": 105
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0d07cf3b-3648-475e-9588-c626fa7cdd66"
                     ],
+                    "listen_count": 102,
                     "artist_name": "Brant Bjork",
-                    "listen_count": 102
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "69bc69f4-53cb-451f-af30-a12533df740b"
                     ],
+                    "listen_count": 99,
                     "artist_name": "Nick Cave & The Bad Seeds",
-                    "listen_count": 99
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a116d7fe-94d2-4a43-a160-e9adb79627d8"
                     ],
+                    "listen_count": 91,
                     "artist_name": "Father John Misty",
-                    "listen_count": 91
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "db5446a5-3019-44ba-b4cf-e07eeec15645"
                     ],
+                    "listen_count": 90,
                     "artist_name": "Beyond Creation",
-                    "listen_count": 90
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "cc8d1b77-14b3-42e4-83ec-802c3a1427fa"
                     ],
+                    "listen_count": 77,
                     "artist_name": "OutKast",
-                    "listen_count": 77
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9266c1c0-30ff-4c7c-9349-05ca1f4f4f02"
                     ],
+                    "listen_count": 76,
                     "artist_name": "Matthew Halsall",
-                    "listen_count": 76
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "78301a87-32ce-4857-b64d-97b4a08850ef"
                     ],
+                    "listen_count": 76,
                     "artist_name": "Abramis Brama",
-                    "listen_count": 76
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "89e429a3-d6e8-4d7a-b500-f2eed40dfe69"
                     ],
+                    "listen_count": 75,
                     "artist_name": "Eli Keszler",
-                    "listen_count": 75
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "563c8c7a-4034-44ed-9a01-7dbf40ad4a36"
                     ],
+                    "listen_count": 71,
                     "artist_name": "Absolute Body Control",
-                    "listen_count": 71
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
                     ],
+                    "listen_count": 70,
                     "artist_name": "Slayer",
-                    "listen_count": 70
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "dafc32d8-6a8e-46b4-ab13-e2a4352028dc"
                     ],
+                    "listen_count": 68,
                     "artist_name": "Born of Osiris",
-                    "listen_count": 68
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1546300800,
@@ -225,211 +255,241 @@
                     "artist_mbids": [
                         "b4ae3356-b8a7-471a-a23a-e471a69ad454"
                     ],
+                    "listen_count": 968,
                     "artist_name": "Ariana Grande",
-                    "listen_count": 968
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "1d743e65-7850-4aed-b248-650c1e8ccfc1"
                     ],
+                    "listen_count": 182,
                     "artist_name": "Theophilus London",
-                    "listen_count": 182
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
                     ],
+                    "listen_count": 156,
                     "artist_name": "Megadeth",
-                    "listen_count": 156
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
                     ],
+                    "listen_count": 132,
                     "artist_name": "David Bowie",
-                    "listen_count": 132
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "62cc4b55-7b65-4676-909c-e3f221a40dfb"
                     ],
+                    "listen_count": 120,
                     "artist_name": "The Beatles",
-                    "listen_count": 120
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "34dcee7e-347d-42fa-9326-1e2ba1a3023b"
                     ],
+                    "listen_count": 112,
                     "artist_name": "Arctic Monkeys",
-                    "listen_count": 112
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "e98b10b6-0208-4157-9544-36041e303f07"
                     ],
+                    "listen_count": 96,
                     "artist_name": "Lauv",
-                    "listen_count": 96
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "bb9e8bc8-e254-4ddd-94fd-184976c04766"
                     ],
+                    "listen_count": 90,
                     "artist_name": "Ghost",
-                    "listen_count": 90
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "9c4c0f38-5e9e-45de-b5fc-da6377a5bdc2"
                     ],
+                    "listen_count": 90,
                     "artist_name": "Elza Soares",
-                    "listen_count": 90
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6ee182ec-fda1-491b-8f13-c19e2da34c82"
                     ],
+                    "listen_count": 90,
                     "artist_name": "Dire Straits",
-                    "listen_count": 90
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "416bd396-6859-4c6a-94bd-36271a9113fc"
                     ],
+                    "listen_count": 85,
                     "artist_name": "Kehlani",
-                    "listen_count": 85
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "89e429a3-d6e8-4d7a-b500-f2eed40dfe69"
                     ],
+                    "listen_count": 81,
                     "artist_name": "Eli Keszler",
-                    "listen_count": 81
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "69bc69f4-53cb-451f-af30-a12533df740b"
                     ],
+                    "listen_count": 79,
                     "artist_name": "Nick Cave & The Bad Seeds",
-                    "listen_count": 79
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "50fa106f-e40d-49ec-bca1-9802fb2157e7"
                     ],
+                    "listen_count": 76,
                     "artist_name": "Radiohead",
-                    "listen_count": 76
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "20beaded-6bea-41d4-bca7-3f0cadbca0c0"
                     ],
+                    "listen_count": 74,
                     "artist_name": "Sleater-Kinney",
-                    "listen_count": 74
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f447378c-6129-4277-b921-d3d8f468871b"
                     ],
+                    "listen_count": 73,
                     "artist_name": "James Chance  The Contortions",
-                    "listen_count": 73
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "6678a29c-cd2d-4954-8d16-a7d2f2e06df2"
                     ],
+                    "listen_count": 73,
                     "artist_name": "Freddie Gibbs",
-                    "listen_count": 73
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f663264b-2618-4976-b4fc-0b96bb23cfad"
                     ],
+                    "listen_count": 70,
                     "artist_name": "Chancha Via Circuito",
-                    "listen_count": 70
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
                     ],
+                    "listen_count": 68,
                     "artist_name": "Within Temptation",
-                    "listen_count": 68
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "183857a7-737d-456a-b301-bb621603a46d"
                     ],
+                    "listen_count": 66,
                     "artist_name": "The Haggis Horns",
-                    "listen_count": 66
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "fa0ad972-a4dc-4948-8610-e2cd48a00906"
                     ],
+                    "listen_count": 65,
                     "artist_name": "Black Lips",
-                    "listen_count": 65
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "2274335d-46f9-4608-af69-2f4c4f6a3970"
                     ],
+                    "listen_count": 61,
                     "artist_name": "Nicola Cruz",
-                    "listen_count": 61
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "27f6c4f6-f7a3-4fe0-b02c-7f3ed494e9fb"
                     ],
+                    "listen_count": 60,
                     "artist_name": "Rosal\u00eda",
-                    "listen_count": 60
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "0de3dfa7-3b11-4d09-b7b0-0aaf30285ecb"
                     ],
+                    "listen_count": 59,
                     "artist_name": "Years & Years",
-                    "listen_count": 59
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "42295e78-0a50-4baa-abbf-d81fda2b7343"
                     ],
+                    "listen_count": 59,
                     "artist_name": "Nirvana",
-                    "listen_count": 59
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f31223bf-43e7-4565-9d5b-34f4e7897d71"
                     ],
+                    "listen_count": 59,
                     "artist_name": "Anathema",
-                    "listen_count": 59
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "99dcf06c-4f49-4fa1-a64e-47ef3ea8075d"
                     ],
+                    "listen_count": 57,
                     "artist_name": "Rimon",
-                    "listen_count": 57
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "b8e44f2e-3e42-4f0d-b7ef-6f874b882bad"
                     ],
+                    "listen_count": 56,
                     "artist_name": "Whitechapel",
-                    "listen_count": 56
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "f88767e0-c644-46f6-9758-06f99dcfa8aa"
                     ],
+                    "listen_count": 56,
                     "artist_name": "Sok\u00f3\u0142",
-                    "listen_count": 56
+                    "artist_msid": null
                 },
                 {
                     "artist_mbids": [
                         "a63d3de8-9c39-4320-8199-784df3f4c74c"
                     ],
+                    "listen_count": 55,
                     "artist_name": "Soen",
-                    "listen_count": 55
+                    "artist_msid": null
                 }
             ],
             "from_ts": 1548979200,

--- a/listenbrainz/testdata/user_top_artists_db.json
+++ b/listenbrainz/testdata/user_top_artists_db.json
@@ -1,17 +1,23 @@
 {
-  "from_ts": 0,
-  "to_ts": 10,
-  "artists": [
-    {
-      "listen_count": 230,
-      "artist_name": "Kanye West",
-      "artist_mbids": ["ed6c388e-ea65-431f-8be5-4959239d8c65"]
-    },
-    {
-      "listen_count": 229,
-      "artist_name": "Frank Ocean",
-      "artist_mbids": ["80ca06c7-07fb-4b3a-a315-ad584cc8eeb0"]
-    }
-  ],
-  "count": 2
+    "from_ts": 0,
+    "to_ts": 10,
+    "artists": [
+        {
+            "artist_mbids": [
+                "ed6c388e-ea65-431f-8be5-4959239d8c65"
+            ],
+            "listen_count": 230,
+            "artist_name": "Kanye West",
+            "artist_msid": null
+        },
+        {
+            "artist_mbids": [
+                "80ca06c7-07fb-4b3a-a315-ad584cc8eeb0"
+            ],
+            "listen_count": 229,
+            "artist_name": "Frank Ocean",
+            "artist_msid": null
+        }
+    ],
+    "count": 2
 }

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test.json
@@ -4,526 +4,601 @@
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
+            "listen_count": 385,
             "artist_name": "The Local train",
-            "listen_count": 385
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
+            "listen_count": 333,
             "artist_name": "Lenka",
-            "listen_count": 333
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "cc197bad-dc9c-440d-a5b5-d52ba2e14234"
             ],
+            "listen_count": 321,
             "artist_name": "Coldplay",
-            "listen_count": 321
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
+            "listen_count": 176,
             "artist_name": "Imagine Dragons",
-            "listen_count": 176
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
+            "listen_count": 118,
             "artist_name": "Maroon 5",
-            "listen_count": 118
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
+            "listen_count": 108,
             "artist_name": "Ellie Goulding",
-            "listen_count": 108
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
+            "listen_count": 65,
             "artist_name": "OneRepublic",
-            "listen_count": 65
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
+            "listen_count": 52,
             "artist_name": "The Weeknd",
-            "listen_count": 52
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
+            "listen_count": 44,
             "artist_name": "The Chainsmokers",
-            "listen_count": 44
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
+            "listen_count": 41,
             "artist_name": "The Fray",
-            "listen_count": 41
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
+            "listen_count": 35,
             "artist_name": "George Ezra",
-            "listen_count": 35
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
+            "listen_count": 34,
             "artist_name": "Taylor Swift",
-            "listen_count": 34
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
+            "listen_count": 34,
             "artist_name": "Train",
-            "listen_count": 34
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
+            "listen_count": 33,
             "artist_name": "M.I.A.",
-            "listen_count": 33
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
+            "listen_count": 30,
             "artist_name": "American Authors",
-            "listen_count": 30
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
+            "listen_count": 30,
             "artist_name": "Tommee Profitt",
-            "listen_count": 30
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
+            "listen_count": 30,
             "artist_name": "Within Temptation",
-            "listen_count": 30
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
+            "listen_count": 24,
             "artist_name": "The Lumineers",
-            "listen_count": 24
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
+            "listen_count": 24,
             "artist_name": "Linkin Park",
-            "listen_count": 24
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
+            "listen_count": 24,
             "artist_name": "Vance Joy",
-            "listen_count": 24
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "f0ff6fbe-ce2f-45d8-bef5-80725471fe5a"
             ],
+            "listen_count": 23,
             "artist_name": "Alan Walker, Noah Cyrus, Digital Farm Animals",
-            "listen_count": 23
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
+            "listen_count": 20,
             "artist_name": "Sia",
-            "listen_count": 20
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "e17a5ee3-3f96-4307-bacc-9ad50073e0ea"
             ],
+            "listen_count": 20,
             "artist_name": "Alan Walker, Alan Walker",
-            "listen_count": 20
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
+            "listen_count": 19,
             "artist_name": "Ed Sheeran",
-            "listen_count": 19
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8fa7a31e-91ea-44ff-8939-9be736d5838d"
             ],
+            "listen_count": 12,
             "artist_name": "Vishal-Shekhar",
-            "listen_count": 12
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
+            "listen_count": 11,
             "artist_name": "Backstreet Boys",
-            "listen_count": 11
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b1e41ca1-529d-4707-8c6a-14c88f052025"
             ],
+            "listen_count": 11,
             "artist_name": "The Chainsmokers, Coldplay, The Chainsmokers, The Chainsmokers & Coldplay, Coldplay",
-            "listen_count": 11
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "abf274d4-a1f8-4477-b5c6-8c1121a13cf6"
             ],
+            "listen_count": 11,
             "artist_name": "Bruno Mars",
-            "listen_count": 11
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b34aa9cf-10ce-4324-9929-edc13a08ea2a"
             ],
+            "listen_count": 10,
             "artist_name": "The Chainsmokers, The Chainsmokers, Halsey",
-            "listen_count": 10
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "afbfb7c6-6a50-48d2-a38e-66f595191438"
             ],
+            "listen_count": 8,
             "artist_name": "Alan Walker, Gavin James",
-            "listen_count": 8
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "c5fe302b-c44e-48b5-9e37-f5d4d6f97e3e"
             ],
+            "listen_count": 7,
             "artist_name": "Jared Moreno Luna",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "29ea9fb1-57da-41af-8296-4708a718147c"
             ],
+            "listen_count": 7,
             "artist_name": "Coldplay, Big Sean",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "78ea0d33-cffa-477a-857c-e2981bac9fe4"
             ],
+            "listen_count": 7,
             "artist_name": "Charlie Puth, Selena Gomez",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "485029d6-bcdc-44a1-bf9f-8863915e43db"
             ],
+            "listen_count": 7,
             "artist_name": "Jasleen Royal",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d8696b51-1a16-4543-b9a2-8e9c6b91b42c"
             ],
+            "listen_count": 7,
             "artist_name": "Amit Trivedi",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fda2dfd0-1886-46c4-8d8a-f441fc14196d"
             ],
+            "listen_count": 6,
             "artist_name": "Sonu Nigam",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "209b0f51-78e2-4333-85b0-bfe756723970"
             ],
+            "listen_count": 5,
             "artist_name": "Shakira",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6a585aed-f74e-4343-a45b-632a12d2db01"
             ],
+            "listen_count": 5,
             "artist_name": "Clean Bandit, Zara Larsson, MK",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "be453392-5c84-4bc3-9442-48e8a24cff90"
             ],
+            "listen_count": 5,
             "artist_name": "Alan Silvestri",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
+            "listen_count": 5,
             "artist_name": "Shawn Mendes",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "46c7f28d-240d-46a2-bf7a-44dda741bb19"
             ],
+            "listen_count": 5,
             "artist_name": "Pritam",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "5a67966d-d775-48fb-a2fb-359ed4666105"
             ],
+            "listen_count": 5,
             "artist_name": "Jason Mraz",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "474b46a9-0c2e-4a27-b1ac-55f3a0b9f6dc"
             ],
+            "listen_count": 5,
             "artist_name": "Ajay Gogavale",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1c498eab-998f-4975-b52b-72243e89c0ba"
             ],
+            "listen_count": 5,
             "artist_name": "One Direction",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "25cee6e6-1623-4575-bc9d-cb4f7c35f37f"
             ],
+            "listen_count": 5,
             "artist_name": "DJ Snake, Justin Bieber",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ea508409-1c39-461c-a7ab-2163f89be757"
             ],
+            "listen_count": 5,
             "artist_name": "Mohit Chauhan",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d25a82aa-1377-43cd-a447-fb52532e9b85"
             ],
+            "listen_count": 5,
             "artist_name": "Clean Bandit [FazMusic.Net]",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "f51e0925-f3a7-4381-bd23-87f6b3468906"
             ],
+            "listen_count": 4,
             "artist_name": "Dev Negi",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "19a05a11-e927-4327-be0d-27dc37278de6"
             ],
+            "listen_count": 4,
             "artist_name": "Kodaline",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b182f99b-982c-4469-8372-8959affe87e7"
             ],
+            "listen_count": 4,
             "artist_name": "Benny Dayal",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "80daf28c-5198-454a-9f74-4a1300f544ac"
             ],
+            "listen_count": 4,
             "artist_name": "Anirudh Ravichander",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "a20eb386-b985-432a-8f50-63f854c4640a"
             ],
+            "listen_count": 4,
             "artist_name": "Eagles",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "bf85aa32-dc19-483d-95c3-754e2ba18540"
             ],
+            "listen_count": 4,
             "artist_name": "The Chainsmokers, The Chainsmokers",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
+            "listen_count": 4,
             "artist_name": "The Script",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b982577e-02da-4e04-beb7-3cb4577f4aad"
             ],
+            "listen_count": 4,
             "artist_name": "Ayushmann Khurrana",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0df3a81c-7820-476a-a9d5-b797e92e17c4"
             ],
+            "listen_count": 4,
             "artist_name": "Passenger",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "a275d8a0-0535-494c-aa2c-1b8978b75305"
             ],
+            "listen_count": 4,
             "artist_name": "Vishal Dadlani",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6fbc15cf-5845-40e1-9dd8-ea8dbb05d871"
             ],
+            "listen_count": 4,
             "artist_name": "Taio Cruz",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "395e3442-5872-4e07-895c-8d8194e4e256"
             ],
+            "listen_count": 4,
             "artist_name": "The Chainsmokers, The Chainsmokers, Phoebe Ryan",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "e54b7dc0-69b4-419d-b71b-95db8bd8d3e9"
             ],
+            "listen_count": 3,
             "artist_name": "Wiz Khalifa, Charlie Puth",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "291bca64-8c93-4790-85db-cf25baacb49e"
             ],
+            "listen_count": 3,
             "artist_name": "James Blunt",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "f0676957-e3d7-4ca6-baf8-ffecaa01f415"
             ],
+            "listen_count": 3,
             "artist_name": "Clean Bandit",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "98184d50-f63d-4232-8a81-c06fa53b1082"
             ],
+            "listen_count": 3,
             "artist_name": "Carly Rae Jepsen",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1e6376d9-5112-4398-9283-6a5f23c8d2aa"
             ],
+            "listen_count": 3,
             "artist_name": "Calvin Harris",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fc0a98da-ddb2-4a93-becb-43a90471a7aa"
             ],
+            "listen_count": 3,
             "artist_name": "Pharrell Williams, Pharrell Williams",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "bcda4610-9da6-4059-92ee-8c539fb69c19"
             ],
+            "listen_count": 3,
             "artist_name": "Maroon 5, Kendrick Lamar",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "2fbb01d7-a799-4a0f-bd14-41c3074a3566"
             ],
+            "listen_count": 3,
             "artist_name": "Major Lazer, DJ Snake, M\u00d8",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b09db02b-5438-4360-a73f-7a3a5b88358f"
             ],
+            "listen_count": 3,
             "artist_name": "Colbie Caillat",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6ed637a9-773d-4c14-a673-9e3c1d4f0bd0"
             ],
+            "listen_count": 3,
             "artist_name": "5 Seconds of Summer",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "e98b10b6-0208-4157-9544-36041e303f07"
             ],
+            "listen_count": 3,
             "artist_name": "Lauv",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ef3e1c0b-d517-4336-83ab-574f5fb7b90a"
             ],
+            "listen_count": 3,
             "artist_name": "Norman D",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         }
     ],
     "count": 75,

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_month.json
@@ -4,176 +4,201 @@
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
+            "listen_count": 35,
             "artist_name": "Ellie Goulding",
-            "listen_count": 35
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
+            "listen_count": 23,
             "artist_name": "Coldplay",
-            "listen_count": 23
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
+            "listen_count": 19,
             "artist_name": "Maroon 5",
-            "listen_count": 19
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
+            "listen_count": 16,
             "artist_name": "OneRepublic",
-            "listen_count": 16
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
+            "listen_count": 14,
             "artist_name": "Ed Sheeran",
-            "listen_count": 14
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
+            "listen_count": 13,
             "artist_name": "Lenka",
-            "listen_count": 13
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
+            "listen_count": 12,
             "artist_name": "The Script",
-            "listen_count": 12
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
+            "listen_count": 12,
             "artist_name": "Imagine Dragons",
-            "listen_count": 12
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
+            "listen_count": 8,
             "artist_name": "The Fray",
-            "listen_count": 8
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
+            "listen_count": 8,
             "artist_name": "Christina Perri",
-            "listen_count": 8
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
+            "listen_count": 7,
             "artist_name": "Tommee Profitt",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
+            "listen_count": 7,
             "artist_name": "Taylor Swift",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 7,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
+            "listen_count": 7,
             "artist_name": "Linkin Park",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
+            "listen_count": 7,
             "artist_name": "George Ezra",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
+            "listen_count": 6,
             "artist_name": "Vance Joy",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
+            "listen_count": 6,
             "artist_name": "Sia",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
+            "listen_count": 6,
             "artist_name": "M.I.A.",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
+            "listen_count": 5,
             "artist_name": "The Chainsmokers",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
+            "listen_count": 4,
             "artist_name": "The Local train",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
+            "listen_count": 4,
             "artist_name": "Ritviz",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
+            "listen_count": 3,
             "artist_name": "Train",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
+            "listen_count": 3,
             "artist_name": "The Weeknd",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
+            "listen_count": 3,
             "artist_name": "The Lumineers",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
+            "listen_count": 3,
             "artist_name": "Backstreet Boys",
-            "listen_count": 3
+            "artist_msid": null
         }
     ],
     "count": 25,

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_too_many.json
@@ -4,701 +4,801 @@
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
+            "listen_count": 385,
             "artist_name": "The Local train",
-            "listen_count": 385
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
+            "listen_count": 333,
             "artist_name": "Lenka",
-            "listen_count": 333
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
+            "listen_count": 321,
             "artist_name": "Coldplay",
-            "listen_count": 321
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
+            "listen_count": 176,
             "artist_name": "Imagine Dragons",
-            "listen_count": 176
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
+            "listen_count": 118,
             "artist_name": "Maroon 5",
-            "listen_count": 118
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
+            "listen_count": 108,
             "artist_name": "Ellie Goulding",
-            "listen_count": 108
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
+            "listen_count": 65,
             "artist_name": "OneRepublic",
-            "listen_count": 65
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
+            "listen_count": 52,
             "artist_name": "The Weeknd",
-            "listen_count": 52
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
+            "listen_count": 44,
             "artist_name": "The Chainsmokers",
-            "listen_count": 44
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
+            "listen_count": 41,
             "artist_name": "The Fray",
-            "listen_count": 41
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
+            "listen_count": 35,
             "artist_name": "George Ezra",
-            "listen_count": 35
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
+            "listen_count": 34,
             "artist_name": "Taylor Swift",
-            "listen_count": 34
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
+            "listen_count": 34,
             "artist_name": "Train",
-            "listen_count": 34
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
+            "listen_count": 33,
             "artist_name": "M.I.A.",
-            "listen_count": 33
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
+            "listen_count": 30,
             "artist_name": "American Authors",
-            "listen_count": 30
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
+            "listen_count": 30,
             "artist_name": "Tommee Profitt",
-            "listen_count": 30
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
+            "listen_count": 30,
             "artist_name": "Within Temptation",
-            "listen_count": 30
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
+            "listen_count": 24,
             "artist_name": "The Lumineers",
-            "listen_count": 24
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
+            "listen_count": 24,
             "artist_name": "Linkin Park",
-            "listen_count": 24
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
+            "listen_count": 24,
             "artist_name": "Vance Joy",
-            "listen_count": 24
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "f0ff6fbe-ce2f-45d8-bef5-80725471fe5a"
             ],
+            "listen_count": 23,
             "artist_name": "Alan Walker, Noah Cyrus, Digital Farm Animals",
-            "listen_count": 23
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
+            "listen_count": 20,
             "artist_name": "Sia",
-            "listen_count": 20
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "e17a5ee3-3f96-4307-bacc-9ad50073e0ea"
             ],
+            "listen_count": 20,
             "artist_name": "Alan Walker, Alan Walker",
-            "listen_count": 20
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
+            "listen_count": 19,
             "artist_name": "Ed Sheeran",
-            "listen_count": 19
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8fa7a31e-91ea-44ff-8939-9be736d5838d"
             ],
+            "listen_count": 12,
             "artist_name": "Vishal-Shekhar",
-            "listen_count": 12
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
+            "listen_count": 11,
             "artist_name": "Backstreet Boys",
-            "listen_count": 11
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b1e41ca1-529d-4707-8c6a-14c88f052025"
             ],
+            "listen_count": 11,
             "artist_name": "The Chainsmokers, Coldplay, The Chainsmokers, The Chainsmokers & Coldplay, Coldplay",
-            "listen_count": 11
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "abf274d4-a1f8-4477-b5c6-8c1121a13cf6"
             ],
+            "listen_count": 11,
             "artist_name": "Bruno Mars",
-            "listen_count": 11
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b34aa9cf-10ce-4324-9929-edc13a08ea2a"
             ],
+            "listen_count": 10,
             "artist_name": "The Chainsmokers, The Chainsmokers, Halsey",
-            "listen_count": 10
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "afbfb7c6-6a50-48d2-a38e-66f595191438"
             ],
+            "listen_count": 8,
             "artist_name": "Alan Walker, Gavin James",
-            "listen_count": 8
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "c5fe302b-c44e-48b5-9e37-f5d4d6f97e3e"
             ],
+            "listen_count": 7,
             "artist_name": "Jared Moreno Luna",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "29ea9fb1-57da-41af-8296-4708a718147c"
             ],
+            "listen_count": 7,
             "artist_name": "Coldplay, Big Sean",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "78ea0d33-cffa-477a-857c-e2981bac9fe4"
             ],
+            "listen_count": 7,
             "artist_name": "Charlie Puth, Selena Gomez",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "485029d6-bcdc-44a1-bf9f-8863915e43db"
             ],
+            "listen_count": 7,
             "artist_name": "Jasleen Royal",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d8696b51-1a16-4543-b9a2-8e9c6b91b42c"
             ],
+            "listen_count": 7,
             "artist_name": "Amit Trivedi",
-            "listen_count": 7
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fda2dfd0-1886-46c4-8d8a-f441fc14196d"
             ],
+            "listen_count": 6,
             "artist_name": "Sonu Nigam",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "209b0f51-78e2-4333-85b0-bfe756723970"
             ],
+            "listen_count": 5,
             "artist_name": "Shakira",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6a585aed-f74e-4343-a45b-632a12d2db01"
             ],
+            "listen_count": 5,
             "artist_name": "Clean Bandit, Zara Larsson, MK",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "be453392-5c84-4bc3-9442-48e8a24cff90"
             ],
+            "listen_count": 5,
             "artist_name": "Alan Silvestri",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
+            "listen_count": 5,
             "artist_name": "Shawn Mendes",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "46c7f28d-240d-46a2-bf7a-44dda741bb19"
             ],
+            "listen_count": 5,
             "artist_name": "Pritam",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "5a67966d-d775-48fb-a2fb-359ed4666105"
             ],
+            "listen_count": 5,
             "artist_name": "Jason Mraz",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "474b46a9-0c2e-4a27-b1ac-55f3a0b9f6dc"
             ],
+            "listen_count": 5,
             "artist_name": "Ajay Gogavale",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1c498eab-998f-4975-b52b-72243e89c0ba"
             ],
+            "listen_count": 5,
             "artist_name": "One Direction",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "25cee6e6-1623-4575-bc9d-cb4f7c35f37f"
             ],
+            "listen_count": 5,
             "artist_name": "DJ Snake, Justin Bieber",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ea508409-1c39-461c-a7ab-2163f89be757"
             ],
+            "listen_count": 5,
             "artist_name": "Mohit Chauhan",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d25a82aa-1377-43cd-a447-fb52532e9b85"
             ],
+            "listen_count": 5,
             "artist_name": "Clean Bandit [FazMusic.Net]",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "f51e0925-f3a7-4381-bd23-87f6b3468906"
             ],
+            "listen_count": 4,
             "artist_name": "Dev Negi",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "19a05a11-e927-4327-be0d-27dc37278de6"
             ],
+            "listen_count": 4,
             "artist_name": "Kodaline",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b182f99b-982c-4469-8372-8959affe87e7"
             ],
+            "listen_count": 4,
             "artist_name": "Benny Dayal",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "80daf28c-5198-454a-9f74-4a1300f544ac"
             ],
+            "listen_count": 4,
             "artist_name": "Anirudh Ravichander",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "a20eb386-b985-432a-8f50-63f854c4640a"
             ],
+            "listen_count": 4,
             "artist_name": "Eagles",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "bf85aa32-dc19-483d-95c3-754e2ba18540"
             ],
+            "listen_count": 4,
             "artist_name": "The Chainsmokers, The Chainsmokers",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
+            "listen_count": 4,
             "artist_name": "The Script",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b982577e-02da-4e04-beb7-3cb4577f4aad"
             ],
+            "listen_count": 4,
             "artist_name": "Ayushmann Khurrana",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0df3a81c-7820-476a-a9d5-b797e92e17c4"
             ],
+            "listen_count": 4,
             "artist_name": "Passenger",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "a275d8a0-0535-494c-aa2c-1b8978b75305"
             ],
+            "listen_count": 4,
             "artist_name": "Vishal Dadlani",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6fbc15cf-5845-40e1-9dd8-ea8dbb05d871"
             ],
+            "listen_count": 4,
             "artist_name": "Taio Cruz",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "395e3442-5872-4e07-895c-8d8194e4e256"
             ],
+            "listen_count": 4,
             "artist_name": "The Chainsmokers, The Chainsmokers, Phoebe Ryan",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "e54b7dc0-69b4-419d-b71b-95db8bd8d3e9"
             ],
+            "listen_count": 3,
             "artist_name": "Wiz Khalifa, Charlie Puth",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "291bca64-8c93-4790-85db-cf25baacb49e"
             ],
+            "listen_count": 3,
             "artist_name": "James Blunt",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "f0676957-e3d7-4ca6-baf8-ffecaa01f415"
             ],
+            "listen_count": 3,
             "artist_name": "Clean Bandit",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "98184d50-f63d-4232-8a81-c06fa53b1082"
             ],
+            "listen_count": 3,
             "artist_name": "Carly Rae Jepsen",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1e6376d9-5112-4398-9283-6a5f23c8d2aa"
             ],
+            "listen_count": 3,
             "artist_name": "Calvin Harris",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fc0a98da-ddb2-4a93-becb-43a90471a7aa"
             ],
+            "listen_count": 3,
             "artist_name": "Pharrell Williams, Pharrell Williams",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "bcda4610-9da6-4059-92ee-8c539fb69c19"
             ],
+            "listen_count": 3,
             "artist_name": "Maroon 5, Kendrick Lamar",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "2fbb01d7-a799-4a0f-bd14-41c3074a3566"
             ],
+            "listen_count": 3,
             "artist_name": "Major Lazer, DJ Snake, M\u00d8",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b09db02b-5438-4360-a73f-7a3a5b88358f"
             ],
+            "listen_count": 3,
             "artist_name": "Colbie Caillat",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6ed637a9-773d-4c14-a673-9e3c1d4f0bd0"
             ],
+            "listen_count": 3,
             "artist_name": "5 Seconds of Summer",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "e98b10b6-0208-4157-9544-36041e303f07"
             ],
+            "listen_count": 3,
             "artist_name": "Lauv",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ef3e1c0b-d517-4336-83ab-574f5fb7b90a"
             ],
+            "listen_count": 3,
             "artist_name": "Norman D",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "53623447-d254-40b1-99f8-3f7dfaaef5e5"
             ],
+            "listen_count": 3,
             "artist_name": "One Direction, One Direction",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d03adfc0-6612-4146-9096-8cc85d3e0554"
             ],
+            "listen_count": 3,
             "artist_name": "James Bay",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "b7b65ade-e87d-4b1e-8f52-3159e7d54e4f"
             ],
+            "listen_count": 3,
             "artist_name": "Badshah",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 3,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 3
+            "artist_msid": null
         }
     ],
     "from_ts": 0,

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_week.json
@@ -4,169 +4,193 @@
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
+            "listen_count": 21,
             "artist_name": "Ellie Goulding",
-            "listen_count": 21
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
+            "listen_count": 12,
             "artist_name": "Coldplay",
-            "listen_count": 12
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
+            "listen_count": 10,
             "artist_name": "OneRepublic",
-            "listen_count": 10
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
+            "listen_count": 10,
             "artist_name": "Maroon 5",
-            "listen_count": 10
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
+            "listen_count": 9,
             "artist_name": "Ed Sheeran",
-            "listen_count": 9
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
+            "listen_count": 8,
             "artist_name": "The Script",
-            "listen_count": 8
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
+            "listen_count": 6,
             "artist_name": "Of Monsters and Men",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
+            "listen_count": 6,
             "artist_name": "Lenka",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
+            "listen_count": 6,
             "artist_name": "Christina Perri",
-            "listen_count": 6
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
+            "listen_count": 5,
             "artist_name": "Tommee Profitt",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
+            "listen_count": 5,
             "artist_name": "The Fray",
-            "listen_count": 5
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
+            "listen_count": 4,
             "artist_name": "Vance Joy",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
+            "listen_count": 4,
             "artist_name": "Taylor Swift",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
+            "listen_count": 4,
             "artist_name": "Sia",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
+            "listen_count": 4,
             "artist_name": "M.I.A.",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
+            "listen_count": 4,
             "artist_name": "Linkin Park",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
+            "listen_count": 4,
             "artist_name": "George Ezra",
-            "listen_count": 4
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
+            "listen_count": 2,
             "artist_name": "The Local train",
-            "listen_count": 2
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
+            "listen_count": 2,
             "artist_name": "Ritviz",
-            "listen_count": 2
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
+            "listen_count": 2,
             "artist_name": "Imagine Dragons",
-            "listen_count": 2
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
+            "listen_count": 2,
             "artist_name": "Backstreet Boys",
-            "listen_count": 2
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
+            "listen_count": 1,
             "artist_name": "Train",
-            "listen_count": 1
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
+            "listen_count": 1,
             "artist_name": "The Chainsmokers",
-            "listen_count": 1
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "aebd2c50-9eed-447d-b8b0-dbdbe5850ba8"
             ],
+            "listen_count": 1,
             "artist_name": "Snow Patrol",
-            "listen_count": 1
+            "artist_msid": null
         }
     ],
     "count": 24,

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_year.json
@@ -4,176 +4,201 @@
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
+            "listen_count": 404,
             "artist_name": "The Local train",
-            "listen_count": 404
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
+            "listen_count": 370,
             "artist_name": "Lenka",
-            "listen_count": 370
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
+            "listen_count": 358,
             "artist_name": "Coldplay",
-            "listen_count": 358
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
+            "listen_count": 216,
             "artist_name": "Ellie Goulding",
-            "listen_count": 216
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
+            "listen_count": 193,
             "artist_name": "Imagine Dragons",
-            "listen_count": 193
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
+            "listen_count": 177,
             "artist_name": "Maroon 5",
-            "listen_count": 177
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
+            "listen_count": 143,
             "artist_name": "OneRepublic",
-            "listen_count": 143
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
+            "listen_count": 107,
             "artist_name": "The Fray",
-            "listen_count": 107
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
+            "listen_count": 64,
             "artist_name": "The Weeknd",
-            "listen_count": 64
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
+            "listen_count": 62,
             "artist_name": "Taylor Swift",
-            "listen_count": 62
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
+            "listen_count": 61,
             "artist_name": "The Chainsmokers",
-            "listen_count": 61
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
+            "listen_count": 60,
             "artist_name": "George Ezra",
-            "listen_count": 60
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
+            "listen_count": 51,
             "artist_name": "Vance Joy",
-            "listen_count": 51
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
+            "listen_count": 50,
             "artist_name": "M.I.A.",
-            "listen_count": 50
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
+            "listen_count": 49,
             "artist_name": "Train",
-            "listen_count": 49
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
+            "listen_count": 48,
             "artist_name": "Tommee Profitt",
-            "listen_count": 48
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
+            "listen_count": 40,
             "artist_name": "The Script",
-            "listen_count": 40
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
+            "listen_count": 40,
             "artist_name": "Linkin Park",
-            "listen_count": 40
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
+            "listen_count": 39,
             "artist_name": "Sia",
-            "listen_count": 39
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
+            "listen_count": 38,
             "artist_name": "American Authors",
-            "listen_count": 38
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
+            "listen_count": 37,
             "artist_name": "Within Temptation",
-            "listen_count": 37
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
+            "listen_count": 32,
             "artist_name": "The Lumineers",
-            "listen_count": 32
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
+            "listen_count": 31,
             "artist_name": "Ritviz",
-            "listen_count": 31
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
+            "listen_count": 31,
             "artist_name": "Ed Sheeran",
-            "listen_count": 31
+            "artist_msid": null
         },
         {
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
+            "listen_count": 25,
             "artist_name": "Christina Perri",
-            "listen_count": 25
+            "artist_msid": null
         }
     ],
     "count": 25,

--- a/listenbrainz/testdata/user_top_recordings_db.json
+++ b/listenbrainz/testdata/user_top_recordings_db.json
@@ -4,7 +4,7 @@
   "recordings": [
     {
       "listen_count": 230,
-      "recording_name": "Burn",
+      "track_name": "Burn",
       "release_name": "Halycon Days",
       "artist_name": "Ellie Goulding",
       "artist_mbids": [],
@@ -13,7 +13,7 @@
     },
     {
       "listen_count": 229,
-      "recording_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
+      "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
       "release_name": "Delirium",
       "artist_name": "Ellie Goulding",
       "artist_mbids": [],

--- a/listenbrainz/testdata/user_top_recordings_db.json
+++ b/listenbrainz/testdata/user_top_recordings_db.json
@@ -1,25 +1,31 @@
 {
-  "from_ts": 0,
-  "to_ts": 10,
-  "recordings": [
-    {
-      "listen_count": 230,
-      "track_name": "Burn",
-      "release_name": "Halycon Days",
-      "artist_name": "Ellie Goulding",
-      "artist_mbids": [],
-      "release_mbid": null,
-      "recording_mbid": null
-    },
-    {
-      "listen_count": 229,
-      "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
-      "release_name": "Delirium",
-      "artist_name": "Ellie Goulding",
-      "artist_mbids": [],
-      "release_mbid": null,
-      "recording_mbid": null
-    }
-  ],
-  "count": 2
+    "from_ts": 0,
+    "to_ts": 10,
+    "recordings": [
+        {
+            "artist_name": "Ellie Goulding",
+            "artist_mbids": [],
+            "recording_mbid": null,
+            "release_name": "Halycon Days",
+            "release_mbid": null,
+            "track_name": "Burn",
+            "listen_count": 230,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
+        },
+        {
+            "artist_name": "Ellie Goulding",
+            "artist_mbids": [],
+            "recording_mbid": null,
+            "release_name": "Delirium",
+            "release_mbid": null,
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
+            "listen_count": 229,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
+        }
+    ],
+    "count": 2
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test.json
@@ -4,1104 +4,1404 @@
     "to_ts": 5,
     "recordings": [
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 25,
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
-            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
+            "listen_count": 25,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 23,
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
-            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "track_name": "How to Save a Life"
+            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
+            "track_name": "How to Save a Life",
+            "listen_count": 23,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 20,
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
-            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "track_name": "Udd Gaye - Bacardi House Party Sessions"
+            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
+            "track_name": "Udd Gaye - Bacardi House Party Sessions",
+            "listen_count": 20,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 18,
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
-            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "track_name": "Counting Stars"
+            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
+            "track_name": "Counting Stars",
+            "listen_count": 18,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 16,
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
-            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "track_name": "Burn"
+            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
+            "track_name": "Burn",
+            "listen_count": 16,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 16,
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
-            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "track_name": "Blank Space"
+            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
+            "track_name": "Blank Space",
+            "listen_count": 16,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Christina Perri",
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 16,
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
-            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "track_name": "A Thousand Years"
+            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
+            "track_name": "A Thousand Years",
+            "listen_count": 16,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Vance Joy",
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 15,
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
-            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "track_name": "Riptide"
+            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
+            "track_name": "Riptide",
+            "listen_count": 15,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 14,
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
-            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "track_name": "Castle on the Hill"
+            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
+            "track_name": "Castle on the Hill",
+            "listen_count": 14,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 13,
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
-            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "track_name": "Start Again (feat. Logic)"
+            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
+            "track_name": "Start Again (feat. Logic)",
+            "listen_count": 13,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "George Ezra",
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 12,
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
-            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "track_name": "Shotgun"
+            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
+            "track_name": "Shotgun",
+            "listen_count": 12,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Tommee Profitt",
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 12,
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
-            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "track_name": "In The End - Mellen Gi Remix"
+            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
+            "track_name": "In The End - Mellen Gi Remix",
+            "listen_count": 12,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Script",
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 12,
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
-            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "track_name": "Hall of Fame"
+            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
+            "track_name": "Hall of Fame",
+            "listen_count": 12,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 11,
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
-            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance",
+            "listen_count": 11,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Of Monsters and Men",
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 11,
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
-            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "track_name": "Little Talks"
+            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
+            "track_name": "Little Talks",
+            "listen_count": 11,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Sia",
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 11,
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
-            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "track_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
+            "track_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 11,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 10,
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
-            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "track_name": "Payphone"
+            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
+            "track_name": "Payphone",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "M.I.A.",
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 10,
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
-            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "track_name": "Paper Planes"
+            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
+            "track_name": "Paper Planes",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Linkin Park",
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 10,
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
-            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "track_name": "Battle Symphony"
+            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
+            "track_name": "Battle Symphony",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Backstreet Boys",
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
-            "artist_name": "Backstreet Boys",
-            "listen_count": 8,
             "recording_mbid": "6c4d9128-ea06-46f5-a6d8-daab439a7e6a",
-            "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
             "release_name": "The Hits--Chapter One",
-            "track_name": "I Want It That Way"
+            "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
+            "track_name": "I Want It That Way",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 8,
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
-            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "track_name": "Everything at Once"
+            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
+            "track_name": "Everything at Once",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Local train",
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 8,
             "recording_mbid": "6bf4c778-d11c-40de-bf28-970ba678d5a6",
-            "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
             "release_name": "Aalas Ka Pedh",
-            "track_name": "Choo Lo"
+            "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
+            "track_name": "Choo Lo",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 6,
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Up&Up"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Up&Up",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 6,
             "recording_mbid": "c17b56c2-7227-4a67-9d54-6d28aefd22f7",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "On Top of the World"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "On Top of the World",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 6,
             "recording_mbid": "8ff3d1f9-dfa5-470e-b9a0-32f94cb0ffb9",
-            "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
             "release_name": "Close To Me (feat. Swae Lee)",
-            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)"
+            "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
+            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "recording_mbid": "af757f8d-fc67-4b3b-98e8-dcc28c2e3bd8",
-            "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
             "release_name": "We Belong",
-            "track_name": "We Belong"
+            "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
+            "track_name": "We Belong",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 5,
             "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
-            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
             "release_name": "Sixteen",
-            "track_name": "Sixteen"
+            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
+            "track_name": "Sixteen",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
-            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "track_name": "Ink"
+            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
+            "track_name": "Ink",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Train",
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 5,
             "recording_mbid": "eb255a08-1486-4ac0-a796-1092421959e8",
-            "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
             "release_name": "Save Me, San Francisco (Golden Gate Edition)",
-            "track_name": "Hey, Soul Sister"
+            "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
+            "track_name": "Hey, Soul Sister",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 5,
             "recording_mbid": "8daff47f-4732-4946-870a-7c1305f1d652",
-            "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
             "release_name": "Girls Like You (feat. Cardi B)",
-            "track_name": "Girls Like You (feat. Cardi B)"
+            "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
+            "track_name": "Girls Like You (feat. Cardi B)",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Within Temptation",
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
-            "artist_name": "Within Temptation",
-            "listen_count": 5,
             "recording_mbid": "c3922480-7ae2-472b-88c0-0acafb207af2",
-            "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
             "release_name": "The Unforgiving",
-            "track_name": "Faster"
+            "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
+            "track_name": "Faster",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Everglow"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Everglow",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "cd00414d-5d44-4f2b-ab39-455a10d68564",
-            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "track_name": "Champion of the World"
+            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
+            "track_name": "Champion of the World",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Weeknd",
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 5,
             "recording_mbid": "c0b51d3f-b0da-4aef-a727-684cc205039b",
-            "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
             "release_name": "Blinding Lights",
-            "track_name": "Blinding Lights"
+            "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
+            "track_name": "Blinding Lights",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "recording_mbid": "864c5fca-4082-4e1d-92b5-6604d41dd391",
-            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "track_name": "Blinded By Love"
+            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
+            "track_name": "Blinded By Love",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "American Authors",
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
-            "artist_name": "American Authors",
-            "listen_count": 5,
             "recording_mbid": "2a5af3dc-3bba-436f-bd8f-7c9ac7a0ac25",
-            "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
             "release_name": "Oh, What A Life",
-            "track_name": "Best Day of My Life"
+            "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
+            "track_name": "Best Day of My Life",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 5,
             "recording_mbid": "3373eda9-3c54-4098-accc-92361ae8dde9",
-            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "track_name": "Believer"
+            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
+            "track_name": "Believer",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "28f8f9f6-f428-411d-a0fc-ac523922bd81",
-            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "track_name": "Viva la Vida"
+            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
+            "track_name": "Viva la Vida",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Chainsmokers",
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 4,
             "recording_mbid": "dccd75d0-4002-4a5c-b6d1-d92c1cac9bd5",
-            "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
             "release_name": "Memories...Do Not Open",
-            "track_name": "Something Just Like This"
+            "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
+            "track_name": "Something Just Like This",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 4,
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "Radioactive"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "Radioactive",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "034fb415-56a1-47c4-8aec-1b7d32cbf0bd",
-            "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
             "release_name": "Mylo Xyloto",
-            "track_name": "Paradise"
+            "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
+            "track_name": "Paradise",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "recording_mbid": "b06e73d8-8a25-4c32-9a84-130ffd0b0bc9",
-            "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
             "release_name": "Memories",
-            "track_name": "Memories"
+            "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
+            "track_name": "Memories",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "938157e9-1c93-4fe5-8797-aa7e6e2a0378",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Hymn for the Weekend"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Hymn for the Weekend",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Lumineers",
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 4,
             "recording_mbid": "fff72a5a-4f9f-48b7-b9e2-fe28852b0387",
-            "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
             "release_name": "The Lumineers (Deluxe Edition)",
-            "track_name": "Ho Hey"
+            "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
+            "track_name": "Ho Hey",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "84535425-6926-416d-9979-18aca3de3672",
-            "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
             "release_name": "X&Y",
-            "track_name": "Fix You"
+            "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
+            "track_name": "Fix You",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 4,
             "recording_mbid": "f40b62dd-c900-4884-bb71-9418ff842561",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "Demons"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "Demons",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 4,
             "recording_mbid": "ae52f909-4004-411a-b513-7b3377dc5d21",
-            "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
             "release_name": "The Bright Side",
-            "track_name": "Blue Skies"
+            "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
+            "track_name": "Blue Skies",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Local train",
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 4,
             "recording_mbid": "65f90a62-a89e-453e-9aed-862781383436",
-            "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
             "release_name": "Vaaqif",
-            "track_name": "Aaftaab"
+            "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
+            "track_name": "Aaftaab",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 3,
             "recording_mbid": "157e2094-b98e-4db0-8219-17f30c7a7f41",
-            "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
             "release_name": "Lenka (Expanded Edition)",
-            "track_name": "Trouble Is a Friend"
+            "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
+            "track_name": "Trouble Is a Friend",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Weeknd",
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 3,
             "recording_mbid": "0f9a63bf-fa0f-4d93-b5c9-a9c537ca633f",
-            "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
             "release_name": "Starboy",
-            "track_name": "Starboy"
+            "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
+            "track_name": "Starboy",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 3,
             "recording_mbid": "b79de255-2d29-40d3-b03e-5b8690817500",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "It's Time"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "It's Time",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Chainsmokers",
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 3,
             "recording_mbid": "0a3337f5-290f-4031-8a7a-4d3d9398c8c0",
-            "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
             "release_name": "Don't Let Me Down (feat. Daya)",
-            "track_name": "Don't Let Me Down (feat. Daya)"
+            "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
+            "track_name": "Don't Let Me Down (feat. Daya)",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 2,
             "recording_mbid": "d37c2481-f971-4ec0-b7aa-7fcf1128abbc",
-            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "track_name": "You Found Me"
+            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
+            "track_name": "You Found Me",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "77fb69de-d4b0-4c41-8be6-d3bc5439b709",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "Yellow - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "Yellow - Live In Buenos Aires",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "ce8ac50f-f14c-48a4-a23b-fdabe95bf491",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "Up&Up - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "Up&Up - Live In Buenos Aires",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Post Malone",
             "artist_mbids": [
                 "efc1ae68-f406-4430-8d94-a00b7280d822"
             ],
-            "artist_name": "Post Malone",
-            "listen_count": 2,
             "recording_mbid": "d36b5e2f-001e-4d7a-8246-53c35cf8a76d",
-            "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
             "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)",
-            "track_name": "Sunflower - Spider-Man: Into the Spider-Verse"
+            "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
+            "track_name": "Sunflower - Spider-Man: Into the Spider-Verse",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Magic!",
             "artist_mbids": [
                 "77e59c9c-cbb3-4566-abe9-5ccf8a92c28f"
             ],
-            "artist_name": "Magic!",
-            "listen_count": 2,
             "recording_mbid": "296e6afc-5507-4855-9e98-f1da8522f38c",
-            "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
             "release_name": "Don't Kill the Magic",
-            "track_name": "Rude"
+            "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
+            "track_name": "Rude",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Joel Adams",
             "artist_mbids": [
                 "4cd95528-7c4f-4ba8-a66f-a3f571e7a002"
             ],
-            "artist_name": "Joel Adams",
-            "listen_count": 2,
             "recording_mbid": "03ccadd6-c197-4be8-941f-7cbad2c9c167",
-            "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
             "release_name": "Please Don't Go",
-            "track_name": "Please Don't Go"
+            "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
+            "track_name": "Please Don't Go",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "a45a2d39-730e-4191-ae3f-2c9c27cff96c",
-            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "track_name": "Orphans"
+            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
+            "track_name": "Orphans",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 2,
             "recording_mbid": "e3229131-d000-4806-bbcf-f2f84d5dbb81",
-            "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
             "release_name": "No Vacancy",
-            "track_name": "No Vacancy"
+            "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
+            "track_name": "No Vacancy",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 2,
             "recording_mbid": "80edf568-6299-448c-9f29-b52e643e36a1",
-            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "track_name": "Never Say Never"
+            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
+            "track_name": "Never Say Never",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 2,
             "recording_mbid": "88f05e72-a832-4b71-b1dd-b0b6a27c1e0c",
-            "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
             "release_name": "Liggi",
-            "track_name": "Liggi"
+            "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
+            "track_name": "Liggi",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Lumineers",
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 2,
             "recording_mbid": "54f149e1-337f-4787-ab85-f5751e7f94e6",
-            "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
             "release_name": "The Lumineers",
-            "track_name": "Ho Hey"
+            "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
+            "track_name": "Ho Hey",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 2,
             "recording_mbid": "cab6930c-42b6-4394-92fe-5a2d30540c1d",
-            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "track_name": "Happier"
+            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
+            "track_name": "Happier",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Vance Joy",
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 2,
             "recording_mbid": "9634914d-d171-4eff-8812-b0d435d4122d",
-            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "track_name": "Georgia"
+            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
+            "track_name": "Georgia",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "4f7209b9-623f-49d4-8bde-ad29fb73b1be",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "Fix You - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "Fix You - Live In Buenos Aires",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Chainsmokers",
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 2,
             "recording_mbid": "5b8b06bd-514b-40ca-b9ea-01cdd444f277",
-            "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
             "release_name": "Don't Let Me Down",
-            "track_name": "Don't Let Me Down"
+            "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
+            "track_name": "Don't Let Me Down",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "George Ezra",
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 2,
             "recording_mbid": "2ee25888-9b0d-4875-8242-2ec699076937",
-            "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
             "release_name": "Wanted on Voyage",
-            "track_name": "Budapest"
+            "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
+            "track_name": "Budapest",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "7ad767a8-6a1e-42ef-9ca4-bcf3be18f7b5",
-            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "track_name": "A Sky Full of Stars"
+            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
+            "track_name": "A Sky Full of Stars",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "James Blunt",
             "artist_mbids": [
                 "291bca64-8c93-4790-85db-cf25baacb49e"
             ],
-            "artist_name": "James Blunt",
-            "listen_count": 1,
             "recording_mbid": "c8f52120-45f5-4af7-8106-7a73bc94a0fb",
-            "release_mbid": "348ab2f1-99e9-46a9-8403-166086807b36",
             "release_name": "Back to Bedlam",
-            "track_name": "You're Beautiful"
+            "release_mbid": "348ab2f1-99e9-46a9-8403-166086807b36",
+            "track_name": "You're Beautiful",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "48658b7c-851d-4683-a983-db282a3a4c47",
-            "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
             "release_name": "AV\u012aCI (01)",
-            "track_name": "Without You (feat. Sandro Cavazza)"
+            "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
+            "track_name": "Without You (feat. Sandro Cavazza)",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "recording_mbid": "e80fae03-21cc-4a27-bf14-35906dd7647a",
-            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "track_name": "Wildest Dreams"
+            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
+            "track_name": "Wildest Dreams",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Anirudh Ravichander",
             "artist_mbids": [
                 "80daf28c-5198-454a-9f74-4a1300f544ac"
             ],
-            "artist_name": "Anirudh Ravichander",
-            "listen_count": 1,
             "recording_mbid": "36091dba-7078-464a-8fd5-07dc35ed5daf",
-            "release_mbid": "69bef805-98e2-4729-ac66-ee78a0b6bb17",
             "release_name": "Why This Kolaveri Di? (The Soup of Love)",
-            "track_name": "Why This Kolaveri Di? - The Soup of Love"
+            "release_mbid": "69bef805-98e2-4729-ac66-ee78a0b6bb17",
+            "track_name": "Why This Kolaveri Di? - The Soup of Love",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 1,
             "recording_mbid": "ffc31aff-d5e9-49ae-a141-8ee76c5bf4e2",
-            "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
             "release_name": "Oh My My (Deluxe)",
-            "track_name": "Wherever I Go"
+            "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
+            "track_name": "Wherever I Go",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "One Direction",
             "artist_mbids": [
                 "1c498eab-998f-4975-b52b-72243e89c0ba"
             ],
-            "artist_name": "One Direction",
-            "listen_count": 1,
             "recording_mbid": "5338e902-bc45-4b30-8cd9-c8727b9d7d1e",
-            "release_mbid": "021be16d-42da-41e3-bee4-8a4e66ce5641",
             "release_name": "Nrj 200% Hits 2012",
-            "track_name": "What Makes You Beautiful"
+            "release_mbid": "021be16d-42da-41e3-bee4-8a4e66ce5641",
+            "track_name": "What Makes You Beautiful",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Charlie Puth",
             "artist_mbids": [
                 "bf8d0eb5-a94c-496a-a4a5-6d370e0c30e9"
             ],
-            "artist_name": "Charlie Puth",
-            "listen_count": 1,
             "recording_mbid": "44c9c270-9a8b-4f4d-92d8-d205c8388660",
-            "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
             "release_name": "Nine Track Mind",
-            "track_name": "We Don't Talk Anymore"
+            "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
+            "track_name": "We Don't Talk Anymore",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "recording_mbid": "8b22b4c1-3b13-4d41-80b6-e37caff2fb8d",
-            "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
             "release_name": "Red (Deluxe Edition)",
-            "track_name": "We Are Never Ever Getting Back Together"
+            "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
+            "track_name": "We Are Never Ever Getting Back Together",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "b4682bba-bffb-42ad-af7d-e3653cd95c9b",
-            "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
             "release_name": "True",
-            "track_name": "Wake Me Up"
+            "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
+            "track_name": "Wake Me Up",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "a4174a41-e323-4fea-a844-c860fab1d6dc",
-            "release_mbid": "2a7e7745-642d-4231-ab80-16a38be05f8b",
             "release_name": "Waiting For Love",
-            "track_name": "Waiting For Love"
+            "release_mbid": "2a7e7745-642d-4231-ab80-16a38be05f8b",
+            "track_name": "Waiting For Love",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 1,
             "recording_mbid": "41e036ef-4fc5-48bc-b496-a86b82783f82",
-            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "track_name": "Ungodly Hour"
+            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
+            "track_name": "Ungodly Hour",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Katy Perry",
             "artist_mbids": [
                 "b650167d-3f75-4a39-a0b5-7cf4e65b7205"
             ],
-            "artist_name": "Katy Perry",
-            "listen_count": 1,
             "recording_mbid": "d6ca58d3-50dd-47c6-8835-a80775e91fdc",
-            "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
             "release_name": "PRISM (Deluxe)",
-            "track_name": "Unconditionally"
+            "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
+            "track_name": "Unconditionally",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "P!nk",
             "artist_mbids": [
                 "0dee16fe-2b7f-4781-8f71-1e4357603ef1"
             ],
-            "artist_name": "P!nk",
-            "listen_count": 1,
             "recording_mbid": "ec5167ab-2972-4b9e-8906-ce9a6834a2b8",
-            "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
             "release_name": "The Truth About Love",
-            "track_name": "Try"
+            "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
+            "track_name": "Try",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Colbie Caillat",
             "artist_mbids": [
                 "b09db02b-5438-4360-a73f-7a3a5b88358f"
             ],
-            "artist_name": "Colbie Caillat",
-            "listen_count": 1,
             "recording_mbid": "6406c5d1-89b9-49ad-bd5b-37284c7fbc7f",
-            "release_mbid": "68804497-2717-47c0-97ce-082b162c1d82",
             "release_name": "Gypsy Heart",
-            "track_name": "Try"
+            "release_mbid": "68804497-2717-47c0-97ce-082b162c1d82",
+            "track_name": "Try",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Shawn Mendes",
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "recording_mbid": "500ac5df-dd13-4a08-8b70-ef930742684d",
-            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "track_name": "Treat You Better"
+            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
+            "track_name": "Treat You Better",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Tyrone Wells",
             "artist_mbids": [
                 "bce2e04f-e3f3-4c91-bd09-115455c43d37"
             ],
-            "artist_name": "Tyrone Wells",
-            "listen_count": 1,
             "recording_mbid": "d22799f2-2330-48d3-a78a-d171904651ae",
-            "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
             "release_name": "Metal & Wood",
-            "track_name": "Time of Our Lives"
+            "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
+            "track_name": "Time of Our Lives",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 1,
             "recording_mbid": "aefae07e-7fe6-45e8-9c85-c11fde5e6f96",
-            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "track_name": "Thunder"
+            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
+            "track_name": "Thunder",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Shawn Mendes",
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "recording_mbid": "4e27fc2a-98cc-4f1c-a204-ad2c1aca0f44",
-            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "track_name": "There's Nothing Holdin' Me Back"
+            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
+            "track_name": "There's Nothing Holdin' Me Back",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 1,
             "recording_mbid": "92d77b07-f5dd-49f0-8468-8d501ff3d221",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "The Scientist - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "The Scientist - Live In Buenos Aires",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "4ea67a2e-72f2-4dff-a9dd-d7721374b645",
-            "release_mbid": "99ff985c-89f3-4b38-a24d-f6f699593f7b",
             "release_name": "Now That's What I Call Pop",
-            "track_name": "The Nights"
+            "release_mbid": "99ff985c-89f3-4b38-a24d-f6f699593f7b",
+            "track_name": "The Nights",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Bruno Mars",
             "artist_mbids": [
                 "abf274d4-a1f8-4477-b5c6-8c1121a13cf6"
             ],
-            "artist_name": "Bruno Mars",
-            "listen_count": 1,
             "recording_mbid": "2449949b-14a7-4986-a382-eb1a1922cc66",
-            "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
             "release_name": "Doo-Wops & Hooligans",
-            "track_name": "The Lazy Song"
+            "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
+            "track_name": "The Lazy Song",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 1,
             "recording_mbid": "434addad-5e28-48cf-9fa2-650791cca44e",
-            "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
             "release_name": "+",
-            "track_name": "The A Team"
+            "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
+            "track_name": "The A Team",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 1,
             "recording_mbid": "834f7cc2-54b5-49a8-af3d-8aac0cacf67a",
-            "release_mbid": "4a8edc98-db22-40cd-9dd9-2ae913763003",
             "release_name": "Thandi Hawa",
-            "track_name": "Thandi Hawa"
+            "release_mbid": "4a8edc98-db22-40cd-9dd9-2ae913763003",
+            "track_name": "Thandi Hawa",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Hozier",
             "artist_mbids": [
                 "530d057e-f444-4e24-ba21-0e88d830fe67"
             ],
-            "artist_name": "Hozier",
-            "listen_count": 1,
             "recording_mbid": "f30c2728-228a-4222-bdb1-fc2512ceed52",
-            "release_mbid": "0c3c1ec5-06b1-4c9a-a6d3-1c7774a1e2ba",
             "release_name": "Hozier (Special Edition)",
-            "track_name": "Take Me to Church"
+            "release_mbid": "0c3c1ec5-06b1-4c9a-a6d3-1c7774a1e2ba",
+            "track_name": "Take Me to Church",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Clean Bandit",
             "artist_mbids": [
                 "f0676957-e3d7-4ca6-baf8-ffecaa01f415"
             ],
-            "artist_name": "Clean Bandit",
-            "listen_count": 1,
             "recording_mbid": "def4cc2f-9138-40bf-9bc6-40e2da2641a4",
-            "release_mbid": "7de6da6f-5f6d-4dbe-9dea-0a09fed0e7e5",
             "release_name": "Symphony (feat. Zara Larsson)",
-            "track_name": "Symphony (feat. Zara Larsson)"
+            "release_mbid": "7de6da6f-5f6d-4dbe-9dea-0a09fed0e7e5",
+            "track_name": "Symphony (feat. Zara Larsson)",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Script",
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 1,
             "recording_mbid": "425c5374-359f-4a55-8f59-2ebe31aab829",
-            "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
             "release_name": "No Sound Without Silence",
-            "track_name": "Superheroes"
+            "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
+            "track_name": "Superheroes",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 1,
             "recording_mbid": "de586967-461c-49eb-83ef-0f68305626af",
-            "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
             "release_name": "V",
-            "track_name": "Sugar"
+            "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
+            "track_name": "Sugar",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 1,
             "recording_mbid": "16235fdd-1408-4510-898b-2434028fafea",
-            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "track_name": "Strawberry Swing"
+            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
+            "track_name": "Strawberry Swing",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "One Direction",
             "artist_mbids": [
                 "1c498eab-998f-4975-b52b-72243e89c0ba"
             ],
-            "artist_name": "One Direction",
-            "listen_count": 1,
             "recording_mbid": "cd81e13d-004d-43ed-b41b-bb8cce73efd9",
-            "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
             "release_name": "Midnight Memories (Deluxe)",
-            "track_name": "Story of My Life"
+            "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
+            "track_name": "Story of My Life",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Shawn Mendes",
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "recording_mbid": "ccdccc03-00ca-470f-948c-6fd6f5394701",
-            "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
             "release_name": "Handwritten (Deluxe)",
-            "track_name": "Stitches"
+            "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
+            "track_name": "Stitches",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Gym Class Heroes",
             "artist_mbids": [
                 "c2007446-79e3-476a-868f-876e48a60893"
             ],
-            "artist_name": "Gym Class Heroes",
-            "listen_count": 1,
             "recording_mbid": "bc69ab9d-5323-477d-a556-df48e849aa28",
-            "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
             "release_name": "The Papercut Chronicles II",
-            "track_name": "Stereo Hearts (feat. Adam Levine)"
+            "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
+            "track_name": "Stereo Hearts (feat. Adam Levine)",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         }
     ]
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test.json
@@ -12,7 +12,7 @@
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "recording_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
         },
         {
             "artist_mbids": [
@@ -23,7 +23,7 @@
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "recording_name": "How to Save a Life"
+            "track_name": "How to Save a Life"
         },
         {
             "artist_mbids": [
@@ -34,7 +34,7 @@
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "recording_name": "Udd Gaye - Bacardi House Party Sessions"
+            "track_name": "Udd Gaye - Bacardi House Party Sessions"
         },
         {
             "artist_mbids": [
@@ -45,7 +45,7 @@
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "recording_name": "Counting Stars"
+            "track_name": "Counting Stars"
         },
         {
             "artist_mbids": [
@@ -56,7 +56,7 @@
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "recording_name": "Burn"
+            "track_name": "Burn"
         },
         {
             "artist_mbids": [
@@ -67,7 +67,7 @@
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "recording_name": "Blank Space"
+            "track_name": "Blank Space"
         },
         {
             "artist_mbids": [
@@ -78,7 +78,7 @@
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "recording_name": "A Thousand Years"
+            "track_name": "A Thousand Years"
         },
         {
             "artist_mbids": [
@@ -89,7 +89,7 @@
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "recording_name": "Riptide"
+            "track_name": "Riptide"
         },
         {
             "artist_mbids": [
@@ -100,7 +100,7 @@
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "recording_name": "Castle on the Hill"
+            "track_name": "Castle on the Hill"
         },
         {
             "artist_mbids": [
@@ -111,7 +111,7 @@
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "recording_name": "Start Again (feat. Logic)"
+            "track_name": "Start Again (feat. Logic)"
         },
         {
             "artist_mbids": [
@@ -122,7 +122,7 @@
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "recording_name": "Shotgun"
+            "track_name": "Shotgun"
         },
         {
             "artist_mbids": [
@@ -133,7 +133,7 @@
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "recording_name": "In The End - Mellen Gi Remix"
+            "track_name": "In The End - Mellen Gi Remix"
         },
         {
             "artist_mbids": [
@@ -144,7 +144,7 @@
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "recording_name": "Hall of Fame"
+            "track_name": "Hall of Fame"
         },
         {
             "artist_mbids": [
@@ -155,7 +155,7 @@
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "recording_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
         },
         {
             "artist_mbids": [
@@ -166,7 +166,7 @@
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "recording_name": "Little Talks"
+            "track_name": "Little Talks"
         },
         {
             "artist_mbids": [
@@ -177,7 +177,7 @@
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "recording_name": "Cheap Thrills (feat. Sean Paul)"
+            "track_name": "Cheap Thrills (feat. Sean Paul)"
         },
         {
             "artist_mbids": [
@@ -188,7 +188,7 @@
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "recording_name": "Payphone"
+            "track_name": "Payphone"
         },
         {
             "artist_mbids": [
@@ -199,7 +199,7 @@
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "recording_name": "Paper Planes"
+            "track_name": "Paper Planes"
         },
         {
             "artist_mbids": [
@@ -210,7 +210,7 @@
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "recording_name": "Battle Symphony"
+            "track_name": "Battle Symphony"
         },
         {
             "artist_mbids": [
@@ -221,7 +221,7 @@
             "recording_mbid": "6c4d9128-ea06-46f5-a6d8-daab439a7e6a",
             "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
             "release_name": "The Hits--Chapter One",
-            "recording_name": "I Want It That Way"
+            "track_name": "I Want It That Way"
         },
         {
             "artist_mbids": [
@@ -232,7 +232,7 @@
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "recording_name": "Everything at Once"
+            "track_name": "Everything at Once"
         },
         {
             "artist_mbids": [
@@ -243,7 +243,7 @@
             "recording_mbid": "6bf4c778-d11c-40de-bf28-970ba678d5a6",
             "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
             "release_name": "Aalas Ka Pedh",
-            "recording_name": "Choo Lo"
+            "track_name": "Choo Lo"
         },
         {
             "artist_mbids": [
@@ -254,7 +254,7 @@
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Up&Up"
+            "track_name": "Up&Up"
         },
         {
             "artist_mbids": [
@@ -265,7 +265,7 @@
             "recording_mbid": "c17b56c2-7227-4a67-9d54-6d28aefd22f7",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "On Top of the World"
+            "track_name": "On Top of the World"
         },
         {
             "artist_mbids": [
@@ -276,7 +276,7 @@
             "recording_mbid": "8ff3d1f9-dfa5-470e-b9a0-32f94cb0ffb9",
             "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
             "release_name": "Close To Me (feat. Swae Lee)",
-            "recording_name": "Close to Me (with Diplo) (feat. Swae Lee)"
+            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)"
         },
         {
             "artist_mbids": [
@@ -287,7 +287,7 @@
             "recording_mbid": "af757f8d-fc67-4b3b-98e8-dcc28c2e3bd8",
             "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
             "release_name": "We Belong",
-            "recording_name": "We Belong"
+            "track_name": "We Belong"
         },
         {
             "artist_mbids": [
@@ -298,7 +298,7 @@
             "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
             "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
             "release_name": "Sixteen",
-            "recording_name": "Sixteen"
+            "track_name": "Sixteen"
         },
         {
             "artist_mbids": [
@@ -309,7 +309,7 @@
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "recording_name": "Ink"
+            "track_name": "Ink"
         },
         {
             "artist_mbids": [
@@ -320,7 +320,7 @@
             "recording_mbid": "eb255a08-1486-4ac0-a796-1092421959e8",
             "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
             "release_name": "Save Me, San Francisco (Golden Gate Edition)",
-            "recording_name": "Hey, Soul Sister"
+            "track_name": "Hey, Soul Sister"
         },
         {
             "artist_mbids": [
@@ -331,7 +331,7 @@
             "recording_mbid": "8daff47f-4732-4946-870a-7c1305f1d652",
             "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
             "release_name": "Girls Like You (feat. Cardi B)",
-            "recording_name": "Girls Like You (feat. Cardi B)"
+            "track_name": "Girls Like You (feat. Cardi B)"
         },
         {
             "artist_mbids": [
@@ -342,7 +342,7 @@
             "recording_mbid": "c3922480-7ae2-472b-88c0-0acafb207af2",
             "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
             "release_name": "The Unforgiving",
-            "recording_name": "Faster"
+            "track_name": "Faster"
         },
         {
             "artist_mbids": [
@@ -353,7 +353,7 @@
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Everglow"
+            "track_name": "Everglow"
         },
         {
             "artist_mbids": [
@@ -364,7 +364,7 @@
             "recording_mbid": "cd00414d-5d44-4f2b-ab39-455a10d68564",
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "recording_name": "Champion of the World"
+            "track_name": "Champion of the World"
         },
         {
             "artist_mbids": [
@@ -375,7 +375,7 @@
             "recording_mbid": "c0b51d3f-b0da-4aef-a727-684cc205039b",
             "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
             "release_name": "Blinding Lights",
-            "recording_name": "Blinding Lights"
+            "track_name": "Blinding Lights"
         },
         {
             "artist_mbids": [
@@ -386,7 +386,7 @@
             "recording_mbid": "864c5fca-4082-4e1d-92b5-6604d41dd391",
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "recording_name": "Blinded By Love"
+            "track_name": "Blinded By Love"
         },
         {
             "artist_mbids": [
@@ -397,7 +397,7 @@
             "recording_mbid": "2a5af3dc-3bba-436f-bd8f-7c9ac7a0ac25",
             "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
             "release_name": "Oh, What A Life",
-            "recording_name": "Best Day of My Life"
+            "track_name": "Best Day of My Life"
         },
         {
             "artist_mbids": [
@@ -408,7 +408,7 @@
             "recording_mbid": "3373eda9-3c54-4098-accc-92361ae8dde9",
             "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "recording_name": "Believer"
+            "track_name": "Believer"
         },
         {
             "artist_mbids": [
@@ -419,7 +419,7 @@
             "recording_mbid": "28f8f9f6-f428-411d-a0fc-ac523922bd81",
             "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "recording_name": "Viva la Vida"
+            "track_name": "Viva la Vida"
         },
         {
             "artist_mbids": [
@@ -430,7 +430,7 @@
             "recording_mbid": "dccd75d0-4002-4a5c-b6d1-d92c1cac9bd5",
             "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
             "release_name": "Memories...Do Not Open",
-            "recording_name": "Something Just Like This"
+            "track_name": "Something Just Like This"
         },
         {
             "artist_mbids": [
@@ -441,7 +441,7 @@
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "Radioactive"
+            "track_name": "Radioactive"
         },
         {
             "artist_mbids": [
@@ -452,7 +452,7 @@
             "recording_mbid": "034fb415-56a1-47c4-8aec-1b7d32cbf0bd",
             "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
             "release_name": "Mylo Xyloto",
-            "recording_name": "Paradise"
+            "track_name": "Paradise"
         },
         {
             "artist_mbids": [
@@ -463,7 +463,7 @@
             "recording_mbid": "b06e73d8-8a25-4c32-9a84-130ffd0b0bc9",
             "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
             "release_name": "Memories",
-            "recording_name": "Memories"
+            "track_name": "Memories"
         },
         {
             "artist_mbids": [
@@ -474,7 +474,7 @@
             "recording_mbid": "938157e9-1c93-4fe5-8797-aa7e6e2a0378",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Hymn for the Weekend"
+            "track_name": "Hymn for the Weekend"
         },
         {
             "artist_mbids": [
@@ -485,7 +485,7 @@
             "recording_mbid": "fff72a5a-4f9f-48b7-b9e2-fe28852b0387",
             "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
             "release_name": "The Lumineers (Deluxe Edition)",
-            "recording_name": "Ho Hey"
+            "track_name": "Ho Hey"
         },
         {
             "artist_mbids": [
@@ -496,7 +496,7 @@
             "recording_mbid": "84535425-6926-416d-9979-18aca3de3672",
             "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
             "release_name": "X&Y",
-            "recording_name": "Fix You"
+            "track_name": "Fix You"
         },
         {
             "artist_mbids": [
@@ -507,7 +507,7 @@
             "recording_mbid": "f40b62dd-c900-4884-bb71-9418ff842561",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "Demons"
+            "track_name": "Demons"
         },
         {
             "artist_mbids": [
@@ -518,7 +518,7 @@
             "recording_mbid": "ae52f909-4004-411a-b513-7b3377dc5d21",
             "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
             "release_name": "The Bright Side",
-            "recording_name": "Blue Skies"
+            "track_name": "Blue Skies"
         },
         {
             "artist_mbids": [
@@ -529,7 +529,7 @@
             "recording_mbid": "65f90a62-a89e-453e-9aed-862781383436",
             "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
             "release_name": "Vaaqif",
-            "recording_name": "Aaftaab"
+            "track_name": "Aaftaab"
         },
         {
             "artist_mbids": [
@@ -540,7 +540,7 @@
             "recording_mbid": "157e2094-b98e-4db0-8219-17f30c7a7f41",
             "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
             "release_name": "Lenka (Expanded Edition)",
-            "recording_name": "Trouble Is a Friend"
+            "track_name": "Trouble Is a Friend"
         },
         {
             "artist_mbids": [
@@ -551,7 +551,7 @@
             "recording_mbid": "0f9a63bf-fa0f-4d93-b5c9-a9c537ca633f",
             "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
             "release_name": "Starboy",
-            "recording_name": "Starboy"
+            "track_name": "Starboy"
         },
         {
             "artist_mbids": [
@@ -562,7 +562,7 @@
             "recording_mbid": "b79de255-2d29-40d3-b03e-5b8690817500",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "It's Time"
+            "track_name": "It's Time"
         },
         {
             "artist_mbids": [
@@ -573,7 +573,7 @@
             "recording_mbid": "0a3337f5-290f-4031-8a7a-4d3d9398c8c0",
             "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
             "release_name": "Don't Let Me Down (feat. Daya)",
-            "recording_name": "Don't Let Me Down (feat. Daya)"
+            "track_name": "Don't Let Me Down (feat. Daya)"
         },
         {
             "artist_mbids": [
@@ -584,7 +584,7 @@
             "recording_mbid": "d37c2481-f971-4ec0-b7aa-7fcf1128abbc",
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "recording_name": "You Found Me"
+            "track_name": "You Found Me"
         },
         {
             "artist_mbids": [
@@ -595,7 +595,7 @@
             "recording_mbid": "77fb69de-d4b0-4c41-8be6-d3bc5439b709",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "Yellow - Live In Buenos Aires"
+            "track_name": "Yellow - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -606,7 +606,7 @@
             "recording_mbid": "ce8ac50f-f14c-48a4-a23b-fdabe95bf491",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "Up&Up - Live In Buenos Aires"
+            "track_name": "Up&Up - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -617,7 +617,7 @@
             "recording_mbid": "d36b5e2f-001e-4d7a-8246-53c35cf8a76d",
             "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
             "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)",
-            "recording_name": "Sunflower - Spider-Man: Into the Spider-Verse"
+            "track_name": "Sunflower - Spider-Man: Into the Spider-Verse"
         },
         {
             "artist_mbids": [
@@ -628,7 +628,7 @@
             "recording_mbid": "296e6afc-5507-4855-9e98-f1da8522f38c",
             "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
             "release_name": "Don't Kill the Magic",
-            "recording_name": "Rude"
+            "track_name": "Rude"
         },
         {
             "artist_mbids": [
@@ -639,7 +639,7 @@
             "recording_mbid": "03ccadd6-c197-4be8-941f-7cbad2c9c167",
             "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
             "release_name": "Please Don't Go",
-            "recording_name": "Please Don't Go"
+            "track_name": "Please Don't Go"
         },
         {
             "artist_mbids": [
@@ -650,7 +650,7 @@
             "recording_mbid": "a45a2d39-730e-4191-ae3f-2c9c27cff96c",
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "recording_name": "Orphans"
+            "track_name": "Orphans"
         },
         {
             "artist_mbids": [
@@ -661,7 +661,7 @@
             "recording_mbid": "e3229131-d000-4806-bbcf-f2f84d5dbb81",
             "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
             "release_name": "No Vacancy",
-            "recording_name": "No Vacancy"
+            "track_name": "No Vacancy"
         },
         {
             "artist_mbids": [
@@ -672,7 +672,7 @@
             "recording_mbid": "80edf568-6299-448c-9f29-b52e643e36a1",
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "recording_name": "Never Say Never"
+            "track_name": "Never Say Never"
         },
         {
             "artist_mbids": [
@@ -683,7 +683,7 @@
             "recording_mbid": "88f05e72-a832-4b71-b1dd-b0b6a27c1e0c",
             "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
             "release_name": "Liggi",
-            "recording_name": "Liggi"
+            "track_name": "Liggi"
         },
         {
             "artist_mbids": [
@@ -694,7 +694,7 @@
             "recording_mbid": "54f149e1-337f-4787-ab85-f5751e7f94e6",
             "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
             "release_name": "The Lumineers",
-            "recording_name": "Ho Hey"
+            "track_name": "Ho Hey"
         },
         {
             "artist_mbids": [
@@ -705,7 +705,7 @@
             "recording_mbid": "cab6930c-42b6-4394-92fe-5a2d30540c1d",
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "recording_name": "Happier"
+            "track_name": "Happier"
         },
         {
             "artist_mbids": [
@@ -716,7 +716,7 @@
             "recording_mbid": "9634914d-d171-4eff-8812-b0d435d4122d",
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "recording_name": "Georgia"
+            "track_name": "Georgia"
         },
         {
             "artist_mbids": [
@@ -727,7 +727,7 @@
             "recording_mbid": "4f7209b9-623f-49d4-8bde-ad29fb73b1be",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "Fix You - Live In Buenos Aires"
+            "track_name": "Fix You - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -738,7 +738,7 @@
             "recording_mbid": "5b8b06bd-514b-40ca-b9ea-01cdd444f277",
             "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
             "release_name": "Don't Let Me Down",
-            "recording_name": "Don't Let Me Down"
+            "track_name": "Don't Let Me Down"
         },
         {
             "artist_mbids": [
@@ -749,7 +749,7 @@
             "recording_mbid": "2ee25888-9b0d-4875-8242-2ec699076937",
             "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
             "release_name": "Wanted on Voyage",
-            "recording_name": "Budapest"
+            "track_name": "Budapest"
         },
         {
             "artist_mbids": [
@@ -760,7 +760,7 @@
             "recording_mbid": "7ad767a8-6a1e-42ef-9ca4-bcf3be18f7b5",
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "recording_name": "A Sky Full of Stars"
+            "track_name": "A Sky Full of Stars"
         },
         {
             "artist_mbids": [
@@ -771,7 +771,7 @@
             "recording_mbid": "c8f52120-45f5-4af7-8106-7a73bc94a0fb",
             "release_mbid": "348ab2f1-99e9-46a9-8403-166086807b36",
             "release_name": "Back to Bedlam",
-            "recording_name": "You're Beautiful"
+            "track_name": "You're Beautiful"
         },
         {
             "artist_mbids": [
@@ -782,7 +782,7 @@
             "recording_mbid": "48658b7c-851d-4683-a983-db282a3a4c47",
             "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
             "release_name": "AV\u012aCI (01)",
-            "recording_name": "Without You (feat. Sandro Cavazza)"
+            "track_name": "Without You (feat. Sandro Cavazza)"
         },
         {
             "artist_mbids": [
@@ -793,7 +793,7 @@
             "recording_mbid": "e80fae03-21cc-4a27-bf14-35906dd7647a",
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "recording_name": "Wildest Dreams"
+            "track_name": "Wildest Dreams"
         },
         {
             "artist_mbids": [
@@ -804,7 +804,7 @@
             "recording_mbid": "36091dba-7078-464a-8fd5-07dc35ed5daf",
             "release_mbid": "69bef805-98e2-4729-ac66-ee78a0b6bb17",
             "release_name": "Why This Kolaveri Di? (The Soup of Love)",
-            "recording_name": "Why This Kolaveri Di? - The Soup of Love"
+            "track_name": "Why This Kolaveri Di? - The Soup of Love"
         },
         {
             "artist_mbids": [
@@ -815,7 +815,7 @@
             "recording_mbid": "ffc31aff-d5e9-49ae-a141-8ee76c5bf4e2",
             "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
             "release_name": "Oh My My (Deluxe)",
-            "recording_name": "Wherever I Go"
+            "track_name": "Wherever I Go"
         },
         {
             "artist_mbids": [
@@ -826,7 +826,7 @@
             "recording_mbid": "5338e902-bc45-4b30-8cd9-c8727b9d7d1e",
             "release_mbid": "021be16d-42da-41e3-bee4-8a4e66ce5641",
             "release_name": "Nrj 200% Hits 2012",
-            "recording_name": "What Makes You Beautiful"
+            "track_name": "What Makes You Beautiful"
         },
         {
             "artist_mbids": [
@@ -837,7 +837,7 @@
             "recording_mbid": "44c9c270-9a8b-4f4d-92d8-d205c8388660",
             "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
             "release_name": "Nine Track Mind",
-            "recording_name": "We Don't Talk Anymore"
+            "track_name": "We Don't Talk Anymore"
         },
         {
             "artist_mbids": [
@@ -848,7 +848,7 @@
             "recording_mbid": "8b22b4c1-3b13-4d41-80b6-e37caff2fb8d",
             "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
             "release_name": "Red (Deluxe Edition)",
-            "recording_name": "We Are Never Ever Getting Back Together"
+            "track_name": "We Are Never Ever Getting Back Together"
         },
         {
             "artist_mbids": [
@@ -859,7 +859,7 @@
             "recording_mbid": "b4682bba-bffb-42ad-af7d-e3653cd95c9b",
             "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
             "release_name": "True",
-            "recording_name": "Wake Me Up"
+            "track_name": "Wake Me Up"
         },
         {
             "artist_mbids": [
@@ -870,7 +870,7 @@
             "recording_mbid": "a4174a41-e323-4fea-a844-c860fab1d6dc",
             "release_mbid": "2a7e7745-642d-4231-ab80-16a38be05f8b",
             "release_name": "Waiting For Love",
-            "recording_name": "Waiting For Love"
+            "track_name": "Waiting For Love"
         },
         {
             "artist_mbids": [
@@ -881,7 +881,7 @@
             "recording_mbid": "41e036ef-4fc5-48bc-b496-a86b82783f82",
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "recording_name": "Ungodly Hour"
+            "track_name": "Ungodly Hour"
         },
         {
             "artist_mbids": [
@@ -892,7 +892,7 @@
             "recording_mbid": "d6ca58d3-50dd-47c6-8835-a80775e91fdc",
             "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
             "release_name": "PRISM (Deluxe)",
-            "recording_name": "Unconditionally"
+            "track_name": "Unconditionally"
         },
         {
             "artist_mbids": [
@@ -903,7 +903,7 @@
             "recording_mbid": "ec5167ab-2972-4b9e-8906-ce9a6834a2b8",
             "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
             "release_name": "The Truth About Love",
-            "recording_name": "Try"
+            "track_name": "Try"
         },
         {
             "artist_mbids": [
@@ -914,7 +914,7 @@
             "recording_mbid": "6406c5d1-89b9-49ad-bd5b-37284c7fbc7f",
             "release_mbid": "68804497-2717-47c0-97ce-082b162c1d82",
             "release_name": "Gypsy Heart",
-            "recording_name": "Try"
+            "track_name": "Try"
         },
         {
             "artist_mbids": [
@@ -925,7 +925,7 @@
             "recording_mbid": "500ac5df-dd13-4a08-8b70-ef930742684d",
             "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "recording_name": "Treat You Better"
+            "track_name": "Treat You Better"
         },
         {
             "artist_mbids": [
@@ -936,7 +936,7 @@
             "recording_mbid": "d22799f2-2330-48d3-a78a-d171904651ae",
             "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
             "release_name": "Metal & Wood",
-            "recording_name": "Time of Our Lives"
+            "track_name": "Time of Our Lives"
         },
         {
             "artist_mbids": [
@@ -947,7 +947,7 @@
             "recording_mbid": "aefae07e-7fe6-45e8-9c85-c11fde5e6f96",
             "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "recording_name": "Thunder"
+            "track_name": "Thunder"
         },
         {
             "artist_mbids": [
@@ -958,7 +958,7 @@
             "recording_mbid": "4e27fc2a-98cc-4f1c-a204-ad2c1aca0f44",
             "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "recording_name": "There's Nothing Holdin' Me Back"
+            "track_name": "There's Nothing Holdin' Me Back"
         },
         {
             "artist_mbids": [
@@ -969,7 +969,7 @@
             "recording_mbid": "92d77b07-f5dd-49f0-8468-8d501ff3d221",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "The Scientist - Live In Buenos Aires"
+            "track_name": "The Scientist - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -980,7 +980,7 @@
             "recording_mbid": "4ea67a2e-72f2-4dff-a9dd-d7721374b645",
             "release_mbid": "99ff985c-89f3-4b38-a24d-f6f699593f7b",
             "release_name": "Now That's What I Call Pop",
-            "recording_name": "The Nights"
+            "track_name": "The Nights"
         },
         {
             "artist_mbids": [
@@ -991,7 +991,7 @@
             "recording_mbid": "2449949b-14a7-4986-a382-eb1a1922cc66",
             "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
             "release_name": "Doo-Wops & Hooligans",
-            "recording_name": "The Lazy Song"
+            "track_name": "The Lazy Song"
         },
         {
             "artist_mbids": [
@@ -1002,7 +1002,7 @@
             "recording_mbid": "434addad-5e28-48cf-9fa2-650791cca44e",
             "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
             "release_name": "+",
-            "recording_name": "The A Team"
+            "track_name": "The A Team"
         },
         {
             "artist_mbids": [
@@ -1013,7 +1013,7 @@
             "recording_mbid": "834f7cc2-54b5-49a8-af3d-8aac0cacf67a",
             "release_mbid": "4a8edc98-db22-40cd-9dd9-2ae913763003",
             "release_name": "Thandi Hawa",
-            "recording_name": "Thandi Hawa"
+            "track_name": "Thandi Hawa"
         },
         {
             "artist_mbids": [
@@ -1024,7 +1024,7 @@
             "recording_mbid": "f30c2728-228a-4222-bdb1-fc2512ceed52",
             "release_mbid": "0c3c1ec5-06b1-4c9a-a6d3-1c7774a1e2ba",
             "release_name": "Hozier (Special Edition)",
-            "recording_name": "Take Me to Church"
+            "track_name": "Take Me to Church"
         },
         {
             "artist_mbids": [
@@ -1035,7 +1035,7 @@
             "recording_mbid": "def4cc2f-9138-40bf-9bc6-40e2da2641a4",
             "release_mbid": "7de6da6f-5f6d-4dbe-9dea-0a09fed0e7e5",
             "release_name": "Symphony (feat. Zara Larsson)",
-            "recording_name": "Symphony (feat. Zara Larsson)"
+            "track_name": "Symphony (feat. Zara Larsson)"
         },
         {
             "artist_mbids": [
@@ -1046,7 +1046,7 @@
             "recording_mbid": "425c5374-359f-4a55-8f59-2ebe31aab829",
             "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
             "release_name": "No Sound Without Silence",
-            "recording_name": "Superheroes"
+            "track_name": "Superheroes"
         },
         {
             "artist_mbids": [
@@ -1057,7 +1057,7 @@
             "recording_mbid": "de586967-461c-49eb-83ef-0f68305626af",
             "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
             "release_name": "V",
-            "recording_name": "Sugar"
+            "track_name": "Sugar"
         },
         {
             "artist_mbids": [
@@ -1068,7 +1068,7 @@
             "recording_mbid": "16235fdd-1408-4510-898b-2434028fafea",
             "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "recording_name": "Strawberry Swing"
+            "track_name": "Strawberry Swing"
         },
         {
             "artist_mbids": [
@@ -1079,7 +1079,7 @@
             "recording_mbid": "cd81e13d-004d-43ed-b41b-bb8cce73efd9",
             "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
             "release_name": "Midnight Memories (Deluxe)",
-            "recording_name": "Story of My Life"
+            "track_name": "Story of My Life"
         },
         {
             "artist_mbids": [
@@ -1090,7 +1090,7 @@
             "recording_mbid": "ccdccc03-00ca-470f-948c-6fd6f5394701",
             "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
             "release_name": "Handwritten (Deluxe)",
-            "recording_name": "Stitches"
+            "track_name": "Stitches"
         },
         {
             "artist_mbids": [
@@ -1101,7 +1101,7 @@
             "recording_mbid": "bc69ab9d-5323-477d-a556-df48e849aa28",
             "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
             "release_name": "The Papercut Chronicles II",
-            "recording_name": "Stereo Hearts (feat. Adam Levine)"
+            "track_name": "Stereo Hearts (feat. Adam Levine)"
         }
     ]
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_month.json
@@ -11,7 +11,7 @@
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "recording_name": "Burn"
+            "track_name": "Burn"
         },
         {
             "artist_mbids": [
@@ -22,7 +22,7 @@
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "recording_name": "Castle on the Hill"
+            "track_name": "Castle on the Hill"
         },
         {
             "artist_mbids": [
@@ -33,7 +33,7 @@
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "recording_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
         },
         {
             "artist_mbids": [
@@ -44,7 +44,7 @@
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "recording_name": "Hall of Fame"
+            "track_name": "Hall of Fame"
         },
         {
             "artist_mbids": [
@@ -55,7 +55,7 @@
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "recording_name": "Start Again (feat. Logic)"
+            "track_name": "Start Again (feat. Logic)"
         },
         {
             "artist_mbids": [
@@ -66,7 +66,7 @@
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "recording_name": "How to Save a Life"
+            "track_name": "How to Save a Life"
         },
         {
             "artist_mbids": [
@@ -77,7 +77,7 @@
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "recording_name": "A Thousand Years"
+            "track_name": "A Thousand Years"
         },
         {
             "artist_mbids": [
@@ -88,7 +88,7 @@
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "recording_name": "Payphone"
+            "track_name": "Payphone"
         },
         {
             "artist_mbids": [
@@ -99,7 +99,7 @@
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "recording_name": "Little Talks"
+            "track_name": "Little Talks"
         },
         {
             "artist_mbids": [
@@ -110,7 +110,7 @@
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "recording_name": "In The End - Mellen Gi Remix"
+            "track_name": "In The End - Mellen Gi Remix"
         },
         {
             "artist_mbids": [
@@ -121,7 +121,7 @@
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "recording_name": "Counting Stars"
+            "track_name": "Counting Stars"
         },
         {
             "artist_mbids": [
@@ -132,7 +132,7 @@
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "recording_name": "Blank Space"
+            "track_name": "Blank Space"
         },
         {
             "artist_mbids": [
@@ -143,7 +143,7 @@
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "recording_name": "Battle Symphony"
+            "track_name": "Battle Symphony"
         },
         {
             "artist_mbids": [
@@ -154,7 +154,7 @@
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "recording_name": "Shotgun"
+            "track_name": "Shotgun"
         },
         {
             "artist_mbids": [
@@ -165,7 +165,7 @@
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "recording_name": "Riptide"
+            "track_name": "Riptide"
         },
         {
             "artist_mbids": [
@@ -176,7 +176,7 @@
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "recording_name": "Paper Planes"
+            "track_name": "Paper Planes"
         },
         {
             "artist_mbids": [
@@ -187,7 +187,7 @@
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "recording_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
         },
         {
             "artist_mbids": [
@@ -198,7 +198,7 @@
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "recording_name": "Cheap Thrills (feat. Sean Paul)"
+            "track_name": "Cheap Thrills (feat. Sean Paul)"
         },
         {
             "artist_mbids": [
@@ -209,7 +209,7 @@
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "recording_name": "Everything at Once"
+            "track_name": "Everything at Once"
         },
         {
             "artist_mbids": [
@@ -220,7 +220,7 @@
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Up&Up"
+            "track_name": "Up&Up"
         },
         {
             "artist_mbids": [
@@ -231,7 +231,7 @@
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "recording_name": "Udd Gaye - Bacardi House Party Sessions"
+            "track_name": "Udd Gaye - Bacardi House Party Sessions"
         },
         {
             "artist_mbids": [
@@ -242,7 +242,7 @@
             "recording_mbid": "c17b56c2-7227-4a67-9d54-6d28aefd22f7",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "On Top of the World"
+            "track_name": "On Top of the World"
         },
         {
             "artist_mbids": [
@@ -253,7 +253,7 @@
             "recording_mbid": "8ff3d1f9-dfa5-470e-b9a0-32f94cb0ffb9",
             "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
             "release_name": "Close To Me (feat. Swae Lee)",
-            "recording_name": "Close to Me (with Diplo) (feat. Swae Lee)"
+            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)"
         },
         {
             "artist_mbids": [
@@ -264,7 +264,7 @@
             "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
             "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
             "release_name": "Sixteen",
-            "recording_name": "Sixteen"
+            "track_name": "Sixteen"
         },
         {
             "artist_mbids": [
@@ -275,7 +275,7 @@
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "Radioactive"
+            "track_name": "Radioactive"
         }
     ],
     "to_ts": 1589496658

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_month.json
@@ -3,279 +3,354 @@
     "from_ts": 1588373458,
     "recordings": [
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 16,
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
-            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "track_name": "Burn"
+            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
+            "track_name": "Burn",
+            "listen_count": 16,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 13,
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
-            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "track_name": "Castle on the Hill"
+            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
+            "track_name": "Castle on the Hill",
+            "listen_count": 13,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 12,
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
-            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
+            "listen_count": 12,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Script",
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 10,
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
-            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "track_name": "Hall of Fame"
+            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
+            "track_name": "Hall of Fame",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 9,
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
-            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "track_name": "Start Again (feat. Logic)"
+            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
+            "track_name": "Start Again (feat. Logic)",
+            "listen_count": 9,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 8,
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
-            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "track_name": "How to Save a Life"
+            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
+            "track_name": "How to Save a Life",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Christina Perri",
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 8,
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
-            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "track_name": "A Thousand Years"
+            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
+            "track_name": "A Thousand Years",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 7,
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
-            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "track_name": "Payphone"
+            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
+            "track_name": "Payphone",
+            "listen_count": 7,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Of Monsters and Men",
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 7,
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
-            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "track_name": "Little Talks"
+            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
+            "track_name": "Little Talks",
+            "listen_count": 7,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Tommee Profitt",
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 7,
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
-            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "track_name": "In The End - Mellen Gi Remix"
+            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
+            "track_name": "In The End - Mellen Gi Remix",
+            "listen_count": 7,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 7,
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
-            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "track_name": "Counting Stars"
+            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
+            "track_name": "Counting Stars",
+            "listen_count": 7,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 7,
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
-            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "track_name": "Blank Space"
+            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
+            "track_name": "Blank Space",
+            "listen_count": 7,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Linkin Park",
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 7,
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
-            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "track_name": "Battle Symphony"
+            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
+            "track_name": "Battle Symphony",
+            "listen_count": 7,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "George Ezra",
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 6,
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
-            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "track_name": "Shotgun"
+            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
+            "track_name": "Shotgun",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Vance Joy",
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 6,
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
-            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "track_name": "Riptide"
+            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
+            "track_name": "Riptide",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "M.I.A.",
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 6,
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
-            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "track_name": "Paper Planes"
+            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
+            "track_name": "Paper Planes",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 6,
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
-            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Sia",
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 6,
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
-            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "track_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
+            "track_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
-            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "track_name": "Everything at Once"
+            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
+            "track_name": "Everything at Once",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Up&Up"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Up&Up",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 4,
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
-            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "track_name": "Udd Gaye - Bacardi House Party Sessions"
+            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
+            "track_name": "Udd Gaye - Bacardi House Party Sessions",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 4,
             "recording_mbid": "c17b56c2-7227-4a67-9d54-6d28aefd22f7",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "On Top of the World"
-        },
-        {
-            "artist_mbids": [
-                "7addbcac-ae39-4b4c-a956-53da336d68e8"
-            ],
-            "artist_name": "Ellie Goulding",
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "On Top of the World",
             "listen_count": 4,
-            "recording_mbid": "8ff3d1f9-dfa5-470e-b9a0-32f94cb0ffb9",
-            "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
-            "release_name": "Close To Me (feat. Swae Lee)",
-            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)"
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 3,
-            "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
-            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
-            "release_name": "Sixteen",
-            "track_name": "Sixteen"
+            "recording_mbid": "8ff3d1f9-dfa5-470e-b9a0-32f94cb0ffb9",
+            "release_name": "Close To Me (feat. Swae Lee)",
+            "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
+            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
+            "artist_mbids": [
+                "7addbcac-ae39-4b4c-a956-53da336d68e8"
+            ],
+            "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
+            "release_name": "Sixteen",
+            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
+            "track_name": "Sixteen",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
+        },
+        {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 3,
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "Radioactive"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "Radioactive",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         }
     ],
     "to_ts": 1589496658

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_too_many.json
@@ -4,1137 +4,1446 @@
     "to_ts": 5,
     "recordings": [
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 25,
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
-            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
+            "listen_count": 25,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 23,
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
-            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "track_name": "How to Save a Life"
+            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
+            "track_name": "How to Save a Life",
+            "listen_count": 23,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 20,
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
-            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "track_name": "Udd Gaye - Bacardi House Party Sessions"
+            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
+            "track_name": "Udd Gaye - Bacardi House Party Sessions",
+            "listen_count": 20,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 18,
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
-            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "track_name": "Counting Stars"
+            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
+            "track_name": "Counting Stars",
+            "listen_count": 18,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 16,
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
-            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "track_name": "Burn"
+            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
+            "track_name": "Burn",
+            "listen_count": 16,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 16,
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
-            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "track_name": "Blank Space"
+            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
+            "track_name": "Blank Space",
+            "listen_count": 16,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Christina Perri",
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 16,
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
-            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "track_name": "A Thousand Years"
+            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
+            "track_name": "A Thousand Years",
+            "listen_count": 16,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Vance Joy",
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 15,
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
-            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "track_name": "Riptide"
+            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
+            "track_name": "Riptide",
+            "listen_count": 15,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 14,
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
-            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "track_name": "Castle on the Hill"
+            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
+            "track_name": "Castle on the Hill",
+            "listen_count": 14,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 13,
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
-            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "track_name": "Start Again (feat. Logic)"
+            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
+            "track_name": "Start Again (feat. Logic)",
+            "listen_count": 13,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "George Ezra",
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 12,
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
-            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "track_name": "Shotgun"
+            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
+            "track_name": "Shotgun",
+            "listen_count": 12,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Tommee Profitt",
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 12,
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
-            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "track_name": "In The End - Mellen Gi Remix"
+            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
+            "track_name": "In The End - Mellen Gi Remix",
+            "listen_count": 12,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Script",
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 12,
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
-            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "track_name": "Hall of Fame"
+            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
+            "track_name": "Hall of Fame",
+            "listen_count": 12,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 11,
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
-            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance",
+            "listen_count": 11,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Of Monsters and Men",
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 11,
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
-            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "track_name": "Little Talks"
+            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
+            "track_name": "Little Talks",
+            "listen_count": 11,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Sia",
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 11,
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
-            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "track_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
+            "track_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 11,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 10,
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
-            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "track_name": "Payphone"
+            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
+            "track_name": "Payphone",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "M.I.A.",
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 10,
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
-            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "track_name": "Paper Planes"
+            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
+            "track_name": "Paper Planes",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Linkin Park",
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 10,
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
-            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "track_name": "Battle Symphony"
+            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
+            "track_name": "Battle Symphony",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Backstreet Boys",
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
-            "artist_name": "Backstreet Boys",
-            "listen_count": 8,
             "recording_mbid": "6c4d9128-ea06-46f5-a6d8-daab439a7e6a",
-            "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
             "release_name": "The Hits--Chapter One",
-            "track_name": "I Want It That Way"
+            "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
+            "track_name": "I Want It That Way",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 8,
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
-            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "track_name": "Everything at Once"
+            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
+            "track_name": "Everything at Once",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Local train",
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 8,
             "recording_mbid": "6bf4c778-d11c-40de-bf28-970ba678d5a6",
-            "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
             "release_name": "Aalas Ka Pedh",
-            "track_name": "Choo Lo"
+            "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
+            "track_name": "Choo Lo",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 6,
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Up&Up"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Up&Up",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 6,
             "recording_mbid": "c17b56c2-7227-4a67-9d54-6d28aefd22f7",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "On Top of the World"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "On Top of the World",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 6,
             "recording_mbid": "8ff3d1f9-dfa5-470e-b9a0-32f94cb0ffb9",
-            "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
             "release_name": "Close To Me (feat. Swae Lee)",
-            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)"
+            "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
+            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "recording_mbid": "af757f8d-fc67-4b3b-98e8-dcc28c2e3bd8",
-            "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
             "release_name": "We Belong",
-            "track_name": "We Belong"
+            "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
+            "track_name": "We Belong",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 5,
             "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
-            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
             "release_name": "Sixteen",
-            "track_name": "Sixteen"
+            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
+            "track_name": "Sixteen",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
-            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "track_name": "Ink"
+            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
+            "track_name": "Ink",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Train",
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 5,
             "recording_mbid": "eb255a08-1486-4ac0-a796-1092421959e8",
-            "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
             "release_name": "Save Me, San Francisco (Golden Gate Edition)",
-            "track_name": "Hey, Soul Sister"
+            "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
+            "track_name": "Hey, Soul Sister",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 5,
             "recording_mbid": "8daff47f-4732-4946-870a-7c1305f1d652",
-            "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
             "release_name": "Girls Like You (feat. Cardi B)",
-            "track_name": "Girls Like You (feat. Cardi B)"
+            "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
+            "track_name": "Girls Like You (feat. Cardi B)",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Within Temptation",
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
-            "artist_name": "Within Temptation",
-            "listen_count": 5,
             "recording_mbid": "c3922480-7ae2-472b-88c0-0acafb207af2",
-            "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
             "release_name": "The Unforgiving",
-            "track_name": "Faster"
+            "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
+            "track_name": "Faster",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Everglow"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Everglow",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "cd00414d-5d44-4f2b-ab39-455a10d68564",
-            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "track_name": "Champion of the World"
+            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
+            "track_name": "Champion of the World",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Weeknd",
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 5,
             "recording_mbid": "c0b51d3f-b0da-4aef-a727-684cc205039b",
-            "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
             "release_name": "Blinding Lights",
-            "track_name": "Blinding Lights"
+            "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
+            "track_name": "Blinding Lights",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "recording_mbid": "864c5fca-4082-4e1d-92b5-6604d41dd391",
-            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "track_name": "Blinded By Love"
+            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
+            "track_name": "Blinded By Love",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "American Authors",
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
-            "artist_name": "American Authors",
-            "listen_count": 5,
             "recording_mbid": "2a5af3dc-3bba-436f-bd8f-7c9ac7a0ac25",
-            "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
             "release_name": "Oh, What A Life",
-            "track_name": "Best Day of My Life"
+            "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
+            "track_name": "Best Day of My Life",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 5,
             "recording_mbid": "3373eda9-3c54-4098-accc-92361ae8dde9",
-            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "track_name": "Believer"
+            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
+            "track_name": "Believer",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "28f8f9f6-f428-411d-a0fc-ac523922bd81",
-            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "track_name": "Viva la Vida"
+            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
+            "track_name": "Viva la Vida",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Chainsmokers",
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 4,
             "recording_mbid": "dccd75d0-4002-4a5c-b6d1-d92c1cac9bd5",
-            "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
             "release_name": "Memories...Do Not Open",
-            "track_name": "Something Just Like This"
+            "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
+            "track_name": "Something Just Like This",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 4,
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "Radioactive"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "Radioactive",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "034fb415-56a1-47c4-8aec-1b7d32cbf0bd",
-            "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
             "release_name": "Mylo Xyloto",
-            "track_name": "Paradise"
+            "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
+            "track_name": "Paradise",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "recording_mbid": "b06e73d8-8a25-4c32-9a84-130ffd0b0bc9",
-            "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
             "release_name": "Memories",
-            "track_name": "Memories"
+            "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
+            "track_name": "Memories",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "938157e9-1c93-4fe5-8797-aa7e6e2a0378",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Hymn for the Weekend"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Hymn for the Weekend",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Lumineers",
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 4,
             "recording_mbid": "fff72a5a-4f9f-48b7-b9e2-fe28852b0387",
-            "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
             "release_name": "The Lumineers (Deluxe Edition)",
-            "track_name": "Ho Hey"
+            "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
+            "track_name": "Ho Hey",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "84535425-6926-416d-9979-18aca3de3672",
-            "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
             "release_name": "X&Y",
-            "track_name": "Fix You"
+            "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
+            "track_name": "Fix You",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 4,
             "recording_mbid": "f40b62dd-c900-4884-bb71-9418ff842561",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "Demons"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "Demons",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 4,
             "recording_mbid": "ae52f909-4004-411a-b513-7b3377dc5d21",
-            "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
             "release_name": "The Bright Side",
-            "track_name": "Blue Skies"
+            "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
+            "track_name": "Blue Skies",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Local train",
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 4,
             "recording_mbid": "65f90a62-a89e-453e-9aed-862781383436",
-            "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
             "release_name": "Vaaqif",
-            "track_name": "Aaftaab"
+            "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
+            "track_name": "Aaftaab",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 3,
             "recording_mbid": "157e2094-b98e-4db0-8219-17f30c7a7f41",
-            "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
             "release_name": "Lenka (Expanded Edition)",
-            "track_name": "Trouble Is a Friend"
+            "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
+            "track_name": "Trouble Is a Friend",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Weeknd",
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 3,
             "recording_mbid": "0f9a63bf-fa0f-4d93-b5c9-a9c537ca633f",
-            "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
             "release_name": "Starboy",
-            "track_name": "Starboy"
+            "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
+            "track_name": "Starboy",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 3,
             "recording_mbid": "b79de255-2d29-40d3-b03e-5b8690817500",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "It's Time"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "It's Time",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Chainsmokers",
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 3,
             "recording_mbid": "0a3337f5-290f-4031-8a7a-4d3d9398c8c0",
-            "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
             "release_name": "Don't Let Me Down (feat. Daya)",
-            "track_name": "Don't Let Me Down (feat. Daya)"
+            "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
+            "track_name": "Don't Let Me Down (feat. Daya)",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 2,
             "recording_mbid": "d37c2481-f971-4ec0-b7aa-7fcf1128abbc",
-            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "track_name": "You Found Me"
+            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
+            "track_name": "You Found Me",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "77fb69de-d4b0-4c41-8be6-d3bc5439b709",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "Yellow - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "Yellow - Live In Buenos Aires",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "ce8ac50f-f14c-48a4-a23b-fdabe95bf491",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "Up&Up - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "Up&Up - Live In Buenos Aires",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Post Malone",
             "artist_mbids": [
                 "efc1ae68-f406-4430-8d94-a00b7280d822"
             ],
-            "artist_name": "Post Malone",
-            "listen_count": 2,
             "recording_mbid": "d36b5e2f-001e-4d7a-8246-53c35cf8a76d",
-            "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
             "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)",
-            "track_name": "Sunflower - Spider-Man: Into the Spider-Verse"
+            "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
+            "track_name": "Sunflower - Spider-Man: Into the Spider-Verse",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Magic!",
             "artist_mbids": [
                 "77e59c9c-cbb3-4566-abe9-5ccf8a92c28f"
             ],
-            "artist_name": "Magic!",
-            "listen_count": 2,
             "recording_mbid": "296e6afc-5507-4855-9e98-f1da8522f38c",
-            "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
             "release_name": "Don't Kill the Magic",
-            "track_name": "Rude"
+            "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
+            "track_name": "Rude",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Joel Adams",
             "artist_mbids": [
                 "4cd95528-7c4f-4ba8-a66f-a3f571e7a002"
             ],
-            "artist_name": "Joel Adams",
-            "listen_count": 2,
             "recording_mbid": "03ccadd6-c197-4be8-941f-7cbad2c9c167",
-            "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
             "release_name": "Please Don't Go",
-            "track_name": "Please Don't Go"
+            "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
+            "track_name": "Please Don't Go",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "a45a2d39-730e-4191-ae3f-2c9c27cff96c",
-            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "track_name": "Orphans"
+            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
+            "track_name": "Orphans",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 2,
             "recording_mbid": "e3229131-d000-4806-bbcf-f2f84d5dbb81",
-            "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
             "release_name": "No Vacancy",
-            "track_name": "No Vacancy"
+            "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
+            "track_name": "No Vacancy",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 2,
             "recording_mbid": "80edf568-6299-448c-9f29-b52e643e36a1",
-            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "track_name": "Never Say Never"
+            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
+            "track_name": "Never Say Never",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 2,
             "recording_mbid": "88f05e72-a832-4b71-b1dd-b0b6a27c1e0c",
-            "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
             "release_name": "Liggi",
-            "track_name": "Liggi"
+            "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
+            "track_name": "Liggi",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Lumineers",
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 2,
             "recording_mbid": "54f149e1-337f-4787-ab85-f5751e7f94e6",
-            "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
             "release_name": "The Lumineers",
-            "track_name": "Ho Hey"
+            "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
+            "track_name": "Ho Hey",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 2,
             "recording_mbid": "cab6930c-42b6-4394-92fe-5a2d30540c1d",
-            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "track_name": "Happier"
+            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
+            "track_name": "Happier",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Vance Joy",
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 2,
             "recording_mbid": "9634914d-d171-4eff-8812-b0d435d4122d",
-            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "track_name": "Georgia"
+            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
+            "track_name": "Georgia",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "4f7209b9-623f-49d4-8bde-ad29fb73b1be",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "Fix You - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "Fix You - Live In Buenos Aires",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Chainsmokers",
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 2,
             "recording_mbid": "5b8b06bd-514b-40ca-b9ea-01cdd444f277",
-            "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
             "release_name": "Don't Let Me Down",
-            "track_name": "Don't Let Me Down"
+            "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
+            "track_name": "Don't Let Me Down",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "George Ezra",
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 2,
             "recording_mbid": "2ee25888-9b0d-4875-8242-2ec699076937",
-            "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
             "release_name": "Wanted on Voyage",
-            "track_name": "Budapest"
+            "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
+            "track_name": "Budapest",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "7ad767a8-6a1e-42ef-9ca4-bcf3be18f7b5",
-            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "track_name": "A Sky Full of Stars"
+            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
+            "track_name": "A Sky Full of Stars",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "James Blunt",
             "artist_mbids": [
                 "291bca64-8c93-4790-85db-cf25baacb49e"
             ],
-            "artist_name": "James Blunt",
-            "listen_count": 1,
             "recording_mbid": "c8f52120-45f5-4af7-8106-7a73bc94a0fb",
-            "release_mbid": "348ab2f1-99e9-46a9-8403-166086807b36",
             "release_name": "Back to Bedlam",
-            "track_name": "You're Beautiful"
+            "release_mbid": "348ab2f1-99e9-46a9-8403-166086807b36",
+            "track_name": "You're Beautiful",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "48658b7c-851d-4683-a983-db282a3a4c47",
-            "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
             "release_name": "AV\u012aCI (01)",
-            "track_name": "Without You (feat. Sandro Cavazza)"
+            "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
+            "track_name": "Without You (feat. Sandro Cavazza)",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "recording_mbid": "e80fae03-21cc-4a27-bf14-35906dd7647a",
-            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "track_name": "Wildest Dreams"
+            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
+            "track_name": "Wildest Dreams",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Anirudh Ravichander",
             "artist_mbids": [
                 "80daf28c-5198-454a-9f74-4a1300f544ac"
             ],
-            "artist_name": "Anirudh Ravichander",
-            "listen_count": 1,
             "recording_mbid": "36091dba-7078-464a-8fd5-07dc35ed5daf",
-            "release_mbid": "69bef805-98e2-4729-ac66-ee78a0b6bb17",
             "release_name": "Why This Kolaveri Di? (The Soup of Love)",
-            "track_name": "Why This Kolaveri Di? - The Soup of Love"
+            "release_mbid": "69bef805-98e2-4729-ac66-ee78a0b6bb17",
+            "track_name": "Why This Kolaveri Di? - The Soup of Love",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 1,
             "recording_mbid": "ffc31aff-d5e9-49ae-a141-8ee76c5bf4e2",
-            "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
             "release_name": "Oh My My (Deluxe)",
-            "track_name": "Wherever I Go"
+            "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
+            "track_name": "Wherever I Go",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "One Direction",
             "artist_mbids": [
                 "1c498eab-998f-4975-b52b-72243e89c0ba"
             ],
-            "artist_name": "One Direction",
-            "listen_count": 1,
             "recording_mbid": "5338e902-bc45-4b30-8cd9-c8727b9d7d1e",
-            "release_mbid": "021be16d-42da-41e3-bee4-8a4e66ce5641",
             "release_name": "Nrj 200% Hits 2012",
-            "track_name": "What Makes You Beautiful"
+            "release_mbid": "021be16d-42da-41e3-bee4-8a4e66ce5641",
+            "track_name": "What Makes You Beautiful",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Charlie Puth",
             "artist_mbids": [
                 "bf8d0eb5-a94c-496a-a4a5-6d370e0c30e9"
             ],
-            "artist_name": "Charlie Puth",
-            "listen_count": 1,
             "recording_mbid": "44c9c270-9a8b-4f4d-92d8-d205c8388660",
-            "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
             "release_name": "Nine Track Mind",
-            "track_name": "We Don't Talk Anymore"
+            "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
+            "track_name": "We Don't Talk Anymore",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "recording_mbid": "8b22b4c1-3b13-4d41-80b6-e37caff2fb8d",
-            "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
             "release_name": "Red (Deluxe Edition)",
-            "track_name": "We Are Never Ever Getting Back Together"
+            "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
+            "track_name": "We Are Never Ever Getting Back Together",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "b4682bba-bffb-42ad-af7d-e3653cd95c9b",
-            "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
             "release_name": "True",
-            "track_name": "Wake Me Up"
+            "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
+            "track_name": "Wake Me Up",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "a4174a41-e323-4fea-a844-c860fab1d6dc",
-            "release_mbid": "2a7e7745-642d-4231-ab80-16a38be05f8b",
             "release_name": "Waiting For Love",
-            "track_name": "Waiting For Love"
+            "release_mbid": "2a7e7745-642d-4231-ab80-16a38be05f8b",
+            "track_name": "Waiting For Love",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 1,
             "recording_mbid": "41e036ef-4fc5-48bc-b496-a86b82783f82",
-            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "track_name": "Ungodly Hour"
+            "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
+            "track_name": "Ungodly Hour",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Katy Perry",
             "artist_mbids": [
                 "b650167d-3f75-4a39-a0b5-7cf4e65b7205"
             ],
-            "artist_name": "Katy Perry",
-            "listen_count": 1,
             "recording_mbid": "d6ca58d3-50dd-47c6-8835-a80775e91fdc",
-            "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
             "release_name": "PRISM (Deluxe)",
-            "track_name": "Unconditionally"
+            "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
+            "track_name": "Unconditionally",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "P!nk",
             "artist_mbids": [
                 "0dee16fe-2b7f-4781-8f71-1e4357603ef1"
             ],
-            "artist_name": "P!nk",
-            "listen_count": 1,
             "recording_mbid": "ec5167ab-2972-4b9e-8906-ce9a6834a2b8",
-            "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
             "release_name": "The Truth About Love",
-            "track_name": "Try"
+            "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
+            "track_name": "Try",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Colbie Caillat",
             "artist_mbids": [
                 "b09db02b-5438-4360-a73f-7a3a5b88358f"
             ],
-            "artist_name": "Colbie Caillat",
-            "listen_count": 1,
             "recording_mbid": "6406c5d1-89b9-49ad-bd5b-37284c7fbc7f",
-            "release_mbid": "68804497-2717-47c0-97ce-082b162c1d82",
             "release_name": "Gypsy Heart",
-            "track_name": "Try"
+            "release_mbid": "68804497-2717-47c0-97ce-082b162c1d82",
+            "track_name": "Try",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Shawn Mendes",
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "recording_mbid": "500ac5df-dd13-4a08-8b70-ef930742684d",
-            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "track_name": "Treat You Better"
+            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
+            "track_name": "Treat You Better",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Tyrone Wells",
             "artist_mbids": [
                 "bce2e04f-e3f3-4c91-bd09-115455c43d37"
             ],
-            "artist_name": "Tyrone Wells",
-            "listen_count": 1,
             "recording_mbid": "d22799f2-2330-48d3-a78a-d171904651ae",
-            "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
             "release_name": "Metal & Wood",
-            "track_name": "Time of Our Lives"
+            "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
+            "track_name": "Time of Our Lives",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 1,
             "recording_mbid": "aefae07e-7fe6-45e8-9c85-c11fde5e6f96",
-            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "track_name": "Thunder"
+            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
+            "track_name": "Thunder",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Shawn Mendes",
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "recording_mbid": "4e27fc2a-98cc-4f1c-a204-ad2c1aca0f44",
-            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "track_name": "There's Nothing Holdin' Me Back"
+            "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
+            "track_name": "There's Nothing Holdin' Me Back",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 1,
             "recording_mbid": "92d77b07-f5dd-49f0-8468-8d501ff3d221",
-            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "track_name": "The Scientist - Live In Buenos Aires"
+            "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
+            "track_name": "The Scientist - Live In Buenos Aires",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Avicii",
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "recording_mbid": "4ea67a2e-72f2-4dff-a9dd-d7721374b645",
-            "release_mbid": "99ff985c-89f3-4b38-a24d-f6f699593f7b",
             "release_name": "Now That's What I Call Pop",
-            "track_name": "The Nights"
+            "release_mbid": "99ff985c-89f3-4b38-a24d-f6f699593f7b",
+            "track_name": "The Nights",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Bruno Mars",
             "artist_mbids": [
                 "abf274d4-a1f8-4477-b5c6-8c1121a13cf6"
             ],
-            "artist_name": "Bruno Mars",
-            "listen_count": 1,
             "recording_mbid": "2449949b-14a7-4986-a382-eb1a1922cc66",
-            "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
             "release_name": "Doo-Wops & Hooligans",
-            "track_name": "The Lazy Song"
+            "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
+            "track_name": "The Lazy Song",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 1,
             "recording_mbid": "434addad-5e28-48cf-9fa2-650791cca44e",
-            "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
             "release_name": "+",
-            "track_name": "The A Team"
+            "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
+            "track_name": "The A Team",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 1,
             "recording_mbid": "834f7cc2-54b5-49a8-af3d-8aac0cacf67a",
-            "release_mbid": "4a8edc98-db22-40cd-9dd9-2ae913763003",
             "release_name": "Thandi Hawa",
-            "track_name": "Thandi Hawa"
+            "release_mbid": "4a8edc98-db22-40cd-9dd9-2ae913763003",
+            "track_name": "Thandi Hawa",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Hozier",
             "artist_mbids": [
                 "530d057e-f444-4e24-ba21-0e88d830fe67"
             ],
-            "artist_name": "Hozier",
-            "listen_count": 1,
             "recording_mbid": "f30c2728-228a-4222-bdb1-fc2512ceed52",
-            "release_mbid": "0c3c1ec5-06b1-4c9a-a6d3-1c7774a1e2ba",
             "release_name": "Hozier (Special Edition)",
-            "track_name": "Take Me to Church"
+            "release_mbid": "0c3c1ec5-06b1-4c9a-a6d3-1c7774a1e2ba",
+            "track_name": "Take Me to Church",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Clean Bandit",
             "artist_mbids": [
                 "f0676957-e3d7-4ca6-baf8-ffecaa01f415"
             ],
-            "artist_name": "Clean Bandit",
-            "listen_count": 1,
             "recording_mbid": "def4cc2f-9138-40bf-9bc6-40e2da2641a4",
-            "release_mbid": "7de6da6f-5f6d-4dbe-9dea-0a09fed0e7e5",
             "release_name": "Symphony (feat. Zara Larsson)",
-            "track_name": "Symphony (feat. Zara Larsson)"
+            "release_mbid": "7de6da6f-5f6d-4dbe-9dea-0a09fed0e7e5",
+            "track_name": "Symphony (feat. Zara Larsson)",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Script",
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 1,
             "recording_mbid": "425c5374-359f-4a55-8f59-2ebe31aab829",
-            "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
             "release_name": "No Sound Without Silence",
-            "track_name": "Superheroes"
+            "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
+            "track_name": "Superheroes",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 1,
             "recording_mbid": "de586967-461c-49eb-83ef-0f68305626af",
-            "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
             "release_name": "V",
-            "track_name": "Sugar"
+            "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
+            "track_name": "Sugar",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 1,
             "recording_mbid": "16235fdd-1408-4510-898b-2434028fafea",
-            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "track_name": "Strawberry Swing"
+            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
+            "track_name": "Strawberry Swing",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "One Direction",
             "artist_mbids": [
                 "1c498eab-998f-4975-b52b-72243e89c0ba"
             ],
-            "artist_name": "One Direction",
-            "listen_count": 1,
             "recording_mbid": "cd81e13d-004d-43ed-b41b-bb8cce73efd9",
-            "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
             "release_name": "Midnight Memories (Deluxe)",
-            "track_name": "Story of My Life"
+            "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
+            "track_name": "Story of My Life",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Shawn Mendes",
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "recording_mbid": "ccdccc03-00ca-470f-948c-6fd6f5394701",
-            "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
             "release_name": "Handwritten (Deluxe)",
-            "track_name": "Stitches"
+            "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
+            "track_name": "Stitches",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Gym Class Heroes",
             "artist_mbids": [
                 "c2007446-79e3-476a-868f-876e48a60893"
             ],
-            "artist_name": "Gym Class Heroes",
-            "listen_count": 1,
             "recording_mbid": "bc69ab9d-5323-477d-a556-df48e849aa28",
-            "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
             "release_name": "The Papercut Chronicles II",
-            "track_name": "Stereo Hearts (feat. Adam Levine)"
+            "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
+            "track_name": "Stereo Hearts (feat. Adam Levine)",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "One Direction",
             "artist_mbids": [
                 "1c498eab-998f-4975-b52b-72243e89c0ba"
             ],
-            "artist_name": "One Direction",
-            "listen_count": 1,
             "recording_mbid": "cd81e13d-004d-43ed-b41b-bb8cce73efd9",
-            "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
             "release_name": "Midnight Memories (Deluxe)",
-            "track_name": "Story of My Life"
+            "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
+            "track_name": "Story of My Life",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Shawn Mendes",
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "recording_mbid": "ccdccc03-00ca-470f-948c-6fd6f5394701",
-            "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
             "release_name": "Handwritten (Deluxe)",
-            "track_name": "Stitches"
+            "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
+            "track_name": "Stitches",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Gym Class Heroes",
             "artist_mbids": [
                 "c2007446-79e3-476a-868f-876e48a60893"
             ],
-            "artist_name": "Gym Class Heroes",
-            "listen_count": 1,
             "recording_mbid": "bc69ab9d-5323-477d-a556-df48e849aa28",
-            "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
             "release_name": "The Papercut Chronicles II",
-            "track_name": "Stereo Hearts (feat. Adam Levine)"
+            "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
+            "track_name": "Stereo Hearts (feat. Adam Levine)",
+            "listen_count": 1,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         }
     ]
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_too_many.json
@@ -12,7 +12,7 @@
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "recording_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
         },
         {
             "artist_mbids": [
@@ -23,7 +23,7 @@
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "recording_name": "How to Save a Life"
+            "track_name": "How to Save a Life"
         },
         {
             "artist_mbids": [
@@ -34,7 +34,7 @@
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "recording_name": "Udd Gaye - Bacardi House Party Sessions"
+            "track_name": "Udd Gaye - Bacardi House Party Sessions"
         },
         {
             "artist_mbids": [
@@ -45,7 +45,7 @@
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "recording_name": "Counting Stars"
+            "track_name": "Counting Stars"
         },
         {
             "artist_mbids": [
@@ -56,7 +56,7 @@
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "recording_name": "Burn"
+            "track_name": "Burn"
         },
         {
             "artist_mbids": [
@@ -67,7 +67,7 @@
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "recording_name": "Blank Space"
+            "track_name": "Blank Space"
         },
         {
             "artist_mbids": [
@@ -78,7 +78,7 @@
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "recording_name": "A Thousand Years"
+            "track_name": "A Thousand Years"
         },
         {
             "artist_mbids": [
@@ -89,7 +89,7 @@
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "recording_name": "Riptide"
+            "track_name": "Riptide"
         },
         {
             "artist_mbids": [
@@ -100,7 +100,7 @@
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "recording_name": "Castle on the Hill"
+            "track_name": "Castle on the Hill"
         },
         {
             "artist_mbids": [
@@ -111,7 +111,7 @@
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "recording_name": "Start Again (feat. Logic)"
+            "track_name": "Start Again (feat. Logic)"
         },
         {
             "artist_mbids": [
@@ -122,7 +122,7 @@
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "recording_name": "Shotgun"
+            "track_name": "Shotgun"
         },
         {
             "artist_mbids": [
@@ -133,7 +133,7 @@
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "recording_name": "In The End - Mellen Gi Remix"
+            "track_name": "In The End - Mellen Gi Remix"
         },
         {
             "artist_mbids": [
@@ -144,7 +144,7 @@
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "recording_name": "Hall of Fame"
+            "track_name": "Hall of Fame"
         },
         {
             "artist_mbids": [
@@ -155,7 +155,7 @@
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "recording_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
         },
         {
             "artist_mbids": [
@@ -166,7 +166,7 @@
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "recording_name": "Little Talks"
+            "track_name": "Little Talks"
         },
         {
             "artist_mbids": [
@@ -177,7 +177,7 @@
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "recording_name": "Cheap Thrills (feat. Sean Paul)"
+            "track_name": "Cheap Thrills (feat. Sean Paul)"
         },
         {
             "artist_mbids": [
@@ -188,7 +188,7 @@
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "recording_name": "Payphone"
+            "track_name": "Payphone"
         },
         {
             "artist_mbids": [
@@ -199,7 +199,7 @@
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "recording_name": "Paper Planes"
+            "track_name": "Paper Planes"
         },
         {
             "artist_mbids": [
@@ -210,7 +210,7 @@
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "recording_name": "Battle Symphony"
+            "track_name": "Battle Symphony"
         },
         {
             "artist_mbids": [
@@ -221,7 +221,7 @@
             "recording_mbid": "6c4d9128-ea06-46f5-a6d8-daab439a7e6a",
             "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
             "release_name": "The Hits--Chapter One",
-            "recording_name": "I Want It That Way"
+            "track_name": "I Want It That Way"
         },
         {
             "artist_mbids": [
@@ -232,7 +232,7 @@
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "recording_name": "Everything at Once"
+            "track_name": "Everything at Once"
         },
         {
             "artist_mbids": [
@@ -243,7 +243,7 @@
             "recording_mbid": "6bf4c778-d11c-40de-bf28-970ba678d5a6",
             "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
             "release_name": "Aalas Ka Pedh",
-            "recording_name": "Choo Lo"
+            "track_name": "Choo Lo"
         },
         {
             "artist_mbids": [
@@ -254,7 +254,7 @@
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Up&Up"
+            "track_name": "Up&Up"
         },
         {
             "artist_mbids": [
@@ -265,7 +265,7 @@
             "recording_mbid": "c17b56c2-7227-4a67-9d54-6d28aefd22f7",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "On Top of the World"
+            "track_name": "On Top of the World"
         },
         {
             "artist_mbids": [
@@ -276,7 +276,7 @@
             "recording_mbid": "8ff3d1f9-dfa5-470e-b9a0-32f94cb0ffb9",
             "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
             "release_name": "Close To Me (feat. Swae Lee)",
-            "recording_name": "Close to Me (with Diplo) (feat. Swae Lee)"
+            "track_name": "Close to Me (with Diplo) (feat. Swae Lee)"
         },
         {
             "artist_mbids": [
@@ -287,7 +287,7 @@
             "recording_mbid": "af757f8d-fc67-4b3b-98e8-dcc28c2e3bd8",
             "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
             "release_name": "We Belong",
-            "recording_name": "We Belong"
+            "track_name": "We Belong"
         },
         {
             "artist_mbids": [
@@ -298,7 +298,7 @@
             "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
             "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
             "release_name": "Sixteen",
-            "recording_name": "Sixteen"
+            "track_name": "Sixteen"
         },
         {
             "artist_mbids": [
@@ -309,7 +309,7 @@
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "recording_name": "Ink"
+            "track_name": "Ink"
         },
         {
             "artist_mbids": [
@@ -320,7 +320,7 @@
             "recording_mbid": "eb255a08-1486-4ac0-a796-1092421959e8",
             "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
             "release_name": "Save Me, San Francisco (Golden Gate Edition)",
-            "recording_name": "Hey, Soul Sister"
+            "track_name": "Hey, Soul Sister"
         },
         {
             "artist_mbids": [
@@ -331,7 +331,7 @@
             "recording_mbid": "8daff47f-4732-4946-870a-7c1305f1d652",
             "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
             "release_name": "Girls Like You (feat. Cardi B)",
-            "recording_name": "Girls Like You (feat. Cardi B)"
+            "track_name": "Girls Like You (feat. Cardi B)"
         },
         {
             "artist_mbids": [
@@ -342,7 +342,7 @@
             "recording_mbid": "c3922480-7ae2-472b-88c0-0acafb207af2",
             "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
             "release_name": "The Unforgiving",
-            "recording_name": "Faster"
+            "track_name": "Faster"
         },
         {
             "artist_mbids": [
@@ -353,7 +353,7 @@
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Everglow"
+            "track_name": "Everglow"
         },
         {
             "artist_mbids": [
@@ -364,7 +364,7 @@
             "recording_mbid": "cd00414d-5d44-4f2b-ab39-455a10d68564",
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "recording_name": "Champion of the World"
+            "track_name": "Champion of the World"
         },
         {
             "artist_mbids": [
@@ -375,7 +375,7 @@
             "recording_mbid": "c0b51d3f-b0da-4aef-a727-684cc205039b",
             "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
             "release_name": "Blinding Lights",
-            "recording_name": "Blinding Lights"
+            "track_name": "Blinding Lights"
         },
         {
             "artist_mbids": [
@@ -386,7 +386,7 @@
             "recording_mbid": "864c5fca-4082-4e1d-92b5-6604d41dd391",
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "recording_name": "Blinded By Love"
+            "track_name": "Blinded By Love"
         },
         {
             "artist_mbids": [
@@ -397,7 +397,7 @@
             "recording_mbid": "2a5af3dc-3bba-436f-bd8f-7c9ac7a0ac25",
             "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
             "release_name": "Oh, What A Life",
-            "recording_name": "Best Day of My Life"
+            "track_name": "Best Day of My Life"
         },
         {
             "artist_mbids": [
@@ -408,7 +408,7 @@
             "recording_mbid": "3373eda9-3c54-4098-accc-92361ae8dde9",
             "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "recording_name": "Believer"
+            "track_name": "Believer"
         },
         {
             "artist_mbids": [
@@ -419,7 +419,7 @@
             "recording_mbid": "28f8f9f6-f428-411d-a0fc-ac523922bd81",
             "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "recording_name": "Viva la Vida"
+            "track_name": "Viva la Vida"
         },
         {
             "artist_mbids": [
@@ -430,7 +430,7 @@
             "recording_mbid": "dccd75d0-4002-4a5c-b6d1-d92c1cac9bd5",
             "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
             "release_name": "Memories...Do Not Open",
-            "recording_name": "Something Just Like This"
+            "track_name": "Something Just Like This"
         },
         {
             "artist_mbids": [
@@ -441,7 +441,7 @@
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "Radioactive"
+            "track_name": "Radioactive"
         },
         {
             "artist_mbids": [
@@ -452,7 +452,7 @@
             "recording_mbid": "034fb415-56a1-47c4-8aec-1b7d32cbf0bd",
             "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
             "release_name": "Mylo Xyloto",
-            "recording_name": "Paradise"
+            "track_name": "Paradise"
         },
         {
             "artist_mbids": [
@@ -463,7 +463,7 @@
             "recording_mbid": "b06e73d8-8a25-4c32-9a84-130ffd0b0bc9",
             "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
             "release_name": "Memories",
-            "recording_name": "Memories"
+            "track_name": "Memories"
         },
         {
             "artist_mbids": [
@@ -474,7 +474,7 @@
             "recording_mbid": "938157e9-1c93-4fe5-8797-aa7e6e2a0378",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Hymn for the Weekend"
+            "track_name": "Hymn for the Weekend"
         },
         {
             "artist_mbids": [
@@ -485,7 +485,7 @@
             "recording_mbid": "fff72a5a-4f9f-48b7-b9e2-fe28852b0387",
             "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
             "release_name": "The Lumineers (Deluxe Edition)",
-            "recording_name": "Ho Hey"
+            "track_name": "Ho Hey"
         },
         {
             "artist_mbids": [
@@ -496,7 +496,7 @@
             "recording_mbid": "84535425-6926-416d-9979-18aca3de3672",
             "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
             "release_name": "X&Y",
-            "recording_name": "Fix You"
+            "track_name": "Fix You"
         },
         {
             "artist_mbids": [
@@ -507,7 +507,7 @@
             "recording_mbid": "f40b62dd-c900-4884-bb71-9418ff842561",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "Demons"
+            "track_name": "Demons"
         },
         {
             "artist_mbids": [
@@ -518,7 +518,7 @@
             "recording_mbid": "ae52f909-4004-411a-b513-7b3377dc5d21",
             "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
             "release_name": "The Bright Side",
-            "recording_name": "Blue Skies"
+            "track_name": "Blue Skies"
         },
         {
             "artist_mbids": [
@@ -529,7 +529,7 @@
             "recording_mbid": "65f90a62-a89e-453e-9aed-862781383436",
             "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
             "release_name": "Vaaqif",
-            "recording_name": "Aaftaab"
+            "track_name": "Aaftaab"
         },
         {
             "artist_mbids": [
@@ -540,7 +540,7 @@
             "recording_mbid": "157e2094-b98e-4db0-8219-17f30c7a7f41",
             "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
             "release_name": "Lenka (Expanded Edition)",
-            "recording_name": "Trouble Is a Friend"
+            "track_name": "Trouble Is a Friend"
         },
         {
             "artist_mbids": [
@@ -551,7 +551,7 @@
             "recording_mbid": "0f9a63bf-fa0f-4d93-b5c9-a9c537ca633f",
             "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
             "release_name": "Starboy",
-            "recording_name": "Starboy"
+            "track_name": "Starboy"
         },
         {
             "artist_mbids": [
@@ -562,7 +562,7 @@
             "recording_mbid": "b79de255-2d29-40d3-b03e-5b8690817500",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "It's Time"
+            "track_name": "It's Time"
         },
         {
             "artist_mbids": [
@@ -573,7 +573,7 @@
             "recording_mbid": "0a3337f5-290f-4031-8a7a-4d3d9398c8c0",
             "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
             "release_name": "Don't Let Me Down (feat. Daya)",
-            "recording_name": "Don't Let Me Down (feat. Daya)"
+            "track_name": "Don't Let Me Down (feat. Daya)"
         },
         {
             "artist_mbids": [
@@ -584,7 +584,7 @@
             "recording_mbid": "d37c2481-f971-4ec0-b7aa-7fcf1128abbc",
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "recording_name": "You Found Me"
+            "track_name": "You Found Me"
         },
         {
             "artist_mbids": [
@@ -595,7 +595,7 @@
             "recording_mbid": "77fb69de-d4b0-4c41-8be6-d3bc5439b709",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "Yellow - Live In Buenos Aires"
+            "track_name": "Yellow - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -606,7 +606,7 @@
             "recording_mbid": "ce8ac50f-f14c-48a4-a23b-fdabe95bf491",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "Up&Up - Live In Buenos Aires"
+            "track_name": "Up&Up - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -617,7 +617,7 @@
             "recording_mbid": "d36b5e2f-001e-4d7a-8246-53c35cf8a76d",
             "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
             "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)",
-            "recording_name": "Sunflower - Spider-Man: Into the Spider-Verse"
+            "track_name": "Sunflower - Spider-Man: Into the Spider-Verse"
         },
         {
             "artist_mbids": [
@@ -628,7 +628,7 @@
             "recording_mbid": "296e6afc-5507-4855-9e98-f1da8522f38c",
             "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
             "release_name": "Don't Kill the Magic",
-            "recording_name": "Rude"
+            "track_name": "Rude"
         },
         {
             "artist_mbids": [
@@ -639,7 +639,7 @@
             "recording_mbid": "03ccadd6-c197-4be8-941f-7cbad2c9c167",
             "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
             "release_name": "Please Don't Go",
-            "recording_name": "Please Don't Go"
+            "track_name": "Please Don't Go"
         },
         {
             "artist_mbids": [
@@ -650,7 +650,7 @@
             "recording_mbid": "a45a2d39-730e-4191-ae3f-2c9c27cff96c",
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "recording_name": "Orphans"
+            "track_name": "Orphans"
         },
         {
             "artist_mbids": [
@@ -661,7 +661,7 @@
             "recording_mbid": "e3229131-d000-4806-bbcf-f2f84d5dbb81",
             "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
             "release_name": "No Vacancy",
-            "recording_name": "No Vacancy"
+            "track_name": "No Vacancy"
         },
         {
             "artist_mbids": [
@@ -672,7 +672,7 @@
             "recording_mbid": "80edf568-6299-448c-9f29-b52e643e36a1",
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "recording_name": "Never Say Never"
+            "track_name": "Never Say Never"
         },
         {
             "artist_mbids": [
@@ -683,7 +683,7 @@
             "recording_mbid": "88f05e72-a832-4b71-b1dd-b0b6a27c1e0c",
             "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
             "release_name": "Liggi",
-            "recording_name": "Liggi"
+            "track_name": "Liggi"
         },
         {
             "artist_mbids": [
@@ -694,7 +694,7 @@
             "recording_mbid": "54f149e1-337f-4787-ab85-f5751e7f94e6",
             "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
             "release_name": "The Lumineers",
-            "recording_name": "Ho Hey"
+            "track_name": "Ho Hey"
         },
         {
             "artist_mbids": [
@@ -705,7 +705,7 @@
             "recording_mbid": "cab6930c-42b6-4394-92fe-5a2d30540c1d",
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "recording_name": "Happier"
+            "track_name": "Happier"
         },
         {
             "artist_mbids": [
@@ -716,7 +716,7 @@
             "recording_mbid": "9634914d-d171-4eff-8812-b0d435d4122d",
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "recording_name": "Georgia"
+            "track_name": "Georgia"
         },
         {
             "artist_mbids": [
@@ -727,7 +727,7 @@
             "recording_mbid": "4f7209b9-623f-49d4-8bde-ad29fb73b1be",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "Fix You - Live In Buenos Aires"
+            "track_name": "Fix You - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -738,7 +738,7 @@
             "recording_mbid": "5b8b06bd-514b-40ca-b9ea-01cdd444f277",
             "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
             "release_name": "Don't Let Me Down",
-            "recording_name": "Don't Let Me Down"
+            "track_name": "Don't Let Me Down"
         },
         {
             "artist_mbids": [
@@ -749,7 +749,7 @@
             "recording_mbid": "2ee25888-9b0d-4875-8242-2ec699076937",
             "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
             "release_name": "Wanted on Voyage",
-            "recording_name": "Budapest"
+            "track_name": "Budapest"
         },
         {
             "artist_mbids": [
@@ -760,7 +760,7 @@
             "recording_mbid": "7ad767a8-6a1e-42ef-9ca4-bcf3be18f7b5",
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "recording_name": "A Sky Full of Stars"
+            "track_name": "A Sky Full of Stars"
         },
         {
             "artist_mbids": [
@@ -771,7 +771,7 @@
             "recording_mbid": "c8f52120-45f5-4af7-8106-7a73bc94a0fb",
             "release_mbid": "348ab2f1-99e9-46a9-8403-166086807b36",
             "release_name": "Back to Bedlam",
-            "recording_name": "You're Beautiful"
+            "track_name": "You're Beautiful"
         },
         {
             "artist_mbids": [
@@ -782,7 +782,7 @@
             "recording_mbid": "48658b7c-851d-4683-a983-db282a3a4c47",
             "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
             "release_name": "AV\u012aCI (01)",
-            "recording_name": "Without You (feat. Sandro Cavazza)"
+            "track_name": "Without You (feat. Sandro Cavazza)"
         },
         {
             "artist_mbids": [
@@ -793,7 +793,7 @@
             "recording_mbid": "e80fae03-21cc-4a27-bf14-35906dd7647a",
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "recording_name": "Wildest Dreams"
+            "track_name": "Wildest Dreams"
         },
         {
             "artist_mbids": [
@@ -804,7 +804,7 @@
             "recording_mbid": "36091dba-7078-464a-8fd5-07dc35ed5daf",
             "release_mbid": "69bef805-98e2-4729-ac66-ee78a0b6bb17",
             "release_name": "Why This Kolaveri Di? (The Soup of Love)",
-            "recording_name": "Why This Kolaveri Di? - The Soup of Love"
+            "track_name": "Why This Kolaveri Di? - The Soup of Love"
         },
         {
             "artist_mbids": [
@@ -815,7 +815,7 @@
             "recording_mbid": "ffc31aff-d5e9-49ae-a141-8ee76c5bf4e2",
             "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
             "release_name": "Oh My My (Deluxe)",
-            "recording_name": "Wherever I Go"
+            "track_name": "Wherever I Go"
         },
         {
             "artist_mbids": [
@@ -826,7 +826,7 @@
             "recording_mbid": "5338e902-bc45-4b30-8cd9-c8727b9d7d1e",
             "release_mbid": "021be16d-42da-41e3-bee4-8a4e66ce5641",
             "release_name": "Nrj 200% Hits 2012",
-            "recording_name": "What Makes You Beautiful"
+            "track_name": "What Makes You Beautiful"
         },
         {
             "artist_mbids": [
@@ -837,7 +837,7 @@
             "recording_mbid": "44c9c270-9a8b-4f4d-92d8-d205c8388660",
             "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
             "release_name": "Nine Track Mind",
-            "recording_name": "We Don't Talk Anymore"
+            "track_name": "We Don't Talk Anymore"
         },
         {
             "artist_mbids": [
@@ -848,7 +848,7 @@
             "recording_mbid": "8b22b4c1-3b13-4d41-80b6-e37caff2fb8d",
             "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
             "release_name": "Red (Deluxe Edition)",
-            "recording_name": "We Are Never Ever Getting Back Together"
+            "track_name": "We Are Never Ever Getting Back Together"
         },
         {
             "artist_mbids": [
@@ -859,7 +859,7 @@
             "recording_mbid": "b4682bba-bffb-42ad-af7d-e3653cd95c9b",
             "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
             "release_name": "True",
-            "recording_name": "Wake Me Up"
+            "track_name": "Wake Me Up"
         },
         {
             "artist_mbids": [
@@ -870,7 +870,7 @@
             "recording_mbid": "a4174a41-e323-4fea-a844-c860fab1d6dc",
             "release_mbid": "2a7e7745-642d-4231-ab80-16a38be05f8b",
             "release_name": "Waiting For Love",
-            "recording_name": "Waiting For Love"
+            "track_name": "Waiting For Love"
         },
         {
             "artist_mbids": [
@@ -881,7 +881,7 @@
             "recording_mbid": "41e036ef-4fc5-48bc-b496-a86b82783f82",
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
             "release_name": "The Fray",
-            "recording_name": "Ungodly Hour"
+            "track_name": "Ungodly Hour"
         },
         {
             "artist_mbids": [
@@ -892,7 +892,7 @@
             "recording_mbid": "d6ca58d3-50dd-47c6-8835-a80775e91fdc",
             "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
             "release_name": "PRISM (Deluxe)",
-            "recording_name": "Unconditionally"
+            "track_name": "Unconditionally"
         },
         {
             "artist_mbids": [
@@ -903,7 +903,7 @@
             "recording_mbid": "ec5167ab-2972-4b9e-8906-ce9a6834a2b8",
             "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
             "release_name": "The Truth About Love",
-            "recording_name": "Try"
+            "track_name": "Try"
         },
         {
             "artist_mbids": [
@@ -914,7 +914,7 @@
             "recording_mbid": "6406c5d1-89b9-49ad-bd5b-37284c7fbc7f",
             "release_mbid": "68804497-2717-47c0-97ce-082b162c1d82",
             "release_name": "Gypsy Heart",
-            "recording_name": "Try"
+            "track_name": "Try"
         },
         {
             "artist_mbids": [
@@ -925,7 +925,7 @@
             "recording_mbid": "500ac5df-dd13-4a08-8b70-ef930742684d",
             "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "recording_name": "Treat You Better"
+            "track_name": "Treat You Better"
         },
         {
             "artist_mbids": [
@@ -936,7 +936,7 @@
             "recording_mbid": "d22799f2-2330-48d3-a78a-d171904651ae",
             "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
             "release_name": "Metal & Wood",
-            "recording_name": "Time of Our Lives"
+            "track_name": "Time of Our Lives"
         },
         {
             "artist_mbids": [
@@ -947,7 +947,7 @@
             "recording_mbid": "aefae07e-7fe6-45e8-9c85-c11fde5e6f96",
             "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "recording_name": "Thunder"
+            "track_name": "Thunder"
         },
         {
             "artist_mbids": [
@@ -958,7 +958,7 @@
             "recording_mbid": "4e27fc2a-98cc-4f1c-a204-ad2c1aca0f44",
             "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
             "release_name": "Illuminate (Deluxe)",
-            "recording_name": "There's Nothing Holdin' Me Back"
+            "track_name": "There's Nothing Holdin' Me Back"
         },
         {
             "artist_mbids": [
@@ -969,7 +969,7 @@
             "recording_mbid": "92d77b07-f5dd-49f0-8468-8d501ff3d221",
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
             "release_name": "Live in Buenos Aires",
-            "recording_name": "The Scientist - Live In Buenos Aires"
+            "track_name": "The Scientist - Live In Buenos Aires"
         },
         {
             "artist_mbids": [
@@ -980,7 +980,7 @@
             "recording_mbid": "4ea67a2e-72f2-4dff-a9dd-d7721374b645",
             "release_mbid": "99ff985c-89f3-4b38-a24d-f6f699593f7b",
             "release_name": "Now That's What I Call Pop",
-            "recording_name": "The Nights"
+            "track_name": "The Nights"
         },
         {
             "artist_mbids": [
@@ -991,7 +991,7 @@
             "recording_mbid": "2449949b-14a7-4986-a382-eb1a1922cc66",
             "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
             "release_name": "Doo-Wops & Hooligans",
-            "recording_name": "The Lazy Song"
+            "track_name": "The Lazy Song"
         },
         {
             "artist_mbids": [
@@ -1002,7 +1002,7 @@
             "recording_mbid": "434addad-5e28-48cf-9fa2-650791cca44e",
             "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
             "release_name": "+",
-            "recording_name": "The A Team"
+            "track_name": "The A Team"
         },
         {
             "artist_mbids": [
@@ -1013,7 +1013,7 @@
             "recording_mbid": "834f7cc2-54b5-49a8-af3d-8aac0cacf67a",
             "release_mbid": "4a8edc98-db22-40cd-9dd9-2ae913763003",
             "release_name": "Thandi Hawa",
-            "recording_name": "Thandi Hawa"
+            "track_name": "Thandi Hawa"
         },
         {
             "artist_mbids": [
@@ -1024,7 +1024,7 @@
             "recording_mbid": "f30c2728-228a-4222-bdb1-fc2512ceed52",
             "release_mbid": "0c3c1ec5-06b1-4c9a-a6d3-1c7774a1e2ba",
             "release_name": "Hozier (Special Edition)",
-            "recording_name": "Take Me to Church"
+            "track_name": "Take Me to Church"
         },
         {
             "artist_mbids": [
@@ -1035,7 +1035,7 @@
             "recording_mbid": "def4cc2f-9138-40bf-9bc6-40e2da2641a4",
             "release_mbid": "7de6da6f-5f6d-4dbe-9dea-0a09fed0e7e5",
             "release_name": "Symphony (feat. Zara Larsson)",
-            "recording_name": "Symphony (feat. Zara Larsson)"
+            "track_name": "Symphony (feat. Zara Larsson)"
         },
         {
             "artist_mbids": [
@@ -1046,7 +1046,7 @@
             "recording_mbid": "425c5374-359f-4a55-8f59-2ebe31aab829",
             "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
             "release_name": "No Sound Without Silence",
-            "recording_name": "Superheroes"
+            "track_name": "Superheroes"
         },
         {
             "artist_mbids": [
@@ -1057,7 +1057,7 @@
             "recording_mbid": "de586967-461c-49eb-83ef-0f68305626af",
             "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
             "release_name": "V",
-            "recording_name": "Sugar"
+            "track_name": "Sugar"
         },
         {
             "artist_mbids": [
@@ -1068,7 +1068,7 @@
             "recording_mbid": "16235fdd-1408-4510-898b-2434028fafea",
             "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "recording_name": "Strawberry Swing"
+            "track_name": "Strawberry Swing"
         },
         {
             "artist_mbids": [
@@ -1079,7 +1079,7 @@
             "recording_mbid": "cd81e13d-004d-43ed-b41b-bb8cce73efd9",
             "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
             "release_name": "Midnight Memories (Deluxe)",
-            "recording_name": "Story of My Life"
+            "track_name": "Story of My Life"
         },
         {
             "artist_mbids": [
@@ -1090,7 +1090,7 @@
             "recording_mbid": "ccdccc03-00ca-470f-948c-6fd6f5394701",
             "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
             "release_name": "Handwritten (Deluxe)",
-            "recording_name": "Stitches"
+            "track_name": "Stitches"
         },
         {
             "artist_mbids": [
@@ -1101,7 +1101,7 @@
             "recording_mbid": "bc69ab9d-5323-477d-a556-df48e849aa28",
             "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
             "release_name": "The Papercut Chronicles II",
-            "recording_name": "Stereo Hearts (feat. Adam Levine)"
+            "track_name": "Stereo Hearts (feat. Adam Levine)"
         },
         {
             "artist_mbids": [
@@ -1112,7 +1112,7 @@
             "recording_mbid": "cd81e13d-004d-43ed-b41b-bb8cce73efd9",
             "release_mbid": "5c776d7d-1a7f-4083-a0cd-36bf8ab1ecd0",
             "release_name": "Midnight Memories (Deluxe)",
-            "recording_name": "Story of My Life"
+            "track_name": "Story of My Life"
         },
         {
             "artist_mbids": [
@@ -1123,7 +1123,7 @@
             "recording_mbid": "ccdccc03-00ca-470f-948c-6fd6f5394701",
             "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
             "release_name": "Handwritten (Deluxe)",
-            "recording_name": "Stitches"
+            "track_name": "Stitches"
         },
         {
             "artist_mbids": [
@@ -1134,7 +1134,7 @@
             "recording_mbid": "bc69ab9d-5323-477d-a556-df48e849aa28",
             "release_mbid": "8a8696e9-400e-4cb9-ac73-71379543278b",
             "release_name": "The Papercut Chronicles II",
-            "recording_name": "Stereo Hearts (feat. Adam Levine)"
+            "track_name": "Stereo Hearts (feat. Adam Levine)"
         }
     ]
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_week.json
@@ -3,279 +3,354 @@
     "from_ts": 1588632658,
     "recordings": [
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 10,
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
-            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "track_name": "Burn"
+            "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
+            "track_name": "Burn",
+            "listen_count": 10,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 9,
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
-            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\"",
+            "listen_count": 9,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ed Sheeran",
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 9,
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
-            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "track_name": "Castle on the Hill"
+            "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
+            "track_name": "Castle on the Hill",
+            "listen_count": 9,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Script",
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 8,
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
-            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "track_name": "Hall of Fame"
+            "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
+            "track_name": "Hall of Fame",
+            "listen_count": 8,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 6,
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
-            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "track_name": "Start Again (feat. Logic)"
+            "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
+            "track_name": "Start Again (feat. Logic)",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Of Monsters and Men",
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 6,
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
-            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "track_name": "Little Talks"
+            "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
+            "track_name": "Little Talks",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Christina Perri",
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 6,
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
-            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "track_name": "A Thousand Years"
+            "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
+            "track_name": "A Thousand Years",
+            "listen_count": 6,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Tommee Profitt",
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 5,
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
-            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "track_name": "In The End - Mellen Gi Remix"
+            "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
+            "track_name": "In The End - Mellen Gi Remix",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Fray",
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 5,
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
-            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "track_name": "How to Save a Life"
+            "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
+            "track_name": "How to Save a Life",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "George Ezra",
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 4,
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
-            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "track_name": "Shotgun"
+            "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
+            "track_name": "Shotgun",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Vance Joy",
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 4,
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
-            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "track_name": "Riptide"
+            "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
+            "track_name": "Riptide",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
-            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "track_name": "Payphone"
+            "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
+            "track_name": "Payphone",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "M.I.A.",
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 4,
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
-            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "track_name": "Paper Planes"
+            "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
+            "track_name": "Paper Planes",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
-            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 4,
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
-            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "track_name": "Everything at Once"
+            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
+            "track_name": "Everything at Once",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "OneRepublic",
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 4,
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
-            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "track_name": "Counting Stars"
+            "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
+            "track_name": "Counting Stars",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Sia",
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 4,
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
-            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "track_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
+            "track_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Taylor Swift",
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 4,
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
-            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "track_name": "Blank Space"
+            "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
+            "track_name": "Blank Space",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Linkin Park",
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 4,
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
-            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "track_name": "Battle Symphony"
+            "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
+            "track_name": "Battle Symphony",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 3,
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Up&Up"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Up&Up",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ritviz",
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 2,
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
-            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "track_name": "Udd Gaye - Bacardi House Party Sessions"
+            "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
+            "track_name": "Udd Gaye - Bacardi House Party Sessions",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
-            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "track_name": "Ink"
+            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
+            "track_name": "Ink",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Backstreet Boys",
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
-            "artist_name": "Backstreet Boys",
-            "listen_count": 2,
             "recording_mbid": "6c4d9128-ea06-46f5-a6d8-daab439a7e6a",
-            "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
             "release_name": "The Hits--Chapter One",
-            "track_name": "I Want It That Way"
+            "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
+            "track_name": "I Want It That Way",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Everglow"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Everglow",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Local train",
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 2,
             "recording_mbid": "6bf4c778-d11c-40de-bf28-970ba678d5a6",
-            "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
             "release_name": "Aalas Ka Pedh",
-            "track_name": "Choo Lo"
+            "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
+            "track_name": "Choo Lo",
+            "listen_count": 2,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         }
     ],
     "to_ts": 1589237458

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_week.json
@@ -11,7 +11,7 @@
             "recording_mbid": "6cd12984-938b-488f-9e13-b9c6c56395bc",
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
             "release_name": "Halcyon Days",
-            "recording_name": "Burn"
+            "track_name": "Burn"
         },
         {
             "artist_mbids": [
@@ -22,7 +22,7 @@
             "recording_mbid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
             "release_name": "Delirium (Deluxe)",
-            "recording_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
+            "track_name": "Love Me Like You Do - From \"Fifty Shades of Grey\""
         },
         {
             "artist_mbids": [
@@ -33,7 +33,7 @@
             "recording_mbid": "73107785-12f0-4ae7-8faa-1b0188212e91",
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
             "release_name": "\u00f7 (Deluxe)",
-            "recording_name": "Castle on the Hill"
+            "track_name": "Castle on the Hill"
         },
         {
             "artist_mbids": [
@@ -44,7 +44,7 @@
             "recording_mbid": "33347f30-6f8b-40c0-937f-b73ea533cba7",
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
             "release_name": "#3",
-            "recording_name": "Hall of Fame"
+            "track_name": "Hall of Fame"
         },
         {
             "artist_mbids": [
@@ -55,7 +55,7 @@
             "recording_mbid": "04c03f78-6844-430d-98bc-071a3c411714",
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
             "release_name": "13 Reasons Why (Season 2)",
-            "recording_name": "Start Again (feat. Logic)"
+            "track_name": "Start Again (feat. Logic)"
         },
         {
             "artist_mbids": [
@@ -66,7 +66,7 @@
             "recording_mbid": "4aaa0b2f-ad3e-4ef2-b2cd-6694657922f1",
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
             "release_name": "My Head Is an Animal",
-            "recording_name": "Little Talks"
+            "track_name": "Little Talks"
         },
         {
             "artist_mbids": [
@@ -77,7 +77,7 @@
             "recording_mbid": "44901cfc-0859-4598-b693-2471d5854869",
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
             "release_name": "A Thousand Years",
-            "recording_name": "A Thousand Years"
+            "track_name": "A Thousand Years"
         },
         {
             "artist_mbids": [
@@ -88,7 +88,7 @@
             "recording_mbid": "4a39137d-1dc5-4875-838e-be92038fcb23",
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
             "release_name": "In The End",
-            "recording_name": "In The End - Mellen Gi Remix"
+            "track_name": "In The End - Mellen Gi Remix"
         },
         {
             "artist_mbids": [
@@ -99,7 +99,7 @@
             "recording_mbid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
             "release_name": "How to Save a Life",
-            "recording_name": "How to Save a Life"
+            "track_name": "How to Save a Life"
         },
         {
             "artist_mbids": [
@@ -110,7 +110,7 @@
             "recording_mbid": "d54e0db1-0cfc-4848-b189-e971cacfe103",
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
             "release_name": "Staying at Tamara's",
-            "recording_name": "Shotgun"
+            "track_name": "Shotgun"
         },
         {
             "artist_mbids": [
@@ -121,7 +121,7 @@
             "recording_mbid": "e3649d0d-76ee-4eb2-a189-bbf07b5f2e26",
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
             "release_name": "Dream Your Life Away (Special Edition)",
-            "recording_name": "Riptide"
+            "track_name": "Riptide"
         },
         {
             "artist_mbids": [
@@ -132,7 +132,7 @@
             "recording_mbid": "eb6760b3-be44-425e-b169-b141e4706fcb",
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
             "release_name": "Overexposed",
-            "recording_name": "Payphone"
+            "track_name": "Payphone"
         },
         {
             "artist_mbids": [
@@ -143,7 +143,7 @@
             "recording_mbid": "db020650-2f04-4a51-8ef6-385f80883510",
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
             "release_name": "Kala",
-            "recording_name": "Paper Planes"
+            "track_name": "Paper Planes"
         },
         {
             "artist_mbids": [
@@ -154,7 +154,7 @@
             "recording_mbid": "2b57123d-3a73-48a9-8b39-d02cf1356649",
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
             "release_name": "Singles",
-            "recording_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
+            "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance"
         },
         {
             "artist_mbids": [
@@ -165,7 +165,7 @@
             "recording_mbid": "e00f4d66-6d92-4eab-8682-a9abc719fff6",
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "recording_name": "Everything at Once"
+            "track_name": "Everything at Once"
         },
         {
             "artist_mbids": [
@@ -176,7 +176,7 @@
             "recording_mbid": "7d660e27-e9f1-4547-9b77-2de4e9913876",
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
             "release_name": "Native",
-            "recording_name": "Counting Stars"
+            "track_name": "Counting Stars"
         },
         {
             "artist_mbids": [
@@ -187,7 +187,7 @@
             "recording_mbid": "4cac26d4-9b0e-4d91-8282-4e9c0d12b349",
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
             "release_name": "Cheap Thrills (feat. Sean Paul)",
-            "recording_name": "Cheap Thrills (feat. Sean Paul)"
+            "track_name": "Cheap Thrills (feat. Sean Paul)"
         },
         {
             "artist_mbids": [
@@ -198,7 +198,7 @@
             "recording_mbid": "11cf3054-23a2-428e-ba4d-1786dc656f4e",
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
             "release_name": "1989",
-            "recording_name": "Blank Space"
+            "track_name": "Blank Space"
         },
         {
             "artist_mbids": [
@@ -209,7 +209,7 @@
             "recording_mbid": "ba054183-f335-44ed-8f3d-c2419b50dc74",
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
             "release_name": "One More Light",
-            "recording_name": "Battle Symphony"
+            "track_name": "Battle Symphony"
         },
         {
             "artist_mbids": [
@@ -220,7 +220,7 @@
             "recording_mbid": "040409c4-6503-4622-b8af-5c8bfcfa8519",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Up&Up"
+            "track_name": "Up&Up"
         },
         {
             "artist_mbids": [
@@ -231,7 +231,7 @@
             "recording_mbid": "62ae8424-3dbd-4d2b-a20a-2b637d32df49",
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
             "release_name": "Udd Gaye (Bacardi House Party Sessions)",
-            "recording_name": "Udd Gaye - Bacardi House Party Sessions"
+            "track_name": "Udd Gaye - Bacardi House Party Sessions"
         },
         {
             "artist_mbids": [
@@ -242,7 +242,7 @@
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "recording_name": "Ink"
+            "track_name": "Ink"
         },
         {
             "artist_mbids": [
@@ -253,7 +253,7 @@
             "recording_mbid": "6c4d9128-ea06-46f5-a6d8-daab439a7e6a",
             "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
             "release_name": "The Hits--Chapter One",
-            "recording_name": "I Want It That Way"
+            "track_name": "I Want It That Way"
         },
         {
             "artist_mbids": [
@@ -264,7 +264,7 @@
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Everglow"
+            "track_name": "Everglow"
         },
         {
             "artist_mbids": [
@@ -275,7 +275,7 @@
             "recording_mbid": "6bf4c778-d11c-40de-bf28-970ba678d5a6",
             "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
             "release_name": "Aalas Ka Pedh",
-            "recording_name": "Choo Lo"
+            "track_name": "Choo Lo"
         }
     ],
     "to_ts": 1589237458

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_year.json
@@ -11,7 +11,7 @@
             "recording_mbid": "af757f8d-fc67-4b3b-98e8-dcc28c2e3bd8",
             "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
             "release_name": "We Belong",
-            "recording_name": "We Belong"
+            "track_name": "We Belong"
         },
         {
             "artist_mbids": [
@@ -22,7 +22,7 @@
             "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
             "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
             "release_name": "Sixteen",
-            "recording_name": "Sixteen"
+            "track_name": "Sixteen"
         },
         {
             "artist_mbids": [
@@ -33,7 +33,7 @@
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "recording_name": "Ink"
+            "track_name": "Ink"
         },
         {
             "artist_mbids": [
@@ -44,7 +44,7 @@
             "recording_mbid": "eb255a08-1486-4ac0-a796-1092421959e8",
             "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
             "release_name": "Save Me, San Francisco (Golden Gate Edition)",
-            "recording_name": "Hey, Soul Sister"
+            "track_name": "Hey, Soul Sister"
         },
         {
             "artist_mbids": [
@@ -55,7 +55,7 @@
             "recording_mbid": "8daff47f-4732-4946-870a-7c1305f1d652",
             "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
             "release_name": "Girls Like You (feat. Cardi B)",
-            "recording_name": "Girls Like You (feat. Cardi B)"
+            "track_name": "Girls Like You (feat. Cardi B)"
         },
         {
             "artist_mbids": [
@@ -66,7 +66,7 @@
             "recording_mbid": "c3922480-7ae2-472b-88c0-0acafb207af2",
             "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
             "release_name": "The Unforgiving",
-            "recording_name": "Faster"
+            "track_name": "Faster"
         },
         {
             "artist_mbids": [
@@ -77,7 +77,7 @@
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Everglow"
+            "track_name": "Everglow"
         },
         {
             "artist_mbids": [
@@ -88,7 +88,7 @@
             "recording_mbid": "cd00414d-5d44-4f2b-ab39-455a10d68564",
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "recording_name": "Champion of the World"
+            "track_name": "Champion of the World"
         },
         {
             "artist_mbids": [
@@ -99,7 +99,7 @@
             "recording_mbid": "c0b51d3f-b0da-4aef-a727-684cc205039b",
             "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
             "release_name": "Blinding Lights",
-            "recording_name": "Blinding Lights"
+            "track_name": "Blinding Lights"
         },
         {
             "artist_mbids": [
@@ -110,7 +110,7 @@
             "recording_mbid": "864c5fca-4082-4e1d-92b5-6604d41dd391",
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "recording_name": "Blinded By Love"
+            "track_name": "Blinded By Love"
         },
         {
             "artist_mbids": [
@@ -121,7 +121,7 @@
             "recording_mbid": "2a5af3dc-3bba-436f-bd8f-7c9ac7a0ac25",
             "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
             "release_name": "Oh, What A Life",
-            "recording_name": "Best Day of My Life"
+            "track_name": "Best Day of My Life"
         },
         {
             "artist_mbids": [
@@ -132,7 +132,7 @@
             "recording_mbid": "3373eda9-3c54-4098-accc-92361ae8dde9",
             "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "recording_name": "Believer"
+            "track_name": "Believer"
         },
         {
             "artist_mbids": [
@@ -143,7 +143,7 @@
             "recording_mbid": "28f8f9f6-f428-411d-a0fc-ac523922bd81",
             "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "recording_name": "Viva la Vida"
+            "track_name": "Viva la Vida"
         },
         {
             "artist_mbids": [
@@ -154,7 +154,7 @@
             "recording_mbid": "dccd75d0-4002-4a5c-b6d1-d92c1cac9bd5",
             "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
             "release_name": "Memories...Do Not Open",
-            "recording_name": "Something Just Like This"
+            "track_name": "Something Just Like This"
         },
         {
             "artist_mbids": [
@@ -165,7 +165,7 @@
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "Radioactive"
+            "track_name": "Radioactive"
         },
         {
             "artist_mbids": [
@@ -176,7 +176,7 @@
             "recording_mbid": "034fb415-56a1-47c4-8aec-1b7d32cbf0bd",
             "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
             "release_name": "Mylo Xyloto",
-            "recording_name": "Paradise"
+            "track_name": "Paradise"
         },
         {
             "artist_mbids": [
@@ -187,7 +187,7 @@
             "recording_mbid": "b06e73d8-8a25-4c32-9a84-130ffd0b0bc9",
             "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
             "release_name": "Memories",
-            "recording_name": "Memories"
+            "track_name": "Memories"
         },
         {
             "artist_mbids": [
@@ -198,7 +198,7 @@
             "recording_mbid": "938157e9-1c93-4fe5-8797-aa7e6e2a0378",
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "recording_name": "Hymn for the Weekend"
+            "track_name": "Hymn for the Weekend"
         },
         {
             "artist_mbids": [
@@ -209,7 +209,7 @@
             "recording_mbid": "fff72a5a-4f9f-48b7-b9e2-fe28852b0387",
             "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
             "release_name": "The Lumineers (Deluxe Edition)",
-            "recording_name": "Ho Hey"
+            "track_name": "Ho Hey"
         },
         {
             "artist_mbids": [
@@ -220,7 +220,7 @@
             "recording_mbid": "84535425-6926-416d-9979-18aca3de3672",
             "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
             "release_name": "X&Y",
-            "recording_name": "Fix You"
+            "track_name": "Fix You"
         },
         {
             "artist_mbids": [
@@ -231,7 +231,7 @@
             "recording_mbid": "f40b62dd-c900-4884-bb71-9418ff842561",
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "recording_name": "Demons"
+            "track_name": "Demons"
         },
         {
             "artist_mbids": [
@@ -242,7 +242,7 @@
             "recording_mbid": "ae52f909-4004-411a-b513-7b3377dc5d21",
             "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
             "release_name": "The Bright Side",
-            "recording_name": "Blue Skies"
+            "track_name": "Blue Skies"
         },
         {
             "artist_mbids": [
@@ -253,7 +253,7 @@
             "recording_mbid": "65f90a62-a89e-453e-9aed-862781383436",
             "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
             "release_name": "Vaaqif",
-            "recording_name": "Aaftaab"
+            "track_name": "Aaftaab"
         },
         {
             "artist_mbids": [
@@ -264,7 +264,7 @@
             "recording_mbid": "157e2094-b98e-4db0-8219-17f30c7a7f41",
             "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
             "release_name": "Lenka (Expanded Edition)",
-            "recording_name": "Trouble Is a Friend"
+            "track_name": "Trouble Is a Friend"
         },
         {
             "artist_mbids": [
@@ -275,7 +275,7 @@
             "recording_mbid": "0f9a63bf-fa0f-4d93-b5c9-a9c537ca633f",
             "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
             "release_name": "Starboy",
-            "recording_name": "Starboy"
+            "track_name": "Starboy"
         }
     ],
     "to_ts": 1589496658

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_year.json
@@ -3,279 +3,354 @@
     "from_ts": 1577919058,
     "recordings": [
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "recording_mbid": "af757f8d-fc67-4b3b-98e8-dcc28c2e3bd8",
-            "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
             "release_name": "We Belong",
-            "track_name": "We Belong"
+            "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
+            "track_name": "We Belong",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Ellie Goulding",
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 5,
             "recording_mbid": "bae65da2-9759-40e4-a493-3f756079b7a6",
-            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
             "release_name": "Sixteen",
-            "track_name": "Sixteen"
+            "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
+            "track_name": "Sixteen",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "b335dccb-3084-4bf3-8ca5-892975323c28",
-            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
             "release_name": "Ghost Stories",
-            "track_name": "Ink"
+            "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
+            "track_name": "Ink",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Train",
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 5,
             "recording_mbid": "eb255a08-1486-4ac0-a796-1092421959e8",
-            "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
             "release_name": "Save Me, San Francisco (Golden Gate Edition)",
-            "track_name": "Hey, Soul Sister"
+            "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
+            "track_name": "Hey, Soul Sister",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 5,
             "recording_mbid": "8daff47f-4732-4946-870a-7c1305f1d652",
-            "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
             "release_name": "Girls Like You (feat. Cardi B)",
-            "track_name": "Girls Like You (feat. Cardi B)"
+            "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
+            "track_name": "Girls Like You (feat. Cardi B)",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Within Temptation",
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
-            "artist_name": "Within Temptation",
-            "listen_count": 5,
             "recording_mbid": "c3922480-7ae2-472b-88c0-0acafb207af2",
-            "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
             "release_name": "The Unforgiving",
-            "track_name": "Faster"
+            "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
+            "track_name": "Faster",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "4691e338-b9dc-4dc8-9538-af7a9e90fd5a",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Everglow"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Everglow",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "recording_mbid": "cd00414d-5d44-4f2b-ab39-455a10d68564",
-            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
             "release_name": "Everyday Life",
-            "track_name": "Champion of the World"
+            "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
+            "track_name": "Champion of the World",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Weeknd",
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 5,
             "recording_mbid": "c0b51d3f-b0da-4aef-a727-684cc205039b",
-            "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
             "release_name": "Blinding Lights",
-            "track_name": "Blinding Lights"
+            "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
+            "track_name": "Blinding Lights",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "recording_mbid": "864c5fca-4082-4e1d-92b5-6604d41dd391",
-            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
             "release_name": "Two (Expanded Edition)",
-            "track_name": "Blinded By Love"
+            "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
+            "track_name": "Blinded By Love",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "American Authors",
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
-            "artist_name": "American Authors",
-            "listen_count": 5,
             "recording_mbid": "2a5af3dc-3bba-436f-bd8f-7c9ac7a0ac25",
-            "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
             "release_name": "Oh, What A Life",
-            "track_name": "Best Day of My Life"
+            "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
+            "track_name": "Best Day of My Life",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 5,
             "recording_mbid": "3373eda9-3c54-4098-accc-92361ae8dde9",
-            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
             "release_name": "Evolve",
-            "track_name": "Believer"
+            "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
+            "track_name": "Believer",
+            "listen_count": 5,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "28f8f9f6-f428-411d-a0fc-ac523922bd81",
-            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
             "release_name": "Viva la Vida or Death and All His Friends",
-            "track_name": "Viva la Vida"
+            "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
+            "track_name": "Viva la Vida",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Chainsmokers",
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 4,
             "recording_mbid": "dccd75d0-4002-4a5c-b6d1-d92c1cac9bd5",
-            "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
             "release_name": "Memories...Do Not Open",
-            "track_name": "Something Just Like This"
+            "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
+            "track_name": "Something Just Like This",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 4,
             "recording_mbid": "2dfc5445-6d53-4b85-899b-ebd55a6476a4",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "Radioactive"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "Radioactive",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "034fb415-56a1-47c4-8aec-1b7d32cbf0bd",
-            "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
             "release_name": "Mylo Xyloto",
-            "track_name": "Paradise"
+            "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
+            "track_name": "Paradise",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Maroon 5",
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "recording_mbid": "b06e73d8-8a25-4c32-9a84-130ffd0b0bc9",
-            "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
             "release_name": "Memories",
-            "track_name": "Memories"
+            "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
+            "track_name": "Memories",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "938157e9-1c93-4fe5-8797-aa7e6e2a0378",
-            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
             "release_name": "A Head Full Of Dreams",
-            "track_name": "Hymn for the Weekend"
+            "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
+            "track_name": "Hymn for the Weekend",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Lumineers",
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 4,
             "recording_mbid": "fff72a5a-4f9f-48b7-b9e2-fe28852b0387",
-            "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
             "release_name": "The Lumineers (Deluxe Edition)",
-            "track_name": "Ho Hey"
+            "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
+            "track_name": "Ho Hey",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Coldplay",
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "recording_mbid": "84535425-6926-416d-9979-18aca3de3672",
-            "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
             "release_name": "X&Y",
-            "track_name": "Fix You"
+            "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
+            "track_name": "Fix You",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Imagine Dragons",
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 4,
             "recording_mbid": "f40b62dd-c900-4884-bb71-9418ff842561",
-            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
             "release_name": "Night Visions (Deluxe)",
-            "track_name": "Demons"
+            "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
+            "track_name": "Demons",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 4,
             "recording_mbid": "ae52f909-4004-411a-b513-7b3377dc5d21",
-            "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
             "release_name": "The Bright Side",
-            "track_name": "Blue Skies"
+            "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
+            "track_name": "Blue Skies",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Local train",
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 4,
             "recording_mbid": "65f90a62-a89e-453e-9aed-862781383436",
-            "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
             "release_name": "Vaaqif",
-            "track_name": "Aaftaab"
+            "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
+            "track_name": "Aaftaab",
+            "listen_count": 4,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "Lenka",
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 3,
             "recording_mbid": "157e2094-b98e-4db0-8219-17f30c7a7f41",
-            "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
             "release_name": "Lenka (Expanded Edition)",
-            "track_name": "Trouble Is a Friend"
+            "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
+            "track_name": "Trouble Is a Friend",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         },
         {
+            "artist_name": "The Weeknd",
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 3,
             "recording_mbid": "0f9a63bf-fa0f-4d93-b5c9-a9c537ca633f",
-            "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
             "release_name": "Starboy",
-            "track_name": "Starboy"
+            "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
+            "track_name": "Starboy",
+            "listen_count": 3,
+            "artist_msid": null,
+            "recording_msid": null,
+            "release_msid": null
         }
     ],
     "to_ts": 1589496658

--- a/listenbrainz/testdata/user_top_releases_db.json
+++ b/listenbrainz/testdata/user_top_releases_db.json
@@ -1,21 +1,25 @@
 {
-  "from_ts": 0,
-  "to_ts": 10,
-  "releases": [
-    {
-      "listen_count": 230,
-      "release_name": "Halycon Days",
-      "artist_name": "Ellie Goulding",
-      "artist_mbids": [],
-      "release_mbid": null
-    },
-    {
-      "listen_count": 229,
-      "release_name": "Delirium",
-      "artist_name": "Ellie Goulding",
-      "artist_mbids": [],
-      "release_mbid": null
-    }
-  ],
-  "count": 2
+    "from_ts": 0,
+    "to_ts": 10,
+    "releases": [
+        {
+            "artist_mbids": [],
+            "release_mbid": null,
+            "release_name": "Halycon Days",
+            "listen_count": 230,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
+        },
+        {
+            "artist_mbids": [],
+            "release_mbid": null,
+            "release_name": "Delirium",
+            "listen_count": 229,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
+        }
+    ],
+    "count": 2
 }

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test.json
@@ -4,901 +4,1101 @@
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 26,
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
-            "release_name": "Live in Buenos Aires"
+            "release_name": "Live in Buenos Aires",
+            "listen_count": 26,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 25,
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
-            "release_name": "Delirium (Deluxe)"
+            "release_name": "Delirium (Deluxe)",
+            "listen_count": 25,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 25,
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
-            "release_name": "How to Save a Life"
+            "release_name": "How to Save a Life",
+            "listen_count": 25,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 20,
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
-            "release_name": "Udd Gaye (Bacardi House Party Sessions)"
+            "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+            "listen_count": 20,
+            "artist_name": "Ritviz",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 18,
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
-            "release_name": "Native"
+            "release_name": "Native",
+            "listen_count": 18,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 18,
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
-            "release_name": "Dream Your Life Away (Special Edition)"
+            "release_name": "Dream Your Life Away (Special Edition)",
+            "listen_count": 18,
+            "artist_name": "Vance Joy",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 17,
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
-            "release_name": "Night Visions (Deluxe)"
+            "release_name": "Night Visions (Deluxe)",
+            "listen_count": 17,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 17,
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
-            "release_name": "\u00f7 (Deluxe)"
+            "release_name": "\u00f7 (Deluxe)",
+            "listen_count": 17,
+            "artist_name": "Ed Sheeran",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 17,
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
-            "release_name": "1989"
+            "release_name": "1989",
+            "listen_count": 17,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 16,
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
-            "release_name": "A Thousand Years"
+            "release_name": "A Thousand Years",
+            "listen_count": 16,
+            "artist_name": "Christina Perri",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 16,
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
-            "release_name": "A Head Full Of Dreams"
+            "release_name": "A Head Full Of Dreams",
+            "listen_count": 16,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 16,
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
-            "release_name": "Halcyon Days"
+            "release_name": "Halcyon Days",
+            "listen_count": 16,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 15,
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
-            "release_name": "Staying at Tamara's"
+            "release_name": "Staying at Tamara's",
+            "listen_count": 15,
+            "artist_name": "George Ezra",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 13,
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
-            "release_name": "Two (Expanded Edition)"
+            "release_name": "Two (Expanded Edition)",
+            "listen_count": 13,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 13,
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
-            "release_name": "13 Reasons Why (Season 2)"
+            "release_name": "13 Reasons Why (Season 2)",
+            "listen_count": 13,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 12,
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
-            "release_name": "In The End"
+            "release_name": "In The End",
+            "listen_count": 12,
+            "artist_name": "Tommee Profitt",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 12,
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
-            "release_name": "#3"
+            "release_name": "#3",
+            "listen_count": 12,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 11,
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
-            "release_name": "My Head Is an Animal"
+            "release_name": "My Head Is an Animal",
+            "listen_count": 11,
+            "artist_name": "Of Monsters and Men",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 11,
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
-            "release_name": "Overexposed"
+            "release_name": "Overexposed",
+            "listen_count": 11,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 11,
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
-            "release_name": "Singles"
+            "release_name": "Singles",
+            "listen_count": 11,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 11,
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
-            "release_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 11,
+            "artist_name": "Sia",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 10,
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
-            "release_name": "Kala"
+            "release_name": "Kala",
+            "listen_count": 10,
+            "artist_name": "M.I.A.",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 10,
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
-            "release_name": "One More Light"
+            "release_name": "One More Light",
+            "listen_count": 10,
+            "artist_name": "Linkin Park",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 9,
             "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
-            "release_name": "Aalas Ka Pedh"
+            "release_name": "Aalas Ka Pedh",
+            "listen_count": 9,
+            "artist_name": "The Local train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
-            "artist_name": "Backstreet Boys",
-            "listen_count": 8,
             "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
-            "release_name": "The Hits--Chapter One"
+            "release_name": "The Hits--Chapter One",
+            "listen_count": 8,
+            "artist_name": "Backstreet Boys",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 7,
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
-            "release_name": "Ghost Stories"
+            "release_name": "Ghost Stories",
+            "listen_count": 7,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 7,
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
-            "release_name": "Everyday Life"
+            "release_name": "Everyday Life",
+            "listen_count": 7,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 6,
             "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
-            "release_name": "Close To Me (feat. Swae Lee)"
+            "release_name": "Close To Me (feat. Swae Lee)",
+            "listen_count": 6,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 6,
             "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
-            "release_name": "Evolve"
+            "release_name": "Evolve",
+            "listen_count": 6,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 5,
             "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
-            "release_name": "Sixteen"
+            "release_name": "Sixteen",
+            "listen_count": 5,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 5,
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
-            "release_name": "The Fray"
+            "release_name": "The Fray",
+            "listen_count": 5,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 5,
             "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
-            "release_name": "Save Me, San Francisco (Golden Gate Edition)"
+            "release_name": "Save Me, San Francisco (Golden Gate Edition)",
+            "listen_count": 5,
+            "artist_name": "Train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
-            "release_name": "Viva la Vida or Death and All His Friends"
+            "release_name": "Viva la Vida or Death and All His Friends",
+            "listen_count": 5,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
-            "artist_name": "Within Temptation",
-            "listen_count": 5,
             "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
-            "release_name": "The Unforgiving"
+            "release_name": "The Unforgiving",
+            "listen_count": 5,
+            "artist_name": "Within Temptation",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 5,
             "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
-            "release_name": "Girls Like You (feat. Cardi B)"
+            "release_name": "Girls Like You (feat. Cardi B)",
+            "listen_count": 5,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 5,
             "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
-            "release_name": "Blinding Lights"
+            "release_name": "Blinding Lights",
+            "listen_count": 5,
+            "artist_name": "The Weeknd",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
-            "release_name": "Mylo Xyloto"
+            "release_name": "Mylo Xyloto",
+            "listen_count": 5,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 5,
             "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
-            "release_name": "Memories...Do Not Open"
+            "release_name": "Memories...Do Not Open",
+            "listen_count": 5,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
-            "release_name": "We Belong"
+            "release_name": "We Belong",
+            "listen_count": 5,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
-            "artist_name": "American Authors",
-            "listen_count": 5,
             "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
-            "release_name": "Oh, What A Life"
+            "release_name": "Oh, What A Life",
+            "listen_count": 5,
+            "artist_name": "American Authors",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
-            "release_name": "X&Y"
+            "release_name": "X&Y",
+            "listen_count": 4,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 4,
             "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
-            "release_name": "The Lumineers (Deluxe Edition)"
+            "release_name": "The Lumineers (Deluxe Edition)",
+            "listen_count": 4,
+            "artist_name": "The Lumineers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 4,
             "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
-            "release_name": "The Bright Side"
+            "release_name": "The Bright Side",
+            "listen_count": 4,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "abf274d4-a1f8-4477-b5c6-8c1121a13cf6"
             ],
-            "artist_name": "Bruno Mars",
-            "listen_count": 4,
             "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
-            "release_name": "Doo-Wops & Hooligans"
+            "release_name": "Doo-Wops & Hooligans",
+            "listen_count": 4,
+            "artist_name": "Bruno Mars",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 4,
             "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
-            "release_name": "Vaaqif"
+            "release_name": "Vaaqif",
+            "listen_count": 4,
+            "artist_name": "The Local train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
-            "release_name": "Memories"
+            "release_name": "Memories",
+            "listen_count": 4,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 3,
             "release_mbid": "0c0db2b5-6758-4907-8af2-6998f874307f",
-            "release_name": "Night Visions"
+            "release_name": "Night Visions",
+            "listen_count": 3,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 3,
             "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
-            "release_name": "Starboy"
+            "release_name": "Starboy",
+            "listen_count": 3,
+            "artist_name": "The Weeknd",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 3,
             "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
-            "release_name": "Lenka (Expanded Edition)"
+            "release_name": "Lenka (Expanded Edition)",
+            "listen_count": 3,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 3,
             "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
-            "release_name": "Don't Let Me Down (feat. Daya)"
+            "release_name": "Don't Let Me Down (feat. Daya)",
+            "listen_count": 3,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0dee16fe-2b7f-4781-8f71-1e4357603ef1"
             ],
-            "artist_name": "P!nk",
-            "listen_count": 2,
             "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
-            "release_name": "The Truth About Love"
+            "release_name": "The Truth About Love",
+            "listen_count": 2,
+            "artist_name": "P!nk",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 2,
             "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
-            "release_name": "True"
+            "release_name": "True",
+            "listen_count": 2,
+            "artist_name": "Avicii",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 2,
             "release_mbid": "a8633d07-b592-4e29-b863-a592e70fc3b6",
-            "release_name": "V (Deluxe)"
+            "release_name": "V (Deluxe)",
+            "listen_count": 2,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 2,
             "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
-            "release_name": "V"
+            "release_name": "V",
+            "listen_count": 2,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "efc1ae68-f406-4430-8d94-a00b7280d822"
             ],
-            "artist_name": "Post Malone",
-            "listen_count": 2,
             "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
-            "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)"
+            "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)",
+            "listen_count": 2,
+            "artist_name": "Post Malone",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "4cd95528-7c4f-4ba8-a66f-a3f571e7a002"
             ],
-            "artist_name": "Joel Adams",
-            "listen_count": 2,
             "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
-            "release_name": "Please Don't Go"
+            "release_name": "Please Don't Go",
+            "listen_count": 2,
+            "artist_name": "Joel Adams",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "77e59c9c-cbb3-4566-abe9-5ccf8a92c28f"
             ],
-            "artist_name": "Magic!",
-            "listen_count": 2,
             "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
-            "release_name": "Don't Kill the Magic"
+            "release_name": "Don't Kill the Magic",
+            "listen_count": 2,
+            "artist_name": "Magic!",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bf8d0eb5-a94c-496a-a4a5-6d370e0c30e9"
             ],
-            "artist_name": "Charlie Puth",
-            "listen_count": 2,
             "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
-            "release_name": "Nine Track Mind"
+            "release_name": "Nine Track Mind",
+            "listen_count": 2,
+            "artist_name": "Charlie Puth",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 2,
             "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
-            "release_name": "Wanted on Voyage"
+            "release_name": "Wanted on Voyage",
+            "listen_count": 2,
+            "artist_name": "George Ezra",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 2,
             "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
-            "release_name": "Liggi"
+            "release_name": "Liggi",
+            "listen_count": 2,
+            "artist_name": "Ritviz",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 2,
             "release_mbid": "05999a21-07ed-402c-9247-29c29b58f592",
-            "release_name": "Overexposed Track By Track"
+            "release_name": "Overexposed Track By Track",
+            "listen_count": 2,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "b650167d-3f75-4a39-a0b5-7cf4e65b7205"
             ],
-            "artist_name": "Katy Perry",
-            "listen_count": 2,
             "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
-            "release_name": "PRISM (Deluxe)"
+            "release_name": "PRISM (Deluxe)",
+            "listen_count": 2,
+            "artist_name": "Katy Perry",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 2,
             "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
-            "release_name": "Don't Let Me Down"
+            "release_name": "Don't Let Me Down",
+            "listen_count": 2,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 2,
             "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
-            "release_name": "The Lumineers"
+            "release_name": "The Lumineers",
+            "listen_count": 2,
+            "artist_name": "The Lumineers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 2,
             "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
-            "release_name": "Illuminate (Deluxe)"
+            "release_name": "Illuminate (Deluxe)",
+            "listen_count": 2,
+            "artist_name": "Shawn Mendes",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 2,
             "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
-            "release_name": "No Vacancy"
+            "release_name": "No Vacancy",
+            "listen_count": 2,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "b982577e-02da-4e04-beb7-3cb4577f4aad"
             ],
-            "artist_name": "Ayushmann Khurrana",
-            "listen_count": 1,
             "release_mbid": "e96df548-a420-4b75-8695-54ea54e88c83",
-            "release_name": "Mere Liye Tum Kaafi Ho (From \"Shubh Mangal Zyada Saavdhan\")"
+            "release_name": "Mere Liye Tum Kaafi Ho (From \"Shubh Mangal Zyada Saavdhan\")",
+            "listen_count": 1,
+            "artist_name": "Ayushmann Khurrana",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 1,
             "release_mbid": "6090ed85-046e-4fd6-8e9a-f2eaac58a2f7",
-            "release_name": "Dream Your Life Away"
+            "release_name": "Dream Your Life Away",
+            "listen_count": 1,
+            "artist_name": "Vance Joy",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 1,
             "release_mbid": "af6517fb-6216-49a6-8671-88f2678bfe96",
-            "release_name": "Love Me Like You Do (From \"Fifty Shades of Grey\")"
+            "release_name": "Love Me Like You Do (From \"Fifty Shades of Grey\")",
+            "listen_count": 1,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bce2e04f-e3f3-4c91-bd09-115455c43d37"
             ],
-            "artist_name": "Tyrone Wells",
-            "listen_count": 1,
             "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
-            "release_name": "Metal & Wood"
+            "release_name": "Metal & Wood",
+            "listen_count": 1,
+            "artist_name": "Tyrone Wells",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 1,
             "release_mbid": "e4dec817-aa00-4f0e-b520-0023bd317727",
-            "release_name": "Acoustic Sessions"
+            "release_name": "Acoustic Sessions",
+            "listen_count": 1,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "18abe6d6-0e0c-430e-b5b5-e9894af74b6a"
             ],
-            "artist_name": "Walk the Moon",
-            "listen_count": 1,
             "release_mbid": "13cde858-1ad6-4905-9dc6-a3156201eb64",
-            "release_name": "Now That's What I Call Music! 91"
+            "release_name": "Now That's What I Call Music! 91",
+            "listen_count": 1,
+            "artist_name": "Walk the Moon",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7888bddc-9b9c-46a2-9125-521a5738cda8"
             ],
-            "artist_name": "Goo Goo Dolls",
-            "listen_count": 1,
             "release_mbid": "e45d0c89-f2f3-4052-9c4c-236a8c881e63",
-            "release_name": "Dizzy Up the Girl"
+            "release_name": "Dizzy Up the Girl",
+            "listen_count": 1,
+            "artist_name": "Goo Goo Dolls",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 1,
             "release_mbid": "807f0307-b8ad-4e55-b84a-1c903340b8e2",
-            "release_name": "California 37"
+            "release_name": "California 37",
+            "listen_count": 1,
+            "artist_name": "Train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "e6a05347-56f6-4f5b-8f05-1b37b33fd5da"
             ],
-            "artist_name": "Echosmith",
-            "listen_count": 1,
             "release_mbid": "aa42f8ac-41cd-4f22-be42-672cb39a996b",
-            "release_name": "Talking Dreams (Deluxe Version)"
+            "release_name": "Talking Dreams (Deluxe Version)",
+            "listen_count": 1,
+            "artist_name": "Echosmith",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 1,
             "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
-            "release_name": "+"
+            "release_name": "+",
+            "listen_count": 1,
+            "artist_name": "Ed Sheeran",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "260a4dc3-19c5-4fae-9f2f-d495a8baa13d"
             ],
-            "artist_name": "Lady Gaga",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Lady Gaga",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "98184d50-f63d-4232-8a81-c06fa53b1082"
             ],
-            "artist_name": "Carly Rae Jepsen",
-            "listen_count": 1,
             "release_mbid": "95c3b485-020b-4c83-8ae1-82dec99ac8bc",
-            "release_name": "Kiss"
+            "release_name": "Kiss",
+            "listen_count": 1,
+            "artist_name": "Carly Rae Jepsen",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
-            "release_name": "AV\u012aCI (01)"
+            "release_name": "AV\u012aCI (01)",
+            "listen_count": 1,
+            "artist_name": "Avicii",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "release_mbid": "4b87cf91-a057-46fd-9bb3-3489a2014bbf",
-            "release_name": "I Knew You Were Trouble."
+            "release_name": "I Knew You Were Trouble.",
+            "listen_count": 1,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "485029d6-bcdc-44a1-bf9f-8863915e43db"
             ],
-            "artist_name": "Jasleen Royal",
-            "listen_count": 1,
             "release_mbid": "cb7e62e2-6272-4c00-a7e1-a36942c43c5a",
-            "release_name": "Phillauri"
+            "release_name": "Phillauri",
+            "listen_count": 1,
+            "artist_name": "Jasleen Royal",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "5a93bfdf-f0df-4b8a-be5e-81d712ba6dbc"
             ],
-            "artist_name": "Alesso",
-            "listen_count": 1,
             "release_mbid": "f54f8246-cecf-4bf8-8bf7-373c7ea4beb7",
-            "release_name": "Heroes (We Could Be)"
+            "release_name": "Heroes (We Could Be)",
+            "listen_count": 1,
+            "artist_name": "Alesso",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "19a05a11-e927-4327-be0d-27dc37278de6"
             ],
-            "artist_name": "Kodaline",
-            "listen_count": 1,
             "release_mbid": "31747ec5-e2a6-462e-90af-7ced08ef0c11",
-            "release_name": "In a Perfect World"
+            "release_name": "In a Perfect World",
+            "listen_count": 1,
+            "artist_name": "Kodaline",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "465edcc5-d7d9-418e-8c6e-45ee5bd07d70"
             ],
-            "artist_name": "Arko",
-            "listen_count": 1,
             "release_mbid": "b27770c5-ee58-4073-9415-d8bf5a2ec0be",
-            "release_name": "The Shaukeens"
+            "release_name": "The Shaukeens",
+            "listen_count": 1,
+            "artist_name": "Arko",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fe56af47-9fb9-4a68-a09e-1b3d0d43e803"
             ],
-            "artist_name": "Elton John",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Elton John",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "38814daf-cc14-410a-a4e9-6b61cf295c10"
             ],
-            "artist_name": "Owl City",
-            "listen_count": 1,
             "release_mbid": "fdb7b377-4e3d-4dd4-ac46-2007e5fa5ebe",
-            "release_name": "Good Time"
+            "release_name": "Good Time",
+            "listen_count": 1,
+            "artist_name": "Owl City",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "c50b5258-792d-4e33-beed-e5b3c4b9cf64"
             ],
-            "artist_name": "Rock City",
-            "listen_count": 1,
             "release_mbid": "bd00c7aa-0919-4890-83f0-ae062e197cd2",
-            "release_name": "What Dreams Are Made Of"
+            "release_name": "What Dreams Are Made Of",
+            "listen_count": 1,
+            "artist_name": "Rock City",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
-            "release_name": "Handwritten (Deluxe)"
+            "release_name": "Handwritten (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "Shawn Mendes",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
-            "release_name": "Red (Deluxe Edition)"
+            "release_name": "Red (Deluxe Edition)",
+            "listen_count": 1,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "f5e64189-e742-4143-a290-da0c1d6bd988"
             ],
-            "artist_name": "Boyce Avenue",
-            "listen_count": 1,
             "release_mbid": "653a00ef-333c-4295-9b31-e0655b9b5895",
-            "release_name": "Cover Sessions, Vol. 2"
+            "release_name": "Cover Sessions, Vol. 2",
+            "listen_count": 1,
+            "artist_name": "Boyce Avenue",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6141d63c-719d-4866-94a8-720b7ed812af"
             ],
-            "artist_name": "Demi Lovato",
-            "listen_count": 1,
             "release_mbid": "57ab04d5-7411-4f31-8f26-13d81bceb0e8",
-            "release_name": "Demi"
+            "release_name": "Demi",
+            "listen_count": 1,
+            "artist_name": "Demi Lovato",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "f9f122c1-422f-4985-8536-7d9eb2e832d9"
             ],
-            "artist_name": "Foster the People",
-            "listen_count": 1,
             "release_mbid": "d3cd3737-48b4-46b3-b703-a3f4d316ea29",
-            "release_name": "Nrj 200% Hits 2012"
+            "release_name": "Nrj 200% Hits 2012",
+            "listen_count": 1,
+            "artist_name": "Foster the People",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "release_mbid": "b02ca09c-9e6a-4cca-bd09-fc855aefc9a0",
-            "release_name": "Mercy"
+            "release_name": "Mercy",
+            "listen_count": 1,
+            "artist_name": "Shawn Mendes",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "f82637b3-5d12-4e35-b1a9-e3d401f8162d"
             ],
-            "artist_name": "Paul McCartney",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Paul McCartney",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 1,
             "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
-            "release_name": "No Sound Without Silence"
+            "release_name": "No Sound Without Silence",
+            "listen_count": 1,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 1,
             "release_mbid": "15c946de-b2fb-40ae-93c1-8e8dd1a1e2fa",
-            "release_name": "Something Just Like This"
+            "release_name": "Something Just Like This",
+            "listen_count": 1,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "19a05a11-e927-4327-be0d-27dc37278de6"
             ],
-            "artist_name": "Kodaline",
-            "listen_count": 1,
             "release_mbid": "be0e40c5-1dd2-4c1e-b85d-5d8a2436bf3f",
-            "release_name": "In A Perfect World (Deluxe)"
+            "release_name": "In A Perfect World (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "Kodaline",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d8696b51-1a16-4543-b9a2-8e9c6b91b42c"
             ],
-            "artist_name": "Amit Trivedi",
-            "listen_count": 1,
             "release_mbid": "b8a9f2f9-ed1b-44b1-a09a-648551b1cb26",
-            "release_name": "Kedarnath"
+            "release_name": "Kedarnath",
+            "listen_count": 1,
+            "artist_name": "Amit Trivedi",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 1,
             "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
-            "release_name": "Oh My My (Deluxe)"
+            "release_name": "Oh My My (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         }
     ],
     "count": 100,

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_month.json
@@ -6,226 +6,276 @@
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 16,
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
-            "release_name": "Halcyon Days"
+            "release_name": "Halcyon Days",
+            "listen_count": 16,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 14,
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
-            "release_name": "\u00f7 (Deluxe)"
+            "release_name": "\u00f7 (Deluxe)",
+            "listen_count": 14,
+            "artist_name": "Ed Sheeran",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 12,
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
-            "release_name": "Delirium (Deluxe)"
+            "release_name": "Delirium (Deluxe)",
+            "listen_count": 12,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 10,
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
-            "release_name": "Night Visions (Deluxe)"
+            "release_name": "Night Visions (Deluxe)",
+            "listen_count": 10,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 10,
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
-            "release_name": "#3"
+            "release_name": "#3",
+            "listen_count": 10,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 9,
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
-            "release_name": "A Head Full Of Dreams"
+            "release_name": "A Head Full Of Dreams",
+            "listen_count": 9,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 9,
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
-            "release_name": "13 Reasons Why (Season 2)"
+            "release_name": "13 Reasons Why (Season 2)",
+            "listen_count": 9,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 8,
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
-            "release_name": "Two (Expanded Edition)"
+            "release_name": "Two (Expanded Edition)",
+            "listen_count": 8,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 8,
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
-            "release_name": "How to Save a Life"
+            "release_name": "How to Save a Life",
+            "listen_count": 8,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 8,
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
-            "release_name": "A Thousand Years"
+            "release_name": "A Thousand Years",
+            "listen_count": 8,
+            "artist_name": "Christina Perri",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 7,
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
-            "release_name": "Overexposed"
+            "release_name": "Overexposed",
+            "listen_count": 7,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 7,
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
-            "release_name": "One More Light"
+            "release_name": "One More Light",
+            "listen_count": 7,
+            "artist_name": "Linkin Park",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 7,
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
-            "release_name": "Native"
+            "release_name": "Native",
+            "listen_count": 7,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 7,
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
-            "release_name": "My Head Is an Animal"
+            "release_name": "My Head Is an Animal",
+            "listen_count": 7,
+            "artist_name": "Of Monsters and Men",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 7,
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
-            "release_name": "In The End"
+            "release_name": "In The End",
+            "listen_count": 7,
+            "artist_name": "Tommee Profitt",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 7,
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
-            "release_name": "1989"
+            "release_name": "1989",
+            "listen_count": 7,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 6,
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
-            "release_name": "Staying at Tamara's"
+            "release_name": "Staying at Tamara's",
+            "listen_count": 6,
+            "artist_name": "George Ezra",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 6,
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
-            "release_name": "Singles"
+            "release_name": "Singles",
+            "listen_count": 6,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 6,
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
-            "release_name": "Kala"
+            "release_name": "Kala",
+            "listen_count": 6,
+            "artist_name": "M.I.A.",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 6,
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
-            "release_name": "Dream Your Life Away (Special Edition)"
+            "release_name": "Dream Your Life Away (Special Edition)",
+            "listen_count": 6,
+            "artist_name": "Vance Joy",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 6,
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
-            "release_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 6,
+            "artist_name": "Sia",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 4,
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
-            "release_name": "Udd Gaye (Bacardi House Party Sessions)"
+            "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+            "listen_count": 4,
+            "artist_name": "Ritviz",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
-            "release_name": "Ghost Stories"
+            "release_name": "Ghost Stories",
+            "listen_count": 4,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
-            "release_name": "Everyday Life"
+            "release_name": "Everyday Life",
+            "listen_count": 4,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 4,
             "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
-            "release_name": "Close To Me (feat. Swae Lee)"
+            "release_name": "Close To Me (feat. Swae Lee)",
+            "listen_count": 4,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         }
     ],
     "to_ts": 1589496658

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_too_many.json
@@ -4,928 +4,1134 @@
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 26,
             "release_mbid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
-            "release_name": "Live in Buenos Aires"
+            "release_name": "Live in Buenos Aires",
+            "listen_count": 26,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 25,
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
-            "release_name": "Delirium (Deluxe)"
+            "release_name": "Delirium (Deluxe)",
+            "listen_count": 25,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 25,
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
-            "release_name": "How to Save a Life"
+            "release_name": "How to Save a Life",
+            "listen_count": 25,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 20,
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
-            "release_name": "Udd Gaye (Bacardi House Party Sessions)"
+            "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+            "listen_count": 20,
+            "artist_name": "Ritviz",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 18,
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
-            "release_name": "Native"
+            "release_name": "Native",
+            "listen_count": 18,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 18,
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
-            "release_name": "Dream Your Life Away (Special Edition)"
+            "release_name": "Dream Your Life Away (Special Edition)",
+            "listen_count": 18,
+            "artist_name": "Vance Joy",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 17,
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
-            "release_name": "Night Visions (Deluxe)"
+            "release_name": "Night Visions (Deluxe)",
+            "listen_count": 17,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 17,
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
-            "release_name": "\u00f7 (Deluxe)"
+            "release_name": "\u00f7 (Deluxe)",
+            "listen_count": 17,
+            "artist_name": "Ed Sheeran",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 17,
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
-            "release_name": "1989"
+            "release_name": "1989",
+            "listen_count": 17,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 16,
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
-            "release_name": "A Thousand Years"
+            "release_name": "A Thousand Years",
+            "listen_count": 16,
+            "artist_name": "Christina Perri",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 16,
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
-            "release_name": "A Head Full Of Dreams"
+            "release_name": "A Head Full Of Dreams",
+            "listen_count": 16,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 16,
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
-            "release_name": "Halcyon Days"
+            "release_name": "Halcyon Days",
+            "listen_count": 16,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 15,
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
-            "release_name": "Staying at Tamara's"
+            "release_name": "Staying at Tamara's",
+            "listen_count": 15,
+            "artist_name": "George Ezra",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 13,
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
-            "release_name": "Two (Expanded Edition)"
+            "release_name": "Two (Expanded Edition)",
+            "listen_count": 13,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 13,
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
-            "release_name": "13 Reasons Why (Season 2)"
+            "release_name": "13 Reasons Why (Season 2)",
+            "listen_count": 13,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 12,
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
-            "release_name": "In The End"
+            "release_name": "In The End",
+            "listen_count": 12,
+            "artist_name": "Tommee Profitt",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 12,
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
-            "release_name": "#3"
+            "release_name": "#3",
+            "listen_count": 12,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 11,
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
-            "release_name": "My Head Is an Animal"
+            "release_name": "My Head Is an Animal",
+            "listen_count": 11,
+            "artist_name": "Of Monsters and Men",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 11,
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
-            "release_name": "Overexposed"
+            "release_name": "Overexposed",
+            "listen_count": 11,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 11,
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
-            "release_name": "Singles"
+            "release_name": "Singles",
+            "listen_count": 11,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 11,
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
-            "release_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 11,
+            "artist_name": "Sia",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 10,
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
-            "release_name": "Kala"
+            "release_name": "Kala",
+            "listen_count": 10,
+            "artist_name": "M.I.A.",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 10,
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
-            "release_name": "One More Light"
+            "release_name": "One More Light",
+            "listen_count": 10,
+            "artist_name": "Linkin Park",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 9,
             "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
-            "release_name": "Aalas Ka Pedh"
+            "release_name": "Aalas Ka Pedh",
+            "listen_count": 9,
+            "artist_name": "The Local train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
-            "artist_name": "Backstreet Boys",
-            "listen_count": 8,
             "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
-            "release_name": "The Hits--Chapter One"
+            "release_name": "The Hits--Chapter One",
+            "listen_count": 8,
+            "artist_name": "Backstreet Boys",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 7,
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
-            "release_name": "Ghost Stories"
+            "release_name": "Ghost Stories",
+            "listen_count": 7,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 7,
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
-            "release_name": "Everyday Life"
+            "release_name": "Everyday Life",
+            "listen_count": 7,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 6,
             "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
-            "release_name": "Close To Me (feat. Swae Lee)"
+            "release_name": "Close To Me (feat. Swae Lee)",
+            "listen_count": 6,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 6,
             "release_mbid": "a094c0cb-54f3-48ca-a279-b110883726e7",
-            "release_name": "Evolve"
+            "release_name": "Evolve",
+            "listen_count": 6,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 5,
             "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
-            "release_name": "Sixteen"
+            "release_name": "Sixteen",
+            "listen_count": 5,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 5,
             "release_mbid": "df5da03d-d06f-4754-b806-4e6714130f50",
-            "release_name": "The Fray"
+            "release_name": "The Fray",
+            "listen_count": 5,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 5,
             "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
-            "release_name": "Save Me, San Francisco (Golden Gate Edition)"
+            "release_name": "Save Me, San Francisco (Golden Gate Edition)",
+            "listen_count": 5,
+            "artist_name": "Train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "release_mbid": "2178027e-5ec0-4b8c-ba93-e8c2f8d311d0",
-            "release_name": "Viva la Vida or Death and All His Friends"
+            "release_name": "Viva la Vida or Death and All His Friends",
+            "listen_count": 5,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
-            "artist_name": "Within Temptation",
-            "listen_count": 5,
             "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
-            "release_name": "The Unforgiving"
+            "release_name": "The Unforgiving",
+            "listen_count": 5,
+            "artist_name": "Within Temptation",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 5,
             "release_mbid": "5162d1cd-c926-4fa0-a52c-fdb183e039b6",
-            "release_name": "Girls Like You (feat. Cardi B)"
+            "release_name": "Girls Like You (feat. Cardi B)",
+            "listen_count": 5,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 5,
             "release_mbid": "51b2ee66-ce30-4c83-8250-1a183f321de6",
-            "release_name": "Blinding Lights"
+            "release_name": "Blinding Lights",
+            "listen_count": 5,
+            "artist_name": "The Weeknd",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 5,
             "release_mbid": "bd043581-8ec5-415d-9270-21eeefadd40e",
-            "release_name": "Mylo Xyloto"
+            "release_name": "Mylo Xyloto",
+            "listen_count": 5,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 5,
             "release_mbid": "90e42fd4-64bd-430a-8326-ee9c7c470763",
-            "release_name": "Memories...Do Not Open"
+            "release_name": "Memories...Do Not Open",
+            "listen_count": 5,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
-            "release_name": "We Belong"
+            "release_name": "We Belong",
+            "listen_count": 5,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0c115c8a-fc71-4649-aa75-aaef5f09d6d1"
             ],
-            "artist_name": "American Authors",
-            "listen_count": 5,
             "release_mbid": "aa3ecedd-c3ea-4d8d-bb75-bec72bc6beea",
-            "release_name": "Oh, What A Life"
+            "release_name": "Oh, What A Life",
+            "listen_count": 5,
+            "artist_name": "American Authors",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 4,
             "release_mbid": "b9e6825b-b079-4c40-88e6-bdfb90267c3b",
-            "release_name": "X&Y"
+            "release_name": "X&Y",
+            "listen_count": 4,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 4,
             "release_mbid": "8b5eadfa-5ae4-4bd6-8db9-88865d92150f",
-            "release_name": "The Lumineers (Deluxe Edition)"
+            "release_name": "The Lumineers (Deluxe Edition)",
+            "listen_count": 4,
+            "artist_name": "The Lumineers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 4,
             "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
-            "release_name": "The Bright Side"
+            "release_name": "The Bright Side",
+            "listen_count": 4,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "abf274d4-a1f8-4477-b5c6-8c1121a13cf6"
             ],
-            "artist_name": "Bruno Mars",
-            "listen_count": 4,
             "release_mbid": "f3376a1c-85c9-4894-823c-9082d494db66",
-            "release_name": "Doo-Wops & Hooligans"
+            "release_name": "Doo-Wops & Hooligans",
+            "listen_count": 4,
+            "artist_name": "Bruno Mars",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 4,
             "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
-            "release_name": "Vaaqif"
+            "release_name": "Vaaqif",
+            "listen_count": 4,
+            "artist_name": "The Local train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "release_mbid": "698e5066-f551-4f90-8c84-f4bf162f99fe",
-            "release_name": "Memories"
+            "release_name": "Memories",
+            "listen_count": 4,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 3,
             "release_mbid": "0c0db2b5-6758-4907-8af2-6998f874307f",
-            "release_name": "Night Visions"
+            "release_name": "Night Visions",
+            "listen_count": 3,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
             ],
-            "artist_name": "The Weeknd",
-            "listen_count": 3,
             "release_mbid": "9db5985a-5ace-4b6c-8516-e41691177bc3",
-            "release_name": "Starboy"
+            "release_name": "Starboy",
+            "listen_count": 3,
+            "artist_name": "The Weeknd",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 3,
             "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
-            "release_name": "Lenka (Expanded Edition)"
+            "release_name": "Lenka (Expanded Edition)",
+            "listen_count": 3,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 3,
             "release_mbid": "350ed5e6-cd0f-46cb-9968-be5af7615feb",
-            "release_name": "Don't Let Me Down (feat. Daya)"
+            "release_name": "Don't Let Me Down (feat. Daya)",
+            "listen_count": 3,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0dee16fe-2b7f-4781-8f71-1e4357603ef1"
             ],
-            "artist_name": "P!nk",
-            "listen_count": 2,
             "release_mbid": "1887db90-7e72-45b8-b871-614c44de1dec",
-            "release_name": "The Truth About Love"
+            "release_name": "The Truth About Love",
+            "listen_count": 2,
+            "artist_name": "P!nk",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 2,
             "release_mbid": "beca4b10-075f-4a30-bffe-8c328fcbe7a5",
-            "release_name": "True"
+            "release_name": "True",
+            "listen_count": 2,
+            "artist_name": "Avicii",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 2,
             "release_mbid": "a8633d07-b592-4e29-b863-a592e70fc3b6",
-            "release_name": "V (Deluxe)"
+            "release_name": "V (Deluxe)",
+            "listen_count": 2,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 2,
             "release_mbid": "a31b241f-dc6c-437e-a9ba-a3f053e423ee",
-            "release_name": "V"
+            "release_name": "V",
+            "listen_count": 2,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "efc1ae68-f406-4430-8d94-a00b7280d822"
             ],
-            "artist_name": "Post Malone",
-            "listen_count": 2,
             "release_mbid": "a4842a28-f517-4a9f-bc5a-1c45e56f2579",
-            "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)"
+            "release_name": "Spider-Man: Into the Spider-Verse (Soundtrack From & Inspired by the Motion Picture)",
+            "listen_count": 2,
+            "artist_name": "Post Malone",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "4cd95528-7c4f-4ba8-a66f-a3f571e7a002"
             ],
-            "artist_name": "Joel Adams",
-            "listen_count": 2,
             "release_mbid": "4800bbb9-e78a-4ef8-9b6c-0620ba53df57",
-            "release_name": "Please Don't Go"
+            "release_name": "Please Don't Go",
+            "listen_count": 2,
+            "artist_name": "Joel Adams",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "77e59c9c-cbb3-4566-abe9-5ccf8a92c28f"
             ],
-            "artist_name": "Magic!",
-            "listen_count": 2,
             "release_mbid": "9011906e-e0b3-41d6-9e25-f53d7581d4e4",
-            "release_name": "Don't Kill the Magic"
+            "release_name": "Don't Kill the Magic",
+            "listen_count": 2,
+            "artist_name": "Magic!",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bf8d0eb5-a94c-496a-a4a5-6d370e0c30e9"
             ],
-            "artist_name": "Charlie Puth",
-            "listen_count": 2,
             "release_mbid": "d830e49e-7647-4aa8-a94a-9b102648f657",
-            "release_name": "Nine Track Mind"
+            "release_name": "Nine Track Mind",
+            "listen_count": 2,
+            "artist_name": "Charlie Puth",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 2,
             "release_mbid": "6ad32942-4d9f-4eb2-b7fe-6a7ef7c0d021",
-            "release_name": "Wanted on Voyage"
+            "release_name": "Wanted on Voyage",
+            "listen_count": 2,
+            "artist_name": "George Ezra",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 2,
             "release_mbid": "05c05ce0-5e83-459b-85bd-37c05430f7cf",
-            "release_name": "Liggi"
+            "release_name": "Liggi",
+            "listen_count": 2,
+            "artist_name": "Ritviz",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 2,
             "release_mbid": "05999a21-07ed-402c-9247-29c29b58f592",
-            "release_name": "Overexposed Track By Track"
+            "release_name": "Overexposed Track By Track",
+            "listen_count": 2,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "b650167d-3f75-4a39-a0b5-7cf4e65b7205"
             ],
-            "artist_name": "Katy Perry",
-            "listen_count": 2,
             "release_mbid": "0e6559b5-6ae6-401a-aca7-8761caa6e126",
-            "release_name": "PRISM (Deluxe)"
+            "release_name": "PRISM (Deluxe)",
+            "listen_count": 2,
+            "artist_name": "Katy Perry",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 2,
             "release_mbid": "14988f41-2188-4a77-94c7-4fe4b7810a8b",
-            "release_name": "Don't Let Me Down"
+            "release_name": "Don't Let Me Down",
+            "listen_count": 2,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1588d970-c277-44bc-8c6d-dc858a82f647"
             ],
-            "artist_name": "The Lumineers",
-            "listen_count": 2,
             "release_mbid": "7ad115c8-a989-497f-8c31-b34c418d87da",
-            "release_name": "The Lumineers"
+            "release_name": "The Lumineers",
+            "listen_count": 2,
+            "artist_name": "The Lumineers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 2,
             "release_mbid": "25d90a0a-e230-474f-b1a1-c94cb3b00f58",
-            "release_name": "Illuminate (Deluxe)"
+            "release_name": "Illuminate (Deluxe)",
+            "listen_count": 2,
+            "artist_name": "Shawn Mendes",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 2,
             "release_mbid": "d6fa315a-34b1-47b3-a879-896abda87313",
-            "release_name": "No Vacancy"
+            "release_name": "No Vacancy",
+            "listen_count": 2,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "b982577e-02da-4e04-beb7-3cb4577f4aad"
             ],
-            "artist_name": "Ayushmann Khurrana",
-            "listen_count": 1,
             "release_mbid": "e96df548-a420-4b75-8695-54ea54e88c83",
-            "release_name": "Mere Liye Tum Kaafi Ho (From \"Shubh Mangal Zyada Saavdhan\")"
+            "release_name": "Mere Liye Tum Kaafi Ho (From \"Shubh Mangal Zyada Saavdhan\")",
+            "listen_count": 1,
+            "artist_name": "Ayushmann Khurrana",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 1,
             "release_mbid": "6090ed85-046e-4fd6-8e9a-f2eaac58a2f7",
-            "release_name": "Dream Your Life Away"
+            "release_name": "Dream Your Life Away",
+            "listen_count": 1,
+            "artist_name": "Vance Joy",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 1,
             "release_mbid": "af6517fb-6216-49a6-8671-88f2678bfe96",
-            "release_name": "Love Me Like You Do (From \"Fifty Shades of Grey\")"
+            "release_name": "Love Me Like You Do (From \"Fifty Shades of Grey\")",
+            "listen_count": 1,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bce2e04f-e3f3-4c91-bd09-115455c43d37"
             ],
-            "artist_name": "Tyrone Wells",
-            "listen_count": 1,
             "release_mbid": "027e75d5-2b10-48ba-a939-47d60c201116",
-            "release_name": "Metal & Wood"
+            "release_name": "Metal & Wood",
+            "listen_count": 1,
+            "artist_name": "Tyrone Wells",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 1,
             "release_mbid": "e4dec817-aa00-4f0e-b520-0023bd317727",
-            "release_name": "Acoustic Sessions"
+            "release_name": "Acoustic Sessions",
+            "listen_count": 1,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "18abe6d6-0e0c-430e-b5b5-e9894af74b6a"
             ],
-            "artist_name": "Walk the Moon",
-            "listen_count": 1,
             "release_mbid": "13cde858-1ad6-4905-9dc6-a3156201eb64",
-            "release_name": "Now That's What I Call Music! 91"
+            "release_name": "Now That's What I Call Music! 91",
+            "listen_count": 1,
+            "artist_name": "Walk the Moon",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7888bddc-9b9c-46a2-9125-521a5738cda8"
             ],
-            "artist_name": "Goo Goo Dolls",
-            "listen_count": 1,
             "release_mbid": "e45d0c89-f2f3-4052-9c4c-236a8c881e63",
-            "release_name": "Dizzy Up the Girl"
+            "release_name": "Dizzy Up the Girl",
+            "listen_count": 1,
+            "artist_name": "Goo Goo Dolls",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 1,
             "release_mbid": "807f0307-b8ad-4e55-b84a-1c903340b8e2",
-            "release_name": "California 37"
+            "release_name": "California 37",
+            "listen_count": 1,
+            "artist_name": "Train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "e6a05347-56f6-4f5b-8f05-1b37b33fd5da"
             ],
-            "artist_name": "Echosmith",
-            "listen_count": 1,
             "release_mbid": "aa42f8ac-41cd-4f22-be42-672cb39a996b",
-            "release_name": "Talking Dreams (Deluxe Version)"
+            "release_name": "Talking Dreams (Deluxe Version)",
+            "listen_count": 1,
+            "artist_name": "Echosmith",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 1,
             "release_mbid": "99c8db69-2959-4b93-8140-8bab55a6d2af",
-            "release_name": "+"
+            "release_name": "+",
+            "listen_count": 1,
+            "artist_name": "Ed Sheeran",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "260a4dc3-19c5-4fae-9f2f-d495a8baa13d"
             ],
-            "artist_name": "Lady Gaga",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Lady Gaga",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "98184d50-f63d-4232-8a81-c06fa53b1082"
             ],
-            "artist_name": "Carly Rae Jepsen",
-            "listen_count": 1,
             "release_mbid": "95c3b485-020b-4c83-8ae1-82dec99ac8bc",
-            "release_name": "Kiss"
+            "release_name": "Kiss",
+            "listen_count": 1,
+            "artist_name": "Carly Rae Jepsen",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "e568204b-c382-48cf-bfbc-04d11cbf8765"
             ],
-            "artist_name": "Avicii",
-            "listen_count": 1,
             "release_mbid": "504bcccd-803e-4ee4-bcbc-2af3da80fdd1",
-            "release_name": "AV\u012aCI (01)"
+            "release_name": "AV\u012aCI (01)",
+            "listen_count": 1,
+            "artist_name": "Avicii",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "release_mbid": "4b87cf91-a057-46fd-9bb3-3489a2014bbf",
-            "release_name": "I Knew You Were Trouble."
+            "release_name": "I Knew You Were Trouble.",
+            "listen_count": 1,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "485029d6-bcdc-44a1-bf9f-8863915e43db"
             ],
-            "artist_name": "Jasleen Royal",
-            "listen_count": 1,
             "release_mbid": "cb7e62e2-6272-4c00-a7e1-a36942c43c5a",
-            "release_name": "Phillauri"
+            "release_name": "Phillauri",
+            "listen_count": 1,
+            "artist_name": "Jasleen Royal",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "5a93bfdf-f0df-4b8a-be5e-81d712ba6dbc"
             ],
-            "artist_name": "Alesso",
-            "listen_count": 1,
             "release_mbid": "f54f8246-cecf-4bf8-8bf7-373c7ea4beb7",
-            "release_name": "Heroes (We Could Be)"
+            "release_name": "Heroes (We Could Be)",
+            "listen_count": 1,
+            "artist_name": "Alesso",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "19a05a11-e927-4327-be0d-27dc37278de6"
             ],
-            "artist_name": "Kodaline",
-            "listen_count": 1,
             "release_mbid": "31747ec5-e2a6-462e-90af-7ced08ef0c11",
-            "release_name": "In a Perfect World"
+            "release_name": "In a Perfect World",
+            "listen_count": 1,
+            "artist_name": "Kodaline",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "465edcc5-d7d9-418e-8c6e-45ee5bd07d70"
             ],
-            "artist_name": "Arko",
-            "listen_count": 1,
             "release_mbid": "b27770c5-ee58-4073-9415-d8bf5a2ec0be",
-            "release_name": "The Shaukeens"
+            "release_name": "The Shaukeens",
+            "listen_count": 1,
+            "artist_name": "Arko",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fe56af47-9fb9-4a68-a09e-1b3d0d43e803"
             ],
-            "artist_name": "Elton John",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Elton John",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "38814daf-cc14-410a-a4e9-6b61cf295c10"
             ],
-            "artist_name": "Owl City",
-            "listen_count": 1,
             "release_mbid": "fdb7b377-4e3d-4dd4-ac46-2007e5fa5ebe",
-            "release_name": "Good Time"
+            "release_name": "Good Time",
+            "listen_count": 1,
+            "artist_name": "Owl City",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "c50b5258-792d-4e33-beed-e5b3c4b9cf64"
             ],
-            "artist_name": "Rock City",
-            "listen_count": 1,
             "release_mbid": "bd00c7aa-0919-4890-83f0-ae062e197cd2",
-            "release_name": "What Dreams Are Made Of"
+            "release_name": "What Dreams Are Made Of",
+            "listen_count": 1,
+            "artist_name": "Rock City",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "release_mbid": "dec62e50-f23c-491f-9507-69a4f1f72bda",
-            "release_name": "Handwritten (Deluxe)"
+            "release_name": "Handwritten (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "Shawn Mendes",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 1,
             "release_mbid": "1ca39c97-3340-45a6-b3d7-f8864e08fda5",
-            "release_name": "Red (Deluxe Edition)"
+            "release_name": "Red (Deluxe Edition)",
+            "listen_count": 1,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "f5e64189-e742-4143-a290-da0c1d6bd988"
             ],
-            "artist_name": "Boyce Avenue",
-            "listen_count": 1,
             "release_mbid": "653a00ef-333c-4295-9b31-e0655b9b5895",
-            "release_name": "Cover Sessions, Vol. 2"
+            "release_name": "Cover Sessions, Vol. 2",
+            "listen_count": 1,
+            "artist_name": "Boyce Avenue",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6141d63c-719d-4866-94a8-720b7ed812af"
             ],
-            "artist_name": "Demi Lovato",
-            "listen_count": 1,
             "release_mbid": "57ab04d5-7411-4f31-8f26-13d81bceb0e8",
-            "release_name": "Demi"
+            "release_name": "Demi",
+            "listen_count": 1,
+            "artist_name": "Demi Lovato",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "f9f122c1-422f-4985-8536-7d9eb2e832d9"
             ],
-            "artist_name": "Foster the People",
-            "listen_count": 1,
             "release_mbid": "d3cd3737-48b4-46b3-b703-a3f4d316ea29",
-            "release_name": "Nrj 200% Hits 2012"
+            "release_name": "Nrj 200% Hits 2012",
+            "listen_count": 1,
+            "artist_name": "Foster the People",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
             ],
-            "artist_name": "Shawn Mendes",
-            "listen_count": 1,
             "release_mbid": "b02ca09c-9e6a-4cca-bd09-fc855aefc9a0",
-            "release_name": "Mercy"
+            "release_name": "Mercy",
+            "listen_count": 1,
+            "artist_name": "Shawn Mendes",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "f82637b3-5d12-4e35-b1a9-e3d401f8162d"
             ],
-            "artist_name": "Paul McCartney",
-            "listen_count": 1,
             "release_mbid": "fa114e6f-46fa-42cc-bca2-fc6e2cb5e26d",
-            "release_name": "One World: Together At Home"
+            "release_name": "One World: Together At Home",
+            "listen_count": 1,
+            "artist_name": "Paul McCartney",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 1,
             "release_mbid": "291cfaaf-d787-45de-89fc-668b3036b73b",
-            "release_name": "No Sound Without Silence"
+            "release_name": "No Sound Without Silence",
+            "listen_count": 1,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "0daecabb-f76d-4914-8726-82cefbecca52"
             ],
-            "artist_name": "The Chainsmokers",
-            "listen_count": 1,
             "release_mbid": "15c946de-b2fb-40ae-93c1-8e8dd1a1e2fa",
-            "release_name": "Something Just Like This"
+            "release_name": "Something Just Like This",
+            "listen_count": 1,
+            "artist_name": "The Chainsmokers",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "19a05a11-e927-4327-be0d-27dc37278de6"
             ],
-            "artist_name": "Kodaline",
-            "listen_count": 1,
             "release_mbid": "be0e40c5-1dd2-4c1e-b85d-5d8a2436bf3f",
-            "release_name": "In A Perfect World (Deluxe)"
+            "release_name": "In A Perfect World (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "Kodaline",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d8696b51-1a16-4543-b9a2-8e9c6b91b42c"
             ],
-            "artist_name": "Amit Trivedi",
-            "listen_count": 1,
             "release_mbid": "b8a9f2f9-ed1b-44b1-a09a-648551b1cb26",
-            "release_name": "Kedarnath"
+            "release_name": "Kedarnath",
+            "listen_count": 1,
+            "artist_name": "Amit Trivedi",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 1,
             "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
-            "release_name": "Oh My My (Deluxe)"
+            "release_name": "Oh My My (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 1,
             "release_mbid": "69bda328-d091-4a67-8553-0cbf648082f5",
-            "release_name": "Oh My My (Deluxe)"
+            "release_name": "Oh My My (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "19a05a11-e927-4327-be0d-27dc37278de6"
             ],
-            "artist_name": "Kodaline",
-            "listen_count": 1,
             "release_mbid": "be0e40c5-1dd2-4c1e-b85d-5d8a2436bf3f",
-            "release_name": "In A Perfect World (Deluxe)"
+            "release_name": "In A Perfect World (Deluxe)",
+            "listen_count": 1,
+            "artist_name": "Kodaline",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d8696b51-1a16-4543-b9a2-8e9c6b91b42c"
             ],
-            "artist_name": "Amit Trivedi",
-            "listen_count": 1,
             "release_mbid": "b8a9f2f9-ed1b-44b1-a09a-648551b1cb26",
-            "release_name": "Kedarnath"
+            "release_name": "Kedarnath",
+            "listen_count": 1,
+            "artist_name": "Amit Trivedi",
+            "artist_msid": null,
+            "release_msid": null
         }
     ],
     "count": 103,

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_week.json
@@ -6,226 +6,276 @@
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 10,
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
-            "release_name": "Halcyon Days"
+            "release_name": "Halcyon Days",
+            "listen_count": 10,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6817e85a-f5ae-4479-b73d-e8e320e1b927"
             ],
-            "artist_name": "Ed Sheeran",
-            "listen_count": 9,
             "release_mbid": "aec9a871-cd3b-467f-a53d-4ef5bc3bbafe",
-            "release_name": "\u00f7 (Deluxe)"
+            "release_name": "\u00f7 (Deluxe)",
+            "listen_count": 9,
+            "artist_name": "Ed Sheeran",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 9,
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
-            "release_name": "Delirium (Deluxe)"
+            "release_name": "Delirium (Deluxe)",
+            "listen_count": 9,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1871df1a-93b7-4e25-9d60-64102ba89913"
             ],
-            "artist_name": "The Script",
-            "listen_count": 8,
             "release_mbid": "1850ad45-5906-458b-89d5-068760d122b5",
-            "release_name": "#3"
+            "release_name": "#3",
+            "listen_count": 8,
+            "artist_name": "The Script",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8f119e29-922e-42da-a5bf-b062f5261a3d"
             ],
-            "artist_name": "Of Monsters and Men",
-            "listen_count": 6,
             "release_mbid": "96c70312-64ce-496d-8604-46a0d20ad347",
-            "release_name": "My Head Is an Animal"
+            "release_name": "My Head Is an Animal",
+            "listen_count": 6,
+            "artist_name": "Of Monsters and Men",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "bad9c78a-cbe3-4a6f-b7c0-f2009cecaabb"
             ],
-            "artist_name": "Christina Perri",
-            "listen_count": 6,
             "release_mbid": "c268bfdc-dbae-49bc-805c-77317c853b03",
-            "release_name": "A Thousand Years"
+            "release_name": "A Thousand Years",
+            "listen_count": 6,
+            "artist_name": "Christina Perri",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 6,
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
-            "release_name": "A Head Full Of Dreams"
+            "release_name": "A Head Full Of Dreams",
+            "listen_count": 6,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 6,
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
-            "release_name": "13 Reasons Why (Season 2)"
+            "release_name": "13 Reasons Why (Season 2)",
+            "listen_count": 6,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 5,
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
-            "release_name": "Two (Expanded Edition)"
+            "release_name": "Two (Expanded Edition)",
+            "listen_count": 5,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 5,
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
-            "release_name": "In The End"
+            "release_name": "In The End",
+            "listen_count": 5,
+            "artist_name": "Tommee Profitt",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 5,
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
-            "release_name": "How to Save a Life"
+            "release_name": "How to Save a Life",
+            "listen_count": 5,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 4,
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
-            "release_name": "Staying at Tamara's"
+            "release_name": "Staying at Tamara's",
+            "listen_count": 4,
+            "artist_name": "George Ezra",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "release_mbid": "d970fc5c-0f03-4912-a385-ba109f615cdc",
-            "release_name": "Singles"
+            "release_name": "Singles",
+            "listen_count": 4,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "9d5adabb-9775-4535-93eb-12b485aed8bf"
             ],
-            "artist_name": "Maroon 5",
-            "listen_count": 4,
             "release_mbid": "a9626819-db11-4d52-adea-7d3c1d9040bb",
-            "release_name": "Overexposed"
+            "release_name": "Overexposed",
+            "listen_count": 4,
+            "artist_name": "Maroon 5",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1b173852-64e9-4c7f-8ed7-01ce6158a6fd"
             ],
-            "artist_name": "Linkin Park",
-            "listen_count": 4,
             "release_mbid": "d6a8788d-2a4d-4883-9d33-d3e9fc839b1b",
-            "release_name": "One More Light"
+            "release_name": "One More Light",
+            "listen_count": 4,
+            "artist_name": "Linkin Park",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 4,
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
-            "release_name": "Native"
+            "release_name": "Native",
+            "listen_count": 4,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 4,
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
-            "release_name": "Kala"
+            "release_name": "Kala",
+            "listen_count": 4,
+            "artist_name": "M.I.A.",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "8cb3fd5a-2194-4c3b-8eb8-3e538d109991"
             ],
-            "artist_name": "Vance Joy",
-            "listen_count": 4,
             "release_mbid": "d1dcbe95-f4d3-4def-8f76-efda6953aa5f",
-            "release_name": "Dream Your Life Away (Special Edition)"
+            "release_name": "Dream Your Life Away (Special Edition)",
+            "listen_count": 4,
+            "artist_name": "Vance Joy",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ac6f4804-6215-4e1b-bb47-3672f085dde6"
             ],
-            "artist_name": "Sia",
-            "listen_count": 4,
             "release_mbid": "db17c56a-bd8c-493c-aa2c-c251494a03d3",
-            "release_name": "Cheap Thrills (feat. Sean Paul)"
+            "release_name": "Cheap Thrills (feat. Sean Paul)",
+            "listen_count": 4,
+            "artist_name": "Sia",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 4,
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
-            "release_name": "1989"
+            "release_name": "1989",
+            "listen_count": 4,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "49ec6dae-0bd3-43f5-9acf-f3462fb3ff8f"
             ],
-            "artist_name": "Ritviz",
-            "listen_count": 2,
             "release_mbid": "1bb9776e-5191-4120-80ce-a93dfd0fff3c",
-            "release_name": "Udd Gaye (Bacardi House Party Sessions)"
+            "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+            "listen_count": 2,
+            "artist_name": "Ritviz",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3dc53e0f-7090-44d2-8500-3012102f29a6"
             ],
-            "artist_name": "Backstreet Boys",
-            "listen_count": 2,
             "release_mbid": "7d6ebd19-f88e-44d0-85dd-21a1f428ea30",
-            "release_name": "The Hits--Chapter One"
+            "release_name": "The Hits--Chapter One",
+            "listen_count": 2,
+            "artist_name": "Backstreet Boys",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 2,
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
-            "release_name": "Night Visions (Deluxe)"
+            "release_name": "Night Visions (Deluxe)",
+            "listen_count": 2,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
-            "release_name": "Ghost Stories"
+            "release_name": "Ghost Stories",
+            "listen_count": 2,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 2,
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
-            "release_name": "Everyday Life"
+            "release_name": "Everyday Life",
+            "listen_count": 2,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         }
     ],
     "to_ts": 1589237458

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_year.json
@@ -6,226 +6,276 @@
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 211,
             "release_mbid": "bbfac9ad-fdd2-4c02-a07d-a994e73323b4",
-            "release_name": "Aalas Ka Pedh"
+            "release_name": "Aalas Ka Pedh",
+            "listen_count": 211,
+            "artist_name": "The Local train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
             ],
-            "artist_name": "The Local train",
-            "listen_count": 168,
             "release_mbid": "f7bca8ea-e17b-4c93-a9d3-f8c48674f901",
-            "release_name": "Vaaqif"
+            "release_name": "Vaaqif",
+            "listen_count": 168,
+            "artist_name": "The Local train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 163,
             "release_mbid": "a9cb9c18-9997-487f-bccf-e3085d957f12",
-            "release_name": "Two (Expanded Edition)"
+            "release_name": "Two (Expanded Edition)",
+            "listen_count": 163,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fecda98e-0533-4b87-a9d1-c89b4521918b"
             ],
-            "artist_name": "Imagine Dragons",
-            "listen_count": 106,
             "release_mbid": "40ae81e6-80df-47cf-a76d-6879794791e0",
-            "release_name": "Night Visions (Deluxe)"
+            "release_name": "Night Visions (Deluxe)",
+            "listen_count": 106,
+            "artist_name": "Imagine Dragons",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 76,
             "release_mbid": "e351ec58-091f-4d56-ada3-3189ff9fc231",
-            "release_name": "Lenka (Expanded Edition)"
-        },
-        {
-            "artist_mbids": [
-                "6599e41e-390c-4855-a2ac-68ee798538b4"
-            ],
-            "artist_name": "Coldplay",
+            "release_name": "Lenka (Expanded Edition)",
             "listen_count": 76,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
+        },
+        {
+            "artist_mbids": [
+                "6599e41e-390c-4855-a2ac-68ee798538b4"
+            ],
             "release_mbid": "452351a2-a730-4df0-88f9-f63f24101562",
-            "release_name": "A Head Full Of Dreams"
+            "release_name": "A Head Full Of Dreams",
+            "listen_count": 76,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 56,
             "release_mbid": "623a3d9d-9d22-418e-9adf-0de145dd871e",
-            "release_name": "Ghost Stories"
+            "release_name": "Ghost Stories",
+            "listen_count": 56,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
             ],
-            "artist_name": "Coldplay",
-            "listen_count": 48,
             "release_mbid": "c287322a-0319-447e-abc2-5c33acdf7d1c",
-            "release_name": "Everyday Life"
+            "release_name": "Everyday Life",
+            "listen_count": 48,
+            "artist_name": "Coldplay",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
+            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
+            "release_name": "Delirium (Deluxe)",
             "listen_count": 46,
-            "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
-            "release_name": "Delirium (Deluxe)"
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 42,
             "release_mbid": "de97ca87-36c4-4995-a5c9-540e35944352",
-            "release_name": "Delirium (Deluxe)"
+            "release_name": "Delirium (Deluxe)",
+            "listen_count": 42,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 38,
             "release_mbid": "a5130c37-c0b5-4917-bd8a-d035e853fe4a",
-            "release_name": "The Bright Side"
+            "release_name": "The Bright Side",
+            "listen_count": 38,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 38,
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
-            "release_name": "How to Save a Life"
+            "release_name": "How to Save a Life",
+            "listen_count": 38,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "ba64b195-01dd-4613-9534-bb87dc44cffb"
             ],
-            "artist_name": "Lenka",
-            "listen_count": 37,
             "release_mbid": "868e1be0-58db-412d-90b5-939f9a9ef63f",
-            "release_name": "We Belong"
+            "release_name": "We Belong",
+            "listen_count": 37,
+            "artist_name": "Lenka",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "52f911d4-8f73-4fc9-9145-a99aff057524"
             ],
-            "artist_name": "George Ezra",
-            "listen_count": 36,
             "release_mbid": "cb654526-2615-46fc-89bc-2268dcc5f294",
-            "release_name": "Staying at Tamara's"
+            "release_name": "Staying at Tamara's",
+            "listen_count": 36,
+            "artist_name": "George Ezra",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "1024e884-3a17-4729-9e59-a026fe8a07ba"
             ],
-            "artist_name": "M.I.A.",
-            "listen_count": 36,
             "release_mbid": "e3852ea5-571a-444e-bf92-8bebeca6fbf8",
-            "release_name": "Kala"
+            "release_name": "Kala",
+            "listen_count": 36,
+            "artist_name": "M.I.A.",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "3b155259-b29e-4515-aa62-cb0b917f4cfd"
             ],
-            "artist_name": "The Fray",
-            "listen_count": 36,
             "release_mbid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
-            "release_name": "How to Save a Life"
+            "release_name": "How to Save a Life",
+            "listen_count": 36,
+            "artist_name": "The Fray",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "cc0f643d-cba9-4a5e-876f-cb3d70cdf5ea"
             ],
-            "artist_name": "Taylor Swift",
-            "listen_count": 36,
             "release_mbid": "dffbc50f-c34c-40b8-ae2e-ad280e07841a",
-            "release_name": "1989"
+            "release_name": "1989",
+            "listen_count": 36,
+            "artist_name": "Taylor Swift",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 36,
             "release_mbid": "7d5a6263-a779-4b8d-93b0-76aaf2fb017a",
-            "release_name": "13 Reasons Why (Season 2)"
+            "release_name": "13 Reasons Why (Season 2)",
+            "listen_count": 36,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 35,
             "release_mbid": "08e09ff8-7dbd-4a2f-af3c-5e3e169b7c76",
-            "release_name": "Halcyon Days"
+            "release_name": "Halcyon Days",
+            "listen_count": 35,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "67f4ae2e-260e-4020-b957-f2df5b719501"
             ],
-            "artist_name": "OneRepublic",
-            "listen_count": 34,
             "release_mbid": "698b05e0-9b74-4fc0-a653-c4cf74d29562",
-            "release_name": "Native"
+            "release_name": "Native",
+            "listen_count": 34,
+            "artist_name": "OneRepublic",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "fbe59c7e-3a75-459b-8fc8-07abaa6d1d2c"
             ],
-            "artist_name": "Train",
-            "listen_count": 33,
             "release_mbid": "09b9ed8f-48b7-49c2-8b2f-ad7b72584bbc",
-            "release_name": "Save Me, San Francisco (Golden Gate Edition)"
+            "release_name": "Save Me, San Francisco (Golden Gate Edition)",
+            "listen_count": 33,
+            "artist_name": "Train",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "4e202a9c-c976-4e9e-8c9f-b0b96916f6a5"
             ],
-            "artist_name": "Tommee Profitt",
-            "listen_count": 32,
             "release_mbid": "40629c90-960b-4b76-90d9-469ee5620f48",
-            "release_name": "In The End"
+            "release_name": "In The End",
+            "listen_count": 32,
+            "artist_name": "Tommee Profitt",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 31,
             "release_mbid": "ee9da2f5-a110-4bff-9cfd-28a56c753bbd",
-            "release_name": "Sixteen"
+            "release_name": "Sixteen",
+            "listen_count": 31,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
             ],
-            "artist_name": "Ellie Goulding",
-            "listen_count": 31,
             "release_mbid": "554b4b5c-b068-48e1-9c25-a18dafc518cf",
-            "release_name": "Close To Me (feat. Swae Lee)"
+            "release_name": "Close To Me (feat. Swae Lee)",
+            "listen_count": 31,
+            "artist_name": "Ellie Goulding",
+            "artist_msid": null,
+            "release_msid": null
         },
         {
             "artist_mbids": [
                 "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
             ],
-            "artist_name": "Within Temptation",
-            "listen_count": 30,
             "release_mbid": "907b37ad-71df-4237-a7ed-3ed5fea96179",
-            "release_name": "The Unforgiving"
+            "release_name": "The Unforgiving",
+            "listen_count": 30,
+            "artist_name": "Within Temptation",
+            "artist_msid": null,
+            "release_msid": null
         }
     ],
     "to_ts": 1590796791

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -45,11 +45,6 @@ class StatisticsRange(Enum):
     all_time = 'all_time'
 
 
-# FIXME: the responses returned by the ger_user_artist,
-#  get_release and get_recordings endpoints has changed.
-#  Front-end code needs to reviewed and fixed as needed.
-#  Notably, we never return msids now.
-
 @stats_api_bp.route("/user/<user_name>/artists")
 @crossdomain()
 @ratelimit()
@@ -67,19 +62,16 @@ def get_user_artist(user_name):
                 "artists": [
                     {
                        "artist_mbids": ["93e6118e-7fa8-49f6-9e02-699a1ebce105"],
-                       "artist_msid": "d340853d-7408-4a0d-89c2-6ff13e568815",
                        "artist_name": "The Local train",
                        "listen_count": 385
                     },
                     {
                        "artist_mbids": ["ae9ed5e2-4caf-4b3d-9cb3-2ad626b91714"],
-                       "artist_msid": "ba64b195-01dd-4613-9534-bb87dc44cffb",
                        "artist_name": "Lenka",
                        "listen_count": 333
                     },
                     {
                        "artist_mbids": ["cc197bad-dc9c-440d-a5b5-d52ba2e14234"],
-                       "artist_msid": "6599e41e-390c-4855-a2ac-68ee798538b4",
                        "artist_name": "Coldplay",
                        "listen_count": 321
                     }
@@ -162,29 +154,23 @@ def get_release(user_name):
                 "releases": [
                     {
                         "artist_mbids": [],
-                        "artist_msid": "6599e41e-390c-4855-a2ac-68ee798538b4",
                         "artist_name": "Coldplay",
                         "listen_count": 26,
                         "release_mbid": "",
-                        "release_msid": "d59730cf-f0e3-441e-a7a7-8e0f589632a5",
                         "release_name": "Live in Buenos Aires"
                     },
                     {
                         "artist_mbids": [],
-                        "artist_msid": "7addbcac-ae39-4b4c-a956-53da336d68e8",
                         "artist_name": "Ellie Goulding",
                         "listen_count": 25,
                         "release_mbid": "",
-                        "release_msid": "de97ca87-36c4-4995-a5c9-540e35944352",
                         "release_name": "Delirium (Deluxe)"
                     },
                     {
                         "artist_mbids": [],
-                        "artist_msid": "3b155259-b29e-4515-aa62-cb0b917f4cfd",
                         "artist_name": "The Fray",
                         "listen_count": 25,
                         "release_mbid": "",
-                        "release_msid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
                         "release_name": "How to Save a Life"
                     },
                 ],
@@ -267,25 +253,19 @@ def get_recording(user_name):
                 "recordings": [
                     {
                         "artist_mbids": [],
-                        "artist_msid": "7addbcac-ae39-4b4c-a956-53da336d68e8",
                         "artist_name": "Ellie Goulding",
                         "listen_count": 25,
                         "recording_mbid": "0fe11cd3-0be4-467b-84fa-0bd524d45d74",
-                        "recording_msid": "c6b65a7e-7284-433e-ac5d-e3ff0aa4738a",
                         "release_mbid": "",
-                        "release_msid": "de97ca87-36c4-4995-a5c9-540e35944352",
                         "release_name": "Delirium (Deluxe)",
                         "track_name": "Love Me Like You Do - From \\"Fifty Shades of Grey\\""
                     },
                     {
                         "artist_mbids": [],
-                        "artist_msid": "3b155259-b29e-4515-aa62-cb0b917f4cfd",
                         "artist_name": "The Fray",
                         "listen_count": 23,
                         "recording_mbid": "0008ab49-a6ad-40b5-aa90-9d2779265c22",
-                        "recording_msid": "4b5bf07c-782f-4324-9242-bf56e4ba1e57",
                         "release_mbid": "",
-                        "release_msid": "2b2a93c3-a0bd-4f46-8507-baf5ad291966",
                         "release_name": "How to Save a Life",
                         "track_name": "How to Save a Life"
                     }
@@ -669,13 +649,11 @@ def get_sitewide_artist():
                         "artists": [
                             {
                                 "artist_mbids": ["f4fdbb4c-e4b7-47a0-b83b-d91bbfcfa387"],
-                                "artist_msid": "b4ae3356-b8a7-471a-a23a-e471a69ad454",
                                 "artist_name": "Ariana Grande",
                                 "listen_count": 519
                             },
                             {
                                 "artist_mbids": ["f4abc0b5-3f7a-4eff-8f78-ac078dbce533"],
-                                "artist_msid": "f9ee09fb-5ab4-46a2-9088-3eac0eed4920",
                                 "artist_name": "Billie Eilish",
                                 "listen_count": 447
                             }
@@ -688,13 +666,11 @@ def get_sitewide_artist():
                         "artists": [
                             {
                                 "artist_mbids": [],
-                                "artist_msid": "2b0646af-f3f0-4a5b-b629-6c31301c1c29",
                                 "artist_name": "The Weeknd",
                                 "listen_count": 621
                             },
                             {
                                 "artist_mbids": [],
-                                "artist_msid": "9720fd77-fe48-41ba-a7a2-b4795718dd97",
                                 "artist_name": "Drake",
                                 "listen_count": 554
                             }

--- a/listenbrainz_spark/stats/user/recording.py
+++ b/listenbrainz_spark/stats/user/recording.py
@@ -14,7 +14,7 @@ def get_recordings(table):
                 {
                     'user1' : [
                         {
-                            'recording_name': str,
+                            'track_name': str,
                             'recording_mbid': str,
                             'artist_name': str,
                             'artist_credit_id': int,
@@ -50,7 +50,7 @@ def get_recordings(table):
                     collect_list(
                         struct(
                             listen_count
-                          , recording_name
+                          , recording_name AS track_name
                           , recording_mbid
                           , artist_name
                           , coalesce(artist_credit_mbids, array()) AS artist_mbids

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -69,7 +69,7 @@ class UserEntityTestCase(StatsTestCase):
                 'artist_mbids': [str(i)],
                 'release_name': 'release_{}'.format(i),
                 'release_mbid': str(i),
-                'recording_name': 'recording_{}'.format(i),
+                'track_name': 'recording_{}'.format(i),
                 'recording_mbid': str(i),
                 'listen_count': i
             })

--- a/listenbrainz_spark/testdata/user_top_recordings_incorrect.json
+++ b/listenbrainz_spark/testdata/user_top_recordings_incorrect.json
@@ -4,7 +4,7 @@
     "artist_mbids": [],
     "release_name": "release_1",
     "release_mbid": "",
-    "recording_name": "track_1",
+    "track_name": "track_1",
     "recording_mbid": "",
     "listen_count": 1
   },
@@ -13,7 +13,7 @@
     "artist_mbids": [],
     "release_name": "release_1",
     "release_mbid": null,
-    "recording_name": "track_1",
+    "track_name": "track_1",
     "recording_mbid": "",
     "listen_count": 1
   },
@@ -22,7 +22,7 @@
     "artist_mbids": [],
     "release_name": "release_2",
     "release_mbid": null,
-    "recording_name": "track_2",
+    "track_name": "track_2",
     "recording_mbid": "",
     "listen_count": null
   },
@@ -31,7 +31,7 @@
     "artist_mbids": [],
     "release_name": "release_2",
     "release_mbid": null,
-    "recording_name": null,
+    "track_name": null,
     "recording_mbid": "",
     "listen_count": null
   }

--- a/listenbrainz_spark/testdata/user_top_recordings_output.json
+++ b/listenbrainz_spark/testdata/user_top_recordings_output.json
@@ -1,1 +1,654 @@
-[{"musicbrainz_id": "rob", "type": "user_entity", "entity": "recordings", "stats_range": "all_time", "from_ts": 1009843200, "to_ts": 1628511763, "data": [{"artist_name": "Portishead", "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"], "recording_mbid": "a7ed3365-affa-4331-8bd9-1ececaf9ae77", "release_name": "Third", "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741", "recording_name": "The Rip", "listen_count": 2}, {"artist_name": "Portishead", "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"], "recording_mbid": "8855e971-0570-4d20-9258-4b7ed7441f10", "release_name": "Third", "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741", "recording_name": "Plastic", "listen_count": 2}, {"artist_name": "Massive Attack", "artist_mbids": ["10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"], "recording_mbid": "e69db070-8ff6-47bc-ab5f-d0291ee08dc6", "release_name": "Protection", "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5", "recording_name": "Euro Child", "listen_count": 2}, {"artist_name": "Aether", "artist_mbids": ["c44ff36b-651f-4c20-98ee-519cf4ed07e7"], "recording_mbid": "bb7601d3-f006-4421-83c9-d71e35962a95", "release_name": "Yamanote", "release_mbid": "b812901e-c598-4635-8b98-72eecf161060", "recording_name": "You Still Echo Here", "listen_count": 1}, {"artist_name": "Aether", "artist_mbids": ["c44ff36b-651f-4c20-98ee-519cf4ed07e7"], "recording_mbid": "40e085a0-9637-42a6-88f7-d5e12c793854", "release_name": "Yamanote", "release_mbid": "b812901e-c598-4635-8b98-72eecf161060", "recording_name": "Yamanote", "listen_count": 1}, {"artist_name": "Jah Wobble, Marconi Union", "artist_mbids": ["904cc1c8-021e-45ac-bbe9-95c01a1f8099", "3f9b5837-ed1c-413e-bfef-ca4f892dcc59"], "recording_mbid": "0ca2a698-7280-4b40-a357-ca966bbd3a96", "release_name": "Anomic", "release_mbid": "39967fee-e436-4f87-b36e-299aae4dc670", "recording_name": "Wealth", "listen_count": 1}, {"artist_name": "Portishead", "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"], "recording_mbid": "b00efba7-0d88-478c-97ad-257aef64cc27", "release_name": "Third", "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741", "recording_name": "We Carry On", "listen_count": 1}, {"artist_name": "The Egg", "artist_mbids": ["6fe91ae9-8ddb-47b0-a2d7-252833ce5500"], "recording_mbid": "975f5943-6c9b-45c2-a219-8f5c34b11014", "release_name": "Forwards (Special Edition)", "release_mbid": "af6fdf7a-fcb0-46f9-b8c5-517fe8cb3e5d", "recording_name": "Venice Beach", "listen_count": 1}, {"artist_name": "The Polish Ambassador", "artist_mbids": ["e9787dd2-5857-4b51-8e59-a190a54820fc"], "recording_mbid": "1991c5e5-053a-4222-ad04-7d84cc11907c", "release_name": "Ecozoic", "release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf", "recording_name": "Two and a Half Moons Away", "listen_count": 1}, {"artist_name": "Sounds From The Ground", "artist_mbids": ["9806e551-9a63-4a9d-be1b-5297b2ac0e76"], "recording_mbid": "986257af-4ed5-4e6e-bb68-a4e6f03eb284", "release_name": "Mosaic Remastered", "release_mbid": "2f7634f3-3bb5-4f2c-9821-d150e8415fb8", "recording_name": "Treasure", "listen_count": 1}, {"artist_name": "Romare", "artist_mbids": ["b014d579-b549-4b21-b90d-5264e0433988"], "recording_mbid": "5176acc7-1b58-4434-ba16-d76e3ca094cd", "release_name": "Projections", "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc", "recording_name": "The Drifter", "listen_count": 1}, {"artist_name": "Aether", "artist_mbids": ["c44ff36b-651f-4c20-98ee-519cf4ed07e7"], "recording_mbid": "c626c408-ecbb-47ac-a3d8-961a072d0819", "release_name": "Yamanote", "release_mbid": "b812901e-c598-4635-8b98-72eecf161060", "recording_name": "Sunshine City", "listen_count": 1}, {"artist_name": "Ott", "artist_mbids": ["1a40f886-0877-4bab-9ab1-761147dadb89"], "recording_mbid": "19cdfa84-f4ec-4e1d-8595-ed2bc4e295d4", "release_name": "Blumenkraft", "release_mbid": "99e39642-cae5-4061-9800-751108bc650b", "recording_name": "Splitting an Atom", "listen_count": 1}, {"artist_name": "Massive Attack", "artist_mbids": ["10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"], "recording_mbid": "f837bff5-faf2-4323-81de-91f056207a42", "release_name": "Protection", "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5", "recording_name": "Sly", "listen_count": 1}, {"artist_name": "Portishead", "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"], "recording_mbid": "83b416db-4ee1-4560-a3b3-52fd453eb285", "release_name": "Third", "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741", "recording_name": "Silence", "listen_count": 1}, {"artist_name": "The Polish Ambassador", "artist_mbids": ["e9787dd2-5857-4b51-8e59-a190a54820fc"], "recording_mbid": "82ac2959-a2d6-4f41-be9f-50bac0976fd1", "release_name": "Ecozoic", "release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf", "recording_name": "Rootshine Revival", "listen_count": 1}, {"artist_name": "Massive Attack, Tracey Thorn", "artist_mbids": ["10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8", "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f"], "recording_mbid": "535b2d75-ce44-41a5-9d7c-12318d219dd4", "release_name": "Protection", "release_mbid": "91231e74-2674-411e-968f-b188bb67b711", "recording_name": "Protection", "listen_count": 1}, {"artist_name": "Romare", "artist_mbids": ["b014d579-b549-4b21-b90d-5264e0433988"], "recording_mbid": "90fb24e7-3b50-4043-a5f1-2c3a78d692f0", "release_name": "Projections", "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc", "recording_name": "Prison Blues", "listen_count": 1}, {"artist_name": "Romare", "artist_mbids": ["b014d579-b549-4b21-b90d-5264e0433988"], "recording_mbid": "d58ebf31-6e08-4baa-857f-2e43f4ff8f0f", "release_name": "Projections", "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc", "recording_name": "Nina's Charm", "listen_count": 1}, {"artist_name": "Little People", "artist_mbids": ["78c94cba-761f-4212-8508-a24bda2e57dc"], "recording_mbid": "793f88ed-2e8c-4cdc-b042-8920877a82fc", "release_name": "Mickey Mouse Operation", "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05", "recording_name": "Moon", "listen_count": 1}, {"artist_name": "Vangelis", "artist_mbids": ["57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"], "recording_mbid": "349101b9-0570-4859-9ad7-f939ea4e68ab", "release_name": "Blade Runner (Music From The Original Soundtrack)", "release_mbid": "d619edca-d766-36b3-a2c0-19cd47ed427b", "recording_name": "Memories of Green", "listen_count": 1}, {"artist_name": "Brazilian Girls", "artist_mbids": ["8b2350de-b682-4fe7-ad8f-4508d7b6c697"], "recording_mbid": "9fc313fc-d213-42f9-984f-4405ccf74e23", "release_name": "Brazilian Girls", "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd", "recording_name": "Me Gustas Cuando Callas", "listen_count": 1}, {"artist_name": "Vangelis", "artist_mbids": ["57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"], "recording_mbid": "1f36b477-3b7c-4a34-a024-a042135fede8", "release_name": "Blade Runner (Music From The Original Soundtrack)", "release_mbid": "9792e059-f7af-4bce-90cf-9a2f78288c72", "recording_name": "Main Titles", "listen_count": 1}, {"artist_name": "Kiasmos", "artist_mbids": ["3252542b-98a7-48ba-9861-7a612b16c227"], "recording_mbid": "7133862a-0fd3-4d1c-9cb6-3be5e051af13", "release_name": "Kiasmos", "release_mbid": "73e4a3e9-bb1d-4243-9c1b-f285fc842248", "recording_name": "Lit", "listen_count": 1}, {"artist_name": "Kalabi", "artist_mbids": [], "release_name": "Support Network", "recording_name": "Like a Feather", "listen_count": 1}, {"artist_name": "Romare", "artist_mbids": ["b014d579-b549-4b21-b90d-5264e0433988"], "recording_mbid": "c497be4a-38f9-4cdd-9d8e-4701d8378067", "release_name": "Projections", "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc", "recording_name": "La Petite Mort", "listen_count": 1}, {"artist_name": "Kalabi", "artist_mbids": [], "release_name": "Support Network", "recording_name": "Keep Falling - Sleeping on the Job Mix", "listen_count": 1}, {"artist_name": "Massive Attack", "artist_mbids": ["10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"], "recording_mbid": "bffca891-5f37-47cf-a38f-4ba51a4d8e0f", "release_name": "Protection", "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5", "recording_name": "Karmacoma", "listen_count": 1}, {"artist_name": "Little People", "artist_mbids": ["78c94cba-761f-4212-8508-a24bda2e57dc"], "recording_mbid": "254c6a77-fa4c-4794-b51b-a3ad2a703bf2", "release_name": "Mickey Mouse Operation", "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05", "recording_name": "Intermezzo", "listen_count": 1}, {"artist_name": "Abakus", "artist_mbids": ["a8b39181-6939-451e-9641-2db231b73706"], "recording_mbid": "10dc3283-a3f1-4357-a74b-5983e1c1483f", "release_name": "Silent Geometry", "release_mbid": "6122ca09-a4ca-4d13-96c5-2b1ea502e7f5", "recording_name": "I Had a Dream Last Night", "listen_count": 1}, {"artist_name": "Daft Punk", "artist_mbids": ["056e4f3e-d505-4dad-8ec1-d04f521cbb56"], "recording_mbid": "4383e23d-59a3-4631-8727-0b3248061cf9", "release_name": "Random Access Memories", "release_mbid": "74fcd7f4-a2c8-4526-b350-558b157942bf", "recording_name": "Give Life Back to Music", "listen_count": 1}, {"artist_name": "All India Radio", "artist_mbids": ["53d2a4d1-556e-4701-a8ac-5fcb74a8e393"], "recording_mbid": "90d0380f-8541-4183-b8c5-fc891b0b361a", "release_name": "Echo Other", "release_mbid": "1a12cb18-84cc-4818-b748-2eceaa63de16", "recording_name": "Four Three", "listen_count": 1}, {"artist_name": "New Order", "artist_mbids": ["f1106b17-dcbb-45f6-b938-199ccfab50cc"], "recording_mbid": "1663fff2-09f4-4257-9aeb-06e53622b1f3", "release_name": "Technique", "release_mbid": "f63bfd08-a085-3a33-8d83-d396ab8d1f6d", "recording_name": "Dream Attack", "listen_count": 1}, {"artist_name": "Brazilian Girls", "artist_mbids": ["8b2350de-b682-4fe7-ad8f-4508d7b6c697"], "recording_mbid": "35e65392-7a92-414c-8fd8-357c7a01a557", "release_name": "Brazilian Girls", "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd", "recording_name": "Don't Stop", "listen_count": 1}, {"artist_name": "Brazilian Girls", "artist_mbids": [], "release_name": "Brazilian Girls", "recording_name": "Die Gedanken Sind Frei (Thoughts Are Free)", "listen_count": 1}, {"artist_name": "Little People, Rachael Roberts", "artist_mbids": ["78c94cba-761f-4212-8508-a24bda2e57dc", "bd43cb68-3a68-429e-9aad-6fc512f7df71"], "recording_mbid": "ba62d5d4-5fb7-4040-b3d0-a4f833482cdd", "release_name": "Mickey Mouse Operation", "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05", "recording_name": "Breathe Again", "listen_count": 1}, {"artist_name": "Vangelis", "artist_mbids": ["57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"], "recording_mbid": "1411b187-2c47-48ca-b44c-474514c4d3b9", "release_name": "Blade Runner (Music From The Original Soundtrack)", "release_mbid": "0efa1563-cbc7-4249-b6ec-fab766c38c81", "recording_name": "Blade Runner Blues", "listen_count": 1}, {"artist_name": "Massive Attack", "artist_mbids": ["10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"], "recording_mbid": "873aeb83-3911-4f75-a343-ec2a9f607a17", "release_name": "Protection", "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5", "recording_name": "Better Things", "listen_count": 1}, {"artist_name": "Brazilian Girls", "artist_mbids": ["8b2350de-b682-4fe7-ad8f-4508d7b6c697"], "recording_mbid": "9a0d552e-f763-4806-8772-0a6ad6dabd84", "release_name": "Brazilian Girls", "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd", "recording_name": "All We Have", "listen_count": 1}, {"artist_name": "Little People", "artist_mbids": ["78c94cba-761f-4212-8508-a24bda2e57dc"], "recording_mbid": "21ea50a4-a82e-48a7-a11d-40f9636e874e", "release_name": "Mickey Mouse Operation", "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05", "recording_name": "Above The Clouds", "listen_count": 1}, {"artist_name": "Aether", "artist_mbids": ["c44ff36b-651f-4c20-98ee-519cf4ed07e7"], "recording_mbid": "2bdb4900-eab3-4428-8a3c-2fc3d824ed48", "release_name": "Yamanote", "release_mbid": "b812901e-c598-4635-8b98-72eecf161060", "recording_name": "151018", "listen_count": 1}], "count": 41}, {"musicbrainz_id": "amCap1712", "type": "user_entity", "entity": "recordings", "stats_range": "all_time", "from_ts": 1009843200, "to_ts": 1628511763, "data": [{"artist_name": "Lucifer Cast, Tom Ellis", "artist_mbids": [], "release_name": "Lucifer: Season 5 - Bloody Celestial Karaoke Jam (Special Episode Soundtrack)", "recording_name": "Wicked Game (feat. Tom Ellis)", "listen_count": 5}, {"artist_name": "Katy Perry", "artist_mbids": ["122d63fc-8671-43e4-9752-34e846d62a9c"], "recording_mbid": "2d6f51c6-afc5-457e-9c58-689679c08d30", "release_name": "Teenage Dream", "release_mbid": "ae8288cf-134e-48bc-a146-f0a2ac35b322", "recording_name": "The One That Got Away", "listen_count": 5}, {"artist_name": "Klergy", "artist_mbids": ["5586fc31-7c41-4a2d-97a2-d358b58b250d"], "recording_mbid": "5fdcd356-600b-40d9-8ebe-9459fba2e6a1", "release_name": "And so It Begins", "release_mbid": "834d8732-8e2d-42b6-9496-55b067d0748f", "recording_name": "And so It Begins", "listen_count": 5}, {"artist_name": "Future, Marshmello", "artist_mbids": [], "release_name": "Mask Off (Marshmello Remix)", "recording_name": "Mask Off - Marshmello Remix", "listen_count": 4}, {"artist_name": "Guy Sebastian, Lupe Fiasco", "artist_mbids": ["cf15719f-51f9-4db8-a15d-5eed9664ce69", "f116b984-45ae-49d0-9445-efc5a61458a1"], "recording_mbid": "b9e26fa2-8d35-456b-ad09-b946d4e0675f", "release_name": "This Is Hip Hop", "release_mbid": "1760ede9-4041-4d64-982e-a8fa76b9ea51", "recording_name": "Battle Scars", "listen_count": 3}, {"artist_name": "Jon Bellion", "artist_mbids": ["2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"], "recording_mbid": "52534f30-d1c6-4313-b7e5-d58a171c7036", "release_name": "The Human Condition", "release_mbid": "7a5d7834-ff3b-4214-95eb-9b14332e9541", "recording_name": "All Time Low", "listen_count": 3}, {"artist_name": "Ursine Vulpine, Annaca", "artist_mbids": ["93cfee41-b1a6-4604-a01c-91243e6926e6", "43736f76-419a-42a0-816a-830876647ba5"], "recording_mbid": "6b7745aa-840c-4bea-b41d-b13c2dc625cc", "release_name": "Wicked Game", "release_mbid": "1355c8b7-f563-4ddc-8b00-620f4a63d081", "recording_name": "Wicked Game", "listen_count": 2}, {"artist_name": "X Ambassadors", "artist_mbids": ["298f4089-1948-44b5-b5e8-d5381f42362f"], "recording_mbid": "1dcae90f-2b49-484e-9e30-3fa7d19221a4", "release_name": "VHS", "release_mbid": "89b9a362-af9b-4a19-8e56-647355a73f39", "recording_name": "Renegades", "listen_count": 2}, {"artist_name": "Beyonc\u00e9", "artist_mbids": ["859d0860-d480-4efd-970c-c05d5f1776b8"], "recording_mbid": "899a043d-67bc-420c-85ea-6fee705baeb3", "release_name": "I Am... Sasha Fierce", "release_mbid": "e00b32b1-a697-4679-b085-52eb6bd5ffd9", "recording_name": "Halo", "listen_count": 2}, {"artist_name": "Bo Burnham", "artist_mbids": [], "release_name": "Inside (The Songs)", "recording_name": "Bezos I", "listen_count": 2}, {"artist_name": "Olivia Rodrigo", "artist_mbids": ["6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"], "recording_mbid": "dbcdb192-8e1f-47f5-9fd6-b6f5dcb2da1a", "release_name": "SOUR", "release_mbid": "92f78019-e5e6-4ce2-86ab-6057a8396f4a", "recording_name": "jealousy, jealousy", "listen_count": 1}, {"artist_name": "Olivia Rodrigo", "artist_mbids": ["6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"], "recording_mbid": "97aa087b-5fa2-42ff-bd48-d162862cdc95", "release_name": "SOUR", "release_mbid": "92f78019-e5e6-4ce2-86ab-6057a8396f4a", "recording_name": "good 4 u", "listen_count": 1}, {"artist_name": "Dua Lipa", "artist_mbids": ["6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"], "recording_mbid": "19ddd84f-0353-4d6e-99a1-f00c0aa22cd1", "release_name": "Ballermann Hits 2020 (XXL Zuhause Edition)", "release_mbid": "96a204c8-e368-436f-a1e6-37f13f302108", "recording_name": "Physical", "listen_count": 1}, {"artist_name": "Shakira", "artist_mbids": ["4f29ecd7-21a5-4c03-b9ba-d0cfe9488f8c", "bf24ca37-25f4-4e34-9aec-460b94364cfc"], "recording_mbid": "2c0b2787-307c-49e9-b2e9-5b1ddd6e713e", "release_mbid": "5fe133cb-d394-4089-a5e1-ec1e27bf4fe3", "recording_name": "Hips Don't Lie ft. Wyclef Jean", "listen_count": 1}, {"artist_name": "Beyonc\u00e9", "artist_mbids": ["859d0860-d480-4efd-970c-c05d5f1776b8"], "recording_mbid": "899a043d-67bc-420c-85ea-6fee705baeb3", "release_name": "I AM...SASHA FIERCE - Platinum Edition", "release_mbid": "2866428a-8a00-354d-af5c-0648746a1202", "recording_name": "Halo", "listen_count": 1}, {"artist_name": "Harry Styles", "artist_mbids": ["7eb1ce54-a355-41f9-8d68-e018b096d427"], "recording_mbid": "c3551fa7-ee72-4295-8fbd-a2d203dd17b6", "release_name": "Fine Line", "release_mbid": "c6a3c8a1-1c6e-4fef-a3f4-6b24eb064c19", "recording_name": "Golden", "listen_count": 1}, {"artist_name": "*NSYNC", "artist_mbids": ["603ba565-3967-4be1-931e-9cb945394e86"], "recording_mbid": "5aa053a9-5b84-418f-bb3c-d61df67b3880", "release_name": "No Strings Attached", "release_mbid": "5f68e32a-ccc1-4b01-a4de-daa880bf3864", "recording_name": "Bye Bye Bye", "listen_count": 1}, {"artist_name": "Dua Lipa", "artist_mbids": ["6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"], "recording_mbid": "ba2a214d-39b0-4b53-8b20-b2b80cf9bfab", "release_name": "Now That's What I Call Music Vol. 83", "release_mbid": "315bbc48-dea9-463c-bfa9-a6ccab78b990", "recording_name": "Break My Heart", "listen_count": 1}], "count": 18}]
+[
+    {
+        "musicbrainz_id": "rob",
+        "type": "user_entity",
+        "entity": "recordings",
+        "stats_range": "all_time",
+        "from_ts": 1009843200,
+        "to_ts": 1628511763,
+        "data": [
+            {
+                "artist_name": "Portishead",
+                "artist_mbids": [
+                    "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+                ],
+                "recording_mbid": "a7ed3365-affa-4331-8bd9-1ececaf9ae77",
+                "release_name": "Third",
+                "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741",
+                "track_name": "The Rip",
+                "listen_count": 2
+            },
+            {
+                "artist_name": "Portishead",
+                "artist_mbids": [
+                    "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+                ],
+                "recording_mbid": "8855e971-0570-4d20-9258-4b7ed7441f10",
+                "release_name": "Third",
+                "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741",
+                "track_name": "Plastic",
+                "listen_count": 2
+            },
+            {
+                "artist_name": "Massive Attack",
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+                ],
+                "recording_mbid": "e69db070-8ff6-47bc-ab5f-d0291ee08dc6",
+                "release_name": "Protection",
+                "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5",
+                "track_name": "Euro Child",
+                "listen_count": 2
+            },
+            {
+                "artist_name": "Aether",
+                "artist_mbids": [
+                    "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
+                ],
+                "recording_mbid": "bb7601d3-f006-4421-83c9-d71e35962a95",
+                "release_name": "Yamanote",
+                "release_mbid": "b812901e-c598-4635-8b98-72eecf161060",
+                "track_name": "You Still Echo Here",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Aether",
+                "artist_mbids": [
+                    "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
+                ],
+                "recording_mbid": "40e085a0-9637-42a6-88f7-d5e12c793854",
+                "release_name": "Yamanote",
+                "release_mbid": "b812901e-c598-4635-8b98-72eecf161060",
+                "track_name": "Yamanote",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Jah Wobble, Marconi Union",
+                "artist_mbids": [
+                    "904cc1c8-021e-45ac-bbe9-95c01a1f8099",
+                    "3f9b5837-ed1c-413e-bfef-ca4f892dcc59"
+                ],
+                "recording_mbid": "0ca2a698-7280-4b40-a357-ca966bbd3a96",
+                "release_name": "Anomic",
+                "release_mbid": "39967fee-e436-4f87-b36e-299aae4dc670",
+                "track_name": "Wealth",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Portishead",
+                "artist_mbids": [
+                    "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+                ],
+                "recording_mbid": "b00efba7-0d88-478c-97ad-257aef64cc27",
+                "release_name": "Third",
+                "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741",
+                "track_name": "We Carry On",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "The Egg",
+                "artist_mbids": [
+                    "6fe91ae9-8ddb-47b0-a2d7-252833ce5500"
+                ],
+                "recording_mbid": "975f5943-6c9b-45c2-a219-8f5c34b11014",
+                "release_name": "Forwards (Special Edition)",
+                "release_mbid": "af6fdf7a-fcb0-46f9-b8c5-517fe8cb3e5d",
+                "track_name": "Venice Beach",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "The Polish Ambassador",
+                "artist_mbids": [
+                    "e9787dd2-5857-4b51-8e59-a190a54820fc"
+                ],
+                "recording_mbid": "1991c5e5-053a-4222-ad04-7d84cc11907c",
+                "release_name": "Ecozoic",
+                "release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf",
+                "track_name": "Two and a Half Moons Away",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Sounds From The Ground",
+                "artist_mbids": [
+                    "9806e551-9a63-4a9d-be1b-5297b2ac0e76"
+                ],
+                "recording_mbid": "986257af-4ed5-4e6e-bb68-a4e6f03eb284",
+                "release_name": "Mosaic Remastered",
+                "release_mbid": "2f7634f3-3bb5-4f2c-9821-d150e8415fb8",
+                "track_name": "Treasure",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Romare",
+                "artist_mbids": [
+                    "b014d579-b549-4b21-b90d-5264e0433988"
+                ],
+                "recording_mbid": "5176acc7-1b58-4434-ba16-d76e3ca094cd",
+                "release_name": "Projections",
+                "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc",
+                "track_name": "The Drifter",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Aether",
+                "artist_mbids": [
+                    "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
+                ],
+                "recording_mbid": "c626c408-ecbb-47ac-a3d8-961a072d0819",
+                "release_name": "Yamanote",
+                "release_mbid": "b812901e-c598-4635-8b98-72eecf161060",
+                "track_name": "Sunshine City",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Ott",
+                "artist_mbids": [
+                    "1a40f886-0877-4bab-9ab1-761147dadb89"
+                ],
+                "recording_mbid": "19cdfa84-f4ec-4e1d-8595-ed2bc4e295d4",
+                "release_name": "Blumenkraft",
+                "release_mbid": "99e39642-cae5-4061-9800-751108bc650b",
+                "track_name": "Splitting an Atom",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Massive Attack",
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+                ],
+                "recording_mbid": "f837bff5-faf2-4323-81de-91f056207a42",
+                "release_name": "Protection",
+                "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5",
+                "track_name": "Sly",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Portishead",
+                "artist_mbids": [
+                    "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+                ],
+                "recording_mbid": "83b416db-4ee1-4560-a3b3-52fd453eb285",
+                "release_name": "Third",
+                "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741",
+                "track_name": "Silence",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "The Polish Ambassador",
+                "artist_mbids": [
+                    "e9787dd2-5857-4b51-8e59-a190a54820fc"
+                ],
+                "recording_mbid": "82ac2959-a2d6-4f41-be9f-50bac0976fd1",
+                "release_name": "Ecozoic",
+                "release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf",
+                "track_name": "Rootshine Revival",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Massive Attack, Tracey Thorn",
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8",
+                    "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f"
+                ],
+                "recording_mbid": "535b2d75-ce44-41a5-9d7c-12318d219dd4",
+                "release_name": "Protection",
+                "release_mbid": "91231e74-2674-411e-968f-b188bb67b711",
+                "track_name": "Protection",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Romare",
+                "artist_mbids": [
+                    "b014d579-b549-4b21-b90d-5264e0433988"
+                ],
+                "recording_mbid": "90fb24e7-3b50-4043-a5f1-2c3a78d692f0",
+                "release_name": "Projections",
+                "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc",
+                "track_name": "Prison Blues",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Romare",
+                "artist_mbids": [
+                    "b014d579-b549-4b21-b90d-5264e0433988"
+                ],
+                "recording_mbid": "d58ebf31-6e08-4baa-857f-2e43f4ff8f0f",
+                "release_name": "Projections",
+                "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc",
+                "track_name": "Nina's Charm",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Little People",
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc"
+                ],
+                "recording_mbid": "793f88ed-2e8c-4cdc-b042-8920877a82fc",
+                "release_name": "Mickey Mouse Operation",
+                "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05",
+                "track_name": "Moon",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Vangelis",
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "recording_mbid": "349101b9-0570-4859-9ad7-f939ea4e68ab",
+                "release_name": "Blade Runner (Music From The Original Soundtrack)",
+                "release_mbid": "d619edca-d766-36b3-a2c0-19cd47ed427b",
+                "track_name": "Memories of Green",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Brazilian Girls",
+                "artist_mbids": [
+                    "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
+                ],
+                "recording_mbid": "9fc313fc-d213-42f9-984f-4405ccf74e23",
+                "release_name": "Brazilian Girls",
+                "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd",
+                "track_name": "Me Gustas Cuando Callas",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Vangelis",
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "recording_mbid": "1f36b477-3b7c-4a34-a024-a042135fede8",
+                "release_name": "Blade Runner (Music From The Original Soundtrack)",
+                "release_mbid": "9792e059-f7af-4bce-90cf-9a2f78288c72",
+                "track_name": "Main Titles",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Kiasmos",
+                "artist_mbids": [
+                    "3252542b-98a7-48ba-9861-7a612b16c227"
+                ],
+                "recording_mbid": "7133862a-0fd3-4d1c-9cb6-3be5e051af13",
+                "release_name": "Kiasmos",
+                "release_mbid": "73e4a3e9-bb1d-4243-9c1b-f285fc842248",
+                "track_name": "Lit",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Kalabi",
+                "artist_mbids": [],
+                "release_name": "Support Network",
+                "track_name": "Like a Feather",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Romare",
+                "artist_mbids": [
+                    "b014d579-b549-4b21-b90d-5264e0433988"
+                ],
+                "recording_mbid": "c497be4a-38f9-4cdd-9d8e-4701d8378067",
+                "release_name": "Projections",
+                "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc",
+                "track_name": "La Petite Mort",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Kalabi",
+                "artist_mbids": [],
+                "release_name": "Support Network",
+                "track_name": "Keep Falling - Sleeping on the Job Mix",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Massive Attack",
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+                ],
+                "recording_mbid": "bffca891-5f37-47cf-a38f-4ba51a4d8e0f",
+                "release_name": "Protection",
+                "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5",
+                "track_name": "Karmacoma",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Little People",
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc"
+                ],
+                "recording_mbid": "254c6a77-fa4c-4794-b51b-a3ad2a703bf2",
+                "release_name": "Mickey Mouse Operation",
+                "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05",
+                "track_name": "Intermezzo",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Abakus",
+                "artist_mbids": [
+                    "a8b39181-6939-451e-9641-2db231b73706"
+                ],
+                "recording_mbid": "10dc3283-a3f1-4357-a74b-5983e1c1483f",
+                "release_name": "Silent Geometry",
+                "release_mbid": "6122ca09-a4ca-4d13-96c5-2b1ea502e7f5",
+                "track_name": "I Had a Dream Last Night",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Daft Punk",
+                "artist_mbids": [
+                    "056e4f3e-d505-4dad-8ec1-d04f521cbb56"
+                ],
+                "recording_mbid": "4383e23d-59a3-4631-8727-0b3248061cf9",
+                "release_name": "Random Access Memories",
+                "release_mbid": "74fcd7f4-a2c8-4526-b350-558b157942bf",
+                "track_name": "Give Life Back to Music",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "All India Radio",
+                "artist_mbids": [
+                    "53d2a4d1-556e-4701-a8ac-5fcb74a8e393"
+                ],
+                "recording_mbid": "90d0380f-8541-4183-b8c5-fc891b0b361a",
+                "release_name": "Echo Other",
+                "release_mbid": "1a12cb18-84cc-4818-b748-2eceaa63de16",
+                "track_name": "Four Three",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "New Order",
+                "artist_mbids": [
+                    "f1106b17-dcbb-45f6-b938-199ccfab50cc"
+                ],
+                "recording_mbid": "1663fff2-09f4-4257-9aeb-06e53622b1f3",
+                "release_name": "Technique",
+                "release_mbid": "f63bfd08-a085-3a33-8d83-d396ab8d1f6d",
+                "track_name": "Dream Attack",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Brazilian Girls",
+                "artist_mbids": [
+                    "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
+                ],
+                "recording_mbid": "35e65392-7a92-414c-8fd8-357c7a01a557",
+                "release_name": "Brazilian Girls",
+                "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd",
+                "track_name": "Don't Stop",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Brazilian Girls",
+                "artist_mbids": [],
+                "release_name": "Brazilian Girls",
+                "track_name": "Die Gedanken Sind Frei (Thoughts Are Free)",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Little People, Rachael Roberts",
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc",
+                    "bd43cb68-3a68-429e-9aad-6fc512f7df71"
+                ],
+                "recording_mbid": "ba62d5d4-5fb7-4040-b3d0-a4f833482cdd",
+                "release_name": "Mickey Mouse Operation",
+                "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05",
+                "track_name": "Breathe Again",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Vangelis",
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "recording_mbid": "1411b187-2c47-48ca-b44c-474514c4d3b9",
+                "release_name": "Blade Runner (Music From The Original Soundtrack)",
+                "release_mbid": "0efa1563-cbc7-4249-b6ec-fab766c38c81",
+                "track_name": "Blade Runner Blues",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Massive Attack",
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+                ],
+                "recording_mbid": "873aeb83-3911-4f75-a343-ec2a9f607a17",
+                "release_name": "Protection",
+                "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5",
+                "track_name": "Better Things",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Brazilian Girls",
+                "artist_mbids": [
+                    "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
+                ],
+                "recording_mbid": "9a0d552e-f763-4806-8772-0a6ad6dabd84",
+                "release_name": "Brazilian Girls",
+                "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd",
+                "track_name": "All We Have",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Little People",
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc"
+                ],
+                "recording_mbid": "21ea50a4-a82e-48a7-a11d-40f9636e874e",
+                "release_name": "Mickey Mouse Operation",
+                "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05",
+                "track_name": "Above The Clouds",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Aether",
+                "artist_mbids": [
+                    "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
+                ],
+                "recording_mbid": "2bdb4900-eab3-4428-8a3c-2fc3d824ed48",
+                "release_name": "Yamanote",
+                "release_mbid": "b812901e-c598-4635-8b98-72eecf161060",
+                "track_name": "151018",
+                "listen_count": 1
+            }
+        ],
+        "count": 41
+    },
+    {
+        "musicbrainz_id": "amCap1712",
+        "type": "user_entity",
+        "entity": "recordings",
+        "stats_range": "all_time",
+        "from_ts": 1009843200,
+        "to_ts": 1628511763,
+        "data": [
+            {
+                "artist_name": "Lucifer Cast, Tom Ellis",
+                "artist_mbids": [],
+                "release_name": "Lucifer: Season 5 - Bloody Celestial Karaoke Jam (Special Episode Soundtrack)",
+                "track_name": "Wicked Game (feat. Tom Ellis)",
+                "listen_count": 5
+            },
+            {
+                "artist_name": "Katy Perry",
+                "artist_mbids": [
+                    "122d63fc-8671-43e4-9752-34e846d62a9c"
+                ],
+                "recording_mbid": "2d6f51c6-afc5-457e-9c58-689679c08d30",
+                "release_name": "Teenage Dream",
+                "release_mbid": "ae8288cf-134e-48bc-a146-f0a2ac35b322",
+                "track_name": "The One That Got Away",
+                "listen_count": 5
+            },
+            {
+                "artist_name": "Klergy",
+                "artist_mbids": [
+                    "5586fc31-7c41-4a2d-97a2-d358b58b250d"
+                ],
+                "recording_mbid": "5fdcd356-600b-40d9-8ebe-9459fba2e6a1",
+                "release_name": "And so It Begins",
+                "release_mbid": "834d8732-8e2d-42b6-9496-55b067d0748f",
+                "track_name": "And so It Begins",
+                "listen_count": 5
+            },
+            {
+                "artist_name": "Future, Marshmello",
+                "artist_mbids": [],
+                "release_name": "Mask Off (Marshmello Remix)",
+                "track_name": "Mask Off - Marshmello Remix",
+                "listen_count": 4
+            },
+            {
+                "artist_name": "Guy Sebastian, Lupe Fiasco",
+                "artist_mbids": [
+                    "cf15719f-51f9-4db8-a15d-5eed9664ce69",
+                    "f116b984-45ae-49d0-9445-efc5a61458a1"
+                ],
+                "recording_mbid": "b9e26fa2-8d35-456b-ad09-b946d4e0675f",
+                "release_name": "This Is Hip Hop",
+                "release_mbid": "1760ede9-4041-4d64-982e-a8fa76b9ea51",
+                "track_name": "Battle Scars",
+                "listen_count": 3
+            },
+            {
+                "artist_name": "Jon Bellion",
+                "artist_mbids": [
+                    "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"
+                ],
+                "recording_mbid": "52534f30-d1c6-4313-b7e5-d58a171c7036",
+                "release_name": "The Human Condition",
+                "release_mbid": "7a5d7834-ff3b-4214-95eb-9b14332e9541",
+                "track_name": "All Time Low",
+                "listen_count": 3
+            },
+            {
+                "artist_name": "Ursine Vulpine, Annaca",
+                "artist_mbids": [
+                    "93cfee41-b1a6-4604-a01c-91243e6926e6",
+                    "43736f76-419a-42a0-816a-830876647ba5"
+                ],
+                "recording_mbid": "6b7745aa-840c-4bea-b41d-b13c2dc625cc",
+                "release_name": "Wicked Game",
+                "release_mbid": "1355c8b7-f563-4ddc-8b00-620f4a63d081",
+                "track_name": "Wicked Game",
+                "listen_count": 2
+            },
+            {
+                "artist_name": "X Ambassadors",
+                "artist_mbids": [
+                    "298f4089-1948-44b5-b5e8-d5381f42362f"
+                ],
+                "recording_mbid": "1dcae90f-2b49-484e-9e30-3fa7d19221a4",
+                "release_name": "VHS",
+                "release_mbid": "89b9a362-af9b-4a19-8e56-647355a73f39",
+                "track_name": "Renegades",
+                "listen_count": 2
+            },
+            {
+                "artist_name": "Beyonc\u00e9",
+                "artist_mbids": [
+                    "859d0860-d480-4efd-970c-c05d5f1776b8"
+                ],
+                "recording_mbid": "899a043d-67bc-420c-85ea-6fee705baeb3",
+                "release_name": "I Am... Sasha Fierce",
+                "release_mbid": "e00b32b1-a697-4679-b085-52eb6bd5ffd9",
+                "track_name": "Halo",
+                "listen_count": 2
+            },
+            {
+                "artist_name": "Bo Burnham",
+                "artist_mbids": [],
+                "release_name": "Inside (The Songs)",
+                "track_name": "Bezos I",
+                "listen_count": 2
+            },
+            {
+                "artist_name": "Olivia Rodrigo",
+                "artist_mbids": [
+                    "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
+                ],
+                "recording_mbid": "dbcdb192-8e1f-47f5-9fd6-b6f5dcb2da1a",
+                "release_name": "SOUR",
+                "release_mbid": "92f78019-e5e6-4ce2-86ab-6057a8396f4a",
+                "track_name": "jealousy, jealousy",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Olivia Rodrigo",
+                "artist_mbids": [
+                    "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
+                ],
+                "recording_mbid": "97aa087b-5fa2-42ff-bd48-d162862cdc95",
+                "release_name": "SOUR",
+                "release_mbid": "92f78019-e5e6-4ce2-86ab-6057a8396f4a",
+                "track_name": "good 4 u",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Dua Lipa",
+                "artist_mbids": [
+                    "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"
+                ],
+                "recording_mbid": "19ddd84f-0353-4d6e-99a1-f00c0aa22cd1",
+                "release_name": "Ballermann Hits 2020 (XXL Zuhause Edition)",
+                "release_mbid": "96a204c8-e368-436f-a1e6-37f13f302108",
+                "track_name": "Physical",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Shakira",
+                "artist_mbids": [
+                    "4f29ecd7-21a5-4c03-b9ba-d0cfe9488f8c",
+                    "bf24ca37-25f4-4e34-9aec-460b94364cfc"
+                ],
+                "recording_mbid": "2c0b2787-307c-49e9-b2e9-5b1ddd6e713e",
+                "release_mbid": "5fe133cb-d394-4089-a5e1-ec1e27bf4fe3",
+                "track_name": "Hips Don't Lie ft. Wyclef Jean",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Beyonc\u00e9",
+                "artist_mbids": [
+                    "859d0860-d480-4efd-970c-c05d5f1776b8"
+                ],
+                "recording_mbid": "899a043d-67bc-420c-85ea-6fee705baeb3",
+                "release_name": "I AM...SASHA FIERCE - Platinum Edition",
+                "release_mbid": "2866428a-8a00-354d-af5c-0648746a1202",
+                "track_name": "Halo",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Harry Styles",
+                "artist_mbids": [
+                    "7eb1ce54-a355-41f9-8d68-e018b096d427"
+                ],
+                "recording_mbid": "c3551fa7-ee72-4295-8fbd-a2d203dd17b6",
+                "release_name": "Fine Line",
+                "release_mbid": "c6a3c8a1-1c6e-4fef-a3f4-6b24eb064c19",
+                "track_name": "Golden",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "*NSYNC",
+                "artist_mbids": [
+                    "603ba565-3967-4be1-931e-9cb945394e86"
+                ],
+                "recording_mbid": "5aa053a9-5b84-418f-bb3c-d61df67b3880",
+                "release_name": "No Strings Attached",
+                "release_mbid": "5f68e32a-ccc1-4b01-a4de-daa880bf3864",
+                "track_name": "Bye Bye Bye",
+                "listen_count": 1
+            },
+            {
+                "artist_name": "Dua Lipa",
+                "artist_mbids": [
+                    "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"
+                ],
+                "recording_mbid": "ba2a214d-39b0-4b53-8b20-b2b80cf9bfab",
+                "release_name": "Now That's What I Call Music Vol. 83",
+                "release_mbid": "315bbc48-dea9-463c-bfa9-a6ccab78b990",
+                "track_name": "Break My Heart",
+                "listen_count": 1
+            }
+        ],
+        "count": 18
+    }
+]


### PR DESCRIPTION
The new Spark parquet dumps use different field names (recording_name vs track_name) and omit the msid fields entirely. The will make the new API responses incompatible and hence an API breaking change. We modify the pydantic models to add fields and rename where needed to maintain API compatibility. 