### PR TITLE
LB-505: Update Flask-Login to 0.5.0

### DIFF
--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -12,7 +12,7 @@ class ServerTestCase(flask_testing.TestCase):
 
     def temporary_login(self, user_login_id):
         with self.client.session_transaction() as session:
-            session['user_id'] = user_login_id
+            session['_user_id'] = user_login_id
             session['_fresh'] = True
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask-Admin == 1.5.7
 Flask-Testing == 0.8.1
-Flask-Login == 0.4.1
+Flask-Login == 0.5.0
 Flask-WTF == 0.14.3
 Flask-SQLAlchemy == 2.4.4
 Flask-UUID == 0.2


### PR DESCRIPTION
The new versions seems to be compatible with the previous version we were using. Only an implementation detail we rely on for testing has changed. The fix is trivial to rename user_id to _user_id to match the name used by Flask-Login internally.