### PR TITLE
Add trailing slash to MB OAuth Callback URL in docs

### DIFF
--- a/docs/dev/devel-env.rst
+++ b/docs/dev/devel-env.rst
@@ -46,7 +46,7 @@ option to `register`_ your application. Fill out the form with the following dat
 
 - **Type**: ``Web Application``
 
-- **Callback URL**: ``http://localhost/login/musicbrainz/post``
+- **Callback URL**: ``http://localhost/login/musicbrainz/post/``
 
 After entering this information, you'll have an OAuth client ID and OAuth client
 secret. You'll use these for configuring ListenBrainz.


### PR DESCRIPTION
When registering for a MusicBrainz application, without including a trailing slash in the callback url, trying to authenticate gives a mismatched url error when trying to authenticate, this should be updated in the docs.
![image](https://user-images.githubusercontent.com/57575778/131191351-395a4d62-ac45-4956-a6fc-3ad53a63788a.png)
