### PR TITLE
Gracefully handle errors due to invalid oauth codes

### DIFF
--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -6,6 +6,8 @@ from listenbrainz.webserver import flash
 import listenbrainz.db.user as db_user
 import datetime
 
+from listenbrainz.webserver.login.provider import MusicBrainzAuthSessionError, MusicBrainzAuthNoEmailError
+
 login_bp = Blueprint('login', __name__)
 
 
@@ -26,29 +28,32 @@ def musicbrainz():
 @login_forbidden
 def musicbrainz_post():
     """Callback endpoint."""
+
+    no_email_warning = Markup('You have not provided an email address. Please provide an '
+                              '<a href="https://musicbrainz.org/account/edit">email address</a> ')
+    blog_link = Markup('Read this <a href="https://blog.metabrainz.org/?p=8915">blog post</a> '
+                       'to understand why we need your email.')
+
     if provider.validate_post_login():
-        user = provider.get_user()
-        no_email_warning = Markup('You have not provided an email address. Please provide an '
-                                  '<a href="https://musicbrainz.org/account/edit">email address</a> ')
-        blog_link = Markup('Read this <a href="https://blog.metabrainz.org/?p=8915">blog post</a> '
-                           'to understand why we need your email.')
+        try:
+            user = provider.get_user()
+            if current_app.config["REJECT_NEW_USERS_WITHOUT_EMAIL"] and not user["email"]:
+                # existing user without email, show a warning
+                flash.warning(no_email_warning + 'before 1 November 2021, or you will be unable to submit '
+                                                 'listens. ' + blog_link)
 
-        if not user:  # new user without email tried to create an account
+            db_user.update_last_login(user["musicbrainz_id"])
+            login_user(User.from_dbrow(user),
+                       remember=True,
+                       duration=datetime.timedelta(current_app.config['SESSION_REMEMBER_ME_DURATION']))
+            next = session.get('next')
+            if next:
+                return redirect(next)
+        except MusicBrainzAuthSessionError:
+            flash.error("Login failed.")
+        except MusicBrainzAuthNoEmailError:
+            # new user without email tried to create an account
             flash.error(no_email_warning + 'before creating a ListenBrainz account. ' + blog_link)
-            return redirect(url_for('index.index'))
-
-        if current_app.config["REJECT_NEW_USERS_WITHOUT_EMAIL"] and not user["email"]:
-            # existing user without email, show a warning
-            flash.warning(no_email_warning + 'before 1 November 2021, or you will be unable to submit '
-                                             'listens. ' + blog_link)
-
-        db_user.update_last_login(user["musicbrainz_id"])
-        login_user(User.from_dbrow(user),
-                   remember=True,
-                   duration=datetime.timedelta(current_app.config['SESSION_REMEMBER_ME_DURATION']))
-        next = session.get('next')
-        if next:
-            return redirect(next)
     else:
         flash.error("Login failed.")
     return redirect(url_for('index.index'))


### PR DESCRIPTION
# Problem

Identified in https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/145812/?environment=production&referrer=alert_email

Although it doesn't happen in a normal successful oauth flow, there are some cases where a manually constructed URL with an invalid `code` parameter could cause an uncaught exception. 


# Solution

Handle the situation where:
 * the auth code isn't valid on the musicbrainz end, therefore returning an error message
 * the response from musicbrainz isn't valid json

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

I added another exception to handle the case where the user has no email address, but I didn't test this in detail. The behaviour should be the same. It might be worth checking it again with a test user to verify that this works as expected.

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


