### PR TITLE
Allow incremental dumps to be imported without a public archive

### DIFF
--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -241,7 +241,7 @@ def create_feedback(location, threads):
 
 @cli.command(name="import_dump")
 @click.option('--private-archive', '-pr', default=None, required=False)
-@click.option('--public-archive', '-pu', default=None, required=True)
+@click.option('--public-archive', '-pu', default=None, required=False)
 @click.option('--listen-archive', '-l', default=None, required=True)
 @click.option('--threads', '-t', type=int, default=DUMP_DEFAULT_THREAD_COUNT)
 def import_dump(private_archive, public_archive, listen_archive, threads):


### PR DESCRIPTION
# Problem

Someone wanting to keep an LB mirror or development environment up to date might want to import daily incremental listen dumps. We only publish a _public_ dump twice a month, and so it makes no sense to import this multiple times when it hasn't changed.

# Solution
make the _public_ dump argument optional.


# Action

It's possible that listens in an incremental dump may be related to a user who was created since the last public dump was made. This means that the mirror database may include listens for a user for who there is no matching user row. As listens are in a separate database with no fk to the user table this won't cause a data integrity issue, however we may wish in the future to provide incremental public dumps that allow us to import new users as well.


