### PR TITLE
Monkey refactor date year

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -243,7 +243,6 @@ const preciseTimestamp = (
     const now = new Date();
     const currentYear = now.getUTCFullYear();
     const listenYear = listenDate.getUTCFullYear();
-    const msDifference = now.getTime() - listenDate.getTime();
     // Date is today : format using timeago
     if (
       now.getUTCDate() === listenDate.getUTCDate() &&

--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -240,17 +240,26 @@ const preciseTimestamp = (
 
   // determine which display setting based on time difference to use if no argument was provided
   if (!display) {
-    const msDifference = new Date().getTime() - listenDate.getTime();
-    // over one year old : show with year
-    if (msDifference / (1000 * 3600 * 24 * 365) > 1) {
-      display = "includeYear";
+    const now = new Date();
+    const currentYear = now.getUTCFullYear();
+    const listenYear = listenDate.getUTCFullYear();
+    const msDifference = now.getTime() - listenDate.getTime();
+    // Date is today : format using timeago
+    if (
+      now.getUTCDate() === listenDate.getUTCDate() &&
+      now.getUTCMonth() === listenDate.getUTCMonth() &&
+      currentYear === listenYear
+    ) {
+      display = "timeAgo";
     }
-    // one year to yesterday : show without year
-    else if (msDifference / (1000 * 3600 * 24 * 1) > 1) {
+    // Date is this current year, don't show the year
+    else if (currentYear === listenYear) {
       display = "excludeYear";
     }
-    // today : format using timeago
-    else display = "timeAgo";
+    // Not this year, show the year
+    else {
+      display = "includeYear";
+    }
   }
 
   switch (display) {


### PR DESCRIPTION
Context: https://chatlogs.metabrainz.org/libera/metabrainz/2021-09-02/?msg=4854802&page=1

Previously the year was shown on the listen card date only if the listen was from > 1 year ago.
It was confusing to not show the year for example now in September 2021 for a listen from November 2020; it would only show November Xth but no year.

Instead, we all agree it is more convenient (and what we all expect) to show the listen is not from _this year_