### PR TITLE
LB-442, LB-321: Update listen format documentation to include source and origin_url

### DIFF
--- a/docs/dev/json.rst
+++ b/docs/dev/json.rst
@@ -81,7 +81,9 @@ A complete submit listen JSON document may look like:
           "listened_at": 1443521965,
           "track_metadata": {
             "additional_info": {
-              "listening_from": "spotify",
+              "media_player": "Rhythmbox",
+              "submission_client": "Rhythmbox ListenBrainz Plugin",
+              "submission_client_version": "1.0",
               "release_mbid": "bf9e91ea-8029-4a04-a26a-224e00a83266",
               "artist_mbids": [
                 "db92a151-1ac2-438b-bc43-b82e149ddd50"
@@ -164,23 +166,200 @@ element                 description
 The following optional elements may also be included in the ``additional_info`` element. If you do not have
 the data for any of the following fields, omit the key entirely:
 
-======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
-element                 description
-======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
-``artist_mbids``        A list of MusicBrainz Artist IDs, one or more Artist IDs may be included here. If you have a complete MusicBrainz artist credit that contains multiple Artist IDs, include them all in this list.
-``release_group_mbid``  A MusicBrainz Release Group ID of the release group this recording was played from.
-``release_mbid``        A MusicBrainz Release ID of the release this recording was played from.
-``recording_mbid``      A MusicBrainz Recording ID of the recording that was played.
-``track_mbid``          A MusicBrainz Track ID associated with the recording that was played.
-``work_mbids``          A list of MusicBrainz Work IDs that may be associated with this recording.
-``tracknumber``         The tracknumber of the recording. This first recording on a release is tracknumber 1.
-``isrc``                The ISRC code associated with the recording.
-``spotify_id``          The Spotify track URL associated with this recording.  e.g.: http://open.spotify.com/track/1rrgWMXGCGHru5bIRxGFV0
-``tags``                A list of user defined tags to be associated with this recording. These tags are similar to last.fm tags. For example, you have apply tags such as ``punk``, ``see-live``, ``smelly``. You may submit up to :data:`~webserver.views.api.MAX_TAGS_PER_LISTEN` tags and each tag may be up to :data:`~webserver.views.api.MAX_TAG_SIZE` characters large.
-``listening_from``       The source of the listen, i.e the name of the client or service which submits the listen.
-======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
+.. list-table:: Title
+   :widths: 25 50
+   :header-rows: 1
 
-At this point, we are not scrubbing any superflous elements that may be
+   * - element
+     - description
+   * - ``artist_mbids``
+     - A list of MusicBrainz Artist IDs, one or more Artist IDs may be included here. If you have a complete MusicBrainz artist credit that contains multiple Artist IDs, include them all in this list.
+   * - ``release_group_mbid``
+     - A MusicBrainz Release Group ID of the release group this recording was played from.
+   * - ``release_mbid``
+     - A MusicBrainz Release ID of the release this recording was played from.
+   * - ``recording_mbid``
+     - A MusicBrainz Recording ID of the recording that was played.
+   * - ``track_mbid``
+     - A MusicBrainz Track ID associated with the recording that was played.
+   * - ``work_mbids``
+     - A list of MusicBrainz Work IDs that may be associated with this recording.
+   * - ``tracknumber``
+     - The tracknumber of the recording. This first recording on a release is tracknumber 1.
+   * - ``isrc``
+     - The ISRC code associated with the recording.
+   * - ``spotify_id``
+     - The Spotify track URL associated with this recording.  e.g.: http://open.spotify.com/track/1rrgWMXGCGHru5bIRxGFV0
+   * - ``tags``
+     - A list of user-defined folksonomy tags to be associated with this recording. For example, you have apply tags such as ``punk``, ``see-live``, ``smelly``. You may submit up to :data:`~webserver.views.api.MAX_TAGS_PER_LISTEN` tags and each tag may be up to :data:`~webserver.views.api.MAX_TAG_SIZE` characters large.
+   * - ``media_player``
+     - The name of the program being used to listen to music. Don't include a version number here.
+   * - ``media_player_version``
+     - The version of the program being used to listen to music.
+   * - ``submission_client``
+     - The name of the client that is being used to submit listens to ListenBrainz. If the media player has the ability to submit listens built-in then this value may be the same as ``media_player``. Don't include a version number here.
+   * - ``submission_client_version``
+     - The version of the submission client.
+   * - ``music_service``
+     - If the song being listened to comes from an online service, the canonical domain of this service (see below for more details).
+   * - ``music_service_name``
+     - If the song being listened to comes from an online service and you don't know the canonical domain, a name that represents the service.
+   * - ``origin_url``
+     - If the song of this listen comes from an online source, the URL to the place where it is available. This could be a spotify url (see ``spotify_id``), a YouTube video URL, a Soundcloud recording page URL, or the full URL to a public MP3 file. If there is a webpage for this song (e.g. Youtube page, Soundcloud page) **do not** try and resolve the URL to an actual audio resource.
+
+.. note::
+
+  **Music service names**
+
+  The ``music_service`` field should be a domain name rather than a textual description or URL. This allows us to refer unambiguously to a service without worrying
+  about capitalization or full/short names (such as the difference between "Internet Archive", "The Internet Archive" or "Archive").
+  If we use this data on ListenBrainz, we will perform a mapping from the domain name to a canonical name. Below is an example of mappings that we currently support.
+  If you are submitting from a service which doesn't appear in this list, you should determine a canonical domain from the domain of the service.
+  Only if you cannot determine a domain for the service should you use the text-only ``music_service_name`` field.
+
+  .. list-table:: Music services domain/name mapping
+     :widths: 25 50
+     :header-rows: 1
+
+     * - domain
+       - name
+     * - ``spotify.com``
+       - Spotify
+     * - ``bandcamp.com``
+       - Bandcamp
+     * - ``youtube.com``
+       - YouTube
+     * - ``music.youtube.com``
+       - YouTube Music
+     * - ``deezer.com``
+       - Deezer
+     * - ``tidal.com``
+       - TIDAL
+     * - ``music.apple.com``
+       - Apple Music
+     * - ``archive.org``
+       - Internet Archive
+     * - ``soundcloud.com``
+       - Soudcloud
+     * - ``jamendo.com``
+       - Jamendo Music
+     * - ``play.google.com``
+       - Google Play Music
+
+
+Client Metadata examples
+------------------------
+
+Here are a few examples of how to fill in the ``media_player``, ``submission_client`` and ``music_service`` fields based on our
+current recommendations.
+
+BrainzPlayer on the ListenBrainz website playing a video from YouTube
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: JSON
+
+  {
+    "track_metadata": {
+        "additional_info": {
+            "media_player": "BrainzPlayer",
+            "music_service": "youtube.com",
+            "origin_url": "https://www.youtube.com/watch?v=JKFBiaoFHoY",
+            "submission_client": "BrainzPlayer"
+        },
+        "artist_name": "Mdou Moctar",
+        "release_name": "Ilana (The Creator)",
+        "track_name": "Inizgam"
+    }
+  }
+
+BrainzPlayer on the ListenBrainz website playing a video from Spotify
+^^^^^^^^^^^^^^^^^
+
+Note that even though the ``origin_url`` is ``https://open.spotify.com``, we set ``music_service``
+to spotify.com (see above note).
+
+.. code-block:: JSON
+
+  {
+    "track_metadata": {
+        "additional_info": {
+            "media_player": "BrainzPlayer",
+            "music_service": "spotify.com",
+            "origin_url": "https://open.spotify.com/track/5fEjp2F0Sqr9fMuLSaDqz0",
+            "submission_client": "BrainzPlayer"
+        },
+        "artist_name": "Les Filles de Illighadad",
+        "release_name": "Eghass Malan",
+        "track_name": "Inssegh Inssegh"
+    }
+  }
+
+
+Using Otter for Funkwhale on android, and submitting with Simple Scrobbler
+^^^^^^^^^^^^^^^^^
+
+In this case, the media player and submission client are completely separate programs. Because music is being played
+from a user's private collection and not a streaming service, don't include music_service or origin_url.
+
+.. code-block:: JSON
+
+  {
+    "track_metadata": {
+        "additional_info": {
+            "media_player": "Otter",
+            "media_player_version": "1.0.21",
+            "submission_client": "Simple Scrobbler"
+            "submission_client_version": "1.7.0"
+        },
+        "artist_name": "Les Filles de Illighadad",
+        "release_name": "Eghass Malan",
+        "track_name": "Inssegh Inssegh"
+    }
+  }
+
+
+Rhythmbox player listening to Jamendo
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: JSON
+
+  {
+    "track_metadata": {
+        "additional_info": {
+            "media_player": "Rhythmbox",
+            "music_service": "jamendo.com",
+            "music_service_name": "Jamendo Music"
+            "origin_url": "https://www.jamendo.com/track/1466090/universal-funk",
+            "submission_client": "Rhythmbox ListenBrainz Plugin"
+        },
+        "artist_name": "Duo Teslar",
+        "track_name": "Universal Funk"
+    }
+  }
+
+Listening to a recording from Bandcamp and submitting with the browser extension WebScrobbler
+^^^^^^^^^^^^^^^^^
+
+Because playback happens in the browser, there is no specific ``media_player``.
+
+.. code-block:: JSON
+
+  {
+	"track_metadata": {
+		"additional_info": {
+			"music_service": "bandcamp.com",
+			"music_service_name": "Bandcamp",
+			"submission_client": "WebScrobbler",
+			"submission_client_version": "v2.48.0"
+			"origin_url": "https://greencookierecords.bandcamp.com/track/shake",
+		},
+		"artist_name": "I Mitomani Beat",
+		"release_name": "Fuori Dal Tempo",
+		"track_name": "Shake",
+	}
+  }
+
+At this point, we are not removing any other elements that may be
 submitted via the ``additional_info`` element. We're open to see how people
 will make use of these unspecified fields and may decide to formally specify or
 scrub elements in the future.


### PR DESCRIPTION
# Problem

LB-442, LB-321
https://community.metabrainz.org/t/what-do-you-want-in-listenbrainz/444888/38

This has been something that has been discussed for some time now. We want to know
* What tool someone is using to submit a file (name and version)
* What service someone is playing from - for local files this won't exist, but in the case that services have multiple clients we can distinguish the two
* Where the song that they're listening to can be found online (if it's online)

# Solution

Add some new recommended fields:

* `listening_from`: Now specifically refers to the **client** being used to submit the listen. This previously said client _or_ service
* `listening_from_version`: In the case that someone wants to submit a software version. I'm still not convinced how useful this is, but others seemed to want it. I think that we should add it as a separate field so that we can easily display listening_from without parsing it, and it's backwards compatible with what we currently have.
* `source`: The name of the place where the song is being listened from
* `origin_url`: the link to the song that is being listened to

This allows us to indicate for example that someone is listening to Jamendo from Rhythmbox, or Spotify from listenbrainz web player.

# Action

I haven't gone through the list of LB clients to ensure that they're compatible with what we've suggested here. Specifically, @MonkeyDo comments that some web-scrobblers use `origin_url` as the url of the webpage that a user is on while they have a player running. I don't think that this is a good idea, as to me having https://listenbrainz.org/user/alastairp/ as an url isn't useful. Soundcloud's player will continue playing from a playlist while the user is on the page of an unrelated song.
If the solution to this is to propose a new key that has this specific meaning then I'm open to doing that as well.
