### PR TITLE
LB-912 (I): Add endpoints and UI to delete feed events

### DIFF
--- a/data/model/user_timeline_event.py
+++ b/data/model/user_timeline_event.py
@@ -77,15 +77,7 @@ APIEventMetadata = Union[APIListen, APIFollowEvent, APINotificationEvent, APIPin
 
 
 class APITimelineEvent(pydantic.BaseModel):
-    event_type: UserTimelineEventType
-    user_name: str
-    created: int
-    metadata: APIEventMetadata
-
-class APIRecommendationNotificationTimelineEvent(pydantic.BaseModel):
-    # since `id` is not sent in APITimelineEvent
-    # this field is needed for deletion of Recommendation and Notification Events
-    id: int
+    id: Optional[int]
     event_type: UserTimelineEventType
     user_name: str
     created: int

--- a/data/model/user_timeline_event.py
+++ b/data/model/user_timeline_event.py
@@ -81,3 +81,12 @@ class APITimelineEvent(pydantic.BaseModel):
     user_name: str
     created: int
     metadata: APIEventMetadata
+
+class APIRecommendationNotificationTimelineEvent(pydantic.BaseModel):
+    # since `id` is not sent in APITimelineEvent
+    # this field is needed for deletion of Recommendation and Notification Events
+    id: int
+    event_type: UserTimelineEventType
+    user_name: str
+    created: int
+    metadata: APIEventMetadata

--- a/listenbrainz/db/tests/test_user_timeline_event.py
+++ b/listenbrainz/db/tests/test_user_timeline_event.py
@@ -270,7 +270,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(UserTimelineEventType.NOTIFICATION, event_not.event_type)
 
         # deleting recording recommendation
-        db_user_timeline_event.delete_user_recommendation_notification_event(
+        db_user_timeline_event.delete_user_timeline_event(
             id=event_rec.id,
             user_id=self.user["id"],
         )
@@ -281,7 +281,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(0, len(event_rec))
 
         # deleting notification
-        db_user_timeline_event.delete_user_recommendation_notification_event(
+        db_user_timeline_event.delete_user_timeline_event(
             id=event_not.id,
             user_id=new_user["id"],
         )
@@ -305,7 +305,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
         with mock.patch("listenbrainz.db.engine.connect", side_effect=Exception):
             with self.assertRaises(DatabaseException):
                 # checking if DatabaseException is raised or not
-                db_user_timeline_event.delete_user_recommendation_notification_event(
+                db_user_timeline_event.delete_user_timeline_event(
                     id=event_rec.id,
                     user_id=self.user["id"],
                 )

--- a/listenbrainz/db/tests/test_user_timeline_event.py
+++ b/listenbrainz/db/tests/test_user_timeline_event.py
@@ -290,3 +290,22 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
             count=1,
         )
         self.assertEqual(0, len(event_not))
+
+    def test_delete_feed_events_for_something_goes_wrong(self):
+        # creating recording recommendation
+        event_rec = db_user_timeline_event.create_user_track_recommendation_event(
+            user_id=self.user['id'],
+            metadata=RecordingRecommendationMetadata(
+                track_name="All Caps",
+                artist_name="MF DOOM",
+                recording_msid=str(uuid.uuid4()),
+                artist_msid=str(uuid.uuid4()),
+            )
+        )
+        with mock.patch("listenbrainz.db.engine.connect", side_effect=Exception):
+            with self.assertRaises(DatabaseException):
+                # checking if DatabaseException is raised or not
+                db_user_timeline_event.delete_user_recommendation_notification_event(
+                    id=event_rec.id,
+                    user_id=self.user["id"],
+                )

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -79,6 +79,31 @@ def create_user_notification_event(user_id: int, metadata: NotificationMetadata)
         metadata=metadata
     )
 
+def delete_user_recommendation_notification_event(
+        id: int,
+        user_id:int
+) -> UserTimelineEvent:
+    ''' Deletes recommendation and notification event using id'''
+    try:
+        with db.engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text('''
+                    DELETE FROM user_timeline_event
+                    WHERE user_id = :user_id
+                    AND id = :id
+                    RETURNING *
+                '''), {
+                    'user_id': user_id,
+                    'id': id
+                })
+            try:
+                r = dict(result.fetchone())
+            except TypeError:
+                r = None
+        if not r:
+            return None
+        return UserTimelineEvent(**r)
+    except Exception as e:
+        raise DatabaseException(str(e))
 
 def get_user_timeline_events(user_id: int, event_type: UserTimelineEventType, count: int = 50) -> List[UserTimelineEvent]:
     """ Gets user timeline events of the specified type associated with the specified user.

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -79,7 +79,7 @@ def create_user_notification_event(user_id: int, metadata: NotificationMetadata)
         metadata=metadata
     )
 
-def delete_user_recommendation_notification_event(
+def delete_user_timeline_event(
         id: int,
         user_id:int
 ) -> bool:

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -82,7 +82,7 @@ def create_user_notification_event(user_id: int, metadata: NotificationMetadata)
 def delete_user_recommendation_notification_event(
         id: int,
         user_id:int
-) -> UserTimelineEvent:
+) -> bool:
     ''' Deletes recommendation and notification event using id'''
     try:
         with db.engine.connect() as connection:
@@ -90,18 +90,11 @@ def delete_user_recommendation_notification_event(
                     DELETE FROM user_timeline_event
                     WHERE user_id = :user_id
                     AND id = :id
-                    RETURNING *
                 '''), {
                     'user_id': user_id,
                     'id': id
                 })
-            try:
-                r = dict(result.fetchone())
-            except TypeError:
-                r = None
-        if not r:
-            return None
-        return UserTimelineEvent(**r)
+            return result.rowcount == 1
     except Exception as e:
         raise DatabaseException(str(e))
 

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -209,12 +209,14 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
             headers={'Authorization': 'Token {}'.format(new_user['auth_token'])},
         )
         # Deleting notification
-        self.client.post(
+        r_del_not = self.client.post(
             url_for('user_timeline_event_api_bp.delete_feed_events',
             user_name=self.user["musicbrainz_id"]),
             data=json.dumps({'event_type': UserTimelineEventType.NOTIFICATION.value, 'id': 1}),
             headers={'Authorization': 'Token {}'.format(self.user['auth_token'])}
         )
+        self.assert200(r_del_not)
+
         # Checking if notification still exists
         r_not = self.client.get(
             url_for('user_timeline_event_api_bp.user_feed',
@@ -226,12 +228,14 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(self.user["musicbrainz_id"], payload_not["user_id"])
 
         # Deleting recommendation event
-        self.client.post(
+        r_del_rec = self.client.post(
             url_for('user_timeline_event_api_bp.delete_feed_events',
             user_name=new_user["musicbrainz_id"]),
             data=json.dumps({'event_type': UserTimelineEventType.RECORDING_RECOMMENDATION.value, 'id': 2}),
             headers={'Authorization': 'Token {}'.format(new_user['auth_token'])}
         )
+        self.assert200(r_del_rec)
+
         # Checking if recording recommendation still exists
         r_rec = self.client.get(
             url_for('user_timeline_event_api_bp.user_feed',

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -286,7 +286,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         )
         self.assert401(r_rec)
 
-    @mock.patch("listenbrainz.db.user_timeline_event.delete_user_recommendation_notification_event",
+    @mock.patch("listenbrainz.db.user_timeline_event.delete_user_timeline_event",
         side_effect=DatabaseException)
     def test_delete_feed_events_for_db_exceptions(self, mock_create_event):
         # Adding notification to the db

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -28,7 +28,6 @@ from flask import Blueprint, jsonify, request, current_app
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 import listenbrainz.db.user_timeline_event as db_user_timeline_event
-import listenbrainz.db.pinned_recording as db_pinned_rec
 
 from data.model.listen import APIListen, TrackMetadata, AdditionalInfo
 from data.model.user_timeline_event import RecordingRecommendationMetadata, APITimelineEvent, UserTimelineEventType, \

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -31,7 +31,7 @@ import listenbrainz.db.user_timeline_event as db_user_timeline_event
 
 from data.model.listen import APIListen, TrackMetadata, AdditionalInfo
 from data.model.user_timeline_event import RecordingRecommendationMetadata, APITimelineEvent, UserTimelineEventType, \
-    APIFollowEvent, NotificationMetadata, APINotificationEvent, APIPinEvent
+    APIFollowEvent, NotificationMetadata, APINotificationEvent, APIPinEvent, APIRecommendationNotificationTimelineEvent
 from listenbrainz.db.pinned_recording import get_pins_for_feed
 from listenbrainz.db.model.pinned_recording import fetch_track_metadata_for_pins
 from listenbrainz import webserver
@@ -323,7 +323,8 @@ def get_notification_events(user: dict, count: int) -> List[APITimelineEvent]:
     notification_events_db = db_user_timeline_event.get_user_notification_events(user_id=user['id'], count=count)
     events = []
     for event in notification_events_db:
-        events.append(APITimelineEvent(
+        events.append(APIRecommendationNotificationTimelineEvent(
+            id=event.id,
             event_type=UserTimelineEventType.NOTIFICATION,
             user_name=event.metadata.creator,
             created=event.created.timestamp(),
@@ -361,7 +362,8 @@ def get_recording_recommendation_events(users_for_events: List[dict], min_ts: in
                 ),
             )
 
-            events.append(APITimelineEvent(
+            events.append(APIRecommendationNotificationTimelineEvent(
+                id=event.id,
                 event_type=UserTimelineEventType.RECORDING_RECOMMENDATION,
                 user_name=listen.user_name,
                 created=event.created.timestamp(),

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -245,7 +245,7 @@ def user_feed(user_name: str):
 def delete_feed_events(user_name):
     '''
     Delete those events from user's feed that they created themselves.
-    Supports deletion of recommendation, notification and pin events.
+    Supports deletion of recommendation and notification.
     Along with the authorization token, post one of the following, according
     to your need.
     {
@@ -265,7 +265,6 @@ def delete_feed_events(user_name):
     :statuscode 500: API Internal Server Error
     :resheader Content-Type: *application/json*
     '''
-    # TODO: maybe implement logging once approved
     user = validate_auth_header()
     if user_name != user['musicbrainz_id']:
         raise APIUnauthorized("You don't have permissions to delete from this user's timeline.")
@@ -276,7 +275,7 @@ def delete_feed_events(user_name):
         if event["event_type"] in [UserTimelineEventType.RECORDING_RECOMMENDATION.value,
                 UserTimelineEventType.NOTIFICATION.value]:
             try:
-                event_deleted = db_user_timeline_event.delete_user_recommendation_notification_event(event["id"], user["id"])
+                event_deleted = db_user_timeline_event.delete_user_timeline_event(event["id"], user["id"])
             except Exception as e:
                 raise APIInternalServerError("Something went wrong. Please try again")
             if not event_deleted:

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -267,7 +267,7 @@ def delete_feed_events(user_name):
     '''
     # TODO: maybe implement logging once approved
     user = validate_auth_header()
-    if user_name != user['musicbrainz_id']:
+    if (user_name != user['musicbrainz_id']) or (user["musicbrainz_id"] not in current_app.config['APPROVED_PLAYLIST_BOTS']):
         raise APIUnauthorized("You don't have permissions to delete from this user's timeline.")
 
     try:

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -263,6 +263,7 @@ def delete_feed_events(user_name):
     :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized
     :statuscode 404: User not found
+    :statuscode 500: API Internal Server Error
     :resheader Content-Type: *application/json*
     '''
     # TODO: maybe implement logging once approved

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -244,7 +244,7 @@ def user_feed(user_name: str):
 @ratelimit()
 def delete_feed_events(user_name):
     '''
-    Delete those events from user's feed that they created themselves.
+    Delete those events from user's feed that belong to them.
     Supports deletion of recommendation and notification.
     Along with the authorization token, post one of the following, according
     to your need.

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -293,11 +293,11 @@ def delete_feed_events(user_name):
         elif event["event_type"] == UserTimelineEventType.RECORDING_PIN.value:
             try:
                 recording_deleted = db_pinned_rec.delete(event["metadata"]["row_id"], user["id"])
-                if not recording_deleted:
-                    raise APINotFound("Cannot find pin with row_id '%s' for user '%s'" % (row_id, user["musicbrainz_id"]))
-                return jsonify({"status": "ok"})
             except Exception as e:
                 raise APIInternalServerError("Something went wrong. Please try again")
+            if not recording_deleted:
+                raise APINotFound("Cannot find pin with row_id '%s' for user '%s'" % (event["metadata"]["row_id"], user["musicbrainz_id"]))
+            return jsonify({"status": "ok"})
         raise APIBadRequest("This event type is not supported for deletion via this method")
     except (ValueError, KeyError) as e:
         raise APIBadRequest(f"Invalid JSON: {str(e)}")

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -257,10 +257,6 @@ def delete_feed_events(user_name):
         "event_type": "notification",
         "id": int
     }
-    {
-        "event_type": "recording_pin",
-        "row_id": int
-    }
     :param user_name: The MusicBrainz ID of the user from whose timeline events are being deleted
     :type user_name: ``str``
     :statuscode 200: Successful deletion
@@ -286,15 +282,6 @@ def delete_feed_events(user_name):
             if not event_deleted:
                 raise APINotFound("Cannot find '%s' event with id '%s' for user '%s'" % (event["event_type"], event["id"],
                     user["id"]))
-            return jsonify({"status": "ok"})
-
-        elif event["event_type"] == UserTimelineEventType.RECORDING_PIN.value:
-            try:
-                recording_deleted = db_pinned_rec.delete(event["row_id"], user["id"])
-            except Exception as e:
-                raise APIInternalServerError("Something went wrong. Please try again")
-            if not recording_deleted:
-                raise APINotFound("Cannot find pin with row_id '%s' for user '%s'" % (event["row_id"], user["musicbrainz_id"]))
             return jsonify({"status": "ok"})
 
         raise APIBadRequest("This event type is not supported for deletion via this method")

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -267,7 +267,7 @@ def delete_feed_events(user_name):
     '''
     # TODO: maybe implement logging once approved
     user = validate_auth_header()
-    if (user_name != user['musicbrainz_id']) or (user["musicbrainz_id"] not in current_app.config['APPROVED_PLAYLIST_BOTS']):
+    if user_name != user['musicbrainz_id']:
         raise APIUnauthorized("You don't have permissions to delete from this user's timeline.")
 
     try:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
[LB-912](https://tickets.metabrainz.org/browse/LB-912) wanted an API endpoint implemented that would delete different events from the user's feed. The problem in initial attempt was that the frontend client never had any unique identification to represent each recommendation or notification event so that it could simply post that to get those events deleted.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Hence I created new data model to represent Notification and Recommendation events. Its a superset of `APITimelineEvent` with just one `id: int` field extra added.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
I implemented a new data model for Notifications and Recommendation events. But one may wish to remove that and add `id: int` field to `APITimelineEvent` itself. Though I didn't do that because it might not be safe serving primary keys of different events, and I was told in IRC by lucifer to only enable `id` for only these 2 respectively.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


