### PR TITLE
LB-697: Migrate entity statistics to relational database

### DIFF
--- a/admin/sql/create_foreign_keys.sql
+++ b/admin/sql/create_foreign_keys.sql
@@ -18,6 +18,12 @@ ALTER TABLE statistics.user
     REFERENCES "user" (id)
     ON DELETE CASCADE;
 
+ALTER TABLE statistics.user_new
+    ADD CONSTRAINT user_stats_new_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
+
 ALTER TABLE reported_users
     ADD CONSTRAINT  reporter_user_id_foreign_key
     FOREIGN KEY (reporter_user_id)

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -20,6 +20,7 @@ CREATE UNIQUE INDEX msid_ndx_release_stats ON statistics.release (msid);
 CREATE UNIQUE INDEX msid_ndx_recording_stats ON statistics.recording (msid);
 
 CREATE UNIQUE INDEX user_type_range_ndx_stats ON statistics.user_new (user_id, stats_type, stats_range);
+CREATE INDEX user_id_ndx__user_stats_new ON statistics.user_new (user_id);
 
 CREATE INDEX latest_listened_at_spotify_auth ON spotify_auth (latest_listened_at DESC NULLS LAST);
 

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -19,6 +19,8 @@ CREATE UNIQUE INDEX msid_ndx_artist_stats ON statistics.artist (msid);
 CREATE UNIQUE INDEX msid_ndx_release_stats ON statistics.release (msid);
 CREATE UNIQUE INDEX msid_ndx_recording_stats ON statistics.recording (msid);
 
+CREATE UNIQUE INDEX user_type_range_ndx_stats ON statistics.user_new (user_id, stats_type, stats_range);
+
 CREATE INDEX latest_listened_at_spotify_auth ON spotify_auth (latest_listened_at DESC NULLS LAST);
 
 CREATE INDEX user_id_ndx_external_service_oauth ON external_service_oauth (user_id);

--- a/admin/sql/create_primary_keys.sql
+++ b/admin/sql/create_primary_keys.sql
@@ -10,6 +10,7 @@ ALTER TABLE statistics.user ADD CONSTRAINT stats_user_pkey PRIMARY KEY (user_id)
 ALTER TABLE statistics.artist ADD CONSTRAINT stats_artist_pkey PRIMARY KEY (id);
 ALTER TABLE statistics.release ADD CONSTRAINT stats_release_pkey PRIMARY KEY (id);
 ALTER TABLE statistics.recording ADD CONSTRAINT stats_recording_pkey PRIMARY KEY (id);
+ALTER TABLE statistics.user_new ADD CONSTRAINT stats_user_new_pkey PRIMARY KEY (user_id);
 
 ALTER TABLE recommendation.cf_recording ADD CONSTRAINT rec_cf_recording_pkey PRIMARY KEY (id);
 ALTER TABLE recommendation.recommender ADD CONSTRAINT rec_recommender_pkey PRIMARY KEY (id);

--- a/admin/sql/create_primary_keys.sql
+++ b/admin/sql/create_primary_keys.sql
@@ -10,7 +10,7 @@ ALTER TABLE statistics.user ADD CONSTRAINT stats_user_pkey PRIMARY KEY (user_id)
 ALTER TABLE statistics.artist ADD CONSTRAINT stats_artist_pkey PRIMARY KEY (id);
 ALTER TABLE statistics.release ADD CONSTRAINT stats_release_pkey PRIMARY KEY (id);
 ALTER TABLE statistics.recording ADD CONSTRAINT stats_recording_pkey PRIMARY KEY (id);
-ALTER TABLE statistics.user_new ADD CONSTRAINT stats_user_new_pkey PRIMARY KEY (user_id);
+ALTER TABLE statistics.user_new ADD CONSTRAINT stats_user_new_pkey PRIMARY KEY (id);
 
 ALTER TABLE recommendation.cf_recording ADD CONSTRAINT rec_cf_recording_pkey PRIMARY KEY (id);
 ALTER TABLE recommendation.recommender ADD CONSTRAINT rec_recommender_pkey PRIMARY KEY (id);

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -180,7 +180,8 @@ CREATE TABLE statistics.user (
 );
 
 CREATE TABLE statistics.user_new (
-    user_id                 INTEGER NOT NULL, -- PK and FK to "user".id
+    id                      SERIAL, -- PK
+    user_id                 INTEGER NOT NULL, -- FK to "user".id
     stats_type              user_stats_type,
     stats_range             stats_range_type,
     data                    JSONB,
@@ -193,7 +194,6 @@ CREATE TABLE statistics.user_new (
     to_ts                   BIGINT,
     last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
-ALTER TABLE statistics.user_new ADD CONSTRAINT user_stats_range_type_uniq UNIQUE (user_id, stats_type, stats_range);
 
 CREATE TABLE statistics.sitewide (
     id                      SERIAL, --pk

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -185,8 +185,12 @@ CREATE TABLE statistics.user_new (
     stats_range             stats_range_type,
     data                    JSONB,
     count                   INTEGER,
-    from_ts                 TIMESTAMP WITH TIME ZONE,
-    to_ts                   TIMESTAMP WITH TIME ZONE,
+    -- we use int timestamps when serializing data in spark, we return the same from the api
+    -- using timestamp with time zone here just complicates stuff. we'll need to add
+    -- datetime/timestamp conversions in code at multiple places and we never seem to use this
+    -- value anyways in LB backend atm.
+    from_ts                 BIGINT,
+    to_ts                   BIGINT,
     last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 ALTER TABLE statistics.user_new ADD CONSTRAINT user_stats_range_type_uniq UNIQUE (user_id, stats_type, stats_range);

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -189,6 +189,7 @@ CREATE TABLE statistics.user_new (
     to_ts                   TIMESTAMP WITH TIME ZONE,
     last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
+ALTER TABLE statistics.user_new ADD CONSTRAINT user_stats_range_type_uniq UNIQUE (user_id, stats_type, stats_range);
 
 CREATE TABLE statistics.sitewide (
     id                      SERIAL, --pk

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -179,6 +179,17 @@ CREATE TABLE statistics.user (
     last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE statistics.user_new (
+    user_id                 INTEGER NOT NULL, -- PK and FK to "user".id
+    stats_type              user_stats_type,
+    stats_range             stats_range_type,
+    data                    JSONB,
+    count                   INTEGER,
+    from_ts                 TIMESTAMP WITH TIME ZONE,
+    to_ts                   TIMESTAMP WITH TIME ZONE,
+    last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE statistics.sitewide (
     id                      SERIAL, --pk
     stats_range             TEXT,

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -9,3 +9,7 @@ CREATE TYPE recommendation_feedback_type_enum AS ENUM('like', 'love', 'dislike',
 CREATE TYPE user_timeline_event_type_enum AS ENUM('recording_recommendation', 'notification');
 
 CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm', 'librefm');
+
+CREATE TYPE stats_range_type AS ENUM ('week', 'month', 'year', 'all_time');
+
+CREATE TYPE user_stats_type AS ENUM('artists', 'releases', 'recordings', 'daily_activity', 'listening_activity', 'artist_map');

--- a/admin/sql/updates/2021-09-14-new-statistics-table.sql
+++ b/admin/sql/updates/2021-09-14-new-statistics-table.sql
@@ -1,0 +1,32 @@
+CREATE TYPE stats_range_type AS ENUM ('week', 'month', 'year', 'all_time');
+
+CREATE TYPE user_stats_type AS ENUM('artists', 'releases', 'recordings', 'daily_activity', 'listening_activity', 'artist_map');
+
+BEGIN;
+
+CREATE TABLE statistics.user_new (
+    user_id                 INTEGER NOT NULL, -- PK and FK to "user".id
+    stats_type              user_stats_type,
+    stats_range             stats_range_type,
+    data                    JSONB,
+    count                   INTEGER,
+    -- we use int timestamps when serializing data in spark, we return the same from the api
+    -- using timestamp with time zone here just complicates stuff. we'll need to add
+    -- datetime/timestamp conversions in code at multiple places and we never seem to use this
+    -- value anyways in LB backend atm.
+    from_ts                 BIGINT,
+    to_ts                   BIGINT,
+    last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE statistics.user_new ADD CONSTRAINT user_stats_range_type_uniq UNIQUE (user_id, stats_type, stats_range);
+
+ALTER TABLE statistics.user_new ADD CONSTRAINT stats_user_new_pkey PRIMARY KEY (user_id);
+
+ALTER TABLE statistics.user_new
+    ADD CONSTRAINT user_stats_new_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
+
+COMMIT;

--- a/admin/sql/updates/2021-09-14-new-statistics-table.sql
+++ b/admin/sql/updates/2021-09-14-new-statistics-table.sql
@@ -23,6 +23,7 @@ CREATE TABLE statistics.user_new (
 ALTER TABLE statistics.user_new ADD CONSTRAINT stats_user_new_pkey PRIMARY KEY (id);
 
 CREATE UNIQUE INDEX user_type_range_ndx_stats ON statistics.user_new (user_id, stats_type, stats_range);
+CREATE INDEX user_id_ndx__user_stats_new ON statistics.user_new (user_id);
 
 ALTER TABLE statistics.user_new
     ADD CONSTRAINT user_stats_new_user_id_foreign_key

--- a/admin/sql/updates/2021-09-14-new-statistics-table.sql
+++ b/admin/sql/updates/2021-09-14-new-statistics-table.sql
@@ -5,7 +5,8 @@ CREATE TYPE user_stats_type AS ENUM('artists', 'releases', 'recordings', 'daily_
 BEGIN;
 
 CREATE TABLE statistics.user_new (
-    user_id                 INTEGER NOT NULL, -- PK and FK to "user".id
+    id                      SERIAL, -- PK
+    user_id                 INTEGER NOT NULL, -- FK to "user".id
     stats_type              user_stats_type,
     stats_range             stats_range_type,
     data                    JSONB,
@@ -19,9 +20,9 @@ CREATE TABLE statistics.user_new (
     last_updated            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-ALTER TABLE statistics.user_new ADD CONSTRAINT user_stats_range_type_uniq UNIQUE (user_id, stats_type, stats_range);
+ALTER TABLE statistics.user_new ADD CONSTRAINT stats_user_new_pkey PRIMARY KEY (id);
 
-ALTER TABLE statistics.user_new ADD CONSTRAINT stats_user_new_pkey PRIMARY KEY (user_id);
+CREATE UNIQUE INDEX user_type_range_ndx_stats ON statistics.user_new (user_id, stats_type, stats_range);
 
 ALTER TABLE statistics.user_new
     ADD CONSTRAINT user_stats_new_user_id_foreign_key

--- a/data/model/common_stat.py
+++ b/data/model/common_stat.py
@@ -7,7 +7,6 @@ from pydantic.generics import GenericModel
 StatT = TypeVar('StatT')
 
 
-# TODO: Use StatRecordList inside StatRange, and remove other list models
 class StatRecordList(GenericModel, Generic[StatT]):
     __root__: List[StatT]
 

--- a/data/model/common_stat.py
+++ b/data/model/common_stat.py
@@ -8,10 +8,18 @@ StatT = TypeVar('StatT')
 
 
 class StatRecordList(GenericModel, Generic[StatT]):
+    """ Generic model with root type as list of given type.
+    Can be used as part of another model where you want to call .json() just on the
+    single member. Without the custom root type, an additional level of nesting will
+    be added to the json and if we used List[StatT] in the models then we wouldn't be
+    able to call .json() on a particular member as we do while inserting stats in the
+    database using .json(exclude_none=True).
+    """
     __root__: List[StatT]
 
 
 class StatRange(GenericModel, Generic[StatT]):
+    """Generic base model representing a stat when it is inserted into the database."""
     to_ts: int
     from_ts: int
     count: Optional[int]
@@ -20,5 +28,7 @@ class StatRange(GenericModel, Generic[StatT]):
 
 
 class StatApi(StatRange[StatT], Generic[StatT]):
+    """ Generic base mode for representing a stat retrieved from the database and
+    to send using the api."""
     user_id: int
     last_updated: datetime

--- a/data/model/common_stat.py
+++ b/data/model/common_stat.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from typing import TypeVar, Generic, Optional
+
+from pydantic.generics import GenericModel
+
+
+StatT = TypeVar('StatT')
+
+
+class StatRange(GenericModel, Generic[StatT]):
+    to_ts: int
+    from_ts: int
+    count: Optional[int]
+    stats_range: str
+    data: StatT
+
+
+class StatApi(StatRange[StatT], Generic[StatT]):
+    user_id: int
+    last_updated: datetime

--- a/data/model/common_stat.py
+++ b/data/model/common_stat.py
@@ -1,10 +1,15 @@
 from datetime import datetime
-from typing import TypeVar, Generic, Optional
+from typing import TypeVar, Generic, Optional, List
 
 from pydantic.generics import GenericModel
 
 
 StatT = TypeVar('StatT')
+
+
+# TODO: Use StatRecordList inside StatRange, and remove other list models
+class StatRecordList(GenericModel, Generic[StatT]):
+    __root__: List[StatT]
 
 
 class StatRange(GenericModel, Generic[StatT]):

--- a/data/model/common_stat.py
+++ b/data/model/common_stat.py
@@ -17,7 +17,7 @@ class StatRange(GenericModel, Generic[StatT]):
     from_ts: int
     count: Optional[int]
     stats_range: str
-    data: StatT
+    data: StatRecordList[StatT]
 
 
 class StatApi(StatRange[StatT], Generic[StatT]):

--- a/data/model/user_artist_map.py
+++ b/data/model/user_artist_map.py
@@ -1,7 +1,6 @@
 import pydantic
 
 from datetime import datetime
-from enum import Enum
 from typing import Optional, List
 
 
@@ -15,26 +14,21 @@ class UserArtistMapRecord(pydantic.BaseModel):
     listen_count: Optional[int]  # Make field optional to maintain backward compatibility
 
 
+class UserArtistMapRecordList(pydantic.BaseModel):
+    __root__: List[UserArtistMapRecord]
+
+
 class UserArtistMapStatRange(pydantic.BaseModel):
     """ Model for user's artist map for a particular
     time range. Currently supports week, month, year and all-time
     """
     to_ts: int
     from_ts: int
-    artist_map: List[UserArtistMapRecord]
-    last_updated: int
+    data: UserArtistMapRecordList
+    stats_range: str
 
 
-class UserArtistMapStatJson(pydantic.BaseModel):
-    """ Model for the JSON stored in the statistics.user table's artist_map column
-    """
-    week: Optional[UserArtistMapStatRange]
-    year: Optional[UserArtistMapStatRange]
-    month: Optional[UserArtistMapStatRange]
-    all_time: Optional[UserArtistMapStatRange]
-
-
-class UserArtistMapStat(UserArtistMapStatJson):
+class UserArtistMapStat(UserArtistMapStatRange):
     """ Model for stats around a user's most listened artists
     """
     user_id: int

--- a/data/model/user_artist_map.py
+++ b/data/model/user_artist_map.py
@@ -1,7 +1,6 @@
 import pydantic
 
-from datetime import datetime
-from typing import Optional, List
+from typing import Optional
 
 
 class UserArtistMapRecord(pydantic.BaseModel):
@@ -12,7 +11,3 @@ class UserArtistMapRecord(pydantic.BaseModel):
     country: str
     artist_count: int
     listen_count: Optional[int]  # Make field optional to maintain backward compatibility
-
-
-class UserArtistMapRecordList(pydantic.BaseModel):
-    __root__: List[UserArtistMapRecord]

--- a/data/model/user_artist_map.py
+++ b/data/model/user_artist_map.py
@@ -16,20 +16,3 @@ class UserArtistMapRecord(pydantic.BaseModel):
 
 class UserArtistMapRecordList(pydantic.BaseModel):
     __root__: List[UserArtistMapRecord]
-
-
-class UserArtistMapStatRange(pydantic.BaseModel):
-    """ Model for user's artist map for a particular
-    time range. Currently supports week, month, year and all-time
-    """
-    to_ts: int
-    from_ts: int
-    data: UserArtistMapRecordList
-    stats_range: str
-
-
-class UserArtistMapStat(UserArtistMapStatRange):
-    """ Model for stats around a user's most listened artists
-    """
-    user_id: int
-    last_updated: datetime

--- a/data/model/user_artist_stat.py
+++ b/data/model/user_artist_stat.py
@@ -16,6 +16,10 @@ class UserArtistRecord(pydantic.BaseModel):
     artist_msid: Optional[str]
 
 
+class UserArtistRecordList(pydantic.BaseModel):
+    __root__: List[UserArtistRecord]
+
+
 class UserArtistStatRange(pydantic.BaseModel):
     """ Model for user's most listened-to artists for a particular
     time range. Currently supports week, month, year and all-time
@@ -23,19 +27,11 @@ class UserArtistStatRange(pydantic.BaseModel):
     to_ts: int
     from_ts: int
     count: int
-    artists: List[UserArtistRecord]
+    stats_range: str
+    data: UserArtistRecordList
 
 
-class UserArtistStatJson(pydantic.BaseModel):
-    """ Model for the JSON stored in the statistics.user table's artist column
-    """
-    week: Optional[UserArtistStatRange]
-    year: Optional[UserArtistStatRange]
-    month: Optional[UserArtistStatRange]
-    all_time: Optional[UserArtistStatRange]
-
-
-class UserArtistStat(UserArtistStatJson):
+class UserArtistStat(UserArtistStatRange):
     """ Model for stats around a user's most listened artists
     """
     user_id: int

--- a/data/model/user_artist_stat.py
+++ b/data/model/user_artist_stat.py
@@ -19,6 +19,13 @@ class UserArtistRecord(pydantic.BaseModel):
     artist_msid: Optional[str]
 
 
+# we need this so that we can call json(exclude_none=True) when inserting in the db
+# not sure if this is necessary but preserving the old behaviour for now. json.dumps
+# does not have an exclude_none option.
+class UserArtistRecordList(pydantic.BaseModel):
+    __root__: List[UserArtistRecord]
+
+
 class UserArtistStatRange(pydantic.BaseModel):
     """ Model for user's most listened-to artists for a particular
     time range. Currently supports week, month, year and all-time
@@ -27,7 +34,7 @@ class UserArtistStatRange(pydantic.BaseModel):
     from_ts: int
     count: int
     stats_range: str
-    data: Union[List[UserArtistRecord], List[UserReleaseRecord], List[UserRecordingRecord]]
+    data: UserArtistRecordList
 
 
 class UserArtistStat(UserArtistStatRange):

--- a/data/model/user_artist_stat.py
+++ b/data/model/user_artist_stat.py
@@ -1,7 +1,10 @@
 import pydantic
 
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Union
+
+from data.model.user_recording_stat import UserRecordingRecord
+from data.model.user_release_stat import UserReleaseRecord
 
 
 class UserArtistRecord(pydantic.BaseModel):
@@ -16,10 +19,6 @@ class UserArtistRecord(pydantic.BaseModel):
     artist_msid: Optional[str]
 
 
-class UserArtistRecordList(pydantic.BaseModel):
-    __root__: List[UserArtistRecord]
-
-
 class UserArtistStatRange(pydantic.BaseModel):
     """ Model for user's most listened-to artists for a particular
     time range. Currently supports week, month, year and all-time
@@ -28,7 +27,7 @@ class UserArtistStatRange(pydantic.BaseModel):
     from_ts: int
     count: int
     stats_range: str
-    data: UserArtistRecordList
+    data: Union[List[UserArtistRecord], List[UserReleaseRecord], List[UserRecordingRecord]]
 
 
 class UserArtistStat(UserArtistStatRange):

--- a/data/model/user_artist_stat.py
+++ b/data/model/user_artist_stat.py
@@ -1,10 +1,6 @@
 import pydantic
 
-from datetime import datetime
-from typing import Optional, List, Union
-
-from data.model.user_recording_stat import UserRecordingRecord
-from data.model.user_release_stat import UserReleaseRecord
+from typing import Optional, List
 
 
 class UserArtistRecord(pydantic.BaseModel):
@@ -17,28 +13,3 @@ class UserArtistRecord(pydantic.BaseModel):
     artist_name: str
     # to add an empty field to stats API response, for compatibility
     artist_msid: Optional[str]
-
-
-# we need this so that we can call json(exclude_none=True) when inserting in the db
-# not sure if this is necessary but preserving the old behaviour for now. json.dumps
-# does not have an exclude_none option.
-class UserArtistRecordList(pydantic.BaseModel):
-    __root__: List[UserArtistRecord]
-
-
-class UserArtistStatRange(pydantic.BaseModel):
-    """ Model for user's most listened-to artists for a particular
-    time range. Currently supports week, month, year and all-time
-    """
-    to_ts: int
-    from_ts: int
-    count: int
-    stats_range: str
-    data: UserArtistRecordList
-
-
-class UserArtistStat(UserArtistStatRange):
-    """ Model for stats around a user's most listened artists
-    """
-    user_id: int
-    last_updated: datetime

--- a/data/model/user_daily_activity.py
+++ b/data/model/user_daily_activity.py
@@ -24,7 +24,3 @@ class UserDailyActivityStatMessage(pydantic.BaseModel):
     from_ts: int
     to_ts: int
     data: List[UserDailyActivityRecord]
-
-
-class UserDailyActivityRecordList(pydantic.BaseModel):
-    __root__: List[UserDailyActivityRecord]

--- a/data/model/user_daily_activity.py
+++ b/data/model/user_daily_activity.py
@@ -28,20 +28,3 @@ class UserDailyActivityStatMessage(pydantic.BaseModel):
 
 class UserDailyActivityRecordList(pydantic.BaseModel):
     __root__: List[UserDailyActivityRecord]
-
-
-class UserDailyActivityStatRange(pydantic.BaseModel):
-    """ Model for user's daily activity for a particular time range.
-        Currently supports week, month, year and all-time
-    """
-    to_ts: int
-    from_ts: int
-    stats_range: str
-    data: UserDailyActivityRecordList
-
-
-class UserDailyActivityStat(UserDailyActivityStatRange):
-    """ Model for stats around user's daily activity
-    """
-    user_id: int
-    last_updated: datetime

--- a/data/model/user_daily_activity.py
+++ b/data/model/user_daily_activity.py
@@ -23,7 +23,11 @@ class UserDailyActivityStatMessage(pydantic.BaseModel):
     stats_range: str  # The range for which the stats are calculated, i.e week, month, year or all_time
     from_ts: int
     to_ts: int
-    daily_activity: List[UserDailyActivityRecord]
+    data: List[UserDailyActivityRecord]
+
+
+class UserDailyActivityRecordList(pydantic.BaseModel):
+    __root__: List[UserDailyActivityRecord]
 
 
 class UserDailyActivityStatRange(pydantic.BaseModel):
@@ -32,19 +36,11 @@ class UserDailyActivityStatRange(pydantic.BaseModel):
     """
     to_ts: int
     from_ts: int
-    daily_activity: List[UserDailyActivityRecord]
+    stats_range: str
+    data: UserDailyActivityRecordList
 
 
-class UserDailyActivityStatJson(pydantic.BaseModel):
-    """ Model for the JSON stored in the statistics.user table's daily_activity column
-    """
-    week: Optional[UserDailyActivityStatRange]
-    month: Optional[UserDailyActivityStatRange]
-    year: Optional[UserDailyActivityStatRange]
-    all_time: Optional[UserDailyActivityStatRange]
-
-
-class UserDailyActivityStat(UserDailyActivityStatJson):
+class UserDailyActivityStat(UserDailyActivityStatRange):
     """ Model for stats around user's daily activity
     """
     user_id: int

--- a/data/model/user_entity.py
+++ b/data/model/user_entity.py
@@ -3,6 +3,7 @@ from typing import List, Union
 
 import pydantic
 
+from data.model.common_stat import StatRange, StatApi
 from data.model.user_artist_stat import UserArtistRecord
 from data.model.user_recording_stat import UserRecordingRecord
 from data.model.user_release_stat import UserReleaseRecord
@@ -29,22 +30,3 @@ class UserEntityStatMessage(pydantic.BaseModel):
 # does not have an exclude_none option.
 class UserEntityRecordList(pydantic.BaseModel):
     __root__: List[UserEntityStatRecord]
-
-
-class UserEntityStatRange(pydantic.BaseModel):
-    """ Model for user's most listened-to releases, recordings and artists
-    for a particular time range. Currently supports week, month, year
-    and all-time
-    """
-    to_ts: int
-    from_ts: int
-    count: int
-    stats_range: str
-    data: UserEntityRecordList
-
-
-class UserEntityStat(UserEntityStatRange):
-    """ Model for stats around a user's most listened releases
-    """
-    user_id: int
-    last_updated: datetime

--- a/data/model/user_entity.py
+++ b/data/model/user_entity.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Union
 
 import pydantic
@@ -6,16 +7,44 @@ from data.model.user_artist_stat import UserArtistRecord
 from data.model.user_recording_stat import UserRecordingRecord
 from data.model.user_release_stat import UserReleaseRecord
 
+# Order of the records in union is important and should be from more specific to less specific
+# For more info read https://pydantic-docs.helpmanual.io/usage/types/#unions
+UserEntityStatRecord = Union[UserRecordingRecord, UserReleaseRecord, UserArtistRecord]
+
 
 class UserEntityStatMessage(pydantic.BaseModel):
-    """ Format of messages sent to the ListenBrainz Server """
+    """ Format of messages sent to the ListenBrainz Server from Spark """
     musicbrainz_id: str
     type: str
     entity: str  # The entity for which stats are calculated, i.e artist, release or recording
     stats_range: str  # The range for which the stats are calculated, i.e week, month, year or all_time
     from_ts: int
     to_ts: int
-    # Order of the records in union is important and should be from more specific to less specific
-    # For more info read https://pydantic-docs.helpmanual.io/usage/types/#unions
-    data: List[Union[UserRecordingRecord, UserReleaseRecord, UserArtistRecord]]
+    data: List[UserEntityStatRecord]
     count: int
+
+
+# we need this so that we can call json(exclude_none=True) when inserting in the db
+# not sure if this is necessary but preserving the old behaviour for now. json.dumps
+# does not have an exclude_none option.
+class UserEntityRecordList(pydantic.BaseModel):
+    __root__: List[UserEntityStatRecord]
+
+
+class UserEntityStatRange(pydantic.BaseModel):
+    """ Model for user's most listened-to releases, recordings and artists
+    for a particular time range. Currently supports week, month, year
+    and all-time
+    """
+    to_ts: int
+    from_ts: int
+    count: int
+    stats_range: str
+    data: UserEntityRecordList
+
+
+class UserEntityStat(UserEntityStatRange):
+    """ Model for stats around a user's most listened releases
+    """
+    user_id: int
+    last_updated: datetime

--- a/data/model/user_entity.py
+++ b/data/model/user_entity.py
@@ -3,14 +3,13 @@ from typing import List, Union
 
 import pydantic
 
-from data.model.common_stat import StatRange, StatApi
 from data.model.user_artist_stat import UserArtistRecord
 from data.model.user_recording_stat import UserRecordingRecord
 from data.model.user_release_stat import UserReleaseRecord
 
 # Order of the records in union is important and should be from more specific to less specific
 # For more info read https://pydantic-docs.helpmanual.io/usage/types/#unions
-UserEntityStatRecord = Union[UserRecordingRecord, UserReleaseRecord, UserArtistRecord]
+UserEntityRecord = Union[UserRecordingRecord, UserReleaseRecord, UserArtistRecord]
 
 
 class UserEntityStatMessage(pydantic.BaseModel):
@@ -21,7 +20,7 @@ class UserEntityStatMessage(pydantic.BaseModel):
     stats_range: str  # The range for which the stats are calculated, i.e week, month, year or all_time
     from_ts: int
     to_ts: int
-    data: List[UserEntityStatRecord]
+    data: List[UserEntityRecord]
     count: int
 
 
@@ -29,4 +28,4 @@ class UserEntityStatMessage(pydantic.BaseModel):
 # not sure if this is necessary but preserving the old behaviour for now. json.dumps
 # does not have an exclude_none option.
 class UserEntityRecordList(pydantic.BaseModel):
-    __root__: List[UserEntityStatRecord]
+    __root__: List[UserEntityRecord]

--- a/data/model/user_entity.py
+++ b/data/model/user_entity.py
@@ -22,10 +22,3 @@ class UserEntityStatMessage(pydantic.BaseModel):
     to_ts: int
     data: List[UserEntityRecord]
     count: int
-
-
-# we need this so that we can call json(exclude_none=True) when inserting in the db
-# not sure if this is necessary but preserving the old behaviour for now. json.dumps
-# does not have an exclude_none option.
-class UserEntityRecordList(pydantic.BaseModel):
-    __root__: List[UserEntityRecord]

--- a/data/model/user_listening_activity.py
+++ b/data/model/user_listening_activity.py
@@ -29,7 +29,7 @@ class UserListeningActivityStatMessage(pydantic.BaseModel):
     stats_range: str  # The range for which the stats are calculated, i.e week, month, year or all_time
     from_ts: int
     to_ts: int
-    listening_activity: List[UserListeningActivityRecord]
+    data: List[UserListeningActivityRecord]
 
 
 class UserListeningActivityRecordList(pydantic.BaseModel):

--- a/data/model/user_listening_activity.py
+++ b/data/model/user_listening_activity.py
@@ -6,6 +6,7 @@ import pydantic
 from datetime import datetime
 from typing import Optional, List, Union
 
+from data.model.user_artist_map import UserArtistMapStatRange, UserArtistMapStat
 from data.model.user_daily_activity import UserDailyActivityStatRange, UserDailyActivityStat
 
 
@@ -55,5 +56,5 @@ class UserListeningActivityStat(UserListeningActivityStatRange):
     last_updated: datetime
 
 
-UserActivityStatRange = Union[UserListeningActivityStatRange, UserDailyActivityStatRange]
-UserActivityStat = Union[UserListeningActivityStat, UserDailyActivityStat]
+UserActivityStatRange = Union[UserListeningActivityStatRange, UserDailyActivityStatRange, UserArtistMapStatRange]
+UserActivityStat = Union[UserListeningActivityStat, UserDailyActivityStat, UserArtistMapStat]

--- a/data/model/user_listening_activity.py
+++ b/data/model/user_listening_activity.py
@@ -29,7 +29,3 @@ class UserListeningActivityStatMessage(pydantic.BaseModel):
     from_ts: int
     to_ts: int
     data: List[UserListeningActivityRecord]
-
-
-class UserListeningActivityRecordList(pydantic.BaseModel):
-    __root__: List[UserListeningActivityRecord]

--- a/data/model/user_listening_activity.py
+++ b/data/model/user_listening_activity.py
@@ -3,11 +3,7 @@
 """
 import pydantic
 
-from datetime import datetime
-from typing import Optional, List, Union
-
-from data.model.user_artist_map import UserArtistMapStatRange, UserArtistMapStat
-from data.model.user_daily_activity import UserDailyActivityStatRange, UserDailyActivityStat
+from typing import List
 
 
 class UserListeningActivityRecord(pydantic.BaseModel):
@@ -37,24 +33,3 @@ class UserListeningActivityStatMessage(pydantic.BaseModel):
 
 class UserListeningActivityRecordList(pydantic.BaseModel):
     __root__: List[UserListeningActivityRecord]
-
-
-class UserListeningActivityStatRange(pydantic.BaseModel):
-    """ Model for user's listening activity for a particular time range.
-        Currently supports week, month, year and all-time
-    """
-    to_ts: int
-    from_ts: int
-    stats_range: str
-    data: UserListeningActivityRecordList
-
-
-class UserListeningActivityStat(UserListeningActivityStatRange):
-    """ Model for stats around user's listening activity
-    """
-    user_id: int
-    last_updated: datetime
-
-
-UserActivityStatRange = Union[UserListeningActivityStatRange, UserDailyActivityStatRange, UserArtistMapStatRange]
-UserActivityStat = Union[UserListeningActivityStat, UserDailyActivityStat, UserArtistMapStat]

--- a/data/model/user_listening_activity.py
+++ b/data/model/user_listening_activity.py
@@ -4,7 +4,9 @@
 import pydantic
 
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Union
+
+from data.model.user_daily_activity import UserDailyActivityStatRange, UserDailyActivityStat
 
 
 class UserListeningActivityRecord(pydantic.BaseModel):
@@ -51,3 +53,7 @@ class UserListeningActivityStat(UserListeningActivityStatRange):
     """
     user_id: int
     last_updated: datetime
+
+
+UserActivityStatRange = Union[UserListeningActivityStatRange, UserDailyActivityStatRange]
+UserActivityStat = Union[UserListeningActivityStat, UserDailyActivityStat]

--- a/data/model/user_listening_activity.py
+++ b/data/model/user_listening_activity.py
@@ -32,25 +32,21 @@ class UserListeningActivityStatMessage(pydantic.BaseModel):
     listening_activity: List[UserListeningActivityRecord]
 
 
+class UserListeningActivityRecordList(pydantic.BaseModel):
+    __root__: List[UserListeningActivityRecord]
+
+
 class UserListeningActivityStatRange(pydantic.BaseModel):
     """ Model for user's listening activity for a particular time range.
         Currently supports week, month, year and all-time
     """
     to_ts: int
     from_ts: int
-    listening_activity: List[UserListeningActivityRecord]
+    stats_range: str
+    data: UserListeningActivityRecordList
 
 
-class UserListeningActivityStatJson(pydantic.BaseModel):
-    """ Model for the JSON stored in the statistics.user table's listening_activity column
-    """
-    week: Optional[UserListeningActivityStatRange]
-    month: Optional[UserListeningActivityStatRange]
-    year: Optional[UserListeningActivityStatRange]
-    all_time: Optional[UserListeningActivityStatRange]
-
-
-class UserListeningActivityStat(UserListeningActivityStatJson):
+class UserListeningActivityStat(UserListeningActivityStatRange):
     """ Model for stats around user's listening activity
     """
     user_id: int

--- a/data/model/user_recording_stat.py
+++ b/data/model/user_recording_stat.py
@@ -27,19 +27,11 @@ class UserRecordingStatRange(pydantic.BaseModel):
     to_ts: int
     from_ts: int
     count: int
-    recordings: List[UserRecordingRecord]
+    stats_range: str
+    data: List[UserRecordingRecord]
 
 
-class UserRecordingStatJson(pydantic.BaseModel):
-    """ Model for the JSON stored in the statistics.user table's recording column
-    """
-    week: Optional[UserRecordingStatRange]
-    year: Optional[UserRecordingStatRange]
-    month: Optional[UserRecordingStatRange]
-    all_time: Optional[UserRecordingStatRange]
-
-
-class UserRecordingStat(UserRecordingStatJson):
+class UserRecordingStat(UserRecordingStatRange):
     """ Model for stats around a user's most listened recordings
     """
     user_id: int

--- a/data/model/user_recording_stat.py
+++ b/data/model/user_recording_stat.py
@@ -20,6 +20,13 @@ class UserRecordingRecord(pydantic.BaseModel):
     release_msid: Optional[str]
 
 
+# we need this so that we can call json(exclude_none=True) when inserting in the db
+# not sure if this is necessary but preserving the old behaviour for now. json.dumps
+# does not have an exclude_none option.
+class UserRecordingRecordList(pydantic.BaseModel):
+    __root__: List[UserRecordingRecord]
+
+
 class UserRecordingStatRange(pydantic.BaseModel):
     """ Model for user's most listened-to recordings for a particular
     time range. Currently supports week, month, year and all-time
@@ -28,7 +35,7 @@ class UserRecordingStatRange(pydantic.BaseModel):
     from_ts: int
     count: int
     stats_range: str
-    data: List[UserRecordingRecord]
+    data: UserRecordingRecordList
 
 
 class UserRecordingStat(UserRecordingStatRange):

--- a/data/model/user_recording_stat.py
+++ b/data/model/user_recording_stat.py
@@ -1,6 +1,5 @@
 import pydantic
 
-from datetime import datetime
 from typing import Optional, List
 
 
@@ -18,28 +17,3 @@ class UserRecordingRecord(pydantic.BaseModel):
     artist_msid: Optional[str]
     recording_msid: Optional[str]
     release_msid: Optional[str]
-
-
-# we need this so that we can call json(exclude_none=True) when inserting in the db
-# not sure if this is necessary but preserving the old behaviour for now. json.dumps
-# does not have an exclude_none option.
-class UserRecordingRecordList(pydantic.BaseModel):
-    __root__: List[UserRecordingRecord]
-
-
-class UserRecordingStatRange(pydantic.BaseModel):
-    """ Model for user's most listened-to recordings for a particular
-    time range. Currently supports week, month, year and all-time
-    """
-    to_ts: int
-    from_ts: int
-    count: int
-    stats_range: str
-    data: UserRecordingRecordList
-
-
-class UserRecordingStat(UserRecordingStatRange):
-    """ Model for stats around a user's most listened recordings
-    """
-    user_id: int
-    last_updated: datetime

--- a/data/model/user_release_stat.py
+++ b/data/model/user_release_stat.py
@@ -1,6 +1,5 @@
 import pydantic
 
-from datetime import datetime
 from typing import Optional, List
 
 

--- a/data/model/user_release_stat.py
+++ b/data/model/user_release_stat.py
@@ -24,19 +24,11 @@ class UserReleaseStatRange(pydantic.BaseModel):
     to_ts: int
     from_ts: int
     count: int
+    stats_range: str
     releases: List[UserReleaseRecord]
 
 
-class UserReleaseStatJson(pydantic.BaseModel):
-    """ Model for the JSON stored in the statistics.user table's release column
-    """
-    week: Optional[UserReleaseStatRange]
-    year: Optional[UserReleaseStatRange]
-    month: Optional[UserReleaseStatRange]
-    all_time: Optional[UserReleaseStatRange]
-
-
-class UserReleaseStat(UserReleaseStatJson):
+class UserReleaseStat(UserReleaseStatRange):
     """ Model for stats around a user's most listened releases
     """
     user_id: int

--- a/data/model/user_release_stat.py
+++ b/data/model/user_release_stat.py
@@ -25,7 +25,7 @@ class UserReleaseStatRange(pydantic.BaseModel):
     from_ts: int
     count: int
     stats_range: str
-    releases: List[UserReleaseRecord]
+    data: List[UserReleaseRecord]
 
 
 class UserReleaseStat(UserReleaseStatRange):

--- a/data/model/user_release_stat.py
+++ b/data/model/user_release_stat.py
@@ -15,28 +15,3 @@ class UserReleaseRecord(pydantic.BaseModel):
     # to add empty fields to stats API response, for compatibility
     artist_msid: Optional[str]
     release_msid: Optional[str]
-
-
-# we need this so that we can call json(exclude_none=True) when inserting in the db
-# not sure if this is necessary but preserving the old behaviour for now. json.dumps
-# does not have an exclude_none option.
-class UserReleaseRecordList(pydantic.BaseModel):
-    __root__: List[UserReleaseRecord]
-
-
-class UserReleaseStatRange(pydantic.BaseModel):
-    """ Model for user's most listened-to releases for a particular
-    time range. Currently supports week, month, year and all-time
-    """
-    to_ts: int
-    from_ts: int
-    count: int
-    stats_range: str
-    data: UserReleaseRecordList
-
-
-class UserReleaseStat(UserReleaseStatRange):
-    """ Model for stats around a user's most listened releases
-    """
-    user_id: int
-    last_updated: datetime

--- a/data/model/user_release_stat.py
+++ b/data/model/user_release_stat.py
@@ -17,6 +17,13 @@ class UserReleaseRecord(pydantic.BaseModel):
     release_msid: Optional[str]
 
 
+# we need this so that we can call json(exclude_none=True) when inserting in the db
+# not sure if this is necessary but preserving the old behaviour for now. json.dumps
+# does not have an exclude_none option.
+class UserReleaseRecordList(pydantic.BaseModel):
+    __root__: List[UserReleaseRecord]
+
+
 class UserReleaseStatRange(pydantic.BaseModel):
     """ Model for user's most listened-to releases for a particular
     time range. Currently supports week, month, year and all-time
@@ -25,7 +32,7 @@ class UserReleaseStatRange(pydantic.BaseModel):
     from_ts: int
     count: int
     stats_range: str
-    data: List[UserReleaseRecord]
+    data: UserReleaseRecordList
 
 
 class UserReleaseStat(UserReleaseStatRange):

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -22,19 +22,17 @@
 
 
 import json
-from typing import Optional, List, Union
+from typing import Optional
 
 import sqlalchemy
 from data.model.sitewide_artist_stat import (SitewideArtistStat,
                                              SitewideArtistStatJson)
 from data.model.user_artist_map import UserArtistMapStat, UserArtistMapStatJson
-from data.model.user_artist_stat import UserArtistStat, UserArtistStatRange
 from data.model.user_daily_activity import (UserDailyActivityStat,
                                             UserDailyActivityStatJson)
+from data.model.user_entity import UserEntityStat, UserEntityStatRange
 from data.model.user_listening_activity import (UserListeningActivityStat,
                                                 UserListeningActivityStatJson)
-from data.model.user_recording_stat import UserRecordingStat, UserRecordingStatRange
-from data.model.user_release_stat import UserReleaseStat, UserReleaseStatRange
 from flask import current_app
 from listenbrainz import db
 from pydantic import ValidationError
@@ -52,8 +50,7 @@ def get_timestamp_for_last_user_stats_update():
         return row['last_update_ts'] if row else None
 
 
-def insert_user_jsonb_data(user_id: int, stats_type: str,
-                           stats: Union[UserArtistStatRange, UserReleaseStatRange, UserRecordingStatRange]):
+def insert_user_jsonb_data(user_id: int, stats_type: str, stats: UserEntityStatRange):
     """ Inserts jsonb data into the given column
 
         Args:
@@ -155,8 +152,7 @@ def insert_sitewide_artists(stats_range: str, artists: SitewideArtistStatJson):
         stats_range, column='artist', data=artists.dict(exclude_none=True))
 
 
-def get_user_stats(user_id: int, stats_range: str, stats_type: str) \
-        -> Optional[Union[UserArtistStat, UserReleaseStat, UserRecordingStat]]:
+def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[UserEntityStat]:
     """ Get top stats of given type in a time range for user with given ID.
 
         Args:
@@ -179,7 +175,7 @@ def get_user_stats(user_id: int, stats_range: str, stats_type: str) \
         row = result.fetchone()
 
     try:
-        return UserArtistStat(**dict(row)) if row else None
+        return UserEntityStat(**dict(row)) if row else None
     except ValidationError:
         current_app.logger.error("""ValidationError when getting {stats_range} top artists for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, user_id=user_id,

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -29,10 +29,10 @@ import sqlalchemy
 from data.model.common_stat import StatRange, StatApi
 from data.model.sitewide_artist_stat import (SitewideArtistStat,
                                              SitewideArtistStatJson)
-from data.model.user_artist_map import UserArtistMapStat, UserArtistMapStatRange
-from data.model.user_daily_activity import UserDailyActivityStat
+from data.model.user_artist_map import UserArtistMapRecordList
+from data.model.user_daily_activity import UserDailyActivityRecordList
 from data.model.user_entity import UserEntityRecordList
-from data.model.user_listening_activity import (UserListeningActivityStat, UserActivityStatRange, UserActivityStat)
+from data.model.user_listening_activity import UserListeningActivityRecordList
 from flask import current_app
 from listenbrainz import db
 from pydantic import ValidationError
@@ -79,7 +79,7 @@ def insert_user_jsonb_data(user_id: int, stats_type: str, stats: StatRange[UserE
         })
 
 
-def insert_user_jsonb_data_without_count(user_id, stats_type: str, stats: UserActivityStatRange):
+def insert_user_jsonb_data_without_count(user_id, stats_type: str, stats: StatRange):
     """Inserts listening_activity stats calculated from Spark into the database.
 
        If stats are already present for some user, they are updated to the new
@@ -130,7 +130,7 @@ def _insert_sitewide_jsonb_data(stats_range: str, column: str, data: dict):
         })
 
 
-def insert_user_artist_map(user_id: int, artist_map: UserArtistMapStatRange):
+def insert_user_artist_map(user_id: int, artist_map: StatRange[UserArtistMapRecordList]):
     """Inserts artist_map stats calculated from Spark into the database.
 
        If stats are already present for some user, they are updated to the new
@@ -188,7 +188,7 @@ def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[
 
 
 def get_user_activity_stats(user_id: int, stats_range: str, stats_type: str, stats_model)\
-        -> Optional[UserActivityStat]:
+        -> Optional[StatApi]:
     """Get activity stats in the given time range for user with given ID.
 
         Args:
@@ -221,34 +221,34 @@ def get_user_activity_stats(user_id: int, stats_range: str, stats_type: str, sta
         return None
 
 
-def get_user_listening_activity(user_id: int, stats_range: str) -> Optional[UserListeningActivityStat]:
+def get_user_listening_activity(user_id: int, stats_range: str) -> Optional[StatApi[UserListeningActivityRecordList]]:
     """Get listening activity in the given time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
             stats_range: the time range to fetch the stats for
     """
-    return get_user_activity_stats(user_id, stats_range, 'listening_activity', UserListeningActivityStat)
+    return get_user_activity_stats(user_id, stats_range, 'listening_activity', StatApi[UserListeningActivityRecordList])
 
 
-def get_user_daily_activity(user_id: int, stats_range: str) -> Optional[UserDailyActivityStat]:
+def get_user_daily_activity(user_id: int, stats_range: str) -> Optional[StatApi[UserDailyActivityRecordList]]:
     """Get daily activity in the given time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
             stats_range: the time range to fetch the stats for
     """
-    return get_user_activity_stats(user_id, stats_range, 'daily_activity', UserDailyActivityStat)
+    return get_user_activity_stats(user_id, stats_range, 'daily_activity', StatApi[UserDailyActivityRecordList])
 
 
-def get_user_artist_map(user_id: int, stats_range: str) -> Optional[UserArtistMapStat]:
+def get_user_artist_map(user_id: int, stats_range: str) -> Optional[StatApi[UserArtistMapRecordList]]:
     """Get artist map in the given time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
             stats_range: the time range to fetch the stats for
     """
-    return get_user_activity_stats(user_id, stats_range, 'artist_map', UserArtistMapStat)
+    return get_user_activity_stats(user_id, stats_range, 'artist_map', StatApi[UserArtistMapRecordList])
 
 
 def get_sitewide_artists(stats_range: str) -> Optional[SitewideArtistStat]:

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -29,7 +29,7 @@ import sqlalchemy
 from data.model.common_stat import StatRange, StatApi
 from data.model.sitewide_artist_stat import (SitewideArtistStat,
                                              SitewideArtistStatJson)
-from data.model.user_artist_map import UserArtistMapRecordList
+from data.model.user_artist_map import UserArtistMapRecord
 from data.model.user_daily_activity import UserDailyActivityRecord
 from data.model.user_entity import UserEntityRecord
 from data.model.user_listening_activity import UserListeningActivityRecord
@@ -198,14 +198,14 @@ def get_user_daily_activity(user_id: int, stats_range: str) -> Optional[StatApi[
     return get_user_activity_stats(user_id, stats_range, 'daily_activity', StatApi[UserDailyActivityRecord])
 
 
-def get_user_artist_map(user_id: int, stats_range: str) -> Optional[StatApi[UserArtistMapRecordList]]:
+def get_user_artist_map(user_id: int, stats_range: str) -> Optional[StatApi[UserArtistMapRecord]]:
     """Get artist map in the given time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
             stats_range: the time range to fetch the stats for
     """
-    return get_user_activity_stats(user_id, stats_range, 'artist_map', StatApi[UserArtistMapRecordList])
+    return get_user_activity_stats(user_id, stats_range, 'artist_map', StatApi[UserArtistMapRecord])
 
 
 def get_sitewide_artists(stats_range: str) -> Optional[SitewideArtistStat]:

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -30,9 +30,9 @@ from data.model.common_stat import StatRange, StatApi
 from data.model.sitewide_artist_stat import (SitewideArtistStat,
                                              SitewideArtistStatJson)
 from data.model.user_artist_map import UserArtistMapRecordList
-from data.model.user_daily_activity import UserDailyActivityRecordList
-from data.model.user_entity import UserEntityRecordList
-from data.model.user_listening_activity import UserListeningActivityRecordList
+from data.model.user_daily_activity import UserDailyActivityRecord
+from data.model.user_entity import UserEntityRecord
+from data.model.user_listening_activity import UserListeningActivityRecord
 from flask import current_app
 from listenbrainz import db
 from pydantic import ValidationError
@@ -113,7 +113,7 @@ def insert_sitewide_artists(stats_range: str, artists: SitewideArtistStatJson):
         stats_range, column='artist', data=artists.dict(exclude_none=True))
 
 
-def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[StatApi[UserEntityRecordList]]:
+def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[StatApi[UserEntityRecord]]:
     """ Get top stats of given type in a time range for user with given ID.
 
         Args:
@@ -136,7 +136,7 @@ def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[
         row = result.fetchone()
 
     try:
-        return StatApi[UserEntityRecordList](**dict(row)) if row else None
+        return StatApi[UserEntityRecord](**dict(row)) if row else None
     except ValidationError:
         current_app.logger.error("""ValidationError when getting {stats_range} top artists for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, user_id=user_id,
@@ -178,24 +178,24 @@ def get_user_activity_stats(user_id: int, stats_range: str, stats_type: str, sta
         return None
 
 
-def get_user_listening_activity(user_id: int, stats_range: str) -> Optional[StatApi[UserListeningActivityRecordList]]:
+def get_user_listening_activity(user_id: int, stats_range: str) -> Optional[StatApi[UserListeningActivityRecord]]:
     """Get listening activity in the given time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
             stats_range: the time range to fetch the stats for
     """
-    return get_user_activity_stats(user_id, stats_range, 'listening_activity', StatApi[UserListeningActivityRecordList])
+    return get_user_activity_stats(user_id, stats_range, 'listening_activity', StatApi[UserListeningActivityRecord])
 
 
-def get_user_daily_activity(user_id: int, stats_range: str) -> Optional[StatApi[UserDailyActivityRecordList]]:
+def get_user_daily_activity(user_id: int, stats_range: str) -> Optional[StatApi[UserDailyActivityRecord]]:
     """Get daily activity in the given time range for user with given ID.
 
         Args:
             user_id: the row ID of the user in the DB
             stats_range: the time range to fetch the stats for
     """
-    return get_user_activity_stats(user_id, stats_range, 'daily_activity', StatApi[UserDailyActivityRecordList])
+    return get_user_activity_stats(user_id, stats_range, 'daily_activity', StatApi[UserDailyActivityRecord])
 
 
 def get_user_artist_map(user_id: int, stats_range: str) -> Optional[StatApi[UserArtistMapRecordList]]:

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -128,7 +128,7 @@ def _insert_sitewide_jsonb_data(stats_range: str, column: str, data: dict):
         })
 
 
-def insert_user_artist_map(user_id: int, artist_map: UserArtistMapStatJson):
+def insert_user_artist_map(user_id: int, artist_map: UserArtistMapStat):
     """Inserts artist_map stats calculated from Spark into the database.
 
        If stats are already present for some user, they are updated to the new

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -27,7 +27,7 @@ from typing import Optional
 import sqlalchemy
 from data.model.sitewide_artist_stat import (SitewideArtistStat,
                                              SitewideArtistStatJson)
-from data.model.user_artist_map import UserArtistMapStat
+from data.model.user_artist_map import UserArtistMapStat, UserArtistMapStatRange
 from data.model.user_daily_activity import UserDailyActivityStat
 from data.model.user_entity import UserEntityStat, UserEntityStatRange
 from data.model.user_listening_activity import (UserListeningActivityStat, UserActivityStatRange, UserActivityStat)
@@ -128,7 +128,7 @@ def _insert_sitewide_jsonb_data(stats_range: str, column: str, data: dict):
         })
 
 
-def insert_user_artist_map(user_id: int, artist_map: UserArtistMapStat):
+def insert_user_artist_map(user_id: int, artist_map: UserArtistMapStatRange):
     """Inserts artist_map stats calculated from Spark into the database.
 
        If stats are already present for some user, they are updated to the new

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -78,8 +78,8 @@ def _insert_user_jsonb_data(user_id: int, stats_type: str, stats: Union[UserArti
             "stats_range": stats.stats_range,
             "data": stats.data.json(exclude_none=True),
             "count": stats.count,
-            "from_ts": unix_timestamp_to_datetime(stats.from_ts),
-            "to_ts": unix_timestamp_to_datetime(stats.to_ts)
+            "from_ts": stats.from_ts,
+            "to_ts": stats.to_ts
         })
 
 

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -234,9 +234,11 @@ def get_user_artists(user_id: int, stats_range: str) -> Optional[UserArtistStat]
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT user_id, artist->:range AS {range}, last_updated
-              FROM statistics.user
+            SELECT user_id, last_updated, data, count, from_ts, to_ts, stats_range
+              FROM statistics.user_new
              WHERE user_id = :user_id
+             AND stats_range = :stats_range
+             AND stats_type = 'artists'
             """.format(range=stats_range)), {
             'range': stats_range,
             'user_id': user_id

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -25,11 +25,13 @@ import json
 from typing import Optional
 
 import sqlalchemy
+
+from data.model.common_stat import StatRange, StatApi
 from data.model.sitewide_artist_stat import (SitewideArtistStat,
                                              SitewideArtistStatJson)
 from data.model.user_artist_map import UserArtistMapStat, UserArtistMapStatRange
 from data.model.user_daily_activity import UserDailyActivityStat
-from data.model.user_entity import UserEntityStat, UserEntityStatRange
+from data.model.user_entity import UserEntityRecordList
 from data.model.user_listening_activity import (UserListeningActivityStat, UserActivityStatRange, UserActivityStat)
 from flask import current_app
 from listenbrainz import db
@@ -48,7 +50,7 @@ def get_timestamp_for_last_user_stats_update():
         return row['last_update_ts'] if row else None
 
 
-def insert_user_jsonb_data(user_id: int, stats_type: str, stats: UserEntityStatRange):
+def insert_user_jsonb_data(user_id: int, stats_type: str, stats: StatRange[UserEntityRecordList]):
     """ Inserts jsonb data into the given column
 
         Args:
@@ -153,7 +155,7 @@ def insert_sitewide_artists(stats_range: str, artists: SitewideArtistStatJson):
         stats_range, column='artist', data=artists.dict(exclude_none=True))
 
 
-def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[UserEntityStat]:
+def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[StatApi[UserEntityRecordList]]:
     """ Get top stats of given type in a time range for user with given ID.
 
         Args:
@@ -176,7 +178,7 @@ def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[
         row = result.fetchone()
 
     try:
-        return UserEntityStat(**dict(row)) if row else None
+        return StatApi[UserEntityRecordList](**dict(row)) if row else None
     except ValidationError:
         current_app.logger.error("""ValidationError when getting {stats_range} top artists for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, user_id=user_id,

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -38,6 +38,7 @@ from data.model.user_recording_stat import (UserRecordingStat,
 from data.model.user_release_stat import UserReleaseStat, UserReleaseStatJson
 from flask import current_app
 from listenbrainz import db
+from listenbrainz.utils import unix_timestamp_to_datetime
 from pydantic import ValidationError
 
 
@@ -77,8 +78,8 @@ def _insert_user_jsonb_data(user_id: int, stats_type: str, stats: Union[UserArti
             "stats_range": stats.stats_range,
             "data": stats.data.json(exclude_none=True),
             "count": stats.count,
-            "from_ts": stats.from_ts,
-            "to_ts": stats.to_ts
+            "from_ts": unix_timestamp_to_datetime(stats.from_ts),
+            "to_ts": unix_timestamp_to_datetime(stats.to_ts)
         })
 
 

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -145,8 +145,7 @@ def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[
         return None
 
 
-def get_user_activity_stats(user_id: int, stats_range: str, stats_type: str, stats_model)\
-        -> Optional[StatApi]:
+def get_user_activity_stats(user_id: int, stats_range: str, stats_type: str, stats_model) -> Optional[StatApi]:
     """Get activity stats in the given time range for user with given ID.
 
         Args:

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -44,7 +44,7 @@ def get_timestamp_for_last_user_stats_update():
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT MAX(last_updated) as last_update_ts
-              FROM statistics.user
+              FROM statistics.user_new
             """))
         row = result.fetchone()
         return row['last_update_ts'] if row else None
@@ -250,7 +250,7 @@ def valid_stats_exist(user_id, days):
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
                 SELECT user_id
-                  FROM statistics.user
+                  FROM statistics.user_new
                  WHERE user_id = :user_id
                    AND last_updated >= NOW() - INTERVAL ':x days'
             """), {
@@ -269,7 +269,7 @@ def delete_user_stats(user_id):
     """
     with db.engine.connect() as connection:
         connection.execute(sqlalchemy.text("""
-            DELETE FROM statistics.user
+            DELETE FROM statistics.user_new
              WHERE user_id = :user_id
             """), {
             'user_id': user_id

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -241,7 +241,7 @@ def get_user_artists(user_id: int, stats_range: str) -> Optional[UserArtistStat]
              AND stats_range = :stats_range
              AND stats_type = 'artists'
             """.format(range=stats_range)), {
-            'range': stats_range,
+            'stats_range': stats_range,
             'user_id': user_id
         })
         row = result.fetchone()

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -33,12 +33,10 @@ from data.model.user_daily_activity import (UserDailyActivityStat,
                                             UserDailyActivityStatJson)
 from data.model.user_listening_activity import (UserListeningActivityStat,
                                                 UserListeningActivityStatJson)
-from data.model.user_recording_stat import (UserRecordingStat,
-                                            UserRecordingStatJson, UserRecordingStatRange)
-from data.model.user_release_stat import UserReleaseStat, UserReleaseStatJson, UserReleaseStatRange
+from data.model.user_recording_stat import UserRecordingStat, UserRecordingStatRange
+from data.model.user_release_stat import UserReleaseStat, UserReleaseStatRange
 from flask import current_app
 from listenbrainz import db
-from listenbrainz.utils import unix_timestamp_to_datetime
 from pydantic import ValidationError
 
 

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -22,16 +22,15 @@
 
 
 import json
-from typing import Optional, Union
+from typing import Optional
 
 import sqlalchemy
 from data.model.sitewide_artist_stat import (SitewideArtistStat,
                                              SitewideArtistStatJson)
-from data.model.user_artist_map import UserArtistMapStat, UserArtistMapStatJson
-from data.model.user_daily_activity import (UserDailyActivityStat, UserDailyActivityStatRange)
+from data.model.user_artist_map import UserArtistMapStat
+from data.model.user_daily_activity import UserDailyActivityStat
 from data.model.user_entity import UserEntityStat, UserEntityStatRange
-from data.model.user_listening_activity import (UserListeningActivityStat, UserListeningActivityStatRange,
-                                                UserActivityStatRange, UserActivityStat)
+from data.model.user_listening_activity import (UserListeningActivityStat, UserActivityStatRange, UserActivityStat)
 from flask import current_app
 from listenbrainz import db
 from pydantic import ValidationError

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -129,7 +129,6 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
                                         stats=StatRange[UserEntityRecordList](**recordings_data))
-        recordings_data['stats_range'] = 'year'
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
                                         stats=StatRange[UserEntityRecordList](**recordings_data_year))
 
@@ -143,27 +142,30 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_listening_activity_db.json')) as f:
             listening_activity_data = json.load(f)
+        listening_activity_data_year = deepcopy(listening_activity_data)
+        listening_activity_data_year['stat_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='listening_activity',
             stats=StatRange[UserListeningActivityRecordList](**listening_activity_data)
         )
-        listening_activity_data['stat_range'] = 'year'
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='listening_activity',
-            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data)
+            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data_year)
         )
 
         result = db_stats.get_user_listening_activity(1, 'all_time')
-        self.assertDictEqual(result.data.dict(), listening_activity_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), listening_activity_data)
 
         result = db_stats.get_user_listening_activity(1, 'year')
-        self.assertDictEqual(result.data.dict(), listening_activity_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), listening_activity_data_year)
 
     def test_insert_user_stats_mult_ranges_daily_activity(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_daily_activity_db.json')) as f:
             daily_activity_data = json.load(f)
+        daily_activity_data_year = deepcopy(daily_activity_data)
+        daily_activity_data_year['stat_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
@@ -172,35 +174,36 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         daily_activity_data['stat_range'] = 'year'
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
-            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data)
+            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data_year)
         )
 
         result = db_stats.get_user_daily_activity(1, 'all_time')
-        self.assertDictEqual(result.data.dict(), daily_activity_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), daily_activity_data)
 
         result = db_stats.get_user_daily_activity(1, 'year')
-        self.assertDictEqual(result.data.dict(), daily_activity_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), daily_activity_data)
 
     def test_insert_user_stats_mult_ranges_artist_map(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_artist_map_db.json')) as f:
             artist_map_data = json.load(f)
+        artist_map_data_year = deepcopy(artist_map_data)
+        artist_map_data_year['stat_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',
             stats=StatRange[UserArtistMapRecordList](**artist_map_data)
         )
-        artist_map_data['stat_range'] = 'year'
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',
-            stats=StatRange[UserArtistMapRecordList](**artist_map_data)
+            stats=StatRange[UserArtistMapRecordList](**artist_map_data_year)
         )
 
         result = db_stats.get_user_artist_map(1, 'all_time')
-        self.assertDictEqual(result.data.dict(), artist_map_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), artist_map_data)
 
         result = db_stats.get_user_artist_map(1, 'year')
-        self.assertDictEqual(result.data.dict(), artist_map_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), artist_map_data)
 
     def test_insert_sitewide_artists(self):
         """ Test if sitewide artist data is inserted correctly """

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -18,6 +18,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
     def setUp(self):
         DatabaseTestCase.setUp(self)
         self.user = db_user.get_or_create(1, 'stats_user')
+        self.maxDiff = None
 
     def test_insert_user_artists(self):
         """ Test if artist stats are inserted correctly """

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -29,7 +29,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
                                         stats=StatRange[UserEntityRecordList](**artists_data))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='artists')
-        self.assertDictEqual(result.dict(), artists_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), artists_data)
 
     def test_insert_user_releases(self):
         """ Test if release stats are inserted correctly """
@@ -39,7 +39,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
                                         stats=StatRange[UserEntityRecordList](**releases_data))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='releases')
-        self.assertDictEqual(result.dict(), releases_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), releases_data)
 
     def test_insert_user_recordings(self):
         """ Test if recording stats are inserted correctly """
@@ -49,7 +49,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
                                         stats=StatRange[UserEntityRecordList](**recordings_data))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='recordings')
-        self.assertDictEqual(result.dict(), recordings_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), recordings_data)
 
     def test_insert_user_listening_activity(self):
         """ Test if listening activity stats are inserted correctly """
@@ -70,7 +70,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         )
 
         result = db_stats.get_user_daily_activity(user_id=self.user['id'], stats_range='all_time')
-        self.assertDictEqual(result.dict(), daily_activity_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), daily_activity_data)
 
     def test_insert_user_artist_map(self):
         """ Test if daily activity stats are inserted correctly """
@@ -82,7 +82,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         )
 
         result = db_stats.get_user_artist_map(user_id=self.user['id'], stats_range='all_time')
-        self.assertDictEqual(result.dict(), artist_map_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), artist_map_data)
 
     def test_insert_user_stats_mult_ranges_artist(self):
         """ Test if multiple time range data is inserted correctly """
@@ -280,22 +280,22 @@ class StatsDatabaseTestCase(DatabaseTestCase):
     def test_get_user_listening_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_listening_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_listening_activity'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), data_inserted['user_listening_activity'])
 
     def test_get_user_daily_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_daily_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_daily_activity'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), data_inserted['user_daily_activity'])
 
     def test_get_user_artist_map(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_artist_map(self.user['id'], 'all_time')
-        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_artist_map'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), data_inserted['user_artist_map'])
 
     def test_get_sitewide_artists(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_sitewide_artists('all_time')
-        self.assertDictEqual(result.dict(), data_inserted['sitewide_artists'])
+        self.assertDictEqual(result.data.dict(), data_inserted['sitewide_artists'])
 
     def test_valid_stats_exist(self):
         self.assertFalse(db_stats.valid_stats_exist(self.user['id'], 7))

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -143,7 +143,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('user_listening_activity_db.json')) as f:
             listening_activity_data = json.load(f)
         listening_activity_data_year = deepcopy(listening_activity_data)
-        listening_activity_data_year['stat_range'] = 'year'
+        listening_activity_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='listening_activity',
@@ -165,7 +165,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('user_daily_activity_db.json')) as f:
             daily_activity_data = json.load(f)
         daily_activity_data_year = deepcopy(daily_activity_data)
-        daily_activity_data_year['stat_range'] = 'year'
+        daily_activity_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
@@ -187,7 +187,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('user_artist_map_db.json')) as f:
             artist_map_data = json.load(f)
         artist_map_data_year = deepcopy(artist_map_data)
-        artist_map_data_year['stat_range'] = 'year'
+        artist_map_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -171,7 +171,6 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             user_id=self.user['id'], stats_type='daily_activity',
             stats=StatRange[UserDailyActivityRecordList](**daily_activity_data)
         )
-        daily_activity_data['stat_range'] = 'year'
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
             stats=StatRange[UserDailyActivityRecordList](**daily_activity_data_year)
@@ -181,7 +180,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), daily_activity_data)
 
         result = db_stats.get_user_daily_activity(1, 'year')
-        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), daily_activity_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), daily_activity_data_year)
 
     def test_insert_user_stats_mult_ranges_artist_map(self):
         """ Test if multiple time range data is inserted correctly """
@@ -203,7 +202,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), artist_map_data)
 
         result = db_stats.get_user_artist_map(1, 'year')
-        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), artist_map_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated', 'count'}), artist_map_data_year)
 
     def test_insert_sitewide_artists(self):
         """ Test if sitewide artist data is inserted correctly """

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -264,37 +264,37 @@ class StatsDatabaseTestCase(DatabaseTestCase):
     def test_get_user_artists(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_stats(self.user['id'], 'all_time', 'artists')
-        self.assertDictEqual(result.data.dict(), data_inserted['user_artists'])
+        self.assertDictEqual(result.dict(), data_inserted['user_artists'])
 
     def test_get_user_releases(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_stats(self.user['id'], 'all_time', 'releases')
-        self.assertDictEqual(result.data.dict(), data_inserted['user_releases'])
+        self.assertDictEqual(result.dict(), data_inserted['user_releases'])
 
     def test_get_user_recordings(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_stats(self.user['id'], 'all_time', 'recordings')
-        self.assertDictEqual(result.data.dict(), data_inserted['user_recordings'])
+        self.assertDictEqual(result.dict(), data_inserted['user_recordings'])
 
     def test_get_user_listening_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_listening_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.data.dict(), data_inserted['user_listening_activity'])
+        self.assertDictEqual(result.dict(), data_inserted['user_listening_activity'])
 
     def test_get_user_daily_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_daily_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.data.dict(), data_inserted['user_daily_activity'])
+        self.assertDictEqual(result.dict(), data_inserted['user_daily_activity'])
 
     def test_get_user_artist_map(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_artist_map(self.user['id'], 'all_time')
-        self.assertDictEqual(result.data.dict(), data_inserted['user_artist_map'])
+        self.assertDictEqual(result.dict(), data_inserted['user_artist_map'])
 
     def test_get_sitewide_artists(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_sitewide_artists('all_time')
-        self.assertDictEqual(result.data.dict(), data_inserted['sitewide_artists'])
+        self.assertDictEqual(result.dict(), data_inserted['sitewide_artists'])
 
     def test_valid_stats_exist(self):
         self.assertFalse(db_stats.valid_stats_exist(self.user['id'], 7))

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -265,32 +265,32 @@ class StatsDatabaseTestCase(DatabaseTestCase):
     def test_get_user_artists(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_stats(self.user['id'], 'all_time', 'artists')
-        self.assertDictEqual(result.dict(), data_inserted['user_artists'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_artists'])
 
     def test_get_user_releases(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_stats(self.user['id'], 'all_time', 'releases')
-        self.assertDictEqual(result.dict(), data_inserted['user_releases'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_releases'])
 
     def test_get_user_recordings(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_stats(self.user['id'], 'all_time', 'recordings')
-        self.assertDictEqual(result.dict(), data_inserted['user_recordings'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_recordings'])
 
     def test_get_user_listening_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_listening_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.dict(), data_inserted['user_listening_activity'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_listening_activity'])
 
     def test_get_user_daily_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_daily_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.dict(), data_inserted['user_daily_activity'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_daily_activity'])
 
     def test_get_user_artist_map(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_artist_map(self.user['id'], 'all_time')
-        self.assertDictEqual(result.dict(), data_inserted['user_artist_map'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['user_artist_map'])
 
     def test_get_sitewide_artists(self):
         data_inserted = self.insert_test_data()

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -6,7 +6,7 @@ import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_artist_map import UserArtistMapRecordList
+from data.model.user_artist_map import UserArtistMapRecord
 from data.model.user_daily_activity import UserDailyActivityRecord
 from data.model.user_entity import UserEntityRecord
 from data.model.user_listening_activity import UserListeningActivityRecord
@@ -78,7 +78,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             artist_map_data = json.load(f)
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',
-            stats=StatRange[UserArtistMapRecordList](**artist_map_data)
+            stats=StatRange[UserArtistMapRecord](**artist_map_data)
         )
 
         result = db_stats.get_user_artist_map(user_id=self.user['id'], stats_range='all_time')
@@ -191,11 +191,11 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',
-            stats=StatRange[UserArtistMapRecordList](**artist_map_data)
+            stats=StatRange[UserArtistMapRecord](**artist_map_data)
         )
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',
-            stats=StatRange[UserArtistMapRecordList](**artist_map_data_year)
+            stats=StatRange[UserArtistMapRecord](**artist_map_data_year)
         )
 
         result = db_stats.get_user_artist_map(1, 'all_time')
@@ -248,7 +248,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         )
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',
-            stats=StatRange[UserArtistMapRecordList](**artist_map)
+            stats=StatRange[UserArtistMapRecord](**artist_map)
         )
         db_stats.insert_sitewide_artists('all_time', SitewideArtistStatJson(**sitewide_artists))
 

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -7,9 +7,9 @@ import listenbrainz.db.user as db_user
 from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecordList
-from data.model.user_daily_activity import UserDailyActivityRecordList
-from data.model.user_entity import UserEntityRecordList
-from data.model.user_listening_activity import UserListeningActivityRecordList
+from data.model.user_daily_activity import UserDailyActivityRecord
+from data.model.user_entity import UserEntityRecord
+from data.model.user_listening_activity import UserListeningActivityRecord
 from listenbrainz.db.testing import DatabaseTestCase
 
 
@@ -26,7 +26,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             artists_data = json.load(f)
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
-                                        stats=StatRange[UserEntityRecordList](**artists_data))
+                                        stats=StatRange[UserEntityRecord](**artists_data))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='artists')
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), artists_data)
@@ -36,7 +36,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('user_top_releases_db.json')) as f:
             releases_data = json.load(f)
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
-                                        stats=StatRange[UserEntityRecordList](**releases_data))
+                                        stats=StatRange[UserEntityRecord](**releases_data))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='releases')
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), releases_data)
@@ -46,7 +46,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('user_top_recordings_db.json')) as f:
             recordings_data = json.load(f)
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
-                                        stats=StatRange[UserEntityRecordList](**recordings_data))
+                                        stats=StatRange[UserEntityRecord](**recordings_data))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='recordings')
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), recordings_data)
@@ -57,7 +57,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             listening_activity_data = json.load(f)
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='listening_activity',
-            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data)
+            stats=StatRange[UserListeningActivityRecord](**listening_activity_data)
         )
 
     def test_insert_user_daily_activity(self):
@@ -66,7 +66,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             daily_activity_data = json.load(f)
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
-            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data)
+            stats=StatRange[UserDailyActivityRecord](**daily_activity_data)
         )
 
         result = db_stats.get_user_daily_activity(user_id=self.user['id'], stats_range='all_time')
@@ -92,9 +92,9 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         artists_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
-                                        stats=StatRange[UserEntityRecordList](**artists_data))
+                                        stats=StatRange[UserEntityRecord](**artists_data))
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
-                                        stats=StatRange[UserEntityRecordList](**artists_data_year))
+                                        stats=StatRange[UserEntityRecord](**artists_data_year))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='artists')
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), artists_data)
@@ -110,9 +110,9 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         releases_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
-                                        stats=StatRange[UserEntityRecordList](**releases_data))
+                                        stats=StatRange[UserEntityRecord](**releases_data))
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
-                                        stats=StatRange[UserEntityRecordList](**releases_data_year))
+                                        stats=StatRange[UserEntityRecord](**releases_data_year))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='releases')
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), releases_data)
@@ -128,9 +128,9 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         recordings_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
-                                        stats=StatRange[UserEntityRecordList](**recordings_data))
+                                        stats=StatRange[UserEntityRecord](**recordings_data))
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
-                                        stats=StatRange[UserEntityRecordList](**recordings_data_year))
+                                        stats=StatRange[UserEntityRecord](**recordings_data_year))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='recordings')
         self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), recordings_data)
@@ -147,11 +147,11 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='listening_activity',
-            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data)
+            stats=StatRange[UserListeningActivityRecord](**listening_activity_data)
         )
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='listening_activity',
-            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data_year)
+            stats=StatRange[UserListeningActivityRecord](**listening_activity_data_year)
         )
 
         result = db_stats.get_user_listening_activity(1, 'all_time')
@@ -169,11 +169,11 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
-            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data)
+            stats=StatRange[UserDailyActivityRecord](**daily_activity_data)
         )
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
-            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data_year)
+            stats=StatRange[UserDailyActivityRecord](**daily_activity_data_year)
         )
 
         result = db_stats.get_user_daily_activity(1, 'all_time')
@@ -233,18 +233,18 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             sitewide_artists = json.load(f)
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
-                                        stats=StatRange[UserEntityRecordList](**user_artists))
+                                        stats=StatRange[UserEntityRecord](**user_artists))
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
-                                        stats=StatRange[UserEntityRecordList](**releases))
+                                        stats=StatRange[UserEntityRecord](**releases))
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
-                                        stats=StatRange[UserEntityRecordList](**recordings))
+                                        stats=StatRange[UserEntityRecord](**recordings))
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='listening_activity',
-            stats=StatRange[UserListeningActivityRecordList](**listening_activity)
+            stats=StatRange[UserListeningActivityRecord](**listening_activity)
         )
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='daily_activity',
-            stats=StatRange[UserDailyActivityRecordList](**daily_activity)
+            stats=StatRange[UserDailyActivityRecord](**daily_activity)
         )
         db_stats.insert_user_jsonb_data(
             user_id=self.user['id'], stats_type='artist_map',

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -1,5 +1,5 @@
 import json
-import os
+from copy import deepcopy
 from datetime import datetime, timezone
 
 import listenbrainz.db.stats as db_stats
@@ -88,52 +88,56 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_top_artists_db.json')) as f:
             artists_data = json.load(f)
+        artists_data_year = deepcopy(artists_data)
+        artists_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
                                         stats=StatRange[UserEntityRecordList](**artists_data))
-        artists_data['stats_range'] = 'year'
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
-                                        stats=StatRange[UserEntityRecordList](**artists_data))
+                                        stats=StatRange[UserEntityRecordList](**artists_data_year))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='artists')
-        self.assertDictEqual(result.dict(), artists_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), artists_data)
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='year', stats_type='artists')
-        self.assertDictEqual(result.dict(), artists_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), artists_data_year)
 
     def test_insert_user_stats_mult_ranges_release(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_top_releases_db.json')) as f:
             releases_data = json.load(f)
+        releases_data_year = deepcopy(releases_data)
+        releases_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
                                         stats=StatRange[UserEntityRecordList](**releases_data))
-        releases_data['stats_range'] = 'year'
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
-                                        stats=StatRange[UserEntityRecordList](**releases_data))
+                                        stats=StatRange[UserEntityRecordList](**releases_data_year))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='releases')
-        self.assertDictEqual(result.dict(), releases_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), releases_data)
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='year', stats_type='releases')
-        self.assertDictEqual(result.dict(), releases_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), releases_data_year)
 
     def test_insert_user_stats_mult_ranges_recording(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_top_recordings_db.json')) as f:
             recordings_data = json.load(f)
+        recordings_data_year = deepcopy(recordings_data)
+        recordings_data_year['stats_range'] = 'year'
 
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
                                         stats=StatRange[UserEntityRecordList](**recordings_data))
         recordings_data['stats_range'] = 'year'
         db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
-                                        stats=StatRange[UserEntityRecordList](**recordings_data))
+                                        stats=StatRange[UserEntityRecordList](**recordings_data_year))
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='recordings')
-        self.assertDictEqual(result.dict(), recordings_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), recordings_data)
 
         result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='year', stats_type='recordings')
-        self.assertDictEqual(result.dict(), recordings_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), recordings_data_year)
 
     def test_insert_user_stats_mult_ranges_listening_activity(self):
         """ Test if multiple time range data is inserted correctly """

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -4,13 +4,12 @@ from datetime import datetime, timezone
 
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
+from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_artist_map import UserArtistMapStatJson
-from data.model.user_artist_stat import UserArtistStatJson
-from data.model.user_daily_activity import UserDailyActivityStatJson
-from data.model.user_listening_activity import UserListeningActivityStatJson
-from data.model.user_recording_stat import UserRecordingStatJson
-from data.model.user_release_stat import UserReleaseStatJson
+from data.model.user_artist_map import UserArtistMapRecordList
+from data.model.user_daily_activity import UserDailyActivityRecordList
+from data.model.user_entity import UserEntityRecordList
+from data.model.user_listening_activity import UserListeningActivityRecordList
 from listenbrainz.db.testing import DatabaseTestCase
 
 
@@ -25,147 +24,178 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('user_top_artists_db.json')) as f:
             artists_data = json.load(f)
 
-        db_stats.insert_user_artists(user_id=self.user['id'], artists=UserArtistStatJson(**{'all_time': artists_data}))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
+                                        stats=StatRange[UserEntityRecordList](**artists_data))
 
-        result = db_stats.get_user_artists(user_id=self.user['id'], stats_range='all_time')
-        self.assertDictEqual(result.all_time.dict(), artists_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='artists')
+        self.assertDictEqual(result.dict(), artists_data)
 
     def test_insert_user_releases(self):
         """ Test if release stats are inserted correctly """
         with open(self.path_to_data_file('user_top_releases_db.json')) as f:
             releases_data = json.load(f)
-        db_stats.insert_user_releases(user_id=self.user['id'], releases=UserReleaseStatJson(**{'all_time': releases_data}))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
+                                        stats=StatRange[UserEntityRecordList](**releases_data))
 
-        result = db_stats.get_user_releases(user_id=self.user['id'], stats_range='all_time')
-        self.assertDictEqual(result.all_time.dict(), releases_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='releases')
+        self.assertDictEqual(result.dict(), releases_data)
 
     def test_insert_user_recordings(self):
         """ Test if recording stats are inserted correctly """
         with open(self.path_to_data_file('user_top_recordings_db.json')) as f:
             recordings_data = json.load(f)
-        db_stats.insert_user_recordings(user_id=self.user['id'],
-                                        recordings=UserRecordingStatJson(**{'all_time': recordings_data}))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
+                                        stats=StatRange[UserEntityRecordList](**recordings_data))
 
-        result = db_stats.get_user_recordings(user_id=self.user['id'], stats_range='all_time')
-        self.assertDictEqual(result.all_time.dict(), recordings_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='recordings')
+        self.assertDictEqual(result.dict(), recordings_data)
 
     def test_insert_user_listening_activity(self):
         """ Test if listening activity stats are inserted correctly """
         with open(self.path_to_data_file('user_listening_activity_db.json')) as f:
             listening_activity_data = json.load(f)
-        db_stats.insert_user_listening_activity(
-            user_id=self.user['id'], listening_activity=UserListeningActivityStatJson(**{'all_time': listening_activity_data}))
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='listening_activity',
+            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data)
+        )
 
     def test_insert_user_daily_activity(self):
         """ Test if daily activity stats are inserted correctly """
         with open(self.path_to_data_file('user_daily_activity_db.json')) as f:
             daily_activity_data = json.load(f)
-        db_stats.insert_user_daily_activity(
-            user_id=self.user['id'], daily_activity=UserDailyActivityStatJson(**{'all_time': daily_activity_data}))
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='daily_activity',
+            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data)
+        )
 
         result = db_stats.get_user_daily_activity(user_id=self.user['id'], stats_range='all_time')
-        self.assertDictEqual(result.all_time.dict(), daily_activity_data)
+        self.assertDictEqual(result.dict(), daily_activity_data)
 
     def test_insert_user_artist_map(self):
         """ Test if daily activity stats are inserted correctly """
         with open(self.path_to_data_file('user_artist_map_db.json')) as f:
             artist_map_data = json.load(f)
-        db_stats.insert_user_artist_map(
-            user_id=self.user['id'], artist_map=UserArtistMapStatJson(**{'all_time': artist_map_data}))
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='artist_map',
+            stats=StatRange[UserArtistMapRecordList](**artist_map_data)
+        )
 
         result = db_stats.get_user_artist_map(user_id=self.user['id'], stats_range='all_time')
-        self.assertDictEqual(result.all_time.dict(), artist_map_data)
+        self.assertDictEqual(result.dict(), artist_map_data)
 
     def test_insert_user_stats_mult_ranges_artist(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_top_artists_db.json')) as f:
             artists_data = json.load(f)
 
-        db_stats.insert_user_artists(user_id=self.user['id'], artists=UserArtistStatJson(**{'all_time': artists_data}))
-        db_stats.insert_user_artists(user_id=self.user['id'], artists=UserArtistStatJson(**{'year': artists_data}))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
+                                        stats=StatRange[UserEntityRecordList](**artists_data))
+        artists_data['stats_range'] = 'year'
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
+                                        stats=StatRange[UserEntityRecordList](**artists_data))
 
-        result = db_stats.get_user_artists(1, 'all_time')
-        self.assertDictEqual(result.all_time.dict(), artists_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='artists')
+        self.assertDictEqual(result.dict(), artists_data)
 
-        result = db_stats.get_user_artists(1, 'year')
-        self.assertDictEqual(result.year.dict(), artists_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='year', stats_type='artists')
+        self.assertDictEqual(result.dict(), artists_data)
 
     def test_insert_user_stats_mult_ranges_release(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_top_releases_db.json')) as f:
             releases_data = json.load(f)
 
-        db_stats.insert_user_releases(user_id=self.user['id'], releases=UserReleaseStatJson(**{'year': releases_data}))
-        db_stats.insert_user_releases(user_id=self.user['id'], releases=UserReleaseStatJson(**{'all_time': releases_data}))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
+                                        stats=StatRange[UserEntityRecordList](**releases_data))
+        releases_data['stats_range'] = 'year'
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
+                                        stats=StatRange[UserEntityRecordList](**releases_data))
 
-        result = db_stats.get_user_releases(1, 'all_time')
-        self.assertDictEqual(result.all_time.dict(), releases_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='releases')
+        self.assertDictEqual(result.dict(), releases_data)
 
-        result = db_stats.get_user_releases(1, 'year')
-        self.assertDictEqual(result.year.dict(), releases_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='year', stats_type='releases')
+        self.assertDictEqual(result.dict(), releases_data)
 
     def test_insert_user_stats_mult_ranges_recording(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_top_recordings_db.json')) as f:
             recordings_data = json.load(f)
 
-        db_stats.insert_user_recordings(user_id=self.user['id'], recordings=UserRecordingStatJson(**{'year': recordings_data}))
-        db_stats.insert_user_recordings(user_id=self.user['id'],
-                                        recordings=UserRecordingStatJson(**{'all_time': recordings_data}))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
+                                        stats=StatRange[UserEntityRecordList](**recordings_data))
+        recordings_data['stats_range'] = 'year'
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
+                                        stats=StatRange[UserEntityRecordList](**recordings_data))
 
-        result = db_stats.get_user_recordings(1, 'all_time')
-        self.assertDictEqual(result.all_time.dict(), recordings_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='all_time', stats_type='recordings')
+        self.assertDictEqual(result.dict(), recordings_data)
 
-        result = db_stats.get_user_recordings(1, 'year')
-        self.assertDictEqual(result.year.dict(), recordings_data)
+        result = db_stats.get_user_stats(user_id=self.user['id'], stats_range='year', stats_type='recordings')
+        self.assertDictEqual(result.dict(), recordings_data)
 
     def test_insert_user_stats_mult_ranges_listening_activity(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_listening_activity_db.json')) as f:
             listening_activity_data = json.load(f)
 
-        db_stats.insert_user_listening_activity(
-            user_id=self.user['id'], listening_activity=UserListeningActivityStatJson(**{'year': listening_activity_data}))
-        db_stats.insert_user_listening_activity(
-            self.user['id'], UserListeningActivityStatJson(**{'all_time': listening_activity_data}))
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='listening_activity',
+            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data)
+        )
+        listening_activity_data['stat_range'] = 'year'
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='listening_activity',
+            stats=StatRange[UserListeningActivityRecordList](**listening_activity_data)
+        )
 
         result = db_stats.get_user_listening_activity(1, 'all_time')
-        self.assertDictEqual(result.all_time.dict(), listening_activity_data)
+        self.assertDictEqual(result.data.dict(), listening_activity_data)
 
         result = db_stats.get_user_listening_activity(1, 'year')
-        self.assertDictEqual(result.year.dict(), listening_activity_data)
+        self.assertDictEqual(result.data.dict(), listening_activity_data)
 
     def test_insert_user_stats_mult_ranges_daily_activity(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_daily_activity_db.json')) as f:
             daily_activity_data = json.load(f)
 
-        db_stats.insert_user_daily_activity(
-            user_id=self.user['id'], daily_activity=UserDailyActivityStatJson(**{'year': daily_activity_data}))
-        db_stats.insert_user_daily_activity(
-            self.user['id'], UserDailyActivityStatJson(**{'all_time': daily_activity_data}))
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='daily_activity',
+            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data)
+        )
+        daily_activity_data['stat_range'] = 'year'
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='daily_activity',
+            stats=StatRange[UserDailyActivityRecordList](**daily_activity_data)
+        )
 
         result = db_stats.get_user_daily_activity(1, 'all_time')
-        self.assertDictEqual(result.all_time.dict(), daily_activity_data)
+        self.assertDictEqual(result.data.dict(), daily_activity_data)
 
         result = db_stats.get_user_daily_activity(1, 'year')
-        self.assertDictEqual(result.year.dict(), daily_activity_data)
+        self.assertDictEqual(result.data.dict(), daily_activity_data)
 
     def test_insert_user_stats_mult_ranges_artist_map(self):
         """ Test if multiple time range data is inserted correctly """
         with open(self.path_to_data_file('user_artist_map_db.json')) as f:
             artist_map_data = json.load(f)
 
-        db_stats.insert_user_artist_map(
-            user_id=self.user['id'], artist_map=UserArtistMapStatJson(**{'year': artist_map_data}))
-        db_stats.insert_user_artist_map(
-            self.user['id'], UserArtistMapStatJson(**{'all_time': artist_map_data}))
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='artist_map',
+            stats=StatRange[UserArtistMapRecordList](**artist_map_data)
+        )
+        artist_map_data['stat_range'] = 'year'
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='artist_map',
+            stats=StatRange[UserArtistMapRecordList](**artist_map_data)
+        )
 
         result = db_stats.get_user_artist_map(1, 'all_time')
-        self.assertDictEqual(result.all_time.dict(), artist_map_data)
+        self.assertDictEqual(result.data.dict(), artist_map_data)
 
         result = db_stats.get_user_artist_map(1, 'year')
-        self.assertDictEqual(result.year.dict(), artist_map_data)
+        self.assertDictEqual(result.data.dict(), artist_map_data)
 
     def test_insert_sitewide_artists(self):
         """ Test if sitewide artist data is inserted correctly """
@@ -195,13 +225,24 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('sitewide_top_artists_db.json')) as f:
             sitewide_artists = json.load(f)
 
-        db_stats.insert_user_artists(self.user['id'], UserArtistStatJson(**{'all_time': user_artists}))
-        db_stats.insert_user_releases(self.user['id'], UserReleaseStatJson(**{'all_time': releases}))
-        db_stats.insert_user_recordings(self.user['id'], UserRecordingStatJson(**{'all_time': recordings}))
-        db_stats.insert_user_listening_activity(
-            self.user['id'], UserListeningActivityStatJson(**{'all_time': listening_activity}))
-        db_stats.insert_user_daily_activity(self.user['id'], UserDailyActivityStatJson(**{'all_time': daily_activity}))
-        db_stats.insert_user_artist_map(self.user['id'], UserArtistMapStatJson(**{'all_time': artist_map}))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
+                                        stats=StatRange[UserEntityRecordList](**user_artists))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='releases',
+                                        stats=StatRange[UserEntityRecordList](**releases))
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='recordings',
+                                        stats=StatRange[UserEntityRecordList](**recordings))
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='listening_activity',
+            stats=StatRange[UserListeningActivityRecordList](**listening_activity)
+        )
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='daily_activity',
+            stats=StatRange[UserDailyActivityRecordList](**daily_activity)
+        )
+        db_stats.insert_user_jsonb_data(
+            user_id=self.user['id'], stats_type='artist_map',
+            stats=StatRange[UserArtistMapRecordList](**artist_map)
+        )
         db_stats.insert_sitewide_artists('all_time', SitewideArtistStatJson(**sitewide_artists))
 
         return {
@@ -222,33 +263,33 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
     def test_get_user_artists(self):
         data_inserted = self.insert_test_data()
-        result = db_stats.get_user_artists(self.user['id'], 'all_time')
-        self.assertDictEqual(result.all_time.dict(), data_inserted['user_artists'])
+        result = db_stats.get_user_stats(self.user['id'], 'all_time', 'artists')
+        self.assertDictEqual(result.data.dict(), data_inserted['user_artists'])
 
     def test_get_user_releases(self):
         data_inserted = self.insert_test_data()
-        result = db_stats.get_user_releases(self.user['id'], 'all_time')
-        self.assertDictEqual(result.all_time.dict(), data_inserted['user_releases'])
+        result = db_stats.get_user_stats(self.user['id'], 'all_time', 'releases')
+        self.assertDictEqual(result.data.dict(), data_inserted['user_releases'])
 
     def test_get_user_recordings(self):
         data_inserted = self.insert_test_data()
-        result = db_stats.get_user_recordings(self.user['id'], 'all_time')
-        self.assertDictEqual(result.all_time.dict(), data_inserted['user_recordings'])
+        result = db_stats.get_user_stats(self.user['id'], 'all_time', 'recordings')
+        self.assertDictEqual(result.data.dict(), data_inserted['user_recordings'])
 
     def test_get_user_listening_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_listening_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.all_time.dict(), data_inserted['user_listening_activity'])
+        self.assertDictEqual(result.data.dict(), data_inserted['user_listening_activity'])
 
     def test_get_user_daily_activity(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_daily_activity(self.user['id'], 'all_time')
-        self.assertDictEqual(result.all_time.dict(), data_inserted['user_daily_activity'])
+        self.assertDictEqual(result.data.dict(), data_inserted['user_daily_activity'])
 
     def test_get_user_artist_map(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_user_artist_map(self.user['id'], 'all_time')
-        self.assertDictEqual(result.all_time.dict(), data_inserted['user_artist_map'])
+        self.assertDictEqual(result.data.dict(), data_inserted['user_artist_map'])
 
     def test_get_sitewide_artists(self):
         data_inserted = self.insert_test_data()

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -9,7 +9,7 @@ import ujson
 
 from data.model.common_stat import StatRange
 from data.model.external_service import ExternalServiceType
-from data.model.user_entity import UserEntityRecordList
+from data.model.user_entity import UserEntityRecord
 from listenbrainz import db
 from listenbrainz.db.similar_users import import_user_similarities
 from listenbrainz.db.testing import DatabaseTestCase
@@ -99,7 +99,7 @@ class UserTestCase(DatabaseTestCase):
         db_stats.insert_user_jsonb_data(
             user_id=user_id,
             stats_type='artists',
-            stats=StatRange[UserEntityRecordList](** artists_data),
+            stats=StatRange[UserEntityRecord](** artists_data),
         )
         user_stats = db_stats.get_user_stats(user_id, 'all_time', 'artists')
         self.assertIsNotNone(user_stats)

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -7,11 +7,12 @@ import sqlalchemy
 import time
 import ujson
 
+from data.model.common_stat import StatRange
 from data.model.external_service import ExternalServiceType
+from data.model.user_entity import UserEntityRecordList
 from listenbrainz import db
 from listenbrainz.db.similar_users import import_user_similarities
 from listenbrainz.db.testing import DatabaseTestCase
-from data.model.user_artist_stat import UserArtistStatJson
 
 
 class UserTestCase(DatabaseTestCase):
@@ -95,17 +96,18 @@ class UserTestCase(DatabaseTestCase):
 
         with open(self.path_to_data_file('user_top_artists_db.json')) as f:
             artists_data = ujson.load(f)
-        db_stats.insert_user_artists(
+        db_stats.insert_user_jsonb_data(
             user_id=user_id,
-            artists=UserArtistStatJson(**{'all_time': artists_data}),
+            stats_type='artists',
+            stats=StatRange[UserEntityRecordList](** artists_data),
         )
-        user_stats = db_stats.get_user_artists(user_id, 'all_time')
+        user_stats = db_stats.get_user_stats(user_id, 'all_time', 'artists')
         self.assertIsNotNone(user_stats)
 
         db_user.delete(user_id)
         user = db_user.get(user_id)
         self.assertIsNone(user)
-        user_stats = db_stats.get_user_artists(user_id, 'all_time')
+        user_stats = db_stats.get_user_stats(user_id, 'all_time', 'artists')
         self.assertIsNone(user_stats)
 
     def test_delete_when_spotify_import_activated(self):

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -49,16 +49,6 @@ def notify_user_stats_update(stat_type):
         )
 
 
-def _get_user_entity_model(entity):
-    if entity == 'artists':
-        return UserArtistStatRange
-    elif entity == 'releases':
-        return UserReleaseStatRange
-    elif entity == 'recordings':
-        return UserRecordingStatRange
-    raise ValueError("Unknown entity type: %s" % entity)
-
-
 def _get_sitewide_entity_model(entity):
     if entity == 'artists':
         return SitewideArtistStatJson

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -14,9 +14,9 @@ from datetime import datetime, timezone, timedelta
 
 from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_daily_activity import UserDailyActivityStatRange
+from data.model.user_daily_activity import UserDailyActivityRecordList
 from data.model.user_entity import UserEntityRecordList
-from data.model.user_listening_activity import UserListeningActivityStatRange
+from data.model.user_listening_activity import UserListeningActivityRecordList
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
 from listenbrainz.db.similar_users import import_user_similarities
@@ -108,12 +108,12 @@ def _handle_user_activity_stats(stats_type, stats_model, data):
 
 def handle_user_listening_activity(data):
     """ Take listening activity stats for user and save it in database. """
-    _handle_user_activity_stats('listening_activity', UserListeningActivityStatRange, data)
+    _handle_user_activity_stats('listening_activity', StatRange[UserListeningActivityRecordList], data)
 
 
 def handle_user_daily_activity(data):
     """ Take daily activity stats for user and save it in database. """
-    _handle_user_activity_stats('daily_activity', UserDailyActivityStatRange, data)
+    _handle_user_activity_stats('daily_activity', StatRange[UserDailyActivityRecordList], data)
 
 
 def handle_sitewide_entity(data):

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -12,15 +12,14 @@ from pydantic import ValidationError
 from brainzutils.mail import send_mail
 from datetime import datetime, timezone, timedelta
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
+from data.model.user_artist_stat import UserArtistStatRange
 from data.model.user_daily_activity import UserDailyActivityStatJson
 from data.model.user_listening_activity import UserListeningActivityStatJson
-from data.model.user_artist_stat import UserArtistStatJson
 from data.model.user_release_stat import UserReleaseStatJson
 from data.model.user_recording_stat import UserRecordingStatJson
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
 from listenbrainz.db.similar_users import import_user_similarities
-
 
 
 TIME_TO_CONSIDER_STATS_AS_OLD = 20  # minutes
@@ -54,7 +53,7 @@ def notify_user_stats_update(stat_type):
 
 def _get_user_entity_model(entity):
     if entity == 'artists':
-        return UserArtistStatJson
+        return UserArtistStatRange
     elif entity == 'releases':
         return UserReleaseStatJson
     elif entity == 'recordings':

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -14,9 +14,9 @@ from datetime import datetime, timezone, timedelta
 
 from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_daily_activity import UserDailyActivityRecordList
-from data.model.user_entity import UserEntityRecordList
-from data.model.user_listening_activity import UserListeningActivityRecordList
+from data.model.user_daily_activity import UserDailyActivityRecord
+from data.model.user_entity import UserEntityRecord
+from data.model.user_listening_activity import UserListeningActivityRecord
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
 from listenbrainz.db.similar_users import import_user_similarities
@@ -73,7 +73,7 @@ def handle_user_entity(data):
     entity = data['entity']
 
     try:
-        db_stats.insert_user_jsonb_data(user['id'], entity, StatRange[UserEntityRecordList](**data))
+        db_stats.insert_user_jsonb_data(user['id'], entity, StatRange[UserEntityRecord](**data))
     except ValidationError:
         current_app.logger.error("""ValidationError while inserting {stats_range} top {entity} for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, entity=entity,
@@ -108,12 +108,12 @@ def _handle_user_activity_stats(stats_type, stats_model, data):
 
 def handle_user_listening_activity(data):
     """ Take listening activity stats for user and save it in database. """
-    _handle_user_activity_stats('listening_activity', StatRange[UserListeningActivityRecordList], data)
+    _handle_user_activity_stats('listening_activity', StatRange[UserListeningActivityRecord], data)
 
 
 def handle_user_daily_activity(data):
     """ Take daily activity stats for user and save it in database. """
-    _handle_user_activity_stats('daily_activity', StatRange[UserDailyActivityRecordList], data)
+    _handle_user_activity_stats('daily_activity', StatRange[UserDailyActivityRecord], data)
 
 
 def handle_sitewide_entity(data):

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -81,12 +81,6 @@ def handle_user_entity(data):
 
     stats_range = data['stats_range']
     entity = data['entity']
-    data[entity] = data['data']
-
-    # Strip extra data
-    # to_remove = {'musicbrainz_id', 'type', 'entity', 'data', 'stats_range'}
-    # data_mod = {key: data[key] for key in data if key not in to_remove}
-
     entity_model = _get_user_entity_model(entity)
 
     try:

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -15,8 +15,8 @@ from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_stat import UserArtistStatRange
 from data.model.user_daily_activity import UserDailyActivityStatJson
 from data.model.user_listening_activity import UserListeningActivityStatJson
-from data.model.user_release_stat import UserReleaseStatJson
-from data.model.user_recording_stat import UserRecordingStatJson
+from data.model.user_release_stat import UserReleaseStatRange
+from data.model.user_recording_stat import UserRecordingStatRange
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
 from listenbrainz.db.similar_users import import_user_similarities
@@ -55,9 +55,9 @@ def _get_user_entity_model(entity):
     if entity == 'artists':
         return UserArtistStatRange
     elif entity == 'releases':
-        return UserReleaseStatJson
+        return UserReleaseStatRange
     elif entity == 'recordings':
-        return UserRecordingStatJson
+        return UserRecordingStatRange
     raise ValueError("Unknown entity type: %s" % entity)
 
 
@@ -89,11 +89,8 @@ def handle_user_entity(data):
 
     entity_model = _get_user_entity_model(entity)
 
-    # Get function to insert statistics
-    db_handler = getattr(db_stats, 'insert_user_{}'.format(entity))
-
     try:
-        db_handler(user['id'], entity_model(**data))
+        db_stats.insert_user_jsonb_data(user['id'], entity, entity_model(**data))
     except ValidationError:
         current_app.logger.error("""ValidationError while inserting {stats_range} top {entity} for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, entity=entity,

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -11,9 +11,11 @@ from flask import current_app, render_template
 from pydantic import ValidationError
 from brainzutils.mail import send_mail
 from datetime import datetime, timezone, timedelta
+
+from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_daily_activity import UserDailyActivityStatRange
-from data.model.user_entity import UserEntityStatRange
+from data.model.user_entity import UserEntityRecordList
 from data.model.user_listening_activity import UserListeningActivityStatRange
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
@@ -71,7 +73,7 @@ def handle_user_entity(data):
     entity = data['entity']
 
     try:
-        db_stats.insert_user_jsonb_data(user['id'], entity, UserEntityStatRange(**data))
+        db_stats.insert_user_jsonb_data(user['id'], entity, StatRange[UserEntityRecordList](**data))
     except ValidationError:
         current_app.logger.error("""ValidationError while inserting {stats_range} top {entity} for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, entity=entity,

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -95,7 +95,7 @@ def _handle_user_activity_stats(stats_type, stats_model, data):
     stats_range = data['stats_range']
 
     try:
-        db_stats.insert_user_jsonb_data_without_count(user['id'], stats_type, stats_model(**data))
+        db_stats.insert_user_jsonb_data(user['id'], stats_type, stats_model(**data))
     except ValidationError:
         current_app.logger.error("""ValidationError while inserting {stats_range} {stats_type} for user with
         user_id: {user_id}. Data: {data}""".format(

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -84,8 +84,8 @@ def handle_user_entity(data):
     data[entity] = data['data']
 
     # Strip extra data
-    to_remove = {'musicbrainz_id', 'type', 'entity', 'data', 'stats_range'}
-    data_mod = {key: data[key] for key in data if key not in to_remove}
+    # to_remove = {'musicbrainz_id', 'type', 'entity', 'data', 'stats_range'}
+    # data_mod = {key: data[key] for key in data if key not in to_remove}
 
     entity_model = _get_user_entity_model(entity)
 
@@ -93,11 +93,11 @@ def handle_user_entity(data):
     db_handler = getattr(db_stats, 'insert_user_{}'.format(entity))
 
     try:
-        db_handler(user['id'], entity_model(**{stats_range: data_mod}))
+        db_handler(user['id'], entity_model(**data))
     except ValidationError:
         current_app.logger.error("""ValidationError while inserting {stats_range} top {entity} for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, entity=entity,
-                                                        user_id=user['id'], data=json.dumps({stats_range: data_mod}, indent=3)),
+                                                        user_id=user['id'], data=json.dumps({stats_range: data}, indent=3)),
                                  exc_info=True)
 
 

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -12,11 +12,9 @@ from pydantic import ValidationError
 from brainzutils.mail import send_mail
 from datetime import datetime, timezone, timedelta
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_artist_stat import UserArtistStatRange
 from data.model.user_daily_activity import UserDailyActivityStatJson
+from data.model.user_entity import UserEntityStatRange
 from data.model.user_listening_activity import UserListeningActivityStatJson
-from data.model.user_release_stat import UserReleaseStatRange
-from data.model.user_recording_stat import UserRecordingStatRange
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
 from listenbrainz.db.similar_users import import_user_similarities
@@ -81,10 +79,9 @@ def handle_user_entity(data):
 
     stats_range = data['stats_range']
     entity = data['entity']
-    entity_model = _get_user_entity_model(entity)
 
     try:
-        db_stats.insert_user_jsonb_data(user['id'], entity, entity_model(**data))
+        db_stats.insert_user_jsonb_data(user['id'], entity, UserEntityStatRange(**data))
     except ValidationError:
         current_app.logger.error("""ValidationError while inserting {stats_range} top {entity} for user with user_id: {user_id}.
                                  Data: {data}""".format(stats_range=stats_range, entity=entity,

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 
-from data.model.common_stat import StatRange
+from data.model.common_stat import StatRange, StatRecordList
 from data.model.sitewide_artist_stat import (SitewideArtistRecord,
                                              SitewideArtistStatJson,
                                              SitewideArtistStatRange)
@@ -68,7 +68,7 @@ class HandlersTestCase(unittest.TestCase):
             from_ts=1,
             count=1,
             stats_range='all_time',
-            data=UserEntityRecord(
+            data=StatRecordList[UserEntityRecord](
                 __root__=[
                     UserArtistRecord(
                         artist_mbids=[],
@@ -109,7 +109,7 @@ class HandlersTestCase(unittest.TestCase):
             to_ts=10,
             from_ts=1,
             stats_range='all_time',
-            data=UserListeningActivityRecord(
+            data=StatRecordList[UserListeningActivityRecord](
                 __root__=[
                     UserListeningActivityRecord(
                         from_ts=1,
@@ -150,7 +150,7 @@ class HandlersTestCase(unittest.TestCase):
             to_ts=10,
             from_ts=1,
             stats_range='all_time',
-            data=UserDailyActivityRecord(
+            data=StatRecordList[UserDailyActivityRecord](
                 __root__=[
                     UserDailyActivityRecord(
                         day='Monday',

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -64,7 +64,7 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_entity(data)
 
-        mock_db_insert.assert_called_with(1, StatRange[UserEntityRecordList](
+        mock_db_insert.assert_called_with(1, 'artists', StatRange[UserEntityRecordList](
             to_ts=10,
             from_ts=1,
             count=1,
@@ -92,7 +92,7 @@ class HandlersTestCase(unittest.TestCase):
             'stats_range': 'all_time',
             'from_ts': 1,
             'to_ts': 10,
-            'listening_activity': [{
+            'data': [{
                 'from_ts': 1,
                 'to_ts': 5,
                 'time_range': '2020',
@@ -106,17 +106,17 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_listening_activity(data)
 
-        mock_db_insert.assert_called_with(1, StatRange[UserListeningActivityRecordList](
+        mock_db_insert.assert_called_with(1, 'listening_activity', StatRange[UserListeningActivityRecordList](
             to_ts=10,
             from_ts=1,
             stats_range='all_time',
-            all_time=UserListeningActivityRecordList(
+            data=UserListeningActivityRecordList(
                 __root__=[
                     UserListeningActivityRecord(
                         from_ts=1,
                         to_ts=5,
                         time_range='2020',
-                        listen_count=200
+                        listen_count=200,
                     )
                 ]
             )

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -6,10 +6,9 @@ from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import (SitewideArtistRecord,
                                              SitewideArtistStatJson,
                                              SitewideArtistStatRange)
-from data.model.user_daily_activity import (UserDailyActivityRecord, UserDailyActivityStatRange,
-                                            UserDailyActivityRecordList)
-from data.model.user_entity import UserEntityRecordList
-from data.model.user_listening_activity import UserListeningActivityRecord, UserListeningActivityRecordList
+from data.model.user_daily_activity import UserDailyActivityRecord, UserDailyActivityRecord
+from data.model.user_entity import UserEntityRecord
+from data.model.user_listening_activity import UserListeningActivityRecord, UserListeningActivityRecord
 from data.model.user_artist_stat import UserArtistRecord
 
 from data.model.user_missing_musicbrainz_data import (UserMissingMusicBrainzDataRecord,
@@ -64,12 +63,12 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_entity(data)
 
-        mock_db_insert.assert_called_with(1, 'artists', StatRange[UserEntityRecordList](
+        mock_db_insert.assert_called_with(1, 'artists', StatRange[UserEntityRecord](
             to_ts=10,
             from_ts=1,
             count=1,
             stats_range='all_time',
-            data=UserEntityRecordList(
+            data=UserEntityRecord(
                 __root__=[
                     UserArtistRecord(
                         artist_mbids=[],
@@ -106,11 +105,11 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_listening_activity(data)
 
-        mock_db_insert.assert_called_with(1, 'listening_activity', StatRange[UserListeningActivityRecordList](
+        mock_db_insert.assert_called_with(1, 'listening_activity', StatRange[UserListeningActivityRecord](
             to_ts=10,
             from_ts=1,
             stats_range='all_time',
-            data=UserListeningActivityRecordList(
+            data=UserListeningActivityRecord(
                 __root__=[
                     UserListeningActivityRecord(
                         from_ts=1,
@@ -147,11 +146,11 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_daily_activity(data)
 
-        mock_db_insert.assert_called_with(1, StatRange[UserDailyActivityRecordList](
+        mock_db_insert.assert_called_with(1, StatRange[UserDailyActivityRecord](
             to_ts=10,
             from_ts=1,
             stats_range='all_time',
-            data=UserDailyActivityRecordList(
+            data=UserDailyActivityRecord(
                 __root__=[
                     UserDailyActivityRecord(
                         day='Monday',

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -2,25 +2,18 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 
+from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import (SitewideArtistRecord,
                                              SitewideArtistStatJson,
                                              SitewideArtistStatRange)
-from data.model.user_artist_stat import (UserArtistRecord, UserArtistStatJson,
-                                         UserArtistStatRange)
-from data.model.user_daily_activity import (UserDailyActivityRecord,
-                                            UserDailyActivityStatJson,
-                                            UserDailyActivityStatRange)
-from data.model.user_listening_activity import (UserListeningActivityRecord,
-                                                UserListeningActivityStatJson,
-                                                UserListeningActivityStatRange)
-
-from data.model.user_artist_stat import (UserArtistRecord,
-                                         UserArtistStatJson,
-                                         UserArtistStatRange)
+from data.model.user_daily_activity import (UserDailyActivityRecord, UserDailyActivityStatRange,
+                                            UserDailyActivityRecordList)
+from data.model.user_entity import UserEntityRecordList
+from data.model.user_listening_activity import UserListeningActivityRecord, UserListeningActivityRecordList
+from data.model.user_artist_stat import UserArtistRecord
 
 from data.model.user_missing_musicbrainz_data import (UserMissingMusicBrainzDataRecord,
-                                                      UserMissingMusicBrainzDataJson,
-                                                      UserMissingMusicBrainzData)
+                                                      UserMissingMusicBrainzDataJson)
 
 from data.model.user_cf_recommendations_recording_message import (UserRecommendationsJson,
                                                                   UserRecommendationsRecord)
@@ -46,7 +39,7 @@ class HandlersTestCase(unittest.TestCase):
     def setUp(self):
         self.app = create_app()
 
-    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_artists')
+    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_jsonb_data')
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
     @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
@@ -71,15 +64,13 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_entity(data)
 
-        mock_db_insert.assert_called_with(1, UserArtistStatJson(
-            week=None,
-            year=None,
-            month=None,
-            all_time=UserArtistStatRange(
-                to_ts=10,
-                from_ts=1,
-                count=1,
-                artists=[
+        mock_db_insert.assert_called_with(1, StatRange[UserEntityRecordList](
+            to_ts=10,
+            from_ts=1,
+            count=1,
+            stats_range='all_time',
+            data=UserEntityRecordList(
+                __root__=[
                     UserArtistRecord(
                         artist_mbids=[],
                         listen_count=200,
@@ -90,7 +81,7 @@ class HandlersTestCase(unittest.TestCase):
         ))
         mock_send_mail.assert_called_once()
 
-    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_listening_activity')
+    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_jsonb_data')
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
     @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
@@ -115,14 +106,12 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_listening_activity(data)
 
-        mock_db_insert.assert_called_with(1, UserListeningActivityStatJson(
-            week=None,
-            year=None,
-            month=None,
-            all_time=UserListeningActivityStatRange(
-                to_ts=10,
-                from_ts=1,
-                listening_activity=[
+        mock_db_insert.assert_called_with(1, StatRange[UserListeningActivityRecordList](
+            to_ts=10,
+            from_ts=1,
+            stats_range='all_time',
+            all_time=UserListeningActivityRecordList(
+                __root__=[
                     UserListeningActivityRecord(
                         from_ts=1,
                         to_ts=5,
@@ -134,7 +123,7 @@ class HandlersTestCase(unittest.TestCase):
         ))
         mock_send_mail.assert_called_once()
 
-    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_daily_activity')
+    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_jsonb_data')
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
     @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
@@ -158,14 +147,12 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_user_daily_activity(data)
 
-        mock_db_insert.assert_called_with(1, UserDailyActivityStatJson(
-            week=None,
-            year=None,
-            month=None,
-            all_time=UserDailyActivityStatRange(
-                to_ts=10,
-                from_ts=1,
-                daily_activity=[
+        mock_db_insert.assert_called_with(1, StatRange[UserDailyActivityRecordList](
+            to_ts=10,
+            from_ts=1,
+            stats_range='all_time',
+            data=UserDailyActivityRecordList(
+                __root__=[
                     UserDailyActivityRecord(
                         day='Monday',
                         hour=20,

--- a/listenbrainz/testdata/user_artist_map_db.json
+++ b/listenbrainz/testdata/user_artist_map_db.json
@@ -2,7 +2,7 @@
   "from_ts": 0,
   "to_ts": 10,
   "last_updated": 0,
-  "artist_map": [
+  "data": [
     {
       "country": "USA",
       "artist_count": 56,
@@ -18,5 +18,6 @@
       "artist_count": 32,
       "listen_count": 56
     }
-  ]
+  ],
+  "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_artist_map_db.json
+++ b/listenbrainz/testdata/user_artist_map_db.json
@@ -1,7 +1,6 @@
 {
   "from_ts": 0,
   "to_ts": 10,
-  "last_updated": 0,
   "data": [
     {
       "country": "USA",

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test.json
@@ -1,5 +1,5 @@
 {
-  "artist_map": [
+  "data": [
     {
       "artist_count": 15,
       "country": "GBR",
@@ -74,5 +74,6 @@
   "from_ts": 1009843200,
   "last_updated": 1599918137,
   "to_ts": 1589496658,
-  "user_id": "ishaanshah"
+  "user_id": "ishaanshah",
+  "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_month.json
@@ -1,5 +1,5 @@
 {
-  "artist_map": [
+  "data": [
     {
       "artist_count": 6,
       "country": "GBR",
@@ -54,5 +54,6 @@
   "from_ts": 1588373458,
   "last_updated": 1599918137,
   "to_ts": 1589496658,
-  "user_id": "ishaanshah"
+  "user_id": "ishaanshah",
+  "stats_range": "month"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_week.json
@@ -1,5 +1,5 @@
 {
-  "artist_map": [
+  "data": [
     {
       "artist_count": 11,
       "country": "USA",
@@ -49,5 +49,6 @@
   "from_ts": 1592265583,
   "last_updated": 1599918137,
   "to_ts": 1592870383,
-  "user_id": "ishaanshah"
+  "user_id": "ishaanshah",
+  "stats_range": "week"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_year.json
@@ -1,5 +1,5 @@
 {
-  "artist_map": [
+  "data": [
     {
       "artist_count": 15,
       "country": "GBR",
@@ -74,5 +74,6 @@
   "from_ts": 1577919058,
   "to_ts": 1589496658,
   "last_updated": 1599918137,
-  "user_id": "ishaanshah"
+  "user_id": "ishaanshah",
+  "stats_range": "year"
 }

--- a/listenbrainz/testdata/user_daily_activity_db.json
+++ b/listenbrainz/testdata/user_daily_activity_db.json
@@ -1,7 +1,7 @@
 {
   "from_ts": 0,
   "to_ts": 10,
-  "daily_activity": [
+  "data": [
     {
       "day": "Friday",
       "hour": 1,
@@ -17,5 +17,6 @@
       "hour": 2,
       "listen_count": 1
     }
-  ]
+  ],
+  "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_daily_activity_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_daily_activity_db_data_for_api_test.json
@@ -1,5 +1,5 @@
 {
-  "daily_activity": [
+  "data": [
     {
       "day": "Friday",
       "hour": 1,
@@ -142,5 +142,6 @@
     }
   ],
   "from_ts": 1009843200,
-  "to_ts": 1593043183
+  "to_ts": 1593043183,
+  "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_daily_activity_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_daily_activity_db_data_for_api_test_month.json
@@ -1,5 +1,5 @@
 {
-  "daily_activity": [
+  "data": [
     {
       "day": "Friday",
       "hour": 1,
@@ -142,5 +142,6 @@
     }
   ],
   "from_ts": 1590969600,
-  "to_ts": 1592956800
+  "to_ts": 1592956800,
+  "stats_range": "month"
 }

--- a/listenbrainz/testdata/user_daily_activity_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_daily_activity_db_data_for_api_test_week.json
@@ -1,5 +1,5 @@
 {
-  "daily_activity": [
+  "data": [
     {
       "day": "Friday",
       "hour": 1,
@@ -142,5 +142,6 @@
     }
   ],
   "from_ts": 1592265583,
-  "to_ts": 1592870383
+  "to_ts": 1592870383,
+  "stats_range": "week"
 }

--- a/listenbrainz/testdata/user_daily_activity_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_daily_activity_db_data_for_api_test_year.json
@@ -1,5 +1,5 @@
 {
-  "daily_activity": [
+  "data": [
     {
       "day": "Friday",
       "hour": 1,
@@ -142,5 +142,6 @@
     }
   ],
   "from_ts": 1546300800,
-  "to_ts": 1593043183
+  "to_ts": 1593043183,
+  "stats_range": "year"
 }

--- a/listenbrainz/testdata/user_listening_activity_db.json
+++ b/listenbrainz/testdata/user_listening_activity_db.json
@@ -1,7 +1,7 @@
 {
   "from_ts": 0,
   "to_ts": 10,
-  "listening_activity": [
+  "data": [
     {
       "listen_count": 230,
       "time_range": "2020",
@@ -14,5 +14,6 @@
       "from_ts": 0,
       "to_ts": 5
     }
-  ]
+  ],
+  "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_listening_activity_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_listening_activity_db_data_for_api_test.json
@@ -1,6 +1,6 @@
 {
   "from_ts": 1009843200,
-  "listening_activity": [
+  "data": [
     {
       "from_ts": 1009843200,
       "listen_count": 0,
@@ -116,5 +116,6 @@
       "to_ts": 1609459199
     }
   ],
-  "to_ts": 1589496658
+  "to_ts": 1589496658,
+  "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_listening_activity_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_listening_activity_db_data_for_api_test_month.json
@@ -1,6 +1,6 @@
 {
   "from_ts": 1585699200,
-  "listening_activity": [
+  "data": [
     {
       "from_ts": 1585699200,
       "listen_count": 0,
@@ -260,5 +260,6 @@
       "to_ts": 1589414399
     }
   ],
-  "to_ts": 1589414400
+  "to_ts": 1589414400,
+  "stats_range": "month"
 }

--- a/listenbrainz/testdata/user_listening_activity_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_listening_activity_db_data_for_api_test_week.json
@@ -1,6 +1,6 @@
 {
   "from_ts": 1587945600,
-  "listening_activity": [
+  "data": [
     {
       "from_ts": 1587945600,
       "listen_count": 26,
@@ -86,5 +86,6 @@
       "to_ts": 1589155199
     }
   ],
-  "to_ts": 1589155200
+  "to_ts": 1589155200,
+  "stats_range": "week"
 }

--- a/listenbrainz/testdata/user_listening_activity_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_listening_activity_db_data_for_api_test_year.json
@@ -1,6 +1,6 @@
 {
   "from_ts": 1546300800,
-  "listening_activity": [
+  "data": [
     {
       "from_ts": 1546300800,
       "listen_count": 0,
@@ -104,5 +104,6 @@
       "to_ts": 1590969599
     }
   ],
-  "to_ts": 1589496658
+  "to_ts": 1589496658,
+  "stats_range": "year"
 }

--- a/listenbrainz/testdata/user_top_artists_db.json
+++ b/listenbrainz/testdata/user_top_artists_db.json
@@ -1,7 +1,7 @@
 {
     "from_ts": 0,
     "to_ts": 10,
-    "artists": [
+    "data": [
         {
             "artist_mbids": [
                 "ed6c388e-ea65-431f-8be5-4959239d8c65"
@@ -19,5 +19,6 @@
             "artist_msid": null
         }
     ],
-    "count": 2
+    "count": 2,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test.json
@@ -1,5 +1,5 @@
 {
-    "artists": [
+    "data": [
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
@@ -603,5 +603,6 @@
     ],
     "count": 75,
     "from_ts": 0,
-    "to_ts": 5
+    "to_ts": 5,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_month.json
@@ -1,5 +1,5 @@
 {
-    "artists": [
+    "data": [
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
@@ -203,5 +203,6 @@
     ],
     "count": 25,
     "from_ts": 1588373458,
-    "to_ts": 1589496658
+    "to_ts": 1589496658,
+    "stats_range": "month"
 }

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_too_many.json
@@ -1,5 +1,5 @@
 {
-    "artists": [
+    "data": [
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
@@ -803,5 +803,6 @@
     ],
     "from_ts": 0,
     "to_ts": 5,
-    "count": 125
+    "count": 125,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_week.json
@@ -1,5 +1,5 @@
 {
-    "artists": [
+    "data": [
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
@@ -195,5 +195,6 @@
     ],
     "count": 24,
     "from_ts": 1588632658,
-    "to_ts": 1589237458
+    "to_ts": 1589237458,
+    "stats_range": "week"
 }

--- a/listenbrainz/testdata/user_top_artists_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_top_artists_db_data_for_api_test_year.json
@@ -1,5 +1,5 @@
 {
-    "artists": [
+    "data": [
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
@@ -203,5 +203,6 @@
     ],
     "count": 25,
     "from_ts": 1577923191,
-    "to_ts": 1590796791
+    "to_ts": 1590796791,
+    "stats_range": "year"
 }

--- a/listenbrainz/testdata/user_top_recordings_db.json
+++ b/listenbrainz/testdata/user_top_recordings_db.json
@@ -1,7 +1,7 @@
 {
     "from_ts": 0,
     "to_ts": 10,
-    "recordings": [
+    "data": [
         {
             "artist_name": "Ellie Goulding",
             "artist_mbids": [],
@@ -27,5 +27,6 @@
             "release_msid": null
         }
     ],
-    "count": 2
+    "count": 2,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test.json
@@ -2,7 +2,7 @@
     "count": 100,
     "from_ts": 0,
     "to_ts": 5,
-    "recordings": [
+    "data": [
         {
             "artist_name": "Ellie Goulding",
             "artist_mbids": [
@@ -1403,5 +1403,6 @@
             "recording_msid": null,
             "release_msid": null
         }
-    ]
+    ],
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_month.json
@@ -1,7 +1,7 @@
 {
     "count": 25,
     "from_ts": 1588373458,
-    "recordings": [
+    "data": [
         {
             "artist_name": "Ellie Goulding",
             "artist_mbids": [
@@ -353,5 +353,6 @@
             "release_msid": null
         }
     ],
-    "to_ts": 1589496658
+    "to_ts": 1589496658,
+    "stats_range": "month"
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_too_many.json
@@ -2,7 +2,7 @@
     "count": 103,
     "from_ts": 0,
     "to_ts": 5,
-    "recordings": [
+    "data": [
         {
             "artist_name": "Ellie Goulding",
             "artist_mbids": [
@@ -1445,5 +1445,6 @@
             "recording_msid": null,
             "release_msid": null
         }
-    ]
+    ],
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_week.json
@@ -1,7 +1,7 @@
 {
     "count": 25,
     "from_ts": 1588632658,
-    "recordings": [
+    "data": [
         {
             "artist_name": "Ellie Goulding",
             "artist_mbids": [
@@ -353,5 +353,6 @@
             "release_msid": null
         }
     ],
-    "to_ts": 1589237458
+    "to_ts": 1589237458,
+    "stats_range": "week"
 }

--- a/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_top_recordings_db_data_for_api_test_year.json
@@ -1,7 +1,7 @@
 {
     "count": 25,
     "from_ts": 1577919058,
-    "recordings": [
+    "data": [
         {
             "artist_name": "Lenka",
             "artist_mbids": [
@@ -353,5 +353,6 @@
             "release_msid": null
         }
     ],
-    "to_ts": 1589496658
+    "to_ts": 1589496658,
+    "stats_range": "year"
 }

--- a/listenbrainz/testdata/user_top_releases_db.json
+++ b/listenbrainz/testdata/user_top_releases_db.json
@@ -1,7 +1,7 @@
 {
     "from_ts": 0,
     "to_ts": 10,
-    "releases": [
+    "data": [
         {
             "artist_mbids": [],
             "release_mbid": null,
@@ -21,5 +21,6 @@
             "release_msid": null
         }
     ],
-    "count": 2
+    "count": 2,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test.json
@@ -1,5 +1,5 @@
 {
-    "releases": [
+    "data": [
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
@@ -1103,5 +1103,6 @@
     ],
     "count": 100,
     "from_ts": 0,
-    "to_ts": 5
+    "to_ts": 5,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_month.json
@@ -1,7 +1,7 @@
 {
     "count": 25,
     "from_ts": 1588373458,
-    "releases": [
+    "data": [
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
@@ -278,5 +278,6 @@
             "release_msid": null
         }
     ],
-    "to_ts": 1589496658
+    "to_ts": 1589496658,
+    "stats_range": "month"
 }

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_too_many.json
@@ -1,5 +1,5 @@
 {
-    "releases": [
+    "data": [
         {
             "artist_mbids": [
                 "6599e41e-390c-4855-a2ac-68ee798538b4"
@@ -1136,5 +1136,6 @@
     ],
     "count": 103,
     "from_ts": 0,
-    "to_ts": 5
+    "to_ts": 5,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_week.json
@@ -1,7 +1,7 @@
 {
     "count": 25,
     "from_ts": 1588632658,
-    "releases": [
+    "data": [
         {
             "artist_mbids": [
                 "7addbcac-ae39-4b4c-a956-53da336d68e8"
@@ -278,5 +278,6 @@
             "release_msid": null
         }
     ],
-    "to_ts": 1589237458
+    "to_ts": 1589237458,
+    "stats_range": "week"
 }

--- a/listenbrainz/testdata/user_top_releases_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_top_releases_db_data_for_api_test_year.json
@@ -1,7 +1,7 @@
 {
     "count": 25,
     "from_ts": 1577923191,
-    "releases": [
+    "data": [
         {
             "artist_mbids": [
                 "d340853d-7408-4a0d-89c2-6ff13e568815"
@@ -278,5 +278,6 @@
             "release_msid": null
         }
     ],
-    "to_ts": 1590796791
+    "to_ts": 1590796791,
+    "stats_range": "year"
 }

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -11,7 +11,7 @@ import requests_mock
 
 from data.model.common_stat import StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecordList
+from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecord
 from flask import current_app, url_for
 
 from data.model.user_daily_activity import UserDailyActivityRecord
@@ -68,7 +68,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_artist_map_db_data_for_api_test.json')) as f:
             self.artist_map_payload = json.load(f)
         db_stats.insert_user_jsonb_data(self.user['id'], 'artist_map',
-                                        StatRange[UserArtistMapRecordList](**self.artist_map_payload))
+                                        StatRange[UserArtistMapRecord](**self.artist_map_payload))
 
         # Insert all_time sitewide top artists
         with open(self.path_to_data_file('sitewide_top_artists_db_data_for_api_test.json'), 'r') as f:
@@ -983,7 +983,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_artist_map_db_data_for_api_test_week.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artist_map', StatRange[UserArtistMapRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artist_map', StatRange[UserArtistMapRecord](**payload))
         response = self.client.get(url_for('stats_api_v1.get_artist_map',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'week'})
         self.assert200(response)
@@ -1000,7 +1000,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_artist_map_db_data_for_api_test_month.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artist_map', StatRange[UserArtistMapRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artist_map', StatRange[UserArtistMapRecord](**payload))
         response = self.client.get(url_for('stats_api_v1.get_artist_map',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'month'})
         self.assert200(response)
@@ -1017,7 +1017,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_artist_map_db_data_for_api_test_year.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artist_map', StatRange[UserArtistMapRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artist_map', StatRange[UserArtistMapRecord](**payload))
         response = self.client.get(url_for('stats_api_v1.get_artist_map',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
         self.assert200(response)

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -1053,7 +1053,7 @@ class StatsAPITestCase(IntegrationTestCase):
 
         # Check if stats have been saved in DB
         data = db_stats.get_user_artist_map(self.user['id'], 'all_time')
-        self.assertEqual(data.data.dict()['artist_map'], sent_artist_map)
+        self.assertEqual(data.data.dict()['__root__'], sent_artist_map)
 
     @patch('listenbrainz.webserver.views.stats_api.db_stats.insert_user_jsonb_data', side_effect=NotImplementedError)
     @patch('listenbrainz.webserver.views.stats_api._get_country_wise_counts')
@@ -1157,7 +1157,7 @@ class StatsAPITestCase(IntegrationTestCase):
             artist['artist_mbids'] = []
             artist['artist_msid'] = None
         db_stats.insert_user_jsonb_data(self.user['id'], 'artists',
-                                        StatRange[UserEntityRecordList](**self.user_artist_payload))
+                                        StatRange[UserEntityRecordList](**artist_stats))
         response = self.client.get(url_for('stats_api_v1.get_artist_map',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'all_time',
                                                                                                  'force_recalculate': 'true'})

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -14,9 +14,9 @@ from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecordList
 from flask import current_app, url_for
 
-from data.model.user_daily_activity import UserDailyActivityRecordList
-from data.model.user_entity import UserEntityRecordList
-from data.model.user_listening_activity import UserListeningActivityRecordList
+from data.model.user_daily_activity import UserDailyActivityRecord
+from data.model.user_entity import UserEntityRecord
+from data.model.user_listening_activity import UserListeningActivityRecord
 from listenbrainz.config import LISTENBRAINZ_LABS_API_URL
 from listenbrainz.tests.integration import IntegrationTestCase
 from redis import Redis
@@ -38,31 +38,31 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test.json'), 'r') as f:
             self.user_artist_payload = json.load(f)
         db_stats.insert_user_jsonb_data(self.user['id'], 'artists',
-                                        StatRange[UserEntityRecordList](**self.user_artist_payload))
+                                        StatRange[UserEntityRecord](**self.user_artist_payload))
 
         # Insert release data
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test.json'), 'r') as f:
             self.user_release_payload = json.load(f)
         db_stats.insert_user_jsonb_data(self.user['id'], 'releases',
-                                        StatRange[UserEntityRecordList](**self.user_release_payload))
+                                        StatRange[UserEntityRecord](**self.user_release_payload))
 
         # Insert recording data
         with open(self.path_to_data_file('user_top_recordings_db_data_for_api_test.json'), 'r') as f:
             self.recording_payload = json.load(f)
         db_stats.insert_user_jsonb_data(self.user['id'], 'recordings',
-                                        StatRange[UserEntityRecordList](**self.recording_payload))
+                                        StatRange[UserEntityRecord](**self.recording_payload))
 
         # Insert listening activity data
         with open(self.path_to_data_file('user_listening_activity_db_data_for_api_test.json')) as f:
             self.listening_activity_payload = json.load(f)
         db_stats.insert_user_jsonb_data(self.user['id'], 'listening_activity',
-                                        StatRange[UserListeningActivityRecordList](**self.listening_activity_payload))
+                                        StatRange[UserListeningActivityRecord](**self.listening_activity_payload))
 
         # Insert daily activity data
         with open(self.path_to_data_file('user_daily_activity_db_data_for_api_test.json')) as f:
             data = json.load(f)
         db_stats.insert_user_jsonb_data(self.user['id'], 'daily_activity',
-                                        StatRange[UserDailyActivityRecordList](**data))
+                                        StatRange[UserDailyActivityRecord](**data))
 
         # Insert artist map data
         with open(self.path_to_data_file('user_artist_map_db_data_for_api_test.json')) as f:
@@ -107,7 +107,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test_too_many.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_user_artist',
                                            user_name=self.user['musicbrainz_id']), query_string={'count': 105})
@@ -145,7 +145,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test_week.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_user_artist',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'week'})
@@ -164,7 +164,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test_month.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_user_artist',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'month'})
@@ -183,7 +183,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test_year.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_user_artist',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
@@ -209,7 +209,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_user_artist',
                                            user_name=self.user['musicbrainz_id']), query_string={'count': 5})
@@ -245,7 +245,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'artists', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_user_artist',
                                            user_name=self.user['musicbrainz_id']), query_string={'offset': 5})
@@ -321,7 +321,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test_too_many.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_release',
                                            user_name=self.user['musicbrainz_id']), query_string={'count': 105})
@@ -359,7 +359,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test_week.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_release',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'week'})
@@ -378,7 +378,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test_month.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_release',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'month'})
@@ -397,7 +397,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test_year.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_release',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
@@ -423,7 +423,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_release',
                                            user_name=self.user['musicbrainz_id']), query_string={'count': 5})
@@ -459,7 +459,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_release',
                                            user_name=self.user['musicbrainz_id']), query_string={'offset': 5})
@@ -535,7 +535,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_recordings_db_data_for_api_test_too_many.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_recording',
                                            user_name=self.user['musicbrainz_id']), query_string={'count': 105})
@@ -573,7 +573,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_recordings_db_data_for_api_test_week.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_recording',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'week'})
@@ -592,7 +592,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_recordings_db_data_for_api_test_month.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_recording',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'month'})
@@ -611,7 +611,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_recordings_db_data_for_api_test_year.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_recording',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
@@ -637,7 +637,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_recordings_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_recording',
                                            user_name=self.user['musicbrainz_id']), query_string={'count': 5})
@@ -673,7 +673,7 @@ class StatsAPITestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_recordings_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
 
-        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'recordings', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_recording',
                                            user_name=self.user['musicbrainz_id']), query_string={'offset': 5})
@@ -730,7 +730,7 @@ class StatsAPITestCase(IntegrationTestCase):
         db_stats.delete_user_stats(self.user['id'])
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_user_artist',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
@@ -744,7 +744,7 @@ class StatsAPITestCase(IntegrationTestCase):
         db_stats.delete_user_stats(self.user['id'])
         with open(self.path_to_data_file('user_top_releases_db_data_for_api_test.json'), 'r') as f:
             payload = json.load(f)
-        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecordList](**payload))
+        db_stats.insert_user_jsonb_data(self.user['id'], 'releases', StatRange[UserEntityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_release',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
@@ -785,7 +785,7 @@ class StatsAPITestCase(IntegrationTestCase):
             payload = json.load(f)
 
         db_stats.insert_user_jsonb_data(self.user['id'], 'listening_activity',
-                                        StatRange[UserListeningActivityRecordList](**payload))
+                                        StatRange[UserListeningActivityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_listening_activity',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'week'})
@@ -803,7 +803,7 @@ class StatsAPITestCase(IntegrationTestCase):
             payload = json.load(f)
 
         db_stats.insert_user_jsonb_data(self.user['id'], 'listening_activity',
-                                        StatRange[UserListeningActivityRecordList](**payload))
+                                        StatRange[UserListeningActivityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_listening_activity',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'month'})
@@ -821,7 +821,7 @@ class StatsAPITestCase(IntegrationTestCase):
             payload = json.load(f)
 
         db_stats.insert_user_jsonb_data(self.user['id'], 'listening_activity',
-                                        StatRange[UserListeningActivityRecordList](**payload))
+                                        StatRange[UserListeningActivityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_listening_activity',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
@@ -888,7 +888,7 @@ class StatsAPITestCase(IntegrationTestCase):
             payload = json.load(f)
 
         db_stats.insert_user_jsonb_data(self.user['id'], 'daily_activity',
-                                        StatRange[UserDailyActivityRecordList](**payload))
+                                        StatRange[UserDailyActivityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_daily_activity',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'week'})
@@ -907,7 +907,7 @@ class StatsAPITestCase(IntegrationTestCase):
             payload = json.load(f)
 
         db_stats.insert_user_jsonb_data(self.user['id'], 'daily_activity',
-                                        StatRange[UserDailyActivityRecordList](**payload))
+                                        StatRange[UserDailyActivityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_daily_activity',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'month'})
@@ -926,7 +926,7 @@ class StatsAPITestCase(IntegrationTestCase):
             payload = json.load(f)
 
         db_stats.insert_user_jsonb_data(self.user['id'], 'daily_activity',
-                                        StatRange[UserDailyActivityRecordList](**payload))
+                                        StatRange[UserDailyActivityRecord](**payload))
 
         response = self.client.get(url_for('stats_api_v1.get_daily_activity',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'year'})
@@ -1038,7 +1038,7 @@ class StatsAPITestCase(IntegrationTestCase):
         db_stats.delete_user_stats(user_id=self.user['id'])
         # Reinsert artist stats
         db_stats.insert_user_jsonb_data(self.user['id'], 'artists',
-                                        StatRange[UserEntityRecordList](**self.user_artist_payload))
+                                        StatRange[UserEntityRecord](**self.user_artist_payload))
 
         response = self.client.get(url_for('stats_api_v1.get_artist_map',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'all_time'})
@@ -1157,7 +1157,7 @@ class StatsAPITestCase(IntegrationTestCase):
             artist['artist_mbids'] = []
             artist['artist_msid'] = None
         db_stats.insert_user_jsonb_data(self.user['id'], 'artists',
-                                        StatRange[UserEntityRecordList](**artist_stats))
+                                        StatRange[UserEntityRecord](**artist_stats))
         response = self.client.get(url_for('stats_api_v1.get_artist_map',
                                            user_name=self.user['musicbrainz_id']), query_string={'range': 'all_time',
                                                                                                  'force_recalculate': 'true'})

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -97,7 +97,7 @@ class StatsAPITestCase(IntegrationTestCase):
         sent_to = self.user_artist_payload['to_ts']
         received_to = data['to_ts']
         self.assertEqual(sent_to, received_to)
-        sent_artist_list = self.user_artist_payload['artists'][:25]
+        sent_artist_list = self.user_artist_payload['data'][:25]
         received_artist_list = data['artists']
         self.assertListEqual(sent_artist_list, received_artist_list)
         self.assertEqual(data['user_id'], self.user['musicbrainz_id'])
@@ -1153,7 +1153,7 @@ class StatsAPITestCase(IntegrationTestCase):
 
         # Overwrite the artist stats so that no artist has msids or mbids present
         artist_stats = deepcopy(self.user_artist_payload)
-        for artist in artist_stats["artists"]:
+        for artist in artist_stats["data"]:
             artist['artist_mbids'] = []
             artist['artist_msid'] = None
         db_stats.insert_user_jsonb_data(self.user['id'], 'artists',

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -669,7 +669,7 @@ def _process_user_entity(stats: StatApi[UserEntityRecordList], offset, count) ->
     return entity_list, total_entity_count
 
 
-def _validate_stats_user_params(user_name):
+def _validate_stats_user_params(user_name) -> Tuple[Dict, str]:
     """ Validate and return the user and common stats params """
     user = db_user.get_by_mb_id(user_name)
     if user is None:
@@ -678,6 +678,7 @@ def _validate_stats_user_params(user_name):
     stats_range = request.args.get("range", default="all_time")
     if not _is_valid_range(stats_range):
         raise APIBadRequest(f"Invalid range: {stats_range}")
+    return user, stats_range
 
 
 def _is_valid_range(stats_range: str) -> bool:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -335,7 +335,7 @@ def get_listening_activity(user_name: str):
         raise APIBadRequest("Invalid range: {}".format(stats_range))
 
     stats = db_stats.get_user_listening_activity(user['id'], stats_range)
-    if stats is None or getattr(stats, stats_range) is None:
+    if stats is None:
         raise APINoContent('')
 
     listening_activity = [x.dict() for x in stats.data]
@@ -412,7 +412,7 @@ def get_daily_activity(user_name: str):
         raise APIBadRequest("Invalid range: {}".format(stats_range))
 
     stats = db_stats.get_user_daily_activity(user['id'], stats_range)
-    if stats is None or getattr(stats, stats_range) is None:
+    if stats is None:
         raise APINoContent('')
 
     daily_activity_unprocessed = [x.dict() for x in stats.data]

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -522,7 +522,7 @@ def get_artist_map(user_name: str):
         artist_stats = db_stats.get_user_stats(user['id'], stats_range, 'artists')
 
         # If top artists are missing, return the stale stats if present, otherwise return 204
-        if artist_stats is None or getattr(artist_stats, stats_range) is None:
+        if artist_stats is None:
             if stale:
                 result = stats
             else:
@@ -530,8 +530,7 @@ def get_artist_map(user_name: str):
         else:
             # Calculate the data
             artist_mbid_counts = defaultdict(int)
-            top_artists = getattr(artist_stats, stats_range).artists
-            for artist in top_artists:
+            for artist in artist_stats.data.__root__:
                 for artist_mbid in artist.artist_mbids:
                     artist_mbid_counts[artist_mbid] += artist.listen_count
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -514,7 +514,7 @@ def get_artist_map(user_name: str):
     # Check if the stats present in DB have been calculated in the past week, if not recalculate them
     stale = False
     if calculated:
-        if (datetime.now() - stats.last_updated.days) >= STATS_CALCULATION_INTERVAL:
+        if (datetime.now() - stats.last_updated).days >= STATS_CALCULATION_INTERVAL:
             stale = True
 
     if stale or not calculated:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -11,7 +11,7 @@ import listenbrainz.db.user as db_user
 import pycountry
 import requests
 
-from data.model.common_stat import StatApi, StatRange
+from data.model.common_stat import StatApi
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecordList
 from flask import Blueprint, current_app, jsonify, request
@@ -512,11 +512,16 @@ def get_artist_map(user_name: str):
                     artist_mbid_counts[artist_mbid] += artist.listen_count
 
             country_code_data = _get_country_wise_counts(artist_mbid_counts)
-            result = StatRange[UserArtistMapRecordList](**{
+            result = StatApi[UserArtistMapRecordList](**{
                 "data": country_code_data,
                 "from_ts": artist_stats.from_ts,
                 "to_ts": artist_stats.to_ts,
                 "stats_range": stats_range,
+                # this isn't stored in the database, but adding it here to avoid a subsequent db call to
+                # just fetch last updated. could just store this value instead in db but that complicates
+                # the implementation a bit
+                "last_updated": datetime.now(),
+                "user_id": user['id']
             })
 
             # Store in DB for future use

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -752,7 +752,7 @@ def _process_user_entity(stats, offset, count, entity) -> Tuple[list, int]:
     count = min(count, MAX_ITEMS_PER_GET)
     count = count + offset
     total_entity_count = stats.count
-    entity_list = [x.dict() for x in _get_user_entity_list(stats, entity, offset, count)]
+    entity_list = [x.dict() for x in stats.data[offset:count]]
 
     return entity_list, total_entity_count
 
@@ -767,23 +767,6 @@ def _is_valid_range(stats_range: str) -> bool:
         result: True if given range is valid
     """
     return stats_range in StatisticsRange.__members__
-
-
-def _get_user_entity_list(
-    stats: Union[UserArtistStat, UserReleaseStat, UserRecordingStat],
-    entity: str,
-    offset: int,
-    count: int,
-) -> List[Union[UserArtistRecord, UserReleaseRecord, UserRecordingRecord]]:
-    """ Gets a list of entity records from the stat passed based on the offset and count
-    """
-    if entity == 'artist':
-        return stats.data.__root__[offset:count]
-    elif entity == 'release':
-        return getattr(stats, stats_range).releases[offset:count]
-    elif entity == 'recording':
-        return getattr(stats, stats_range).recordings[offset:count]
-    raise APIBadRequest("Unknown entity: %s" % entity)
 
 
 def _get_sitewide_entity_list(

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -11,7 +11,7 @@ import listenbrainz.db.user as db_user
 import pycountry
 import requests
 
-from data.model.common_stat import StatApi
+from data.model.common_stat import StatApi, StatRange
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecordList
 from flask import Blueprint, current_app, jsonify, request
@@ -512,7 +512,7 @@ def get_artist_map(user_name: str):
                     artist_mbid_counts[artist_mbid] += artist.listen_count
 
             country_code_data = _get_country_wise_counts(artist_mbid_counts)
-            result = StatApi[UserArtistMapRecordList](**{
+            result = StatRange[UserArtistMapRecordList](**{
                 "data": country_code_data,
                 "from_ts": artist_stats.from_ts,
                 "to_ts": artist_stats.to_ts,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -116,11 +116,11 @@ def get_user_artist(user_name):
     offset = get_non_negative_param('offset', default=0)
     count = get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
-    stats = db_stats.get_user_artists(user['id'], stats_range)
+    stats = db_stats.get_user_stats(user['id'], stats_range, 'artists')
     if stats is None:
         raise APINoContent('')
 
-    entity_list, total_entity_count = _process_user_entity(stats, offset, count, entity='artist')
+    entity_list, total_entity_count = _process_user_entity(stats, offset, count)
 
     return jsonify({'payload': {
         "user_id": user_name,
@@ -212,14 +212,11 @@ def get_release(user_name):
     offset = get_non_negative_param('offset', default=0)
     count = get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
-    stats = db_stats.get_user_releases(user['id'], stats_range)
-    if stats is None or getattr(stats, stats_range) is None:
+    stats = db_stats.get_user_stats(user['id'], stats_range, 'releases')
+    if stats is None:
         raise APINoContent('')
 
-    entity_list, total_entity_count = _process_user_entity(stats, stats_range, offset, count, entity='release')
-    from_ts = int(getattr(stats, stats_range).from_ts)
-    to_ts = int(getattr(stats, stats_range).to_ts)
-    last_updated = int(stats.last_updated.timestamp())
+    entity_list, total_entity_count = _process_user_entity(stats, offset, count)
 
     return jsonify({'payload': {
         "user_id": user_name,
@@ -228,9 +225,9 @@ def get_release(user_name):
         "total_release_count": total_entity_count,
         "offset": offset,
         "range": stats_range,
-        "from_ts": from_ts,
-        "to_ts": to_ts,
-        "last_updated": last_updated,
+        "from_ts": stats.from_ts,
+        "to_ts": stats.to_ts,
+        "last_updated": int(stats.last_updated.timestamp()),
     }})
 
 
@@ -309,14 +306,11 @@ def get_recording(user_name):
     offset = get_non_negative_param('offset', default=0)
     count = get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
-    stats = db_stats.get_user_recordings(user['id'], stats_range)
-    if stats is None or getattr(stats, stats_range) is None:
+    stats = db_stats.get_user_stats(user['id'], stats_range, 'recordings')
+    if stats is None:
         raise APINoContent('')
 
-    entity_list, total_entity_count = _process_user_entity(stats, stats_range, offset, count, entity='recording')
-    from_ts = int(getattr(stats, stats_range).from_ts)
-    to_ts = int(getattr(stats, stats_range).to_ts)
-    last_updated = int(stats.last_updated.timestamp())
+    entity_list, total_entity_count = _process_user_entity(stats, offset, count)
 
     return jsonify({'payload': {
         "user_id": user_name,
@@ -325,9 +319,9 @@ def get_recording(user_name):
         "total_recording_count": total_entity_count,
         "offset": offset,
         "range": stats_range,
-        "from_ts": from_ts,
-        "to_ts": to_ts,
-        "last_updated": last_updated,
+        "from_ts": stats.from_ts,
+        "to_ts": stats.to_ts,
+        "last_updated": int(stats.last_updated.timestamp()),
     }})
 
 
@@ -733,7 +727,7 @@ def get_sitewide_artist():
     })
 
 
-def _process_user_entity(stats, offset, count, entity) -> Tuple[list, int]:
+def _process_user_entity(stats, offset, count) -> Tuple[list, int]:
     """ Process the statistics data according to query params
 
         Args:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -16,7 +16,7 @@ from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecordList
 from flask import Blueprint, current_app, jsonify, request
 
-from data.model.user_entity import UserEntityRecordList
+from data.model.user_entity import UserEntityRecord
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import (APIBadRequest,
                                            APIInternalServerError,
@@ -652,7 +652,7 @@ def get_sitewide_artist():
     })
 
 
-def _process_user_entity(stats: StatApi[UserEntityRecordList], offset, count) -> Tuple[list, int]:
+def _process_user_entity(stats: StatApi[UserEntityRecord], offset, count) -> Tuple[list, int]:
     """ Process the statistics data according to query params
 
         Args:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -2,7 +2,7 @@ import bisect
 import calendar
 import json
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Tuple, Union, Iterable
 
@@ -514,7 +514,7 @@ def get_artist_map(user_name: str):
     # Check if the stats present in DB have been calculated in the past week, if not recalculate them
     stale = False
     if calculated:
-        if (datetime.now() - stats.last_updated).days >= STATS_CALCULATION_INTERVAL:
+        if (datetime.now(timezone.utc) - stats.last_updated).days >= STATS_CALCULATION_INTERVAL:
             stale = True
 
     if stale or not calculated:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -338,12 +338,12 @@ def get_listening_activity(user_name: str):
     if stats is None or getattr(stats, stats_range) is None:
         raise APINoContent('')
 
-    listening_activity = [x.dict() for x in getattr(stats, stats_range).listening_activity]
+    listening_activity = [x.dict() for x in stats.data]
     return jsonify({"payload": {
         "user_id": user_name,
         "listening_activity": listening_activity,
-        "from_ts": int(getattr(stats, stats_range).from_ts),
-        "to_ts": int(getattr(stats, stats_range).to_ts),
+        "from_ts": stats.from_ts,
+        "to_ts": stats.to_ts,
         "range": stats_range,
         "last_updated": int(stats.last_updated.timestamp())
     }})
@@ -415,7 +415,7 @@ def get_daily_activity(user_name: str):
     if stats is None or getattr(stats, stats_range) is None:
         raise APINoContent('')
 
-    daily_activity_unprocessed = [x.dict() for x in getattr(stats, stats_range).daily_activity]
+    daily_activity_unprocessed = [x.dict() for x in stats.data]
     daily_activity = {calendar.day_name[day]: [{"hour": hour, "listen_count": 0} for hour in range(0, 24)] for day in range(0, 7)}
 
     for day, day_data in daily_activity.items():
@@ -432,8 +432,8 @@ def get_daily_activity(user_name: str):
     return jsonify({"payload": {
         "user_id": user_name,
         "daily_activity": daily_activity,
-        "from_ts": int(getattr(stats, stats_range).from_ts),
-        "to_ts": int(getattr(stats, stats_range).to_ts),
+        "from_ts": stats.from_ts,
+        "to_ts": stats.to_ts,
         "range": stats_range,
         "last_updated": int(stats.last_updated.timestamp())
     }})

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -117,10 +117,10 @@ def get_user_artist(user_name):
     count = get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
     stats = db_stats.get_user_artists(user['id'], stats_range)
-    if stats is None or getattr(stats, stats_range) is None:
+    if stats is None:
         raise APINoContent('')
 
-    entity_list, total_entity_count = _process_user_entity(stats, stats_range, offset, count, entity='artist')
+    entity_list, total_entity_count = _process_user_entity(stats, offset, count, entity='artist')
     from_ts = int(getattr(stats, stats_range).from_ts)
     to_ts = int(getattr(stats, stats_range).to_ts)
     last_updated = int(stats.last_updated.timestamp())
@@ -754,7 +754,7 @@ def _process_user_entity(stats, stats_range, offset, count, entity) -> Tuple[lis
 
     count = min(count, MAX_ITEMS_PER_GET)
     count = count + offset
-    total_entity_count = getattr(stats, stats_range).count
+    total_entity_count = stats.count
     entity_list = [x.dict() for x in _get_user_entity_list(stats, stats_range, entity, offset, count)]
 
     return entity_list, total_entity_count
@@ -782,7 +782,7 @@ def _get_user_entity_list(
     """ Gets a list of entity records from the stat passed based on the offset and count
     """
     if entity == 'artist':
-        return getattr(stats, stats_range).artists[offset:count]
+        return stats.data[offset:count]
     elif entity == 'release':
         return getattr(stats, stats_range).releases[offset:count]
     elif entity == 'recording':

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -746,7 +746,7 @@ def _process_user_entity(stats, offset, count) -> Tuple[list, int]:
     count = min(count, MAX_ITEMS_PER_GET)
     count = count + offset
     total_entity_count = stats.count
-    entity_list = [x.dict() for x in stats.data[offset:count]]
+    entity_list = [x.dict() for x in stats.data.__root__[offset:count]]
 
     return entity_list, total_entity_count
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -521,7 +521,7 @@ def get_artist_map(user_name: str):
 
             # Store in DB for future use
             try:
-                db_stats.insert_user_artist_map(user['id'], result)
+                db_stats.insert_user_jsonb_data(user['id'], 'artist_map', result)
             except Exception as err:
                 current_app.logger.error("Error while inserting artist map stats for {user}. Error: {err}. Data: {data}".format(
                     user=user_name, err=err, data=result), exc_info=True)

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -13,7 +13,7 @@ import requests
 
 from data.model.common_stat import StatApi
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecordList
+from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecord
 from flask import Blueprint, current_app, jsonify, request
 
 from data.model.user_entity import UserEntityRecord
@@ -512,7 +512,7 @@ def get_artist_map(user_name: str):
                     artist_mbid_counts[artist_mbid] += artist.listen_count
 
             country_code_data = _get_country_wise_counts(artist_mbid_counts)
-            result = StatApi[UserArtistMapRecordList](**{
+            result = StatApi[UserArtistMapRecord](**{
                 "data": country_code_data,
                 "from_ts": artist_stats.from_ts,
                 "to_ts": artist_stats.to_ts,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -338,7 +338,7 @@ def get_listening_activity(user_name: str):
     if stats is None:
         raise APINoContent('')
 
-    listening_activity = [x.dict() for x in stats.data]
+    listening_activity = [x.dict() for x in stats.data.__root__]
     return jsonify({"payload": {
         "user_id": user_name,
         "listening_activity": listening_activity,
@@ -415,7 +415,7 @@ def get_daily_activity(user_name: str):
     if stats is None:
         raise APINoContent('')
 
-    daily_activity_unprocessed = [x.dict() for x in stats.data]
+    daily_activity_unprocessed = [x.dict() for x in stats.data.__root__]
     daily_activity = {calendar.day_name[day]: [{"hour": hour, "listen_count": 0} for hour in range(0, 24)] for day in range(0, 7)}
 
     for day, day_data in daily_activity.items():

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -10,17 +10,8 @@ import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 import pycountry
 import requests
-from data.model.sitewide_artist_stat import (SitewideArtistRecord,
-                                             SitewideArtistStatJson)
-from data.model.user_artist_map import (UserArtistMapRecord, UserArtistMapStat,
-                                        UserArtistMapStatJson,
-                                        UserArtistMapStatRange)
-from data.model.user_artist_stat import UserArtistRecord, UserArtistStat
-from data.model.user_listening_activity import (UserListeningActivityRecord,
-                                                UserListeningActivityStat)
-from data.model.user_recording_stat import (UserRecordingRecord,
-                                            UserRecordingStat)
-from data.model.user_release_stat import UserReleaseRecord, UserReleaseStat
+from data.model.sitewide_artist_stat import SitewideArtistStatJson
+from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapStatJson
 from flask import Blueprint, current_app, jsonify, request
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import (APIBadRequest,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -13,7 +13,7 @@ import requests
 
 from data.model.common_stat import StatApi
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
-from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapStatRange
+from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecordList
 from flask import Blueprint, current_app, jsonify, request
 
 from data.model.user_entity import UserEntityRecordList
@@ -512,7 +512,7 @@ def get_artist_map(user_name: str):
                     artist_mbid_counts[artist_mbid] += artist.listen_count
 
             country_code_data = _get_country_wise_counts(artist_mbid_counts)
-            result = UserArtistMapStatRange(**{
+            result = StatApi[UserArtistMapRecordList](**{
                 "data": country_code_data,
                 "from_ts": artist_stats.from_ts,
                 "to_ts": artist_stats.to_ts,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -121,9 +121,6 @@ def get_user_artist(user_name):
         raise APINoContent('')
 
     entity_list, total_entity_count = _process_user_entity(stats, offset, count, entity='artist')
-    from_ts = int(getattr(stats, stats_range).from_ts)
-    to_ts = int(getattr(stats, stats_range).to_ts)
-    last_updated = int(stats.last_updated.timestamp())
 
     return jsonify({'payload': {
         "user_id": user_name,
@@ -132,9 +129,9 @@ def get_user_artist(user_name):
         "total_artist_count": total_entity_count,
         "offset": offset,
         "range": stats_range,
-        "from_ts": from_ts,
-        "to_ts": to_ts,
-        "last_updated": last_updated,
+        "from_ts": stats.from_ts,
+        "to_ts": stats.to_ts,
+        "last_updated": int(stats.last_updated.timestamp()),
     }})
 
 
@@ -736,7 +733,7 @@ def get_sitewide_artist():
     })
 
 
-def _process_user_entity(stats, stats_range, offset, count, entity) -> Tuple[list, int]:
+def _process_user_entity(stats, offset, count, entity) -> Tuple[list, int]:
     """ Process the statistics data according to query params
 
         Args:
@@ -755,7 +752,7 @@ def _process_user_entity(stats, stats_range, offset, count, entity) -> Tuple[lis
     count = min(count, MAX_ITEMS_PER_GET)
     count = count + offset
     total_entity_count = stats.count
-    entity_list = [x.dict() for x in _get_user_entity_list(stats, stats_range, entity, offset, count)]
+    entity_list = [x.dict() for x in _get_user_entity_list(stats, entity, offset, count)]
 
     return entity_list, total_entity_count
 
@@ -774,7 +771,6 @@ def _is_valid_range(stats_range: str) -> bool:
 
 def _get_user_entity_list(
     stats: Union[UserArtistStat, UserReleaseStat, UserRecordingStat],
-    stats_range: StatisticsRange,
     entity: str,
     offset: int,
     count: int,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -556,10 +556,10 @@ def get_artist_map(user_name: str):
         "payload": {
             "user_id": user_name,
             "range": stats_range,
-            "from_ts": stats.from_ts,
-            "to_ts": stats.to_ts,
-            "last_updated": int(stats.last_updated.timestamp()),
-            "artist_map": [x.dict() for x in stats.data.__root__]
+            "from_ts": result.from_ts,
+            "to_ts": result.to_ts,
+            "last_updated": int(result.last_updated.timestamp()),
+            "artist_map": [x.dict() for x in result.data.__root__]
         }
     })
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -778,7 +778,7 @@ def _get_user_entity_list(
     """ Gets a list of entity records from the stat passed based on the offset and count
     """
     if entity == 'artist':
-        return stats.data[offset:count]
+        return stats.data.__root__[offset:count]
     elif entity == 'release':
         return getattr(stats, stats_range).releases[offset:count]
     elif entity == 'recording':

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -10,11 +10,13 @@ import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 import pycountry
 import requests
+
+from data.model.common_stat import StatApi
 from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapStatRange
 from flask import Blueprint, current_app, jsonify, request
 
-from data.model.user_entity import UserEntityStat
+from data.model.user_entity import UserEntityRecordList
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import (APIBadRequest,
                                            APIInternalServerError,
@@ -645,7 +647,7 @@ def get_sitewide_artist():
     })
 
 
-def _process_user_entity(stats: UserEntityStat, offset, count) -> Tuple[list, int]:
+def _process_user_entity(stats: StatApi[UserEntityRecordList], offset, count) -> Tuple[list, int]:
     """ Process the statistics data according to query params
 
         Args:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -514,8 +514,7 @@ def get_artist_map(user_name: str):
     # Check if the stats present in DB have been calculated in the past week, if not recalculate them
     stale = False
     if calculated:
-        last_updated = getattr(stats, stats_range).last_updated
-        if (datetime.now() - datetime.fromtimestamp(last_updated)).days >= STATS_CALCULATION_INTERVAL:
+        if (datetime.now() - stats.last_updated.days) >= STATS_CALCULATION_INTERVAL:
             stale = True
 
     if stale or not calculated:

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -8,7 +8,7 @@ from flask import url_for, current_app
 
 from data.model.common_stat import StatRange
 from data.model.external_service import ExternalServiceType
-from data.model.user_entity import UserEntityRecordList
+from data.model.user_entity import UserEntityRecord
 
 from listenbrainz.db import external_service_oauth as db_oauth
 from listenbrainz.listenstore.tests.util import create_test_data_for_timescalelistenstore
@@ -117,7 +117,7 @@ class UserViewsTestCase(IntegrationTestCase):
             artists_data = ujson.load(f)
 
         db_stats.insert_user_jsonb_data(user_id=self.user.id, stats_type='artists',
-                                        stats=StatRange[UserEntityRecordList](**artists_data))
+                                        stats=StatRange[UserEntityRecord](**artists_data))
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
         self.assertTemplateUsed('user/profile.html')

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -6,8 +6,9 @@ from unittest import mock
 
 from flask import url_for, current_app
 
+from data.model.common_stat import StatRange
 from data.model.external_service import ExternalServiceType
-from data.model.user_artist_stat import UserArtistStatJson
+from data.model.user_entity import UserEntityRecordList
 
 from listenbrainz.db import external_service_oauth as db_oauth
 from listenbrainz.listenstore.tests.util import create_test_data_for_timescalelistenstore
@@ -115,10 +116,8 @@ class UserViewsTestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db.json')) as f:
             artists_data = ujson.load(f)
 
-        db_stats.insert_user_artists(
-            user_id=self.user.id,
-            artists=UserArtistStatJson(**{'all_time': artists_data})
-        )
+        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
+                                        stats=StatRange[UserEntityRecordList](**artists_data))
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
         self.assertTemplateUsed('user/profile.html')

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -116,7 +116,7 @@ class UserViewsTestCase(IntegrationTestCase):
         with open(self.path_to_data_file('user_top_artists_db.json')) as f:
             artists_data = ujson.load(f)
 
-        db_stats.insert_user_jsonb_data(user_id=self.user['id'], stats_type='artists',
+        db_stats.insert_user_jsonb_data(user_id=self.user.id, stats_type='artists',
                                         stats=StatRange[UserEntityRecordList](**artists_data))
         response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -109,11 +109,7 @@ def profile(user_name):
             }
             listens.insert(0, listen)
 
-    user_stats = db_stats.get_user_artists(user.id, 'all_time')
-    try:
-        artist_count = user_stats.all_time.count
-    except (AttributeError, ValidationError):
-        artist_count = None
+    user_stats = db_stats.get_user_stats(user.id, 'all_time', 'artists')
 
     logged_in_user_follows_user = None
     already_reported_user = False
@@ -134,7 +130,7 @@ def profile(user_name):
         "latest_listen_ts": max_ts_per_user,
         "oldest_listen_ts": min_ts_per_user,
         "latest_spotify_uri": _get_spotify_uri_for_listens(listens),
-        "artist_count": format(artist_count, ",d") if artist_count else None,
+        "artist_count": format(user_stats.count, ",d") if user_stats.count else None,
         "profile_url": url_for('user.profile', user_name=user_name),
         "mode": "listens",
         "userPinnedRecording": pin,

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -130,7 +130,7 @@ def profile(user_name):
         "latest_listen_ts": max_ts_per_user,
         "oldest_listen_ts": min_ts_per_user,
         "latest_spotify_uri": _get_spotify_uri_for_listens(listens),
-        "artist_count": format(user_stats.count, ",d") if user_stats.count else None,
+        "artist_count": format(user_stats.count, ",d") if user_stats else None,
         "profile_url": url_for('user.profile', user_name=user_name),
         "mode": "listens",
         "userPinnedRecording": pin,

--- a/listenbrainz_spark/stats/user/daily_activity.py
+++ b/listenbrainz_spark/stats/user/daily_activity.py
@@ -150,7 +150,7 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
         try:
             model = UserDailyActivityStatMessage(**{
                 'musicbrainz_id': _dict['user_name'],
-                'type': 'user_daily_activity',
+                'type': 'daily_activity',
                 'from_ts': from_ts,
                 'to_ts': to_ts,
                 'stats_range': stats_range,

--- a/listenbrainz_spark/stats/user/daily_activity.py
+++ b/listenbrainz_spark/stats/user/daily_activity.py
@@ -150,7 +150,7 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
         try:
             model = UserDailyActivityStatMessage(**{
                 'musicbrainz_id': _dict['user_name'],
-                'type': 'daily_activity',
+                'type': 'user_daily_activity',
                 'from_ts': from_ts,
                 'to_ts': to_ts,
                 'stats_range': stats_range,

--- a/listenbrainz_spark/stats/user/daily_activity.py
+++ b/listenbrainz_spark/stats/user/daily_activity.py
@@ -154,7 +154,7 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
                 'from_ts': from_ts,
                 'to_ts': to_ts,
                 'stats_range': stats_range,
-                'daily_activity': _dict['daily_activity']
+                'data': _dict['daily_activity']
             })
             result = model.dict(exclude_none=True)
             yield result

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -117,7 +117,8 @@ def get_entity_all_time(entity: str) -> Iterator[Optional[UserEntityStatMessage]
     return messages
 
 
-def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: int) -> Iterator[Optional[UserEntityStatMessage]]:
+def create_messages(data, entity: str, stats_range: str, from_ts: float, to_ts: float) \
+        -> Iterator[Optional[UserEntityStatMessage]]:
     """
     Create messages to send the data to the webserver via RabbitMQ
 
@@ -160,8 +161,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: int, to_ts: in
             result = model.dict(exclude_none=True)
             yield result
         except ValidationError:
-            logger.error("""ValidationError while calculating {stats_range} top {entity} for user: {user_name}.
-                                     Data: {data}""".format(stats_range=stats_range, entity=entity, user_name=_dict['user_name'],
-                                                            data=json.dumps(_dict, indent=3)),
-                                     exc_info=True)
+            logger.error("""ValidationError while calculating {stats_range} top {entity} for user: {user_name}. 
+            Data: {data}""".format(stats_range=stats_range, entity=entity, user_name=_dict['user_name'],
+                                   data=json.dumps(_dict, indent=3)), exc_info=True)
             yield None

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -208,15 +208,14 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
                 'stats_range': stats_range,
                 'from_ts': from_ts,
                 'to_ts': to_ts,
-                'listening_activity': _dict['listening_activity']
+                'data': _dict['listening_activity']
             })
             result = model.dict(exclude_none=True)
             yield result
         except ValidationError:
-            logger.error("""ValidationError while calculating {stats_range} listening_activity for user: {user_name}.
-                                     Data: {data}""".format(stats_range=stats_range, user_name=_dict['user_name'],
-                                                            data=json.dumps(_dict, indent=3)),
-                                     exc_info=True)
+            logger.error("""ValidationError while calculating {stats_range} listening_activity for user: {user_name}. 
+            Data: {data}""".format(stats_range=stats_range, user_name=_dict['user_name'],
+                                   data=json.dumps(_dict, indent=3)), exc_info=True)
             yield None
 
 

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -204,7 +204,7 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
         try:
             model = UserListeningActivityStatMessage(**{
                 'musicbrainz_id': _dict['user_name'],
-                'type': 'listening_activity',
+                'type': 'user_listening_activity',
                 'stats_range': stats_range,
                 'from_ts': from_ts,
                 'to_ts': to_ts,

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -204,7 +204,7 @@ def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterato
         try:
             model = UserListeningActivityStatMessage(**{
                 'musicbrainz_id': _dict['user_name'],
-                'type': 'user_listening_activity',
+                'type': 'listening_activity',
                 'stats_range': stats_range,
                 'from_ts': from_ts,
                 'to_ts': to_ts,

--- a/listenbrainz_spark/testdata/user_daily_activity.json
+++ b/listenbrainz_spark/testdata/user_daily_activity.json
@@ -5,7 +5,7 @@
         "stats_range": "all_time",
         "from_ts": 1009843200,
         "to_ts": 1628511763,
-        "daily_activity": [
+        "data": [
             {
                 "day": "Monday",
                 "hour": 8,
@@ -134,7 +134,7 @@
         "stats_range": "all_time",
         "from_ts": 1009843200,
         "to_ts": 1628511763,
-        "daily_activity": [
+        "data": [
             {
                 "day": "Monday",
                 "hour": 9,

--- a/listenbrainz_spark/testdata/user_listening_activity.json
+++ b/listenbrainz_spark/testdata/user_listening_activity.json
@@ -5,7 +5,7 @@
         "stats_range": "all_time",
         "from_ts": 1009843200,
         "to_ts": 1628511763,
-        "listening_activity": [
+        "data": [
             {
                 "time_range": "2020",
                 "from_ts": 1577836800,
@@ -26,7 +26,7 @@
         "stats_range": "all_time",
         "from_ts": 1009843200,
         "to_ts": 1628511763,
-        "listening_activity": [
+        "data": [
             {
                 "time_range": "2021",
                 "from_ts": 1609459200,


### PR DESCRIPTION
Moving statistics to the new format makes the storage simpler and easier to new ones. Plus, also allows for a lot of simplifcation in code. 