### PR TITLE
Allow love/hate feedback and pin recording on another user's page

### DIFF
--- a/listenbrainz/webserver/static/js/src/PinRecordingModal.test.tsx
+++ b/listenbrainz/webserver/static/js/src/PinRecordingModal.test.tsx
@@ -42,11 +42,7 @@ describe("PinRecordingModal", () => {
       .mockImplementation(() => mockDate.getTime());
 
     const wrapper = mount<PinRecordingModal>(
-      <PinRecordingModal
-        recordingToPin={recordingToPin}
-        isCurrentUser
-        newAlert={jest.fn()}
-      />
+      <PinRecordingModal recordingToPin={recordingToPin} newAlert={jest.fn()} />
     );
     expect(wrapper.html()).toMatchSnapshot();
     fakeDateNow.mockRestore();
@@ -59,7 +55,6 @@ describe("submitPinRecording", () => {
       <GlobalAppContext.Provider value={globalProps}>
         <PinRecordingModal
           recordingToPin={recordingToPin}
-          isCurrentUser
           newAlert={jest.fn()}
         />
       </GlobalAppContext.Provider>
@@ -86,7 +81,6 @@ describe("submitPinRecording", () => {
       <GlobalAppContext.Provider value={globalProps}>
         <PinRecordingModal
           recordingToPin={recordingToPin}
-          isCurrentUser
           newAlert={jest.fn()}
         />
       </GlobalAppContext.Provider>
@@ -106,25 +100,6 @@ describe("submitPinRecording", () => {
     expect(wrapper.state("blurbContent")).toEqual("");
   });
 
-  it("does nothing if isCurrentUser is false", async () => {
-    const wrapper = mount<PinRecordingModal>(
-      <GlobalAppContext.Provider value={globalProps}>
-        <PinRecordingModal
-          recordingToPin={recordingToPin}
-          isCurrentUser={false} // isCurrentUser is false
-          newAlert={jest.fn()}
-        />
-      </GlobalAppContext.Provider>
-    );
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.context.APIService, "submitPinRecording");
-    spy.mockImplementation(() => Promise.resolve(200));
-
-    await instance.submitPinRecording();
-    expect(spy).toHaveBeenCalledTimes(0);
-  });
-
   it("does nothing if CurrentUser.authtoken is not set", async () => {
     const wrapper = mount<PinRecordingModal>(
       <GlobalAppContext.Provider
@@ -135,7 +110,6 @@ describe("submitPinRecording", () => {
       >
         <PinRecordingModal
           recordingToPin={recordingToPin}
-          isCurrentUser
           newAlert={jest.fn()}
         />
       </GlobalAppContext.Provider>
@@ -154,7 +128,6 @@ describe("submitPinRecording", () => {
       <GlobalAppContext.Provider value={globalProps}>
         <PinRecordingModal
           recordingToPin={recordingToPin}
-          isCurrentUser
           newAlert={jest.fn()}
         />
       </GlobalAppContext.Provider>
@@ -183,7 +156,6 @@ describe("handleBlurbInputChange", () => {
       <GlobalAppContext.Provider value={globalProps}>
         <PinRecordingModal
           recordingToPin={recordingToPin}
-          isCurrentUser
           newAlert={jest.fn()}
         />
       </GlobalAppContext.Provider>
@@ -212,7 +184,6 @@ describe("handleBlurbInputChange", () => {
       <GlobalAppContext.Provider value={globalProps}>
         <PinRecordingModal
           recordingToPin={recordingToPin}
-          isCurrentUser
           newAlert={jest.fn()}
         />
       </GlobalAppContext.Provider>
@@ -245,11 +216,7 @@ describe("handleBlurbInputChange", () => {
 describe("handleError", () => {
   it("calls newAlert", async () => {
     const wrapper = mount<PinRecordingModal>(
-      <PinRecordingModal
-        recordingToPin={recordingToPin}
-        isCurrentUser
-        newAlert={jest.fn()}
-      />
+      <PinRecordingModal recordingToPin={recordingToPin} newAlert={jest.fn()} />
     );
     const instance = wrapper.instance();
 

--- a/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
+++ b/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
@@ -5,7 +5,6 @@ import { preciseTimestamp } from "./utils";
 
 export type PinRecordingModalProps = {
   recordingToPin: Listen;
-  isCurrentUser: Boolean;
   newAlert: (
     alertType: AlertType,
     title: string,
@@ -31,11 +30,11 @@ export default class PinRecordingModal extends React.Component<
   }
 
   submitPinRecording = async () => {
-    const { recordingToPin, isCurrentUser, newAlert } = this.props;
+    const { recordingToPin, newAlert } = this.props;
     const { blurbContent } = this.state;
     const { APIService, currentUser } = this.context;
 
-    if (isCurrentUser && currentUser?.auth_token) {
+    if (currentUser?.auth_token) {
       const recordingMSID = _get(
         recordingToPin,
         "track_metadata.additional_info.recording_msid"

--- a/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.test.tsx
@@ -853,7 +853,6 @@ describe("pinRecordingModal", () => {
 
     // recentListens renders pinRecordingModal with listens[0] as recordingToPin by default
     expect(pinRecordingModal.props()).toEqual({
-      isCurrentUser: true,
       recordingToPin: props.listens[0],
       newAlert: props.newAlert,
     });
@@ -863,7 +862,6 @@ describe("pinRecordingModal", () => {
 
     pinRecordingModal = wrapper.find(PinRecordingModal).first();
     expect(pinRecordingModal.props()).toEqual({
-      isCurrentUser: true,
       recordingToPin,
       newAlert: props.newAlert,
     });

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -759,7 +759,6 @@ export default class RecentListens extends React.Component<
                 {currentUser && (
                   <PinRecordingModal
                     recordingToPin={recordingToPin || listens[0]}
-                    isCurrentUser={currentUser?.name === user?.name}
                     newAlert={newAlert}
                   />
                 )}

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
@@ -127,25 +127,6 @@ describe("ListenCard", () => {
       expect(instance.props.updateFeedback).toHaveBeenCalledWith("bar", -1);
     });
 
-    it("does nothing if isCurrentUser is false", async () => {
-      const wrapper = mount<ListenCard>(
-        <GlobalAppContext.Provider value={globalProps}>
-          <ListenCard {...{ ...props, isCurrentUser: false }} />
-        </GlobalAppContext.Provider>
-      );
-      const instance = wrapper.instance();
-
-      const { APIService } = instance.context;
-      const spy = jest.spyOn(APIService, "submitFeedback");
-      spy.mockImplementation(() => Promise.resolve(200));
-
-      expect(wrapper.state("feedback")).toEqual(1);
-
-      instance.submitFeedback(-1);
-      expect(spy).toHaveBeenCalledTimes(0);
-      expect(wrapper.state("feedback")).toEqual(1);
-    });
-
     it("does nothing if CurrentUser.authtoken is not set", async () => {
       const wrapper = mount<ListenCard>(
         <GlobalAppContext.Provider
@@ -383,25 +364,6 @@ describe("ListenCard", () => {
       });
 
       expect(instance.props.newAlert).toHaveBeenCalledTimes(1);
-    });
-
-    it("does nothing if isCurrentUser is false", async () => {
-      const wrapper = mount<ListenCard>(
-        <GlobalAppContext.Provider value={globalProps}>
-          <ListenCard {...{ ...props, isCurrentUser: false }} />
-        </GlobalAppContext.Provider>
-      );
-
-      const instance = wrapper.instance();
-
-      const spy = jest.spyOn(
-        instance.context.APIService,
-        "recommendTrackToFollowers"
-      );
-      spy.mockImplementation(() => Promise.resolve(200));
-
-      instance.recommendListenToFollowers();
-      expect(spy).toHaveBeenCalledTimes(0);
     });
 
     it("does nothing if CurrentUser.authtoken is not set", async () => {

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -73,10 +73,9 @@ export default class ListenCard extends React.Component<
   }
 
   submitFeedback = async (score: ListenFeedBack) => {
-    const { listen, isCurrentUser, updateFeedback } = this.props;
+    const { listen, updateFeedback } = this.props;
     const { APIService, currentUser } = this.context;
-    // const { submitFeedback } = APIService;
-    if (isCurrentUser && currentUser?.auth_token) {
+    if (currentUser?.auth_token) {
       const recordingMSID = _get(
         listen,
         "track_metadata.additional_info.recording_msid"
@@ -130,10 +129,10 @@ export default class ListenCard extends React.Component<
   };
 
   recommendListenToFollowers = async () => {
-    const { listen, isCurrentUser, newAlert } = this.props;
+    const { listen, newAlert } = this.props;
     const { APIService, currentUser } = this.context;
 
-    if (isCurrentUser && currentUser?.auth_token) {
+    if (currentUser?.auth_token) {
       const metadata: UserTrackRecommendationMetadata = {
         artist_name: _get(listen, "track_metadata.artist_name"),
         track_name: _get(listen, "track_metadata.track_name"),


### PR DESCRIPTION
PR #1612 displays love/hate feedback and other actions on listens when viewing another user's page, but I forgot that the methods that perform the actions still check if user is viewing their own page.