### PR TITLE
Fix tests for preciseTimestamp formatting utility

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils.test.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.test.tsx
@@ -34,9 +34,15 @@ describe("preciseTimestamp", () => {
   const currentDate: Date = new Date();
 
   it("uses timeago formatting for if timestamp is on the same day", () => {
-    const date: Date = new Date("2021-09-14T16:16:16.161Z"); // 4PM UTC
-    const testDate: number = date.getTime() - 1000 * 3600 * 12; // 12 hours ago was already today
+    const dateString = "2021-09-14T16:16:16.161Z"; // 4PM
+    const setDate: Date = new Date(dateString);
+    const epoch = setDate.getTime();
+    const testDate: number = epoch - 1000 * 3600 * 12; // 12 hours (6AM) ago was already 'today'
+
+    const dateNowMock = jest.spyOn(Date, "now").mockImplementation(() => epoch);
+
     expect(preciseTimestamp(testDate)).toMatch(timeago.ago(testDate));
+    dateNowMock.mockRestore();
   });
 
   it("uses no-year formatting if timestamp is 'yesterday'", () => {

--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -249,13 +249,15 @@ const preciseTimestamp = (
 
   // determine which display setting based on time difference to use if no argument was provided
   if (!display) {
-    const now = new Date();
-    const currentYear = now.getFullYear();
+    // We can easily mock Date.now in our tests to mock the current dateTime
+    const now = Date.now();
+    const nowDate = new Date(now);
+    const currentYear = nowDate.getFullYear();
     const listenYear = listenDate.getFullYear();
     // Date is today : format using timeago
     if (
-      now.getDate() === listenDate.getDate() &&
-      now.getMonth() === listenDate.getMonth() &&
+      nowDate.getDate() === listenDate.getDate() &&
+      nowDate.getMonth() === listenDate.getMonth() &&
       currentYear === listenYear
     ) {
       display = "timeAgo";

--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -251,13 +251,13 @@ const preciseTimestamp = (
   if (!display) {
     // We can easily mock Date.now in our tests to mock the current dateTime
     const now = Date.now();
-    const nowDate = new Date(now);
-    const currentYear = nowDate.getFullYear();
+    const currentDate = new Date(now);
+    const currentYear = currentDate.getFullYear();
     const listenYear = listenDate.getFullYear();
     // Date is today : format using timeago
     if (
-      nowDate.getDate() === listenDate.getDate() &&
-      nowDate.getMonth() === listenDate.getMonth() &&
+      currentDate.getDate() === listenDate.getDate() &&
+      currentDate.getMonth() === listenDate.getMonth() &&
       currentYear === listenYear
     ) {
       display = "timeAgo";


### PR DESCRIPTION
I already wrote this test twice: once in the original PR #1603 then after realizing the test broke depending on time of day #1613 

Third time's the charm!

This time I decided to use `Date.now()` in our utility and then construct a `new Date(…)` from that epoch timestamp, because it is much easier to mock in our test suite.
We need this because the utility compares a given date to *the current date-time*, which means we need to fake what the current date-time is in order to compare it to a given date-time.
