### PR TITLE
Move sitewide stats to new statistics table

### DIFF
--- a/data/model/sitewide_artist_stat.py
+++ b/data/model/sitewide_artist_stat.py
@@ -15,30 +15,3 @@ class SitewideArtistRecord(pydantic.BaseModel):
     artist_name: str
     # to add an empty field to stats API response, for compatibility
     artist_msid: Optional[str]
-
-
-class SitewideArtistStatRange(pydantic.BaseModel):
-    """ Model for storing most listened-to artists on the website for a
-        particular time range.
-    """
-    to_ts: int
-    from_ts: int
-    time_range: str
-    artists: List[SitewideArtistRecord]
-
-
-class SitewideArtistStatJson(pydantic.BaseModel):
-    """ Model for the JSON stored in the statistics.sitewide table's
-        artist column.
-    """
-    to_ts: int
-    from_ts: int
-    time_ranges: List[SitewideArtistStatRange]
-
-
-class SitewideArtistStat(pydantic.BaseModel):
-    """ Model for stats around a most listened artists on the website
-    """
-    stats_range: str
-    data: Optional[SitewideArtistStatJson]
-    last_updated: datetime

--- a/data/model/sitewide_artist_stat.py
+++ b/data/model/sitewide_artist_stat.py
@@ -1,8 +1,6 @@
 import pydantic
 
-from datetime import datetime
-from enum import Enum
-from typing import Optional, List, Dict
+from typing import Optional, List
 
 
 class SitewideArtistRecord(pydantic.BaseModel):

--- a/data/model/sitewide_entity.py
+++ b/data/model/sitewide_entity.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Union
 
 import pydantic
-from data.model.sitewide_artist_stat import SitewideArtistStatRange
+
+from data.model.sitewide_artist_stat import SitewideArtistRecord
 
 
 class SitewideEntityStatMessage(pydantic.BaseModel):
@@ -11,6 +12,7 @@ class SitewideEntityStatMessage(pydantic.BaseModel):
     stats_range: str  # The range for which the stats are calculated, i.e week, month, year or all_time
     from_ts: int
     to_ts: int
+    count: int
     # Order of the records in union is important and should be from more specific to less specific
     # For more info read https://pydantic-docs.helpmanual.io/usage/types/#unions
-    data: List[Union[SitewideArtistStatRange]]
+    data: List[SitewideArtistRecord]

--- a/data/model/user_artist_stat.py
+++ b/data/model/user_artist_stat.py
@@ -4,7 +4,7 @@ from typing import Optional, List
 
 
 class UserArtistRecord(pydantic.BaseModel):
-    """ Each individual record for a user's artists
+    """ Each individual record for top artists
 
     Contains the artist name, MessyBrainz ID, MusicBrainz IDs and listen count.
     """

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -37,7 +37,8 @@ from pydantic import ValidationError
 
 
 # sitewide statistics are stored in the user statistics table
-# as statistics for a special user with the following user_id
+# as statistics for a special user with the following user_id.
+# Note: this is the id from LB's "user" table and *not musicbrainz_row_id*.
 SITEWIDE_STATS_USER_ID = 15753
 
 

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -27,8 +27,6 @@ from typing import Optional
 import sqlalchemy
 
 from data.model.common_stat import StatRange, StatApi
-from data.model.sitewide_artist_stat import (SitewideArtistStat,
-                                             SitewideArtistStatJson)
 from data.model.user_artist_map import UserArtistMapRecord
 from data.model.user_daily_activity import UserDailyActivityRecord
 from data.model.user_entity import UserEntityRecord
@@ -92,19 +90,6 @@ def insert_sitewide_jsonb_data(stats_type: str, stats: StatRange):
             stats: the data to be inserted
     """
     insert_user_jsonb_data(SITEWIDE_STATS_USER_ID, stats_type, stats)
-
-
-def insert_sitewide_artists(stats_range: str, artists: SitewideArtistStatJson):
-    """Inserts sitewide artist stats calculated from Spark into the database.
-
-       If stats are already present for a time range, they are updated to the new
-       values passed.
-
-       Args: stats_range: the range for which the stats have been calculated,
-             artists: the top artists for a particular stats_range
-    """
-    _insert_sitewide_jsonb_data(
-        stats_range, column='artist', data=artists.dict(exclude_none=True))
 
 
 def get_user_stats(user_id: int, stats_range: str, stats_type: str) -> Optional[StatApi[UserEntityRecord]]:
@@ -202,7 +187,7 @@ def get_user_artist_map(user_id: int, stats_range: str) -> Optional[StatApi[User
     return get_user_activity_stats(user_id, stats_range, 'artist_map', StatApi[UserArtistMapRecord])
 
 
-def get_sitewide_artists(stats_range: str) -> Optional[SitewideArtistStat]:
+def get_sitewide_artists(stats_range: str):
     """ Get sitewide top artists for from the DB.
 
         Args:

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -187,30 +187,14 @@ def get_user_artist_map(user_id: int, stats_range: str) -> Optional[StatApi[User
     return get_user_activity_stats(user_id, stats_range, 'artist_map', StatApi[UserArtistMapRecord])
 
 
-def get_sitewide_artists(stats_range: str):
-    """ Get sitewide top artists for from the DB.
+def get_sitewide_stats(stats_range: str, stats_type: str) -> Optional[StatApi[UserEntityRecord]]:
+    """ Get top stats of given type in a time range for user with given ID.
 
         Args:
-            stats_range: The time range for which to fetch the stats for.
-
-        Returns:
-            data: The top artists for the given time_range if they are present else None
+            stats_range: the time range to fetch the stats for
+            stats_type: the entity type to fetch stats for
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-                SELECT stats_range, artist as data, last_updated
-                  FROM statistics.sitewide
-                 WHERE stats_range = :stats_range
-            """), {
-            'stats_range': stats_range
-        })
-        row = result.fetchone()
-
-    try:
-        return SitewideArtistStat(**dict(row)) if row else None
-    except ValidationError:
-        current_app.logger.error("""ValidationError when getting {stats_range} sitewide top artists.
-                                 Data: {data}""".format(stats_range, data=json.dumps(dict(row)['data'], indent=3)), exc_info=True)
+    return get_user_stats(SITEWIDE_STATS_USER_ID, stats_range, stats_type)
 
 
 def valid_stats_exist(user_id, days):
@@ -258,16 +242,6 @@ def delete_user_stats(user_id):
 # TODO: Add tests for this function
 
 
-def delete_sitewide_stats(stats_range: str):
-    """ Delete stats for a particular time_range
-
-        Args:
-            stats_range: The stats_range for which stats should be deleted
-    """
-    with db.engine.connect() as connection:
-        connection.execute(sqlalchemy.text("""
-            DELETE FROM statistics.sitewide
-             WHERE stats_range = :stats_range
-            """), {
-            'stats_range': stats_range
-        })
+def delete_sitewide_stats():
+    """ Delete sitewide stats """
+    delete_user_stats(SITEWIDE_STATS_USER_ID)

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -2,6 +2,9 @@
 import os
 import unittest
 
+import sqlalchemy
+import uuid
+
 from listenbrainz import config
 from listenbrainz import db
 from listenbrainz.db import timescale as ts
@@ -47,6 +50,19 @@ class DatabaseTestCase(unittest.TestCase):
                 file_name: the name of the data file
         """
         return os.path.join(TEST_DATA_PATH, file_name)
+
+    def create_user_with_id(self, lb_id:int, musicbrainz_row_id: int, musicbrainz_id: str):
+        """ Create a new user with the specified LB id. """
+        with db.engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text("""
+                INSERT INTO "user" (id, musicbrainz_id, musicbrainz_row_id, auth_token)
+                     VALUES (:id, :mb_id, :mb_row_id, :token)
+            """), {
+                "id": lb_id,
+                "mb_id": musicbrainz_id,
+                "token": str(uuid.uuid4()),
+                "mb_row_id": musicbrainz_row_id,
+            })
 
 
 class TimescaleTestCase(unittest.TestCase):

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -250,7 +250,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             user_id=self.user['id'], stats_type='artist_map',
             stats=StatRange[UserArtistMapRecord](**artist_map)
         )
-        db_stats.insert_sitewide_jsonb_data('all_time', StatRange[UserEntityRecord](**sitewide_artists))
+        db_stats.insert_sitewide_jsonb_data('artists', StatRange[UserEntityRecord](**sitewide_artists))
 
         return {
             'user_artists': user_artists,

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 from data.model.common_stat import StatRange
-from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecord
 from data.model.user_daily_activity import UserDailyActivityRecord
 from data.model.user_entity import UserEntityRecord
@@ -18,6 +17,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
     def setUp(self):
         DatabaseTestCase.setUp(self)
         self.user = db_user.get_or_create(1, 'stats_user')
+        self.create_user_with_id(db_stats.SITEWIDE_STATS_USER_ID, 2, "listenbrainz-stats-user")
         self.maxDiff = None
 
     def test_insert_user_artists(self):
@@ -209,9 +209,9 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         with open(self.path_to_data_file('sitewide_top_artists_db.json')) as f:
             artists_data = json.load(f)
 
-        db_stats.insert_sitewide_artists(stats_range='all_time', artists=SitewideArtistStatJson(**artists_data))
+        db_stats.insert_sitewide_jsonb_data('artists', StatRange[UserEntityRecord](**artists_data))
 
-        result = db_stats.get_sitewide_artists('all_time')
+        result = db_stats.get_sitewide_stats('all_time', 'artists')
         self.assertDictEqual(result.data.dict(), artists_data)
 
     def insert_test_data(self):
@@ -250,7 +250,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
             user_id=self.user['id'], stats_type='artist_map',
             stats=StatRange[UserArtistMapRecord](**artist_map)
         )
-        db_stats.insert_sitewide_artists('all_time', SitewideArtistStatJson(**sitewide_artists))
+        db_stats.insert_sitewide_jsonb_data('all_time', StatRange[UserEntityRecord](**sitewide_artists))
 
         return {
             'user_artists': user_artists,
@@ -300,7 +300,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
 
     def test_get_sitewide_artists(self):
         data_inserted = self.insert_test_data()
-        result = db_stats.get_sitewide_artists('all_time')
+        result = db_stats.get_sitewide_stats('all_time', 'artists')
         self.assertDictEqual(result.data.dict(), data_inserted['sitewide_artists'])
 
     def test_valid_stats_exist(self):

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -212,7 +212,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         db_stats.insert_sitewide_jsonb_data('artists', StatRange[UserEntityRecord](**artists_data))
 
         result = db_stats.get_sitewide_stats('all_time', 'artists')
-        self.assertDictEqual(result.data.dict(), artists_data)
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), artists_data)
 
     def insert_test_data(self):
         """ Insert test data into the database """
@@ -301,7 +301,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
     def test_get_sitewide_artists(self):
         data_inserted = self.insert_test_data()
         result = db_stats.get_sitewide_stats('all_time', 'artists')
-        self.assertDictEqual(result.data.dict(), data_inserted['sitewide_artists'])
+        self.assertDictEqual(result.dict(exclude={'user_id', 'last_updated'}), data_inserted['sitewide_artists'])
 
     def test_valid_stats_exist(self):
         self.assertFalse(db_stats.valid_stats_exist(self.user['id'], 7))

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -3,12 +3,9 @@ from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 from data.model.common_stat import StatRange, StatRecordList
-from data.model.sitewide_artist_stat import (SitewideArtistRecord,
-                                             SitewideArtistStatJson,
-                                             SitewideArtistStatRange)
-from data.model.user_daily_activity import UserDailyActivityRecord, UserDailyActivityRecord
+from data.model.user_daily_activity import UserDailyActivityRecord
 from data.model.user_entity import UserEntityRecord
-from data.model.user_listening_activity import UserListeningActivityRecord, UserListeningActivityRecord
+from data.model.user_listening_activity import UserListeningActivityRecord
 from data.model.user_artist_stat import UserArtistRecord
 
 from data.model.user_missing_musicbrainz_data import (UserMissingMusicBrainzDataRecord,
@@ -162,10 +159,10 @@ class HandlersTestCase(unittest.TestCase):
         ))
         mock_send_mail.assert_called_once()
 
-    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_sitewide_artists')
+    @mock.patch('listenbrainz.spark.handlers.db_stats.insert_sitewide_jsonb_data')
     @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
-    def test_handle_user_daily_activity(self, mock_send_mail, mock_new_user_stats, mock_db_insert):
+    def test_handle_user_daily_activity(self, mock_send_mail, mock_sitewide_stats, mock_db_insert):
         data = {
             'type': 'sitewide_entity',
             'stats_range': 'all_time',
@@ -174,38 +171,30 @@ class HandlersTestCase(unittest.TestCase):
             'entity': 'artists',
             'data': [
                 {
-                    'time_range': 'Monday',
-                    'from_ts': 1,
-                    'to_ts': 2,
-                    'artists': [
-                        {
-                            'artist_name': 'Coldplay',
-                            'artist_mbid': [],
-                            'listen_count': 20
-                        }
-                    ]
+                    'artist_name': 'Coldplay',
+                    'artist_mbid': [],
+                    'listen_count': 20
                 }
             ],
+            'count': 1
         }
 
         with self.app.app_context():
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_sitewide_entity(data)
 
-        mock_db_insert.assert_called_with('all_time', SitewideArtistStatJson(
+        mock_db_insert.assert_called_with('all_time', StatRange[UserEntityRecord](
             to_ts=10,
             from_ts=1,
-            time_ranges=[SitewideArtistStatRange(
-                time_range="Monday",
-                from_ts=1,
-                to_ts=2,
-                artists=[SitewideArtistRecord(
+            count=1,
+            stats_range="artists",
+            data=StatRange[UserArtistRecord](__root__=[
+                UserArtistRecord(
                     artist_name='Coldplay',
                     artist_mbid=[],
                     listen_count=20,
-                )]
-            )]
-        ))
+                )
+            ])))
         mock_send_mail.assert_called_once()
 
     @mock.patch('listenbrainz.spark.handlers.db_stats.get_timestamp_for_last_user_stats_update')

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -188,7 +188,7 @@ class HandlersTestCase(unittest.TestCase):
             from_ts=1,
             count=1,
             stats_range="artists",
-            data=StatRange[UserArtistRecord](__root__=[
+            data=StatRecordList[UserArtistRecord](__root__=[
                 UserArtistRecord(
                     artist_name='Coldplay',
                     artist_mbid=[],

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -183,11 +183,11 @@ class HandlersTestCase(unittest.TestCase):
             current_app.config['TESTING'] = False  # set testing to false to check the notifications
             handle_sitewide_entity(data)
 
-        mock_db_insert.assert_called_with('all_time', StatRange[UserEntityRecord](
+        mock_db_insert.assert_called_with('artists', StatRange[UserArtistRecord](
             to_ts=10,
             from_ts=1,
             count=1,
-            stats_range="artists",
+            stats_range='all_time',
             data=StatRecordList[UserArtistRecord](__root__=[
                 UserArtistRecord(
                     artist_name='Coldplay',

--- a/listenbrainz/testdata/sitewide_top_artists_db.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db.json
@@ -18,5 +18,7 @@
             "artist_msid": null
         }
     ],
-    "to_ts": 1593043183
+    "to_ts": 1593043183,
+    "stats_range": "all_time",
+    "count": 2
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db.json
@@ -1,35 +1,21 @@
 {
     "from_ts": 1009843200,
-    "time_ranges": [
+    "data": [
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
-                    ],
-                    "listen_count": 2521,
-                    "artist_name": "Judas Priest",
-                    "artist_msid": null
-                }
+            "artist_mbids": [
+                "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
             ],
-            "from_ts": 1104537600,
-            "time_range": "2005",
-            "to_ts": 1136073599
+            "listen_count": 2521,
+            "artist_name": "Judas Priest",
+            "artist_msid": null
         },
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
-                    ],
-                    "listen_count": 1354,
-                    "artist_name": "Judas Priest",
-                    "artist_msid": null
-                }
+            "artist_mbids": [
+                "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
             ],
-            "from_ts": 1136073600,
-            "time_range": "2006",
-            "to_ts": 1167609599
+            "listen_count": 1354,
+            "artist_name": "Judas Priest",
+            "artist_msid": null
         }
     ],
     "to_ts": 1593043183

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test.json
@@ -1,500 +1,488 @@
 {
     "to_ts": 1593043183,
     "from_ts": 1009843200,
-    "time_ranges": [
+    "data": [
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
-                    ],
-                    "listen_count": 2521,
-                    "artist_name": "Judas Priest",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
-                    ],
-                    "listen_count": 813,
-                    "artist_name": "Slayer",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2f13b1cb-32e3-45c6-8b87-25629490ac44"
-                    ],
-                    "listen_count": 770,
-                    "artist_name": "Iron Maiden",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
-                    ],
-                    "listen_count": 726,
-                    "artist_name": "Black Label Society",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
-                    ],
-                    "listen_count": 667,
-                    "artist_name": "Arch Enemy",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e6a8399-a625-4151-9bba-3994b033957e"
-                    ],
-                    "listen_count": 608,
-                    "artist_name": "Black Sabbath",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "87e396ef-3ee0-4ff2-853c-6174c4243df6"
-                    ],
-                    "listen_count": 592,
-                    "artist_name": "Foo Fighters",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f6804334-5021-4e52-9f71-3ea924e6abc6"
-                    ],
-                    "listen_count": 569,
-                    "artist_name": "Evergrey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
-                    ],
-                    "listen_count": 558,
-                    "artist_name": "Alanis Morissette",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "61746abb-76a5-465d-aee7-c4c42d61b7c4"
-                    ],
-                    "listen_count": 501,
-                    "artist_name": "Massive Attack",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "79f83982-a0a1-4907-b12e-dc974868e219"
-                    ],
-                    "listen_count": 475,
-                    "artist_name": "Audioslave",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "38742bd1-2ceb-4854-a138-206d095cdcc0"
-                    ],
-                    "listen_count": 473,
-                    "artist_name": "Opeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
-                    ],
-                    "listen_count": 466,
-                    "artist_name": "Tiamat",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c707783d-53b6-47fc-8c94-4d5323489209"
-                    ],
-                    "listen_count": 457,
-                    "artist_name": "Avril Lavigne",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "58914eb6-0518-45eb-a917-9985aa1cd374"
-                    ],
-                    "listen_count": 453,
-                    "artist_name": "Emperor",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "69ab35a3-c877-484a-8db9-4569010e72ed"
-                    ],
-                    "listen_count": 451,
-                    "artist_name": "Nine Inch Nails",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "844c13e8-9264-41f1-acc1-a59be2af611e"
-                    ],
-                    "listen_count": 440,
-                    "artist_name": "In Flames",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
-                    ],
-                    "listen_count": 414,
-                    "artist_name": "Megadeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a3c5dedf-13bb-4df2-be11-285972577112"
-                    ],
-                    "listen_count": 406,
-                    "artist_name": "Metallica",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
-                    ],
-                    "listen_count": 371,
-                    "artist_name": "Katatonia",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "94f867bb-3542-4675-858e-86dafdd7a647"
-                    ],
-                    "listen_count": 366,
-                    "artist_name": "Ayreon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
-                    ],
-                    "listen_count": 357,
-                    "artist_name": "Darkthrone",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f5b259cb-2323-41f7-9d19-32e69e79a87e"
-                    ],
-                    "listen_count": 313,
-                    "artist_name": "Kitaro",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "114378b9-019b-48ab-a6af-0e122cf6c056"
-                    ],
-                    "listen_count": 312,
-                    "artist_name": "Bathory",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8d0f8872-4527-4604-8e35-705afc9f50e6"
-                    ],
-                    "listen_count": 299,
-                    "artist_name": "Dream Theater",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "12379346-99d9-4941-b4a2-f04144a39863"
-                    ],
-                    "listen_count": 294,
-                    "artist_name": "Iced Earth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
-                    ],
-                    "listen_count": 269,
-                    "artist_name": "System of a Down",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "662105c0-9830-4ea7-9637-1aa5cedc9650"
-                    ],
-                    "listen_count": 269,
-                    "artist_name": "Paradise Lost",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f0aa3926-f243-4c5d-9162-6fee7f811934"
-                    ],
-                    "listen_count": 269,
-                    "artist_name": "Cradle of Filth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
-                    ],
-                    "listen_count": 268,
-                    "artist_name": "Sentenced",
-                    "artist_msid": null
-                }
+            "listen_count": 2521,
+            "artist_name": "Judas Priest",
+            "artist_mbids": [
+                "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
             ],
-            "from_ts": 1104537600,
-            "time_range": "2005",
-            "to_ts": 1136073599
+            "artist_msid": null
         },
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
-                    ],
-                    "listen_count": 1354,
-                    "artist_name": "Judas Priest",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f6804334-5021-4e52-9f71-3ea924e6abc6"
-                    ],
-                    "listen_count": 691,
-                    "artist_name": "Evergrey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "431cc9fb-ef90-4819-9c7b-2229c298727c"
-                    ],
-                    "listen_count": 641,
-                    "artist_name": "Danko Jones",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "87e396ef-3ee0-4ff2-853c-6174c4243df6"
-                    ],
-                    "listen_count": 606,
-                    "artist_name": "Foo Fighters",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
-                    ],
-                    "listen_count": 584,
-                    "artist_name": "Katatonia",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4b321558-10b1-4d93-9bed-7c9048e28ecb"
-                    ],
-                    "listen_count": 556,
-                    "artist_name": "The Hellacopters",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fcee89d2-70a6-4149-afd3-90806ddc650d"
-                    ],
-                    "listen_count": 504,
-                    "artist_name": "Death Cab for Cutie",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "645129c1-9b76-48c0-a3af-c87b284265a3"
-                    ],
-                    "listen_count": 470,
-                    "artist_name": "The Darkness",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e9e619a9-5170-4ef7-bfeb-29ef64ed3f5d"
-                    ],
-                    "listen_count": 461,
-                    "artist_name": "Turbonegro",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
-                    ],
-                    "listen_count": 415,
-                    "artist_name": "Black Label Society",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "79f83982-a0a1-4907-b12e-dc974868e219"
-                    ],
-                    "listen_count": 405,
-                    "artist_name": "Audioslave",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "94f867bb-3542-4675-858e-86dafdd7a647"
-                    ],
-                    "listen_count": 402,
-                    "artist_name": "Ayreon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ceff4c9-fe82-444a-ba9d-20e724e04190"
-                    ],
-                    "listen_count": 394,
-                    "artist_name": "Strapping Young Lad",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
-                    ],
-                    "listen_count": 385,
-                    "artist_name": "Slayer",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
-                    ],
-                    "listen_count": 347,
-                    "artist_name": "The Cardigans",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
-                    ],
-                    "listen_count": 342,
-                    "artist_name": "The Offspring",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
-                    ],
-                    "listen_count": 329,
-                    "artist_name": "Arch Enemy",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "574dfe13-97aa-4318-8e4a-0ec79e05db24"
-                    ],
-                    "listen_count": 324,
-                    "artist_name": "Hoobastank",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "540eebc9-0fc6-41df-8372-2c1a534e92e3"
-                    ],
-                    "listen_count": 316,
-                    "artist_name": "Depeche Mode",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99eec84e-42cb-4f47-b80f-ce46ca65735b"
-                    ],
-                    "listen_count": 305,
-                    "artist_name": "Panic! at the Disco",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
-                    ],
-                    "listen_count": 297,
-                    "artist_name": "Mot\u00f6rhead",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dbed7c10-e68c-4805-9295-09c48c06b897"
-                    ],
-                    "listen_count": 292,
-                    "artist_name": "W.A.S.P.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "38742bd1-2ceb-4854-a138-206d095cdcc0"
-                    ],
-                    "listen_count": 275,
-                    "artist_name": "Opeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
-                    ],
-                    "listen_count": 268,
-                    "artist_name": "The Postal Service",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2f13b1cb-32e3-45c6-8b87-25629490ac44"
-                    ],
-                    "listen_count": 264,
-                    "artist_name": "Iron Maiden",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d3e64ede-3456-4f67-952c-fa0b7d05231a"
-                    ],
-                    "listen_count": 262,
-                    "artist_name": "Wizo",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e6a8399-a625-4151-9bba-3994b033957e"
-                    ],
-                    "listen_count": 249,
-                    "artist_name": "Black Sabbath",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6599e41e-390c-4855-a2ac-68ee798538b4"
-                    ],
-                    "listen_count": 246,
-                    "artist_name": "Coldplay",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
-                    ],
-                    "listen_count": 244,
-                    "artist_name": "D-A-D",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "12379346-99d9-4941-b4a2-f04144a39863"
-                    ],
-                    "listen_count": 238,
-                    "artist_name": "Iced Earth",
-                    "artist_msid": null
-                }
+            "listen_count": 813,
+            "artist_name": "Slayer",
+            "artist_mbids": [
+                "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
             ],
-            "from_ts": 1136073600,
-            "time_range": "2006",
-            "to_ts": 1167609599
+            "artist_msid": null
+        },
+        {
+            "listen_count": 770,
+            "artist_name": "Iron Maiden",
+            "artist_mbids": [
+                "2f13b1cb-32e3-45c6-8b87-25629490ac44"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 726,
+            "artist_name": "Black Label Society",
+            "artist_mbids": [
+                "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 667,
+            "artist_name": "Arch Enemy",
+            "artist_mbids": [
+                "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 608,
+            "artist_name": "Black Sabbath",
+            "artist_mbids": [
+                "9e6a8399-a625-4151-9bba-3994b033957e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 592,
+            "artist_name": "Foo Fighters",
+            "artist_mbids": [
+                "87e396ef-3ee0-4ff2-853c-6174c4243df6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 569,
+            "artist_name": "Evergrey",
+            "artist_mbids": [
+                "f6804334-5021-4e52-9f71-3ea924e6abc6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 558,
+            "artist_name": "Alanis Morissette",
+            "artist_mbids": [
+                "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 501,
+            "artist_name": "Massive Attack",
+            "artist_mbids": [
+                "61746abb-76a5-465d-aee7-c4c42d61b7c4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 475,
+            "artist_name": "Audioslave",
+            "artist_mbids": [
+                "79f83982-a0a1-4907-b12e-dc974868e219"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 473,
+            "artist_name": "Opeth",
+            "artist_mbids": [
+                "38742bd1-2ceb-4854-a138-206d095cdcc0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 466,
+            "artist_name": "Tiamat",
+            "artist_mbids": [
+                "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 457,
+            "artist_name": "Avril Lavigne",
+            "artist_mbids": [
+                "c707783d-53b6-47fc-8c94-4d5323489209"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 453,
+            "artist_name": "Emperor",
+            "artist_mbids": [
+                "58914eb6-0518-45eb-a917-9985aa1cd374"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 451,
+            "artist_name": "Nine Inch Nails",
+            "artist_mbids": [
+                "69ab35a3-c877-484a-8db9-4569010e72ed"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 440,
+            "artist_name": "In Flames",
+            "artist_mbids": [
+                "844c13e8-9264-41f1-acc1-a59be2af611e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 414,
+            "artist_name": "Megadeth",
+            "artist_mbids": [
+                "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 406,
+            "artist_name": "Metallica",
+            "artist_mbids": [
+                "a3c5dedf-13bb-4df2-be11-285972577112"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 371,
+            "artist_name": "Katatonia",
+            "artist_mbids": [
+                "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 366,
+            "artist_name": "Ayreon",
+            "artist_mbids": [
+                "94f867bb-3542-4675-858e-86dafdd7a647"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 357,
+            "artist_name": "Darkthrone",
+            "artist_mbids": [
+                "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 313,
+            "artist_name": "Kitaro",
+            "artist_mbids": [
+                "f5b259cb-2323-41f7-9d19-32e69e79a87e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 312,
+            "artist_name": "Bathory",
+            "artist_mbids": [
+                "114378b9-019b-48ab-a6af-0e122cf6c056"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 299,
+            "artist_name": "Dream Theater",
+            "artist_mbids": [
+                "8d0f8872-4527-4604-8e35-705afc9f50e6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 294,
+            "artist_name": "Iced Earth",
+            "artist_mbids": [
+                "12379346-99d9-4941-b4a2-f04144a39863"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 269,
+            "artist_name": "System of a Down",
+            "artist_mbids": [
+                "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 269,
+            "artist_name": "Paradise Lost",
+            "artist_mbids": [
+                "662105c0-9830-4ea7-9637-1aa5cedc9650"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 269,
+            "artist_name": "Cradle of Filth",
+            "artist_mbids": [
+                "f0aa3926-f243-4c5d-9162-6fee7f811934"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 268,
+            "artist_name": "Sentenced",
+            "artist_mbids": [
+                "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 1354,
+            "artist_name": "Judas Priest",
+            "artist_mbids": [
+                "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 691,
+            "artist_name": "Evergrey",
+            "artist_mbids": [
+                "f6804334-5021-4e52-9f71-3ea924e6abc6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 641,
+            "artist_name": "Danko Jones",
+            "artist_mbids": [
+                "431cc9fb-ef90-4819-9c7b-2229c298727c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 606,
+            "artist_name": "Foo Fighters",
+            "artist_mbids": [
+                "87e396ef-3ee0-4ff2-853c-6174c4243df6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 584,
+            "artist_name": "Katatonia",
+            "artist_mbids": [
+                "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 556,
+            "artist_name": "The Hellacopters",
+            "artist_mbids": [
+                "4b321558-10b1-4d93-9bed-7c9048e28ecb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 504,
+            "artist_name": "Death Cab for Cutie",
+            "artist_mbids": [
+                "fcee89d2-70a6-4149-afd3-90806ddc650d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 470,
+            "artist_name": "The Darkness",
+            "artist_mbids": [
+                "645129c1-9b76-48c0-a3af-c87b284265a3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 461,
+            "artist_name": "Turbonegro",
+            "artist_mbids": [
+                "e9e619a9-5170-4ef7-bfeb-29ef64ed3f5d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 415,
+            "artist_name": "Black Label Society",
+            "artist_mbids": [
+                "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 405,
+            "artist_name": "Audioslave",
+            "artist_mbids": [
+                "79f83982-a0a1-4907-b12e-dc974868e219"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 402,
+            "artist_name": "Ayreon",
+            "artist_mbids": [
+                "94f867bb-3542-4675-858e-86dafdd7a647"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 394,
+            "artist_name": "Strapping Young Lad",
+            "artist_mbids": [
+                "6ceff4c9-fe82-444a-ba9d-20e724e04190"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 385,
+            "artist_name": "Slayer",
+            "artist_mbids": [
+                "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 347,
+            "artist_name": "The Cardigans",
+            "artist_mbids": [
+                "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 342,
+            "artist_name": "The Offspring",
+            "artist_mbids": [
+                "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 329,
+            "artist_name": "Arch Enemy",
+            "artist_mbids": [
+                "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 324,
+            "artist_name": "Hoobastank",
+            "artist_mbids": [
+                "574dfe13-97aa-4318-8e4a-0ec79e05db24"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 316,
+            "artist_name": "Depeche Mode",
+            "artist_mbids": [
+                "540eebc9-0fc6-41df-8372-2c1a534e92e3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 305,
+            "artist_name": "Panic! at the Disco",
+            "artist_mbids": [
+                "99eec84e-42cb-4f47-b80f-ce46ca65735b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 297,
+            "artist_name": "Mot\u00f6rhead",
+            "artist_mbids": [
+                "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 292,
+            "artist_name": "W.A.S.P.",
+            "artist_mbids": [
+                "dbed7c10-e68c-4805-9295-09c48c06b897"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 275,
+            "artist_name": "Opeth",
+            "artist_mbids": [
+                "38742bd1-2ceb-4854-a138-206d095cdcc0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 268,
+            "artist_name": "The Postal Service",
+            "artist_mbids": [
+                "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 264,
+            "artist_name": "Iron Maiden",
+            "artist_mbids": [
+                "2f13b1cb-32e3-45c6-8b87-25629490ac44"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 262,
+            "artist_name": "Wizo",
+            "artist_mbids": [
+                "d3e64ede-3456-4f67-952c-fa0b7d05231a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 249,
+            "artist_name": "Black Sabbath",
+            "artist_mbids": [
+                "9e6a8399-a625-4151-9bba-3994b033957e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 246,
+            "artist_name": "Coldplay",
+            "artist_mbids": [
+                "6599e41e-390c-4855-a2ac-68ee798538b4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 244,
+            "artist_name": "D-A-D",
+            "artist_mbids": [
+                "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 238,
+            "artist_name": "Iced Earth",
+            "artist_mbids": [
+                "12379346-99d9-4941-b4a2-f04144a39863"
+            ],
+            "artist_msid": null
         }
-    ]
+    ],
+    "count": 60,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_month.json
@@ -1,500 +1,488 @@
 {
     "from_ts": 1588291200,
     "to_ts": 1592956800,
-    "time_ranges": [
+    "data": [
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "a200b8a0-2248-4abb-9454-5f99750be117"
-                    ],
-                    "listen_count": 90,
-                    "artist_name": "Dance Gavin Dance",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b9956564-f7fd-4c97-a3fa-b88b157affa1"
-                    ],
-                    "listen_count": 42,
-                    "artist_name": "Vader",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b5e3b53e-34e1-4dd3-bb39-6ffcf61e0855"
-                    ],
-                    "listen_count": 31,
-                    "artist_name": "The Clash",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "000a993a-03af-48f4-a810-e0524fda111a"
-                    ],
-                    "listen_count": 25,
-                    "artist_name": "Webb Pierce",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b6082729-fc87-4a0f-b874-00ae560c6f29"
-                    ],
-                    "listen_count": 24,
-                    "artist_name": "Citizen Bravo & Raymond MacDonald",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e29fd013-45c0-4edd-abe2-8635fdd0502a"
-                    ],
-                    "listen_count": 20,
-                    "artist_name": "Lana Del Rey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "517ac5e2-0a9f-4974-8233-44be9bec9c42"
-                    ],
-                    "listen_count": 20,
-                    "artist_name": "Grinderman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "52758846-744f-4295-8dbc-6a4caf77459c"
-                    ],
-                    "listen_count": 18,
-                    "artist_name": "Pink Floyd",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "aa5bc83f-70a7-4f21-8b00-60309b7fa1d1"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "The Colorist & Emil\u00edana Torrini",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3f4ed551-99ce-422a-aaee-04829c60cbb9"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "David Thomas Broughton",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "bf4cb1ee-7a93-44d6-9463-c46063506a20"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "Portishead",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "50789a5a-0fcf-4427-b105-2270cd9baf0b"
-                    ],
-                    "listen_count": 15,
-                    "artist_name": "Witchcraft",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "abe14328-4e15-413c-8ad6-ac8a174aedcd"
-                    ],
-                    "listen_count": 15,
-                    "artist_name": "Sampa The Great",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "92867b62-c838-4bbd-97dc-07681b3b0439"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Moacir Santos",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8bf0a378-f5e9-4029-9733-debf6bbf75f8"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Crash Test Dummies",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "bfff03a0-bb31-4225-a12b-fc11df420cc6"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Code Orange",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Bring Me the Horizon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f7c2b580-1935-4bbb-8f3b-476cc6215ef2"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "The Warlocks",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c8fee4af-cf1c-4676-809b-930251b57289"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "Solange",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "aebd2c50-9eed-447d-b8b0-dbdbe5850ba8"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "Snow Patrol",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c613a9c8-9b8d-4cf6-89a8-fd40afe62e59"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Suzanne Vega",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "38ff2a96-ef90-42ef-b4f7-ef6afc9de0b7"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Jace Everett",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0a93648a-7c2f-4346-b117-f6eeb4395fa9"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Inka",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6f5db00a-3ddc-47cf-aa90-0fffc4fb6d58"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "EL VY",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f7422d0f-6dd6-4c16-97b9-8c8500a0567a"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Alex Rex",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b55293d2-87eb-4ca3-93bd-72d1529e21ae"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Rokia Traor\u00e9",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "bba02547-375b-46cb-b5e4-c94bdfc29693"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Havok",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "feff5fdb-cfba-40b7-af26-541445a15ef9"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Bonny Light Horseman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "24a56abe-bcbc-4408-835e-739124e9f818"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Westside Gunn",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "92423ebd-10d7-478d-85db-920b1fb94ead"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Voivod",
-                    "artist_msid": null
-                }
+            "listen_count": 90,
+            "artist_name": "Dance Gavin Dance",
+            "artist_mbids": [
+                "a200b8a0-2248-4abb-9454-5f99750be117"
             ],
-            "from_ts": 1588291200,
-            "time_range": "01 May 2020",
-            "to_ts": 1588377599
+            "artist_msid": null
         },
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "a200b8a0-2248-4abb-9454-5f99750be117"
-                    ],
-                    "listen_count": 95,
-                    "artist_name": "Dance Gavin Dance",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e29fd013-45c0-4edd-abe2-8635fdd0502a"
-                    ],
-                    "listen_count": 52,
-                    "artist_name": "Lana Del Rey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1fd33ffc-d262-4fbd-9d8a-0cc28795cec1"
-                    ],
-                    "listen_count": 34,
-                    "artist_name": "Vel the Wonder",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "97d4de44-fd69-4865-b25c-2f93a5110046"
-                    ],
-                    "listen_count": 30,
-                    "artist_name": "Fu Manchu",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fcee89d2-70a6-4149-afd3-90806ddc650d"
-                    ],
-                    "listen_count": 28,
-                    "artist_name": "Death Cab for Cutie",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "61b56aa7-6b17-4a12-987d-f6e3027d1a3c"
-                    ],
-                    "listen_count": 26,
-                    "artist_name": "Karnivool",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
-                    ],
-                    "listen_count": 19,
-                    "artist_name": "Bring Me the Horizon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ff73b406-2a9f-430a-9ea3-eebd241ae0b3"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "R.E.M.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "bb89657c-c0c6-4c2d-9233-619823a3b043"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Seth Lakeman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "32150f6d-5ad6-4913-83fc-7b15bd847588"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Mastodon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "00a2e257-eccc-466e-9c3f-c424281e20d3"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Torgeir Waldemar",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "732032de-66d9-44d0-8db8-eb139db32824"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Rita Marley",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "afa1780e-1194-476e-aa3a-31466ce62f2c"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "New Order",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9f5e9335-ca47-4f2d-979b-1890076ededc"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Silverstein",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "093b9f69-79bc-4e9c-bd00-040e926b0bf3"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Kaukasus",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b63ad51b-f30e-405a-abb3-75c57f4bc2f7"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Bones",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "be444ee2-0c08-4b49-9f7c-cf848ea27c69"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Trevor Daniel",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e9e1e99c-7439-4152-a170-d52d607b90b1"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Doja Cat",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cb43ab86-25c7-49b4-a086-83af74393978"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "The fin.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "42b34077-464d-4e09-877e-077db701469d"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Jaira Burns",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4ffe7e89-a6f2-449a-92be-4ce0a62d9257"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "IAMDDB",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0006cb8e-897f-43a0-bdc4-b56b62d6ec29"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Black Veil Brides",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "54a3ad2a-a98e-436f-b0bf-8e48c4b79106"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Yorkston/Thorne/Khan",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b8e44f2e-3e42-4f0d-b7ef-6f874b882bad"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Whitechapel",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "139e13e9-1ebc-48fb-af90-97cf9909e632"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Vulfpeck",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9820da6d-66d9-424d-9f67-2654ed2f31e4"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Tame Impala",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "System of a Down",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "50fa106f-e40d-49ec-bca1-9802fb2157e7"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Radiohead",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4aa12451-67b1-413e-86e4-71416e913aa6"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "New Hope Club",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "78df245f-0fe0-4a21-b1d4-e79f695354fd"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Gorillaz",
-                    "artist_msid": null
-                }
+            "listen_count": 42,
+            "artist_name": "Vader",
+            "artist_mbids": [
+                "b9956564-f7fd-4c97-a3fa-b88b157affa1"
             ],
-            "from_ts": 1588377600,
-            "time_range": "02 May 2020",
-            "to_ts": 1588463999
+            "artist_msid": null
+        },
+        {
+            "listen_count": 31,
+            "artist_name": "The Clash",
+            "artist_mbids": [
+                "b5e3b53e-34e1-4dd3-bb39-6ffcf61e0855"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 25,
+            "artist_name": "Webb Pierce",
+            "artist_mbids": [
+                "000a993a-03af-48f4-a810-e0524fda111a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 24,
+            "artist_name": "Citizen Bravo & Raymond MacDonald",
+            "artist_mbids": [
+                "b6082729-fc87-4a0f-b874-00ae560c6f29"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 20,
+            "artist_name": "Lana Del Rey",
+            "artist_mbids": [
+                "e29fd013-45c0-4edd-abe2-8635fdd0502a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 20,
+            "artist_name": "Grinderman",
+            "artist_mbids": [
+                "517ac5e2-0a9f-4974-8233-44be9bec9c42"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 18,
+            "artist_name": "Pink Floyd",
+            "artist_mbids": [
+                "52758846-744f-4295-8dbc-6a4caf77459c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "The Colorist & Emil\u00edana Torrini",
+            "artist_mbids": [
+                "aa5bc83f-70a7-4f21-8b00-60309b7fa1d1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "David Thomas Broughton",
+            "artist_mbids": [
+                "3f4ed551-99ce-422a-aaee-04829c60cbb9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "Portishead",
+            "artist_mbids": [
+                "bf4cb1ee-7a93-44d6-9463-c46063506a20"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 15,
+            "artist_name": "Witchcraft",
+            "artist_mbids": [
+                "50789a5a-0fcf-4427-b105-2270cd9baf0b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 15,
+            "artist_name": "Sampa The Great",
+            "artist_mbids": [
+                "abe14328-4e15-413c-8ad6-ac8a174aedcd"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Moacir Santos",
+            "artist_mbids": [
+                "92867b62-c838-4bbd-97dc-07681b3b0439"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Crash Test Dummies",
+            "artist_mbids": [
+                "8bf0a378-f5e9-4029-9733-debf6bbf75f8"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Code Orange",
+            "artist_mbids": [
+                "bfff03a0-bb31-4225-a12b-fc11df420cc6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Bring Me the Horizon",
+            "artist_mbids": [
+                "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "The Warlocks",
+            "artist_mbids": [
+                "f7c2b580-1935-4bbb-8f3b-476cc6215ef2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "Solange",
+            "artist_mbids": [
+                "c8fee4af-cf1c-4676-809b-930251b57289"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "Snow Patrol",
+            "artist_mbids": [
+                "aebd2c50-9eed-447d-b8b0-dbdbe5850ba8"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Suzanne Vega",
+            "artist_mbids": [
+                "c613a9c8-9b8d-4cf6-89a8-fd40afe62e59"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Jace Everett",
+            "artist_mbids": [
+                "38ff2a96-ef90-42ef-b4f7-ef6afc9de0b7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Inka",
+            "artist_mbids": [
+                "0a93648a-7c2f-4346-b117-f6eeb4395fa9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "EL VY",
+            "artist_mbids": [
+                "6f5db00a-3ddc-47cf-aa90-0fffc4fb6d58"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Alex Rex",
+            "artist_mbids": [
+                "f7422d0f-6dd6-4c16-97b9-8c8500a0567a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Rokia Traor\u00e9",
+            "artist_mbids": [
+                "b55293d2-87eb-4ca3-93bd-72d1529e21ae"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Havok",
+            "artist_mbids": [
+                "bba02547-375b-46cb-b5e4-c94bdfc29693"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Bonny Light Horseman",
+            "artist_mbids": [
+                "feff5fdb-cfba-40b7-af26-541445a15ef9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Westside Gunn",
+            "artist_mbids": [
+                "24a56abe-bcbc-4408-835e-739124e9f818"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Voivod",
+            "artist_mbids": [
+                "92423ebd-10d7-478d-85db-920b1fb94ead"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 95,
+            "artist_name": "Dance Gavin Dance",
+            "artist_mbids": [
+                "a200b8a0-2248-4abb-9454-5f99750be117"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 52,
+            "artist_name": "Lana Del Rey",
+            "artist_mbids": [
+                "e29fd013-45c0-4edd-abe2-8635fdd0502a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 34,
+            "artist_name": "Vel the Wonder",
+            "artist_mbids": [
+                "1fd33ffc-d262-4fbd-9d8a-0cc28795cec1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 30,
+            "artist_name": "Fu Manchu",
+            "artist_mbids": [
+                "97d4de44-fd69-4865-b25c-2f93a5110046"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 28,
+            "artist_name": "Death Cab for Cutie",
+            "artist_mbids": [
+                "fcee89d2-70a6-4149-afd3-90806ddc650d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 26,
+            "artist_name": "Karnivool",
+            "artist_mbids": [
+                "61b56aa7-6b17-4a12-987d-f6e3027d1a3c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 19,
+            "artist_name": "Bring Me the Horizon",
+            "artist_mbids": [
+                "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "R.E.M.",
+            "artist_mbids": [
+                "ff73b406-2a9f-430a-9ea3-eebd241ae0b3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Seth Lakeman",
+            "artist_mbids": [
+                "bb89657c-c0c6-4c2d-9233-619823a3b043"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Mastodon",
+            "artist_mbids": [
+                "32150f6d-5ad6-4913-83fc-7b15bd847588"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Torgeir Waldemar",
+            "artist_mbids": [
+                "00a2e257-eccc-466e-9c3f-c424281e20d3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Rita Marley",
+            "artist_mbids": [
+                "732032de-66d9-44d0-8db8-eb139db32824"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "New Order",
+            "artist_mbids": [
+                "afa1780e-1194-476e-aa3a-31466ce62f2c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Silverstein",
+            "artist_mbids": [
+                "9f5e9335-ca47-4f2d-979b-1890076ededc"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Kaukasus",
+            "artist_mbids": [
+                "093b9f69-79bc-4e9c-bd00-040e926b0bf3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Bones",
+            "artist_mbids": [
+                "b63ad51b-f30e-405a-abb3-75c57f4bc2f7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Trevor Daniel",
+            "artist_mbids": [
+                "be444ee2-0c08-4b49-9f7c-cf848ea27c69"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Doja Cat",
+            "artist_mbids": [
+                "e9e1e99c-7439-4152-a170-d52d607b90b1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "The fin.",
+            "artist_mbids": [
+                "cb43ab86-25c7-49b4-a086-83af74393978"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Jaira Burns",
+            "artist_mbids": [
+                "42b34077-464d-4e09-877e-077db701469d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "IAMDDB",
+            "artist_mbids": [
+                "4ffe7e89-a6f2-449a-92be-4ce0a62d9257"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Black Veil Brides",
+            "artist_mbids": [
+                "0006cb8e-897f-43a0-bdc4-b56b62d6ec29"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Yorkston/Thorne/Khan",
+            "artist_mbids": [
+                "54a3ad2a-a98e-436f-b0bf-8e48c4b79106"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Whitechapel",
+            "artist_mbids": [
+                "b8e44f2e-3e42-4f0d-b7ef-6f874b882bad"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Vulfpeck",
+            "artist_mbids": [
+                "139e13e9-1ebc-48fb-af90-97cf9909e632"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Tame Impala",
+            "artist_mbids": [
+                "9820da6d-66d9-424d-9f67-2654ed2f31e4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "System of a Down",
+            "artist_mbids": [
+                "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Radiohead",
+            "artist_mbids": [
+                "50fa106f-e40d-49ec-bca1-9802fb2157e7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "New Hope Club",
+            "artist_mbids": [
+                "4aa12451-67b1-413e-86e4-71416e913aa6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Gorillaz",
+            "artist_mbids": [
+                "78df245f-0fe0-4a21-b1d4-e79f695354fd"
+            ],
+            "artist_msid": null
         }
-    ]
+    ],
+    "count": 60,
+    "stats_range": "month"
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_too_many.json
@@ -1,1636 +1,1624 @@
 {
     "from_ts": 1009843200,
     "to_ts": 1593043183,
-    "time_ranges": [
+    "data": [
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
-                    ],
-                    "listen_count": 2521,
-                    "artist_name": "Judas Priest",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
-                    ],
-                    "listen_count": 813,
-                    "artist_name": "Slayer",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2f13b1cb-32e3-45c6-8b87-25629490ac44"
-                    ],
-                    "listen_count": 770,
-                    "artist_name": "Iron Maiden",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
-                    ],
-                    "listen_count": 726,
-                    "artist_name": "Black Label Society",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
-                    ],
-                    "listen_count": 667,
-                    "artist_name": "Arch Enemy",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e6a8399-a625-4151-9bba-3994b033957e"
-                    ],
-                    "listen_count": 608,
-                    "artist_name": "Black Sabbath",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "87e396ef-3ee0-4ff2-853c-6174c4243df6"
-                    ],
-                    "listen_count": 592,
-                    "artist_name": "Foo Fighters",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f6804334-5021-4e52-9f71-3ea924e6abc6"
-                    ],
-                    "listen_count": 569,
-                    "artist_name": "Evergrey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
-                    ],
-                    "listen_count": 558,
-                    "artist_name": "Alanis Morissette",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "61746abb-76a5-465d-aee7-c4c42d61b7c4"
-                    ],
-                    "listen_count": 501,
-                    "artist_name": "Massive Attack",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "79f83982-a0a1-4907-b12e-dc974868e219"
-                    ],
-                    "listen_count": 475,
-                    "artist_name": "Audioslave",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "38742bd1-2ceb-4854-a138-206d095cdcc0"
-                    ],
-                    "listen_count": 473,
-                    "artist_name": "Opeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
-                    ],
-                    "listen_count": 466,
-                    "artist_name": "Tiamat",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c707783d-53b6-47fc-8c94-4d5323489209"
-                    ],
-                    "listen_count": 457,
-                    "artist_name": "Avril Lavigne",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "58914eb6-0518-45eb-a917-9985aa1cd374"
-                    ],
-                    "listen_count": 453,
-                    "artist_name": "Emperor",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "69ab35a3-c877-484a-8db9-4569010e72ed"
-                    ],
-                    "listen_count": 451,
-                    "artist_name": "Nine Inch Nails",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "844c13e8-9264-41f1-acc1-a59be2af611e"
-                    ],
-                    "listen_count": 440,
-                    "artist_name": "In Flames",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
-                    ],
-                    "listen_count": 414,
-                    "artist_name": "Megadeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a3c5dedf-13bb-4df2-be11-285972577112"
-                    ],
-                    "listen_count": 406,
-                    "artist_name": "Metallica",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
-                    ],
-                    "listen_count": 371,
-                    "artist_name": "Katatonia",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "94f867bb-3542-4675-858e-86dafdd7a647"
-                    ],
-                    "listen_count": 366,
-                    "artist_name": "Ayreon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
-                    ],
-                    "listen_count": 357,
-                    "artist_name": "Darkthrone",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f5b259cb-2323-41f7-9d19-32e69e79a87e"
-                    ],
-                    "listen_count": 313,
-                    "artist_name": "Kitaro",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "114378b9-019b-48ab-a6af-0e122cf6c056"
-                    ],
-                    "listen_count": 312,
-                    "artist_name": "Bathory",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8d0f8872-4527-4604-8e35-705afc9f50e6"
-                    ],
-                    "listen_count": 299,
-                    "artist_name": "Dream Theater",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "12379346-99d9-4941-b4a2-f04144a39863"
-                    ],
-                    "listen_count": 294,
-                    "artist_name": "Iced Earth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
-                    ],
-                    "listen_count": 269,
-                    "artist_name": "System of a Down",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "662105c0-9830-4ea7-9637-1aa5cedc9650"
-                    ],
-                    "listen_count": 269,
-                    "artist_name": "Paradise Lost",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f0aa3926-f243-4c5d-9162-6fee7f811934"
-                    ],
-                    "listen_count": 269,
-                    "artist_name": "Cradle of Filth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
-                    ],
-                    "listen_count": 268,
-                    "artist_name": "Sentenced",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7ef97e12-5648-4261-89ed-982da0eed624"
-                    ],
-                    "listen_count": 266,
-                    "artist_name": "Green Day",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b2451d61-1e02-45e9-970e-bb122048c4f1"
-                    ],
-                    "listen_count": 264,
-                    "artist_name": "Pain of Salvation",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fc9bf307-4b19-42fa-a1f1-f445e5d79bf2"
-                    ],
-                    "listen_count": 252,
-                    "artist_name": "Entombed",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3d6d2533-f3f9-4859-a3c9-5c3a8db9b628"
-                    ],
-                    "listen_count": 250,
-                    "artist_name": "Bj\u00f6rk",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0279d8a2-a1bc-4255-9e48-8abf9e2854e0"
-                    ],
-                    "listen_count": 247,
-                    "artist_name": "Dimmu Borgir",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cba89705-8c5d-4a47-8bad-fd5d0dcc353e"
-                    ],
-                    "listen_count": 246,
-                    "artist_name": "Dark Tranquillity",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1a21143a-ce09-40b1-95ef-8c2b97eb5170"
-                    ],
-                    "listen_count": 234,
-                    "artist_name": "Lamb",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cf0654b0-14c1-400b-a1f5-58b03ededca3"
-                    ],
-                    "listen_count": 215,
-                    "artist_name": "Bruce Dickinson",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "645129c1-9b76-48c0-a3af-c87b284265a3"
-                    ],
-                    "listen_count": 213,
-                    "artist_name": "The Darkness",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "70b2e0d6-2c39-4044-bd88-1c1ad31fd21a"
-                    ],
-                    "listen_count": 208,
-                    "artist_name": "HammerFall",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ceff4c9-fe82-444a-ba9d-20e724e04190"
-                    ],
-                    "listen_count": 203,
-                    "artist_name": "Strapping Young Lad",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99a7dfc9-ace3-4fbe-b502-4894c21d59af"
-                    ],
-                    "listen_count": 200,
-                    "artist_name": "Welle:Erdball",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "93648a14-2239-42ff-8339-944038c78a5b"
-                    ],
-                    "listen_count": 200,
-                    "artist_name": "Garbage",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9cf2d25e-948f-4be3-8e52-d34221faaeec"
-                    ],
-                    "listen_count": 189,
-                    "artist_name": "Helloween",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ff73b406-2a9f-430a-9ea3-eebd241ae0b3"
-                    ],
-                    "listen_count": 185,
-                    "artist_name": "R.E.M.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0ff71cac-a18a-4472-b3e0-d58219081544"
-                    ],
-                    "listen_count": 183,
-                    "artist_name": "Gluecifer",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7fc48e0d-36bd-479e-928e-87dcf610a782"
-                    ],
-                    "listen_count": 177,
-                    "artist_name": "The Killers",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a66d6e61-f261-4a07-8bdb-abb122b2e284"
-                    ],
-                    "listen_count": 167,
-                    "artist_name": "In Strict Confidence",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3105cdac-628b-4a55-bcdd-e2bd11e21288"
-                    ],
-                    "listen_count": 159,
-                    "artist_name": "The Project Hate MCMXCIX",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4a35fa46-b647-422b-bf66-0650ad3091ef"
-                    ],
-                    "listen_count": 158,
-                    "artist_name": "Rage Against the Machine",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
-                    ],
-                    "listen_count": 154,
-                    "artist_name": "The Cardigans",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3711919c-c8d3-459d-b753-48b7117d0e21"
-                    ],
-                    "listen_count": 153,
-                    "artist_name": "Hypocrisy",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3d851dd4-4c5b-411c-af24-11aa44bdc26f"
-                    ],
-                    "listen_count": 151,
-                    "artist_name": "R\u00f6yksopp",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e6456dc5-3519-4547-993a-4e87e91a85df"
-                    ],
-                    "listen_count": 151,
-                    "artist_name": "Kent",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
-                    ],
-                    "listen_count": 149,
-                    "artist_name": "The Offspring",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "540eebc9-0fc6-41df-8372-2c1a534e92e3"
-                    ],
-                    "listen_count": 145,
-                    "artist_name": "Depeche Mode",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fe7912cc-3102-4277-9df8-c20ed3b1499d"
-                    ],
-                    "listen_count": 144,
-                    "artist_name": "The Soundtrack of Our Lives",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6599e41e-390c-4855-a2ac-68ee798538b4"
-                    ],
-                    "listen_count": 143,
-                    "artist_name": "Coldplay",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ff67daaa-dc6c-4e29-a1d1-f40b2457489d"
-                    ],
-                    "listen_count": 134,
-                    "artist_name": "Nationalteatern",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ff2404ad-86ea-499e-8c09-127f487fa06e"
-                    ],
-                    "listen_count": 134,
-                    "artist_name": "A Perfect Circle",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f64cb322-70ba-4d70-9107-449c007414a5"
-                    ],
-                    "listen_count": 132,
-                    "artist_name": "The Devin Townsend Band",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4b321558-10b1-4d93-9bed-7c9048e28ecb"
-                    ],
-                    "listen_count": 131,
-                    "artist_name": "The Hellacopters",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e7c27081-e80d-4641-aed3-356e28320f6f"
-                    ],
-                    "listen_count": 131,
-                    "artist_name": "Red Hot Chili Peppers",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c7f68e27-4e43-4b70-8aae-39e0f9397914"
-                    ],
-                    "listen_count": 131,
-                    "artist_name": "Queens of the Stone Age",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "775f251e-7635-405c-89bc-4d985c44f92c"
-                    ],
-                    "listen_count": 130,
-                    "artist_name": "Sahara Hotnights",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d290cd3b-40a4-47c8-a476-7dfc2f8b3895"
-                    ],
-                    "listen_count": 127,
-                    "artist_name": "The Cure",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4e735f68-1b0c-481d-b1c4-1449f7d14550"
-                    ],
-                    "listen_count": 124,
-                    "artist_name": "The Donnas",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "805b29f9-07c9-4d1d-98fa-e326e58363d9"
-                    ],
-                    "listen_count": 121,
-                    "artist_name": "Pearl Jam",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b0346a81-4a99-461d-870a-de5d086ea1c3"
-                    ],
-                    "listen_count": 118,
-                    "artist_name": "Apocalyptica",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "aee14ac9-e46d-4867-8425-8476b63fb767"
-                    ],
-                    "listen_count": 116,
-                    "artist_name": "The Crown",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "05953c3e-c5c4-4410-9877-18e85132629c"
-                    ],
-                    "listen_count": 114,
-                    "artist_name": "Satyricon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "519b9bed-e6d5-4b8b-b65e-88a8d219c85d"
-                    ],
-                    "listen_count": 113,
-                    "artist_name": "Testament",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8d41e541-9edd-4de8-961a-e30f847f54a7"
-                    ],
-                    "listen_count": 109,
-                    "artist_name": "At the Gates",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7cc9d360-061f-4ada-999c-52ccda412795"
-                    ],
-                    "listen_count": 108,
-                    "artist_name": "Marit Bergman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6797b29b-a94c-4f99-b602-ab606a0bf4e6"
-                    ],
-                    "listen_count": 108,
-                    "artist_name": "Karunesh",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6bf52c09-6b35-4d7c-af51-6a47245f21a7"
-                    ],
-                    "listen_count": 104,
-                    "artist_name": "No Doubt",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "765fba92-fae2-498b-b04a-327690869e15"
-                    ],
-                    "listen_count": 102,
-                    "artist_name": "Nickelback",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "de5825a7-9b41-4e8d-9e64-ac6f0617ed83"
-                    ],
-                    "listen_count": 102,
-                    "artist_name": "Epica",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
-                    ],
-                    "listen_count": 99,
-                    "artist_name": "The Postal Service",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e2fe00d2-810b-4a91-a3b4-ba9b7406c6c1"
-                    ],
-                    "listen_count": 99,
-                    "artist_name": "Borknagar",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b648c557-dd92-4bfd-a0d4-569e903b8666"
-                    ],
-                    "listen_count": 98,
-                    "artist_name": "Middleman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dbed7c10-e68c-4805-9295-09c48c06b897"
-                    ],
-                    "listen_count": 97,
-                    "artist_name": "W.A.S.P.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2f68b232-a2fa-4f35-9eba-f2f3ab956e87"
-                    ],
-                    "listen_count": 95,
-                    "artist_name": "Velvet Revolver",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ee182ec-fda1-491b-8f13-c19e2da34c82"
-                    ],
-                    "listen_count": 95,
-                    "artist_name": "Dire Straits",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "af4fa0d4-a060-4171-84cf-f40a20600cac"
-                    ],
-                    "listen_count": 94,
-                    "artist_name": "Progg",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "093d1c46-f28c-427c-a521-c5abe25fa75d"
-                    ],
-                    "listen_count": 94,
-                    "artist_name": "Apoptygma Berzerk",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0739cfee-131b-41c8-8caa-fc846d6ae9be"
-                    ],
-                    "listen_count": 93,
-                    "artist_name": "Front 242",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "361ce71c-80b1-4717-b91f-3b0d9fccf906"
-                    ],
-                    "listen_count": 91,
-                    "artist_name": "M\u00f6rk Gryning",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
-                    ],
-                    "listen_count": 87,
-                    "artist_name": "D-A-D",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "addd9cc5-1964-49cd-b607-431349991084"
-                    ],
-                    "listen_count": 86,
-                    "artist_name": "Cemetary",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "85d4d644-822b-4596-a83d-a0373158027a"
-                    ],
-                    "listen_count": 85,
-                    "artist_name": "Front Line Assembly",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "87b24ec1-b811-422a-bf9f-a52d4e6bb249"
-                    ],
-                    "listen_count": 83,
-                    "artist_name": "Sonata Arctica",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4f7ac8db-ccb1-4411-af5d-395c785b2566"
-                    ],
-                    "listen_count": 83,
-                    "artist_name": "Queen",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "13da5ac3-039a-4a29-b2d8-18b287de7d4e"
-                    ],
-                    "listen_count": 81,
-                    "artist_name": "They Might Be Giants",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99fa93b3-796a-45a0-855e-6fe0e1b1a0b0"
-                    ],
-                    "listen_count": 81,
-                    "artist_name": "Tale",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2d6e3002-fbf7-4fa5-a38f-c58ba12349b2"
-                    ],
-                    "listen_count": 81,
-                    "artist_name": "Dream Evil",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
-                    ],
-                    "listen_count": 77,
-                    "artist_name": "Mot\u00f6rhead",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4ed8e056-d7da-442f-8699-75d638041ca3"
-                    ],
-                    "listen_count": 77,
-                    "artist_name": "Grip Inc.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "78301a87-32ce-4857-b64d-97b4a08850ef"
-                    ],
-                    "listen_count": 76,
-                    "artist_name": "Abramis Brama",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1738561e-cdcb-454a-98c0-58bfa7b54796"
-                    ],
-                    "listen_count": 75,
-                    "artist_name": "Pain",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1738561e-cdca-454a-98c0-58bfa7b54796"
-                    ],
-                    "listen_count": 73,
-                    "artist_name": "Ellie Goulding",
-                    "artist_msid": null
-                }
+            "listen_count": 2521,
+            "artist_name": "Judas Priest",
+            "artist_mbids": [
+                "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
             ],
-            "from_ts": 1104537600,
-            "time_range": "2005",
-            "to_ts": 1136073599
+            "artist_msid": null
         },
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
-                    ],
-                    "listen_count": 1354,
-                    "artist_name": "Judas Priest",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f6804334-5021-4e52-9f71-3ea924e6abc6"
-                    ],
-                    "listen_count": 691,
-                    "artist_name": "Evergrey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "431cc9fb-ef90-4819-9c7b-2229c298727c"
-                    ],
-                    "listen_count": 641,
-                    "artist_name": "Danko Jones",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "87e396ef-3ee0-4ff2-853c-6174c4243df6"
-                    ],
-                    "listen_count": 606,
-                    "artist_name": "Foo Fighters",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
-                    ],
-                    "listen_count": 584,
-                    "artist_name": "Katatonia",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4b321558-10b1-4d93-9bed-7c9048e28ecb"
-                    ],
-                    "listen_count": 556,
-                    "artist_name": "The Hellacopters",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fcee89d2-70a6-4149-afd3-90806ddc650d"
-                    ],
-                    "listen_count": 504,
-                    "artist_name": "Death Cab for Cutie",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "645129c1-9b76-48c0-a3af-c87b284265a3"
-                    ],
-                    "listen_count": 470,
-                    "artist_name": "The Darkness",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e9e619a9-5170-4ef7-bfeb-29ef64ed3f5d"
-                    ],
-                    "listen_count": 461,
-                    "artist_name": "Turbonegro",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
-                    ],
-                    "listen_count": 415,
-                    "artist_name": "Black Label Society",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "79f83982-a0a1-4907-b12e-dc974868e219"
-                    ],
-                    "listen_count": 405,
-                    "artist_name": "Audioslave",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "94f867bb-3542-4675-858e-86dafdd7a647"
-                    ],
-                    "listen_count": 402,
-                    "artist_name": "Ayreon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ceff4c9-fe82-444a-ba9d-20e724e04190"
-                    ],
-                    "listen_count": 394,
-                    "artist_name": "Strapping Young Lad",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
-                    ],
-                    "listen_count": 385,
-                    "artist_name": "Slayer",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
-                    ],
-                    "listen_count": 347,
-                    "artist_name": "The Cardigans",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
-                    ],
-                    "listen_count": 342,
-                    "artist_name": "The Offspring",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
-                    ],
-                    "listen_count": 329,
-                    "artist_name": "Arch Enemy",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "574dfe13-97aa-4318-8e4a-0ec79e05db24"
-                    ],
-                    "listen_count": 324,
-                    "artist_name": "Hoobastank",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "540eebc9-0fc6-41df-8372-2c1a534e92e3"
-                    ],
-                    "listen_count": 316,
-                    "artist_name": "Depeche Mode",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99eec84e-42cb-4f47-b80f-ce46ca65735b"
-                    ],
-                    "listen_count": 305,
-                    "artist_name": "Panic! at the Disco",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
-                    ],
-                    "listen_count": 297,
-                    "artist_name": "Mot\u00f6rhead",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dbed7c10-e68c-4805-9295-09c48c06b897"
-                    ],
-                    "listen_count": 292,
-                    "artist_name": "W.A.S.P.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "38742bd1-2ceb-4854-a138-206d095cdcc0"
-                    ],
-                    "listen_count": 275,
-                    "artist_name": "Opeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
-                    ],
-                    "listen_count": 268,
-                    "artist_name": "The Postal Service",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2f13b1cb-32e3-45c6-8b87-25629490ac44"
-                    ],
-                    "listen_count": 264,
-                    "artist_name": "Iron Maiden",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d3e64ede-3456-4f67-952c-fa0b7d05231a"
-                    ],
-                    "listen_count": 262,
-                    "artist_name": "Wizo",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e6a8399-a625-4151-9bba-3994b033957e"
-                    ],
-                    "listen_count": 249,
-                    "artist_name": "Black Sabbath",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6599e41e-390c-4855-a2ac-68ee798538b4"
-                    ],
-                    "listen_count": 246,
-                    "artist_name": "Coldplay",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
-                    ],
-                    "listen_count": 244,
-                    "artist_name": "D-A-D",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "12379346-99d9-4941-b4a2-f04144a39863"
-                    ],
-                    "listen_count": 238,
-                    "artist_name": "Iced Earth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4f7ac8db-ccb1-4411-af5d-395c785b2566"
-                    ],
-                    "listen_count": 235,
-                    "artist_name": "Queen",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d01b7459-4a8e-4c00-a0d5-0a373634eb47"
-                    ],
-                    "listen_count": 219,
-                    "artist_name": "The Knife",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "92133235-e98d-48cf-be8c-85693bec10fa"
-                    ],
-                    "listen_count": 218,
-                    "artist_name": "Alkaline Trio",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "765fba92-fae2-498b-b04a-327690869e15"
-                    ],
-                    "listen_count": 215,
-                    "artist_name": "Nickelback",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b0346a81-4a99-461d-870a-de5d086ea1c3"
-                    ],
-                    "listen_count": 214,
-                    "artist_name": "Apocalyptica",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
-                    ],
-                    "listen_count": 206,
-                    "artist_name": "Sentenced",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
-                    ],
-                    "listen_count": 203,
-                    "artist_name": "System of a Down",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "162be21e-3e55-43ef-95f4-2f741c6e58b1"
-                    ],
-                    "listen_count": 201,
-                    "artist_name": "Symphony X",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a3c5dedf-13bb-4df2-be11-285972577112"
-                    ],
-                    "listen_count": 201,
-                    "artist_name": "Metallica",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "30f8806c-e6b2-4a5a-92d5-454cdd41bbcc"
-                    ],
-                    "listen_count": 201,
-                    "artist_name": "Green Carnation",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fe7912cc-3102-4277-9df8-c20ed3b1499d"
-                    ],
-                    "listen_count": 198,
-                    "artist_name": "The Soundtrack of Our Lives",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2f3568d9-9ac0-4936-9712-a95302ca51a3"
-                    ],
-                    "listen_count": 198,
-                    "artist_name": "The Kristet Utseende",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8716eb48-0079-4a90-b561-2fa5bbd03862"
-                    ],
-                    "listen_count": 178,
-                    "artist_name": "Amorphis",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "5627d327-7d81-43ae-ae7c-bb5c7d4f0d24"
-                    ],
-                    "listen_count": 172,
-                    "artist_name": "Nevermore",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
-                    ],
-                    "listen_count": 171,
-                    "artist_name": "Tiamat",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7fc48e0d-36bd-479e-928e-87dcf610a782"
-                    ],
-                    "listen_count": 167,
-                    "artist_name": "The Killers",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3d6d2533-f3f9-4859-a3c9-5c3a8db9b628"
-                    ],
-                    "listen_count": 167,
-                    "artist_name": "Bj\u00f6rk",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c707783d-53b6-47fc-8c94-4d5323489209"
-                    ],
-                    "listen_count": 158,
-                    "artist_name": "Avril Lavigne",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4920ba92-d2bb-4826-ba31-c82dae4a633b"
-                    ],
-                    "listen_count": 147,
-                    "artist_name": "Queensr\u00ffche",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "58914eb6-0518-45eb-a917-9985aa1cd374"
-                    ],
-                    "listen_count": 144,
-                    "artist_name": "Emperor",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "599e16ce-3705-450d-8014-1d9292b69dd9"
-                    ],
-                    "listen_count": 137,
-                    "artist_name": "Type O Negative",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99fa93b3-796a-45a0-855e-6fe0e1b1a0b0"
-                    ],
-                    "listen_count": 136,
-                    "artist_name": "Tale",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "114378b9-019b-48ab-a6af-0e122cf6c056"
-                    ],
-                    "listen_count": 136,
-                    "artist_name": "Bathory",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8a75931e-2a0e-4f39-9fe1-7233b344efaf"
-                    ],
-                    "listen_count": 127,
-                    "artist_name": "Prince",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "70b2e0d6-2c39-4044-bd88-1c1ad31fd21a"
-                    ],
-                    "listen_count": 122,
-                    "artist_name": "HammerFall",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
-                    ],
-                    "listen_count": 121,
-                    "artist_name": "Alanis Morissette",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f9c8e154-2986-4dec-96ce-345ff327a271"
-                    ],
-                    "listen_count": 120,
-                    "artist_name": "Wise Guys",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "78df245f-0fe0-4a21-b1d4-e79f695354fd"
-                    ],
-                    "listen_count": 118,
-                    "artist_name": "Gorillaz",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fc9bf307-4b19-42fa-a1f1-f445e5d79bf2"
-                    ],
-                    "listen_count": 113,
-                    "artist_name": "Entombed",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
-                    ],
-                    "listen_count": 112,
-                    "artist_name": "Megadeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "93648a14-2239-42ff-8339-944038c78a5b"
-                    ],
-                    "listen_count": 112,
-                    "artist_name": "Garbage",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4e735f68-1b0c-481d-b1c4-1449f7d14550"
-                    ],
-                    "listen_count": 111,
-                    "artist_name": "The Donnas",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "72ee05f0-bed3-41be-ab77-e5523332e3b6"
-                    ],
-                    "listen_count": 110,
-                    "artist_name": "Stream of Passion",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "844c13e8-9264-41f1-acc1-a59be2af611e"
-                    ],
-                    "listen_count": 109,
-                    "artist_name": "In Flames",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3d851dd4-4c5b-411c-af24-11aa44bdc26f"
-                    ],
-                    "listen_count": 108,
-                    "artist_name": "R\u00f6yksopp",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e7c27081-e80d-4641-aed3-356e28320f6f"
-                    ],
-                    "listen_count": 106,
-                    "artist_name": "Red Hot Chili Peppers",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "13da5ac3-039a-4a29-b2d8-18b287de7d4e"
-                    ],
-                    "listen_count": 104,
-                    "artist_name": "They Might Be Giants",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "31e65ed7-cb97-482f-93a5-6dae925761e4"
-                    ],
-                    "listen_count": 104,
-                    "artist_name": "Porcupine Tree",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4155b1d3-5b20-402c-9117-b7d1d0ee6204"
-                    ],
-                    "listen_count": 104,
-                    "artist_name": "Ice-T",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3105cdac-628b-4a55-bcdd-e2bd11e21288"
-                    ],
-                    "listen_count": 103,
-                    "artist_name": "The Project Hate MCMXCIX",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "32150f6d-5ad6-4913-83fc-7b15bd847588"
-                    ],
-                    "listen_count": 100,
-                    "artist_name": "Mastodon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0e3ebeae-9b2c-4a1e-aa2e-e99aab0cdc5c"
-                    ],
-                    "listen_count": 98,
-                    "artist_name": "Fight",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "723245dd-68c3-42c6-ab02-095e30e3dca9"
-                    ],
-                    "listen_count": 93,
-                    "artist_name": "J.B.O.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "136cb38f-3cd6-4a97-8031-e5c8d0cc6eb9"
-                    ],
-                    "listen_count": 92,
-                    "artist_name": "Wolfmother",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e82bddba-140d-418b-bde9-8e6ee9e9aa5c"
-                    ],
-                    "listen_count": 91,
-                    "artist_name": "Falconer",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "841f458f-a940-4220-8120-5e2f719c771e"
-                    ],
-                    "listen_count": 90,
-                    "artist_name": "The Haunted",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "02264268-7813-455b-b97a-9437b4a048cd"
-                    ],
-                    "listen_count": 89,
-                    "artist_name": "LOK",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ff67daaa-dc6c-4e29-a1d1-f40b2457489d"
-                    ],
-                    "listen_count": 88,
-                    "artist_name": "Nationalteatern",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f31223bf-43e7-4565-9d5b-34f4e7897d71"
-                    ],
-                    "listen_count": 88,
-                    "artist_name": "Anathema",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b958833f-4d74-4f94-8402-7cd1a6e6fb21"
-                    ],
-                    "listen_count": 84,
-                    "artist_name": "U2",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
-                    ],
-                    "listen_count": 84,
-                    "artist_name": "David Bowie",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d834dd3d-653f-496e-895b-1885ee6b0d68"
-                    ],
-                    "listen_count": 81,
-                    "artist_name": "The Doors",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "be15b50e-8df8-481b-b0af-3991db5e3ee9"
-                    ],
-                    "listen_count": 81,
-                    "artist_name": "LCD Soundsystem",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "52758846-744f-4295-8dbc-6a4caf77459c"
-                    ],
-                    "listen_count": 80,
-                    "artist_name": "Pink Floyd",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
-                    ],
-                    "listen_count": 80,
-                    "artist_name": "Darkthrone",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0ebbb014-d2f4-4588-a1a2-dafc1c777b22"
-                    ],
-                    "listen_count": 78,
-                    "artist_name": "Tenacious D",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "171f623b-5ca6-4081-ae7b-faf92724500a"
-                    ],
-                    "listen_count": 78,
-                    "artist_name": "Magnatune Compilation (PREVIEW: buy it at www.magnatune.com)",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9b11fcf9-8282-418c-bc8c-c4003aa16963"
-                    ],
-                    "listen_count": 76,
-                    "artist_name": "Witchery",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cfc09e6a-5d59-4c07-b14d-3a55bd7a8c1b"
-                    ],
-                    "listen_count": 75,
-                    "artist_name": "Combustible Edison",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0ce6d420-1273-46a5-98ed-faee68c3d269"
-                    ],
-                    "listen_count": 74,
-                    "artist_name": "Zyklon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "183a545e-416b-49c5-ba35-08497fbf732b"
-                    ],
-                    "listen_count": 72,
-                    "artist_name": "Kaizers Orchestra",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7ffc4fc1-b158-4e8c-9b88-bac95af3225b"
-                    ],
-                    "listen_count": 71,
-                    "artist_name": "Raise Hell",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "addd9cc5-1964-49cd-b607-431349991084"
-                    ],
-                    "listen_count": 68,
-                    "artist_name": "Cemetary",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4dd5aff8-49f4-4f37-b412-ca0227f4534f"
-                    ],
-                    "listen_count": 67,
-                    "artist_name": "Jan Delay",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e6456dc5-3519-4547-993a-4e87e91a85df"
-                    ],
-                    "listen_count": 66,
-                    "artist_name": "Kent",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "51a562cf-9515-4c63-8d7d-80eca213c30b"
-                    ],
-                    "listen_count": 65,
-                    "artist_name": "Khoma",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8d0f8872-4527-4604-8e35-705afc9f50e6"
-                    ],
-                    "listen_count": 65,
-                    "artist_name": "Dream Theater",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "704872ad-8327-4b72-8cf2-53b2fb6977f1"
-                    ],
-                    "listen_count": 65,
-                    "artist_name": "Astrud Gilberto",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "59812ffc-6782-4427-878b-1116ff5c769c"
-                    ],
-                    "listen_count": 64,
-                    "artist_name": "Tool",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "775f251e-7635-405c-89bc-4d985c44f92c"
-                    ],
-                    "listen_count": 64,
-                    "artist_name": "Sahara Hotnights",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8r5f251e-7635-405c-89bc-4d985c44f92c"
-                    ],
-                    "listen_count": 63,
-                    "artist_name": "Hotnights Sahara",
-                    "artist_msid": null
-                }
+            "listen_count": 813,
+            "artist_name": "Slayer",
+            "artist_mbids": [
+                "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
             ],
-            "from_ts": 1136073600,
-            "time_range": "2006",
-            "to_ts": 1167609599
+            "artist_msid": null
+        },
+        {
+            "listen_count": 770,
+            "artist_name": "Iron Maiden",
+            "artist_mbids": [
+                "2f13b1cb-32e3-45c6-8b87-25629490ac44"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 726,
+            "artist_name": "Black Label Society",
+            "artist_mbids": [
+                "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 667,
+            "artist_name": "Arch Enemy",
+            "artist_mbids": [
+                "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 608,
+            "artist_name": "Black Sabbath",
+            "artist_mbids": [
+                "9e6a8399-a625-4151-9bba-3994b033957e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 592,
+            "artist_name": "Foo Fighters",
+            "artist_mbids": [
+                "87e396ef-3ee0-4ff2-853c-6174c4243df6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 569,
+            "artist_name": "Evergrey",
+            "artist_mbids": [
+                "f6804334-5021-4e52-9f71-3ea924e6abc6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 558,
+            "artist_name": "Alanis Morissette",
+            "artist_mbids": [
+                "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 501,
+            "artist_name": "Massive Attack",
+            "artist_mbids": [
+                "61746abb-76a5-465d-aee7-c4c42d61b7c4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 475,
+            "artist_name": "Audioslave",
+            "artist_mbids": [
+                "79f83982-a0a1-4907-b12e-dc974868e219"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 473,
+            "artist_name": "Opeth",
+            "artist_mbids": [
+                "38742bd1-2ceb-4854-a138-206d095cdcc0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 466,
+            "artist_name": "Tiamat",
+            "artist_mbids": [
+                "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 457,
+            "artist_name": "Avril Lavigne",
+            "artist_mbids": [
+                "c707783d-53b6-47fc-8c94-4d5323489209"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 453,
+            "artist_name": "Emperor",
+            "artist_mbids": [
+                "58914eb6-0518-45eb-a917-9985aa1cd374"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 451,
+            "artist_name": "Nine Inch Nails",
+            "artist_mbids": [
+                "69ab35a3-c877-484a-8db9-4569010e72ed"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 440,
+            "artist_name": "In Flames",
+            "artist_mbids": [
+                "844c13e8-9264-41f1-acc1-a59be2af611e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 414,
+            "artist_name": "Megadeth",
+            "artist_mbids": [
+                "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 406,
+            "artist_name": "Metallica",
+            "artist_mbids": [
+                "a3c5dedf-13bb-4df2-be11-285972577112"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 371,
+            "artist_name": "Katatonia",
+            "artist_mbids": [
+                "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 366,
+            "artist_name": "Ayreon",
+            "artist_mbids": [
+                "94f867bb-3542-4675-858e-86dafdd7a647"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 357,
+            "artist_name": "Darkthrone",
+            "artist_mbids": [
+                "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 313,
+            "artist_name": "Kitaro",
+            "artist_mbids": [
+                "f5b259cb-2323-41f7-9d19-32e69e79a87e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 312,
+            "artist_name": "Bathory",
+            "artist_mbids": [
+                "114378b9-019b-48ab-a6af-0e122cf6c056"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 299,
+            "artist_name": "Dream Theater",
+            "artist_mbids": [
+                "8d0f8872-4527-4604-8e35-705afc9f50e6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 294,
+            "artist_name": "Iced Earth",
+            "artist_mbids": [
+                "12379346-99d9-4941-b4a2-f04144a39863"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 269,
+            "artist_name": "System of a Down",
+            "artist_mbids": [
+                "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 269,
+            "artist_name": "Paradise Lost",
+            "artist_mbids": [
+                "662105c0-9830-4ea7-9637-1aa5cedc9650"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 269,
+            "artist_name": "Cradle of Filth",
+            "artist_mbids": [
+                "f0aa3926-f243-4c5d-9162-6fee7f811934"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 268,
+            "artist_name": "Sentenced",
+            "artist_mbids": [
+                "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 266,
+            "artist_name": "Green Day",
+            "artist_mbids": [
+                "7ef97e12-5648-4261-89ed-982da0eed624"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 264,
+            "artist_name": "Pain of Salvation",
+            "artist_mbids": [
+                "b2451d61-1e02-45e9-970e-bb122048c4f1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 252,
+            "artist_name": "Entombed",
+            "artist_mbids": [
+                "fc9bf307-4b19-42fa-a1f1-f445e5d79bf2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 250,
+            "artist_name": "Bj\u00f6rk",
+            "artist_mbids": [
+                "3d6d2533-f3f9-4859-a3c9-5c3a8db9b628"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 247,
+            "artist_name": "Dimmu Borgir",
+            "artist_mbids": [
+                "0279d8a2-a1bc-4255-9e48-8abf9e2854e0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 246,
+            "artist_name": "Dark Tranquillity",
+            "artist_mbids": [
+                "cba89705-8c5d-4a47-8bad-fd5d0dcc353e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 234,
+            "artist_name": "Lamb",
+            "artist_mbids": [
+                "1a21143a-ce09-40b1-95ef-8c2b97eb5170"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 215,
+            "artist_name": "Bruce Dickinson",
+            "artist_mbids": [
+                "cf0654b0-14c1-400b-a1f5-58b03ededca3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 213,
+            "artist_name": "The Darkness",
+            "artist_mbids": [
+                "645129c1-9b76-48c0-a3af-c87b284265a3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 208,
+            "artist_name": "HammerFall",
+            "artist_mbids": [
+                "70b2e0d6-2c39-4044-bd88-1c1ad31fd21a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 203,
+            "artist_name": "Strapping Young Lad",
+            "artist_mbids": [
+                "6ceff4c9-fe82-444a-ba9d-20e724e04190"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 200,
+            "artist_name": "Welle:Erdball",
+            "artist_mbids": [
+                "99a7dfc9-ace3-4fbe-b502-4894c21d59af"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 200,
+            "artist_name": "Garbage",
+            "artist_mbids": [
+                "93648a14-2239-42ff-8339-944038c78a5b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 189,
+            "artist_name": "Helloween",
+            "artist_mbids": [
+                "9cf2d25e-948f-4be3-8e52-d34221faaeec"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 185,
+            "artist_name": "R.E.M.",
+            "artist_mbids": [
+                "ff73b406-2a9f-430a-9ea3-eebd241ae0b3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 183,
+            "artist_name": "Gluecifer",
+            "artist_mbids": [
+                "0ff71cac-a18a-4472-b3e0-d58219081544"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 177,
+            "artist_name": "The Killers",
+            "artist_mbids": [
+                "7fc48e0d-36bd-479e-928e-87dcf610a782"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 167,
+            "artist_name": "In Strict Confidence",
+            "artist_mbids": [
+                "a66d6e61-f261-4a07-8bdb-abb122b2e284"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 159,
+            "artist_name": "The Project Hate MCMXCIX",
+            "artist_mbids": [
+                "3105cdac-628b-4a55-bcdd-e2bd11e21288"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 158,
+            "artist_name": "Rage Against the Machine",
+            "artist_mbids": [
+                "4a35fa46-b647-422b-bf66-0650ad3091ef"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 154,
+            "artist_name": "The Cardigans",
+            "artist_mbids": [
+                "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 153,
+            "artist_name": "Hypocrisy",
+            "artist_mbids": [
+                "3711919c-c8d3-459d-b753-48b7117d0e21"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 151,
+            "artist_name": "R\u00f6yksopp",
+            "artist_mbids": [
+                "3d851dd4-4c5b-411c-af24-11aa44bdc26f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 151,
+            "artist_name": "Kent",
+            "artist_mbids": [
+                "e6456dc5-3519-4547-993a-4e87e91a85df"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 149,
+            "artist_name": "The Offspring",
+            "artist_mbids": [
+                "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 145,
+            "artist_name": "Depeche Mode",
+            "artist_mbids": [
+                "540eebc9-0fc6-41df-8372-2c1a534e92e3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 144,
+            "artist_name": "The Soundtrack of Our Lives",
+            "artist_mbids": [
+                "fe7912cc-3102-4277-9df8-c20ed3b1499d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 143,
+            "artist_name": "Coldplay",
+            "artist_mbids": [
+                "6599e41e-390c-4855-a2ac-68ee798538b4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 134,
+            "artist_name": "Nationalteatern",
+            "artist_mbids": [
+                "ff67daaa-dc6c-4e29-a1d1-f40b2457489d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 134,
+            "artist_name": "A Perfect Circle",
+            "artist_mbids": [
+                "ff2404ad-86ea-499e-8c09-127f487fa06e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 132,
+            "artist_name": "The Devin Townsend Band",
+            "artist_mbids": [
+                "f64cb322-70ba-4d70-9107-449c007414a5"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 131,
+            "artist_name": "The Hellacopters",
+            "artist_mbids": [
+                "4b321558-10b1-4d93-9bed-7c9048e28ecb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 131,
+            "artist_name": "Red Hot Chili Peppers",
+            "artist_mbids": [
+                "e7c27081-e80d-4641-aed3-356e28320f6f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 131,
+            "artist_name": "Queens of the Stone Age",
+            "artist_mbids": [
+                "c7f68e27-4e43-4b70-8aae-39e0f9397914"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 130,
+            "artist_name": "Sahara Hotnights",
+            "artist_mbids": [
+                "775f251e-7635-405c-89bc-4d985c44f92c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 127,
+            "artist_name": "The Cure",
+            "artist_mbids": [
+                "d290cd3b-40a4-47c8-a476-7dfc2f8b3895"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 124,
+            "artist_name": "The Donnas",
+            "artist_mbids": [
+                "4e735f68-1b0c-481d-b1c4-1449f7d14550"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 121,
+            "artist_name": "Pearl Jam",
+            "artist_mbids": [
+                "805b29f9-07c9-4d1d-98fa-e326e58363d9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 118,
+            "artist_name": "Apocalyptica",
+            "artist_mbids": [
+                "b0346a81-4a99-461d-870a-de5d086ea1c3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 116,
+            "artist_name": "The Crown",
+            "artist_mbids": [
+                "aee14ac9-e46d-4867-8425-8476b63fb767"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 114,
+            "artist_name": "Satyricon",
+            "artist_mbids": [
+                "05953c3e-c5c4-4410-9877-18e85132629c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 113,
+            "artist_name": "Testament",
+            "artist_mbids": [
+                "519b9bed-e6d5-4b8b-b65e-88a8d219c85d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 109,
+            "artist_name": "At the Gates",
+            "artist_mbids": [
+                "8d41e541-9edd-4de8-961a-e30f847f54a7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 108,
+            "artist_name": "Marit Bergman",
+            "artist_mbids": [
+                "7cc9d360-061f-4ada-999c-52ccda412795"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 108,
+            "artist_name": "Karunesh",
+            "artist_mbids": [
+                "6797b29b-a94c-4f99-b602-ab606a0bf4e6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 104,
+            "artist_name": "No Doubt",
+            "artist_mbids": [
+                "6bf52c09-6b35-4d7c-af51-6a47245f21a7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 102,
+            "artist_name": "Nickelback",
+            "artist_mbids": [
+                "765fba92-fae2-498b-b04a-327690869e15"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 102,
+            "artist_name": "Epica",
+            "artist_mbids": [
+                "de5825a7-9b41-4e8d-9e64-ac6f0617ed83"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 99,
+            "artist_name": "The Postal Service",
+            "artist_mbids": [
+                "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 99,
+            "artist_name": "Borknagar",
+            "artist_mbids": [
+                "e2fe00d2-810b-4a91-a3b4-ba9b7406c6c1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 98,
+            "artist_name": "Middleman",
+            "artist_mbids": [
+                "b648c557-dd92-4bfd-a0d4-569e903b8666"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 97,
+            "artist_name": "W.A.S.P.",
+            "artist_mbids": [
+                "dbed7c10-e68c-4805-9295-09c48c06b897"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 95,
+            "artist_name": "Velvet Revolver",
+            "artist_mbids": [
+                "2f68b232-a2fa-4f35-9eba-f2f3ab956e87"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 95,
+            "artist_name": "Dire Straits",
+            "artist_mbids": [
+                "6ee182ec-fda1-491b-8f13-c19e2da34c82"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 94,
+            "artist_name": "Progg",
+            "artist_mbids": [
+                "af4fa0d4-a060-4171-84cf-f40a20600cac"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 94,
+            "artist_name": "Apoptygma Berzerk",
+            "artist_mbids": [
+                "093d1c46-f28c-427c-a521-c5abe25fa75d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 93,
+            "artist_name": "Front 242",
+            "artist_mbids": [
+                "0739cfee-131b-41c8-8caa-fc846d6ae9be"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 91,
+            "artist_name": "M\u00f6rk Gryning",
+            "artist_mbids": [
+                "361ce71c-80b1-4717-b91f-3b0d9fccf906"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 87,
+            "artist_name": "D-A-D",
+            "artist_mbids": [
+                "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 86,
+            "artist_name": "Cemetary",
+            "artist_mbids": [
+                "addd9cc5-1964-49cd-b607-431349991084"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 85,
+            "artist_name": "Front Line Assembly",
+            "artist_mbids": [
+                "85d4d644-822b-4596-a83d-a0373158027a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 83,
+            "artist_name": "Sonata Arctica",
+            "artist_mbids": [
+                "87b24ec1-b811-422a-bf9f-a52d4e6bb249"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 83,
+            "artist_name": "Queen",
+            "artist_mbids": [
+                "4f7ac8db-ccb1-4411-af5d-395c785b2566"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 81,
+            "artist_name": "They Might Be Giants",
+            "artist_mbids": [
+                "13da5ac3-039a-4a29-b2d8-18b287de7d4e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 81,
+            "artist_name": "Tale",
+            "artist_mbids": [
+                "99fa93b3-796a-45a0-855e-6fe0e1b1a0b0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 81,
+            "artist_name": "Dream Evil",
+            "artist_mbids": [
+                "2d6e3002-fbf7-4fa5-a38f-c58ba12349b2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 77,
+            "artist_name": "Mot\u00f6rhead",
+            "artist_mbids": [
+                "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 77,
+            "artist_name": "Grip Inc.",
+            "artist_mbids": [
+                "4ed8e056-d7da-442f-8699-75d638041ca3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 76,
+            "artist_name": "Abramis Brama",
+            "artist_mbids": [
+                "78301a87-32ce-4857-b64d-97b4a08850ef"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 75,
+            "artist_name": "Pain",
+            "artist_mbids": [
+                "1738561e-cdcb-454a-98c0-58bfa7b54796"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 73,
+            "artist_name": "Ellie Goulding",
+            "artist_mbids": [
+                "1738561e-cdca-454a-98c0-58bfa7b54796"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 1354,
+            "artist_name": "Judas Priest",
+            "artist_mbids": [
+                "cf7b0f9c-cd96-4e16-a0e7-acc7adfec457"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 691,
+            "artist_name": "Evergrey",
+            "artist_mbids": [
+                "f6804334-5021-4e52-9f71-3ea924e6abc6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 641,
+            "artist_name": "Danko Jones",
+            "artist_mbids": [
+                "431cc9fb-ef90-4819-9c7b-2229c298727c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 606,
+            "artist_name": "Foo Fighters",
+            "artist_mbids": [
+                "87e396ef-3ee0-4ff2-853c-6174c4243df6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 584,
+            "artist_name": "Katatonia",
+            "artist_mbids": [
+                "dea48322-8fce-4a9b-8d5e-276f0dffc6da"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 556,
+            "artist_name": "The Hellacopters",
+            "artist_mbids": [
+                "4b321558-10b1-4d93-9bed-7c9048e28ecb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 504,
+            "artist_name": "Death Cab for Cutie",
+            "artist_mbids": [
+                "fcee89d2-70a6-4149-afd3-90806ddc650d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 470,
+            "artist_name": "The Darkness",
+            "artist_mbids": [
+                "645129c1-9b76-48c0-a3af-c87b284265a3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 461,
+            "artist_name": "Turbonegro",
+            "artist_mbids": [
+                "e9e619a9-5170-4ef7-bfeb-29ef64ed3f5d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 415,
+            "artist_name": "Black Label Society",
+            "artist_mbids": [
+                "a5c6cde7-4f8c-458a-8625-28ad28c87c25"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 405,
+            "artist_name": "Audioslave",
+            "artist_mbids": [
+                "79f83982-a0a1-4907-b12e-dc974868e219"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 402,
+            "artist_name": "Ayreon",
+            "artist_mbids": [
+                "94f867bb-3542-4675-858e-86dafdd7a647"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 394,
+            "artist_name": "Strapping Young Lad",
+            "artist_mbids": [
+                "6ceff4c9-fe82-444a-ba9d-20e724e04190"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 385,
+            "artist_name": "Slayer",
+            "artist_mbids": [
+                "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 347,
+            "artist_name": "The Cardigans",
+            "artist_mbids": [
+                "2215d1a8-5f33-4fcf-b569-7353e106cdf1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 342,
+            "artist_name": "The Offspring",
+            "artist_mbids": [
+                "f3d7c01e-8055-48c1-963b-109cd0f7ec78"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 329,
+            "artist_name": "Arch Enemy",
+            "artist_mbids": [
+                "6de4fa2c-05f1-44ce-a769-e1adeee81abe"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 324,
+            "artist_name": "Hoobastank",
+            "artist_mbids": [
+                "574dfe13-97aa-4318-8e4a-0ec79e05db24"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 316,
+            "artist_name": "Depeche Mode",
+            "artist_mbids": [
+                "540eebc9-0fc6-41df-8372-2c1a534e92e3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 305,
+            "artist_name": "Panic! at the Disco",
+            "artist_mbids": [
+                "99eec84e-42cb-4f47-b80f-ce46ca65735b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 297,
+            "artist_name": "Mot\u00f6rhead",
+            "artist_mbids": [
+                "c28b39fc-90f5-4dbe-9094-23d3700a2bce"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 292,
+            "artist_name": "W.A.S.P.",
+            "artist_mbids": [
+                "dbed7c10-e68c-4805-9295-09c48c06b897"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 275,
+            "artist_name": "Opeth",
+            "artist_mbids": [
+                "38742bd1-2ceb-4854-a138-206d095cdcc0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 268,
+            "artist_name": "The Postal Service",
+            "artist_mbids": [
+                "d5ae6898-a1e5-4ee8-a891-0e4442cac1d4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 264,
+            "artist_name": "Iron Maiden",
+            "artist_mbids": [
+                "2f13b1cb-32e3-45c6-8b87-25629490ac44"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 262,
+            "artist_name": "Wizo",
+            "artist_mbids": [
+                "d3e64ede-3456-4f67-952c-fa0b7d05231a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 249,
+            "artist_name": "Black Sabbath",
+            "artist_mbids": [
+                "9e6a8399-a625-4151-9bba-3994b033957e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 246,
+            "artist_name": "Coldplay",
+            "artist_mbids": [
+                "6599e41e-390c-4855-a2ac-68ee798538b4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 244,
+            "artist_name": "D-A-D",
+            "artist_mbids": [
+                "44640f0b-8700-4f0e-a30f-e33e4e20c4d9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 238,
+            "artist_name": "Iced Earth",
+            "artist_mbids": [
+                "12379346-99d9-4941-b4a2-f04144a39863"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 235,
+            "artist_name": "Queen",
+            "artist_mbids": [
+                "4f7ac8db-ccb1-4411-af5d-395c785b2566"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 219,
+            "artist_name": "The Knife",
+            "artist_mbids": [
+                "d01b7459-4a8e-4c00-a0d5-0a373634eb47"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 218,
+            "artist_name": "Alkaline Trio",
+            "artist_mbids": [
+                "92133235-e98d-48cf-be8c-85693bec10fa"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 215,
+            "artist_name": "Nickelback",
+            "artist_mbids": [
+                "765fba92-fae2-498b-b04a-327690869e15"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 214,
+            "artist_name": "Apocalyptica",
+            "artist_mbids": [
+                "b0346a81-4a99-461d-870a-de5d086ea1c3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 206,
+            "artist_name": "Sentenced",
+            "artist_mbids": [
+                "788df19a-4f74-4a73-8ced-c2e1b1b5bc1b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 203,
+            "artist_name": "System of a Down",
+            "artist_mbids": [
+                "9e5f26f1-95ab-43ad-b7f9-22ff5cd29dee"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 201,
+            "artist_name": "Symphony X",
+            "artist_mbids": [
+                "162be21e-3e55-43ef-95f4-2f741c6e58b1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 201,
+            "artist_name": "Metallica",
+            "artist_mbids": [
+                "a3c5dedf-13bb-4df2-be11-285972577112"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 201,
+            "artist_name": "Green Carnation",
+            "artist_mbids": [
+                "30f8806c-e6b2-4a5a-92d5-454cdd41bbcc"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 198,
+            "artist_name": "The Soundtrack of Our Lives",
+            "artist_mbids": [
+                "fe7912cc-3102-4277-9df8-c20ed3b1499d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 198,
+            "artist_name": "The Kristet Utseende",
+            "artist_mbids": [
+                "2f3568d9-9ac0-4936-9712-a95302ca51a3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 178,
+            "artist_name": "Amorphis",
+            "artist_mbids": [
+                "8716eb48-0079-4a90-b561-2fa5bbd03862"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 172,
+            "artist_name": "Nevermore",
+            "artist_mbids": [
+                "5627d327-7d81-43ae-ae7c-bb5c7d4f0d24"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 171,
+            "artist_name": "Tiamat",
+            "artist_mbids": [
+                "06502aa4-ddff-4cd6-88bb-2af99d4a5ad1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 167,
+            "artist_name": "The Killers",
+            "artist_mbids": [
+                "7fc48e0d-36bd-479e-928e-87dcf610a782"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 167,
+            "artist_name": "Bj\u00f6rk",
+            "artist_mbids": [
+                "3d6d2533-f3f9-4859-a3c9-5c3a8db9b628"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 158,
+            "artist_name": "Avril Lavigne",
+            "artist_mbids": [
+                "c707783d-53b6-47fc-8c94-4d5323489209"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 147,
+            "artist_name": "Queensr\u00ffche",
+            "artist_mbids": [
+                "4920ba92-d2bb-4826-ba31-c82dae4a633b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 144,
+            "artist_name": "Emperor",
+            "artist_mbids": [
+                "58914eb6-0518-45eb-a917-9985aa1cd374"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 137,
+            "artist_name": "Type O Negative",
+            "artist_mbids": [
+                "599e16ce-3705-450d-8014-1d9292b69dd9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 136,
+            "artist_name": "Tale",
+            "artist_mbids": [
+                "99fa93b3-796a-45a0-855e-6fe0e1b1a0b0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 136,
+            "artist_name": "Bathory",
+            "artist_mbids": [
+                "114378b9-019b-48ab-a6af-0e122cf6c056"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 127,
+            "artist_name": "Prince",
+            "artist_mbids": [
+                "8a75931e-2a0e-4f39-9fe1-7233b344efaf"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 122,
+            "artist_name": "HammerFall",
+            "artist_mbids": [
+                "70b2e0d6-2c39-4044-bd88-1c1ad31fd21a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 121,
+            "artist_name": "Alanis Morissette",
+            "artist_mbids": [
+                "2b96162d-97d7-4dd0-95cc-8b27e23b2d43"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 120,
+            "artist_name": "Wise Guys",
+            "artist_mbids": [
+                "f9c8e154-2986-4dec-96ce-345ff327a271"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 118,
+            "artist_name": "Gorillaz",
+            "artist_mbids": [
+                "78df245f-0fe0-4a21-b1d4-e79f695354fd"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 113,
+            "artist_name": "Entombed",
+            "artist_mbids": [
+                "fc9bf307-4b19-42fa-a1f1-f445e5d79bf2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 112,
+            "artist_name": "Megadeth",
+            "artist_mbids": [
+                "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 112,
+            "artist_name": "Garbage",
+            "artist_mbids": [
+                "93648a14-2239-42ff-8339-944038c78a5b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 111,
+            "artist_name": "The Donnas",
+            "artist_mbids": [
+                "4e735f68-1b0c-481d-b1c4-1449f7d14550"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 110,
+            "artist_name": "Stream of Passion",
+            "artist_mbids": [
+                "72ee05f0-bed3-41be-ab77-e5523332e3b6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 109,
+            "artist_name": "In Flames",
+            "artist_mbids": [
+                "844c13e8-9264-41f1-acc1-a59be2af611e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 108,
+            "artist_name": "R\u00f6yksopp",
+            "artist_mbids": [
+                "3d851dd4-4c5b-411c-af24-11aa44bdc26f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 106,
+            "artist_name": "Red Hot Chili Peppers",
+            "artist_mbids": [
+                "e7c27081-e80d-4641-aed3-356e28320f6f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 104,
+            "artist_name": "They Might Be Giants",
+            "artist_mbids": [
+                "13da5ac3-039a-4a29-b2d8-18b287de7d4e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 104,
+            "artist_name": "Porcupine Tree",
+            "artist_mbids": [
+                "31e65ed7-cb97-482f-93a5-6dae925761e4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 104,
+            "artist_name": "Ice-T",
+            "artist_mbids": [
+                "4155b1d3-5b20-402c-9117-b7d1d0ee6204"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 103,
+            "artist_name": "The Project Hate MCMXCIX",
+            "artist_mbids": [
+                "3105cdac-628b-4a55-bcdd-e2bd11e21288"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 100,
+            "artist_name": "Mastodon",
+            "artist_mbids": [
+                "32150f6d-5ad6-4913-83fc-7b15bd847588"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 98,
+            "artist_name": "Fight",
+            "artist_mbids": [
+                "0e3ebeae-9b2c-4a1e-aa2e-e99aab0cdc5c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 93,
+            "artist_name": "J.B.O.",
+            "artist_mbids": [
+                "723245dd-68c3-42c6-ab02-095e30e3dca9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 92,
+            "artist_name": "Wolfmother",
+            "artist_mbids": [
+                "136cb38f-3cd6-4a97-8031-e5c8d0cc6eb9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 91,
+            "artist_name": "Falconer",
+            "artist_mbids": [
+                "e82bddba-140d-418b-bde9-8e6ee9e9aa5c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 90,
+            "artist_name": "The Haunted",
+            "artist_mbids": [
+                "841f458f-a940-4220-8120-5e2f719c771e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 89,
+            "artist_name": "LOK",
+            "artist_mbids": [
+                "02264268-7813-455b-b97a-9437b4a048cd"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 88,
+            "artist_name": "Nationalteatern",
+            "artist_mbids": [
+                "ff67daaa-dc6c-4e29-a1d1-f40b2457489d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 88,
+            "artist_name": "Anathema",
+            "artist_mbids": [
+                "f31223bf-43e7-4565-9d5b-34f4e7897d71"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 84,
+            "artist_name": "U2",
+            "artist_mbids": [
+                "b958833f-4d74-4f94-8402-7cd1a6e6fb21"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 84,
+            "artist_name": "David Bowie",
+            "artist_mbids": [
+                "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 81,
+            "artist_name": "The Doors",
+            "artist_mbids": [
+                "d834dd3d-653f-496e-895b-1885ee6b0d68"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 81,
+            "artist_name": "LCD Soundsystem",
+            "artist_mbids": [
+                "be15b50e-8df8-481b-b0af-3991db5e3ee9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 80,
+            "artist_name": "Pink Floyd",
+            "artist_mbids": [
+                "52758846-744f-4295-8dbc-6a4caf77459c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 80,
+            "artist_name": "Darkthrone",
+            "artist_mbids": [
+                "b17c1ee9-8340-45ab-ab75-92bb6a9481da"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 78,
+            "artist_name": "Tenacious D",
+            "artist_mbids": [
+                "0ebbb014-d2f4-4588-a1a2-dafc1c777b22"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 78,
+            "artist_name": "Magnatune Compilation (PREVIEW: buy it at www.magnatune.com)",
+            "artist_mbids": [
+                "171f623b-5ca6-4081-ae7b-faf92724500a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 76,
+            "artist_name": "Witchery",
+            "artist_mbids": [
+                "9b11fcf9-8282-418c-bc8c-c4003aa16963"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 75,
+            "artist_name": "Combustible Edison",
+            "artist_mbids": [
+                "cfc09e6a-5d59-4c07-b14d-3a55bd7a8c1b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 74,
+            "artist_name": "Zyklon",
+            "artist_mbids": [
+                "0ce6d420-1273-46a5-98ed-faee68c3d269"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 72,
+            "artist_name": "Kaizers Orchestra",
+            "artist_mbids": [
+                "183a545e-416b-49c5-ba35-08497fbf732b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 71,
+            "artist_name": "Raise Hell",
+            "artist_mbids": [
+                "7ffc4fc1-b158-4e8c-9b88-bac95af3225b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 68,
+            "artist_name": "Cemetary",
+            "artist_mbids": [
+                "addd9cc5-1964-49cd-b607-431349991084"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 67,
+            "artist_name": "Jan Delay",
+            "artist_mbids": [
+                "4dd5aff8-49f4-4f37-b412-ca0227f4534f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 66,
+            "artist_name": "Kent",
+            "artist_mbids": [
+                "e6456dc5-3519-4547-993a-4e87e91a85df"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 65,
+            "artist_name": "Khoma",
+            "artist_mbids": [
+                "51a562cf-9515-4c63-8d7d-80eca213c30b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 65,
+            "artist_name": "Dream Theater",
+            "artist_mbids": [
+                "8d0f8872-4527-4604-8e35-705afc9f50e6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 65,
+            "artist_name": "Astrud Gilberto",
+            "artist_mbids": [
+                "704872ad-8327-4b72-8cf2-53b2fb6977f1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 64,
+            "artist_name": "Tool",
+            "artist_mbids": [
+                "59812ffc-6782-4427-878b-1116ff5c769c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 64,
+            "artist_name": "Sahara Hotnights",
+            "artist_mbids": [
+                "775f251e-7635-405c-89bc-4d985c44f92c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 63,
+            "artist_name": "Hotnights Sahara",
+            "artist_mbids": [
+                "8r5f251e-7635-405c-89bc-4d985c44f92c"
+            ],
+            "artist_msid": null
         }
-    ]
+    ],
+    "count": 202,
+    "stats_range": "all_time"
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_week.json
@@ -1,1620 +1,1608 @@
 {
     "from_ts": 1591574400,
     "to_ts": 1592784000,
-    "time_ranges": [
+    "data": [
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "3e58ced5-c379-4b6f-92b8-492f909d53ef"
-                    ],
-                    "listen_count": 139,
-                    "artist_name": "Clarence Clarity",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "45515fc0-28b4-4e9c-b530-47b0fc256ead"
-                    ],
-                    "listen_count": 86,
-                    "artist_name": "Bomba Est\u00e9reo",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "92274620-f425-4d74-af9f-49a8ea3a0fb6"
-                    ],
-                    "listen_count": 72,
-                    "artist_name": "John Carpenter, Cody Carpenter & Daniel Davies",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8c0fe262-b4c0-4835-bf56-cb1597ca8306"
-                    ],
-                    "listen_count": 72,
-                    "artist_name": "Flying Lotus",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99a3f584-0c1f-422d-9581-daa935892166"
-                    ],
-                    "listen_count": 48,
-                    "artist_name": "MNEK",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4bba65ae-b6bc-49b4-a6de-2b18a357797c"
-                    ],
-                    "listen_count": 48,
-                    "artist_name": "Janet Jackson",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "bb89657c-c0c6-4c2d-9233-619823a3b043"
-                    ],
-                    "listen_count": 46,
-                    "artist_name": "Seth Lakeman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ff5c0560-a3c4-45b7-81de-56a56f14a899"
-                    ],
-                    "listen_count": 46,
-                    "artist_name": "100 gecs",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c8910ef9-c8b6-434c-95e0-be44c3c4a47e"
-                    ],
-                    "listen_count": 41,
-                    "artist_name": "John Carpenter",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "180fcf80-8de9-4efa-889e-3bb545cc5252"
-                    ],
-                    "listen_count": 36,
-                    "artist_name": "Metaform",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "052fef56-cfea-41de-b07d-72ecf607e5be"
-                    ],
-                    "listen_count": 32,
-                    "artist_name": "Calexico",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a200b8a0-2248-4abb-9454-5f99750be117"
-                    ],
-                    "listen_count": 31,
-                    "artist_name": "Dance Gavin Dance",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8fd0aeee-23f9-4cb7-8801-2566cf116607"
-                    ],
-                    "listen_count": 30,
-                    "artist_name": "Exmag",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9820da6d-66d9-424d-9f67-2654ed2f31e4"
-                    ],
-                    "listen_count": 27,
-                    "artist_name": "Tame Impala",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cbb9a699-457c-4082-9ee7-46238d95b76a"
-                    ],
-                    "listen_count": 24,
-                    "artist_name": "Zayn",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ac24a1a7-3ef5-4adc-8438-1f8bcce70f43"
-                    ],
-                    "listen_count": 24,
-                    "artist_name": "Rina Sawayama",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9720fd77-fe48-41ba-a7a2-b4795718dd97"
-                    ],
-                    "listen_count": 23,
-                    "artist_name": "Drake",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c8fee4af-cf1c-4676-809b-930251b57289"
-                    ],
-                    "listen_count": 20,
-                    "artist_name": "Solange",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3b2f4fcd-6305-44cb-9312-b7d1fbc91b4c"
-                    ],
-                    "listen_count": 19,
-                    "artist_name": "The 1975",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a97e8d2b-73dc-46f6-9e6b-26e9eac7b574"
-                    ],
-                    "listen_count": 18,
-                    "artist_name": "Pentangle",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "503ea1d1-92d6-4b68-9019-99a53ed45348"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "Yabby You & Prophets",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "13ad5913-a409-4b6d-b7ab-f853d3a84007"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "TomppaBeats",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b558a0d1-6f28-4134-8110-e625a30389a2"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "Redman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0b2aab1a-7ec2-4b8e-87c7-80c1313f9398"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "Emarosa",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "288235cb-1187-4d24-8f73-cbeece34dee2"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "Vikingur Olafsson",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "025a1214-9225-40ea-b32a-fa1da63f9a5f"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "The Damned",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ad11bf90-ed19-438e-b661-8e3a8f922124"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "Stray Kids",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b50d094d-a722-40b9-83ef-74d5c1de2866"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "Showbiz & A.G.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b4ae3356-b8a7-471a-a23a-e471a69ad454"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "Ariana Grande",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "543f38fd-2126-4924-8d69-fb753f281dbb"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Zuco 103",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "428b6e4c-795e-4a08-8d0b-7bef7aaf8582"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Kanye West",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4f409234-d8d3-4a4a-a664-7186614a9c09"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Big Sean",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0a3cacb2-f1f6-4426-a758-e41e395caf9f"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "Onyx",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "98168481-f215-4115-bd5e-a603b0b33280"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "Odetta",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6599e41e-390c-4855-a2ac-68ee798538b4"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "Coldplay",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "560271d1-cea8-4a39-92c4-ac9e448c20f4"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Tom Odell",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fef3595e-cfaa-4dbc-ba8f-55ba76305c64"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Tinashe",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "47ba76ad-dcd2-41e8-8d8a-91c3ba0e73eb"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "The Mountain Goats",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "34314f1c-de56-4556-b6c5-78bbf15590f1"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Sleep Token",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fe2cbb92-9164-40d2-a4fd-76fdd20ecf08"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Sam Gellaitry",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d51d9a4a-1cf9-4ce3-aba8-33d8958e7845"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Nuclear Assault",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "270bca08-33f6-40ce-9508-869f484d20fe"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "LoFi Hip Hop",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "50fbeb99-f068-41f7-beaf-cf18daf19124"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Justin Bieber",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "74985888-541e-4992-9290-7149e5919270"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "William Orbit",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a84bc968-c327-4f84-baca-01aad2e508b5"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Thrice",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cb620508-f737-4348-aad1-27bab9bc3f02"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Organectomy",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dc9a749f-f1fa-4acc-9f6e-12c411ed301b"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Instra:mental",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7d22f0c5-7f70-4d97-8a9c-c381d8ebbf3a"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Ahtme",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0f85c13d-cb10-4ade-b69c-ee159ba09a1c"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "tmantz625",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4f7ac8db-ccb1-4411-af5d-395c785b2566"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Queen",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2040ef57-13b6-4c0c-a3be-470a1a6edc2e"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Osunlade",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c66f95c3-8e7f-4286-b1c6-1d52f078cc70"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Martin O'Donnell",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f883661c-de05-4050-b62b-88474a7223d2"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Black Honey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4e279c33-5f70-4f06-a9d8-9e8ab5ba0166"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Andy Stott",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "17fa7925-eca7-4edb-b5fe-e68843139a25"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "The Night Game",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "5201944d-b08d-4cd6-a580-9cda7b7c9b60"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Seether",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8a19ab32-a2f8-4b64-9b1c-6deb297a1587"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Recondite",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3eb81b8a-7cae-4fff-bed8-4c4f036e4a69"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Emancipator",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7167a53b-536a-4b15-9e93-babfed0888fe"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Candlemass",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "410bd3e3-49d4-4417-b3af-7493bdcf00c7"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Bleed from Within",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "78048022-8412-4658-8fa2-e77398cc3d4f"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Yann Tiersen",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8b64f68f-e56e-4681-80f6-5f83e12b03a7"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Shinedown",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "008657f2-43ae-41d5-937d-36e5439b0944"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Richard Henshall",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9235923c-1c5b-467f-964d-5841c38797f4"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "RZA",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "260a4dc3-19c5-4fae-9f2f-d495a8baa13d"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Lady Gaga",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3e9567ef-1549-4196-9241-c8b8c9330a8f"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Eidola",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "5ff10afa-6f42-442f-8883-ea6169542f7f"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Abra",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d1a03708-1cc0-4134-9577-c1382b322d83"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "16",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "59812ffc-6782-4427-878b-1116ff5c769c"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Tool",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "The Weeknd",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "83c6f015-ea59-43ac-a1a7-8ac2ca20ce14"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Sianvar",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dcd4245a-0ad2-47f2-a217-06d0c78c108b"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Pontiac Streator & Ulla Straus",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "40dc813f-3336-49ab-80aa-e8fce8ae6935"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Missy Elliott",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "53e4814d-705e-4768-979f-9cf918d9c6bd"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Mansionair",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "11009d8b-8206-46d1-b1fd-e3cfca7b507e"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Jupiter One",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "38c3e14d-e614-48dc-9395-860e68619385"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Jim White",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c9f2dede-fc69-4b2f-af51-346bf506d113"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Hannes Grossmann",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8669e61f-d379-4ee9-b51c-66bc83777aae"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Dog Eat Dog",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ee182ec-fda1-491b-8f13-c19e2da34c82"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Dire Straits",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f5592c17-0b2f-4f58-8a2e-923e3cd8da93"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Charli XCX",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8d05c31c-78b1-4bb6-b80a-8ef6bc6f2b58"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "dgoHn",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3f00c1e3-17ce-423f-a35c-0037a4c172f0"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Three Days Grace",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7fa344b3-258a-4bd2-b321-db9297b249ed"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "The Pretty Reckless",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7a7abbe4-ab1b-49c1-9276-9bc4cee66661"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Special Request",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8d9dce0a-4aca-4273-916c-612fc481c783"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Rosie Carney",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "5c330293-3c1d-4ddb-a8e9-6b647cb0db85"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "PARK RD",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "76f85521-163f-427f-a3e8-27fa23b3d602"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Little Brother",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "bf57daba-fc3a-4d32-9e8f-4a02ebdff84d"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Fjord",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7165726f-7b7e-4c65-a222-df1b95ef4199"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Eve",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7eeeae6a-30b9-401d-9f37-c3d23dad8f98"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Circa Survive",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7a4756b9-e47a-407c-85c0-667514d2ffed"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Bridgit Mendler",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2eb58555-10ac-422b-b0ff-9d17367f91ad"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Atlus Sound Team",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e2e65849-a5f0-441b-b6a7-0948a0bde559"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Aim",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "83df9d14-ba3b-4ab1-bf4c-21dcbb92e324"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Wormed",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a2503d0a-4dde-4848-8fff-a4352cdb3384"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Wax Tailor",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a5dcf727-2234-4ddb-a743-808e18a4cd3f"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Waajeed",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ea42c685-2b12-4f68-b8e0-e3bb9b207102"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Tierra Whack",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fcdf75e0-5eaf-47a0-9dcc-04784514f5ca"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "The Maine",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0d5aad58-2e55-4e84-870b-99edbf958fe6"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Sum 41",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6a3996f1-c0a5-447a-a434-a41812f09f3d"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Sam Martin",
-                    "artist_msid": null
-                }
+            "listen_count": 139,
+            "artist_name": "Clarence Clarity",
+            "artist_mbids": [
+                "3e58ced5-c379-4b6f-92b8-492f909d53ef"
             ],
-            "from_ts": 1591574400,
-            "time_range": "Monday 08 June 2020",
-            "to_ts": 1591660799
+            "artist_msid": null
         },
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "a200b8a0-2248-4abb-9454-5f99750be117"
-                    ],
-                    "listen_count": 119,
-                    "artist_name": "Dance Gavin Dance",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3e58ced5-c379-4b6f-92b8-492f909d53ef"
-                    ],
-                    "listen_count": 88,
-                    "artist_name": "Clarence Clarity",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "45515fc0-28b4-4e9c-b530-47b0fc256ead"
-                    ],
-                    "listen_count": 58,
-                    "artist_name": "Bomba Est\u00e9reo",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "92274620-f425-4d74-af9f-49a8ea3a0fb6"
-                    ],
-                    "listen_count": 55,
-                    "artist_name": "John Carpenter, Cody Carpenter & Daniel Davies",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ac24a1a7-3ef5-4adc-8438-1f8bcce70f43"
-                    ],
-                    "listen_count": 41,
-                    "artist_name": "Rina Sawayama",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4f2da2f8-22c5-4d6d-989f-c6899d7e683e"
-                    ],
-                    "listen_count": 38,
-                    "artist_name": "Richard Thompson Band",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "288235cb-1187-4d24-8f73-cbeece34dee2"
-                    ],
-                    "listen_count": 33,
-                    "artist_name": "Vikingur Olafsson",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3f513bed-50e1-4890-b666-0f45d726043c"
-                    ],
-                    "listen_count": 31,
-                    "artist_name": "Pyre",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e29fd013-45c0-4edd-abe2-8635fdd0502a"
-                    ],
-                    "listen_count": 25,
-                    "artist_name": "Lana Del Rey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "94c767b1-0068-483b-b233-a3c56776bea8"
-                    ],
-                    "listen_count": 23,
-                    "artist_name": "SZA",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "73c6dfb8-9a66-4967-a965-46532d412693"
-                    ],
-                    "listen_count": 23,
-                    "artist_name": "Caligula's Horse",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cbb9a699-457c-4082-9ee7-46238d95b76a"
-                    ],
-                    "listen_count": 22,
-                    "artist_name": "Zayn",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ae5c875b-3f76-4ab2-935e-6c6f11be6d0e"
-                    ],
-                    "listen_count": 20,
-                    "artist_name": "wavvyboi",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "74985888-541e-4992-9290-7149e5919270"
-                    ],
-                    "listen_count": 20,
-                    "artist_name": "William Orbit",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a84bc968-c327-4f84-baca-01aad2e508b5"
-                    ],
-                    "listen_count": 20,
-                    "artist_name": "Thrice",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ce675bb2-5424-4936-9424-30a98f81b059"
-                    ],
-                    "listen_count": 18,
-                    "artist_name": "Miguel",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "42b34077-464d-4e09-877e-077db701469d"
-                    ],
-                    "listen_count": 18,
-                    "artist_name": "Jaira Burns",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b650167d-3f75-4a39-a0b5-7cf4e65b7205"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "Katy Perry",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ad541512-7c48-4c7c-91a0-0dc68b2e4c85"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "Insomnium",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d1d1189c-9842-4d87-949e-0cfe7093da2c"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "Amon Tobin",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ff5c0560-a3c4-45b7-81de-56a56f14a899"
-                    ],
-                    "listen_count": 17,
-                    "artist_name": "100 gecs",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99a3f584-0c1f-422d-9581-daa935892166"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "MNEK",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "19a802c6-9b4e-4128-b291-0893077b3d31"
-                    ],
-                    "listen_count": 16,
-                    "artist_name": "Anelis Assump\u00e7\u00e3o",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "30fd3091-0127-4746-89cd-493b35ad0112"
-                    ],
-                    "listen_count": 15,
-                    "artist_name": "Riverside",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
-                    ],
-                    "listen_count": 15,
-                    "artist_name": "David Bowie",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dcb5740f-949d-4ccf-9e9e-40755da0a336"
-                    ],
-                    "listen_count": 14,
-                    "artist_name": "Bilmuri",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9092d3a9-a24d-490f-a758-7537905ddfb2"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "Thank You Scientist",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
-                    ],
-                    "listen_count": 13,
-                    "artist_name": "Shawn Mendes",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a76a3ee6-8a46-468f-a24f-2fe5f3be77b2"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "The Tourist Company",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "46ceff00-4f51-4d47-b49b-cae6420eeb63"
-                    ],
-                    "listen_count": 12,
-                    "artist_name": "Abstract Void",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b9956564-f7fd-4c97-a3fa-b88b157affa1"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "Vader",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2090ff2e-6657-4997-9d4f-2d3baa0017f0"
-                    ],
-                    "listen_count": 11,
-                    "artist_name": "The Strokes",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a1328477-0e85-4bb6-8913-7f472e0e736e"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Shaka Ponk",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "84d50322-0713-4461-aaf0-18a7c0eaabc6"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Sade",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d1d0b7db-4b6c-4032-9c20-ab4fa862f62c"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Red Vox",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "53056a48-242c-4fa4-a7df-1ce749acf4be"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "NeuroWulf",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6599e41e-390c-4855-a2ac-68ee798538b4"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Coldplay",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "991c78a3-9242-4354-b48b-276b2563e2cf"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Between the Buried and Me",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "89d99f49-e6c5-4f33-a497-364f00443250"
-                    ],
-                    "listen_count": 10,
-                    "artist_name": "Baco Exu do Blues",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b100da12-be6b-43c2-a0a6-91d6dfa31d2d"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Ms Nina",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4c267f9f-95b7-4a77-9ba8-275695bb5c77"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Kosheen",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "46f46533-0545-4204-a3a0-3460025e9bc8"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Kelsea Ballerini",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "961bfa0a-407d-4a23-a0dd-b8e458fb7278"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Kari Faux",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0130abed-3ff5-407a-a814-581ab1b13c65"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Jessie J",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f1993b30-8616-4de2-bb7d-93dc0ba45521"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Harry Styles",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "78180459-0eac-4664-87d6-2a729ac0f5af"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Camila Cabello",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fcaef907-0ed4-43b7-bb98-b0b8afe9df5c"
-                    ],
-                    "listen_count": 9,
-                    "artist_name": "Caligula\u2019s Horse",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7ba181fe-0133-4ba3-8628-e4a3961194d1"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Lola Marsh",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4f409234-d8d3-4a4a-a664-7186614a9c09"
-                    ],
-                    "listen_count": 8,
-                    "artist_name": "Big Sean",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3f00c1e3-17ce-423f-a35c-0037a4c172f0"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Three Days Grace",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "48037460-0837-460f-b2c8-2794f4bc1406"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "The Wanted",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c8fee4af-cf1c-4676-809b-930251b57289"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Solange",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "5b7f6101-c781-4664-8c4b-48192fed83eb"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Snakehips",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ac6f4804-6215-4e1b-bb47-3672f085dde6"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Sia",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "254069ee-0bcd-49bf-b4a0-ece111ae541b"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Robert Francis",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8c69c8e8-c42d-4ba5-82f2-f687934c9e13"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Piano",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d501dda5-2735-4b7d-a2c9-a20f2e78b418"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Mac Miller",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ea88d5da-63b0-4410-a893-294d61d07033"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Lu\u00edsa Sonza",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "db5f18d9-0319-4a0d-bc75-08354b92bff5"
-                    ],
-                    "listen_count": 7,
-                    "artist_name": "Amy Winehouse",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7f103972-1ade-4b78-bb74-c0a70731097a"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Zero 7",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "The Weeknd",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "44985283-048c-4fd4-8817-4bf278104d49"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Sid Sriram",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "070844c0-d715-471d-9141-ac02aaeb1896"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Rick Wakeman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "37733b1f-e682-45ef-a509-51b7ee61f9e0"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "October Tide",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "865022b8-09bf-4cc6-9a2a-db9b679e137f"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Jorja Smith",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7ef97e12-5648-4261-89ed-982da0eed624"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Green Day",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d09497af-2736-44f1-832a-e796201d89a4"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Freddie Gibbs & The Alchemist",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "01304329-2423-4ad7-b2ff-d4d9b796b2c6"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Death in Vegas",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c8009cbf-fffe-476e-a94c-27c2199d68af"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Bamao Yend\u00e9",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "3239a1ee-2405-477d-a296-e2a82324af79"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Alice Phoebe Lou",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "78301a87-32ce-4857-b64d-97b4a08850ef"
-                    ],
-                    "listen_count": 6,
-                    "artist_name": "Abramis Brama",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "00a2e257-eccc-466e-9c3f-c424281e20d3"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Torgeir Waldemar",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "87fc6bdb-50ba-4fcc-9819-24e2b78053ec"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Team Sleep",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7db97ead-5341-466a-8436-1d14bf25a6ec"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Papa Roach",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "000efb44-525a-4f95-a717-a2503ce66adf"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Morrissey",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a6347ef8-b6bf-4eec-87fb-6a366090f1b3"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Lucky Daye",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "68b03150-d13f-4d85-bf51-ddfb2a06b028"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Ling Tosite Sigure",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b0b5b781-fca0-4152-a500-8f9c00d7d1a0"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Janelle Mon\u00e1e",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "97d4de44-fd69-4865-b25c-2f93a5110046"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Fu Manchu",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "811158af-6dd8-49eb-a3ae-a73fa16a4ca6"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Elder",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ee182ec-fda1-491b-8f13-c19e2da34c82"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Dire Straits",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7309f023-a3f8-45cf-83f8-ac898b588220"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Danna Paola",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "97913071-2c2e-4669-b7ab-ad48f89a8e92"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Bibi",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8be7c18f-70e6-4e26-985c-769a45d3b64a"
-                    ],
-                    "listen_count": 5,
-                    "artist_name": "Bebe Rexha",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1e7a13d0-c053-47b6-9c06-2a0fafe33009"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "bomb the bass feat. bim sherman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1910e8be-1950-4b32-aeda-3f86b6adac1e"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Zendaya",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4ae89ac4-67f3-4ec8-bc0e-484dcb2b4183"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Wolfman",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "29d92749-b0a0-42de-ba68-6fa8b0c45dc9"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Theme",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "5f6d94d6-072f-4a3a-8e3d-e2c0b7d0a254"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "The Sword",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0d5aad58-2e55-4e84-870b-99edbf958fe6"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Sum 41",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "4522e59f-1250-485f-aa6e-403c4aecdb30"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Special D.",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "30e74976-ab8e-4cf8-a44e-5a123f04eb3a"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Royal Republic",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8e170cec-b5f2-4dc2-8599-c097165a5ffc"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Princess Nokia",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "edd660e7-70a5-4385-ac87-1a773b806891"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Pop Will Eat Itself",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "8a253b0f-4a3a-4557-a293-7a99e9d5fad5"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Peter Andre",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "21416da1-b660-4376-a7c5-2324499277cb"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Pennywise",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cc8d1b77-14b3-42e4-83ec-802c3a1427fa"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "OutKast",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "ab24f28b-6b72-42ed-8086-aeb738427e58"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Nu Era",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0d915677-5f4c-4101-99c6-8108729ce9aa"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Mike Posner",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a2c1ed01-991f-4a9d-81e0-9b04c8df1c80"
-                    ],
-                    "listen_count": 4,
-                    "artist_name": "Michelle McManus",
-                    "artist_msid": null
-                }
+            "listen_count": 86,
+            "artist_name": "Bomba Est\u00e9reo",
+            "artist_mbids": [
+                "45515fc0-28b4-4e9c-b530-47b0fc256ead"
             ],
-            "from_ts": 1591660800,
-            "time_range": "Tuesday 09 June 2020",
-            "to_ts": 1591747199
+            "artist_msid": null
+        },
+        {
+            "listen_count": 72,
+            "artist_name": "John Carpenter, Cody Carpenter & Daniel Davies",
+            "artist_mbids": [
+                "92274620-f425-4d74-af9f-49a8ea3a0fb6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 72,
+            "artist_name": "Flying Lotus",
+            "artist_mbids": [
+                "8c0fe262-b4c0-4835-bf56-cb1597ca8306"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 48,
+            "artist_name": "MNEK",
+            "artist_mbids": [
+                "99a3f584-0c1f-422d-9581-daa935892166"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 48,
+            "artist_name": "Janet Jackson",
+            "artist_mbids": [
+                "4bba65ae-b6bc-49b4-a6de-2b18a357797c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 46,
+            "artist_name": "Seth Lakeman",
+            "artist_mbids": [
+                "bb89657c-c0c6-4c2d-9233-619823a3b043"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 46,
+            "artist_name": "100 gecs",
+            "artist_mbids": [
+                "ff5c0560-a3c4-45b7-81de-56a56f14a899"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 41,
+            "artist_name": "John Carpenter",
+            "artist_mbids": [
+                "c8910ef9-c8b6-434c-95e0-be44c3c4a47e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 36,
+            "artist_name": "Metaform",
+            "artist_mbids": [
+                "180fcf80-8de9-4efa-889e-3bb545cc5252"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 32,
+            "artist_name": "Calexico",
+            "artist_mbids": [
+                "052fef56-cfea-41de-b07d-72ecf607e5be"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 31,
+            "artist_name": "Dance Gavin Dance",
+            "artist_mbids": [
+                "a200b8a0-2248-4abb-9454-5f99750be117"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 30,
+            "artist_name": "Exmag",
+            "artist_mbids": [
+                "8fd0aeee-23f9-4cb7-8801-2566cf116607"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 27,
+            "artist_name": "Tame Impala",
+            "artist_mbids": [
+                "9820da6d-66d9-424d-9f67-2654ed2f31e4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 24,
+            "artist_name": "Zayn",
+            "artist_mbids": [
+                "cbb9a699-457c-4082-9ee7-46238d95b76a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 24,
+            "artist_name": "Rina Sawayama",
+            "artist_mbids": [
+                "ac24a1a7-3ef5-4adc-8438-1f8bcce70f43"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 23,
+            "artist_name": "Drake",
+            "artist_mbids": [
+                "9720fd77-fe48-41ba-a7a2-b4795718dd97"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 20,
+            "artist_name": "Solange",
+            "artist_mbids": [
+                "c8fee4af-cf1c-4676-809b-930251b57289"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 19,
+            "artist_name": "The 1975",
+            "artist_mbids": [
+                "3b2f4fcd-6305-44cb-9312-b7d1fbc91b4c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 18,
+            "artist_name": "Pentangle",
+            "artist_mbids": [
+                "a97e8d2b-73dc-46f6-9e6b-26e9eac7b574"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "Yabby You & Prophets",
+            "artist_mbids": [
+                "503ea1d1-92d6-4b68-9019-99a53ed45348"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "TomppaBeats",
+            "artist_mbids": [
+                "13ad5913-a409-4b6d-b7ab-f853d3a84007"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "Redman",
+            "artist_mbids": [
+                "b558a0d1-6f28-4134-8110-e625a30389a2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "Emarosa",
+            "artist_mbids": [
+                "0b2aab1a-7ec2-4b8e-87c7-80c1313f9398"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "Vikingur Olafsson",
+            "artist_mbids": [
+                "288235cb-1187-4d24-8f73-cbeece34dee2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "The Damned",
+            "artist_mbids": [
+                "025a1214-9225-40ea-b32a-fa1da63f9a5f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "Stray Kids",
+            "artist_mbids": [
+                "ad11bf90-ed19-438e-b661-8e3a8f922124"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "Showbiz & A.G.",
+            "artist_mbids": [
+                "b50d094d-a722-40b9-83ef-74d5c1de2866"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "Ariana Grande",
+            "artist_mbids": [
+                "b4ae3356-b8a7-471a-a23a-e471a69ad454"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Zuco 103",
+            "artist_mbids": [
+                "543f38fd-2126-4924-8d69-fb753f281dbb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Kanye West",
+            "artist_mbids": [
+                "428b6e4c-795e-4a08-8d0b-7bef7aaf8582"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Big Sean",
+            "artist_mbids": [
+                "4f409234-d8d3-4a4a-a664-7186614a9c09"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "Onyx",
+            "artist_mbids": [
+                "0a3cacb2-f1f6-4426-a758-e41e395caf9f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "Odetta",
+            "artist_mbids": [
+                "98168481-f215-4115-bd5e-a603b0b33280"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "Coldplay",
+            "artist_mbids": [
+                "6599e41e-390c-4855-a2ac-68ee798538b4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Tom Odell",
+            "artist_mbids": [
+                "560271d1-cea8-4a39-92c4-ac9e448c20f4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Tinashe",
+            "artist_mbids": [
+                "fef3595e-cfaa-4dbc-ba8f-55ba76305c64"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "The Mountain Goats",
+            "artist_mbids": [
+                "47ba76ad-dcd2-41e8-8d8a-91c3ba0e73eb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Sleep Token",
+            "artist_mbids": [
+                "34314f1c-de56-4556-b6c5-78bbf15590f1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Sam Gellaitry",
+            "artist_mbids": [
+                "fe2cbb92-9164-40d2-a4fd-76fdd20ecf08"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Nuclear Assault",
+            "artist_mbids": [
+                "d51d9a4a-1cf9-4ce3-aba8-33d8958e7845"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "LoFi Hip Hop",
+            "artist_mbids": [
+                "270bca08-33f6-40ce-9508-869f484d20fe"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Justin Bieber",
+            "artist_mbids": [
+                "50fbeb99-f068-41f7-beaf-cf18daf19124"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "William Orbit",
+            "artist_mbids": [
+                "74985888-541e-4992-9290-7149e5919270"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Thrice",
+            "artist_mbids": [
+                "a84bc968-c327-4f84-baca-01aad2e508b5"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Organectomy",
+            "artist_mbids": [
+                "cb620508-f737-4348-aad1-27bab9bc3f02"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Instra:mental",
+            "artist_mbids": [
+                "dc9a749f-f1fa-4acc-9f6e-12c411ed301b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Ahtme",
+            "artist_mbids": [
+                "7d22f0c5-7f70-4d97-8a9c-c381d8ebbf3a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "tmantz625",
+            "artist_mbids": [
+                "0f85c13d-cb10-4ade-b69c-ee159ba09a1c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Queen",
+            "artist_mbids": [
+                "4f7ac8db-ccb1-4411-af5d-395c785b2566"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Osunlade",
+            "artist_mbids": [
+                "2040ef57-13b6-4c0c-a3be-470a1a6edc2e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Martin O'Donnell",
+            "artist_mbids": [
+                "c66f95c3-8e7f-4286-b1c6-1d52f078cc70"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Black Honey",
+            "artist_mbids": [
+                "f883661c-de05-4050-b62b-88474a7223d2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Andy Stott",
+            "artist_mbids": [
+                "4e279c33-5f70-4f06-a9d8-9e8ab5ba0166"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "The Night Game",
+            "artist_mbids": [
+                "17fa7925-eca7-4edb-b5fe-e68843139a25"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Seether",
+            "artist_mbids": [
+                "5201944d-b08d-4cd6-a580-9cda7b7c9b60"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Recondite",
+            "artist_mbids": [
+                "8a19ab32-a2f8-4b64-9b1c-6deb297a1587"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Emancipator",
+            "artist_mbids": [
+                "3eb81b8a-7cae-4fff-bed8-4c4f036e4a69"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Candlemass",
+            "artist_mbids": [
+                "7167a53b-536a-4b15-9e93-babfed0888fe"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Bleed from Within",
+            "artist_mbids": [
+                "410bd3e3-49d4-4417-b3af-7493bdcf00c7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Yann Tiersen",
+            "artist_mbids": [
+                "78048022-8412-4658-8fa2-e77398cc3d4f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Shinedown",
+            "artist_mbids": [
+                "8b64f68f-e56e-4681-80f6-5f83e12b03a7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Richard Henshall",
+            "artist_mbids": [
+                "008657f2-43ae-41d5-937d-36e5439b0944"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "RZA",
+            "artist_mbids": [
+                "9235923c-1c5b-467f-964d-5841c38797f4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Lady Gaga",
+            "artist_mbids": [
+                "260a4dc3-19c5-4fae-9f2f-d495a8baa13d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Eidola",
+            "artist_mbids": [
+                "3e9567ef-1549-4196-9241-c8b8c9330a8f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Abra",
+            "artist_mbids": [
+                "5ff10afa-6f42-442f-8883-ea6169542f7f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "16",
+            "artist_mbids": [
+                "d1a03708-1cc0-4134-9577-c1382b322d83"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Tool",
+            "artist_mbids": [
+                "59812ffc-6782-4427-878b-1116ff5c769c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "The Weeknd",
+            "artist_mbids": [
+                "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Sianvar",
+            "artist_mbids": [
+                "83c6f015-ea59-43ac-a1a7-8ac2ca20ce14"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Pontiac Streator & Ulla Straus",
+            "artist_mbids": [
+                "dcd4245a-0ad2-47f2-a217-06d0c78c108b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Missy Elliott",
+            "artist_mbids": [
+                "40dc813f-3336-49ab-80aa-e8fce8ae6935"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Mansionair",
+            "artist_mbids": [
+                "53e4814d-705e-4768-979f-9cf918d9c6bd"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Jupiter One",
+            "artist_mbids": [
+                "11009d8b-8206-46d1-b1fd-e3cfca7b507e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Jim White",
+            "artist_mbids": [
+                "38c3e14d-e614-48dc-9395-860e68619385"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Hannes Grossmann",
+            "artist_mbids": [
+                "c9f2dede-fc69-4b2f-af51-346bf506d113"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Dog Eat Dog",
+            "artist_mbids": [
+                "8669e61f-d379-4ee9-b51c-66bc83777aae"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Dire Straits",
+            "artist_mbids": [
+                "6ee182ec-fda1-491b-8f13-c19e2da34c82"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Charli XCX",
+            "artist_mbids": [
+                "f5592c17-0b2f-4f58-8a2e-923e3cd8da93"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "dgoHn",
+            "artist_mbids": [
+                "8d05c31c-78b1-4bb6-b80a-8ef6bc6f2b58"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Three Days Grace",
+            "artist_mbids": [
+                "3f00c1e3-17ce-423f-a35c-0037a4c172f0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "The Pretty Reckless",
+            "artist_mbids": [
+                "7fa344b3-258a-4bd2-b321-db9297b249ed"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Special Request",
+            "artist_mbids": [
+                "7a7abbe4-ab1b-49c1-9276-9bc4cee66661"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Rosie Carney",
+            "artist_mbids": [
+                "8d9dce0a-4aca-4273-916c-612fc481c783"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "PARK RD",
+            "artist_mbids": [
+                "5c330293-3c1d-4ddb-a8e9-6b647cb0db85"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Little Brother",
+            "artist_mbids": [
+                "76f85521-163f-427f-a3e8-27fa23b3d602"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Fjord",
+            "artist_mbids": [
+                "bf57daba-fc3a-4d32-9e8f-4a02ebdff84d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Eve",
+            "artist_mbids": [
+                "7165726f-7b7e-4c65-a222-df1b95ef4199"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Circa Survive",
+            "artist_mbids": [
+                "7eeeae6a-30b9-401d-9f37-c3d23dad8f98"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Bridgit Mendler",
+            "artist_mbids": [
+                "7a4756b9-e47a-407c-85c0-667514d2ffed"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Atlus Sound Team",
+            "artist_mbids": [
+                "2eb58555-10ac-422b-b0ff-9d17367f91ad"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Aim",
+            "artist_mbids": [
+                "e2e65849-a5f0-441b-b6a7-0948a0bde559"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Wormed",
+            "artist_mbids": [
+                "83df9d14-ba3b-4ab1-bf4c-21dcbb92e324"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Wax Tailor",
+            "artist_mbids": [
+                "a2503d0a-4dde-4848-8fff-a4352cdb3384"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Waajeed",
+            "artist_mbids": [
+                "a5dcf727-2234-4ddb-a743-808e18a4cd3f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Tierra Whack",
+            "artist_mbids": [
+                "ea42c685-2b12-4f68-b8e0-e3bb9b207102"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "The Maine",
+            "artist_mbids": [
+                "fcdf75e0-5eaf-47a0-9dcc-04784514f5ca"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Sum 41",
+            "artist_mbids": [
+                "0d5aad58-2e55-4e84-870b-99edbf958fe6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Sam Martin",
+            "artist_mbids": [
+                "6a3996f1-c0a5-447a-a434-a41812f09f3d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 119,
+            "artist_name": "Dance Gavin Dance",
+            "artist_mbids": [
+                "a200b8a0-2248-4abb-9454-5f99750be117"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 88,
+            "artist_name": "Clarence Clarity",
+            "artist_mbids": [
+                "3e58ced5-c379-4b6f-92b8-492f909d53ef"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 58,
+            "artist_name": "Bomba Est\u00e9reo",
+            "artist_mbids": [
+                "45515fc0-28b4-4e9c-b530-47b0fc256ead"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 55,
+            "artist_name": "John Carpenter, Cody Carpenter & Daniel Davies",
+            "artist_mbids": [
+                "92274620-f425-4d74-af9f-49a8ea3a0fb6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 41,
+            "artist_name": "Rina Sawayama",
+            "artist_mbids": [
+                "ac24a1a7-3ef5-4adc-8438-1f8bcce70f43"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 38,
+            "artist_name": "Richard Thompson Band",
+            "artist_mbids": [
+                "4f2da2f8-22c5-4d6d-989f-c6899d7e683e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 33,
+            "artist_name": "Vikingur Olafsson",
+            "artist_mbids": [
+                "288235cb-1187-4d24-8f73-cbeece34dee2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 31,
+            "artist_name": "Pyre",
+            "artist_mbids": [
+                "3f513bed-50e1-4890-b666-0f45d726043c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 25,
+            "artist_name": "Lana Del Rey",
+            "artist_mbids": [
+                "e29fd013-45c0-4edd-abe2-8635fdd0502a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 23,
+            "artist_name": "SZA",
+            "artist_mbids": [
+                "94c767b1-0068-483b-b233-a3c56776bea8"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 23,
+            "artist_name": "Caligula's Horse",
+            "artist_mbids": [
+                "73c6dfb8-9a66-4967-a965-46532d412693"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 22,
+            "artist_name": "Zayn",
+            "artist_mbids": [
+                "cbb9a699-457c-4082-9ee7-46238d95b76a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 20,
+            "artist_name": "wavvyboi",
+            "artist_mbids": [
+                "ae5c875b-3f76-4ab2-935e-6c6f11be6d0e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 20,
+            "artist_name": "William Orbit",
+            "artist_mbids": [
+                "74985888-541e-4992-9290-7149e5919270"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 20,
+            "artist_name": "Thrice",
+            "artist_mbids": [
+                "a84bc968-c327-4f84-baca-01aad2e508b5"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 18,
+            "artist_name": "Miguel",
+            "artist_mbids": [
+                "ce675bb2-5424-4936-9424-30a98f81b059"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 18,
+            "artist_name": "Jaira Burns",
+            "artist_mbids": [
+                "42b34077-464d-4e09-877e-077db701469d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "Katy Perry",
+            "artist_mbids": [
+                "b650167d-3f75-4a39-a0b5-7cf4e65b7205"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "Insomnium",
+            "artist_mbids": [
+                "ad541512-7c48-4c7c-91a0-0dc68b2e4c85"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "Amon Tobin",
+            "artist_mbids": [
+                "d1d1189c-9842-4d87-949e-0cfe7093da2c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 17,
+            "artist_name": "100 gecs",
+            "artist_mbids": [
+                "ff5c0560-a3c4-45b7-81de-56a56f14a899"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "MNEK",
+            "artist_mbids": [
+                "99a3f584-0c1f-422d-9581-daa935892166"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 16,
+            "artist_name": "Anelis Assump\u00e7\u00e3o",
+            "artist_mbids": [
+                "19a802c6-9b4e-4128-b291-0893077b3d31"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 15,
+            "artist_name": "Riverside",
+            "artist_mbids": [
+                "30fd3091-0127-4746-89cd-493b35ad0112"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 15,
+            "artist_name": "David Bowie",
+            "artist_mbids": [
+                "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 14,
+            "artist_name": "Bilmuri",
+            "artist_mbids": [
+                "dcb5740f-949d-4ccf-9e9e-40755da0a336"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "Thank You Scientist",
+            "artist_mbids": [
+                "9092d3a9-a24d-490f-a758-7537905ddfb2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 13,
+            "artist_name": "Shawn Mendes",
+            "artist_mbids": [
+                "7bb2fcd0-1edb-4c35-bde2-052f9c8efd2f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "The Tourist Company",
+            "artist_mbids": [
+                "a76a3ee6-8a46-468f-a24f-2fe5f3be77b2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 12,
+            "artist_name": "Abstract Void",
+            "artist_mbids": [
+                "46ceff00-4f51-4d47-b49b-cae6420eeb63"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "Vader",
+            "artist_mbids": [
+                "b9956564-f7fd-4c97-a3fa-b88b157affa1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 11,
+            "artist_name": "The Strokes",
+            "artist_mbids": [
+                "2090ff2e-6657-4997-9d4f-2d3baa0017f0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Shaka Ponk",
+            "artist_mbids": [
+                "a1328477-0e85-4bb6-8913-7f472e0e736e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Sade",
+            "artist_mbids": [
+                "84d50322-0713-4461-aaf0-18a7c0eaabc6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Red Vox",
+            "artist_mbids": [
+                "d1d0b7db-4b6c-4032-9c20-ab4fa862f62c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "NeuroWulf",
+            "artist_mbids": [
+                "53056a48-242c-4fa4-a7df-1ce749acf4be"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Coldplay",
+            "artist_mbids": [
+                "6599e41e-390c-4855-a2ac-68ee798538b4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Between the Buried and Me",
+            "artist_mbids": [
+                "991c78a3-9242-4354-b48b-276b2563e2cf"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 10,
+            "artist_name": "Baco Exu do Blues",
+            "artist_mbids": [
+                "89d99f49-e6c5-4f33-a497-364f00443250"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Ms Nina",
+            "artist_mbids": [
+                "b100da12-be6b-43c2-a0a6-91d6dfa31d2d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Kosheen",
+            "artist_mbids": [
+                "4c267f9f-95b7-4a77-9ba8-275695bb5c77"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Kelsea Ballerini",
+            "artist_mbids": [
+                "46f46533-0545-4204-a3a0-3460025e9bc8"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Kari Faux",
+            "artist_mbids": [
+                "961bfa0a-407d-4a23-a0dd-b8e458fb7278"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Jessie J",
+            "artist_mbids": [
+                "0130abed-3ff5-407a-a814-581ab1b13c65"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Harry Styles",
+            "artist_mbids": [
+                "f1993b30-8616-4de2-bb7d-93dc0ba45521"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Camila Cabello",
+            "artist_mbids": [
+                "78180459-0eac-4664-87d6-2a729ac0f5af"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 9,
+            "artist_name": "Caligula\u2019s Horse",
+            "artist_mbids": [
+                "fcaef907-0ed4-43b7-bb98-b0b8afe9df5c"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Lola Marsh",
+            "artist_mbids": [
+                "7ba181fe-0133-4ba3-8628-e4a3961194d1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 8,
+            "artist_name": "Big Sean",
+            "artist_mbids": [
+                "4f409234-d8d3-4a4a-a664-7186614a9c09"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Three Days Grace",
+            "artist_mbids": [
+                "3f00c1e3-17ce-423f-a35c-0037a4c172f0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "The Wanted",
+            "artist_mbids": [
+                "48037460-0837-460f-b2c8-2794f4bc1406"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Solange",
+            "artist_mbids": [
+                "c8fee4af-cf1c-4676-809b-930251b57289"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Snakehips",
+            "artist_mbids": [
+                "5b7f6101-c781-4664-8c4b-48192fed83eb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Sia",
+            "artist_mbids": [
+                "ac6f4804-6215-4e1b-bb47-3672f085dde6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Robert Francis",
+            "artist_mbids": [
+                "254069ee-0bcd-49bf-b4a0-ece111ae541b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Piano",
+            "artist_mbids": [
+                "8c69c8e8-c42d-4ba5-82f2-f687934c9e13"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Mac Miller",
+            "artist_mbids": [
+                "d501dda5-2735-4b7d-a2c9-a20f2e78b418"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Lu\u00edsa Sonza",
+            "artist_mbids": [
+                "ea88d5da-63b0-4410-a893-294d61d07033"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 7,
+            "artist_name": "Amy Winehouse",
+            "artist_mbids": [
+                "db5f18d9-0319-4a0d-bc75-08354b92bff5"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Zero 7",
+            "artist_mbids": [
+                "7f103972-1ade-4b78-bb74-c0a70731097a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "The Weeknd",
+            "artist_mbids": [
+                "2b0646af-f3f0-4a5b-b629-6c31301c1c29"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Sid Sriram",
+            "artist_mbids": [
+                "44985283-048c-4fd4-8817-4bf278104d49"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Rick Wakeman",
+            "artist_mbids": [
+                "070844c0-d715-471d-9141-ac02aaeb1896"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "October Tide",
+            "artist_mbids": [
+                "37733b1f-e682-45ef-a509-51b7ee61f9e0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Jorja Smith",
+            "artist_mbids": [
+                "865022b8-09bf-4cc6-9a2a-db9b679e137f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Green Day",
+            "artist_mbids": [
+                "7ef97e12-5648-4261-89ed-982da0eed624"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Freddie Gibbs & The Alchemist",
+            "artist_mbids": [
+                "d09497af-2736-44f1-832a-e796201d89a4"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Death in Vegas",
+            "artist_mbids": [
+                "01304329-2423-4ad7-b2ff-d4d9b796b2c6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Bamao Yend\u00e9",
+            "artist_mbids": [
+                "c8009cbf-fffe-476e-a94c-27c2199d68af"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Alice Phoebe Lou",
+            "artist_mbids": [
+                "3239a1ee-2405-477d-a296-e2a82324af79"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 6,
+            "artist_name": "Abramis Brama",
+            "artist_mbids": [
+                "78301a87-32ce-4857-b64d-97b4a08850ef"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Torgeir Waldemar",
+            "artist_mbids": [
+                "00a2e257-eccc-466e-9c3f-c424281e20d3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Team Sleep",
+            "artist_mbids": [
+                "87fc6bdb-50ba-4fcc-9819-24e2b78053ec"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Papa Roach",
+            "artist_mbids": [
+                "7db97ead-5341-466a-8436-1d14bf25a6ec"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Morrissey",
+            "artist_mbids": [
+                "000efb44-525a-4f95-a717-a2503ce66adf"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Lucky Daye",
+            "artist_mbids": [
+                "a6347ef8-b6bf-4eec-87fb-6a366090f1b3"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Ling Tosite Sigure",
+            "artist_mbids": [
+                "68b03150-d13f-4d85-bf51-ddfb2a06b028"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Janelle Mon\u00e1e",
+            "artist_mbids": [
+                "b0b5b781-fca0-4152-a500-8f9c00d7d1a0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Fu Manchu",
+            "artist_mbids": [
+                "97d4de44-fd69-4865-b25c-2f93a5110046"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Elder",
+            "artist_mbids": [
+                "811158af-6dd8-49eb-a3ae-a73fa16a4ca6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Dire Straits",
+            "artist_mbids": [
+                "6ee182ec-fda1-491b-8f13-c19e2da34c82"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Danna Paola",
+            "artist_mbids": [
+                "7309f023-a3f8-45cf-83f8-ac898b588220"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Bibi",
+            "artist_mbids": [
+                "97913071-2c2e-4669-b7ab-ad48f89a8e92"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 5,
+            "artist_name": "Bebe Rexha",
+            "artist_mbids": [
+                "8be7c18f-70e6-4e26-985c-769a45d3b64a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "bomb the bass feat. bim sherman",
+            "artist_mbids": [
+                "1e7a13d0-c053-47b6-9c06-2a0fafe33009"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Zendaya",
+            "artist_mbids": [
+                "1910e8be-1950-4b32-aeda-3f86b6adac1e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Wolfman",
+            "artist_mbids": [
+                "4ae89ac4-67f3-4ec8-bc0e-484dcb2b4183"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Theme",
+            "artist_mbids": [
+                "29d92749-b0a0-42de-ba68-6fa8b0c45dc9"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "The Sword",
+            "artist_mbids": [
+                "5f6d94d6-072f-4a3a-8e3d-e2c0b7d0a254"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Sum 41",
+            "artist_mbids": [
+                "0d5aad58-2e55-4e84-870b-99edbf958fe6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Special D.",
+            "artist_mbids": [
+                "4522e59f-1250-485f-aa6e-403c4aecdb30"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Royal Republic",
+            "artist_mbids": [
+                "30e74976-ab8e-4cf8-a44e-5a123f04eb3a"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Princess Nokia",
+            "artist_mbids": [
+                "8e170cec-b5f2-4dc2-8599-c097165a5ffc"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Pop Will Eat Itself",
+            "artist_mbids": [
+                "edd660e7-70a5-4385-ac87-1a773b806891"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Peter Andre",
+            "artist_mbids": [
+                "8a253b0f-4a3a-4557-a293-7a99e9d5fad5"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Pennywise",
+            "artist_mbids": [
+                "21416da1-b660-4376-a7c5-2324499277cb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "OutKast",
+            "artist_mbids": [
+                "cc8d1b77-14b3-42e4-83ec-802c3a1427fa"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Nu Era",
+            "artist_mbids": [
+                "ab24f28b-6b72-42ed-8086-aeb738427e58"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Mike Posner",
+            "artist_mbids": [
+                "0d915677-5f4c-4101-99c6-8108729ce9aa"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 4,
+            "artist_name": "Michelle McManus",
+            "artist_mbids": [
+                "a2c1ed01-991f-4a9d-81e0-9b04c8df1c80"
+            ],
+            "artist_msid": null
         }
-    ]
+    ],
+    "count": 200,
+    "stats_range": "week"
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_year.json
@@ -1,500 +1,488 @@
 {
     "from_ts": 1546300800,
     "to_ts": 1593043183,
-    "time_ranges": [
+    "data": [
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "75c5f0fe-ff02-4f36-bd79-9db14041b6d2"
-                    ],
-                    "listen_count": 424,
-                    "artist_name": "Bob Dylan",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "50fa106f-e40d-49ec-bca1-9802fb2157e7"
-                    ],
-                    "listen_count": 363,
-                    "artist_name": "Radiohead",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e12b120c-9b69-49ac-9d22-6a904edff32b"
-                    ],
-                    "listen_count": 286,
-                    "artist_name": "The Rolling Stones",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b4ae3356-b8a7-471a-a23a-e471a69ad454"
-                    ],
-                    "listen_count": 286,
-                    "artist_name": "Ariana Grande",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "27f6c4f6-f7a3-4fe0-b02c-7f3ed494e9fb"
-                    ],
-                    "listen_count": 207,
-                    "artist_name": "Rosal\u00eda",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "62cc4b55-7b65-4676-909c-e3f221a40dfb"
-                    ],
-                    "listen_count": 194,
-                    "artist_name": "The Beatles",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d290cd3b-40a4-47c8-a476-7dfc2f8b3895"
-                    ],
-                    "listen_count": 187,
-                    "artist_name": "The Cure",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e98b10b6-0208-4157-9544-36041e303f07"
-                    ],
-                    "listen_count": 166,
-                    "artist_name": "Lauv",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1d743e65-7850-4aed-b248-650c1e8ccfc1"
-                    ],
-                    "listen_count": 151,
-                    "artist_name": "Theophilus London",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
-                    ],
-                    "listen_count": 133,
-                    "artist_name": "Bring Me the Horizon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e03b3c0c-f1b1-4647-aa87-c6a9a05da72e"
-                    ],
-                    "listen_count": 132,
-                    "artist_name": "Kedr Livanskiy",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "34dcee7e-347d-42fa-9326-1e2ba1a3023b"
-                    ],
-                    "listen_count": 132,
-                    "artist_name": "Arctic Monkeys",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "416bd396-6859-4c6a-94bd-36271a9113fc"
-                    ],
-                    "listen_count": 114,
-                    "artist_name": "Kehlani",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2e7243ec-b05c-40ff-8e89-200a1b0b8474"
-                    ],
-                    "listen_count": 113,
-                    "artist_name": "Broken Social Scene",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ee182ec-fda1-491b-8f13-c19e2da34c82"
-                    ],
-                    "listen_count": 107,
-                    "artist_name": "Dire Straits",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "c1c80ec1-9153-482f-b0f9-2d3b94645920"
-                    ],
-                    "listen_count": 107,
-                    "artist_name": "Beyonc\u00e9",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "7388fe00-a3bd-4c03-a242-02fcd92a867e"
-                    ],
-                    "listen_count": 106,
-                    "artist_name": "Kamasi Washington",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b18756d6-bb73-4233-8715-1b46a9e7b904"
-                    ],
-                    "listen_count": 106,
-                    "artist_name": "James Blake",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "089c6d19-4157-4d57-9859-2c57e3d7ccf1"
-                    ],
-                    "listen_count": 105,
-                    "artist_name": "Led Zeppelin",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0d07cf3b-3648-475e-9588-c626fa7cdd66"
-                    ],
-                    "listen_count": 102,
-                    "artist_name": "Brant Bjork",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "69bc69f4-53cb-451f-af30-a12533df740b"
-                    ],
-                    "listen_count": 99,
-                    "artist_name": "Nick Cave & The Bad Seeds",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a116d7fe-94d2-4a43-a160-e9adb79627d8"
-                    ],
-                    "listen_count": 91,
-                    "artist_name": "Father John Misty",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "db5446a5-3019-44ba-b4cf-e07eeec15645"
-                    ],
-                    "listen_count": 90,
-                    "artist_name": "Beyond Creation",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "cc8d1b77-14b3-42e4-83ec-802c3a1427fa"
-                    ],
-                    "listen_count": 77,
-                    "artist_name": "OutKast",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9266c1c0-30ff-4c7c-9349-05ca1f4f4f02"
-                    ],
-                    "listen_count": 76,
-                    "artist_name": "Matthew Halsall",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "78301a87-32ce-4857-b64d-97b4a08850ef"
-                    ],
-                    "listen_count": 76,
-                    "artist_name": "Abramis Brama",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "89e429a3-d6e8-4d7a-b500-f2eed40dfe69"
-                    ],
-                    "listen_count": 75,
-                    "artist_name": "Eli Keszler",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "563c8c7a-4034-44ed-9a01-7dbf40ad4a36"
-                    ],
-                    "listen_count": 71,
-                    "artist_name": "Absolute Body Control",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
-                    ],
-                    "listen_count": 70,
-                    "artist_name": "Slayer",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "dafc32d8-6a8e-46b4-ab13-e2a4352028dc"
-                    ],
-                    "listen_count": 68,
-                    "artist_name": "Born of Osiris",
-                    "artist_msid": null
-                }
+            "listen_count": 424,
+            "artist_name": "Bob Dylan",
+            "artist_mbids": [
+                "75c5f0fe-ff02-4f36-bd79-9db14041b6d2"
             ],
-            "from_ts": 1546300800,
-            "time_range": "January 2019",
-            "to_ts": 1548979199
+            "artist_msid": null
         },
         {
-            "artists": [
-                {
-                    "artist_mbids": [
-                        "b4ae3356-b8a7-471a-a23a-e471a69ad454"
-                    ],
-                    "listen_count": 968,
-                    "artist_name": "Ariana Grande",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "1d743e65-7850-4aed-b248-650c1e8ccfc1"
-                    ],
-                    "listen_count": 182,
-                    "artist_name": "Theophilus London",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
-                    ],
-                    "listen_count": 156,
-                    "artist_name": "Megadeth",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
-                    ],
-                    "listen_count": 132,
-                    "artist_name": "David Bowie",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "62cc4b55-7b65-4676-909c-e3f221a40dfb"
-                    ],
-                    "listen_count": 120,
-                    "artist_name": "The Beatles",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "34dcee7e-347d-42fa-9326-1e2ba1a3023b"
-                    ],
-                    "listen_count": 112,
-                    "artist_name": "Arctic Monkeys",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "e98b10b6-0208-4157-9544-36041e303f07"
-                    ],
-                    "listen_count": 96,
-                    "artist_name": "Lauv",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "bb9e8bc8-e254-4ddd-94fd-184976c04766"
-                    ],
-                    "listen_count": 90,
-                    "artist_name": "Ghost",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "9c4c0f38-5e9e-45de-b5fc-da6377a5bdc2"
-                    ],
-                    "listen_count": 90,
-                    "artist_name": "Elza Soares",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6ee182ec-fda1-491b-8f13-c19e2da34c82"
-                    ],
-                    "listen_count": 90,
-                    "artist_name": "Dire Straits",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "416bd396-6859-4c6a-94bd-36271a9113fc"
-                    ],
-                    "listen_count": 85,
-                    "artist_name": "Kehlani",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "89e429a3-d6e8-4d7a-b500-f2eed40dfe69"
-                    ],
-                    "listen_count": 81,
-                    "artist_name": "Eli Keszler",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "69bc69f4-53cb-451f-af30-a12533df740b"
-                    ],
-                    "listen_count": 79,
-                    "artist_name": "Nick Cave & The Bad Seeds",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "50fa106f-e40d-49ec-bca1-9802fb2157e7"
-                    ],
-                    "listen_count": 76,
-                    "artist_name": "Radiohead",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "20beaded-6bea-41d4-bca7-3f0cadbca0c0"
-                    ],
-                    "listen_count": 74,
-                    "artist_name": "Sleater-Kinney",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f447378c-6129-4277-b921-d3d8f468871b"
-                    ],
-                    "listen_count": 73,
-                    "artist_name": "James Chance  The Contortions",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "6678a29c-cd2d-4954-8d16-a7d2f2e06df2"
-                    ],
-                    "listen_count": 73,
-                    "artist_name": "Freddie Gibbs",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f663264b-2618-4976-b4fc-0b96bb23cfad"
-                    ],
-                    "listen_count": 70,
-                    "artist_name": "Chancha Via Circuito",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
-                    ],
-                    "listen_count": 68,
-                    "artist_name": "Within Temptation",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "183857a7-737d-456a-b301-bb621603a46d"
-                    ],
-                    "listen_count": 66,
-                    "artist_name": "The Haggis Horns",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "fa0ad972-a4dc-4948-8610-e2cd48a00906"
-                    ],
-                    "listen_count": 65,
-                    "artist_name": "Black Lips",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "2274335d-46f9-4608-af69-2f4c4f6a3970"
-                    ],
-                    "listen_count": 61,
-                    "artist_name": "Nicola Cruz",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "27f6c4f6-f7a3-4fe0-b02c-7f3ed494e9fb"
-                    ],
-                    "listen_count": 60,
-                    "artist_name": "Rosal\u00eda",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "0de3dfa7-3b11-4d09-b7b0-0aaf30285ecb"
-                    ],
-                    "listen_count": 59,
-                    "artist_name": "Years & Years",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "42295e78-0a50-4baa-abbf-d81fda2b7343"
-                    ],
-                    "listen_count": 59,
-                    "artist_name": "Nirvana",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f31223bf-43e7-4565-9d5b-34f4e7897d71"
-                    ],
-                    "listen_count": 59,
-                    "artist_name": "Anathema",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "99dcf06c-4f49-4fa1-a64e-47ef3ea8075d"
-                    ],
-                    "listen_count": 57,
-                    "artist_name": "Rimon",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "b8e44f2e-3e42-4f0d-b7ef-6f874b882bad"
-                    ],
-                    "listen_count": 56,
-                    "artist_name": "Whitechapel",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "f88767e0-c644-46f6-9758-06f99dcfa8aa"
-                    ],
-                    "listen_count": 56,
-                    "artist_name": "Sok\u00f3\u0142",
-                    "artist_msid": null
-                },
-                {
-                    "artist_mbids": [
-                        "a63d3de8-9c39-4320-8199-784df3f4c74c"
-                    ],
-                    "listen_count": 55,
-                    "artist_name": "Soen",
-                    "artist_msid": null
-                }
+            "listen_count": 363,
+            "artist_name": "Radiohead",
+            "artist_mbids": [
+                "50fa106f-e40d-49ec-bca1-9802fb2157e7"
             ],
-            "from_ts": 1548979200,
-            "time_range": "February 2019",
-            "to_ts": 1551398399
+            "artist_msid": null
+        },
+        {
+            "listen_count": 286,
+            "artist_name": "The Rolling Stones",
+            "artist_mbids": [
+                "e12b120c-9b69-49ac-9d22-6a904edff32b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 286,
+            "artist_name": "Ariana Grande",
+            "artist_mbids": [
+                "b4ae3356-b8a7-471a-a23a-e471a69ad454"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 207,
+            "artist_name": "Rosal\u00eda",
+            "artist_mbids": [
+                "27f6c4f6-f7a3-4fe0-b02c-7f3ed494e9fb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 194,
+            "artist_name": "The Beatles",
+            "artist_mbids": [
+                "62cc4b55-7b65-4676-909c-e3f221a40dfb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 187,
+            "artist_name": "The Cure",
+            "artist_mbids": [
+                "d290cd3b-40a4-47c8-a476-7dfc2f8b3895"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 166,
+            "artist_name": "Lauv",
+            "artist_mbids": [
+                "e98b10b6-0208-4157-9544-36041e303f07"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 151,
+            "artist_name": "Theophilus London",
+            "artist_mbids": [
+                "1d743e65-7850-4aed-b248-650c1e8ccfc1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 133,
+            "artist_name": "Bring Me the Horizon",
+            "artist_mbids": [
+                "855e2998-40bc-4dbb-8ea5-4b28cd9447e0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 132,
+            "artist_name": "Kedr Livanskiy",
+            "artist_mbids": [
+                "e03b3c0c-f1b1-4647-aa87-c6a9a05da72e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 132,
+            "artist_name": "Arctic Monkeys",
+            "artist_mbids": [
+                "34dcee7e-347d-42fa-9326-1e2ba1a3023b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 114,
+            "artist_name": "Kehlani",
+            "artist_mbids": [
+                "416bd396-6859-4c6a-94bd-36271a9113fc"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 113,
+            "artist_name": "Broken Social Scene",
+            "artist_mbids": [
+                "2e7243ec-b05c-40ff-8e89-200a1b0b8474"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 107,
+            "artist_name": "Dire Straits",
+            "artist_mbids": [
+                "6ee182ec-fda1-491b-8f13-c19e2da34c82"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 107,
+            "artist_name": "Beyonc\u00e9",
+            "artist_mbids": [
+                "c1c80ec1-9153-482f-b0f9-2d3b94645920"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 106,
+            "artist_name": "Kamasi Washington",
+            "artist_mbids": [
+                "7388fe00-a3bd-4c03-a242-02fcd92a867e"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 106,
+            "artist_name": "James Blake",
+            "artist_mbids": [
+                "b18756d6-bb73-4233-8715-1b46a9e7b904"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 105,
+            "artist_name": "Led Zeppelin",
+            "artist_mbids": [
+                "089c6d19-4157-4d57-9859-2c57e3d7ccf1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 102,
+            "artist_name": "Brant Bjork",
+            "artist_mbids": [
+                "0d07cf3b-3648-475e-9588-c626fa7cdd66"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 99,
+            "artist_name": "Nick Cave & The Bad Seeds",
+            "artist_mbids": [
+                "69bc69f4-53cb-451f-af30-a12533df740b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 91,
+            "artist_name": "Father John Misty",
+            "artist_mbids": [
+                "a116d7fe-94d2-4a43-a160-e9adb79627d8"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 90,
+            "artist_name": "Beyond Creation",
+            "artist_mbids": [
+                "db5446a5-3019-44ba-b4cf-e07eeec15645"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 77,
+            "artist_name": "OutKast",
+            "artist_mbids": [
+                "cc8d1b77-14b3-42e4-83ec-802c3a1427fa"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 76,
+            "artist_name": "Matthew Halsall",
+            "artist_mbids": [
+                "9266c1c0-30ff-4c7c-9349-05ca1f4f4f02"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 76,
+            "artist_name": "Abramis Brama",
+            "artist_mbids": [
+                "78301a87-32ce-4857-b64d-97b4a08850ef"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 75,
+            "artist_name": "Eli Keszler",
+            "artist_mbids": [
+                "89e429a3-d6e8-4d7a-b500-f2eed40dfe69"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 71,
+            "artist_name": "Absolute Body Control",
+            "artist_mbids": [
+                "563c8c7a-4034-44ed-9a01-7dbf40ad4a36"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 70,
+            "artist_name": "Slayer",
+            "artist_mbids": [
+                "839badfe-0687-46a7-94f8-c95fb6b5e8b6"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 68,
+            "artist_name": "Born of Osiris",
+            "artist_mbids": [
+                "dafc32d8-6a8e-46b4-ab13-e2a4352028dc"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 968,
+            "artist_name": "Ariana Grande",
+            "artist_mbids": [
+                "b4ae3356-b8a7-471a-a23a-e471a69ad454"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 182,
+            "artist_name": "Theophilus London",
+            "artist_mbids": [
+                "1d743e65-7850-4aed-b248-650c1e8ccfc1"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 156,
+            "artist_name": "Megadeth",
+            "artist_mbids": [
+                "713d3cbf-25ec-4600-b2f0-0d5805c2b4c2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 132,
+            "artist_name": "David Bowie",
+            "artist_mbids": [
+                "d4a7fa18-f99d-46ec-97e3-c93cbaad05ea"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 120,
+            "artist_name": "The Beatles",
+            "artist_mbids": [
+                "62cc4b55-7b65-4676-909c-e3f221a40dfb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 112,
+            "artist_name": "Arctic Monkeys",
+            "artist_mbids": [
+                "34dcee7e-347d-42fa-9326-1e2ba1a3023b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 96,
+            "artist_name": "Lauv",
+            "artist_mbids": [
+                "e98b10b6-0208-4157-9544-36041e303f07"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 90,
+            "artist_name": "Ghost",
+            "artist_mbids": [
+                "bb9e8bc8-e254-4ddd-94fd-184976c04766"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 90,
+            "artist_name": "Elza Soares",
+            "artist_mbids": [
+                "9c4c0f38-5e9e-45de-b5fc-da6377a5bdc2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 90,
+            "artist_name": "Dire Straits",
+            "artist_mbids": [
+                "6ee182ec-fda1-491b-8f13-c19e2da34c82"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 85,
+            "artist_name": "Kehlani",
+            "artist_mbids": [
+                "416bd396-6859-4c6a-94bd-36271a9113fc"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 81,
+            "artist_name": "Eli Keszler",
+            "artist_mbids": [
+                "89e429a3-d6e8-4d7a-b500-f2eed40dfe69"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 79,
+            "artist_name": "Nick Cave & The Bad Seeds",
+            "artist_mbids": [
+                "69bc69f4-53cb-451f-af30-a12533df740b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 76,
+            "artist_name": "Radiohead",
+            "artist_mbids": [
+                "50fa106f-e40d-49ec-bca1-9802fb2157e7"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 74,
+            "artist_name": "Sleater-Kinney",
+            "artist_mbids": [
+                "20beaded-6bea-41d4-bca7-3f0cadbca0c0"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 73,
+            "artist_name": "James Chance  The Contortions",
+            "artist_mbids": [
+                "f447378c-6129-4277-b921-d3d8f468871b"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 73,
+            "artist_name": "Freddie Gibbs",
+            "artist_mbids": [
+                "6678a29c-cd2d-4954-8d16-a7d2f2e06df2"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 70,
+            "artist_name": "Chancha Via Circuito",
+            "artist_mbids": [
+                "f663264b-2618-4976-b4fc-0b96bb23cfad"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 68,
+            "artist_name": "Within Temptation",
+            "artist_mbids": [
+                "50751cf3-40c6-454e-99d9-3d5777e4ad4f"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 66,
+            "artist_name": "The Haggis Horns",
+            "artist_mbids": [
+                "183857a7-737d-456a-b301-bb621603a46d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 65,
+            "artist_name": "Black Lips",
+            "artist_mbids": [
+                "fa0ad972-a4dc-4948-8610-e2cd48a00906"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 61,
+            "artist_name": "Nicola Cruz",
+            "artist_mbids": [
+                "2274335d-46f9-4608-af69-2f4c4f6a3970"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 60,
+            "artist_name": "Rosal\u00eda",
+            "artist_mbids": [
+                "27f6c4f6-f7a3-4fe0-b02c-7f3ed494e9fb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 59,
+            "artist_name": "Years & Years",
+            "artist_mbids": [
+                "0de3dfa7-3b11-4d09-b7b0-0aaf30285ecb"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 59,
+            "artist_name": "Nirvana",
+            "artist_mbids": [
+                "42295e78-0a50-4baa-abbf-d81fda2b7343"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 59,
+            "artist_name": "Anathema",
+            "artist_mbids": [
+                "f31223bf-43e7-4565-9d5b-34f4e7897d71"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 57,
+            "artist_name": "Rimon",
+            "artist_mbids": [
+                "99dcf06c-4f49-4fa1-a64e-47ef3ea8075d"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 56,
+            "artist_name": "Whitechapel",
+            "artist_mbids": [
+                "b8e44f2e-3e42-4f0d-b7ef-6f874b882bad"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 56,
+            "artist_name": "Sok\u00f3\u0142",
+            "artist_mbids": [
+                "f88767e0-c644-46f6-9758-06f99dcfa8aa"
+            ],
+            "artist_msid": null
+        },
+        {
+            "listen_count": 55,
+            "artist_name": "Soen",
+            "artist_mbids": [
+                "a63d3de8-9c39-4320-8199-784df3f4c74c"
+            ],
+            "artist_msid": null
         }
-    ]
+    ],
+    "count": 60,
+    "stats_range": "year"
 }

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -12,7 +12,6 @@ import pycountry
 import requests
 
 from data.model.common_stat import StatApi
-from data.model.sitewide_artist_stat import SitewideArtistStatJson
 from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecord
 from flask import Blueprint, current_app, jsonify, request
 
@@ -699,7 +698,7 @@ def _is_valid_range(stats_range: str) -> bool:
 
 
 def _get_sitewide_entity_list(
-    stats: Union[SitewideArtistStatJson],
+    stats,
     entity: str,
     offset: int,
     count: int,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -1,10 +1,8 @@
-import bisect
 import calendar
-import json
 from collections import defaultdict
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, List, Tuple, Union, Iterable
+from typing import Dict, List, Tuple
 
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
@@ -12,16 +10,14 @@ import pycountry
 import requests
 
 from data.model.common_stat import StatApi
-from data.model.user_artist_map import UserArtistMapRecord, UserArtistMapRecord
+from data.model.user_artist_map import UserArtistMapRecord
 from flask import Blueprint, current_app, jsonify, request
 
 from data.model.user_entity import UserEntityRecord
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import (APIBadRequest,
                                            APIInternalServerError,
-                                           APINoContent, APINotFound,
-                                           APIServiceUnavailable,
-                                           APIUnauthorized)
+                                           APINoContent, APINotFound)
 from brainzutils.ratelimit import ratelimit
 from listenbrainz.webserver.views.api_tools import (DEFAULT_ITEMS_PER_GET,
                                                     MAX_ITEMS_PER_GET,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -554,40 +554,16 @@ def get_sitewide_artist():
 
         {
             "payload": {
-                "time_ranges": [
+                "artists": [
                     {
-                        "time_range": "April 2020",
-                        "artists": [
-                            {
-                                "artist_mbids": ["f4fdbb4c-e4b7-47a0-b83b-d91bbfcfa387"],
-                                "artist_name": "Ariana Grande",
-                                "listen_count": 519
-                            },
-                            {
-                                "artist_mbids": ["f4abc0b5-3f7a-4eff-8f78-ac078dbce533"],
-                                "artist_name": "Billie Eilish",
-                                "listen_count": 447
-                            }
-                        ],
-                        "from_ts": 1585699200,
-                        "to_ts": 1588291199,
+                        "artist_mbids": [],
+                        "artist_name": "Kanye West",
+                        "listen_count": 1305
                     },
                     {
-                        "time_range": "May 2020",
-                        "artists": [
-                            {
-                                "artist_mbids": [],
-                                "artist_name": "The Weeknd",
-                                "listen_count": 621
-                            },
-                            {
-                                "artist_mbids": [],
-                                "artist_name": "Drake",
-                                "listen_count": 554
-                            }
-                        ],
-                        "from_ts": 1588291200,
-                        "to_ts": 1590969599
+                        "artist_mbids": ["0b30341b-b59d-4979-8130-b66c0e475321"],
+                        "artist_name": "Lil Nas X",
+                        "listen_count": 1267
                     }
                 ],
                 "offset": 0,
@@ -602,9 +578,6 @@ def get_sitewide_artist():
     .. note::
         - This endpoint is currently in beta
         - ``artist_mbids`` and ``artist_msid`` are optional fields and may not be present in all the entries
-        - The example above shows the data for two days only, however we calculate the statistics for
-          the current time range and the previous time range. For example for yearly statistics the data
-          is calculated for the months in current as well as the past year.
         - We only calculate the top 1000 artists for each time period.
 
     :param count: Optional, number of artists to return for each time range,

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -2,7 +2,7 @@ from listenbrainz_spark.stats import run_query
 from pyspark.sql.functions import collect_list, sort_array, struct
 
 
-def get_artists(table: str, limit: int):
+def get_artists(table: str, limit: int = 1000):
     """ Get artist information (artist_name, artist_msid etc) for every time range specified
         the "time_range" table ordered by listen count
 

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -1,7 +1,9 @@
 from listenbrainz_spark.stats import run_query
 
+SITEWIDE_STATS_ENTITY_LIMIT = 1000  # number of top artists to retain in sitewide stats
 
-def get_artists(table: str, limit: int = 1000):
+
+def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
     """ Get artist information (artist_name, artist_msid etc) for every time range specified
         the "time_range" table ordered by listen count
 

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -1,5 +1,4 @@
 from listenbrainz_spark.stats import run_query
-from pyspark.sql.functions import collect_list, sort_array, struct
 
 
 def get_artists(table: str, limit: int = 1000):

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -2,48 +2,36 @@ from listenbrainz_spark.stats import run_query
 from pyspark.sql.functions import collect_list, sort_array, struct
 
 
-def get_artists(table: str, date_format: str):
+def get_artists(table: str, limit: int):
     """ Get artist information (artist_name, artist_msid etc) for every time range specified
         the "time_range" table ordered by listen count
 
         Args:
             table: Name of the temporary table.
-            date_format: Format in which the listened_at field should be formatted.
-
+            limit: number of top artists to retain
         Returns:
             iterator (iter): An iterator over result
     """
 
-    # Format the listened_at field according to the provided date_format string
-    formatted_listens = run_query(f"""
-                SELECT artist_name
-                     , artist_credit_mbids
-                     , date_format(listened_at, '{date_format}') as listened_at
-                  FROM {table}
-            """)
-    formatted_listens.createOrReplaceTempView('listens')
+    result = run_query(f"""
+        WITH intermediate_table as (
+            SELECT artist_name
+                 , artist_credit_mbids
+                 , count(*) as listen_count
+              FROM {table}
+          GROUP BY artist_name
+                 , artist_credit_mbids
+          ORDER BY listen_count DESC
+             LIMIT {limit}
+        )
+        SELECT collect_list(
+                    struct(
+                        artist_name
+                      , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                      , listen_count
+                    )
+               ) AS stats
+          FROM intermediate_table
+    """)
 
-    result = run_query("""
-                SELECT listens.artist_name
-                     , coalesce(listens.artist_credit_mbids, array()) AS artist_mbids
-                     , time_range.time_range
-                     , time_range.from_ts
-                     , time_range.to_ts
-                     , count(*) as listen_count
-                  FROM listens
-                  JOIN time_range
-                    ON listens.listened_at == time_range.time_range
-              GROUP BY listens.artist_name
-                     , listens.artist_credit_mbids
-                     , time_range.time_range
-                     , time_range.from_ts
-                     , time_range.to_ts
-              """)
-
-    iterator = result \
-        .withColumn("artists", struct("listen_count", "artist_name", "artist_mbids")) \
-        .groupBy("time_range", "from_ts", "to_ts") \
-        .agg(sort_array(collect_list("artists"), asc=False).alias("artists")) \
-        .toLocalIterator()
-
-    return iterator
+    return result.toLocalIterator()

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -219,7 +219,7 @@ def create_messages(data, entity: str, stats_range: str, from_ts: float, to_ts: 
         'to_ts': to_ts,
         'entity': entity,
     }
-    entry = data[0]['stats']
+    entry = next(data)['stats']
     _dict = entry.asDict(recursive=True)
     message['count'] = len(entry)
 

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -3,12 +3,10 @@ import logging
 from datetime import datetime
 from typing import List, Optional
 
-import listenbrainz_spark
 from data.model.sitewide_artist_stat import SitewideArtistRecord
 from data.model.sitewide_entity import SitewideEntityStatMessage
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
-from listenbrainz_spark.stats import (offset_days, offset_months, replace_days,
-                                      run_query, get_day_end, get_year_end, get_month_end, get_last_monday)
+from listenbrainz_spark.stats import offset_days, replace_days, get_last_monday, replace_months
 from listenbrainz_spark.stats.sitewide.artist import get_artists
 from listenbrainz_spark.utils import get_listens_from_new_dump, get_latest_listen_ts
 from pydantic import ValidationError
@@ -28,13 +26,13 @@ entity_model_map = {
 
 def get_entity_week(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the weekly sitewide top entity """
-    logger.debug("Calculating sitewide_{}_week...".format(entity))
+    logger.debug(f"Calculating sitewide_{entity}_week...")
 
     to_date = get_last_monday(get_latest_listen_ts())
     from_date = offset_days(to_date, 7)
 
     listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = 'sitewide_{}_week'.format(entity)
+    table_name = f'sitewide_{entity}_week'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
@@ -52,33 +50,21 @@ def get_entity_month(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
     logger.debug(f"Calculating sitewide_{entity}_month...")
 
     to_date = get_latest_listen_ts()
-    # Set time to 00:00
-    to_date = datetime(to_date.year, to_date.month, to_date.day)
-    from_date = replace_days(offset_months(to_date, 1, shift_backwards=True), 1)
-    day = from_date
-
-    # Genarate a dataframe containing days of last and current month along with start and end time
-    time_range = []
-    while day < to_date:
-        time_range.append([day.strftime('%d %B %Y'), int(day.timestamp()), int(get_day_end(day).timestamp())])
-        day = offset_days(day, 1, shift_backwards=False)
-
-    time_range_df = listenbrainz_spark.session.createDataFrame(time_range, schema=time_range_schema)
-    time_range_df.createOrReplaceTempView('time_range')
+    from_date = replace_days(to_date, 1)
 
     listens_df = get_listens_from_new_dump(from_date, to_date)
     table_name = f'sitewide_{entity}_month'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
-    data = handler(table_name, "dd MMMM yyyy")
+    data = handler(table_name)
 
-    message = create_message(data=data, entity=entity, stats_range='month',
-                             from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    messages = create_messages(data=data, entity=entity, stats_range='month',
+                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
     logger.debug("Done!")
 
-    return message
+    return messages
 
 
 def get_entity_year(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
@@ -86,30 +72,21 @@ def get_entity_year(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
     logger.debug(f"Calculating sitewide_{entity}_year...")
 
     to_date = get_latest_listen_ts()
-    from_date = datetime(to_date.year-1, 1, 1)
-    month = from_date
-
-    time_range = []
-    # Genarate a dataframe containing months of last and current year along with start and end time
-    while month < to_date:
-        time_range.append([month.strftime('%B %Y'), int(month.timestamp()), int(get_month_end(month).timestamp())])
-        month = offset_months(month, 1, shift_backwards=False)
-
-    time_range_df = listenbrainz_spark.session.createDataFrame(time_range, schema=time_range_schema)
-    time_range_df.createOrReplaceTempView('time_range')
+    from_date = replace_days(replace_months(to_date, 1), 1)
 
     listens_df = get_listens_from_new_dump(from_date, to_date)
     table_name = f'sitewide_{entity}_year'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
-    data = handler(table_name, "MMMM yyyy")
-    message = create_message(data=data, entity=entity, stats_range='year',
-                             from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    data = handler(table_name)
+
+    messages = create_messages(data=data, entity=entity, stats_range='year',
+                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
     logger.debug("Done!")
 
-    return message
+    return messages
 
 
 def get_entity_all_time(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
@@ -119,82 +96,19 @@ def get_entity_all_time(entity: str) -> Optional[List[SitewideEntityStatMessage]
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
 
-    # Generate a dataframe containing years from "from_date" to "to_date"
-    time_range = [
-        [str(year), int(datetime(year, 1, 1).timestamp()), int(get_year_end(year).timestamp())]
-        for year in range(from_date.year, to_date.year + 1)
-    ]
-    time_range_df = listenbrainz_spark.session.createDataFrame(time_range, schema=time_range_schema)
-    time_range_df.createOrReplaceTempView('time_range')
-
     listens_df = get_listens_from_new_dump(from_date, to_date)
     table_name = f'sitewide_{entity}_all_time'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
-    data = handler(table_name, "yyyy")
-    message = create_message(data=data, entity=entity, stats_range='all_time',
-                             from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    data = handler(table_name)
+
+    messages = create_messages(data=data, entity=entity, stats_range='all_time',
+                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
     logger.debug("Done!")
 
-    return message
-
-
-def create_message(data, entity: str, stats_range: str, from_ts: int, to_ts: int) -> Optional[List[SitewideEntityStatMessage]]:
-    """
-    Create message to send the data to the webserver via RabbitMQ
-
-    Args:
-        data (iterator): Data to sent to the webserver
-        entity: The entity for which statistics are calculated, i.e 'artists',
-            'releases' or 'recordings'
-        stats_range: The range for which the statistics have been calculated
-        from_ts: The UNIX timestamp of start time of the stats
-        to_ts: The UNIX timestamp of end time of the stats
-
-    Returns:
-        message: A list of message to be sent via RabbitMQ
-    """
-    message = {
-        'type': 'sitewide_entity',
-        'stats_range': stats_range,
-        'from_ts': from_ts,
-        'to_ts': to_ts,
-        'entity': entity,
-        'data': []
-    }
-
-    for entry in data:
-        _dict = entry.asDict(recursive=True)
-
-        entity_list = []
-        for item in _dict[entity][:1000]:
-            try:
-                model = entity_model_map[entity](**item)
-                entity_list.append(model.dict())
-            except ValidationError:
-                logger.warning("""Invalid entry present in sitewide {stats_range} top {entity} for
-                                        time_range: {time_range}, skipping""".format(stats_range=stats_range, entity=entity,
-                                                                                     time_range=_dict['time_range']))
-
-        message["data"].append({
-            entity: entity_list,
-            "from_ts": _dict["from_ts"],
-            "to_ts": _dict["to_ts"],
-            "time_range": _dict["time_range"]
-        })
-
-    try:
-        model = SitewideEntityStatMessage(**message)
-        result = model.dict(exclude_none=True)
-        return [result]
-    except ValidationError:
-        logger.error("""ValidationError while calculating {stats_range} sitewide top {entity}.
-                                 Data: {data}""".format(stats_range=stats_range, entity=entity,
-                                                        data=json.dumps(message, indent=4)),
-                                 exc_info=True)
-        return None
+    return messages
 
 
 def create_messages(data, entity: str, stats_range: str, from_ts: float, to_ts: float):

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -219,11 +219,12 @@ def create_messages(data, entity: str, stats_range: str, from_ts: float, to_ts: 
         'to_ts': to_ts,
         'entity': entity,
     }
-    entry = next(data)['stats']
-    message['count'] = len(entry)
+    entry = next(data).asDict(recursive=True)
+    stats = entry['stats']
+    message['count'] = len(stats)
 
     entity_list = []
-    for item in entry:
+    for item in stats:
         try:
             entity_list.append(entity_model_map[entity](**item))
         except ValidationError:

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -220,11 +220,10 @@ def create_messages(data, entity: str, stats_range: str, from_ts: float, to_ts: 
         'entity': entity,
     }
     entry = next(data)['stats']
-    _dict = entry.asDict(recursive=True)
     message['count'] = len(entry)
 
     entity_list = []
-    for item in _dict[entity]:
+    for item in entry:
         try:
             entity_list.append(entity_model_map[entity](**item))
         except ValidationError:

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -39,8 +39,8 @@ def get_entity_week(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
 
     handler = entity_handler_map[entity]
     data = handler(table_name)
-    messages = create_message(data=data, entity=entity, stats_range='week',
-                              from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    messages = create_messages(data=data, entity=entity, stats_range='week',
+                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
     logger.debug("Done!")
 

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
@@ -4,8 +4,6 @@ from unittest.mock import MagicMock, patch
 
 from listenbrainz_spark.stats.sitewide import entity
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
-from listenbrainz_spark.stats import (offset_days, offset_months,
-                                      run_query, get_day_end, get_year_end, get_month_end)
 from listenbrainz_spark.stats.user.tests import StatsTestCase
 
 
@@ -17,106 +15,68 @@ class SitewideEntityTestCase(StatsTestCase):
         entity.entity_handler_map['test'] = MagicMock(return_value="sample_test_data")
 
     @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
-    @patch('listenbrainz_spark.stats.sitewide.entity.create_message')
-    def test_get_entity_week(self, mock_create_message, mock_get_listens):
+    @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
+    def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_week('test')
-        from_date = day = datetime(2021, 7, 26)
-        to_date = datetime(2021, 8, 9)
-
-        time_range = []
-        while day < to_date:
-            time_range.append([day.strftime('%A %d %B %Y'), int(day.timestamp()), int(get_day_end(day).timestamp())])
-            day = offset_days(day, 1, shift_backwards=False)
-        time_range_df = run_query("SELECT * FROM time_range")
-        time_range_result = time_range_df.rdd.map(list).collect()
-        self.assertListEqual(time_range_result, time_range)
-
-        mock_get_listens.assert_called_with(from_date, to_date)
-        mock_create_message.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
-                                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
-
-    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
-    @patch('listenbrainz_spark.stats.sitewide.entity.create_message')
-    def test_get_entity_month(self, mock_create_message, mock_get_listens):
-        entity.get_entity_month('test')
-        from_date = datetime(2021, 7, 1)
-        to_date = datetime(2021, 8, 9)
-        day = from_date
-
-        time_range = []
-        while day < to_date:
-            time_range.append([day.strftime('%d %B %Y'), int(day.timestamp()), int(get_day_end(day).timestamp())])
-            day = offset_days(day, 1, shift_backwards=False)
-        time_range_df = run_query("SELECT * FROM time_range")
-        time_range_result = time_range_df.rdd.map(list).collect()
-        self.assertListEqual(time_range_result, time_range)
-
-        mock_get_listens.assert_called_with(from_date, to_date)
-        mock_create_message.assert_called_with(data='sample_test_data', entity='test', stats_range='month',
-                                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
-
-    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
-    @patch('listenbrainz_spark.stats.sitewide.entity.create_message')
-    def test_get_entity_year(self, mock_create_message, mock_get_listens):
-        entity.get_entity_year('test')
-        from_date = datetime(2020, 1, 1)
+        from_date = day = datetime(2021, 8, 2, 12, 22, 43)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
-        month = from_date
-
-        time_range = []
-        while month < to_date:
-            time_range.append([month.strftime('%B %Y'), int(month.timestamp()), int(get_month_end(month).timestamp())])
-            month = offset_months(month, 1, shift_backwards=False)
-        time_range_df = run_query("SELECT * FROM time_range")
-        time_range_result = time_range_df.rdd.map(list).collect()
-        self.assertListEqual(time_range_result, time_range)
-
         mock_get_listens.assert_called_with(from_date, to_date)
-        mock_create_message.assert_called_with(data='sample_test_data', entity='test', stats_range='year',
-                                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+        mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
+                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
     @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
-    @patch('listenbrainz_spark.stats.sitewide.entity.create_message')
-    def test_get_entity_all_time(self, mock_create_message, mock_get_listens):
+    @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
+    def test_get_entity_month(self, mock_create_messages, mock_get_listens):
+        entity.get_entity_month('test')
+        from_date = datetime(2021, 8, 1, 12, 22, 43)
+        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        mock_get_listens.assert_called_with(from_date, to_date)
+        mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='month',
+                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+
+    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
+    def test_get_entity_year(self, mock_create_messages, mock_get_listens):
+        entity.get_entity_year('test')
+        from_date = datetime(2021, 1, 1, 12, 22, 43)
+        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        mock_get_listens.assert_called_with(from_date, to_date)
+        mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='year',
+                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+
+    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
+    def test_get_entity_all_time(self, mock_create_messages, mock_get_listens):
         entity.get_entity_all_time('test')
         from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
-
-        time_range = [
-            [str(year), int(datetime(year, 1, 1).timestamp()), int(get_year_end(year).timestamp())]
-            for year in range(from_date.year, to_date.year + 1)
-        ]
-        time_range_df = run_query("SELECT * FROM time_range")
-        time_range_result = time_range_df.rdd.map(list).collect()
-        self.assertListEqual(time_range_result, time_range)
-
         mock_get_listens.assert_called_with(from_date, to_date)
-        mock_create_message.assert_called_with(data='sample_test_data', entity='test', stats_range='all_time',
-                                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+        mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='all_time',
+                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    def test_create_message(self):
-        """ Test to check if the number of entities are clipped to top 1000 """
-        artists = []
-        for i in range(0, 2000):
-            artists.append({
-                'artist_name': 'artist_{}'.format(i),
-                'artist_mbids': [str(i)],
-                'listen_count': i
-            })
-
-        mock_result = MagicMock()
-        mock_result.asDict.return_value = {
-            'time_range': "range",
-            'artists': artists,
-            'from_ts': 0,
-            'to_ts': 1
-        }
-
-        message = entity.create_message([mock_result], 'artists', 'all_time', 0, 10)
-
-        expected_list = artists[:1000]
-        received_list = message[0]['data'][0]['artists']
-        self.assertListEqual(received_list, expected_list)
+    # def test_create_message(self):
+    #     """ Test to check if the number of entities are clipped to top 1000 """
+    #     artists = []
+    #     for i in range(0, 2000):
+    #         artists.append({
+    #             'artist_name': 'artist_{}'.format(i),
+    #             'artist_mbids': [str(i)],
+    #             'listen_count': i
+    #         })
+    #
+    #     mock_result = MagicMock()
+    #     mock_result.asDict.return_value = {
+    #         'time_range': "range",
+    #         'artists': artists,
+    #         'from_ts': 0,
+    #         'to_ts': 1
+    #     }
+    #
+    #     message = entity.create_messages(iter([mock_result]), 'artists', 'all_time', 0, 10)
+    #
+    #     expected_list = artists[:1000]
+    #     received_list = message[0]['data'][0]['artists']
+    #     self.assertListEqual(received_list, expected_list)
 
     def test_skip_incorrect_artists_stats(self):
         """ Test to check if entries with incorrect data is skipped for top sitewide artists """
@@ -126,8 +86,7 @@ class SitewideEntityTestCase(StatsTestCase):
         mock_result = MagicMock()
         mock_result.asDict.return_value = data
 
-        message = entity.create_message([mock_result], 'artists', 'all_time', 0, 10)
-        received_list = message[0]['data'][0]['artists']
+        message = entity.create_messages(iter([mock_result]), 'artists', 'all_time', 0, 10)
 
         # Only the first entry in file is valid, all others must be skipped
-        self.assertListEqual(data['artists'][:1], received_list)
+        self.assertListEqual(data['stats'][:1], message[0]['data'])

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
@@ -54,30 +54,6 @@ class SitewideEntityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='all_time',
                                                 from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
 
-    # def test_create_message(self):
-    #     """ Test to check if the number of entities are clipped to top 1000 """
-    #     artists = []
-    #     for i in range(0, 2000):
-    #         artists.append({
-    #             'artist_name': 'artist_{}'.format(i),
-    #             'artist_mbids': [str(i)],
-    #             'listen_count': i
-    #         })
-    #
-    #     mock_result = MagicMock()
-    #     mock_result.asDict.return_value = {
-    #         'time_range': "range",
-    #         'artists': artists,
-    #         'from_ts': 0,
-    #         'to_ts': 1
-    #     }
-    #
-    #     message = entity.create_messages(iter([mock_result]), 'artists', 'all_time', 0, 10)
-    #
-    #     expected_list = artists[:1000]
-    #     received_list = message[0]['data'][0]['artists']
-    #     self.assertListEqual(received_list, expected_list)
-
     def test_skip_incorrect_artists_stats(self):
         """ Test to check if entries with incorrect data is skipped for top sitewide artists """
         with open(self.path_to_data_file('sitewide_top_artists_incorrect.json')) as f:

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -10,8 +10,7 @@ from data.model.user_artist_stat import UserArtistRecord
 from data.model.user_release_stat import UserReleaseRecord
 from data.model.user_recording_stat import UserRecordingRecord
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
-from listenbrainz_spark.stats import (offset_days, replace_days,
-                                      replace_months, run_query, get_last_monday)
+from listenbrainz_spark.stats import offset_days, replace_days, replace_months, get_last_monday
 from listenbrainz_spark.stats.user.artist import get_artists
 from listenbrainz_spark.stats.user.recording import get_recordings
 from listenbrainz_spark.stats.user.release import get_releases
@@ -34,13 +33,13 @@ entity_model_map = {
 
 def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the weekly top entity for all users """
-    logger.debug("Calculating {}_week...".format(entity))
+    logger.debug(f"Calculating {entity}_week...")
 
     to_date = get_last_monday(get_latest_listen_ts())
     from_date = offset_days(to_date, 7)
 
     listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = 'user_{}_week'.format(entity)
+    table_name = f'user_{entity}_week'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
@@ -55,13 +54,13 @@ def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
 
 def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the month top entity for all users """
-    logger.debug("Calculating {}_month...".format(entity))
+    logger.debug(f"Calculating {entity}_month...")
 
     to_date = get_latest_listen_ts()
     from_date = replace_days(to_date, 1)
 
     listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = 'user_{}_month'.format(entity)
+    table_name = f'user_{entity}_month'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
@@ -77,13 +76,13 @@ def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
 
 def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the year top entity for all users """
-    logger.debug("Calculating {}_year...".format(entity))
+    logger.debug(f"Calculating {entity}_year...")
 
     to_date = get_latest_listen_ts()
     from_date = replace_days(replace_months(to_date, 1), 1)
 
     listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = 'user_{}_year'.format(entity)
+    table_name = f'user_{entity}_year'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
@@ -98,13 +97,13 @@ def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
 
 def get_entity_all_time(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the all_time top entity for all users """
-    logger.debug("Calculating {}_all_time...".format(entity))
+    logger.debug(f"Calculating {entity}_all_time...")
 
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
 
     listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = 'user_{}_all_time'.format(entity)
+    table_name = f'user_{entity}_all_time'
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]

--- a/listenbrainz_spark/testdata/sitewide_top_artists_incorrect.json
+++ b/listenbrainz_spark/testdata/sitewide_top_artists_incorrect.json
@@ -1,22 +1,19 @@
 {
-  "time_range": "range",
-  "to_ts": 0,
-  "from_ts": 1,
-  "artists": [
-    {
-      "artist_name": "artist_1",
-      "artist_mbids": [],
-      "listen_count": 1
-    },
-    {
-      "artist_name": null,
-      "artist_mbids": [],
-      "listen_count": 1
-    },
-    {
-      "artist_name": "artist_2",
-      "artist_mbids": [],
-      "listen_count": null
-    }
-  ]
+    "stats": [
+        {
+          "artist_name": "artist_1",
+          "artist_mbids": [],
+          "listen_count": 1
+        },
+        {
+          "artist_name": null,
+          "artist_mbids": [],
+          "listen_count": 1
+        },
+        {
+          "artist_name": "artist_2",
+          "artist_mbids": [],
+          "listen_count": null
+        }
+    ]
 }

--- a/listenbrainz_spark/testdata/sitewide_top_artists_output.json
+++ b/listenbrainz_spark/testdata/sitewide_top_artists_output.json
@@ -5,268 +5,255 @@
         "stats_range": "all_time",
         "from_ts": 1009843200,
         "to_ts": 1628511763,
+        "count": 36,
         "data": [
             {
-                "to_ts": 1609459199,
-                "from_ts": 1577836800,
-                "time_range": "2020",
-                "artists": [
-                    {
-                        "artist_mbids": [
-                            "6fe91ae9-8ddb-47b0-a2d7-252833ce5500"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "The Egg"
-                    },
-                    {
-                        "artist_mbids": [
-                            "3252542b-98a7-48ba-9861-7a612b16c227"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Kiasmos"
-                    },
-                    {
-                        "artist_mbids": [
-                            "904cc1c8-021e-45ac-bbe9-95c01a1f8099",
-                            "3f9b5837-ed1c-413e-bfef-ca4f892dcc59"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Jah Wobble, Marconi Union"
-                    },
-                    {
-                        "artist_mbids": [
-                            "53d2a4d1-556e-4701-a8ac-5fcb74a8e393"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "All India Radio"
-                    }
-                ]
+                "artist_mbids": [
+                    "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+                ],
+                "listen_count": 6,
+                "artist_name": "Portishead"
             },
             {
-                "to_ts": 1640995199,
-                "from_ts": 1609459200,
-                "time_range": "2021",
-                "artists": [
-                    {
-                        "artist_mbids": [
-                            "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
-                        ],
-                        "listen_count": 6,
-                        "artist_name": "Portishead"
-                    },
-                    {
-                        "artist_mbids": [
-                            "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
-                        ],
-                        "listen_count": 5,
-                        "artist_name": "Massive Attack"
-                    },
-                    {
-                        "artist_mbids": [],
-                        "listen_count": 5,
-                        "artist_name": "Lucifer Cast, Tom Ellis"
-                    },
-                    {
-                        "artist_mbids": [
-                            "5586fc31-7c41-4a2d-97a2-d358b58b250d"
-                        ],
-                        "listen_count": 5,
-                        "artist_name": "Klergy"
-                    },
-                    {
-                        "artist_mbids": [
-                            "122d63fc-8671-43e4-9752-34e846d62a9c"
-                        ],
-                        "listen_count": 5,
-                        "artist_name": "Katy Perry"
-                    },
-                    {
-                        "artist_mbids": [
-                            "b014d579-b549-4b21-b90d-5264e0433988"
-                        ],
-                        "listen_count": 4,
-                        "artist_name": "Romare"
-                    },
-                    {
-                        "artist_mbids": [],
-                        "listen_count": 4,
-                        "artist_name": "Future, Marshmello"
-                    },
-                    {
-                        "artist_mbids": [
-                            "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
-                        ],
-                        "listen_count": 4,
-                        "artist_name": "Aether"
-                    },
-                    {
-                        "artist_mbids": [
-                            "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
-                        ],
-                        "listen_count": 3,
-                        "artist_name": "Vangelis"
-                    },
-                    {
-                        "artist_mbids": [
-                            "78c94cba-761f-4212-8508-a24bda2e57dc"
-                        ],
-                        "listen_count": 3,
-                        "artist_name": "Little People"
-                    },
-                    {
-                        "artist_mbids": [
-                            "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"
-                        ],
-                        "listen_count": 3,
-                        "artist_name": "Jon Bellion"
-                    },
-                    {
-                        "artist_mbids": [
-                            "cf15719f-51f9-4db8-a15d-5eed9664ce69",
-                            "f116b984-45ae-49d0-9445-efc5a61458a1"
-                        ],
-                        "listen_count": 3,
-                        "artist_name": "Guy Sebastian, Lupe Fiasco"
-                    },
-                    {
-                        "artist_mbids": [
-                            "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
-                        ],
-                        "listen_count": 3,
-                        "artist_name": "Brazilian Girls"
-                    },
-                    {
-                        "artist_mbids": [
-                            "859d0860-d480-4efd-970c-c05d5f1776b8"
-                        ],
-                        "listen_count": 3,
-                        "artist_name": "Beyonc\u00e9"
-                    },
-                    {
-                        "artist_mbids": [
-                            "298f4089-1948-44b5-b5e8-d5381f42362f"
-                        ],
-                        "listen_count": 2,
-                        "artist_name": "X Ambassadors"
-                    },
-                    {
-                        "artist_mbids": [
-                            "93cfee41-b1a6-4604-a01c-91243e6926e6",
-                            "43736f76-419a-42a0-816a-830876647ba5"
-                        ],
-                        "listen_count": 2,
-                        "artist_name": "Ursine Vulpine, Annaca"
-                    },
-                    {
-                        "artist_mbids": [
-                            "e9787dd2-5857-4b51-8e59-a190a54820fc"
-                        ],
-                        "listen_count": 2,
-                        "artist_name": "The Polish Ambassador"
-                    },
-                    {
-                        "artist_mbids": [
-                            "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
-                        ],
-                        "listen_count": 2,
-                        "artist_name": "Olivia Rodrigo"
-                    },
-                    {
-                        "artist_mbids": [],
-                        "listen_count": 2,
-                        "artist_name": "Kalabi"
-                    },
-                    {
-                        "artist_mbids": [
-                            "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"
-                        ],
-                        "listen_count": 2,
-                        "artist_name": "Dua Lipa"
-                    },
-                    {
-                        "artist_mbids": [],
-                        "listen_count": 2,
-                        "artist_name": "Bo Burnham"
-                    },
-                    {
-                        "artist_mbids": [
-                            "9806e551-9a63-4a9d-be1b-5297b2ac0e76"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Sounds From The Ground"
-                    },
-                    {
-                        "artist_mbids": [
-                            "4f29ecd7-21a5-4c03-b9ba-d0cfe9488f8c",
-                            "bf24ca37-25f4-4e34-9aec-460b94364cfc"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Shakira"
-                    },
-                    {
-                        "artist_mbids": [
-                            "1a40f886-0877-4bab-9ab1-761147dadb89"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Ott"
-                    },
-                    {
-                        "artist_mbids": [
-                            "f1106b17-dcbb-45f6-b938-199ccfab50cc"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "New Order"
-                    },
-                    {
-                        "artist_mbids": [
-                            "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8",
-                            "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Massive Attack, Tracey Thorn"
-                    },
-                    {
-                        "artist_mbids": [
-                            "78c94cba-761f-4212-8508-a24bda2e57dc",
-                            "bd43cb68-3a68-429e-9aad-6fc512f7df71"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Little People, Rachael Roberts"
-                    },
-                    {
-                        "artist_mbids": [
-                            "7eb1ce54-a355-41f9-8d68-e018b096d427"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Harry Styles"
-                    },
-                    {
-                        "artist_mbids": [
-                            "056e4f3e-d505-4dad-8ec1-d04f521cbb56"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Daft Punk"
-                    },
-                    {
-                        "artist_mbids": [],
-                        "listen_count": 1,
-                        "artist_name": "Brazilian Girls"
-                    },
-                    {
-                        "artist_mbids": [
-                            "a8b39181-6939-451e-9641-2db231b73706"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "Abakus"
-                    },
-                    {
-                        "artist_mbids": [
-                            "603ba565-3967-4be1-931e-9cb945394e86"
-                        ],
-                        "listen_count": 1,
-                        "artist_name": "*NSYNC"
-                    }
-                ]
+                "artist_mbids": [],
+                "listen_count": 5,
+                "artist_name": "Lucifer Cast, Tom Ellis"
+            },
+            {
+                "artist_mbids": [
+                    "5586fc31-7c41-4a2d-97a2-d358b58b250d"
+                ],
+                "listen_count": 5,
+                "artist_name": "Klergy"
+            },
+            {
+                "artist_mbids": [
+                    "122d63fc-8671-43e4-9752-34e846d62a9c"
+                ],
+                "listen_count": 5,
+                "artist_name": "Katy Perry"
+            },
+            {
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+                ],
+                "listen_count": 5,
+                "artist_name": "Massive Attack"
+            },
+            {
+                "artist_mbids": [],
+                "listen_count": 4,
+                "artist_name": "Future, Marshmello"
+            },
+            {
+                "artist_mbids": [
+                    "b014d579-b549-4b21-b90d-5264e0433988"
+                ],
+                "listen_count": 4,
+                "artist_name": "Romare"
+            },
+            {
+                "artist_mbids": [
+                    "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
+                ],
+                "listen_count": 4,
+                "artist_name": "Aether"
+            },
+            {
+                "artist_mbids": [
+                    "cf15719f-51f9-4db8-a15d-5eed9664ce69",
+                    "f116b984-45ae-49d0-9445-efc5a61458a1"
+                ],
+                "listen_count": 3,
+                "artist_name": "Guy Sebastian, Lupe Fiasco"
+            },
+            {
+                "artist_mbids": [
+                    "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
+                ],
+                "listen_count": 3,
+                "artist_name": "Brazilian Girls"
+            },
+            {
+                "artist_mbids": [
+                    "859d0860-d480-4efd-970c-c05d5f1776b8"
+                ],
+                "listen_count": 3,
+                "artist_name": "Beyonc\u00e9"
+            },
+            {
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc"
+                ],
+                "listen_count": 3,
+                "artist_name": "Little People"
+            },
+            {
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "listen_count": 3,
+                "artist_name": "Vangelis"
+            },
+            {
+                "artist_mbids": [
+                    "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"
+                ],
+                "listen_count": 3,
+                "artist_name": "Jon Bellion"
+            },
+            {
+                "artist_mbids": [],
+                "listen_count": 2,
+                "artist_name": "Kalabi"
+            },
+            {
+                "artist_mbids": [
+                    "298f4089-1948-44b5-b5e8-d5381f42362f"
+                ],
+                "listen_count": 2,
+                "artist_name": "X Ambassadors"
+            },
+            {
+                "artist_mbids": [
+                    "93cfee41-b1a6-4604-a01c-91243e6926e6",
+                    "43736f76-419a-42a0-816a-830876647ba5"
+                ],
+                "listen_count": 2,
+                "artist_name": "Ursine Vulpine, Annaca"
+            },
+            {
+                "artist_mbids": [
+                    "e9787dd2-5857-4b51-8e59-a190a54820fc"
+                ],
+                "listen_count": 2,
+                "artist_name": "The Polish Ambassador"
+            },
+            {
+                "artist_mbids": [],
+                "listen_count": 2,
+                "artist_name": "Bo Burnham"
+            },
+            {
+                "artist_mbids": [
+                    "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
+                ],
+                "listen_count": 2,
+                "artist_name": "Olivia Rodrigo"
+            },
+            {
+                "artist_mbids": [
+                    "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"
+                ],
+                "listen_count": 2,
+                "artist_name": "Dua Lipa"
+            },
+            {
+                "artist_mbids": [],
+                "listen_count": 1,
+                "artist_name": "Brazilian Girls"
+            },
+            {
+                "artist_mbids": [
+                    "a8b39181-6939-451e-9641-2db231b73706"
+                ],
+                "listen_count": 1,
+                "artist_name": "Abakus"
+            },
+            {
+                "artist_mbids": [
+                    "f1106b17-dcbb-45f6-b938-199ccfab50cc"
+                ],
+                "listen_count": 1,
+                "artist_name": "New Order"
+            },
+            {
+                "artist_mbids": [
+                    "056e4f3e-d505-4dad-8ec1-d04f521cbb56"
+                ],
+                "listen_count": 1,
+                "artist_name": "Daft Punk"
+            },
+            {
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8",
+                    "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f"
+                ],
+                "listen_count": 1,
+                "artist_name": "Massive Attack, Tracey Thorn"
+            },
+            {
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc",
+                    "bd43cb68-3a68-429e-9aad-6fc512f7df71"
+                ],
+                "listen_count": 1,
+                "artist_name": "Little People, Rachael Roberts"
+            },
+            {
+                "artist_mbids": [
+                    "603ba565-3967-4be1-931e-9cb945394e86"
+                ],
+                "listen_count": 1,
+                "artist_name": "*NSYNC"
+            },
+            {
+                "artist_mbids": [
+                    "7eb1ce54-a355-41f9-8d68-e018b096d427"
+                ],
+                "listen_count": 1,
+                "artist_name": "Harry Styles"
+            },
+            {
+                "artist_mbids": [
+                    "4f29ecd7-21a5-4c03-b9ba-d0cfe9488f8c",
+                    "bf24ca37-25f4-4e34-9aec-460b94364cfc"
+                ],
+                "listen_count": 1,
+                "artist_name": "Shakira"
+            },
+            {
+                "artist_mbids": [
+                    "9806e551-9a63-4a9d-be1b-5297b2ac0e76"
+                ],
+                "listen_count": 1,
+                "artist_name": "Sounds From The Ground"
+            },
+            {
+                "artist_mbids": [
+                    "1a40f886-0877-4bab-9ab1-761147dadb89"
+                ],
+                "listen_count": 1,
+                "artist_name": "Ott"
+            },
+            {
+                "artist_mbids": [
+                    "3252542b-98a7-48ba-9861-7a612b16c227"
+                ],
+                "listen_count": 1,
+                "artist_name": "Kiasmos"
+            },
+            {
+                "artist_mbids": [
+                    "904cc1c8-021e-45ac-bbe9-95c01a1f8099",
+                    "3f9b5837-ed1c-413e-bfef-ca4f892dcc59"
+                ],
+                "listen_count": 1,
+                "artist_name": "Jah Wobble, Marconi Union"
+            },
+            {
+                "artist_mbids": [
+                    "6fe91ae9-8ddb-47b0-a2d7-252833ce5500"
+                ],
+                "listen_count": 1,
+                "artist_name": "The Egg"
+            },
+            {
+                "artist_mbids": [
+                    "53d2a4d1-556e-4701-a8ac-5fcb74a8e393"
+                ],
+                "listen_count": 1,
+                "artist_name": "All India Radio"
             }
         ]
     }


### PR DESCRIPTION
Migrate sitewide stats to new table and store as a special user's stats to simplify handling.

The PR also changes the structure of sitewide stats's API response but these stats haven't been generated since a year so it is unlikely any user is using this API. Hence, this change should be fine.