### PR TITLE
Refactor ListenCard component

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -199,7 +199,6 @@
 	}
 	
 	> div {
-		padding: 0 1em;
 		display: flex;
 		flex:1;
 	}
@@ -213,7 +212,8 @@
 		flex-direction: column;
 		justify-content: center;
 		align-items: flex-end;
-		flex-basis: 60px;
+		// flex-basis: 60px;
+		padding-right: 1em;
 	}
 	
 	.listen-details{
@@ -222,18 +222,20 @@
 		max-width: 100%;
 		
 		
-		> * {
+		.artist-and-timestamp {
 			display: flex;
-    flex-flow: column;
+			flex-wrap: wrap;
+		}
+		.ellipsis {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space:nowrap;
-			margin-bottom: 0px;
 		}
 	}
 	
 	.listen-controls-container {
-		max-width: 150px;
+		max-width: 110px;
+    	min-width: 110px;
 		> * {
 			flex: 1;
 			align-self: center;

--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -7,436 +7,431 @@
 @player-min-height: 320px;
 
 #music-player {
-  position: relative;
-  margin: auto;
-  width: 100%;
-  max-width: 500px;
-  min-height: @player-min-height;
-  border-radius: 5px;
-  overflow: hidden;
-  box-shadow: 5px 5px 15px fadeout(@dark, 60%);
-  
-  .info {
-    width: 100%;
-    position: absolute;
-    z-index: 2;
-    transition: all .5s ease;
-  }
-  .info:not(.showControls){
-    bottom: -@controlsHeight;
-  }
-  &:hover .info, .info.showControls{
-    bottom:0;
-    .currently-playing .progress{
-      height: 0.6em;
-    }
-  }
-  
-
-  
-  .currently-playing {
-    text-align: center;
-    padding-top: 10px;
-    background: fadeout(@white, 15%);
-    .song-name, .artist-name {
-      text-transform: uppercase;
-      font-weight: 400;
-      margin: 0;
-    }
-    
-    .song-name {
-      font-size: 1.2em;
-      letter-spacing: 2px;
-      color: @dark;
-    }
-    
-    .artist-name {
-      font-size: .8em;
-      letter-spacing: 1.5px;
-      color: lighten(@dark, 15%);
-      margin: 5px 0;
-    }
-    /** Progress **/
-    .progress {
-      height: 0.3em;
-      background-color: rgba(205, 235, 255, 0.2);
-      border: 0.5px solid fadeout(@dark,70%);
-      border-right: 0;
-      border-left: 0;
-    }
-
-    .progress-bar {
-      height: 100%;
-      background-color: @primary;
-      border-right: 1px solid @dark;
-    }
-  }
-  
-  
-  .controls {
-    background: fadeout(@white, 40%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: @secondary;
-    font-size: 1.5em;
-    height: @controlsHeight;
-    .play {
-      color: darken(@secondary, 10%);
-      font-size: 1em;
-    }
-    > *:not(.play){
-      font-size: .8em;
-    }
-    > * {
-      transition: all .5s ease;
-      background: none;
-      &:hover {
-        color: lighten(@dark, 15%);
-      }
-    }
-    .right{
-      position: absolute;
-      right: 10px;
-    }
-    .left{
-      position: absolute;
-      left: 10px;
-    }
-  }
-
-  .content {
-    position:relative;
-    > *:not(.no-album-art){
-      position: relative;
-      z-index: 1;
-    }
-	.connect-services-message{
-		z-index: 2;
-		text-align: center;
+	position: relative;
+	margin: auto;
+	width: 100%;
+	max-width: 500px;
+	min-height: @player-min-height;
+	border-radius: 5px;
+	overflow: hidden;
+	box-shadow: 5px 5px 15px fadeout(@dark, 60%);
+	
+	.info {
+		width: 100%;
 		position: absolute;
-		top: 0;
-		background: #ffffffd9;
-		padding: 1em;
+		z-index: 2;
+		transition: all .5s ease;
 	}
-    // Youtube iframe
-    .youtube {
-      padding-top: 100%;
-      position: relative;
-      iframe {
-        position: absolute;
-        top: 0;
-        left: 0;
-      }
-    }
-    .no-album-art{
-      position: absolute;
-      top: 0;
-      min-height: @player-min-height;
-      min-width: 100%;
-      background-image: url(../img/logo_big.svg);
-      background-repeat: no-repeat;
-      background-position: center top;
-      background-color: aliceblue;
-      opacity: 0.3;
-      text-align: center;
-    }
-}
-  
+	.info:not(.showControls){
+		bottom: -@controlsHeight;
+	}
+	&:hover .info, .info.showControls{
+		bottom:0;
+		.currently-playing .progress{
+			height: 0.6em;
+		}
+	}
+	
+	
+	
+	.currently-playing {
+		text-align: center;
+		padding-top: 10px;
+		background: fadeout(@white, 15%);
+		.song-name, .artist-name {
+			text-transform: uppercase;
+			font-weight: 400;
+			margin: 0;
+		}
+		
+		.song-name {
+			font-size: 1.2em;
+			letter-spacing: 2px;
+			color: @dark;
+		}
+		
+		.artist-name {
+			font-size: .8em;
+			letter-spacing: 1.5px;
+			color: lighten(@dark, 15%);
+			margin: 5px 0;
+		}
+		/** Progress **/
+		.progress {
+			height: 0.3em;
+			background-color: rgba(205, 235, 255, 0.2);
+			border: 0.5px solid fadeout(@dark,70%);
+			border-right: 0;
+			border-left: 0;
+		}
+		
+		.progress-bar {
+			height: 100%;
+			background-color: @primary;
+			border-right: 1px solid @dark;
+		}
+	}
+	
+	
+	.controls {
+		background: fadeout(@white, 40%);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: @secondary;
+		font-size: 1.5em;
+		height: @controlsHeight;
+		.play {
+			color: darken(@secondary, 10%);
+			font-size: 1em;
+		}
+		> *:not(.play){
+			font-size: .8em;
+		}
+		> * {
+			transition: all .5s ease;
+			background: none;
+			&:hover {
+				color: lighten(@dark, 15%);
+			}
+		}
+		.right{
+			position: absolute;
+			right: 10px;
+		}
+		.left{
+			position: absolute;
+			left: 10px;
+		}
+	}
+	
+	.content {
+		position:relative;
+		> *:not(.no-album-art){
+			position: relative;
+			z-index: 1;
+		}
+		.connect-services-message{
+			z-index: 2;
+			text-align: center;
+			position: absolute;
+			top: 0;
+			background: #ffffffd9;
+			padding: 1em;
+		}
+		// Youtube iframe
+		.youtube {
+			padding-top: 100%;
+			position: relative;
+			iframe {
+				position: absolute;
+				top: 0;
+				left: 0;
+			}
+		}
+		.no-album-art{
+			position: absolute;
+			top: 0;
+			min-height: @player-min-height;
+			min-width: 100%;
+			background-image: url(../img/logo_big.svg);
+			background-repeat: no-repeat;
+			background-position: center top;
+			background-color: aliceblue;
+			opacity: 0.3;
+			text-align: center;
+		}
+	}
+	
 }
 
 
 .listens-table > tbody {
-  
-  > tr {
-    &.playing_now {
-      background-color: #fffcca ;
-    }
-    & > td {
-      vertical-align: middle;
-      &.playButton {
-        padding: 0;
-        & > * {
-          font-size: 1.2em;
-          padding-top: 0;
-          padding-bottom: 0;
-          opacity: 0;
-          transition: opacity .3s ease-in-out;
-        }
-      }
-    }
-
-    &:hover > td.playButton > *{
-      opacity: 1;
-    }
-  }
+	
+	> tr {
+		&.playing_now {
+			background-color: #fffcca ;
+		}
+		& > td {
+			vertical-align: middle;
+			&.playButton {
+				padding: 0;
+				& > * {
+					font-size: 1.2em;
+					padding-top: 0;
+					padding-bottom: 0;
+					opacity: 0;
+					transition: opacity .3s ease-in-out;
+				}
+			}
+		}
+		
+		&:hover > td.playButton > *{
+			opacity: 1;
+		}
+	}
 }
 
 #listens {
-  @media (min-width: @screen-phone) {
-    padding: 10px;
-  }
-  
-  .listen-card {
-    padding: 10px 5px;
-    @media (min-width: @screen-phone) {
-      padding: 15px;
-    }
-    margin-bottom: 7px;
-    max-height: 72px;
-    
-    &.playing-now {
-      background-color: rgba(255, 252, 202, 0.3) !important ;
-    }
-    
-    &.current-listen {
-      background-color: rgba(217, 237, 247, 0.3) !important ;
-      .play-button {
-        opacity: 1;
-      }
-    }
-
-    > div {
-      padding: 0px;
-    }
-
-    .track-details {
-      width: 100%;
-
-      p {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space:nowrap;
-        margin-bottom: 0px;
-      }
-    }
-    .listen-time {
-      font-style: italic;
-    }
-    
-    > .listen-details, .col-xs-9, .col-xs-12 {
-
-      > .col-xs-8, .col-xs-12 {
-        display: flex;
-      }
-
-      > .col-xs-4 {
-        display: table;
-        height: 40px;
-
-        > span {
-          display: table-cell;
-          vertical-align: middle;
-        }
-      }
-
-    }
-
-    
-    > .listen-controls-container {
-      height:40px;
-      display: flex;
-      justify-content: flex-end;
-
-      > * {
-        flex: 1;
-        align-self: center;
-      }
-
-      a {
-        word-break: break-word;
-      }
-
-    }
-    
-    .listen-controls {
-      max-width:150px;
-      display: flex;
-      flex-wrap: nowrap;
-      align-content: center;
-      align-items: center;
-      > * {
-        flex:1;
-      }
-      
-      > svg:hover {
-        cursor: pointer;
-      }
-
-      .fa-heart, .fa-heart-broken, .fa-ellipsis-v {
-        stroke-width: 40px;
-        font-size: 18px;
-        margin: 0% 7%;
-        width: 1em;
-      }
-
-      .fa-heart, .fa-heart-broken {
-        color: transparent;
-        stroke: #8d8d8d;
-      }
-
-      .fa-ellipsis-v {
-        color: #8d8d8d;
-        stroke: #ffffff;
-
-        &:hover {
-          color: #46433a;
-        }
-      }
-
-      .fa-heart {
-
-        &:hover {
-          stroke: @love;
-        }
-
-        &.loved {
-          stroke: transparent;
-          color: @love;
-        }
-      }
-        
-      .fa-heart-broken {
-
-        &:hover {
-          stroke: @hate;
-        }
-
-        &.hated {
-          stroke: transparent;
-          color: @hate;
-        }
-      }
-
-      .dropdown-menu {
-        min-width: 140px;
-        border-radius: 4px;
-        padding: 10px 0px;
-        width: 250px;
-
-        button {
-          width: 100%;
-          background: none;
-          color: inherit;
-          border: none;
-          padding: 5px 20px;
-          font: inherit;
-          cursor: pointer;
-          outline: inherit;
-          text-align: left;
-
-          &:hover {
-            color: #ffffff;
-            background-color: #eb743b;
-          }
-        }
-      }
-    }
-
-    .play-button {
-      padding: 0;
-      color: #8d8d8d;
-    }
-	// If the user has an input method compatible with hoering (f.e. a mouse)
+	@media (min-width: @screen-phone) {
+		padding: 10px;
+	}
+}
+.listen-card {
+	padding: 10px 5px;
+	@media (min-width: @screen-phone) {
+		padding: 15px;
+	}
+	margin-bottom: 7px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: end;
+	
+	&.playing-now {
+		background-color: rgba(255, 252, 202, 0.3) !important ;
+	}
+	
+	&.current-listen {
+		background-color: rgba(217, 237, 247, 0.3) !important ;
+		.play-button {
+			opacity: 1;
+		}
+	}
+	
+	> div {
+		padding: 0 1em;
+		display: flex;
+		flex:1;
+	}
+	
+	
+	.listen-time {
+		font-style: italic;
+		&:extend(.text-muted);
+	}
+	.username-and-timestamp{
+		flex-direction: column;
+		justify-content: center;
+		align-items: flex-end;
+		flex-basis: 60px;
+	}
+	
+	.listen-details{
+		flex: 3;
+		flex-direction: column;
+		max-width: 100%;
+		
+		
+		> * {
+			display: flex;
+    flex-flow: column;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space:nowrap;
+			margin-bottom: 0px;
+		}
+	}
+	
+	.listen-controls-container {
+		max-width: 150px;
+		> * {
+			flex: 1;
+			align-self: center;
+		}
+		
+		a {
+			word-break: break-word;
+		}
+		
+	}
+	
+	.listen-controls {
+		max-width:150px;
+		display: flex;
+		flex-wrap: nowrap;
+		align-content: center;
+		align-items: center;
+		> * {
+			flex:1;
+		}
+		
+		> svg:hover {
+			cursor: pointer;
+		}
+		
+		.fa-heart, .fa-heart-broken, .fa-ellipsis-v {
+			stroke-width: 40px;
+			font-size: 18px;
+			margin: 0% 7%;
+			width: 1em;
+		}
+		
+		.fa-heart, .fa-heart-broken {
+			color: transparent;
+			stroke: #8d8d8d;
+		}
+		
+		.fa-ellipsis-v {
+			color: #8d8d8d;
+			stroke: #ffffff;
+			
+			&:hover {
+				color: #46433a;
+			}
+		}
+		
+		.fa-heart {
+			
+			&:hover {
+				stroke: @love;
+			}
+			
+			&.loved {
+				stroke: transparent;
+				color: @love;
+			}
+		}
+		
+		.fa-heart-broken {
+			
+			&:hover {
+				stroke: @hate;
+			}
+			
+			&.hated {
+				stroke: transparent;
+				color: @hate;
+			}
+		}
+		
+		.dropdown-menu {
+			min-width: 140px;
+			border-radius: 4px;
+			padding: 10px 0px;
+			width: 250px;
+			
+			button {
+				width: 100%;
+				background: none;
+				color: inherit;
+				border: none;
+				padding: 5px 20px;
+				font: inherit;
+				cursor: pointer;
+				outline: inherit;
+				text-align: left;
+				
+				&:hover {
+					color: #ffffff;
+					background-color: #eb743b;
+				}
+			}
+		}
+	}
+	
+	.play-button {
+		padding: 0;
+		color: #8d8d8d;
+	}
+	// If the user has an input method compatible with hovering (f.e. a mouse)
 	// hide the play button by default and show it on card hover
 	@media (hover: hover) {
-      .play-button {
-        transition: opacity .3s ease-in-out;
-        opacity: 0;
-      }
-      &:hover .play-button {
-        opacity: 1;
-      }
-    }
-
-    &.deleted {
-      animation: deleted-animation 0.3s linear forwards;
-    }
-    
-    @keyframes deleted-animation {
-      0% {
-        opacity: 1;
-        padding: inherit;
-        height: inherit;
-        margin: inherit;
-        transform: scaleY(1);
-      }
-
-      50% {
-        opacity: 0;
-      }
-
-      100% {
-        opacity: 0;
-        height: 0px;
-        margin-top: -40px;
-        transform: scaleY(0);
-        display:none;
-      }
-    }
-  }
+		.play-button {
+			transition: opacity .3s ease-in-out;
+			opacity: 0;
+		}
+		&:hover .play-button {
+			opacity: 1;
+		}
+	}
+	
+	&.deleted {
+		animation: deleted-animation 0.3s linear forwards;
+	}
+	
+	@keyframes deleted-animation {
+		0% {
+			opacity: 1;
+			padding: inherit;
+			height: inherit;
+			margin: inherit;
+			transform: scaleY(1);
+		}
+		
+		50% {
+			opacity: 0;
+		}
+		
+		100% {
+			opacity: 0;
+			height: 0px;
+			margin-top: -40px;
+			transform: scaleY(0);
+			display:none;
+		}
+	}
 }
 
 .input-group-flex {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  width: 100%;
-  > *:not(.form-control) {
-    width: auto;
-    line-height: 1.4;
-  }
-  > .form-control {
-    flex: 1 1 120px;
-  }
-  > .input-group-btn {
-    flex: 1;
-    display: flex;
-    > .btn {
-      flex: 1 1 auto
-    }
-  }
+	display: flex;
+	flex-wrap: wrap;
+	align-items: stretch;
+	width: 100%;
+	> *:not(.form-control) {
+		width: auto;
+		line-height: 1.4;
+	}
+	> .form-control {
+		flex: 1 1 120px;
+	}
+	> .input-group-btn {
+		flex: 1;
+		display: flex;
+		> .btn {
+			flex: 1 1 auto
+		}
+	}
 }
 
 .input-group > .input-group-btn > .btn {
-  margin-top: 0px;
-  margin-bottom: 0px;
+	margin-top: 0px;
+	margin-bottom: 0px;
 }
 
 #listen-count-card {
-  padding: 15px 50px;
-  margin-bottom: 20px;
-  text-align: center;
-  
-  > h4 {
-    font-weight: 400;
-    
-    hr {
-      margin: 8px 0px 40px 0px;
-      border-top: 1px solid #eeeeee;
-    }
-  }
-
-  > div > h4 {
-    height: 26px;
-    font-weight: 500;
-    font-size: 20px;
-    margin-bottom: 0;
-    letter-spacing: 1px;
-  }
+	padding: 15px 50px;
+	margin-bottom: 20px;
+	text-align: center;
+	
+	> h4 {
+		font-weight: 400;
+		
+		hr {
+			margin: 8px 0px 40px 0px;
+			border-top: 1px solid #eeeeee;
+		}
+	}
+	
+	> div > h4 {
+		height: 26px;
+		font-weight: 500;
+		font-size: 20px;
+		margin-bottom: 0;
+		letter-spacing: 1px;
+	}
 }
 
 #navigation.pager{
-  display: flex;
-  flex-wrap: wrap;
-  & > .date-time-picker {
-   flex: 1;
-   order: 0;
-   
-   @media (max-width: @screen-phone) {
-     // on phones, put the datepicker below the arrow nav
-     order: 1;
-	 margin-top:10px;
-    }
- }
+	display: flex;
+	flex-wrap: wrap;
+	& > .date-time-picker {
+		flex: 1;
+		order: 0;
+		
+		@media (max-width: @screen-phone) {
+			// on phones, put the datepicker below the arrow nav
+			order: 1;
+			margin-top:10px;
+		}
+	}
 }

--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -202,6 +202,9 @@
 		display: flex;
 		flex:1;
 	}
+	> * {
+		padding: 0 1em;
+	}
 	
 	
 	.listen-time {
@@ -233,9 +236,14 @@
 		}
 	}
 	
+	.additional-details{
+		margin-top: 1em;
+		font-style: italic;
+	}
+	
 	.listen-controls-container {
 		max-width: 110px;
-    	min-width: 110px;
+		min-width: 110px;
 		> * {
 			flex: 1;
 			align-self: center;

--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -185,7 +185,6 @@
 	margin-bottom: 7px;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: end;
 	
 	&.playing-now {
 		background-color: rgba(255, 252, 202, 0.3) !important ;
@@ -202,8 +201,10 @@
 		display: flex;
 		flex:1;
 	}
-	> * {
-		padding: 0 1em;
+	@media (min-width: @screen-md-min) {
+		> * {
+			padding: 0 1em;
+		}
 	}
 	
 	
@@ -244,6 +245,7 @@
 	.listen-controls-container {
 		max-width: 110px;
 		min-width: 110px;
+		margin-left: auto; // align flexbox item at flex-end
 		> * {
 			flex: 1;
 			align-self: center;

--- a/listenbrainz/webserver/static/css/playlists.less
+++ b/listenbrainz/webserver/static/css/playlists.less
@@ -113,8 +113,6 @@
 		}
 	}
 	.playlist-item-card {
-		&:extend(#listens .listen-card);
-		display:flex;
 		align-items: center;
 		margin-bottom: 0px;
 		
@@ -123,7 +121,6 @@
 		}
 
 		.listen-controls {
-			&:extend(#listens .listen-card .listen-controls all);
 			flex: 0 6em;
 		}
 		> div {

--- a/listenbrainz/webserver/static/css/timeline.less
+++ b/listenbrainz/webserver/static/css/timeline.less
@@ -75,7 +75,6 @@
 				padding-top: 1em;
 				padding-left: 3.5em;
 				.listen-card {
-					&:extend(#listens .listen-card all);
 					> *:last-child{
 						display: flex;
     					align-items: center;

--- a/listenbrainz/webserver/static/css/timeline.less
+++ b/listenbrainz/webserver/static/css/timeline.less
@@ -74,25 +74,6 @@
 			.event-content {
 				padding-top: 1em;
 				padding-left: 3.5em;
-				.listen-card {
-					> *:last-child{
-						display: flex;
-    					align-items: center;
-						> * {
-							flex: 1;
-    						text-align: right;
-						}
-					}
-					&.has-additional-details {
-						max-height: none;
-					}
-					.track-details{
-						.additional-details {
-							padding-top: 5px;
-							white-space: normal;
-						}
-					}
-				}
 			}
 		}
 	}

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -639,10 +639,8 @@ export default class RecentListens extends React.Component<
                               ?.recording_msid
                           )}
                           playListen={this.playListen}
-                          removeListenFromListenList={
-                            this.removeListenFromListenList
-                          }
-                          updateFeedback={this.updateFeedback}
+                          removeListenCallback={this.removeListenFromListenList}
+                          updateFeedbackCallback={this.updateFeedback}
                           updateRecordingToPin={this.updateRecordingToPin}
                           newAlert={newAlert}
                           className={`${

--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -630,10 +630,10 @@ export default class RecentListens extends React.Component<
                       return (
                         <ListenCard
                           key={`${listen.listened_at}-${listen.track_metadata?.track_name}-${listen.track_metadata?.additional_info?.recording_msid}-${listen.user_name}`}
-                          isCurrentUser={currentUser?.name === user?.name}
+                          showTimestamp
+                          showUsername={mode === "recent"}
                           isCurrentListen={this.isCurrentListen(listen)}
                           listen={listen}
-                          mode={mode}
                           currentFeedback={this.getFeedbackForRecordingMsid(
                             listen.track_metadata?.additional_info
                               ?.recording_msid

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
@@ -27,9 +27,9 @@ const listen: Listen = {
 
 const props: ListenCardProps = {
   listen,
-  mode: "listens",
   currentFeedback: 1,
-  isCurrentUser: true,
+  showTimestamp: true,
+  showUsername: true,
   isCurrentListen: false,
   playListen: () => {},
   removeListenFromListenList: () => {},

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.test.tsx
@@ -32,8 +32,8 @@ const props: ListenCardProps = {
   showUsername: true,
   isCurrentListen: false,
   playListen: () => {},
-  removeListenFromListenList: () => {},
-  updateFeedback: () => {},
+  removeListenCallback: () => {},
+  updateFeedbackCallback: () => {},
   newAlert: () => {},
   updateRecordingToPin: () => {},
 };
@@ -103,10 +103,10 @@ describe("ListenCard", () => {
   });
 
   describe("submitFeedback", () => {
-    it("calls API, updates feedback state and calls updateFeedback correctly", async () => {
+    it("calls API, updates feedback state and calls updateFeedbackCallback correctly", async () => {
       const wrapper = mount<ListenCard>(
         <GlobalAppContext.Provider value={globalProps}>
-          <ListenCard {...{ ...props, updateFeedback: jest.fn() }} />
+          <ListenCard {...{ ...props, updateFeedbackCallback: jest.fn() }} />
         </GlobalAppContext.Provider>
       );
       const instance = wrapper.instance();
@@ -123,8 +123,11 @@ describe("ListenCard", () => {
       expect(spy).toHaveBeenCalledWith("baz", "bar", -1);
 
       expect(wrapper.state("feedback")).toEqual(-1);
-      expect(instance.props.updateFeedback).toHaveBeenCalledTimes(1);
-      expect(instance.props.updateFeedback).toHaveBeenCalledWith("bar", -1);
+      expect(instance.props.updateFeedbackCallback).toHaveBeenCalledTimes(1);
+      expect(instance.props.updateFeedbackCallback).toHaveBeenCalledWith(
+        "bar",
+        -1
+      );
     });
 
     it("does nothing if CurrentUser.authtoken is not set", async () => {
@@ -135,7 +138,7 @@ describe("ListenCard", () => {
             currentUser: { auth_token: undefined, name: "test" },
           }}
         >
-          <ListenCard {...{ ...props, updateFeedback: jest.fn() }} />
+          <ListenCard {...{ ...props, updateFeedbackCallback: jest.fn() }} />
         </GlobalAppContext.Provider>
       );
       const instance = wrapper.instance();
@@ -151,14 +154,14 @@ describe("ListenCard", () => {
       expect(wrapper.state("feedback")).toEqual(1);
     });
 
-    it("doesn't update feedback state or call updateFeedback if status code is not 200", async () => {
+    it("doesn't update feedback state or call updateFeedbackCallback if status code is not 200", async () => {
       const wrapper = mount<ListenCard>(
         <GlobalAppContext.Provider value={globalProps}>
           <ListenCard {...props} />
         </GlobalAppContext.Provider>
       );
       const instance = wrapper.instance();
-      props.updateFeedback = jest.fn();
+      props.updateFeedbackCallback = jest.fn();
 
       const { APIService } = instance.context;
       const spy = jest.spyOn(APIService, "submitFeedback");
@@ -172,7 +175,7 @@ describe("ListenCard", () => {
       expect(spy).toHaveBeenCalledWith("baz", "bar", -1);
 
       expect(wrapper.state("feedback")).toEqual(1);
-      expect(props.updateFeedback).toHaveBeenCalledTimes(0);
+      expect(props.updateFeedbackCallback).toHaveBeenCalledTimes(0);
     });
 
     it("calls handleError if error is returned", async () => {
@@ -219,12 +222,10 @@ describe("ListenCard", () => {
   });
 
   describe("deleteListen", () => {
-    it("calls API, sets isDeleted state and removeListenFromListenList correctly", async () => {
+    it("calls API, sets isDeleted state and removeListenCallback correctly", async () => {
       const wrapper = mount<ListenCard>(
         <GlobalAppContext.Provider value={globalProps}>
-          <ListenCard
-            {...{ ...props, removeListenFromListenList: jest.fn() }}
-          />
+          <ListenCard {...{ ...props, removeListenCallback: jest.fn() }} />
         </GlobalAppContext.Provider>
       );
       const instance = wrapper.instance();
@@ -243,10 +244,8 @@ describe("ListenCard", () => {
       expect(wrapper.state("isDeleted")).toEqual(true);
 
       setTimeout(() => {
-        expect(instance.props.removeListenFromListenList).toHaveBeenCalledTimes(
-          1
-        );
-        expect(instance.props.removeListenFromListenList).toHaveBeenCalledWith(
+        expect(instance.props.removeListenCallback).toHaveBeenCalledTimes(1);
+        expect(instance.props.removeListenCallback).toHaveBeenCalledWith(
           instance.props.listen
         );
       }, 1000);
@@ -289,14 +288,14 @@ describe("ListenCard", () => {
       expect(wrapper.state("isDeleted")).toEqual(false);
     });
 
-    it("doesn't update isDeleted state call removeListenFromListenList if status code is not 200", async () => {
+    it("doesn't update isDeleted state call removeListenCallback if status code is not 200", async () => {
       const wrapper = mount<ListenCard>(
         <GlobalAppContext.Provider value={globalProps}>
           <ListenCard {...props} />
         </GlobalAppContext.Provider>
       );
       const instance = wrapper.instance();
-      props.removeListenFromListenList = jest.fn();
+      props.removeListenCallback = jest.fn();
 
       const { APIService } = instance.context;
       const spy = jest.spyOn(APIService, "deleteListen");
@@ -307,7 +306,7 @@ describe("ListenCard", () => {
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith("baz", "bar", 0);
 
-      expect(props.removeListenFromListenList).toHaveBeenCalledTimes(0);
+      expect(props.removeListenCallback).toHaveBeenCalledTimes(0);
       expect(wrapper.state("isDeleted")).toEqual(false);
     });
 

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -41,6 +41,7 @@ export type ListenCardProps = {
     title: string,
     message: string | JSX.Element
   ) => void;
+  additionalDetails?: string | JSX.Element;
 };
 
 type ListenCardState = {
@@ -189,6 +190,7 @@ export default class ListenCard extends React.Component<
 
   render() {
     const {
+      additionalDetails,
       listen,
       className,
       isCurrentListen,
@@ -345,6 +347,14 @@ export default class ListenCard extends React.Component<
             {getPlayButton(listen, isCurrentListen, this.playListen)}
           </div>
         </div>
+        {additionalDetails && (
+          <span
+            className="additional-details"
+            title={listen.track_metadata?.track_name}
+          >
+            {additionalDetails}
+          </span>
+        )}
       </Card>
     );
   }

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -240,6 +240,14 @@ export default class ListenCard extends React.Component<
       </>
     );
 
+    const listenedAt = _get(listen, "listened_at");
+    const recordingMSID = _get(
+      listen,
+      "track_metadata.additional_info.recording_msid"
+    );
+    const canDelete =
+      isCurrentUser && Boolean(listenedAt) && Boolean(recordingMSID);
+
     return (
       <Card
         onDoubleClick={isCurrentListen ? undefined : this.playListen}
@@ -323,9 +331,9 @@ export default class ListenCard extends React.Component<
                     dataTarget="#PinRecordingModal"
                   />
                   <ListenControl
-                    disabled={!isCurrentUser}
+                    disabled={!canDelete}
                     title="Delete Listen"
-                    action={isCurrentUser ? this.deleteListen : undefined}
+                    action={canDelete ? this.deleteListen : undefined}
                   />
                 </ul>
               </>

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -218,24 +218,22 @@ export default class ListenCard extends React.Component<
             <FontAwesomeIcon icon={faMusic as IconProp} /> Playing now &#8212;
           </span>
         ) : (
-          showTimestamp && (
-            <span
-              className="listen-time"
-              title={
-                listen.listened_at
-                  ? fullLocalizedDateFromTimestampOrISODate(
-                      listen.listened_at * 1000
-                    )
-                  : fullLocalizedDateFromTimestampOrISODate(
-                      listen.listened_at_iso
-                    )
-              }
-            >
-              {preciseTimestamp(
-                listen.listened_at_iso || listen.listened_at * 1000
-              )}
-            </span>
-          )
+          <span
+            className="listen-time"
+            title={
+              listen.listened_at
+                ? fullLocalizedDateFromTimestampOrISODate(
+                    listen.listened_at * 1000
+                  )
+                : fullLocalizedDateFromTimestampOrISODate(
+                    listen.listened_at_iso
+                  )
+            }
+          >
+            {preciseTimestamp(
+              listen.listened_at_iso || listen.listened_at * 1000
+            )}
+          </span>
         )}
       </>
     );
@@ -257,17 +255,21 @@ export default class ListenCard extends React.Component<
 		 ${className || ""}`}
       >
         <div className="listen-details">
-          <p title={listen.track_metadata?.track_name}>
+          <div title={listen.track_metadata?.track_name} className="ellipsis">
             {getTrackLink(listen)}
-          </p>
-          <span
-            className="small text-muted"
-            title={listen.track_metadata?.artist_name}
-          >
-            {getArtistLink(listen)}
-          </span>
-          <span className="small visible-xs-inline">
-            &nbsp; &#8212; &nbsp;{timeStampForDisplay}
+          </div>
+          <span className="artist-and-timestamp">
+            {showTimestamp && (
+              <span className="small visible-xs-inline ellipsis">
+                {timeStampForDisplay}&nbsp;-&nbsp;
+              </span>
+            )}
+            <span
+              className="small text-muted ellipsis"
+              title={listen.track_metadata?.artist_name}
+            >
+              {getArtistLink(listen)}
+            </span>
           </span>
         </div>
         <div className="username-and-timestamp">
@@ -281,7 +283,9 @@ export default class ListenCard extends React.Component<
               {listen.user_name}
             </a>
           )}
-          <div className="hidden-xs">{timeStampForDisplay}</div>
+          {showTimestamp && (
+            <div className="hidden-xs">{timeStampForDisplay}</div>
+          )}
         </div>
         <div className="listen-controls-container">
           <div className="listen-controls">

--- a/listenbrainz/webserver/static/js/src/listens/ListenControl.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenControl.tsx
@@ -11,22 +11,32 @@ export type ListenControlProps = {
   title: string;
   dataToggle?: string;
   dataTarget?: string;
+  disabled?: boolean;
 };
 
 const ListenControl = (props: ListenControlProps) => {
-  const { className, action, icon, title, dataToggle, dataTarget } = props;
+  const {
+    className,
+    action,
+    icon,
+    title,
+    dataToggle,
+    dataTarget,
+    disabled,
+  } = props;
   return icon ? (
     <FontAwesomeIcon
       icon={icon as IconProp}
       className={className}
       title={title}
-      onClick={action}
+      onClick={disabled ? undefined : action}
     />
   ) : (
     <button
+      disabled={disabled ?? false}
       className={className}
       title={title}
-      onClick={action}
+      onClick={disabled ? undefined : action}
       type="button"
       data-toggle={dataToggle}
       data-target={dataTarget}

--- a/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
+++ b/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
@@ -18,7 +18,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
-import { isEqual } from "lodash";
+import { isEqual, get as _get } from "lodash";
 import { sanitize } from "dompurify";
 import {
   WithAlertNotificationsInjectedProps,
@@ -30,7 +30,7 @@ import GlobalAppContext, { GlobalAppContextT } from "../GlobalAppContext";
 import BrainzPlayer from "../BrainzPlayer";
 import ErrorBoundary from "../ErrorBoundary";
 import Loader from "../components/Loader";
-import TimelineEventCard from "./TimelineEventCard";
+import ListenCard from "../listens/ListenCard";
 import { getPageProps, preciseTimestamp } from "../utils";
 import UserSocialNetwork from "../follow/UserSocialNetwork";
 
@@ -275,10 +275,10 @@ export default class UserFeedPage extends React.Component<
       const { newAlert } = this.props;
       return (
         <div className="event-content">
-          <TimelineEventCard
-            className={
-              this.isCurrentListen(metadata as Listen) ? " current-listen" : ""
-            }
+          <ListenCard
+            isCurrentListen={this.isCurrentListen(metadata as Listen)}
+            showUsername={false}
+            showTimestamp={false}
             listen={metadata as Listen}
             additionalDetails={
               (metadata as PinEventMetadata).blurb_content
@@ -411,7 +411,7 @@ export default class UserFeedPage extends React.Component<
         <div role="main">
           {/* display:flex to allow right-column to take all available height, for sticky player */}
           <div className="row" style={{ display: "flex", flexWrap: "wrap" }}>
-            <div className="col-md-7">
+            <div className="col-md-7 col-xs-12">
               <div
                 style={{
                   height: 0,


### PR DESCRIPTION
The time has come to refactor the ListenCard!

The ListenCard component is one of the main components we have, the one used to display your listens or on the recent listens page.
1. It was in dire need of a refactor to get rid of MediaQuery react component (it's not good to have two different layouts which duplicate content, which is quite error prone and can be solved easily with CSS
2. The CSS also needed some refactoring
3. The component required some changes in order to be used it in all pages that display a list of tracks that should be playable, like/hatable, pinnable, etc. Those user features are currently not available on other pages such as the Feed page (!), recommendations page, etc. (which each use their own card component)

To limit the size and scope of this PR a bit, I'm only replacing the refactored ListenCard in the UserFeed component.
I will still have to do the same and replace the PlaylistItemCard, RecommendationCard and maybe PinnedRecordingCard components in other pages.

Desktop size:
![image](https://user-images.githubusercontent.com/6179856/134034856-665eb788-13a9-4533-92ce-32aac9ce2865.png)

Tablet size:
![image](https://user-images.githubusercontent.com/6179856/134034555-66c568c0-39cf-4721-b902-ba8017ecf96a.png)

Small phone size:
![image](https://user-images.githubusercontent.com/6179856/134034452-da3bbbd3-ab0e-4101-86f2-a6e3bdf9b12e.png)

And used in the UserFeed component (notice we now have like/hate and more actions menu):
![image](https://user-images.githubusercontent.com/6179856/134035586-5344df78-8858-4cbe-b7c9-c1005b0443bc.png)
