### PR TITLE
Don't submit MBIDs in PinRecordingModal

### DIFF
--- a/listenbrainz/webserver/static/js/src/PinRecordingModal.test.tsx
+++ b/listenbrainz/webserver/static/js/src/PinRecordingModal.test.tsx
@@ -70,7 +70,9 @@ describe("submitPinRecording", () => {
     expect(spy).toHaveBeenCalledWith(
       "auth_token",
       "recording_msid",
-      "recording_mbid",
+      // Disabling temporarily
+      //   "recording_mbid",
+      undefined,
       undefined
     );
     expect(instance.props.newAlert).toHaveBeenCalledTimes(1);

--- a/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
+++ b/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
@@ -39,10 +39,13 @@ export default class PinRecordingModal extends React.Component<
         recordingToPin,
         "track_metadata.additional_info.recording_msid"
       );
-      const recordingMBID = _get(
-        recordingToPin,
-        "track_metadata.additional_info.recording_mbid"
-      );
+      // We currently have an issue with submitting MSID and MBID at the same time
+      // So we temporarily remove the MBID from the submition
+      const recordingMBID = undefined;
+      //   const recordingMBID = _get(
+      //     recordingToPin,
+      //     "track_metadata.additional_info.recording_mbid"
+      //   );
 
       try {
         const status = await APIService.submitPinRecording(


### PR DESCRIPTION
We have an issue with submitting MSID and MBID, so we temporarily remove the MBID from the pin submission.

See discussion here: https://chatlogs.metabrainz.org/libera/metabrainz/2021-09-21/?msg=4862910&page=3