### PR TITLE
Remove stats duplicates caused due to casing

### DIFF
--- a/listenbrainz_spark/stats/user/artist.py
+++ b/listenbrainz_spark/stats/user/artist.py
@@ -28,12 +28,12 @@ def get_artists(table: str) -> Iterator[UserArtistRecord]:
     result = run_query(f"""
         WITH intermediate_table as (
             SELECT user_name
-                 , artist_name
+                 , first(artist_name) AS any_artist_name
                  , artist_credit_mbids
                  , count(*) as listen_count
               FROM {table}
           GROUP BY user_name
-                 , artist_name
+                 , lower(artist_name)
                  , artist_credit_mbids
         )
         SELECT user_name
@@ -41,7 +41,7 @@ def get_artists(table: str) -> Iterator[UserArtistRecord]:
                     collect_list(
                         struct(
                             listen_count
-                          , artist_name
+                          , any_artist_name AS artist_name
                           , coalesce(artist_credit_mbids, array()) AS artist_mbids
                         )
                     )

--- a/listenbrainz_spark/stats/user/recording.py
+++ b/listenbrainz_spark/stats/user/recording.py
@@ -29,20 +29,20 @@ def get_recordings(table):
     result = run_query(f"""
         WITH intermediate_table as (
             SELECT user_name
-                 , recording_name
+                 , first(recording_name) AS any_recording_name
                  , recording_mbid
-                 , artist_name
+                 , first(artist_name) AS any_artist_name
                  , artist_credit_mbids
-                 , nullif(release_name, '') as release_name
+                 , nullif(first(release_name), '') as any_release_name
                  , release_mbid
                  , count(*) as listen_count
               FROM {table}
           GROUP BY user_name
-                 , recording_name
+                 , lower(recording_name)
                  , recording_mbid
-                 , artist_name
+                 , lower(artist_name)
                  , artist_credit_mbids
-                 , release_name
+                 , lower(release_name)
                  , release_mbid
         )
         SELECT user_name
@@ -50,11 +50,11 @@ def get_recordings(table):
                     collect_list(
                         struct(
                             listen_count
-                          , recording_name AS track_name
+                          , any_recording_name AS track_name
                           , recording_mbid
-                          , artist_name
+                          , any_artist_name AS artist_name
                           , coalesce(artist_credit_mbids, array()) AS artist_mbids
-                          , release_name
+                          , any_release_name AS release_name
                           , release_mbid
                         )
                     )

--- a/listenbrainz_spark/stats/user/release.py
+++ b/listenbrainz_spark/stats/user/release.py
@@ -28,17 +28,17 @@ def get_releases(table):
     result = run_query(f"""
         WITH intermediate_table as (
             SELECT user_name
-                , release_name
+                , first(release_name) AS any_release_name
                 , release_mbid
-                , artist_name
+                , first(artist_name) AS any_artist_name
                 , artist_credit_mbids
                 , count(*) as listen_count
               FROM {table}
              WHERE release_name != ''
           GROUP BY user_name
-                , release_name
+                , lower(release_name)
                 , release_mbid
-                , artist_name
+                , lower(artist_name)
                 , artist_credit_mbids
         )
         SELECT user_name
@@ -46,9 +46,9 @@ def get_releases(table):
                     collect_list(
                         struct(
                             listen_count
-                          , release_name
+                          , any_release_name AS release_name
                           , release_mbid
-                          , artist_name
+                          , any_artist_name AS artist_name
                           , coalesce(artist_credit_mbids, array()) AS artist_mbids
                         )
                     )


### PR DESCRIPTION
The artist_name, release_name and recording_name fields are case-sensitive. Grouping by them creates duplicates like BoB and BOB even if the artist_mbids is same for both. Hence, lowercase these fields in GROUP BY clause and in select choose any one case (like using first).