### PR TITLE
LB-934, LB-935 (I): Spark statistics time fix and code deduplication

### DIFF
--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
@@ -18,31 +18,31 @@ class SitewideEntityTestCase(StatsTestCase):
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_week('test')
-        from_date = day = datetime(2021, 8, 2, 12, 22, 43)
+        from_date = datetime(2021, 8, 2)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_month(self, mock_create_messages, mock_get_listens):
         entity.get_entity_month('test')
-        from_date = datetime(2021, 8, 1, 12, 22, 43)
+        from_date = datetime(2021, 8, 1)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='month',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_year(self, mock_create_messages, mock_get_listens):
         entity.get_entity_year('test')
-        from_date = datetime(2021, 1, 1, 12, 22, 43)
+        from_date = datetime(2021, 1, 1)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='year',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
@@ -52,7 +52,7 @@ class SitewideEntityTestCase(StatsTestCase):
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='all_time',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     def test_skip_incorrect_artists_stats(self):
         """ Test to check if entries with incorrect data is skipped for top sitewide artists """
@@ -62,7 +62,7 @@ class SitewideEntityTestCase(StatsTestCase):
         mock_result = MagicMock()
         mock_result.asDict.return_value = data
 
-        message = entity.create_messages(iter([mock_result]), 'artists', 'all_time', 0, 10)
+        message = entity.create_messages(iter([mock_result]), 'artists', 'all_time', datetime.now(), datetime.now())
 
         # Only the first entry in file is valid, all others must be skipped
         self.assertListEqual(data['stats'][:1], message[0]['data'])

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -19,119 +19,87 @@ from listenbrainz_spark.utils import get_listens_from_new_dump, get_latest_liste
 logger = logging.getLogger(__name__)
 
 entity_handler_map = {
-    'artists': get_artists,
-    'releases': get_releases,
-    'recordings': get_recordings
+    "artists": get_artists,
+    "releases": get_releases,
+    "recordings": get_recordings
 }
 
 entity_model_map = {
-    'artists': UserArtistRecord,
-    'releases': UserReleaseRecord,
-    'recordings': UserRecordingRecord
+    "artists": UserArtistRecord,
+    "releases": UserReleaseRecord,
+    "recordings": UserRecordingRecord
 }
 
 
 def get_entity_week(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the weekly top entity for all users """
-    logger.debug(f"Calculating {entity}_week...")
-
     to_date = get_last_monday(get_latest_listen_ts())
     from_date = offset_days(to_date, 7)
-
-    listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = f'user_{entity}_week'
-    listens_df.createOrReplaceTempView(table_name)
-
-    handler = entity_handler_map[entity]
-    data = handler(table_name)
-    messages = create_messages(data=data, entity=entity, stats_range='week',
-                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
-
-    logger.debug("Done!")
-
-    return messages
+    # Set time to 00:00
+    from_date = datetime(from_date.year, from_date.month, from_date.day)
+    return _get_entity_stats(entity, "week", from_date, to_date)
 
 
 def get_entity_month(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the month top entity for all users """
-    logger.debug(f"Calculating {entity}_month...")
-
     to_date = get_latest_listen_ts()
     from_date = replace_days(to_date, 1)
-
-    listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = f'user_{entity}_month'
-    listens_df.createOrReplaceTempView(table_name)
-
-    handler = entity_handler_map[entity]
-    data = handler(table_name)
-
-    messages = create_messages(data=data, entity=entity, stats_range='month',
-                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
-
-    logger.debug("Done!")
-
-    return messages
+    # Set time to 00:00
+    from_date = datetime(from_date.year, from_date.month, from_date.day)
+    return _get_entity_stats(entity, "month", from_date, to_date)
 
 
 def get_entity_year(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the year top entity for all users """
-    logger.debug(f"Calculating {entity}_year...")
-
     to_date = get_latest_listen_ts()
     from_date = replace_days(replace_months(to_date, 1), 1)
-
-    listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = f'user_{entity}_year'
-    listens_df.createOrReplaceTempView(table_name)
-
-    handler = entity_handler_map[entity]
-    data = handler(table_name)
-    messages = create_messages(data=data, entity=entity, stats_range='year',
-                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
-
-    logger.debug("Done!")
-
-    return messages
+    # Set time to 00:00
+    from_date = datetime(from_date.year, from_date.month, from_date.day)
+    return _get_entity_stats(entity, "year", from_date, to_date)
 
 
 def get_entity_all_time(entity: str) -> Iterator[Optional[UserEntityStatMessage]]:
     """ Get the all_time top entity for all users """
-    logger.debug(f"Calculating {entity}_all_time...")
-
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
+    return _get_entity_stats(entity, "all_time", from_date, to_date)
 
+
+def _get_entity_stats(entity: str, stats_range: str, from_date: datetime, to_date: datetime) \
+        -> Iterator[Optional[UserEntityStatMessage]]:
     listens_df = get_listens_from_new_dump(from_date, to_date)
-    table_name = f'user_{entity}_all_time'
+    table_name = f"user_{entity}_{stats_range}"
     listens_df.createOrReplaceTempView(table_name)
 
     handler = entity_handler_map[entity]
     data = handler(table_name)
-    messages = create_messages(data=data, entity=entity, stats_range='all_time',
-                               from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    messages = create_messages(data=data, entity=entity, stats_range=stats_range,
+                               from_date=from_date, to_date=to_date)
 
     logger.debug("Done!")
 
     return messages
 
 
-def create_messages(data, entity: str, stats_range: str, from_ts: float, to_ts: float) \
+def create_messages(data, entity: str, stats_range: str, from_date: datetime, to_date: datetime) \
         -> Iterator[Optional[UserEntityStatMessage]]:
     """
     Create messages to send the data to the webserver via RabbitMQ
 
     Args:
-        data (iterator): Data to sent to the webserver
+        data: Data to sent to the webserver
         entity: The entity for which statistics are calculated, i.e 'artists',
             'releases' or 'recordings'
         stats_range: The range for which the statistics have been calculated
-        from_ts: The UNIX timestamp of start time of the stats
-        to_ts: The UNIX timestamp of end time of the stats
+        from_date: The start time of the stats
+        to_date: The end time of the stats
 
     Returns:
         messages: A list of messages to be sent via RabbitMQ
     """
+    from_ts = int(from_date.timestamp())
+    to_ts = int(to_date.timestamp())
+
     for entry in data:
         _dict = entry.asDict(recursive=True)
         total_entity_count = len(_dict[entity])
@@ -148,19 +116,19 @@ def create_messages(data, entity: str, stats_range: str, from_ts: float, to_ts: 
                 logger.error("Invalid entry in entity stats", exc_info=True)
         try:
             model = UserEntityStatMessage(**{
-                'musicbrainz_id': _dict['user_name'],
-                'type': 'user_entity',
-                'stats_range': stats_range,
-                'from_ts': from_ts,
-                'to_ts': to_ts,
-                'data': entity_list,
-                'entity': entity,
-                'count': total_entity_count
+                "musicbrainz_id": _dict["user_name"],
+                "type": "user_entity",
+                "stats_range": stats_range,
+                "from_ts": from_ts,
+                "to_ts": to_ts,
+                "data": entity_list,
+                "entity": entity,
+                "count": total_entity_count
             })
             result = model.dict(exclude_none=True)
             yield result
         except ValidationError:
             logger.error("""ValidationError while calculating {stats_range} top {entity} for user: {user_name}. 
-            Data: {data}""".format(stats_range=stats_range, entity=entity, user_name=_dict['user_name'],
+            Data: {data}""".format(stats_range=stats_range, entity=entity, user_name=_dict["user_name"],
                                    data=json.dumps(_dict, indent=3)), exc_info=True)
             yield None

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -11,21 +11,21 @@ from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.exceptions import HDFSException
 from listenbrainz_spark.stats import (offset_days, offset_months, get_day_end,
                                       get_month_end, get_year_end,
-                                      replace_days, replace_months, run_query, get_last_monday)
+                                      replace_days, run_query, get_last_monday)
 from listenbrainz_spark.utils import get_listens_from_new_dump, get_latest_listen_ts
 from pyspark.sql.functions import collect_list, sort_array, struct, lit
 from pyspark.sql.types import (StringType, StructField, StructType,
                                TimestampType)
 
-time_range_schema = StructType((StructField('time_range', StringType()), StructField(
-    'start', TimestampType()), StructField('end', TimestampType())))
+time_range_schema = StructType((StructField("time_range", StringType()), StructField(
+    "start", TimestampType()), StructField("end", TimestampType())))
 
 
 logger = logging.getLogger(__name__)
 
 
 def get_listening_activity():
-    """ Calculate number of listens for each user in time ranges given in the 'time_range' table """
+    """ Calculate number of listens for each user in time ranges given in the "time_range" table """
     # Calculate the number of listens in each time range for each user except the time ranges which have zero listens.
     result_without_zero_days = run_query("""
             SELECT listens.user_name
@@ -38,7 +38,7 @@ def get_listening_activity():
           GROUP BY listens.user_name
                  , time_range.time_range
             """)
-    result_without_zero_days.createOrReplaceTempView('result_without_zero_days')
+    result_without_zero_days.createOrReplaceTempView("result_without_zero_days")
 
     # Add the time ranges which have zero listens to the previous dataframe
     result = run_query("""
@@ -77,16 +77,16 @@ def get_listening_activity_week() -> Iterator[Optional[UserListeningActivityStat
     # Genarate a dataframe containing days of last and current week along with start and end time
     time_range = []
     while day < to_date:
-        time_range.append([day.strftime('%A %d %B %Y'), day, get_day_end(day)])
+        time_range.append([day.strftime("%A %d %B %Y"), day, get_day_end(day)])
         day = offset_days(day, 1, shift_backwards=False)
 
     time_range_df = listenbrainz_spark.session.createDataFrame(time_range, time_range_schema)
-    time_range_df.createOrReplaceTempView('time_range')
+    time_range_df.createOrReplaceTempView("time_range")
 
     _get_listens(from_date, to_date)
 
     data = get_listening_activity()
-    messages = create_messages(data=data, stats_range='week', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    messages = create_messages(data=data, stats_range="week", from_date=from_date, to_date=to_date)
 
     logger.debug("Done!")
 
@@ -106,16 +106,16 @@ def get_listening_activity_month() -> Iterator[Optional[UserListeningActivitySta
     # Genarate a dataframe containing days of last and current month along with start and end time
     time_range = []
     while day < to_date:
-        time_range.append([day.strftime('%d %B %Y'), day, get_day_end(day)])
+        time_range.append([day.strftime("%d %B %Y"), day, get_day_end(day)])
         day = offset_days(day, 1, shift_backwards=False)
 
     time_range_df = listenbrainz_spark.session.createDataFrame(time_range, time_range_schema)
-    time_range_df.createOrReplaceTempView('time_range')
+    time_range_df.createOrReplaceTempView("time_range")
 
     _get_listens(from_date, to_date)
 
     data = get_listening_activity()
-    messages = create_messages(data=data, stats_range='month', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    messages = create_messages(data=data, stats_range="month", from_date=from_date, to_date=to_date)
 
     logger.debug("Done!")
 
@@ -127,22 +127,22 @@ def get_listening_activity_year() -> Iterator[Optional[UserListeningActivityStat
     logger.debug("Calculating listening_activity_year")
 
     to_date = get_latest_listen_ts()
-    from_date = datetime(to_date.year-1, 1, 1)
-    month = datetime(to_date.year-1, 1, 1)
+    from_date = datetime(to_date.year - 1, 1, 1)
+    month = from_date
     time_range = []
 
     # Genarate a dataframe containing months of last and current year along with start and end time
     while month < to_date:
-        time_range.append([month.strftime('%B %Y'), month, get_month_end(month)])
+        time_range.append([month.strftime("%B %Y"), month, get_month_end(month)])
         month = offset_months(month, 1, shift_backwards=False)
 
     time_range_df = listenbrainz_spark.session.createDataFrame(time_range, time_range_schema)
-    time_range_df.createOrReplaceTempView('time_range')
+    time_range_df.createOrReplaceTempView("time_range")
 
     _get_listens(from_date, to_date)
 
     data = get_listening_activity()
-    messages = create_messages(data=data, stats_range='year', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    messages = create_messages(data=data, stats_range="year", from_date=from_date, to_date=to_date)
 
     logger.debug("Done!")
 
@@ -157,7 +157,7 @@ def get_listening_activity_all_time() -> Iterator[Optional[UserListeningActivity
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
 
     result_without_zero_years = None
-    for year in range(from_date.year, to_date.year+1):
+    for year in range(from_date.year, to_date.year + 1):
         year_start = datetime(year, 1, 1)
         year_end = get_year_end(year)
         try:
@@ -171,8 +171,8 @@ def get_listening_activity_all_time() -> Iterator[Optional[UserListeningActivity
                       FROM listens
                   GROUP BY user_name
                   """)
-        year_df = year_df.withColumn('time_range', lit(str(year))).withColumn(
-            'from_ts', lit(year_start.timestamp())).withColumn('to_ts', lit(year_end.timestamp()))
+        year_df = year_df.withColumn("time_range", lit(str(year))).withColumn(
+            "from_ts", lit(year_start.timestamp())).withColumn("to_ts", lit(year_end.timestamp()))
         result_without_zero_years = result_without_zero_years.union(year_df) if result_without_zero_years else year_df
 
     # Create a table with a list of time ranges and corresponding listen count for each user
@@ -182,43 +182,47 @@ def get_listening_activity_all_time() -> Iterator[Optional[UserListeningActivity
         .agg(sort_array(collect_list("listening_activity")).alias("listening_activity")) \
         .toLocalIterator()
 
-    messages = create_messages(data=data, stats_range='all_time', from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+    messages = create_messages(data=data, stats_range="all_time", from_date=from_date, to_date=to_date)
 
     logger.debug("Done!")
 
     return messages
 
 
-def create_messages(data, stats_range: str, from_ts: int, to_ts: int) -> Iterator[Optional[UserListeningActivityStatMessage]]:
+def create_messages(data, stats_range: str, from_date: datetime, to_date: datetime) \
+        -> Iterator[Optional[UserListeningActivityStatMessage]]:
     """
     Create messages to send the data to webserver via RabbitMQ
 
     Args:
         data: Data to send to webserver
-
+        stats_range: The range for which the statistics have been calculated
+        from_date: The start time of the stats
+        to_date: The end time of the stats
     Returns:
         messages: A list of messages to be sent via RabbitMQ
     """
+    from_ts = int(from_date.timestamp())
+    to_ts = int(to_date.timestamp())
     for entry in data:
         _dict = entry.asDict(recursive=True)
         try:
             model = UserListeningActivityStatMessage(**{
-                'musicbrainz_id': _dict['user_name'],
-                'type': 'user_listening_activity',
-                'stats_range': stats_range,
-                'from_ts': from_ts,
-                'to_ts': to_ts,
-                'data': _dict['listening_activity']
+                "musicbrainz_id": _dict["user_name"],
+                "type": "user_listening_activity",
+                "stats_range": stats_range,
+                "from_ts": from_ts,
+                "to_ts": to_ts,
+                "data": _dict["listening_activity"]
             })
             result = model.dict(exclude_none=True)
             yield result
         except ValidationError:
-            logger.error("""ValidationError while calculating {stats_range} listening_activity for user: {user_name}. 
-            Data: {data}""".format(stats_range=stats_range, user_name=_dict['user_name'],
-                                   data=json.dumps(_dict, indent=3)), exc_info=True)
+            logger.error(f"""ValidationError while calculating {stats_range} listening_activity for user: 
+            {_dict["user_name"]}. Data: {json.dumps(_dict, indent=3)}""", exc_info=True)
             yield None
 
 
 def _get_listens(from_date: datetime, to_date: datetime):
     get_listens_from_new_dump(from_date, to_date) \
-        .createOrReplaceTempView('listens')
+        .createOrReplaceTempView("listens")

--- a/listenbrainz_spark/stats/user/tests/test_daily_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_daily_activity.py
@@ -30,11 +30,11 @@ class DailyActivityTestCase(StatsTestCase):
     def test_get_daily_activity_week(self, mock_create_messages, _, mock_get_listens):
         daily_activity.get_daily_activity_week()
 
-        from_date = datetime(2021, 8, 2, 12, 22, 43)
+        from_date = datetime(2021, 8, 2)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='week',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.daily_activity.get_daily_activity', return_value='daily_activity_table')
@@ -42,11 +42,11 @@ class DailyActivityTestCase(StatsTestCase):
     def test_get_daily_activity_month(self, mock_create_messages, _, mock_get_listens):
         daily_activity.get_daily_activity_month()
 
-        from_date = datetime(2021, 8, 1, 0, 0, 0)
+        from_date = datetime(2021, 8, 1)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='month',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.daily_activity.get_daily_activity', return_value='daily_activity_table')
@@ -54,11 +54,11 @@ class DailyActivityTestCase(StatsTestCase):
     def test_get_daily_activity_year(self, mock_create_messages, _, mock_get_listens):
         daily_activity.get_daily_activity_year()
 
-        from_date = datetime(2021, 1, 1, 0, 0, 0)
+        from_date = datetime(2021, 1, 1)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='year',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.daily_activity.get_daily_activity', return_value='daily_activity_table')
@@ -70,4 +70,4 @@ class DailyActivityTestCase(StatsTestCase):
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='all_time',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -21,33 +21,33 @@ class UserEntityTestCase(StatsTestCase):
     def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_week('test')
 
-        from_date = datetime(2021, 8, 2, 12, 22, 43)
+        from_date = datetime(2021, 8, 2)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.entity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.entity.create_messages')
     def test_get_entity_month(self, mock_create_messages, mock_get_listens):
         entity.get_entity_month('test')
 
-        from_date = datetime(2021, 8, 1, 12, 22, 43)
+        from_date = datetime(2021, 8, 1)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='month',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.entity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.entity.create_messages')
     def test_get_entity_year(self, mock_create_messages, mock_get_listens):
         entity.get_entity_year('test')
 
-        from_date = datetime(2021, 1, 1, 12, 22, 43)
+        from_date = datetime(2021, 1, 1)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='year',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.entity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.entity.create_messages')
@@ -58,7 +58,7 @@ class UserEntityTestCase(StatsTestCase):
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='all_time',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     def test_create_messages_recordings(self):
         """ Test to check if the number of recordings are clipped to top 1000 """
@@ -80,7 +80,7 @@ class UserEntityTestCase(StatsTestCase):
             'recordings': recordings
         }
 
-        messages = entity.create_messages([mock_result], 'recordings', 'all_time', 0, 10)
+        messages = entity.create_messages([mock_result], 'recordings', 'all_time', datetime.now(), datetime.now())
 
         message = next(messages)
         received_list = message['data']
@@ -102,7 +102,7 @@ class UserEntityTestCase(StatsTestCase):
             'artists': data
         }
 
-        messages = entity.create_messages([mock_result], 'artists', 'all_time', 0, 10)
+        messages = entity.create_messages([mock_result], 'artists', 'all_time', datetime.now(), datetime.now())
         received_list = next(messages)['data']
 
         # Only the first entry in file is valid, all others must be skipped
@@ -119,7 +119,7 @@ class UserEntityTestCase(StatsTestCase):
             'releases': data
         }
 
-        messages = entity.create_messages([mock_result], 'releases', 'all_time', 0, 10)
+        messages = entity.create_messages([mock_result], 'releases', 'all_time', datetime.now(), datetime.now())
         received_list = next(messages)['data']
 
         # Only the first entry in file is valid, all others must be skipped
@@ -136,7 +136,7 @@ class UserEntityTestCase(StatsTestCase):
             'recordings': data
         }
 
-        messages = entity.create_messages([mock_result], 'recordings', 'all_time', 0, 10)
+        messages = entity.create_messages([mock_result], 'recordings', 'all_time', datetime.now(), datetime.now())
         received_list = next(messages)['data']
 
         # Only the first entry in file is valid, all others must be skipped

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -46,7 +46,7 @@ class ListeningActivityTestCase(StatsTestCase):
     def test_get_listening_activity_week(self, mock_create_messages, _, mock_get_listens):
         listening_activity_stats.get_listening_activity_week()
 
-        from_date = day = datetime(2021, 8, 2, 0, 0, 0)
+        from_date = day = datetime(2021, 8, 2)
         to_date = datetime(2021, 8, 9, 12, 22, 43)
         time_range = []
         while day < to_date:
@@ -58,7 +58,7 @@ class ListeningActivityTestCase(StatsTestCase):
 
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='activity_table', stats_range='week',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listening_activity', return_value='activity_table')
@@ -78,7 +78,7 @@ class ListeningActivityTestCase(StatsTestCase):
 
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='activity_table', stats_range='month',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)
 
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_new_dump')
     @patch('listenbrainz_spark.stats.user.listening_activity.get_listening_activity', return_value='activity_table')
@@ -98,4 +98,4 @@ class ListeningActivityTestCase(StatsTestCase):
 
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='activity_table', stats_range='year',
-                                                from_ts=from_date.timestamp(), to_ts=to_date.timestamp())
+                                                from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/testdata/user_listening_activity.json
+++ b/listenbrainz_spark/testdata/user_listening_activity.json
@@ -1,11 +1,248 @@
 [
     {
+        "musicbrainz_id": "amCap1712",
+        "type": "user_listening_activity",
+        "stats_range": "all_time",
+        "from_ts": 1009843200,
+        "to_ts": 1628511763,
+        "data": [
+            {
+                "time_range": "2002",
+                "from_ts": 1009843200,
+                "to_ts": 1041379199,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2003",
+                "from_ts": 1041379200,
+                "to_ts": 1072915199,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2004",
+                "from_ts": 1072915200,
+                "to_ts": 1104537599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2005",
+                "from_ts": 1104537600,
+                "to_ts": 1136073599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2006",
+                "from_ts": 1136073600,
+                "to_ts": 1167609599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2007",
+                "from_ts": 1167609600,
+                "to_ts": 1199145599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2008",
+                "from_ts": 1199145600,
+                "to_ts": 1230767999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2009",
+                "from_ts": 1230768000,
+                "to_ts": 1262303999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2010",
+                "from_ts": 1262304000,
+                "to_ts": 1293839999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2011",
+                "from_ts": 1293840000,
+                "to_ts": 1325375999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2012",
+                "from_ts": 1325376000,
+                "to_ts": 1356998399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2013",
+                "from_ts": 1356998400,
+                "to_ts": 1388534399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2014",
+                "from_ts": 1388534400,
+                "to_ts": 1420070399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2015",
+                "from_ts": 1420070400,
+                "to_ts": 1451606399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2016",
+                "from_ts": 1451606400,
+                "to_ts": 1483228799,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2017",
+                "from_ts": 1483228800,
+                "to_ts": 1514764799,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2018",
+                "from_ts": 1514764800,
+                "to_ts": 1546300799,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2019",
+                "from_ts": 1546300800,
+                "to_ts": 1577836799,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2020",
+                "from_ts": 1577836800,
+                "to_ts": 1609459199,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2021",
+                "from_ts": 1609459200,
+                "to_ts": 1640995199,
+                "listen_count": 41
+            }
+        ]
+    },
+    {
         "musicbrainz_id": "rob",
         "type": "user_listening_activity",
         "stats_range": "all_time",
         "from_ts": 1009843200,
         "to_ts": 1628511763,
         "data": [
+            {
+                "time_range": "2002",
+                "from_ts": 1009843200,
+                "to_ts": 1041379199,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2003",
+                "from_ts": 1041379200,
+                "to_ts": 1072915199,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2004",
+                "from_ts": 1072915200,
+                "to_ts": 1104537599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2005",
+                "from_ts": 1104537600,
+                "to_ts": 1136073599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2006",
+                "from_ts": 1136073600,
+                "to_ts": 1167609599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2007",
+                "from_ts": 1167609600,
+                "to_ts": 1199145599,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2008",
+                "from_ts": 1199145600,
+                "to_ts": 1230767999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2009",
+                "from_ts": 1230768000,
+                "to_ts": 1262303999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2010",
+                "from_ts": 1262304000,
+                "to_ts": 1293839999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2011",
+                "from_ts": 1293840000,
+                "to_ts": 1325375999,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2012",
+                "from_ts": 1325376000,
+                "to_ts": 1356998399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2013",
+                "from_ts": 1356998400,
+                "to_ts": 1388534399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2014",
+                "from_ts": 1388534400,
+                "to_ts": 1420070399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2015",
+                "from_ts": 1420070400,
+                "to_ts": 1451606399,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2016",
+                "from_ts": 1451606400,
+                "to_ts": 1483228799,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2017",
+                "from_ts": 1483228800,
+                "to_ts": 1514764799,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2018",
+                "from_ts": 1514764800,
+                "to_ts": 1546300799,
+                "listen_count": 0
+            },
+            {
+                "time_range": "2019",
+                "from_ts": 1546300800,
+                "to_ts": 1577836799,
+                "listen_count": 0
+            },
             {
                 "time_range": "2020",
                 "from_ts": 1577836800,
@@ -17,21 +254,6 @@
                 "from_ts": 1609459200,
                 "to_ts": 1640995199,
                 "listen_count": 40
-            }
-        ]
-    },
-    {
-        "musicbrainz_id": "amCap1712",
-        "type": "user_listening_activity",
-        "stats_range": "all_time",
-        "from_ts": 1009843200,
-        "to_ts": 1628511763,
-        "data": [
-            {
-                "time_range": "2021",
-                "from_ts": 1609459200,
-                "to_ts": 1640995199,
-                "listen_count": 41
             }
         ]
     }

--- a/listenbrainz_spark/testdata/user_top_releases_output.json
+++ b/listenbrainz_spark/testdata/user_top_releases_output.json
@@ -1,1 +1,365 @@
-[{"musicbrainz_id": "rob", "type": "user_entity", "entity": "releases", "stats_range": "all_time", "from_ts": 1009843200, "to_ts": 1628511763, "data": [{"artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"], "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741", "release_name": "Third", "listen_count": 6, "artist_name": "Portishead"}, {"artist_mbids": ["10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"], "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5", "release_name": "Protection", "listen_count": 5, "artist_name": "Massive Attack"}, {"artist_mbids": ["c44ff36b-651f-4c20-98ee-519cf4ed07e7"], "release_mbid": "b812901e-c598-4635-8b98-72eecf161060", "release_name": "Yamanote", "listen_count": 4, "artist_name": "Aether"}, {"artist_mbids": ["b014d579-b549-4b21-b90d-5264e0433988"], "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc", "release_name": "Projections", "listen_count": 4, "artist_name": "Romare"}, {"artist_mbids": ["78c94cba-761f-4212-8508-a24bda2e57dc"], "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05", "release_name": "Mickey Mouse Operation", "listen_count": 3, "artist_name": "Little People"}, {"artist_mbids": ["8b2350de-b682-4fe7-ad8f-4508d7b6c697"], "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd", "release_name": "Brazilian Girls", "listen_count": 3, "artist_name": "Brazilian Girls"}, {"artist_mbids": [], "release_name": "Support Network", "listen_count": 2, "artist_name": "Kalabi"}, {"artist_mbids": ["e9787dd2-5857-4b51-8e59-a190a54820fc"], "release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf", "release_name": "Ecozoic", "listen_count": 2, "artist_name": "The Polish Ambassador"}, {"artist_mbids": ["f1106b17-dcbb-45f6-b938-199ccfab50cc"], "release_mbid": "f63bfd08-a085-3a33-8d83-d396ab8d1f6d", "release_name": "Technique", "listen_count": 1, "artist_name": "New Order"}, {"artist_mbids": ["a8b39181-6939-451e-9641-2db231b73706"], "release_mbid": "6122ca09-a4ca-4d13-96c5-2b1ea502e7f5", "release_name": "Silent Geometry", "listen_count": 1, "artist_name": "Abakus"}, {"artist_mbids": ["056e4f3e-d505-4dad-8ec1-d04f521cbb56"], "release_mbid": "74fcd7f4-a2c8-4526-b350-558b157942bf", "release_name": "Random Access Memories", "listen_count": 1, "artist_name": "Daft Punk"}, {"artist_mbids": ["10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8", "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f"], "release_mbid": "91231e74-2674-411e-968f-b188bb67b711", "release_name": "Protection", "listen_count": 1, "artist_name": "Massive Attack, Tracey Thorn"}, {"artist_mbids": ["9806e551-9a63-4a9d-be1b-5297b2ac0e76"], "release_mbid": "2f7634f3-3bb5-4f2c-9821-d150e8415fb8", "release_name": "Mosaic Remastered", "listen_count": 1, "artist_name": "Sounds From The Ground"}, {"artist_mbids": ["78c94cba-761f-4212-8508-a24bda2e57dc", "bd43cb68-3a68-429e-9aad-6fc512f7df71"], "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05", "release_name": "Mickey Mouse Operation", "listen_count": 1, "artist_name": "Little People, Rachael Roberts"}, {"artist_mbids": ["3252542b-98a7-48ba-9861-7a612b16c227"], "release_mbid": "73e4a3e9-bb1d-4243-9c1b-f285fc842248", "release_name": "Kiasmos", "listen_count": 1, "artist_name": "Kiasmos"}, {"artist_mbids": ["6fe91ae9-8ddb-47b0-a2d7-252833ce5500"], "release_mbid": "af6fdf7a-fcb0-46f9-b8c5-517fe8cb3e5d", "release_name": "Forwards (Special Edition)", "listen_count": 1, "artist_name": "The Egg"}, {"artist_mbids": ["53d2a4d1-556e-4701-a8ac-5fcb74a8e393"], "release_mbid": "1a12cb18-84cc-4818-b748-2eceaa63de16", "release_name": "Echo Other", "listen_count": 1, "artist_name": "All India Radio"}, {"artist_mbids": [], "release_name": "Brazilian Girls", "listen_count": 1, "artist_name": "Brazilian Girls"}, {"artist_mbids": ["1a40f886-0877-4bab-9ab1-761147dadb89"], "release_mbid": "99e39642-cae5-4061-9800-751108bc650b", "release_name": "Blumenkraft", "listen_count": 1, "artist_name": "Ott"}, {"artist_mbids": ["57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"], "release_mbid": "d619edca-d766-36b3-a2c0-19cd47ed427b", "release_name": "Blade Runner (Music From The Original Soundtrack)", "listen_count": 1, "artist_name": "Vangelis"}, {"artist_mbids": ["57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"], "release_mbid": "9792e059-f7af-4bce-90cf-9a2f78288c72", "release_name": "Blade Runner (Music From The Original Soundtrack)", "listen_count": 1, "artist_name": "Vangelis"}, {"artist_mbids": ["57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"], "release_mbid": "0efa1563-cbc7-4249-b6ec-fab766c38c81", "release_name": "Blade Runner (Music From The Original Soundtrack)", "listen_count": 1, "artist_name": "Vangelis"}, {"artist_mbids": ["904cc1c8-021e-45ac-bbe9-95c01a1f8099", "3f9b5837-ed1c-413e-bfef-ca4f892dcc59"], "release_mbid": "39967fee-e436-4f87-b36e-299aae4dc670", "release_name": "Anomic", "listen_count": 1, "artist_name": "Jah Wobble, Marconi Union"}], "count": 23}, {"musicbrainz_id": "amCap1712", "type": "user_entity", "entity": "releases", "stats_range": "all_time", "from_ts": 1009843200, "to_ts": 1628511763, "data": [{"artist_mbids": ["122d63fc-8671-43e4-9752-34e846d62a9c"], "release_mbid": "ae8288cf-134e-48bc-a146-f0a2ac35b322", "release_name": "Teenage Dream", "listen_count": 5, "artist_name": "Katy Perry"}, {"artist_mbids": [], "release_name": "Lucifer: Season 5 - Bloody Celestial Karaoke Jam (Special Episode Soundtrack)", "listen_count": 5, "artist_name": "Lucifer Cast, Tom Ellis"}, {"artist_mbids": ["5586fc31-7c41-4a2d-97a2-d358b58b250d"], "release_mbid": "834d8732-8e2d-42b6-9496-55b067d0748f", "release_name": "And so It Begins", "listen_count": 5, "artist_name": "Klergy"}, {"artist_mbids": [], "release_name": "Mask Off (Marshmello Remix)", "listen_count": 4, "artist_name": "Future, Marshmello"}, {"artist_mbids": ["cf15719f-51f9-4db8-a15d-5eed9664ce69", "f116b984-45ae-49d0-9445-efc5a61458a1"], "release_mbid": "1760ede9-4041-4d64-982e-a8fa76b9ea51", "release_name": "This Is Hip Hop", "listen_count": 3, "artist_name": "Guy Sebastian, Lupe Fiasco"}, {"artist_mbids": ["2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"], "release_mbid": "7a5d7834-ff3b-4214-95eb-9b14332e9541", "release_name": "The Human Condition", "listen_count": 3, "artist_name": "Jon Bellion"}, {"artist_mbids": ["93cfee41-b1a6-4604-a01c-91243e6926e6", "43736f76-419a-42a0-816a-830876647ba5"], "release_mbid": "1355c8b7-f563-4ddc-8b00-620f4a63d081", "release_name": "Wicked Game", "listen_count": 2, "artist_name": "Ursine Vulpine, Annaca"}, {"artist_mbids": ["298f4089-1948-44b5-b5e8-d5381f42362f"], "release_mbid": "89b9a362-af9b-4a19-8e56-647355a73f39", "release_name": "VHS", "listen_count": 2, "artist_name": "X Ambassadors"}, {"artist_mbids": ["6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"], "release_mbid": "92f78019-e5e6-4ce2-86ab-6057a8396f4a", "release_name": "SOUR", "listen_count": 2, "artist_name": "Olivia Rodrigo"}, {"artist_mbids": [], "release_name": "Inside (The Songs)", "listen_count": 2, "artist_name": "Bo Burnham"}, {"artist_mbids": ["859d0860-d480-4efd-970c-c05d5f1776b8"], "release_mbid": "e00b32b1-a697-4679-b085-52eb6bd5ffd9", "release_name": "I Am... Sasha Fierce", "listen_count": 2, "artist_name": "Beyonc\u00e9"}, {"artist_mbids": ["6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"], "release_mbid": "315bbc48-dea9-463c-bfa9-a6ccab78b990", "release_name": "Now That's What I Call Music Vol. 83", "listen_count": 1, "artist_name": "Dua Lipa"}, {"artist_mbids": ["603ba565-3967-4be1-931e-9cb945394e86"], "release_mbid": "5f68e32a-ccc1-4b01-a4de-daa880bf3864", "release_name": "No Strings Attached", "listen_count": 1, "artist_name": "*NSYNC"}, {"artist_mbids": ["859d0860-d480-4efd-970c-c05d5f1776b8"], "release_mbid": "2866428a-8a00-354d-af5c-0648746a1202", "release_name": "I AM...SASHA FIERCE - Platinum Edition", "listen_count": 1, "artist_name": "Beyonc\u00e9"}, {"artist_mbids": ["7eb1ce54-a355-41f9-8d68-e018b096d427"], "release_mbid": "c6a3c8a1-1c6e-4fef-a3f4-6b24eb064c19", "release_name": "Fine Line", "listen_count": 1, "artist_name": "Harry Styles"}, {"artist_mbids": ["6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"], "release_mbid": "96a204c8-e368-436f-a1e6-37f13f302108", "release_name": "Ballermann Hits 2020 (XXL Zuhause Edition)", "listen_count": 1, "artist_name": "Dua Lipa"}], "count": 16}]
+[
+    {
+        "musicbrainz_id": "rob",
+        "type": "user_entity",
+        "entity": "releases",
+        "stats_range": "all_time",
+        "from_ts": 1009843200,
+        "to_ts": 1628511763,
+        "data": [
+            {
+                "artist_mbids": [
+                    "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+                ],
+                "release_mbid": "930345b1-a970-3495-a1dd-55147bea7741",
+                "release_name": "Third",
+                "listen_count": 6,
+                "artist_name": "Portishead"
+            },
+            {
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+                ],
+                "release_mbid": "8ec7bce7-27ee-3144-a52b-b5bd765860c5",
+                "release_name": "Protection",
+                "listen_count": 5,
+                "artist_name": "Massive Attack"
+            },
+            {
+                "artist_mbids": [
+                    "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
+                ],
+                "release_mbid": "b812901e-c598-4635-8b98-72eecf161060",
+                "release_name": "Yamanote",
+                "listen_count": 4,
+                "artist_name": "Aether"
+            },
+            {
+                "artist_mbids": [
+                    "b014d579-b549-4b21-b90d-5264e0433988"
+                ],
+                "release_mbid": "a4bb5de1-b856-40e3-8b8b-1130faf9afbc",
+                "release_name": "Projections",
+                "listen_count": 4,
+                "artist_name": "Romare"
+            },
+            {
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc"
+                ],
+                "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05",
+                "release_name": "Mickey Mouse Operation",
+                "listen_count": 3,
+                "artist_name": "Little People"
+            },
+            {
+                "artist_mbids": [
+                    "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
+                ],
+                "release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd",
+                "release_name": "Brazilian Girls",
+                "listen_count": 3,
+                "artist_name": "Brazilian Girls"
+            },
+            {
+                "artist_mbids": [],
+                "release_name": "Support Network",
+                "listen_count": 2,
+                "artist_name": "Kalabi"
+            },
+            {
+                "artist_mbids": [
+                    "e9787dd2-5857-4b51-8e59-a190a54820fc"
+                ],
+                "release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf",
+                "release_name": "Ecozoic",
+                "listen_count": 2,
+                "artist_name": "The Polish Ambassador"
+            },
+            {
+                "artist_mbids": [
+                    "f1106b17-dcbb-45f6-b938-199ccfab50cc"
+                ],
+                "release_mbid": "f63bfd08-a085-3a33-8d83-d396ab8d1f6d",
+                "release_name": "Technique",
+                "listen_count": 1,
+                "artist_name": "New Order"
+            },
+            {
+                "artist_mbids": [
+                    "a8b39181-6939-451e-9641-2db231b73706"
+                ],
+                "release_mbid": "6122ca09-a4ca-4d13-96c5-2b1ea502e7f5",
+                "release_name": "Silent Geometry",
+                "listen_count": 1,
+                "artist_name": "Abakus"
+            },
+            {
+                "artist_mbids": [
+                    "056e4f3e-d505-4dad-8ec1-d04f521cbb56"
+                ],
+                "release_mbid": "74fcd7f4-a2c8-4526-b350-558b157942bf",
+                "release_name": "Random Access Memories",
+                "listen_count": 1,
+                "artist_name": "Daft Punk"
+            },
+            {
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8",
+                    "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f"
+                ],
+                "release_mbid": "91231e74-2674-411e-968f-b188bb67b711",
+                "release_name": "Protection",
+                "listen_count": 1,
+                "artist_name": "Massive Attack, Tracey Thorn"
+            },
+            {
+                "artist_mbids": [
+                    "9806e551-9a63-4a9d-be1b-5297b2ac0e76"
+                ],
+                "release_mbid": "2f7634f3-3bb5-4f2c-9821-d150e8415fb8",
+                "release_name": "Mosaic Remastered",
+                "listen_count": 1,
+                "artist_name": "Sounds From The Ground"
+            },
+            {
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc",
+                    "bd43cb68-3a68-429e-9aad-6fc512f7df71"
+                ],
+                "release_mbid": "db4d5128-f065-4938-8161-c50cf64b6f05",
+                "release_name": "Mickey Mouse Operation",
+                "listen_count": 1,
+                "artist_name": "Little People, Rachael Roberts"
+            },
+            {
+                "artist_mbids": [
+                    "3252542b-98a7-48ba-9861-7a612b16c227"
+                ],
+                "release_mbid": "73e4a3e9-bb1d-4243-9c1b-f285fc842248",
+                "release_name": "Kiasmos",
+                "listen_count": 1,
+                "artist_name": "Kiasmos"
+            },
+            {
+                "artist_mbids": [
+                    "6fe91ae9-8ddb-47b0-a2d7-252833ce5500"
+                ],
+                "release_mbid": "af6fdf7a-fcb0-46f9-b8c5-517fe8cb3e5d",
+                "release_name": "Forwards (Special Edition)",
+                "listen_count": 1,
+                "artist_name": "The Egg"
+            },
+            {
+                "artist_mbids": [
+                    "53d2a4d1-556e-4701-a8ac-5fcb74a8e393"
+                ],
+                "release_mbid": "1a12cb18-84cc-4818-b748-2eceaa63de16",
+                "release_name": "Echo Other",
+                "listen_count": 1,
+                "artist_name": "All India Radio"
+            },
+            {
+                "artist_mbids": [],
+                "release_name": "Brazilian Girls",
+                "listen_count": 1,
+                "artist_name": "Brazilian Girls"
+            },
+            {
+                "artist_mbids": [
+                    "1a40f886-0877-4bab-9ab1-761147dadb89"
+                ],
+                "release_mbid": "99e39642-cae5-4061-9800-751108bc650b",
+                "release_name": "Blumenkraft",
+                "listen_count": 1,
+                "artist_name": "Ott"
+            },
+            {
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "release_mbid": "d619edca-d766-36b3-a2c0-19cd47ed427b",
+                "release_name": "Blade Runner (Music From The Original Soundtrack)",
+                "listen_count": 1,
+                "artist_name": "Vangelis"
+            },
+            {
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "release_mbid": "9792e059-f7af-4bce-90cf-9a2f78288c72",
+                "release_name": "Blade Runner (Music From The Original Soundtrack)",
+                "listen_count": 1,
+                "artist_name": "Vangelis"
+            },
+            {
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "release_mbid": "0efa1563-cbc7-4249-b6ec-fab766c38c81",
+                "release_name": "Blade Runner (Music From The Original Soundtrack)",
+                "listen_count": 1,
+                "artist_name": "Vangelis"
+            },
+            {
+                "artist_mbids": [
+                    "904cc1c8-021e-45ac-bbe9-95c01a1f8099",
+                    "3f9b5837-ed1c-413e-bfef-ca4f892dcc59"
+                ],
+                "release_mbid": "39967fee-e436-4f87-b36e-299aae4dc670",
+                "release_name": "Anomic",
+                "listen_count": 1,
+                "artist_name": "Jah Wobble, Marconi Union"
+            }
+        ],
+        "count": 23
+    },
+    {
+        "musicbrainz_id": "amCap1712",
+        "type": "user_entity",
+        "entity": "releases",
+        "stats_range": "all_time",
+        "from_ts": 1009843200,
+        "to_ts": 1628511763,
+        "data": [
+            {
+                "artist_mbids": [
+                    "122d63fc-8671-43e4-9752-34e846d62a9c"
+                ],
+                "release_mbid": "ae8288cf-134e-48bc-a146-f0a2ac35b322",
+                "release_name": "Teenage Dream",
+                "listen_count": 5,
+                "artist_name": "Katy Perry"
+            },
+            {
+                "artist_mbids": [],
+                "release_name": "Lucifer: Season 5 - Bloody Celestial Karaoke Jam (Special Episode Soundtrack)",
+                "listen_count": 5,
+                "artist_name": "Lucifer Cast, Tom Ellis"
+            },
+            {
+                "artist_mbids": [
+                    "5586fc31-7c41-4a2d-97a2-d358b58b250d"
+                ],
+                "release_mbid": "834d8732-8e2d-42b6-9496-55b067d0748f",
+                "release_name": "And so It Begins",
+                "listen_count": 5,
+                "artist_name": "Klergy"
+            },
+            {
+                "artist_mbids": [],
+                "release_name": "Mask Off (Marshmello Remix)",
+                "listen_count": 4,
+                "artist_name": "Future, Marshmello"
+            },
+            {
+                "artist_mbids": [
+                    "cf15719f-51f9-4db8-a15d-5eed9664ce69",
+                    "f116b984-45ae-49d0-9445-efc5a61458a1"
+                ],
+                "release_mbid": "1760ede9-4041-4d64-982e-a8fa76b9ea51",
+                "release_name": "This Is Hip Hop",
+                "listen_count": 3,
+                "artist_name": "Guy Sebastian, Lupe Fiasco"
+            },
+            {
+                "artist_mbids": [
+                    "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"
+                ],
+                "release_mbid": "7a5d7834-ff3b-4214-95eb-9b14332e9541",
+                "release_name": "The Human Condition",
+                "listen_count": 3,
+                "artist_name": "Jon Bellion"
+            },
+            {
+                "artist_mbids": [
+                    "93cfee41-b1a6-4604-a01c-91243e6926e6",
+                    "43736f76-419a-42a0-816a-830876647ba5"
+                ],
+                "release_mbid": "1355c8b7-f563-4ddc-8b00-620f4a63d081",
+                "release_name": "Wicked Game",
+                "listen_count": 2,
+                "artist_name": "Ursine Vulpine, Annaca"
+            },
+            {
+                "artist_mbids": [
+                    "298f4089-1948-44b5-b5e8-d5381f42362f"
+                ],
+                "release_mbid": "89b9a362-af9b-4a19-8e56-647355a73f39",
+                "release_name": "VHS",
+                "listen_count": 2,
+                "artist_name": "X Ambassadors"
+            },
+            {
+                "artist_mbids": [
+                    "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
+                ],
+                "release_mbid": "92f78019-e5e6-4ce2-86ab-6057a8396f4a",
+                "release_name": "SOUR",
+                "listen_count": 2,
+                "artist_name": "Olivia Rodrigo"
+            },
+            {
+                "artist_mbids": [],
+                "release_name": "Inside (The Songs)",
+                "listen_count": 2,
+                "artist_name": "Bo Burnham"
+            },
+            {
+                "artist_mbids": [
+                    "859d0860-d480-4efd-970c-c05d5f1776b8"
+                ],
+                "release_mbid": "e00b32b1-a697-4679-b085-52eb6bd5ffd9",
+                "release_name": "I Am... Sasha Fierce",
+                "listen_count": 2,
+                "artist_name": "Beyonc\u00e9"
+            },
+            {
+                "artist_mbids": [
+                    "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"
+                ],
+                "release_mbid": "315bbc48-dea9-463c-bfa9-a6ccab78b990",
+                "release_name": "Now That's What I Call Music Vol. 83",
+                "listen_count": 1,
+                "artist_name": "Dua Lipa"
+            },
+            {
+                "artist_mbids": [
+                    "603ba565-3967-4be1-931e-9cb945394e86"
+                ],
+                "release_mbid": "5f68e32a-ccc1-4b01-a4de-daa880bf3864",
+                "release_name": "No Strings Attached",
+                "listen_count": 1,
+                "artist_name": "*NSYNC"
+            },
+            {
+                "artist_mbids": [
+                    "859d0860-d480-4efd-970c-c05d5f1776b8"
+                ],
+                "release_mbid": "2866428a-8a00-354d-af5c-0648746a1202",
+                "release_name": "I AM...SASHA FIERCE - Platinum Edition",
+                "listen_count": 1,
+                "artist_name": "Beyonc\u00e9"
+            },
+            {
+                "artist_mbids": [
+                    "7eb1ce54-a355-41f9-8d68-e018b096d427"
+                ],
+                "release_mbid": "c6a3c8a1-1c6e-4fef-a3f4-6b24eb064c19",
+                "release_name": "Fine Line",
+                "listen_count": 1,
+                "artist_name": "Harry Styles"
+            },
+            {
+                "artist_mbids": [
+                    "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"
+                ],
+                "release_mbid": "96a204c8-e368-436f-a1e6-37f13f302108",
+                "release_name": "Ballermann Hits 2020 (XXL Zuhause Edition)",
+                "listen_count": 1,
+                "artist_name": "Dua Lipa"
+            }
+        ],
+        "count": 16
+    }
+]


### PR DESCRIPTION
1) Refactor the spark code and extract common code into separate method.

2) Set from_date to midnight of that day. Till now, we used to calculate the latest listen's timestamp as the ending limit and then subtract 7 days to get from_ts. However, some stats manually set the from_ts to midnight of that date. For consistency, I suggest we do this always.

3) Refactor and fix all time listening activity code. All ranges in listening_activity add years for which the user has no listens as years with listen_count = 0. week, month and year code share the code to do this and worked as expected. Due to some reason, all_time range had difference code to do this but looking at current output of API that didn't work. I changed the all time code to use the same query and other ranges and it works now.

Will open a subsequent PR for some more code simplifiation to avoid making this one too large.