### PR TITLE
Make stats time code consistent

### DIFF
--- a/listenbrainz_spark/stats/__init__.py
+++ b/listenbrainz_spark/stats/__init__.py
@@ -94,18 +94,18 @@ def offset_days(date, days, shift_backwards=True):
 
 def get_day_end(day: datetime) -> datetime:
     """ Returns a datetime object denoting the end of the day """
-    return datetime(day.year, day.month, day.day, hour=23, minute=59, second=59)
+    return datetime(day.year, day.month, day.day, hour=23, minute=59, second=59, microsecond=999999)
 
 
 def get_month_end(month: datetime) -> datetime:
     """ Returns a datetime object denoting the end of the month """
     _, num_of_days = monthrange(month.year, month.month)
-    return datetime(month.year, month.month, num_of_days, hour=23, minute=59, second=59)
+    return datetime(month.year, month.month, num_of_days, hour=23, minute=59, second=59, microsecond=999999)
 
 
 def get_year_end(year: datetime) -> datetime:
     """ Returns a datetime object denoting the end of the year """
-    return datetime(year.year, month=12, day=31, hour=23, minute=59, second=59)
+    return datetime(year.year, month=12, day=31, hour=23, minute=59, second=59, microsecond=999999)
 
 
 def get_last_monday(date: datetime) -> datetime:

--- a/listenbrainz_spark/stats/__init__.py
+++ b/listenbrainz_spark/stats/__init__.py
@@ -103,9 +103,9 @@ def get_month_end(month: datetime) -> datetime:
     return datetime(month.year, month.month, num_of_days, hour=23, minute=59, second=59)
 
 
-def get_year_end(year: int) -> datetime:
+def get_year_end(year: datetime) -> datetime:
     """ Returns a datetime object denoting the end of the year """
-    return datetime(year, month=12, day=31, hour=23, minute=59, second=59)
+    return datetime(year.year, month=12, day=31, hour=23, minute=59, second=59)
 
 
 def get_last_monday(date: datetime) -> datetime:

--- a/listenbrainz_spark/stats/__init__.py
+++ b/listenbrainz_spark/stats/__init__.py
@@ -140,7 +140,7 @@ def get_dates_for_stats_range(stats_range: str) -> Tuple[datetime, datetime]:
     # from_offset: this is applied to the latest_listen_date to get from_date
     # to_offset: this is applied to from_date to get to_date
     if stats_range == "week":
-        from_offset = relativedelta(days=-1, weekday=MO(-1))  # monday of previous week
+        from_offset = relativedelta(weeks=-1, weekday=MO(-1))  # monday of previous week
         to_offset = relativedelta(weeks=+1)
     elif stats_range == "month":
         from_offset = relativedelta(months=-1, day=1)  # first day of previous month

--- a/listenbrainz_spark/stats/__init__.py
+++ b/listenbrainz_spark/stats/__init__.py
@@ -1,11 +1,16 @@
 from calendar import monthrange
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
+from datetime import datetime, time
+from typing import Tuple
+
+from dateutil.relativedelta import relativedelta, MO
 
 import listenbrainz_spark
+from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.exceptions import SQLException
 
 from pyspark.sql.utils import *
+
+from listenbrainz_spark.utils import get_latest_listen_ts
 
 
 def run_query(query):
@@ -106,3 +111,49 @@ def get_year_end(year: int) -> datetime:
 def get_last_monday(date: datetime) -> datetime:
     """ Get date for Monday before 'date' """
     return offset_days(date, date.weekday())
+
+
+def get_dates_for_stats_range(stats_range: str) -> Tuple[datetime, datetime]:
+    """ Return the range of datetimes for which stats should be calculated.
+
+        Args:
+            stats_range: the stats range (week/month/year/all_time) for
+                which to get datetimes.
+    """
+    latest_listen_ts = get_latest_listen_ts()
+    if stats_range == "all_time":
+        # all_time stats range is easy, just return time from LASTFM founding
+        # to the latest listen we have in spark
+        from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
+        to_date = latest_listen_ts
+        return from_date, to_date
+
+    # following are "last" week/month/year stats, here we want the stats of the
+    # previous week/month/year and *not* from 7 days ago to today so on.
+
+    # If we had used datetime.now or date.today here and the data in spark
+    # became outdated due to some reason, empty stats would be sent to LB.
+    # Hence, we use get_latest_listen_ts to get the time of the latest listen
+    # in spark and so that instead of no stats, outdated stats are calculated.
+    latest_listen_date = latest_listen_ts.date()
+
+    # from_offset: this is applied to the latest_listen_date to get from_date
+    # to_offset: this is applied to from_date to get to_date
+    if stats_range == "week":
+        from_offset = relativedelta(days=-1, weekday=MO(-1))  # monday of previous week
+        to_offset = relativedelta(weeks=+1)
+    elif stats_range == "month":
+        from_offset = relativedelta(months=-1, day=1)  # first day of previous month
+        to_offset = relativedelta(months=+1)
+    else:  # year
+        from_offset = relativedelta(years=-1, month=1, day=1)  # first day of previous year
+        to_offset = relativedelta(years=+1)
+
+    from_date = latest_listen_date + from_offset
+    to_date = from_date + to_offset
+
+    # set time to 00:00
+    from_date = datetime.combine(from_date, time.min)
+    to_date = datetime.combine(to_date, time.min)
+
+    return from_date, to_date

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -5,10 +5,9 @@ from typing import List, Optional
 
 from data.model.sitewide_artist_stat import SitewideArtistRecord
 from data.model.sitewide_entity import SitewideEntityStatMessage
-from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
-from listenbrainz_spark.stats import offset_days, replace_days, get_last_monday, replace_months
+from listenbrainz_spark.stats import get_dates_for_stats_range
 from listenbrainz_spark.stats.sitewide.artist import get_artists
-from listenbrainz_spark.utils import get_listens_from_new_dump, get_latest_listen_ts
+from listenbrainz_spark.utils import get_listens_from_new_dump
 from pydantic import ValidationError
 
 
@@ -26,45 +25,29 @@ entity_model_map = {
 
 def get_entity_week(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the weekly sitewide top entity """
-    to_date = get_last_monday(get_latest_listen_ts())
-    from_date = offset_days(to_date, 7)
-    # Set time to 00:00
-    from_date = datetime(from_date.year, from_date.month, from_date.day)
-    return _get_entity_stats(entity, "week", from_date, to_date)
+    return _get_entity_stats(entity, "week")
 
 
 def get_entity_month(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the montly sitewide top entity """
-    to_date = get_latest_listen_ts()
-    from_date = replace_days(to_date, 1)
-    # Set time to 00:00
-    from_date = datetime(from_date.year, from_date.month, from_date.day)
-    return _get_entity_stats(entity, "month", from_date, to_date)
+    return _get_entity_stats(entity, "month")
 
 
 def get_entity_year(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the yearly sitewide top entity """
-    to_date = get_latest_listen_ts()
-    from_date = replace_days(replace_months(to_date, 1), 1)
-    # Set time to 00:00
-    from_date = datetime(from_date.year, from_date.month, from_date.day)
-    return _get_entity_stats(entity, "year", from_date, to_date)
+    return _get_entity_stats(entity, "year")
 
 
 def get_entity_all_time(entity: str) -> Optional[List[SitewideEntityStatMessage]]:
     """ Get the all_time sitewide top entity """
-    to_date = get_latest_listen_ts()
-    from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
-    # Set time to 00:00
-    from_date = datetime(from_date.year, from_date.month, from_date.day)
-    return _get_entity_stats(entity, "all_time", from_date, to_date)
+    return _get_entity_stats(entity, "all_time")
 
 
-def _get_entity_stats(entity: str, stats_range: str, from_date: datetime, to_date: datetime) \
-        -> Optional[List[SitewideEntityStatMessage]]:
+def _get_entity_stats(entity: str, stats_range: str) -> Optional[List[SitewideEntityStatMessage]]:
     """ Returns top entity stats for given time period """
     logger.debug(f"Calculating sitewide_{entity}_{stats_range}...")
 
+    from_date, to_date = get_dates_for_stats_range(stats_range)
     listens_df = get_listens_from_new_dump(from_date, to_date)
     table_name = f"sitewide_{entity}_{stats_range}"
     listens_df.createOrReplaceTempView(table_name)

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
@@ -19,7 +19,7 @@ class SitewideEntityTestCase(StatsTestCase):
     def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_week('test')
         from_date = datetime(2021, 8, 2)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        to_date = datetime(2021, 8, 9)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
                                                 from_date=from_date, to_date=to_date)
@@ -28,8 +28,8 @@ class SitewideEntityTestCase(StatsTestCase):
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_month(self, mock_create_messages, mock_get_listens):
         entity.get_entity_month('test')
-        from_date = datetime(2021, 8, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        from_date = datetime(2021, 7, 1)
+        to_date = datetime(2021, 8, 1)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='month',
                                                 from_date=from_date, to_date=to_date)
@@ -38,8 +38,8 @@ class SitewideEntityTestCase(StatsTestCase):
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_year(self, mock_create_messages, mock_get_listens):
         entity.get_entity_year('test')
-        from_date = datetime(2021, 1, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        from_date = datetime(2020, 1, 1)
+        to_date = datetime(2021, 1, 1,)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='year',
                                                 from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/tests/test_init.py
+++ b/listenbrainz_spark/stats/tests/test_init.py
@@ -45,7 +45,7 @@ class InitTestCase(SparkNewTestCase):
         self.assertEqual(datetime.datetime(2020, 6, 30, 23, 59, 59), stats.get_month_end(month))
 
     def test_get_year_end(self):
-        self.assertEqual(datetime.datetime(2020, 12, 31, 23, 59, 59), stats.get_year_end(2020))
+        self.assertEqual(datetime.datetime(2020, 12, 31, 23, 59, 59), stats.get_year_end(datetime.datetime(2020, 1, 1)))
 
     def test_get_last_monday(self):
         date = datetime.datetime(2020, 5, 19)

--- a/listenbrainz_spark/stats/tests/test_init.py
+++ b/listenbrainz_spark/stats/tests/test_init.py
@@ -38,14 +38,14 @@ class InitTestCase(SparkNewTestCase):
 
     def test_get_day_end(self):
         day = datetime.datetime(2020, 6, 19)
-        self.assertEqual(datetime.datetime(2020, 6, 19, 23, 59, 59), stats.get_day_end(day))
+        self.assertEqual(datetime.datetime(2020, 6, 19, 23, 59, 59, 999999), stats.get_day_end(day))
 
     def test_get_month_end(self):
         month = datetime.datetime(2020, 6, 1)
-        self.assertEqual(datetime.datetime(2020, 6, 30, 23, 59, 59), stats.get_month_end(month))
+        self.assertEqual(datetime.datetime(2020, 6, 30, 23, 59, 59, 999999), stats.get_month_end(month))
 
     def test_get_year_end(self):
-        self.assertEqual(datetime.datetime(2020, 12, 31, 23, 59, 59), stats.get_year_end(datetime.datetime(2020, 1, 1)))
+        self.assertEqual(datetime.datetime(2020, 12, 31, 23, 59, 59, 999999), stats.get_year_end(datetime.datetime(2020, 1, 1)))
 
     def test_get_last_monday(self):
         date = datetime.datetime(2020, 5, 19)

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -9,11 +9,9 @@ from pydantic import ValidationError
 import listenbrainz_spark
 from data.model.user_listening_activity import UserListeningActivityStatMessage
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
-from listenbrainz_spark.stats import (offset_days, offset_months, get_day_end,
-                                      get_month_end, get_year_end,
-                                      replace_days, run_query, get_last_monday)
+from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import get_listens_from_new_dump, get_latest_listen_ts
-from pyspark.sql.functions import collect_list, sort_array, struct, lit
+from pyspark.sql.functions import collect_list, sort_array, struct
 from pyspark.sql.types import (StringType, StructField, StructType,
                                TimestampType)
 

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -51,7 +51,7 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
     # from_offset: this is applied to the latest_listen_date to get from_date
     # to_offset: this is applied to from_date to get to_date
     if stats_range == "week":
-        from_offset = relativedelta(days=-1, weekday=MO(-2))
+        from_offset = relativedelta(weeks=-2, weekday=MO(-1))
         to_offset = relativedelta(weeks=+2)
         # compute listening activity for each day, include weekday in date format
         step = relativedelta(days=+1)

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -17,8 +17,11 @@ from pyspark.sql.functions import collect_list, sort_array, struct, lit
 from pyspark.sql.types import (StringType, StructField, StructType,
                                TimestampType)
 
-time_range_schema = StructType((StructField("time_range", StringType()), StructField(
-    "start", TimestampType()), StructField("end", TimestampType())))
+time_range_schema = StructType([
+    StructField("time_range", StringType()),
+    StructField("start", TimestampType()),
+    StructField("end", TimestampType())
+])
 
 
 logger = logging.getLogger(__name__)

--- a/listenbrainz_spark/stats/user/tests/test_daily_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_daily_activity.py
@@ -30,8 +30,8 @@ class DailyActivityTestCase(StatsTestCase):
     def test_get_daily_activity_week(self, mock_create_messages, _, mock_get_listens):
         daily_activity.get_daily_activity_week()
 
-        from_date = datetime(2021, 7, 26)
-        to_date = datetime(2021, 8, 2)
+        from_date = datetime(2021, 8, 2)
+        to_date = datetime(2021, 8, 9)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='week',
                                                 from_date=from_date, to_date=to_date)
@@ -67,7 +67,7 @@ class DailyActivityTestCase(StatsTestCase):
         daily_activity.get_daily_activity_all_time()
 
         from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
-        to_date = datetime(2021, 8, 9)
+        to_date = datetime(2021, 8, 9, 12, 22, 43)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='all_time',
                                                 from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/user/tests/test_daily_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_daily_activity.py
@@ -30,8 +30,8 @@ class DailyActivityTestCase(StatsTestCase):
     def test_get_daily_activity_week(self, mock_create_messages, _, mock_get_listens):
         daily_activity.get_daily_activity_week()
 
-        from_date = datetime(2021, 8, 2)
-        to_date = datetime(2021, 8, 9)
+        from_date = datetime(2021, 7, 26)
+        to_date = datetime(2021, 8, 2)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='week',
                                                 from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/user/tests/test_daily_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_daily_activity.py
@@ -31,7 +31,7 @@ class DailyActivityTestCase(StatsTestCase):
         daily_activity.get_daily_activity_week()
 
         from_date = datetime(2021, 8, 2)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        to_date = datetime(2021, 8, 9)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='week',
                                                 from_date=from_date, to_date=to_date)
@@ -42,8 +42,8 @@ class DailyActivityTestCase(StatsTestCase):
     def test_get_daily_activity_month(self, mock_create_messages, _, mock_get_listens):
         daily_activity.get_daily_activity_month()
 
-        from_date = datetime(2021, 8, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        from_date = datetime(2021, 7, 1)
+        to_date = datetime(2021, 8, 1)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='month',
                                                 from_date=from_date, to_date=to_date)
@@ -54,8 +54,8 @@ class DailyActivityTestCase(StatsTestCase):
     def test_get_daily_activity_year(self, mock_create_messages, _, mock_get_listens):
         daily_activity.get_daily_activity_year()
 
-        from_date = datetime(2021, 1, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        from_date = datetime(2020, 1, 1)
+        to_date = datetime(2021, 1, 1)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='year',
                                                 from_date=from_date, to_date=to_date)
@@ -67,7 +67,7 @@ class DailyActivityTestCase(StatsTestCase):
         daily_activity.get_daily_activity_all_time()
 
         from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        to_date = datetime(2021, 8, 9)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='all_time',
                                                 from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -22,7 +22,7 @@ class UserEntityTestCase(StatsTestCase):
         entity.get_entity_week('test')
 
         from_date = datetime(2021, 8, 2)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        to_date = datetime(2021, 8, 9)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
                                                 from_date=from_date, to_date=to_date)
@@ -32,8 +32,8 @@ class UserEntityTestCase(StatsTestCase):
     def test_get_entity_month(self, mock_create_messages, mock_get_listens):
         entity.get_entity_month('test')
 
-        from_date = datetime(2021, 8, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        from_date = datetime(2021, 7, 1)
+        to_date = datetime(2021, 8, 1)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='month',
                                                 from_date=from_date, to_date=to_date)
@@ -43,8 +43,8 @@ class UserEntityTestCase(StatsTestCase):
     def test_get_entity_year(self, mock_create_messages, mock_get_listens):
         entity.get_entity_year('test')
 
-        from_date = datetime(2021, 1, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        from_date = datetime(2020, 1, 1)
+        to_date = datetime(2021, 1, 1)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='year',
                                                 from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -21,8 +21,8 @@ class UserEntityTestCase(StatsTestCase):
     def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_week('test')
 
-        from_date = datetime(2021, 8, 2)
-        to_date = datetime(2021, 8, 9)
+        from_date = datetime(2021, 7, 26)
+        to_date = datetime(2021, 8, 2)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
                                                 from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -21,8 +21,8 @@ class UserEntityTestCase(StatsTestCase):
     def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_week('test')
 
-        from_date = datetime(2021, 7, 26)
-        to_date = datetime(2021, 8, 2)
+        from_date = datetime(2021, 8, 2)
+        to_date = datetime(2021, 8, 9)
         mock_get_listens.assert_called_with(from_date, to_date)
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
                                                 from_date=from_date, to_date=to_date)

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -4,12 +4,10 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import listenbrainz_spark.stats.user.listening_activity as listening_activity_stats
-import listenbrainz_spark
 from listenbrainz_spark import utils
-from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.exceptions import HDFSException
 from listenbrainz_spark.stats import (offset_days, offset_months, get_day_end,
-                                      get_month_end, get_year_end, run_query)
+                                      get_month_end, run_query)
 from listenbrainz_spark.stats.user.tests import StatsTestCase
 from pyspark.sql import Row
 

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -45,7 +45,7 @@ class ListeningActivityTestCase(StatsTestCase):
         listening_activity_stats.get_listening_activity_week()
 
         from_date = day = datetime(2021, 7, 26)
-        to_date = datetime(2021, 8, 2)
+        to_date = datetime(2021, 8, 9)
         time_range = []
         while day < to_date:
             time_range.append([day.strftime('%A %d %B %Y'), day, get_day_end(day)])
@@ -64,7 +64,7 @@ class ListeningActivityTestCase(StatsTestCase):
     def test_get_listening_activity_month(self, mock_create_messages, _, mock_get_listens):
         listening_activity_stats.get_listening_activity_month()
 
-        from_date = day = datetime(2021, 7, 1)
+        from_date = day = datetime(2021, 6, 1)
         to_date = datetime(2021, 8, 1)
         time_range = []
         while day < to_date:
@@ -84,7 +84,7 @@ class ListeningActivityTestCase(StatsTestCase):
     def test_get_listening_activity_year(self, mock_create_messages, _, mock_get_listens):
         listening_activity_stats.get_listening_activity_year()
 
-        from_date = month = datetime(2020, 1, 1)
+        from_date = month = datetime(2019, 1, 1)
         to_date = datetime(2021, 1, 1)
         time_range = []
         while month < to_date:

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -44,8 +44,8 @@ class ListeningActivityTestCase(StatsTestCase):
     def test_get_listening_activity_week(self, mock_create_messages, _, mock_get_listens):
         listening_activity_stats.get_listening_activity_week()
 
-        from_date = day = datetime(2021, 8, 2)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        from_date = day = datetime(2021, 7, 26)
+        to_date = datetime(2021, 8, 2)
         time_range = []
         while day < to_date:
             time_range.append([day.strftime('%A %d %B %Y'), day, get_day_end(day)])
@@ -65,7 +65,7 @@ class ListeningActivityTestCase(StatsTestCase):
         listening_activity_stats.get_listening_activity_month()
 
         from_date = day = datetime(2021, 7, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        to_date = datetime(2021, 8, 1)
         time_range = []
         while day < to_date:
             time_range.append([day.strftime('%d %B %Y'), day, get_day_end(day)])
@@ -85,7 +85,7 @@ class ListeningActivityTestCase(StatsTestCase):
         listening_activity_stats.get_listening_activity_year()
 
         from_date = month = datetime(2020, 1, 1)
-        to_date = datetime(2021, 8, 9, 12, 22, 43)
+        to_date = datetime(2021, 1, 1)
         time_range = []
         while month < to_date:
             time_range.append([month.strftime('%B %Y'), month, get_month_end(month)])

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -12,14 +12,13 @@ from pyspark.sql.utils import AnalysisException
 
 import listenbrainz_spark
 from hdfs.util import HdfsError
-from listenbrainz_spark import config, hdfs_connection, path, stats
+from listenbrainz_spark import config, hdfs_connection, path
 from listenbrainz_spark.schema import listens_new_schema
 from listenbrainz_spark.exceptions import (DataFrameNotAppendedException,
                                            DataFrameNotCreatedException,
                                            FileNotFetchedException,
                                            FileNotSavedException,
                                            HDFSDirectoryNotDeletedException,
-                                           HDFSException,
                                            PathNotFoundException,
                                            ViewNotRegisteredException)
 


### PR DESCRIPTION
Clarify what periods stats are calcualted for and make them consistent across all type/range of stats. The stats are to be calculated for the "last" period as per discussion in IRC. Comments in code describe what this means. We should probably explain this on the website as well so that users know when to expect a stats update and why their current listens are no longer reflecting in the stats the next day.