### PR TITLE
Fix Youtube search URL encoding issue

### DIFF
--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -206,7 +206,7 @@ export default class YoutubePlayer
         onTrackNotFound();
       }
     } catch (error) {
-      handleWarning(error, "Youtube player error");
+      handleWarning(error?.message ?? error.toString(), "Youtube player error");
       onTrackNotFound();
     }
   };

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -132,7 +132,6 @@ export default class YoutubePlayer
       state === YouTube.PlayerState.BUFFERING
     ) {
       onPlayerPausedChange(false);
-      onDurationChange(player.getDuration() * 1000);
     }
     if (state === YouTube.PlayerState.PAUSED) {
       onPlayerPausedChange(true);
@@ -141,6 +140,11 @@ export default class YoutubePlayer
       onPlayerPausedChange(false);
     }
     onProgressChange(player.getCurrentTime() * 1000);
+    const duration =
+      this.youtubePlayer?.getDuration && this.youtubePlayer?.getDuration();
+    if (duration) {
+      onDurationChange(duration * 1000);
+    }
   };
 
   handleAccountError = (): void => {

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -5,6 +5,7 @@ import {
   get as _get,
   isNil as _isNil,
   isString as _isString,
+  isFunction as _isFunction,
 } from "lodash";
 import { DataSourceType, DataSourceProps } from "./BrainzPlayer";
 import { searchForYoutubeTrack } from "./utils";
@@ -140,8 +141,7 @@ export default class YoutubePlayer
       onPlayerPausedChange(false);
     }
     onProgressChange(player.getCurrentTime() * 1000);
-    const duration =
-      this.youtubePlayer?.getDuration && this.youtubePlayer?.getDuration();
+    const duration = _isFunction(player.getDuration) && player.getDuration();
     if (duration) {
       onDurationChange(duration * 1000);
     }

--- a/listenbrainz/webserver/static/js/src/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils.tsx
@@ -73,8 +73,13 @@ const searchForYoutubeTrack = async (
   // if (releaseName) {
   //   query += ` ${releaseName}`;
   // }
+  if (!query) {
+    return null;
+  }
   const response = await fetch(
-    `https://youtube.googleapis.com/youtube/v3/search?part=snippet&q=${query}&videoEmbeddable=true&type=video&key=${apiKey}`,
+    `https://youtube.googleapis.com/youtube/v3/search?part=snippet&q=${encodeURIComponent(
+      query
+    )}&videoEmbeddable=true&type=video&key=${apiKey}`,
     {
       method: "GET",
       headers: {


### PR DESCRIPTION
This PR solves three issues:
1. The track & artist names used for the search query were not URL-encoded, resulting in some failures when the track name contained certain characters like `#`
2. When those requests were failing, the error handling was itself throwing an error and breaking the page.
  The error was: `Objects are not valid as a React child (found: object with keys {code, message, errors, status}). If you meant to render a collection of children, use an array instead.` because of this line:
https://github.com/metabrainz/listenbrainz-server/blob/bef43a7e0b5eaac6e66261230e52203b0a5fd919/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx#L209 
  The `error` here is an object, while handleWarning expects a string or JSX element. And React doesn't like rendering objects.
3. Update track duration on all player updates (in some cases the duration wasn't updated at the right time)