### PR TITLE
Fix playlist card layout

### DIFF
--- a/listenbrainz/webserver/static/css/playlists.less
+++ b/listenbrainz/webserver/static/css/playlists.less
@@ -113,9 +113,15 @@
 		}
 	}
 	.playlist-item-card {
+		display: flex;
 		align-items: center;
 		margin-bottom: 0px;
+		padding: 10px 5px;
+    	max-height: 72px;
 		
+		@media (min-width: @screen-sm){
+			padding: 15px;
+		}
 		&.current-track {
 			background-color: rgba(217, 237, 247, 0.3) !important ;
 		}


### PR DESCRIPTION
Ruh-roh! I broke the playlist card layout in #1620 :
![image](https://user-images.githubusercontent.com/6179856/135484320-095ba625-b8df-469b-99d5-83ac6425601f.png)

Quick fix to get it back to previous layout until I replace it with the ListenCard component

After:
![image](https://user-images.githubusercontent.com/6179856/135485089-47d80167-8fc3-4610-bf1a-f94343ea550e.png)
