### PR TITLE
Switch from curl to wget for key downloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN wget -O- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ENV PG_MAJOR 12
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
because curl fails with the following error

```
...
 => CACHED [listenbrainz-base  2/13] RUN wget https://github.com/jwilder/  0.0s
 => CACHED [listenbrainz-base  3/13] RUN wget -O /usr/local/bin/sentry-cl  0.0s
 => CACHED [listenbrainz-base  4/13] RUN apt-get update     && apt-get in  0.0s
 => CACHED [listenbrainz-base  5/13] RUN update-ca-certificates            0.0s
 => ERROR [listenbrainz-base  6/13] RUN curl https://www.postgresql.org/m  1.1s
------                                                                          
 > [listenbrainz-base  6/13] RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -:                                                       
#9 0.229   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                        
#9 0.237                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
#9 0.812 curl: (60) server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
#9 0.812 More details here: http://curl.haxx.se/docs/sslcerts.html
#9 0.812 
#9 0.812 curl performs SSL certificate verification by default, using a "bundle"
#9 0.812  of Certificate Authority (CA) public keys (CA certs). If the default
#9 0.812  bundle file isn't adequate, you can specify an alternate file
#9 0.812  using the --cacert option.
#9 0.812 If this HTTPS server uses a certificate signed by a CA represented in
#9 0.812  the bundle, the certificate verification probably failed due to a
#9 0.812  problem with the certificate (it might be expired, or the name might
#9 0.812  not match the domain name in the URL).
#9 0.812 If you'd like to turn off curl's verification of the certificate, use
#9 0.812  the -k (or --insecure) option.
#9 1.091 gpg: no valid OpenPGP data found.
------
executor failed running [/bin/sh -c curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -]: exit code: 2
ERROR: Service 'web' failed to build : Build failed
```

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Switch from curl to wget
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


