### PR TITLE
LB-908: Listens sent to front-end via websockets have a lot of unused keys

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -232,6 +232,13 @@ class NowPlayingListen:
             data['additional_info'] = flatten_dict(additional_info)
             self.data = data
 
+    def to_api(self):
+        return {
+            "user_name": self.user_name,
+            "track_metadata": self.data,
+            "playing_now": True
+        }
+
     def __repr__(self):
         from pprint import pformat
         return pformat(vars(self))

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -234,7 +234,6 @@ class NowPlayingListen:
 
     def to_api(self):
         return {
-            "user_name": self.user_name,
             "track_metadata": self.data,
             "playing_now": True
         }

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -204,10 +204,8 @@ def get_playing_now(user_name):
     listen_data = []
     count = 0
     if playing_now_listen:
-        count += 1
-        listen_data = [{
-            'track_metadata': playing_now_listen.data,
-        }]
+        count = 1
+        listen_data = [playing_now_listen.to_api()]
 
     return jsonify({
         'payload': {

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -110,11 +110,7 @@ def profile(user_name):
     if not listens or listens[0]['listened_at'] >= max_ts_per_user:
         playing_now = playing_now_conn.get_playing_now(user.id)
         if playing_now:
-            listen = {
-                "track_metadata": playing_now.data,
-                "playing_now": "true",
-            }
-            listens.insert(0, listen)
+            listens.insert(0, playing_now.to_api())
 
     user_stats = db_stats.get_user_stats(user.id, 'all_time', 'artists')
 
@@ -477,7 +473,7 @@ def delete_listens_history(musicbrainz_id):
 def feedback(user_name: str):
     """ Show user feedback, with filter on score (love/hate).
 
-    Args: 
+    Args:
         musicbrainz_id (str): the MusicBrainz ID of the user
     Raises:
         NotFound if user isn't present in the database


### PR DESCRIPTION
1. Make the listen data sent by Websockets consistent with the API. 

2. The API response for now playing listens now also contains the now playing field and user name inside the listen body. This will make writing frontend code easier.

Its a field addition hence should be backward compatible. The fields at top level are not removed to maintain compatibility.

Old:
```
{
  payload: {
  count: 1,
  listens: [
    {
      track_metadata: {
        additional_info: { },
        artist_name: "All Time Low, Demi Lovato, blackbear",
        release_name: "Monsters (feat. Demi Lovato and blackbear)",
        track_name: "Monsters (feat. Demi Lovato and blackbear)"
      }
    }
  ],
  playing_now: true,
  user_id: "amcap1712"
  }
}
```

New:
```
{
  payload: {
  count: 1,
  listens: [
    {
      playing_now: true,
      track_metadata: {
        additional_info: { },
        artist_name: "All Time Low, Demi Lovato, blackbear",
        release_name: "Monsters (feat. Demi Lovato and blackbear)",
        track_name: "Monsters (feat. Demi Lovato and blackbear)"
      },
      user_name: "amCap1712"
    }
  ],
  playing_now: true,
  user_id: "amcap1712"
  }
}
```
