### PR TITLE
Improve ListenCard CSS layout

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -225,13 +225,10 @@
 		padding: 10px;
 		margin: 0;
     	margin-bottom: 3px;
-		.listen-details{
-			flex: 1;
-			// Parent's width minus controls and thumbnail elements' width
-			max-width: calc(100% - 60px);
+		.listen-details {
+			flex-basis: 0%;
 		}
 		.listen-controls {
-
 			flex-grow: 0;
 		}
 	}
@@ -255,40 +252,33 @@
 		flex-direction: column;
 		justify-content: center;
 		padding-right: 1em;
-		padding-top: 0.5em;
-		@media (min-width: @listen-small-break) {
-    		padding-right: 2em;
-			align-items: flex-end;
-			padding-top: 0;
-		}
+		align-items: flex-end;
 	}
 	
 	.listen-details{
-		flex: 0 0 auto;
 		flex-direction: column;
-		width: 100%;
 		line-height: 1.3em;
-
-		@media (min-width: @listen-small-break) {
-			flex: 3;
-		}
+		overflow: hidden;
+		flex: 3;
+		flex-basis: 270px;
 		
 		.artist-and-timestamp {
 			display: flex;
 			flex-wrap: wrap;
 		}
-		.ellipsis {
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space:nowrap;
-		}
-		.ellipsis-2-lines {
-			display: -webkit-box;
-			-webkit-line-clamp: 2;
-			-webkit-box-orient: vertical;
-			overflow: hidden;
-			text-overflow: ellipsis;
-		}
+	}
+	
+	.ellipsis {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space:nowrap;
+	}
+	.ellipsis-2-lines {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 	
 	.additional-details{


### PR DESCRIPTION
Better management of available space, especially in mobile device sizes and in the new compact mode used on charts pages, relying more on flexbox instead of breakpoints

Before:
![image](https://user-images.githubusercontent.com/6179856/136786642-95e8bfed-5a2a-426d-a5b9-d0d5ffb04956.png)

After:
![image](https://user-images.githubusercontent.com/6179856/136786612-85fb090c-af62-465c-a6d8-60b7fabcadb2.png)



In compact mode:
Before:
![image](https://user-images.githubusercontent.com/6179856/136792705-f6aadf00-b822-4fb6-a649-92848d5ec3b3.png)

After:
![image](https://user-images.githubusercontent.com/6179856/136792733-836f891e-dfcd-479e-8858-f2f39aa94c1c.png)


Feed page:

Before: 
![image](https://user-images.githubusercontent.com/6179856/136794196-d735e166-de3a-4ead-a78b-01fb7caa29bf.png)

After:
![image](https://user-images.githubusercontent.com/6179856/136794232-4fa3b697-02cc-447c-ac00-bd0c7743691c.png)
