### PR TITLE
LB-960: My Listens -> Delete Listen doesn't work for me

### DIFF
--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -105,11 +105,7 @@ def profile(user_name):
 
     listens = []
     for listen in data:
-        listens.append({
-            "track_metadata": listen.data,
-            "listened_at": listen.ts_since_epoch,
-            "listened_at_iso": listen.timestamp.isoformat() + "Z",
-        })
+        listens.append(listen.to_api())
 
     # If there are no previous listens then display now_playing
     if not listens or listens[0]['listened_at'] >= max_ts_per_user:


### PR DESCRIPTION
The user_name field is missing here and the frontend relies on it to show the Delete Listen button. As a result, the Delete Listen button is currently not being shown on the frontend. Use the to_api method which is also used by the API endpoints when returning listens.