### PR TITLE
Catch potential errors when calling getUserListenCount

### DIFF
--- a/listenbrainz/webserver/static/js/src/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/RecentListens.tsx
@@ -92,6 +92,7 @@ export default class RecentListens extends React.Component<
 
   componentDidMount(): void {
     const { mode } = this.state;
+    const { newAlert } = this.props;
     // Get API instance from React context provided for in top-level component
     const { APIService, currentUser } = this.context;
     this.APIService = APIService;
@@ -105,9 +106,17 @@ export default class RecentListens extends React.Component<
       const { user } = this.props;
       // Get the user listen count
       if (user?.name) {
-        this.APIService.getUserListenCount(user.name).then((listenCount) => {
-          this.setState({ listenCount });
-        });
+        this.APIService.getUserListenCount(user.name)
+          .then((listenCount) => {
+            this.setState({ listenCount });
+          })
+          .catch((error) => {
+            newAlert(
+              "danger",
+              "Sorry, we couldn't load your listens count…",
+              error?.toString()
+            );
+          });
       }
       if (currentUser?.name && currentUser?.name === user?.name) {
         this.loadFeedback();


### PR DESCRIPTION
`getUserListenCount` function in RecentListens is not properly called with a `.catch`
This can result in an uncaught error which breaks the page entirely (showing only the error as page content).
See an example here: https://sentry.metabrainz.org/organizations/metabrainz/issues/139

