### PR TITLE
AISOTT: Adding rough version of release submitter

### DIFF
--- a/listenbrainz/misc/submit_album.py
+++ b/listenbrainz/misc/submit_album.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import sys
+from time import time, sleep
+from uuid import uuid4
+from random import randint
+
+import click
+import requests
+
+ROOT = 'https://api.listenbrainz.org'
+ROOT = 'http://localhost'
+
+
+def submit_listen(url, listen_type, payload, token):
+    """Submits listens for the track(s) in payload.
+
+    Args:
+        listen_type (str): either of 'single', 'import' or 'playing_now'
+        payload: A list of Track dictionaries.
+        token: the auth token of the user you're submitting listens for
+
+    Returns:
+         The json response if there's an OK status.
+
+    Raises:
+         An HTTPError if there's a failure.
+         A ValueError is the JSON in the response is invalid.
+    """
+
+    response = requests.post(
+        url="{0}/1/submit-listens".format(url),
+        json={
+            "listen_type": listen_type,
+            "payload": payload,
+        },
+        headers={
+            "Authorization": "Token {0}".format(token)
+        }
+    )
+    response.raise_for_status()
+
+
+@click.command()
+@click.option('--url', '-u', help="Host to submit to. default: http://localhost", default="http://localhost")
+@click.argument('token', nargs=1)
+@click.argument('release', nargs=1)
+def submit_release(token, release, url):
+    """ Fetch a release from MusicBrainz and submit it as listens to LB
+
+        Arguments:
+           User token from user profile page
+           MusicBrainz release MBID to fetch and submit
+    """
+
+    resp = requests.get(
+        "https://musicbrainz.org/ws/2/release/%s?inc=recordings+artists&fmt=json" % release)
+    if resp.status_code != 200:
+        print("Failed to fetch album: %d" % resp.code)
+        sys.exit(-1)
+
+    jdata = resp.json()
+    artist = jdata["artist-credit"][0]["artist"]["name"]
+    recordings = jdata['media'][0]['tracks']
+
+    time_index = int(time())
+    for rec in recordings:
+        time_index -= int(rec["length"]) // 1000
+        payload = [
+            {
+                "listened_at": time_index,
+                "track_metadata": {
+                    "artist_name": artist,
+                    "track_name": rec['title']
+                }
+            }
+        ]
+        try:
+            submit_listen(url=url, listen_type='single',
+                          payload=payload, token=token)
+        except requests.exceptions.ConnectionError as err:
+            print("Cannot connect to server: %s" % str(err))
+            sys.exit(0)
+        except requests.exceptions.HTTPError as err:
+            print("Cannot submit listen. Is your user token correct?\n%s" % str(err))
+            sys.exit(0)
+
+        sleep(.2)
+
+    sys.exit(0)
+
+
+def usage(command):
+    with click.Context(command) as ctx:
+        click.echo(command.get_help(ctx))
+
+
+if __name__ == '__main__':
+    submit_release()


### PR DESCRIPTION
One of the frustrating things about starting with LB dev is not having sample data in the DB. This script, which is intended to be run on the host (not using docker) allows the user to provide a user token and a MB release MBID to submit the given release as a series of listens, timestamped from now(), going back in time.

Requires the use of a venv or to have requests and click installed.

This quick hack allows users to have fresh data in the DB and get started with LB dev (or after a DB reset). This is a quick hack job that has been kicking around on my machine for eons, but I keep missing it on other machines, so I am checking it in for others to use. However, I don't particularly care to much about this much. Let's accept it, but if there is too much nitpicking about it, I'll just close this PR, I don't care enough. 

