### PR TITLE
Remove unused flask route - /privacy

### DIFF
--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -103,11 +103,6 @@ def roadmap():
     return render_template("index/roadmap.html")
 
 
-@index_bp.route("/privacy/")
-def privacy_policy():
-    return render_template("index/privacy-policy.html")
-
-
 @index_bp.route("/current-status/")
 @web_listenstore_needed
 def current_status():


### PR DESCRIPTION
We had removed the LB privacy page but forgot to remove this route. The template is gone and all links point to the MeB privacy policy but if someone tries to open lb.org/privacy, they get a 500 error (as found in sentry). Removing the route fixes the issue and the user sees a 404.