### PR TITLE
LB-975: Fix docs for validate-token API endpoint

### DIFF
--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -416,7 +416,7 @@ def validate_token():
             "code": 200,
             "message": "Token valid.",
             "valid": true,
-            "user": "MusicBrainz ID of the user with the passed token"
+            "user_name": "MusicBrainz ID of the user with the passed token"
         }
 
     - If the given token is invalid:


### PR DESCRIPTION
Fixes documented return format of `validate-token` API endpoint for LB-975