### PR TITLE
Prevent calendar picker from changing height

### DIFF
--- a/listenbrainz/webserver/static/css/DatePicker.less
+++ b/listenbrainz/webserver/static/css/DatePicker.less
@@ -113,6 +113,7 @@
   }
   
   .react-calendar {
+	height: 305px; // Prevent changing height from one month to the next
 	width: 350px;
 	max-width: 100%;
 	background: white;


### PR DESCRIPTION
The calendar picker in "My listens" page has the annoying habit of changing height depending on the month (and the number of rows to display). Time to fix it.
This is unpleasant when quickly navigating from month to month as the navigation buttons are suddenly not under your cursor anymore.