### PR TITLE
Use correct BrainzPlayer event key

### DIFF
--- a/listenbrainz/webserver/static/js/src/PinnedRecordingCard.tsx
+++ b/listenbrainz/webserver/static/js/src/PinnedRecordingCard.tsx
@@ -84,8 +84,8 @@ export default class PinnedRecordingCard extends React.Component<
       // Received postMessage from different origin, ignoring it
       return;
     }
-    const { type, payload } = event.data;
-    switch (type) {
+    const { brainzplayer_event, payload } = event.data;
+    switch (brainzplayer_event) {
       case "current-listen-change":
         this.onCurrentListenChange(payload);
         break;

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -117,8 +117,8 @@ export default class ListenCard extends React.Component<
       // Received postMessage from different origin, ignoring it
       return;
     }
-    const { type, payload } = event.data;
-    switch (type) {
+    const { brainzplayer_event, payload } = event.data;
+    switch (brainzplayer_event) {
       case "current-listen-change":
         this.onCurrentListenChange(payload);
         break;

--- a/listenbrainz/webserver/static/js/src/playlists/PlaylistItemCard.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/PlaylistItemCard.tsx
@@ -70,8 +70,8 @@ export default class PlaylistItemCard extends React.Component<
       // Received postMessage from different origin, ignoring it
       return;
     }
-    const { type, payload } = event.data;
-    switch (type) {
+    const { brainzplayer_event, payload } = event.data;
+    switch (brainzplayer_event) {
       case "current-listen-change":
         this.onCurrentListenChange(payload);
         break;


### PR DESCRIPTION
I made a mistake during the last BrainzPlayer refactor in PR #1643 , using the wrong BrainzPlayer event key.
That means the currently playing track does not display any differently than others (we expect it to change colour and show a fixed play icon). Oops 😓 .