### PR TITLE
(LB-980) AISOTT: Improve incremental dumps by sorting on created, rather than listened_at

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE INDEX listened_at_user_name_ndx_listen ON listen (listened_at DESC, user_name);
-CREATE INDEX created_user_name_ndx_listen ON listen (created);
+CREATE INDEX created_ndx_listen ON listen (created);
 CREATE UNIQUE INDEX listened_at_track_name_user_name_ndx_listen ON listen (listened_at DESC, track_name, user_name);
 
 -- View indexes are created in listenbrainz/db/timescale.py

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -704,9 +704,8 @@ class TimescaleListenStore(ListenStore):
                             archive_dir,
                             temp_dir,
                             tar_file,
-                            start_time=None,
-                            end_time=None,
-                            full_dump=True,
+                            start_time,
+                            end_time,
                             parquet_file_id=0):
         """
             Carry out fetching listens from the DB, joining them to the MBID mapping table and
@@ -714,11 +713,10 @@ class TimescaleListenStore(ListenStore):
 
         Args:
             archive_dir: the directory where the listens dump archive should be created
-            tmp_dir: the directory where tmp files should be written
+            temp_dir: the directory where tmp files should be written
+            tar_file: the tarfile object that the dumps are being written to
             dump_id (int): the ID of the dump in the dump sequence
             start_time and end_time (datetime): the time range for which listens should be dumped
-                start_time defaults to utc 0 (meaning a full dump) and end_time defaults to the current time
-            full_dump (bool): Is this a full or incremental dump?
             parquet_file_id: the file id number to use for indexing parquet files
 
         Returns:
@@ -727,9 +725,6 @@ class TimescaleListenStore(ListenStore):
         """
 
         listen_count = 0
-
-        if end_time is None:
-            end_time = datetime.now()
 
         query = """SELECT listened_at,
                           user_name,
@@ -891,7 +886,7 @@ class TimescaleListenStore(ListenStore):
                 # Without it sometimes test pass and sometimes they give totally unrelated errors.
                 # Keeping this block should help with future testing...
                 try:
-                    parquet_index = self.write_parquet_files(archive_name, temp_dir, tar, start, end, full_dump, parquet_index)
+                    parquet_index = self.write_parquet_files(archive_name, temp_dir, tar, start, end, parquet_index)
                 except Exception as err:
                     self.log.info("likely test failure: " + str(err))
                     raise


### PR DESCRIPTION
Lucifer discovered a bug where the incremental dump should clearly be sorted by created, rather than listened_at. As it stands now, an incremental dump will never show stats for imported listens that fall outside of the current incremental dump window (e.g. nearly all of them).

The fix is fairly easy and with the addition of an index on created, the query executes snappily. There is no DB upgrade script, because the production server already has this index in place.