### PR TITLE
AISOTT: Do not double encode artist_mbids for exact matches

### DIFF
--- a/listenbrainz/mbid_mapping_writer/matcher.py
+++ b/listenbrainz/mbid_mapping_writer/matcher.py
@@ -29,24 +29,21 @@ def process_listens(app, listens, is_legacy_listen=False):
     msids = {str(listen['recording_msid']): listen for listen in listens}
     stats["total"] = len(msids)
     if len(msids):
-        if not is_legacy_listen:
-            with timescale.engine.connect() as connection:
-                query = """SELECT recording_msid 
-                             FROM listen_join_listen_mbid_mapping lj
-                             JOIN listen_mbid_mapping mbid
-                               ON mbid.id = lj.listen_mbid_mapping
-                            WHERE recording_msid IN :msids"""
-                curs = connection.execute(sqlalchemy.text(
-                    query), msids=tuple(msids.keys()))
-                while True:
-                    result = curs.fetchone()
-                    if not result:
-                        break
-                    del msids[str(result[0])]
-                    stats["processed"] += 1
-                    skipped += 1
-        else:
-            stats["processed"] += len(msids)
+        with timescale.engine.connect() as connection:
+            query = """SELECT recording_msid 
+                         FROM listen_join_listen_mbid_mapping lj
+                         JOIN listen_mbid_mapping mbid
+                           ON mbid.id = lj.listen_mbid_mapping
+                        WHERE recording_msid IN :msids"""
+            curs = connection.execute(sqlalchemy.text(
+                query), msids=tuple(msids.keys()))
+            while True:
+                result = curs.fetchone()
+                if not result:
+                    break
+                del msids[str(result[0])]
+                stats["processed"] += 1
+                skipped += 1
 
         if len(msids) == 0:
             return stats
@@ -121,7 +118,8 @@ def process_listens(app, listens, is_legacy_listen=False):
                                   JOIN join_insert ji
                                     ON ji.recording_mbid = d.recording_mbid
                                    AND ji.release_mbid = d.release_mbid
-                                   AND ji.artist_credit_id = d.artist_credit_id""" % ",".join(mogrified)
+                                   AND ji.artist_credit_id = d.artist_credit_id
+                           ON CONFLICT DO NOTHING""" % ",".join(mogrified)
                 curs.execute(query)
 
             except (psycopg2.OperationalError, psycopg2.errors.DatatypeMismatch) as err:


### PR DESCRIPTION
This fixes a problem where artist_mbids in the mapping where being double {} encoded. Also ensure that all inbound listens are checked for existence in the DB and should something go wrong, ignore the insert.