### PR TITLE
Add array dimension constraint check to listen_mbid_mapping.artist_mbids

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -61,4 +61,8 @@ create table listen_mbid_mapping (
         last_updated        TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
 );
 
+-- postgres does not enforce dimensionality of arrays. add explicit check to avoid regressions (once burnt, twice shy!).
+ALTER TABLE listen_mbid_mapping
+    ADD CONSTRAINT listen_mbid_mapping_artist_mbids_check
+    CHECK ( array_ndims(artist_mbids) = 1 );
 COMMIT;

--- a/admin/timescale/updates/2021-10-27-add-artist-mbids-constraint.sql
+++ b/admin/timescale/updates/2021-10-27-add-artist-mbids-constraint.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE listen_mbid_mapping
+    ADD CONSTRAINT listen_mbid_mapping_artist_mbids_check
+    CHECK ( array_ndims(artist_mbids) = 1 );
+COMMIT;


### PR DESCRIPTION
We had this bug in mbid mapping writer where some artist_mbids were being inserted as nested arrays (see #1682). Hence, a check to avoid regression.
