### PR TITLE
AISOTT: Add index on FK referenced join table for mapping

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -22,6 +22,7 @@ CREATE INDEX collaborator_id_playlist_collaborator ON playlist.playlist_collabor
 -- MBID Mapping
 
 CREATE UNIQUE INDEX id_ndx_listen_join_listen_mbid_mapping ON listen_mbid_mapping (id);
+CREATE INDEX listen_mbid_mapping_ndx_listen_join_listen_mbid_mapping on listen_join_listen_mbid_mapping(listen_mbid_mapping);
 CREATE UNIQUE INDEX recording_msid_ndx_listen_join_listen_mbid_mapping ON listen_join_listen_mbid_mapping (recording_msid);
 
 COMMIT;


### PR DESCRIPTION
Deleting incorrect rows from the mapping table was super slow. Googling found:

   https://dba.stackexchange.com/questions/37034/very-slow-delete-in-postgresql-workaround

That worked great, so here is the PR to add the index. Already applied in production.