### PR TITLE
Improve mbid mapper error reporting

### DIFF
--- a/listenbrainz/mbid_mapping_writer/job_queue.py
+++ b/listenbrainz/mbid_mapping_writer/job_queue.py
@@ -241,11 +241,7 @@ class MappingJobQueue(threading.Thread):
                         for complete in completed:
                             exc = complete.exception()
                             if exc:
-                                f = StringIO()
-                                traceback.print_exception(
-                                    None, exc, exc.__traceback__, limit=None, file=f)
-                                f.seek(0)
-                                self.app.logger.error(f.read())
+                                self.app.logger.error("Error in listen mbid mapping writer:", exc_info=exc)
                                 stats["errors"] += 1
                             else:
                                 job_stats = complete.result()


### PR DESCRIPTION
Passing the exception as exc_info will cause logger.error to use the exception's stacktrace. This way we should get better error grouping in sentry and more info in logs.