### PR TITLE
Fix errors returned by API compat for invalid listens 

### DIFF
--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -1,5 +1,4 @@
 from flask import render_template, make_response, jsonify, request, has_request_context, _request_ctx_stack, current_app
-from werkzeug.exceptions import InternalServerError
 from yattag import Doc
 import yattag
 import ujson
@@ -232,3 +231,15 @@ class InvalidAPIUsage(Exception):
             with tag('error', code=self.api_error.code):
                 text(self.api_error.message)
         return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
+
+
+class ValidationError(Exception):
+    """ Error class for raising when the submitted payload does not pass validation.
+    Only use for code paths common to LB API, API compat & API compat deprecated.
+    Throw this error from an util method, capture it in each of the corresponding
+    views and re-raise the API dependent error.
+    """
+
+    def __init__(self, message, payload=None):
+        self.message = message
+        self.payload = payload

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -233,7 +233,7 @@ class InvalidAPIUsage(Exception):
         return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
 
 
-class ValidationError(Exception):
+class ListenValidationError(Exception):
     """ Error class for raising when the submitted payload does not pass validation.
     Only use for code paths common to LB API, API compat & API compat deprecated.
     Throw this error from an util method, capture it in each of the corresponding

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -7,7 +7,7 @@ from brainzutils.musicbrainz_db import engine as mb_engine
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIServiceUnavailable, \
-    APIUnauthorized, ValidationError
+    APIUnauthorized, ListenValidationError
 from listenbrainz.webserver.decorators import api_listenstore_needed
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.webserver.decorators import crossdomain
@@ -87,7 +87,7 @@ def submit_listen():
     try:
         # validate listens to make sure json is okay
         validated_payload = [validate_listen(listen, listen_type) for listen in payload]
-    except ValidationError as err:
+    except ListenValidationError as err:
         raise APIBadRequest(err.message, err.payload)
 
     user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -7,7 +7,7 @@ from brainzutils.musicbrainz_db import engine as mb_engine
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIServiceUnavailable, \
-    APIUnauthorized
+    APIUnauthorized, ValidationError
 from listenbrainz.webserver.decorators import api_listenstore_needed
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.webserver.decorators import crossdomain
@@ -84,16 +84,14 @@ def submit_listen():
     except KeyError:
         log_raise_400("Invalid JSON document submitted.", raw_data)
 
-    # validate listens to make sure json is okay
-    validated_payload = [validate_listen(listen, listen_type) for listen in payload]
-
     try:
-        user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])
-        insert_payload(validated_payload, user_metadata, listen_type)
-    except APIServiceUnavailable as e:
-        raise
-    except Exception as e:
-        raise APIInternalServerError("Something went wrong. Please try again.")
+        # validate listens to make sure json is okay
+        validated_payload = [validate_listen(listen, listen_type) for listen in payload]
+    except ValidationError as err:
+        raise APIBadRequest(err.message, err.payload)
+
+    user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])
+    insert_payload(validated_payload, user_metadata, listen_type)
 
     return jsonify({'status': 'ok'})
 
@@ -396,7 +394,7 @@ def latest_import():
             current_app.logger.error("Error while updating latest import: ", exc_info=True)
             raise APIInternalServerError('Could not update latest_import, try again')
 
-        # During unrelated tests _ts may be None -- improving this would be a great headache. 
+        # During unrelated tests _ts may be None -- improving this would be a great headache.
         # However, during the test of this code and while serving requests _ts is set.
         if _ts:
             _ts.set_listen_count_expiry_for_user(user['musicbrainz_id'])

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -8,7 +8,7 @@ from flask import Blueprint, request, render_template, current_app
 from flask_login import login_required, current_user
 from brainzutils.ratelimit import ratelimit
 from brainzutils.musicbrainz_db import engine as mb_engine
-from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError, ValidationError
+from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError, ListenValidationError
 import xmltodict
 
 from listenbrainz.webserver.models import SubmitListenUserMetadata
@@ -276,7 +276,7 @@ def record_listens(request, data):
     listen_type, native_payload = _to_native_api(lookup, data['method'], output_format)
     try:
         validated_payload = [validate_listen(listen, listen_type) for listen in native_payload]
-    except ValidationError as err:
+    except ListenValidationError as err:
         raise InvalidAPIUsage(err.message, 400, output_format)
 
     user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -1,5 +1,3 @@
-
-import time
 import json
 import re
 import listenbrainz.db.user as db_user
@@ -10,8 +8,7 @@ from flask import Blueprint, request, render_template, current_app
 from flask_login import login_required, current_user
 from brainzutils.ratelimit import ratelimit
 from brainzutils.musicbrainz_db import engine as mb_engine
-from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError
-from listenbrainz.webserver.decorators import api_listenstore_needed
+from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError, ValidationError
 import xmltodict
 
 from listenbrainz.webserver.models import SubmitListenUserMetadata
@@ -277,7 +274,10 @@ def record_listens(request, data):
 
     # Convert to native payload then submit 'em after validation.
     listen_type, native_payload = _to_native_api(lookup, data['method'], output_format)
-    validated_payload = [validate_listen(listen, listen_type) for listen in native_payload]
+    try:
+        validated_payload = [validate_listen(listen, listen_type) for listen in native_payload]
+    except ValidationError as err:
+        raise InvalidAPIUsage(err.message, 400, output_format)
 
     user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])
     augmented_listens = insert_payload(validated_payload, user_metadata, listen_type=listen_type)

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -33,7 +33,7 @@ from flask import current_app, Blueprint, request, render_template, redirect
 from werkzeug.exceptions import BadRequest
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.webserver.models import SubmitListenUserMetadata
-from listenbrainz.webserver.errors import ValidationError
+from listenbrainz.webserver.errors import ListenValidationError
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
 from listenbrainz.webserver.views.api_tools import insert_payload, is_valid_timestamp, LISTEN_TYPE_PLAYING_NOW, \
     is_valid_uuid, check_for_unicode_null_recursively
@@ -197,7 +197,7 @@ def _to_native_api(data, append_key):
 
     try:
         check_for_unicode_null_recursively(listen)
-    except ValidationError:
+    except ListenValidationError:
         return None
 
     return listen

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -33,7 +33,7 @@ from flask import current_app, Blueprint, request, render_template, redirect
 from werkzeug.exceptions import BadRequest
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.webserver.models import SubmitListenUserMetadata
-from listenbrainz.webserver.errors import APIBadRequest
+from listenbrainz.webserver.errors import ValidationError
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
 from listenbrainz.webserver.views.api_tools import insert_payload, is_valid_timestamp, LISTEN_TYPE_PLAYING_NOW, \
     is_valid_uuid, check_for_unicode_null_recursively
@@ -197,7 +197,7 @@ def _to_native_api(data, append_key):
 
     try:
         check_for_unicode_null_recursively(listen)
-    except APIBadRequest:
+    except ValidationError:
         return None
 
     return listen

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -54,14 +54,8 @@ def insert_payload(payload, user: SubmitListenUserMetadata, listen_type=LISTEN_T
     """ Convert the payload into augmented listens then submit them.
         Returns: augmented_listens
     """
-    try:
-        augmented_listens = _get_augmented_listens(payload, user)
-        _send_listens_to_queue(listen_type, augmented_listens)
-    except (APIInternalServerError, APIServiceUnavailable):
-        raise
-    except Exception as e:
-        current_app.logger.error("Error while inserting payload: %s", str(e), exc_info=True)
-        raise APIInternalServerError("Something went wrong. Please try again.")
+    augmented_listens = _get_augmented_listens(payload, user)
+    _send_listens_to_queue(listen_type, augmented_listens)
     return augmented_listens
 
 

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -17,7 +17,9 @@ import sentry_sdk
 from flask import current_app, request
 
 from listenbrainz.webserver import API_LISTENED_AT_ALLOWED_SKEW
-from listenbrainz.webserver.errors import APIInternalServerError, APIServiceUnavailable, APIBadRequest, APIUnauthorized
+from listenbrainz.webserver.errors import APIInternalServerError, APIServiceUnavailable, APIBadRequest, APIUnauthorized, \
+    ValidationError
+
 #: Maximum overall listen size in bytes, to prevent egregious spamming.
 from listenbrainz.webserver.models import SubmitListenUserMetadata
 
@@ -154,62 +156,62 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
     in place if needed."""
 
     if listen is None:
-        raise APIBadRequest("Listen is empty and cannot be validated.")
+        raise ValidationError("Listen is empty and cannot be validated.")
 
     if listen_type in (LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT):
         if 'listened_at' not in listen:
-            raise APIBadRequest("JSON document must contain the key listened_at at the top level.", listen)
+            raise ValidationError("JSON document must contain the key listened_at at the top level.", listen)
 
         try:
             listen['listened_at'] = int(listen['listened_at'])
         except ValueError:
-            raise APIBadRequest("JSON document must contain an int value for listened_at.", listen)
+            raise ValidationError("JSON document must contain an int value for listened_at.", listen)
 
         if 'listened_at' in listen and 'track_metadata' in listen and len(listen) > 2:
-            raise APIBadRequest("JSON document may only contain listened_at and "
-                                "track_metadata top level keys", listen)
+            raise ValidationError("JSON document may only contain listened_at and "
+                                  "track_metadata top level keys", listen)
 
         # if timestamp is too high, raise BadRequest
         # in order to make up for possible clock skew, we allow
         # timestamps to be one hour ahead of server time
         if not is_valid_timestamp(listen['listened_at']):
-            raise APIBadRequest("Value for key listened_at is too high.", listen)
+            raise ValidationError("Value for key listened_at is too high.", listen)
 
         # check that listened_at value is greater than last.fm founding year.
         if listen['listened_at'] < LISTEN_MINIMUM_TS:
-            raise APIBadRequest("Value for key listened_at is too low. listened_at timestamp"
-                                " should be greater than 1033410600 (2002-10-01 00:00:00 UTC).", listen)
+            raise ValidationError("Value for key listened_at is too low. listened_at timestamp "
+                                  "should be greater than 1033410600 (2002-10-01 00:00:00 UTC).", listen)
 
     elif listen_type == LISTEN_TYPE_PLAYING_NOW:
         if 'listened_at' in listen:
-            raise APIBadRequest("JSON document must not contain listened_at while submitting "
-                                "playing_now.", listen)
+            raise ValidationError("JSON document must not contain listened_at while submitting"
+                                  " playing_now.", listen)
 
         if 'track_metadata' in listen and len(listen) > 1:
-            raise APIBadRequest("JSON document may only contain track_metadata as top level "
-                                "key when submitting playing_now.", listen)
+            raise ValidationError("JSON document may only contain track_metadata as top level"
+                                  " key when submitting playing_now.", listen)
 
     # Basic metadata
     if 'track_name' in listen['track_metadata']:
         if not isinstance(listen['track_metadata']['track_name'], str):
-            raise APIBadRequest("track_metadata.track_name must be a single string.", listen)
+            raise ValidationError("track_metadata.track_name must be a single string.", listen)
 
         listen['track_metadata']['track_name'] = listen['track_metadata']['track_name'].strip()
         if len(listen['track_metadata']['track_name']) == 0:
-            raise APIBadRequest("required field track_metadata.track_name is empty.", listen)
+            raise ValidationError("required field track_metadata.track_name is empty.", listen)
     else:
-        raise APIBadRequest("JSON document does not contain required track_metadata.track_name.", listen)
+        raise ValidationError("JSON document does not contain required track_metadata.track_name.", listen)
 
 
     if 'artist_name' in listen['track_metadata']:
         if not isinstance(listen['track_metadata']['artist_name'], str):
-            raise APIBadRequest("track_metadata.artist_name must be a single string.", listen)
+            raise ValidationError("track_metadata.artist_name must be a single string.", listen)
 
         listen['track_metadata']['artist_name'] = listen['track_metadata']['artist_name'].strip()
         if len(listen['track_metadata']['artist_name']) == 0:
-            raise APIBadRequest("required field track_metadata.artist_name is empty.", listen)
+            raise ValidationError("required field track_metadata.artist_name is empty.", listen)
     else:
-        raise APIBadRequest("JSON document does not contain required track_metadata.artist_name.", listen)
+        raise ValidationError("JSON document does not contain required track_metadata.artist_name.", listen)
 
 
     if 'additional_info' in listen['track_metadata']:
@@ -217,12 +219,12 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         if 'tags' in listen['track_metadata']['additional_info']:
             tags = listen['track_metadata']['additional_info']['tags']
             if len(tags) > MAX_TAGS_PER_LISTEN:
-                raise APIBadRequest("JSON document may not contain more than %d items in "
-                                    "track_metadata.additional_info.tags." % MAX_TAGS_PER_LISTEN, listen)
+                raise ValidationError("JSON document may not contain more than %d items in "
+                                      "track_metadata.additional_info.tags." % MAX_TAGS_PER_LISTEN, listen)
             for tag in tags:
                 if len(tag) > MAX_TAG_SIZE:
-                    raise APIBadRequest("JSON document may not contain track_metadata.additional_info.tags "
-                                        "longer than %d characters." % MAX_TAG_SIZE, listen)
+                    raise ValidationError("JSON document may not contain track_metadata.additional_info.tags "
+                                          "longer than %d characters." % MAX_TAG_SIZE, listen)
         # MBIDs, both of the mbid validation methods mutate the listen payload if needed.
         single_mbid_keys = ['release_mbid', 'recording_mbid', 'release_group_mbid', 'track_mbid']
         for key in single_mbid_keys:
@@ -273,7 +275,7 @@ def log_raise_400(msg, data=""):
 
 def validate_single_mbid_field(listen, key):
     """ Verify that mbid if present in the listen with given key is valid.
-    An APIBadRequest error is raised for invalid values of mbids.
+    A ValidationError is raised for invalid values of mbids.
 
     NOTE: If the mbid at the key is None or "", the key is dropped without
      raising an error.
@@ -289,12 +291,12 @@ def validate_single_mbid_field(listen, key):
             return
 
         if not is_valid_uuid(mbid):  # if the mbid is invalid raise an error
-            log_raise_400("%s MBID format invalid." % (key, ), listen)
+            raise ValidationError("%s MBID format invalid." % (key, ), listen)
 
 
 def validate_multiple_mbids_field(listen, key):
     """ Verify that all the mbids in the list if present in the listen with
-    given key are valid. An APIBadRequest error is raised for if any mbid is
+    given key are valid. An ValidationError error is raised for if any mbid is
     invalid.
 
     NOTE: If an mbid in the list is None or "", it is dropped from the list
@@ -315,7 +317,7 @@ def validate_multiple_mbids_field(listen, key):
 
         for mbid in mbids:
             if not is_valid_uuid(mbid):   # if the mbid is invalid raise an error
-                log_raise_400("%s MBID format invalid." % (key,), listen)
+                raise ValidationError("%s MBID format invalid." % (key,), listen)
 
         listen['track_metadata']['additional_info'][key] = mbids  # set the filtered in the listen payload
 

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -163,7 +163,7 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
 
         if 'listened_at' in listen and 'track_metadata' in listen and len(listen) > 2:
             raise ListenValidationError("JSON document may only contain listened_at and "
-                                  "track_metadata top level keys", listen)
+                                        "track_metadata top level keys", listen)
 
         # if timestamp is too high, raise BadRequest
         # in order to make up for possible clock skew, we allow
@@ -174,16 +174,16 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         # check that listened_at value is greater than last.fm founding year.
         if listen['listened_at'] < LISTEN_MINIMUM_TS:
             raise ListenValidationError("Value for key listened_at is too low. listened_at timestamp "
-                                  "should be greater than 1033410600 (2002-10-01 00:00:00 UTC).", listen)
+                                        "should be greater than 1033410600 (2002-10-01 00:00:00 UTC).", listen)
 
     elif listen_type == LISTEN_TYPE_PLAYING_NOW:
         if 'listened_at' in listen:
             raise ListenValidationError("JSON document must not contain listened_at while submitting"
-                                  " playing_now.", listen)
+                                        " playing_now.", listen)
 
         if 'track_metadata' in listen and len(listen) > 1:
             raise ListenValidationError("JSON document may only contain track_metadata as top level"
-                                  " key when submitting playing_now.", listen)
+                                        " key when submitting playing_now.", listen)
 
     # Basic metadata
     if 'track_name' in listen['track_metadata']:
@@ -214,11 +214,11 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
             tags = listen['track_metadata']['additional_info']['tags']
             if len(tags) > MAX_TAGS_PER_LISTEN:
                 raise ListenValidationError("JSON document may not contain more than %d items in "
-                                      "track_metadata.additional_info.tags." % MAX_TAGS_PER_LISTEN, listen)
+                                            "track_metadata.additional_info.tags." % MAX_TAGS_PER_LISTEN, listen)
             for tag in tags:
                 if len(tag) > MAX_TAG_SIZE:
                     raise ListenValidationError("JSON document may not contain track_metadata.additional_info.tags "
-                                          "longer than %d characters." % MAX_TAG_SIZE, listen)
+                                                "longer than %d characters." % MAX_TAG_SIZE, listen)
         # MBIDs, both of the mbid validation methods mutate the listen payload if needed.
         single_mbid_keys = ['release_mbid', 'recording_mbid', 'release_group_mbid', 'track_mbid']
         for key in single_mbid_keys:


### PR DESCRIPTION
API compat uses the same validate_listen method as LB API to validate listens. validate_listens used to raise APIBadRequest when validation failed. This is problematic because the API compat error format is different from that of LB. To solve this issue, introduce a ValidationError exception.