### PR TITLE
Huesound: Fix cover art grid minimum height on startup

### DIFF
--- a/listenbrainz/webserver/static/css/huesound.less
+++ b/listenbrainz/webserver/static/css/huesound.less
@@ -7,11 +7,6 @@
   }
   
   .cover-art-grid {
-    &.invisible{
-      flex: 0 1 0px;
-      width: 0px;
-      padding: 0;
-    }
     flex: 1 0 320px;
     border-radius: 10px;
     transition: all 1s;
@@ -40,6 +35,12 @@
     
     @media(min-width: @screen-lg) {
       min-height: 794px;
+    }
+    &.invisible{
+      flex: 0 1 0px;
+      width: 0px;
+      padding: 0;
+      min-height: initial;
     }
     .cover-art-container{
       // Using a <button> element for semantic behaviour, we need to reset the browser styles


### PR DESCRIPTION
When no color is selected (i.e when a user first loads the page), the cover art grid is hidden but set with a minimum height which gave the colourwheel (vertically centered) too much vertical margin space and hiding the text that sits underneath from the initial viewport.

Before:
![image](https://user-images.githubusercontent.com/6179856/139445513-b6c59828-446c-4cfd-9100-61ee357d9f1b.png)

After:
![image](https://user-images.githubusercontent.com/6179856/139445369-8661ed0a-5641-4a7b-a054-3a0c18087d0f.png)



