### PR TITLE
Improve validation of listen submission

### DIFF
--- a/listenbrainz/testdata/invalid_listen_missing_track_metadata.json
+++ b/listenbrainz/testdata/invalid_listen_missing_track_metadata.json
@@ -1,0 +1,14 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": 1486449409,
+            "foobar": {
+                "artist_name": "Kanye West",
+                "track_name": "Fade",
+                "release_name": "The Life of Pablo",
+                "artist_mbid": "5441c29d-3602-4898-b1a1-b77fa23b8e50"
+            }
+        }
+    ]
+}

--- a/listenbrainz/testdata/invalid_listen_null_listened_at.json
+++ b/listenbrainz/testdata/invalid_listen_null_listened_at.json
@@ -1,0 +1,14 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": null,
+            "track_metadata": {
+                "artist_name": "Kanye West",
+                "track_name": "Fade",
+                "release_name": "The Life of Pablo",
+                "artist_mbid": "5441c29d-3602-4898-b1a1-b77fa23b8e50"
+            }
+        }
+    ]
+}

--- a/listenbrainz/testdata/invalid_listen_null_track_metadata.json
+++ b/listenbrainz/testdata/invalid_listen_null_track_metadata.json
@@ -1,0 +1,9 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": 1486449409,
+            "track_metadata": null
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -148,7 +148,6 @@ class APITestCase(ListenAPIIntegrationTestCase):
         response = self.client.get(url)
         self.assert404(response)
 
-
     def test_get_listens_order(self):
         """ Test to make sure that the api sends listens in valid order.
         """
@@ -413,6 +412,30 @@ class APITestCase(ListenAPIIntegrationTestCase):
         """ Test for invalid submission in which a listen contains a tag of length > 64
         """
         with open(self.path_to_data_file('too_long_tag.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+
+    def test_missing_track_metadata(self):
+        """ Test for invalid submission in which a listen does not contain track_metadata field """
+        with open(self.path_to_data_file('invalid_listen_missing_track_metadata.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+
+    def test_null_track_metadata(self):
+        """ Test for invalid submission in which a listen has null track_metadata field """
+        with open(self.path_to_data_file('invalid_listen_null_track_metadata.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+
+    def test_null_listened_at(self):
+        """ Test for invalid submission in which a listen has null listened_at field """
+        with open(self.path_to_data_file('invalid_listen_null_listened_at.json'), 'r') as f:
             payload = json.load(f)
         response = self.send_data(payload)
         self.assert400(response)

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -35,7 +35,7 @@ from listenbrainz.webserver.models import SubmitListenUserMetadata
 from listenbrainz.webserver.errors import ListenValidationError
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
 from listenbrainz.webserver.views.api_tools import insert_payload, LISTEN_TYPE_PLAYING_NOW, \
-    is_valid_uuid, check_for_unicode_null_recursively, validate_timestamp
+    is_valid_uuid, check_for_unicode_null_recursively, validate_listened_at
 
 api_compat_old_bp = Blueprint('api_compat_old', __name__)
 
@@ -164,8 +164,8 @@ def _to_native_api(data, append_key):
     if append_key != '':
         try:
             listen['listened_at'] = int(data['i{}'.format(append_key)])
-            validate_timestamp(listen)
-        except (KeyError, ValueError, ValidationError):
+            validate_listened_at(listen)
+        except (KeyError, ValueError, ListenValidationError):
             return None
 
     if 'o{}'.format(append_key) in data:

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -27,16 +27,15 @@ import listenbrainz.db.user as db_user
 from brainzutils.musicbrainz_db import engine as mb_engine
 
 from hashlib import md5
-from time import time
 
-from flask import current_app, Blueprint, request, render_template, redirect
+from flask import current_app, Blueprint, request, redirect
 from werkzeug.exceptions import BadRequest
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.webserver.models import SubmitListenUserMetadata
 from listenbrainz.webserver.errors import ListenValidationError
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
-from listenbrainz.webserver.views.api_tools import insert_payload, is_valid_timestamp, LISTEN_TYPE_PLAYING_NOW, \
-    is_valid_uuid, check_for_unicode_null_recursively
+from listenbrainz.webserver.views.api_tools import insert_payload, LISTEN_TYPE_PLAYING_NOW, \
+    is_valid_uuid, check_for_unicode_null_recursively, validate_timestamp
 
 api_compat_old_bp = Blueprint('api_compat_old', __name__)
 
@@ -165,13 +164,8 @@ def _to_native_api(data, append_key):
     if append_key != '':
         try:
             listen['listened_at'] = int(data['i{}'.format(append_key)])
-        except (KeyError, ValueError):
-            return None
-
-        # if timestamp is too high, this is an invalid listen
-        # in order to make up for possible clock skew, we allow
-        # timestamps to be one hour ahead of server time
-        if not is_valid_timestamp(listen['listened_at']):
+            validate_timestamp(listen)
+        except (KeyError, ValueError, ValidationError):
             return None
 
     if 'o{}'.format(append_key) in data:

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -153,8 +153,7 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         raise ListenValidationError("Listen is empty and cannot be validated.")
 
     if listen_type in (LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT):
-        if 'listened_at' not in listen:
-            raise ListenValidationError("JSON document must contain the key listened_at at the top level.", listen)
+        validate_listened_at(listen)
 
         if "track_metadata" not in listen:
             raise ListenValidationError("JSON document must contain the key track_metadata"
@@ -163,8 +162,6 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         if len(listen) > 2:
             raise ListenValidationError("JSON document may only contain listened_at and "
                                         "track_metadata top level keys", listen)
-
-        validate_listened_at(listen)
 
         # check that listened_at value is greater than last.fm founding year.
         if listen['listened_at'] < LISTEN_MINIMUM_TS:
@@ -316,9 +313,9 @@ def validate_multiple_mbids_field(listen, key):
 
 
 def validate_listened_at(listen):
-    """ Raises an error if the listened_at field is invalid. The field can be invalid
-     if it is missing, contains a non integer value, the timestamp it represents is
-     too high or too low.
+    """ Raises an error if the listened_at timestamp is invalid. The timestamp is invalid
+    if it is lower than the minimum acceptable timestamp or if its in future beyond
+    tolerable skew.
 
     Args:
         listen: the listen to be validated

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -181,6 +181,9 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
             raise ListenValidationError("JSON document may only contain track_metadata as top level"
                                         " key when submitting playing_now.", listen)
 
+    if listen["track_metadata"] is None:
+        raise ValidationError("JSON document may not have track_metadata with null value.", listen)
+
     # Basic metadata
     if 'track_name' in listen['track_metadata']:
         if not isinstance(listen['track_metadata']['track_name'], str):

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -182,7 +182,7 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
                                         " key when submitting playing_now.", listen)
 
     if listen["track_metadata"] is None:
-        raise ValidationError("JSON document may not have track_metadata with null value.", listen)
+        raise ListenValidationError("JSON document may not have track_metadata with null value.", listen)
 
     # Basic metadata
     if 'track_name' in listen['track_metadata']:

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -156,20 +156,15 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         if 'listened_at' not in listen:
             raise ListenValidationError("JSON document must contain the key listened_at at the top level.", listen)
 
-        try:
-            listen['listened_at'] = int(listen['listened_at'])
-        except ValueError:
-            raise ListenValidationError("JSON document must contain an int value for listened_at.", listen)
+        if "track_metadata" not in listen:
+            raise ListenValidationError("JSON document must contain the key track_metadata"
+                                        " at the top level.", listen)
 
-        if 'listened_at' in listen and 'track_metadata' in listen and len(listen) > 2:
+        if len(listen) > 2:
             raise ListenValidationError("JSON document may only contain listened_at and "
                                         "track_metadata top level keys", listen)
 
-        # if timestamp is too high, raise BadRequest
-        # in order to make up for possible clock skew, we allow
-        # timestamps to be one hour ahead of server time
-        if not is_valid_timestamp(listen['listened_at']):
-            raise ListenValidationError("Value for key listened_at is too high.", listen)
+        validate_listened_at(listen)
 
         # check that listened_at value is greater than last.fm founding year.
         if listen['listened_at'] < LISTEN_MINIMUM_TS:
@@ -177,11 +172,15 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
                                         "should be greater than 1033410600 (2002-10-01 00:00:00 UTC).", listen)
 
     elif listen_type == LISTEN_TYPE_PLAYING_NOW:
-        if 'listened_at' in listen:
+        if "listened_at" in listen:
             raise ListenValidationError("JSON document must not contain listened_at while submitting"
                                         " playing_now.", listen)
 
-        if 'track_metadata' in listen and len(listen) > 1:
+        if "track_metadata" not in listen:
+            raise ListenValidationError("JSON document must contain the key track_metadata"
+                                        " at the top level.", listen)
+
+        if len(listen) > 1:
             raise ListenValidationError("JSON document may only contain track_metadata as top level"
                                         " key when submitting playing_now.", listen)
 
@@ -316,17 +315,31 @@ def validate_multiple_mbids_field(listen, key):
         listen['track_metadata']['additional_info'][key] = mbids  # set the filtered in the listen payload
 
 
-def is_valid_timestamp(ts):
-    """ Returns True if the timestamp passed is in the API's
-    allowed range of timestamps, False otherwise
+def validate_listened_at(listen):
+    """ Raises an error if the listened_at field is invalid. The field can be invalid
+     if it is missing, contains a non integer value, the timestamp it represents is
+     too high or too low.
 
     Args:
-        ts (int): the timestamp to be checked for validity
-
-    Returns:
-        bool: True if timestamp is valid, False otherwise
+        listen: the listen to be validated
     """
-    return ts <= int(time.time()) + API_LISTENED_AT_ALLOWED_SKEW
+    if "listened_at" not in listen:
+        raise ListenValidationError("JSON document must contain the key listened_at at the top level.", listen)
+
+    try:
+        listen["listened_at"] = int(listen["listened_at"])
+    except (ValueError, TypeError):
+        raise ListenValidationError("JSON document must contain an int value for listened_at.", listen)
+
+    # raise error if timestamp is too high
+    # in order to make up for possible clock skew, we allow
+    # timestamps to be one hour ahead of server time
+    if listen["listened_at"] >= int(time.time()) + API_LISTENED_AT_ALLOWED_SKEW:
+        raise ListenValidationError("Value for key listened_at is too high.", listen)
+
+    if listen["listened_at"] < LISTEN_MINIMUM_TS:
+        raise ListenValidationError("Value for key listened_at is too low. listened_at timestamp "
+                                    "should be greater than 1033410600 (2002-10-01 00:00:00 UTC).", listen)
 
 
 def publish_data_to_queue(data, exchange, queue, error_msg):


### PR DESCRIPTION
The whack-a-mole of listen validation continues,
1.  Consolidate the validation of listened_at field in one method.
2.  Add some more validation checks:
    - int(listen["listened_at"]) raises TypeError if the value is null. So TypeError needs to be caught.
    - if the track_metadata field is missing from submission json, when we later try to access it we will get a KeyError.
    - track_metadata field is present but has value null.
Also add tests for the same.