### PR TITLE
Fix user listen timestamp update :eyes:

### DIFF
--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -286,13 +286,13 @@ class TimescaleListenStore(ListenStore):
         user_timestamps = {}
         user_counts = defaultdict(int)
         for ts, _, user_name in inserted_rows:
-            if listen.user_name in user_timestamps:
-                if ts < user_timestamps[listen.user_name][0]:
-                    user_timestamps[listen.user_name][0] = ts
-                if ts > user_timestamps[listen.user_name][1]:
-                    user_timestamps[listen.user_name][1] = ts
+            if user_name in user_timestamps:
+                if ts < user_timestamps[user_name][0]:
+                    user_timestamps[user_name][0] = ts
+                if ts > user_timestamps[user_name][1]:
+                    user_timestamps[user_name][1] = ts
             else:
-                user_timestamps[listen.user_name] = [ts, ts]
+                user_timestamps[user_name] = [ts, ts]
 
             user_counts[user_name] += 1
 


### PR DESCRIPTION
The code was using listen.user_name which means it was referring to the batch's last listen user name. However, we are in a loop and comparing ts of each listen so we probably also want to use the user_name of each listen instead.