### PR TITLE
Add support for giving feedback on now playing listens

### DIFF
--- a/docs/dev/feedback-json.rst
+++ b/docs/dev/feedback-json.rst
@@ -20,6 +20,19 @@ A sample feedback may look like:
         "score": 1
     }
 
+If a recording_msid is unavailable (as in the case for now playing listens), an alternative
+API endpoint is available at ``recording-feedback-now-playing`` which accepts json as the
+following sample:
+
+.. code-block:: json
+
+    {
+        "artist_name": "Anne-Marie",
+        "track_name": "Alarm",
+        "release_name": "Speak Your Mind",
+        "score": 1
+    }
+
 Score can have one of these three values:
 
 - ``1``: Mark the track as loved

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -109,7 +109,7 @@ def recording_feedback_now_playing():
         msb_listen["release"] = data["release_name"]
 
     msb_response = messybrainz.submit_listens_and_sing_me_a_sweet_song([msb_listen])
-    recording_msid = msb_response["payload"]["ids"]["recording_msid"]
+    recording_msid = msb_response["payload"][0]["ids"]["recording_msid"]
     feedback = Feedback(user_id=user["id"], recording_msid=recording_msid, score=data["score"])
     if feedback.score == 0:
         db_feedback.delete(feedback)


### PR DESCRIPTION
(Another half finished PR found in stash so pushing this out as draft for now.)

It is not possible to like now playing listens currently because those do not have a msid associated with them. So add an endpoint that lets users to like/hate by artist_name, track_name and release_name.

# Todos
- [ ] Discuss whether this should be a different endpoint or add this support to the existing one
- [ ] Discuss if we should accept an additional info because this endpoint may create a new msid like submit listens endpoint
- [ ] Add tests
- [ ] Add frontend support 