### PR TITLE
Move brainzplayer_metadata object in submitted listens

### DIFF
--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
@@ -723,10 +723,10 @@ describe("BrainzPlayer", () => {
             submission_client: "BrainzPlayer",
             music_service: "https://open.spotify.com",
             origin_url: "https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT",
-            brainzplayer_metadata: {
-              artist_name: "Rick Astley",
-              track_name: "Never Gonna Give You Up",
-            },
+          },
+          brainzplayer_metadata: {
+            artist_name: "Rick Astley",
+            track_name: "Never Gonna Give You Up",
           },
         },
       };
@@ -793,10 +793,10 @@ describe("BrainzPlayer", () => {
             submission_client: "BrainzPlayer",
             music_service: "https://open.spotify.com",
             origin_url: "https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT",
-            brainzplayer_metadata: {
-              artist_name: "Rick Astley",
-              track_name: "Never Gonna Give You Up",
-            },
+          },
+          brainzplayer_metadata: {
+            artist_name: "Rick Astley",
+            track_name: "Never Gonna Give You Up",
           },
         },
       };

--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.test.tsx
@@ -721,7 +721,8 @@ describe("BrainzPlayer", () => {
           additional_info: {
             media_player: "BrainzPlayer",
             submission_client: "BrainzPlayer",
-            music_service: "https://open.spotify.com",
+            music_service: "spotify.com",
+            music_service_name: "spotify",
             origin_url: "https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT",
           },
           brainzplayer_metadata: {
@@ -791,7 +792,8 @@ describe("BrainzPlayer", () => {
           additional_info: {
             media_player: "BrainzPlayer",
             submission_client: "BrainzPlayer",
-            music_service: "https://open.spotify.com",
+            music_service: "spotify.com",
+            music_service_name: "spotify",
             origin_url: "https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT",
           },
           brainzplayer_metadata: {

--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -589,12 +589,16 @@ export default class BrainzPlayer extends React.Component<
         cloneDeep((currentListen as BaseListenFormat)?.track_metadata) ?? {},
     };
 
-    let musicService = dataSource.current?.name;
-    try {
-      // Browser could potentially be missing the URL constructor
-      musicService = new URL(currentTrackURL ?? "").origin;
-    } catch (e) {
-      // Do nothing, we just fallback gracefully to dataSource name.
+    const musicServiceName = dataSource.current?.name;
+    let musicServiceDomain = dataSource.current?.domainName;
+    // Best effort try?
+    if (!musicServiceDomain && currentTrackURL) {
+      try {
+        // Browser could potentially be missing the URL constructor
+        musicServiceDomain = new URL(currentTrackURL).hostname;
+      } catch (e) {
+        // Do nothing, we just fallback gracefully to dataSource name.
+      }
     }
 
     // ensure the track_metadata.additional_info path exists and add brainzplayer_metadata field
@@ -605,7 +609,8 @@ export default class BrainzPlayer extends React.Component<
         submission_client: "BrainzPlayer",
         // TODO:  passs the GIT_COMMIT_SHA env variable to the globalprops and add it here as submission_client_version
         // submission_client_version:"",
-        music_service: musicService,
+        music_service: musicServiceDomain,
+        music_service_name: musicServiceName,
         origin_url: currentTrackURL,
       },
     });

--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -599,8 +599,8 @@ export default class BrainzPlayer extends React.Component<
 
     // ensure the track_metadata.additional_info path exists and add brainzplayer_metadata field
     assign(newListen.track_metadata, {
+      brainzplayer_metadata,
       additional_info: {
-        brainzplayer_metadata,
         media_player: "BrainzPlayer",
         submission_client: "BrainzPlayer",
         // TODO:  passs the GIT_COMMIT_SHA env variable to the globalprops and add it here as submission_client_version

--- a/listenbrainz/webserver/static/js/src/SoundcloudPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SoundcloudPlayer.tsx
@@ -57,6 +57,7 @@ export default class SoundcloudPlayer
   extends React.Component<DataSourceProps, SoundcloudPlayerState>
   implements DataSourceType {
   public name = "soundcloud";
+  public domainName = "soundcloud.com";
   iFrameRef?: React.RefObject<HTMLIFrameElement>;
   soundcloudPlayer?: SoundCloudHTML5Widget;
   retries = 0;

--- a/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/SpotifyPlayer.tsx
@@ -81,6 +81,7 @@ export default class SpotifyPlayer
   };
 
   public name = "spotify";
+  public domainName = "spotify.com";
   spotifyPlayer?: SpotifyPlayerType;
   debouncedOnTrackEnd: () => void;
 

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -29,6 +29,7 @@ export default class YoutubePlayer
   extends React.Component<YoutubePlayerProps, YoutubePlayerState>
   implements DataSourceType {
   public name = "youtube";
+  public domainName = "youtube.com";
   youtubePlayer?: ExtendedYoutubePlayer;
   checkVideoLoadedTimerId?: NodeJS.Timeout;
 


### PR DESCRIPTION
Previously, the `brainzplayer_metadata` object was nested in `track_metadata.additional_info.brainzplayer_metadata`.
We only allow two levels of deep nesting in the listens metadata, so this `brainzplayer_metadata` object was getting flattened.
We need to move it one level up to `track_metadata.brainzplayer_metadata` in order to preserve its structure.

Before:
![image](https://user-images.githubusercontent.com/6179856/139676196-88ce2da1-e785-4965-befd-aefa06534e12.png)

After:
![image](https://user-images.githubusercontent.com/6179856/139676483-3801d6ed-7652-47aa-a8d5-c398904de269.png)
