### PR TITLE
Use http for CAA

### DIFF
--- a/listenbrainz/webserver/static/js/src/huesound/ColorPlay.tsx
+++ b/listenbrainz/webserver/static/js/src/huesound/ColorPlay.tsx
@@ -160,7 +160,7 @@ export default class ColorPlay extends React.Component<
                     className="cover-art-container"
                   >
                     <img
-                      src={`https://coverartarchive.org/release/${release.release_mbid}/${release.caa_id}-250.jpg`}
+                      src={`http://coverartarchive.org/release/${release.release_mbid}/${release.caa_id}-250.jpg`}
                       alt={`Cover art for Release ${release.release_name}`}
                       height={150}
                     />
@@ -178,7 +178,7 @@ export default class ColorPlay extends React.Component<
                   <img
                     className="img-rounded"
                     style={{ flex: 1 }}
-                    src={`https://coverartarchive.org/release/${selectedRelease.release_mbid}/${selectedRelease.caa_id}-250.jpg`}
+                    src={`http://coverartarchive.org/release/${selectedRelease.release_mbid}/${selectedRelease.caa_id}-250.jpg`}
                     alt={`Cover art for Release ${selectedRelease.release_name}`}
                     width={200}
                     height={200}


### PR DESCRIPTION
Debug gateways slowdown

https://github.com/metabrainz/listenbrainz-server/search?q=https%3A%2F%2Fcoverartarchive.org shows only 2 instances of CAA on https.