### PR TITLE
Bypass CAA

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/release_colors.py
+++ b/listenbrainz/mbid_mapping/mapping/release_colors.py
@@ -79,8 +79,8 @@ def process_row(row):
     while True:
         headers = {
             'User-Agent': 'ListenBrainz HueSound Color Bot ( rob@metabrainz.org )'}
-        url = "https://coverartarchive.org/release/%s/%d-250.jpg" % (
-            row["release_mbid"], row["caa_id"])
+        release_mbid, caa_id = row["release_mbid"], row["caa_id"]
+        url = f"https://archive.org/download/mbid-{release_mbid}/mbid-{release_mbid}-{caa_id}_thumb250.jpg"
         r = requests.get(url, headers=headers)
         if r.status_code == 200:
             filename = "/tmp/release-colors-%s.img" % get_ident()

--- a/listenbrainz/webserver/static/js/src/huesound/ColorPlay.tsx
+++ b/listenbrainz/webserver/static/js/src/huesound/ColorPlay.tsx
@@ -160,7 +160,7 @@ export default class ColorPlay extends React.Component<
                     className="cover-art-container"
                   >
                     <img
-                      src={`https://coverartarchive.org/release/${release.release_mbid}/${release.caa_id}-250.jpg`}
+                      src={`https://archive.org/download/mbid-${release.release_mbid}/mbid-${release.release_mbid}-${release.caa_id}_thumb250.jpg`}
                       alt={`Cover art for Release ${release.release_name}`}
                       height={150}
                     />
@@ -178,7 +178,7 @@ export default class ColorPlay extends React.Component<
                   <img
                     className="img-rounded"
                     style={{ flex: 1 }}
-                    src={`https://coverartarchive.org/release/${selectedRelease.release_mbid}/${selectedRelease.caa_id}-250.jpg`}
+                    src={`https://archive.org/download/mbid-${selectedRelease.release_mbid}/mbid-${selectedRelease.release_mbid}-${selectedRelease.caa_id}_thumb250.jpg`}
                     alt={`Cover art for Release ${selectedRelease.release_name}`}
                     width={200}
                     height={200}


### PR DESCRIPTION
We can construct the url for the image thumbnail at archive.org using the release mbid and caa id. Since we have both available, we do not need to query CAA url just to be redirected to the archive. This helps reduce load from CAA.