### PR TITLE
Close FTP connection after download

### DIFF
--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -32,11 +32,13 @@ def import_full_dump_to_hdfs(dump_id: int = None) -> str:
         the name of the imported dump
     """
     with tempfile.TemporaryDirectory() as temp_dir:
-        src, dump_name, dump_id = ListenbrainzDataDownloader().download_listens(
+        downloader = ListenbrainzDataDownloader()
+        src, dump_name, dump_id = downloader.download_listens(
             directory=temp_dir,
             dump_type=DumpType.FULL,
             listens_dump_id=dump_id
         )
+        downloader.connection.close()
         ListenbrainzDataUploader().upload_new_listens_full_dump(src)
     utils.insert_dump_data(dump_id, DumpType.FULL, datetime.utcnow())
     return dump_name


### PR DESCRIPTION
Importing spark dumps was failing repeatedly with errors like `('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))`. Looking at the stack trace, these errors were occuring much later after the download finished like when half of the dump was already transferred from temp dir to HDFS. My hunch is that the ftp connection was being disconnected due to being idle for long time. So, I put in the `close()` the after the download of the dump finished. After that the dump imported fine.

As a future enhancement, we could make the downloader a context manager so as to use it in with, probably not worth it currently though.