### PR TITLE
LB-840: Clear search input on playlist track add

### DIFF
--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
@@ -206,6 +206,8 @@ export default class PlaylistPage extends React.Component<
           {
             playlist: { ...playlist, track: [...playlist.track, jspfTrack] },
             // recordingFeedbackMap,
+            searchInputValue: "",
+            cachedSearchResults: [],
           },
           this.emitPlaylistChanged
         );


### PR DESCRIPTION
When adding a new track to a playlist, both the search input and cached search results stay as is, and users have to click a "clear" button to clear them.
This was a feature, not a bug, but goes contrary to users' instincts.