### PR TITLE
Use mapped mbid data in Pinned Recordings

### DIFF
--- a/listenbrainz/db/model/pinned_recording.py
+++ b/listenbrainz/db/model/pinned_recording.py
@@ -108,19 +108,19 @@ def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRec
         with timescale.engine.connect() as connection:
             mbid_metadatas = connection.execute(sqlalchemy.text(query), mbids=mbids)
 
-        # we can zip the pins and metadata because the query returns
-        # the metadata in same order of the mbid list passed to it
-        for pin, metadata in zip(mbid_pins, mbid_metadatas):
-            pin.track_metadata = {
-                "track_name": metadata["title"],
-                "artist_name": metadata["artist"],
-                "release_name": metadata["release"],
-                "additional_info": {
-                    "recording_mbid": metadata["recording_mbid"],
-                    "release_mbid": metadata["release_mbid"],
-                    "artist_mbids": metadata["artist_mbids"],
+            # we can zip the pins and metadata because the query returns
+            # the metadata in same order of the mbid list passed to it
+            for pin, metadata in zip(mbid_pins, mbid_metadatas):
+                pin.track_metadata = {
+                    "track_name": metadata["title"],
+                    "artist_name": metadata["artist"],
+                    "release_name": metadata["release"],
+                    "additional_info": {
+                        "recording_mbid": metadata["recording_mbid"],
+                        "release_mbid": metadata["release_mbid"],
+                        "artist_mbids": metadata["artist_mbids"],
+                    }
                 }
-            }
 
     if msid_pins:
         fetch_msids = [pin.recording_msid for pin in msid_pins]  # retrieves list of msid's to fetch with

--- a/listenbrainz/db/model/pinned_recording.py
+++ b/listenbrainz/db/model/pinned_recording.py
@@ -100,7 +100,7 @@ def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRec
     if mbid_pins:
         query = """SELECT artist_credit_name AS artist, recording_name AS title, release_name AS release,
                           recording_mbid::TEXT, release_mbid::TEXT, artist_mbids::TEXT[]
-                     FROM listen_mbid_mapping
+                     FROM mbid_mapping_metadata
                     WHERE recording_mbid IN :mbids
                  ORDER BY recording_mbid"""
         # retrieves list of mbid's to fetch with
@@ -119,6 +119,7 @@ def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRec
                         "recording_mbid": metadata["recording_mbid"],
                         "release_mbid": metadata["release_mbid"],
                         "artist_mbids": metadata["artist_mbids"],
+                        "recording_msid": pin.recording_msid
                     }
                 }
 
@@ -131,7 +132,10 @@ def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRec
             pin.track_metadata = {
                 "track_name": metadata["payload"]["title"],
                 "artist_name": metadata["payload"]["artist"],
-                "artist_msid": metadata["ids"]["artist_msid"]
+                "additional_info": {
+                    "artist_msid": metadata["ids"]["artist_msid"],
+                    "recording_msid": pin.recording_msid
+                }
             }
 
     return pins

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -1,25 +1,30 @@
-# -*- coding: utf-8 -*-
-import json
+import logging
 from datetime import datetime
+
+import sqlalchemy
 from pydantic import ValidationError
 import time
 
 from listenbrainz.db.model.pinned_recording import (
-    PinnedRecording,
     WritablePinnedRecording,
-    DAYS_UNTIL_UNPIN,
-    MAX_BLURB_CONTENT_LENGTH,
+    MAX_BLURB_CONTENT_LENGTH, fetch_track_metadata_for_pins,
 )
 import listenbrainz.db.pinned_recording as db_pinned_rec
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 
-from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
+from listenbrainz.messybrainz.testing import MessyBrainzTestCase
+from listenbrainz.db import timescale as ts
+from listenbrainz import messybrainz as msb_db
 
 
-class PinnedRecDatabaseTestCase(DatabaseTestCase):
+class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzTestCase):
+
     def setUp(self):
         DatabaseTestCase.setUp(self)
+        TimescaleTestCase.setUp(self)
+        MessyBrainzTestCase.setUp(self)
         self.user = db_user.get_or_create(1, "test_user")
         self.followed_user_1 = db_user.get_or_create(2, "followed_user_1")
         self.followed_user_2 = db_user.get_or_create(3, "followed_user_2")
@@ -88,6 +93,97 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase):
 
         db_pinned_rec.pin(recording_to_pin)
         return recording_to_pin
+
+    def test_pinned_recording_with_metadata(self):
+        recordings = [
+            {
+                "title": "Strangers",
+                "artist": "Portishead",
+                "release": "Dummy"
+            },
+            {
+                "title": "Wicked Game",
+                "artist": "Tom Ellis",
+                "release": "Lucifer"
+            }
+        ]
+
+        submitted_data = msb_db.insert_all_in_transaction(recordings)
+        msids = [(x["ids"]["recording_msid"], x["ids"]["artist_msid"]) for x in submitted_data]
+
+        with ts.engine.connect() as connection:
+            query = """
+                INSERT INTO mbid_mapping_metadata
+                            (recording_mbid, release_mbid, release_name, artist_credit_id,
+                             artist_mbids, artist_credit_name, recording_name)
+                     VALUES ('076255b4-1575-11ec-ac84-135bf6a670e3',
+                            '1fd178b4-1575-11ec-b98a-d72392cd8c97',
+                            'Dummy',
+                            65,
+                            '{6a221fda-2200-11ec-ac7d-dfa16a57158f}'::UUID[],
+                            'Portishead', 'Strangers')
+            """
+            connection.execute(sqlalchemy.text(query))
+
+            query = """INSERT INTO mbid_mapping
+                                   (recording_msid, recording_mbid, match_type, last_updated)
+                            VALUES (:msid, '076255b4-1575-11ec-ac84-135bf6a670e3', 'exact_match', now())"""
+            connection.execute(sqlalchemy.text(query), {"msid": msids[0][0]})
+
+        pinned_recs = [
+            {
+                "recording_msid": msids[0][0],
+                "recording_mbid": "076255b4-1575-11ec-ac84-135bf6a670e3",
+                "blurb_content": "Awesome recordings with mapped data"
+            },
+            {
+                "recording_msid": msids[1][0],
+                "recording_mbid": None,
+                "blurb_content": "Great recording but unmapped"
+            }
+        ]
+
+        for data in pinned_recs:
+            db_pinned_rec.pin(
+                WritablePinnedRecording(
+                    user_id=self.user["id"],
+                    recording_msid=data["recording_msid"],
+                    recording_mbid=data["recording_mbid"],
+                    blurb_content=data["blurb_content"],
+                )
+            )
+
+        pins = db_pinned_rec.get_pin_history_for_user(self.user["id"], 5, 0)
+        pins_with_metadata = fetch_track_metadata_for_pins(pins)
+
+        received = [x.dict() for x in pins_with_metadata]
+        # pinned recs returned in reverse order of submitted because order newest to oldest
+        self.assertEqual(received[0]["recording_msid"], pinned_recs[1]["recording_msid"])
+        self.assertEqual(received[0]["recording_mbid"], pinned_recs[1]["recording_mbid"])
+        self.assertEqual(received[0]["blurb_content"], pinned_recs[1]["blurb_content"])
+        self.assertEqual(received[0]["track_metadata"], {
+            "track_name": "Wicked Game",
+            "artist_name": "Tom Ellis",
+            "additional_info": {
+                "recording_msid": msids[1][0],
+                "artist_msid": msids[1][1]
+            }
+        })
+
+        self.assertEqual(received[1]["recording_msid"], pinned_recs[0]["recording_msid"])
+        self.assertEqual(received[1]["recording_mbid"], pinned_recs[0]["recording_mbid"])
+        self.assertEqual(received[1]["blurb_content"], pinned_recs[0]["blurb_content"])
+        self.assertEqual(received[1]["track_metadata"], {
+            "track_name": "Strangers",
+            "artist_name": "Portishead",
+            "release_name": "Dummy",
+            "additional_info": {
+                "recording_mbid": "076255b4-1575-11ec-ac84-135bf6a670e3",
+                "release_mbid": "1fd178b4-1575-11ec-b98a-d72392cd8c97",
+                "artist_mbids": ["6a221fda-2200-11ec-ac7d-dfa16a57158f"],
+                "recording_msid": msids[0][0],
+            }
+        })
 
     def test_Pinned_Recording_model(self):
         # test missing required arguments error

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -182,6 +182,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainz
                 "release_mbid": "1fd178b4-1575-11ec-b98a-d72392cd8c97",
                 "artist_mbids": ["6a221fda-2200-11ec-ac7d-dfa16a57158f"],
                 "recording_msid": msids[0][0],
+                "artist_msid": msids[0][1]
             }
         })
 

--- a/listenbrainz/webserver/static/js/src/PinRecordingModal.test.tsx
+++ b/listenbrainz/webserver/static/js/src/PinRecordingModal.test.tsx
@@ -70,9 +70,7 @@ describe("submitPinRecording", () => {
     expect(spy).toHaveBeenCalledWith(
       "auth_token",
       "recording_msid",
-      // Disabling temporarily
-      //   "recording_mbid",
-      undefined,
+      "recording_mbid",
       undefined
     );
     expect(instance.props.newAlert).toHaveBeenCalledTimes(1);

--- a/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
+++ b/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { get as _get } from "lodash";
 import GlobalAppContext from "./GlobalAppContext";
-import {getRecordingMBID, preciseTimestamp} from "./utils";
+import { getRecordingMBID, preciseTimestamp } from "./utils";
 
 export type PinRecordingModalProps = {
   recordingToPin: Listen;

--- a/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
+++ b/listenbrainz/webserver/static/js/src/PinRecordingModal.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { get as _get } from "lodash";
 import GlobalAppContext from "./GlobalAppContext";
-import { preciseTimestamp } from "./utils";
+import {getRecordingMBID, preciseTimestamp} from "./utils";
 
 export type PinRecordingModalProps = {
   recordingToPin: Listen;
@@ -40,13 +40,7 @@ export default class PinRecordingModal extends React.Component<
         recordingToPin,
         "track_metadata.additional_info.recording_msid"
       );
-      // We currently have an issue with submitting MSID and MBID at the same time
-      // So we temporarily remove the MBID from the submition
-      const recordingMBID = undefined;
-      //   const recordingMBID = _get(
-      //     recordingToPin,
-      //     "track_metadata.additional_info.recording_mbid"
-      //   );
+      const recordingMBID = getRecordingMBID(recordingToPin);
 
       try {
         const status = await APIService.submitPinRecording(


### PR DESCRIPTION
The PR modifies pinned recordings backend to use data from listen_mbid_mapping table when a mbid is available. This change has some implications. The data in listen_mbid_mapping table is populated from MB and not user submitted track/artist/release names whereas the existing practice is to use the data from recording_json table which has user submitted data. IMO, this is a step in the right direction but let's discuss it before finalizing.

For some context, the track_metadata from user submitted listens is used to populate the recording_json. So using data from listen table or recording_json table should be mostly the same. The data in listen_mbid_mapping is on the other hand filled from MB by mbid mapping writer.

We have quite a few combinations regarding use of this data in LB, I am describing all the ones that come to mind here. 

- Listens Page (Prefer user submitted over mapped) : Listens have user submitted data stored in track_metadata. When sending to the frontend, we add a mbid_mapping dict to this which contains the mapped mbids. Note, here we only send mapped mbids to the frontend. The mapped artist/track/release name are not used here. The frontend uses user submitted mbids if available otherwise tries to fallback on mapped mbids. The mapped track/artist/release names never displayed to the user.

- Stats (Prefer mapped over user submitted): Stats are generated from spark dumps. While doing spark dumps, we prefer mapped data over user submitted data. We use mapped names if available otherwise user submitted names. Only mapped mbids are used. User submitted mbids are never used.

- Feedback: Use user submitted names always. Add mapped mbids if available.

- Pinned Recordings Existing: Use user submitted data mbid data from recording_json table. If mbid not available, use msids to get data from recording_json.

- Pinned Recordings New: Use mapped mbid data if available including mapped names. If no mapping available, use user submitted data from recording_json using msids.

We should evaluate each use case and decide on what to use accordingly. I think feedback and pinned recording are similar enough that we should use the same way for these two at least. 