### PR TITLE
Fix pinned recording link color

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -198,6 +198,10 @@
 	display: flex;
 	flex-wrap: wrap;
 	
+	a:focus, a:hover {
+		text-decoration: underline;
+	}
+	
 	&.playing-now {
 		background-color: rgba(255, 252, 202, 0.3) !important ;
 	}

--- a/listenbrainz/webserver/static/css/pinned-recordings.less
+++ b/listenbrainz/webserver/static/css/pinned-recordings.less
@@ -6,6 +6,10 @@
     &.currently-pinned {
       background-color: @blue;
       color: white;
+      
+      a {
+        color: inherit;
+      }
 
       &.current-listen {
         background-color: lighten(@blue,20%) !important;


### PR DESCRIPTION
With #1672 merged and deployed in beta, I realized there's an issue with the link color on a currently pinned card. The links are the same blue as the card background.

I changed that to inherit the color of text from the parent.

I also modified the listen-card (in all its forms) to add underline when hovering links.
This is the default browser behavior which is helpful in making it clearer to users that those are links.

Before (links barely visible on hover, invisible without hovering):
![image](https://user-images.githubusercontent.com/6179856/140622440-64f78a98-74cd-4110-b5f9-546140c07196.png)


After:
![image](https://user-images.githubusercontent.com/6179856/140622268-0a9d9ee1-1899-493a-999f-3cd3a528bb9d.png)
