### PR TITLE
Make new URL(… instantiation safe

### DIFF
--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -313,7 +313,7 @@ export default class YoutubePlayer
           youtubeId = searchParams.get("v");
         }
       } catch {
-        return false;
+        // URL is not valid, do nothing
       }
     }
     if (youtubeId) {

--- a/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/YoutubePlayer.tsx
@@ -83,10 +83,14 @@ export default class YoutubePlayer
     // or if the origin URL contains youtube.com
     const originURL = _get(listen, "track_metadata.additional_info.origin_url");
     if (_isString(originURL) && originURL.length) {
-      const parsedURL = new URL(originURL);
-      const { hostname, searchParams } = parsedURL;
-      if (/youtube\.com/.test(hostname)) {
-        return originURL;
+      try {
+        const parsedURL = new URL(originURL);
+        const { hostname, searchParams } = parsedURL;
+        if (/youtube\.com/.test(hostname)) {
+          return originURL;
+        }
+      } catch {
+        return undefined;
       }
     }
     return undefined;
@@ -270,10 +274,14 @@ export default class YoutubePlayer
     // or if the origin URL contains youtube.com
     const originURL = _get(listen, "track_metadata.additional_info.origin_url");
     if (_isString(originURL) && originURL.length) {
-      const parsedURL = new URL(originURL);
-      const { hostname, searchParams } = parsedURL;
-      if (/youtube\.com/.test(hostname)) {
-        return true;
+      try {
+        const parsedURL = new URL(originURL);
+        const { hostname, searchParams } = parsedURL;
+        if (/youtube\.com/.test(hostname)) {
+          return true;
+        }
+      } catch {
+        return false;
       }
     }
 
@@ -298,10 +306,14 @@ export default class YoutubePlayer
     let youtubeId = _get(listen, "track_metadata.additional_info.youtube_id");
     const originURL = _get(listen, "track_metadata.additional_info.origin_url");
     if (!youtubeId && _isString(originURL) && originURL.length) {
-      const parsedURL = new URL(originURL);
-      const { hostname, searchParams } = parsedURL;
-      if (/youtube\.com/.test(hostname)) {
-        youtubeId = searchParams.get("v");
+      try {
+        const parsedURL = new URL(originURL);
+        const { hostname, searchParams } = parsedURL;
+        if (/youtube\.com/.test(hostname)) {
+          youtubeId = searchParams.get("v");
+        }
+      } catch {
+        return false;
       }
     }
     if (youtubeId) {


### PR DESCRIPTION
Getting some errors on the front-end: "Failed to construct 'URL': Invalid URL"
![image](https://user-images.githubusercontent.com/6179856/140797972-2bba4ef1-74d6-4ebe-bb73-b736b9ec1925.png)

After a quick debug, it turns out some metadata is dirty (no way!) and a youtube video id ended up in `origin_url`.
Calling `new URL(x)` on that throws an error, which I didn't guard for.