### PR TITLE
LB-999: Safer API response header access

### DIFF
--- a/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
+++ b/listenbrainz/webserver/static/js/src/LastFMImporter.tsx
@@ -519,8 +519,12 @@ export default class LastFmImporter extends React.Component<
 
   updateRateLimitParameters(response: Response) {
     /* Update the variables we use to honor LB's rate limits */
-    this.rlRemain = Number(response.headers.get("X-RateLimit-Remaining"));
-    this.rlReset = Number(response.headers.get("X-RateLimit-Reset-In"));
+    if (response?.headers?.get("X-RateLimit-Remaining")) {
+      this.rlRemain = Number(response.headers.get("X-RateLimit-Remaining"));
+    }
+    if (response?.headers?.get("X-RateLimit-Reset-In")) {
+      this.rlReset = Number(response.headers.get("X-RateLimit-Reset-In"));
+    }
     this.rlOrigin = new Date().getTime() / 1000;
   }
 


### PR DESCRIPTION
Saw this issue in sentry for multiple users:
`TypeError: Cannot read properties of undefined (reading 'get')`
The offending lines are
https://github.com/metabrainz/listenbrainz-server/blob/959f58d15b9e23105c26fe693918ecd97074883f/listenbrainz/webserver/static/js/src/LastFMImporter.tsx#L522-L523

We don't know for sure if the request will have headers, so we can't assume they are there.
