### PR TITLE
LB-992: Too many LB full dumps on FTP site

### DIFF
--- a/admin/rsync-dump-files.sh
+++ b/admin/rsync-dump-files.sh
@@ -48,5 +48,5 @@ retry rsync \
     -FF \
     --rsh "ssh -i $SSH_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_FULLEXPORT_PORT" \
     --verbose \
-    $SOURCE_DIR/* \
+    $SOURCE_DIR/ \
     brainz@$RSYNC_FULLEXPORT_HOST:./


### PR DESCRIPTION
Remove * from end of $SOURCE_DIR otherwise rsync --delete won't work as expected.