### PR TITLE
Create public (mbid mapping) and private (playlists) timescale tables dump

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -190,6 +190,9 @@ add_rsync_include_rule \
     "listenbrainz-public-dump-$DUMP_TIMESTAMP.tar.xz"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
+    "listenbrainz-public-timescale-dump-$DUMP_TIMESTAMP.tar.xz"
+add_rsync_include_rule \
+    "$FTP_CURRENT_DUMP_DIR" \
     "listenbrainz-listens-dump-$DUMP_ID-$DUMP_TIMESTAMP-$DUMP_TYPE.tar.xz"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \

--- a/listenbrainz/db/__init__.py
+++ b/listenbrainz/db/__init__.py
@@ -5,8 +5,12 @@ from sqlalchemy.pool import NullPool
 import time
 import psycopg2
 
-# This value must be incremented after schema changes on replicated tables!
-SCHEMA_VERSION = 5
+# The schema version of the core database. This includes data in the "user" database
+# (tables created from ./admin/sql/create-tables.sql) and includes user data,
+# statistics, feedback, and results of user interaction on the site.
+# This value must be incremented after schema changes on tables that are included in the
+# public dump
+SCHEMA_VERSION_CORE = 5
 
 engine = None
 

--- a/listenbrainz/db/__init__.py
+++ b/listenbrainz/db/__init__.py
@@ -10,7 +10,7 @@ import psycopg2
 # statistics, feedback, and results of user interaction on the site.
 # This value must be incremented after schema changes on tables that are included in the
 # public dump
-SCHEMA_VERSION_CORE = 5
+SCHEMA_VERSION_CORE = 6
 
 engine = None
 

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -412,8 +412,12 @@ def _create_dump(location: str, db_engine: sqlalchemy.engine.Engine, dump_type: 
                                 raise
                         transaction.rollback()
 
-            tar.add(archive_tables_dir, arcname=os.path.join(
-                archive_name, 'lbdump'.format(dump_type)))
+            # Add the files to the archive in the order that they are defined in the dump definition.
+            # This is so that when imported into a db with FK constraints added, we import dependent
+            # tables first
+            for table in tables:
+                tar.add(os.path.join(archive_tables_dir, table),
+                        arcname=os.path.join(archive_name, 'lbdump', table))
 
             shutil.rmtree(temp_dir)
 

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -113,7 +113,9 @@ def create_full(location, threads, dump_id):
             sys.exit(-1)
 
         try:
-            if not sanity_check_dumps(dump_path, 12):
+            # 6 types of dumps, archive, md5, sha256 for each
+            EXPECTED_NUM_DUMP_FILES = 6 * 3
+            if not sanity_check_dumps(dump_path, EXPECTED_NUM_DUMP_FILES):
                 return sys.exit(-1)
         except OSError as e:
             sys.exit(-1)

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -22,28 +22,19 @@ create and import postgres data dumps.
 
 import click
 from datetime import datetime, timedelta
-from ftplib import FTP
 import listenbrainz.db.dump as db_dump
-import logging
 import os
 import re
 import shutil
 import subprocess
 import sys
-import tarfile
-import tempfile
-from time import sleep
 
 import psycopg2
-import ujson
 from flask import current_app, render_template
 from brainzutils.mail import send_mail
-from listenbrainz import db
-from listenbrainz.listen import convert_dump_row_to_spark_row
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
 from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app
-from listenbrainz.webserver.timescale_connection import init_timescale_connection
 from listenbrainz.db.dump import check_ftp_dump_ages
 
 
@@ -73,7 +64,10 @@ def send_dump_creation_notification(dump_name, dump_type):
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'))
 @click.option('--threads', '-t', type=int, default=DUMP_DEFAULT_THREAD_COUNT)
 @click.option('--dump-id', type=int, default=None)
-def create_full(location, threads, dump_id):
+@click.option('--listen/--no-listen', 'do_listen_dump', default=True)
+@click.option('--spark/--no-spark', 'do_spark_dump', type=bool, default=True)
+@click.option('--db/--no-db', 'do_db_dump', type=bool, default=True)
+def create_full(location, threads, dump_id, do_listen_dump: bool, do_spark_dump: bool, do_db_dump: bool):
     """ Create a ListenBrainz data dump which includes a private dump, a statistics dump
         and a dump of the actual listens from the listenstore
 
@@ -81,6 +75,9 @@ def create_full(location, threads, dump_id):
             location (str): path to the directory where the dump should be made
             threads (int): the number of threads to be used while compression
             dump_id (int): the ID of the ListenBrainz data dump
+            do_listen_dump: If True, make a listens dump
+            do_spark_dump: If True, make a spark listens dump
+            do_db_dump: If True, make a public/private postgres/timescale dump
     """
     app = create_app()
     with app.app_context():
@@ -101,9 +98,16 @@ def create_full(location, threads, dump_id):
         dump_path = os.path.join(location, dump_name)
         create_path(dump_path)
 
-        db_dump.dump_postgres_db(dump_path, end_time, threads)
-        ls.dump_listens(dump_path, dump_id=dump_id, end_time=end_time, threads=threads)
-        ls.dump_listens_for_spark(dump_path, dump_id=dump_id, end_time=end_time)
+        expected_num_dumps = 0
+        if do_db_dump:
+            db_dump.dump_postgres_db(dump_path, end_time, threads)
+            expected_num_dumps += 4
+        if do_listen_dump:
+            ls.dump_listens(dump_path, dump_id=dump_id, end_time=end_time, threads=threads)
+            expected_num_dumps += 1
+        if do_spark_dump:
+            ls.dump_listens_for_spark(dump_path, dump_id=dump_id, end_time=end_time)
+            expected_num_dumps += 1
 
         try:
             write_hashes(dump_path)
@@ -114,10 +118,10 @@ def create_full(location, threads, dump_id):
 
         try:
             # 6 types of dumps, archive, md5, sha256 for each
-            EXPECTED_NUM_DUMP_FILES = 6 * 3
-            if not sanity_check_dumps(dump_path, EXPECTED_NUM_DUMP_FILES):
+            expected_num_dump_files = expected_num_dumps * 3
+            if not sanity_check_dumps(dump_path, expected_num_dump_files):
                 return sys.exit(-1)
-        except OSError as e:
+        except OSError:
             sys.exit(-1)
 
         current_app.logger.info(

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -243,10 +243,13 @@ def create_feedback(location, threads):
 
 @cli.command(name="import_dump")
 @click.option('--private-archive', '-pr', default=None, required=False)
+@click.option('--private-timescale-archive', default=None, required=False)
 @click.option('--public-archive', '-pu', default=None, required=False)
+@click.option('--public-timescale-archive', default=None, required=False)
 @click.option('--listen-archive', '-l', default=None, required=True)
 @click.option('--threads', '-t', type=int, default=DUMP_DEFAULT_THREAD_COUNT)
-def import_dump(private_archive, public_archive, listen_archive, threads):
+def import_dump(private_archive, private_timescale_archive,
+                public_archive, public_timescale_archive, listen_archive, threads):
     """ Import a ListenBrainz dump into the database.
 
         Note: This method tries to import the private db dump first, followed by the public db
@@ -257,13 +260,17 @@ def import_dump(private_archive, public_archive, listen_archive, threads):
 
         Args:
             private_archive (str): the path to the ListenBrainz private dump to be imported
+            private_timescale_archive (str): the path to the ListenBrainz private timescale dump to be imported
             public_archive (str): the path to the ListenBrainz public dump to be imported
+            public_timescale_archive (str): the path to the ListenBrainz public timescale dump to be imported
             listen_archive (str): the path to the ListenBrainz listen dump archive to be imported
             threads (int): the number of threads to use during decompression, defaults to 1
     """
     app = create_app()
     with app.app_context():
-        db_dump.import_postgres_dump(private_archive, public_archive, threads)
+        db_dump.import_postgres_dump(private_archive, private_timescale_archive,
+                                     public_archive, public_timescale_archive,
+                                     threads)
 
         from listenbrainz.webserver.timescale_connection import _ts as ls
         try:

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -85,7 +85,7 @@ class DumpTestCase(DatabaseTestCase):
             self.assertEqual(user_count, 1)
 
             # do a db dump and reset the db
-            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir)
+            private_dump, private_ts_dump, public_dump, public_ts_dump = db_dump.dump_postgres_db(self.tempdir)
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)
@@ -123,7 +123,7 @@ class DumpTestCase(DatabaseTestCase):
             db_feedback.insert(feedback)
 
             # do a db dump and reset the db
-            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir)
+            private_dump, private_ts_dump, public_dump, public_ts_dump = db_dump.dump_postgres_db(self.tempdir)
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -91,7 +91,7 @@ class DumpTestCase(DatabaseTestCase):
             self.assertEqual(user_count, 0)
 
             # import the dump
-            db_dump.import_postgres_dump(private_dump, public_dump)
+            db_dump.import_postgres_dump(private_dump, None, public_dump, None)
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
 
@@ -100,7 +100,7 @@ class DumpTestCase(DatabaseTestCase):
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)
 
-            db_dump.import_postgres_dump(private_dump, public_dump, threads=2)
+            db_dump.import_postgres_dump(private_dump, None, public_dump, None, threads=2)
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
             two_id = db_user.create(2, 'vnskprk')
@@ -130,7 +130,7 @@ class DumpTestCase(DatabaseTestCase):
             self.assertEqual(db_feedback.get_feedback_count_for_user(user_id=one_id), 0)
 
             # import the dump and check the records are inserted
-            db_dump.import_postgres_dump(private_dump, public_dump)
+            db_dump.import_postgres_dump(private_dump, None, public_dump, None)
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
 
@@ -146,7 +146,7 @@ class DumpTestCase(DatabaseTestCase):
             self.assertEqual(user_count, 0)
             dumped_feedback = []
 
-            db_dump.import_postgres_dump(private_dump, public_dump, threads=2)
+            db_dump.import_postgres_dump(private_dump, None, public_dump, None, threads=2)
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
 

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -204,13 +204,13 @@ class DumpManagerTestCase(DatabaseTestCase):
         dump_name = os.listdir(self.tempdir)[0]
         mock_notify.assert_called_with(dump_name, 'fullexport')
 
-        # make sure that the dump contains a full listens dump, a public dump
-        # a private dump and a spark dump.
+        # make sure that the dump contains a full listens dump, a public and private dump (postgres),
+        # a public and private dump (timescale) and a spark dump.
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
             if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
                 archive_count += 1
-        self.assertEqual(archive_count, 4)
+        self.assertEqual(archive_count, 6)
 
     def test_create_full_dump_with_id(self):
 
@@ -232,12 +232,12 @@ class DumpManagerTestCase(DatabaseTestCase):
         created_dump_id = int(dump_name.split('-')[2])
         self.assertEqual(dump_id, created_dump_id)
 
-        # dump should contain the 4 archives
+        # dump should contain the 6 archives
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
             if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
                 archive_count += 1
-        self.assertEqual(archive_count, 4)
+        self.assertEqual(archive_count, 6)
 
     @patch('listenbrainz.db.dump_manager.send_dump_creation_notification')
     def test_create_incremental(self, mock_notify):

--- a/listenbrainz/db/timescale.py
+++ b/listenbrainz/db/timescale.py
@@ -7,8 +7,13 @@ import psycopg2
 
 from listenbrainz import config
 
-# This value must be incremented after schema changes on replicated tables!
-SCHEMA_VERSION = 6
+# The schema version of the timescale database (tables created
+# from ./admin/timescale/create-tables.sql). This includes user playlists
+# and mbid mappings.
+# Listens are tracked with `listenstore.LISTENS_DUMP_SCHEMA_VERSION`
+# This value must be incremented after schema changes on tables that are included in the
+# public dump
+SCHEMA_VERSION_TIMESCALE = 6
 
 engine = None
 

--- a/listenbrainz/listenstore/__init__.py
+++ b/listenbrainz/listenstore/__init__.py
@@ -5,6 +5,8 @@ ORDER_ASC = 1
 ORDER_TEXT = [ "DESC", "ASC" ]
 DEFAULT_LISTENS_PER_FETCH = 25
 
+# Schema version for the public listens dump, this should be updated
+# when the format of the json document in the public dumps changes
 LISTENS_DUMP_SCHEMA_VERSION = 1
 
 from listenbrainz.listenstore import listenstore

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -401,7 +401,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
     def test_schema_mismatch_exception_for_dump_incorrect_schema(self):
         """ Tests that SchemaMismatchException is raised when the schema of the dump is old """
 
-        # create a temp archive with incorrect SCHEMA_VERSION
+        # create a temp archive with incorrect SCHEMA_VERSION_CORE
         temp_dir = tempfile.mkdtemp()
         archive_name = 'temp_dump'
         archive_path = os.path.join(temp_dir, archive_name + '.tar.xz')


### PR DESCRIPTION
# Problem

We want to make dump files of non-listens data in the timescale database:

- playlists
- mbid mapping


# Solution

The dump script is currently only designed to dump from the main postgres database, so in the interests of speed, I just copy/pasted a few things to make the db engine a configurable option.

Dump 2 extra files (private-timescale and public-timescale) that include the relevant public/private split of this database.

# Action

Still work in progress, things to fix:
- [x] Dump fails with `Expected 12 dump files, found 15. Aborting.`, update check
- [x] Also make public dump (mbid mapping)
- [x] Double-check that when this runs that we won't upload the private playlists dump to FTP
- [x] Tests need to be fixed, they'll be failing
- [x] Add import part, double-check that tables are dumped in the right order to fulfill fk requirements when importing to a db with fks set up
- [x] Sort out various schema ids. In discussion in IRC we thought that we should probably have 1 for pg db, 1 for ts db, 1 for listen dumps
- [x] Update SCHEMA_VERSION_CORE, related to https://github.com/metabrainz/listenbrainz-server/pull/1422 - wrong value was updated, so we should increase the db version as well.
- [x] Identify problem with dumping timescale public dump tables out of order
- [x] ~~Ideally deduplicate code by using https://github.com/metabrainz/brainzutils-python/pull/50/files~~ later


