### PR TITLE
Use kombu for rabbitmq connections in websockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,15 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*
 
+# need to build librabbitmq
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        pkg-config \
+        libtool \
+    && rm -rf /var/lib/apt/lists/*
+
 # While WORKDIR will create a directory if it doesn't already exist, we do it explicitly here
 # so that we know what user it is created as: https://github.com/moby/moby/issues/36677
 RUN mkdir -p /code/listenbrainz /static
@@ -57,6 +66,11 @@ RUN pip3 install pip==21.0.1
 COPY requirements.txt /code/listenbrainz/
 RUN pip3 install --no-cache-dir -r requirements.txt
 
+# remove build dependencies
+RUN apt remove -y autoconf \
+        automake \
+        pkg-config \
+        libtool
 
 ############################################
 # NOTE: The development image starts here. #

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,15 +48,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*
 
-# need to build librabbitmq
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        autoconf \
-        automake \
-        pkg-config \
-        libtool \
-    && rm -rf /var/lib/apt/lists/*
-
 # While WORKDIR will create a directory if it doesn't already exist, we do it explicitly here
 # so that we know what user it is created as: https://github.com/moby/moby/issues/36677
 RUN mkdir -p /code/listenbrainz /static
@@ -65,12 +56,6 @@ WORKDIR /code/listenbrainz
 RUN pip3 install pip==21.0.1
 COPY requirements.txt /code/listenbrainz/
 RUN pip3 install --no-cache-dir -r requirements.txt
-
-# remove build dependencies
-RUN apt remove -y autoconf \
-        automake \
-        pkg-config \
-        libtool
 
 ############################################
 # NOTE: The development image starts here. #

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN pip3 install pip==21.0.1
 COPY requirements.txt /code/listenbrainz/
 RUN pip3 install --no-cache-dir -r requirements.txt
 
+
 ############################################
 # NOTE: The development image starts here. #
 ############################################

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -6,6 +6,9 @@ from kombu.mixins import ConsumerMixin
 from listenbrainz.utils import get_fallback_connection_name
 
 from kombu import Connection, Exchange, Queue, Consumer
+from kombu.utils.debug import setup_logging
+
+setup_logging()
 
 
 class ListensDispatcher(ConsumerMixin):

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -17,8 +17,8 @@ class ListensDispatcher(ConsumerMixin):
         self.connection = None
         self.channel2 = None
 
-        self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout")
-        self.playing_now_exchange = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout")
+        self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)
+        self.playing_now_exchange = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=False)
         self.websockets_queue = Queue(app.config["WEBSOCKETS_QUEUE"], exchange=self.unique_exchange, durable=True)
         self.playing_now_queue = Queue(app.config["PLAYING_NOW_QUEUE"], exchange=self.playing_now_exchange, durable=True)
 

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -32,7 +32,7 @@ class ListensDispatcher(ConsumerMixin):
         message.ack()
 
     def get_consumers(self, _, channel):
-        self.channel2 = self.connection.channel()
+        self.channel2 = channel.connection.channel()
         return [
             Consumer(self.channel2, queues=[self.websockets_queue], on_message=lambda x: self.send_listens("listen", x))
           , Consumer(channel, queues=[self.playing_now_queue], on_message=lambda x: self.send_listens("playing_now", x))

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -17,6 +17,9 @@ class ListensDispatcher(ConsumerMixin):
         self.app = app
         self.socketio = socketio
         self.connection = None
+        # there are two consumers: one for playing now queue and another for normal listens
+        # queue when using ConsumerMixin, it sets up a default channel itself. we create the
+        # other channel here. we also need to handle its cleanup later
         self.channel2 = None
 
         self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)
@@ -26,7 +29,6 @@ class ListensDispatcher(ConsumerMixin):
                                        durable=True)
 
     def send_listens(self, event_name, message):
-        self.app.logger.info("Callback called")
         listens = json.loads(message.body.decode("utf-8"))
         for listen in listens:
             self.socketio.emit(event_name, json.dumps(listen), to=listen["user_name"])

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -17,8 +17,8 @@ class ListensDispatcher(ConsumerMixin):
         self.connection = None
         self.channel2 = None
 
-        self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout", durable=True)
-        self.playing_now_exchange = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=True)
+        self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout")
+        self.playing_now_exchange = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout")
         self.websockets_queue = Queue(app.config["WEBSOCKETS_QUEUE"], exchange=self.unique_exchange, durable=True)
         self.playing_now_queue = Queue(app.config["PLAYING_NOW_QUEUE"], exchange=self.playing_now_exchange, durable=True)
 

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -17,9 +17,9 @@ class ListensDispatcher(ConsumerMixin):
         self.app = app
         self.socketio = socketio
         self.connection = None
-        # there are two consumers: one for playing now queue and another for normal listens
-        # queue when using ConsumerMixin, it sets up a default channel itself. we create the
-        # other channel here. we also need to handle its cleanup later
+        # there are two consumers, so we need two channels: one for playing now queue and another
+        # for normal listens queue. when using ConsumerMixin, it sets up a default channel itself.
+        # we create the other channel here. we also need to handle its cleanup later
         self.channel2 = None
 
         self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -34,9 +34,9 @@ class ListensDispatcher(ConsumerMixin):
     def get_consumers(self, _, channel):
         self.channel2 = self.connection.channel()
         return [
-            Consumer(channel, queues=[self.websockets_queue],
+            Consumer(self.channel2, queues=[self.websockets_queue],
                      callbacks=[lambda body, message: self.send_listens("listen", body, message)]),
-            Consumer(self.channel2, queues=[self.playing_now_queue],
+            Consumer(channel, queues=[self.playing_now_queue],
                      callbacks=[lambda body, message: self.send_listens("playing_now", body, message)])
         ]
 

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -1,78 +1,69 @@
 import json
-import pika
 import time
-import threading
+
+from kombu.mixins import ConsumerMixin
 
 from listenbrainz.utils import get_fallback_connection_name
 
+from kombu import Connection, Exchange, Queue, Consumer
 from flask import current_app
-from listenbrainz.webserver.views.api_tools import LISTEN_TYPE_PLAYING_NOW, LISTEN_TYPE_IMPORT
 
 
-class ListensDispatcher(threading.Thread):
+class ListensDispatcher(ConsumerMixin):
 
     def __init__(self, app, socketio):
-        threading.Thread.__init__(self)
         self.app = app
         self.socketio = socketio
+        self.connection = None
+        self.channel2 = None
 
-    def send_listens(self, listens, listen_type):
-        if listen_type == LISTEN_TYPE_PLAYING_NOW:
-            event_name = 'playing_now'
-        else:
-            event_name = 'listen'
+        self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout", durable=True)
+        self.playing_now_exchange = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=True)
+        self.websockets_queue = Queue(app.config["WEBSOCKETS_QUEUE"], exchange=self.unique_exchange, durable=True)
+        self.playing_now_queue = Queue(app.config["PLAYING_NOW_QUEUE"], exchange=self.playing_now_exchange, durable=True)
+
+    def send_listens(self, event_name, body, message):
+        listens = json.loads(body)
         for listen in listens:
-            self.socketio.emit(event_name, json.dumps(listen), to=listen['user_name'])
+            self.socketio.emit(event_name, json.dumps(listen), to=listen["user_name"])
+        message.ack()
 
-    def callback_listen(self, channel, method, properties, body):
-        listens = json.loads(body)
-        self.send_listens(listens, LISTEN_TYPE_IMPORT)
-        channel.basic_ack(delivery_tag=method.delivery_tag)
+    def get_consumers(self, _, channel):
+        self.channel2 = self.connection.channel()
+        return [
+            Consumer(channel, queues=[self.websockets_queue],
+                     callbacks=[lambda body, message: self.send_listens("listen", body, message)]),
+            Consumer(self.channel2, queues=[self.playing_now_queue],
+                     callbacks=[lambda body, message: self.send_listens("playing_now", body, message)])
+        ]
 
-    def callback_playing_now(self, channel, method, properties, body):
-        listens = json.loads(body)
-        self.send_listens(listens, LISTEN_TYPE_PLAYING_NOW)
-        channel.basic_ack(delivery_tag=method.delivery_tag)
-
-    def create_and_bind_exchange_and_queue(self, channel, exchange, queue):
-        channel.exchange_declare(exchange=exchange, exchange_type='fanout')
-        channel.queue_declare(callback=lambda x: None, queue=queue, durable=True)
-        channel.queue_bind(callback=lambda x: None, exchange=exchange, queue=queue)
-
-    def on_open_callback(self, channel):
-        self.create_and_bind_exchange_and_queue(channel, current_app.config['UNIQUE_EXCHANGE'], current_app.config['WEBSOCKETS_QUEUE'])
-        channel.basic_consume(queue=current_app.config['WEBSOCKETS_QUEUE'], on_message_callback=self.callback_listen)
-
-        self.create_and_bind_exchange_and_queue(channel, current_app.config['PLAYING_NOW_EXCHANGE'], current_app.config['PLAYING_NOW_QUEUE'])
-        channel.basic_consume(queue=current_app.config['PLAYING_NOW_QUEUE'], on_message_callback=self.callback_playing_now)
-
-    def on_open(self, connection):
-        connection.channel(on_open_callback=self.on_open_callback)
+    def on_consume_end(self, connection, default_channel):
+        if self.channel2:
+            self.channel2.close()
 
     def init_rabbitmq_connection(self):
         while True:
             try:
-                credentials = pika.PlainCredentials(current_app.config['RABBITMQ_USERNAME'], current_app.config['RABBITMQ_PASSWORD'])
-                connection_parameters = pika.ConnectionParameters(
-                    host=current_app.config['RABBITMQ_HOST'],
-                    port=current_app.config['RABBITMQ_PORT'],
-                    virtual_host=current_app.config['RABBITMQ_VHOST'],
-                    credentials=credentials,
+                self.connection = Connection(
+                    hostname=current_app.config["RABBITMQ_HOST"],
+                    userid=current_app.config["RABBITMQ_USERNAME"],
+                    port=current_app.config["RABBITMQ_PORT"],
+                    password=current_app.config["RABBITMQ_PASSWORD"],
+                    virtual_host=current_app.config["RABBITMQ_VHOST"],
                     client_properties={"connection_name": get_fallback_connection_name()}
                 )
-                self.connection = pika.SelectConnection(parameters=connection_parameters, on_open_callback=self.on_open)
                 break
             except Exception as e:
                 current_app.logger.error("Error while connecting to RabbitMQ: %s", str(e), exc_info=True)
                 time.sleep(3)
 
-    def run(self):
+    def start(self):
         with self.app.app_context():
             while True:
                 current_app.logger.info("Starting player writer...")
                 self.init_rabbitmq_connection()
                 try:
-                    self.connection.ioloop.start()
+                    self.run()
                 except KeyboardInterrupt:
                     current_app.logger.error("Keyboard interrupt!")
                     break

--- a/listenbrainz/websockets/websockets.py
+++ b/listenbrainz/websockets/websockets.py
@@ -52,5 +52,5 @@ def joined(data):
 
 def run_websockets(host='0.0.0.0', port=8082, debug=True):
     dispatcher = ListensDispatcher(app, socketio)
-    dispatcher.start()
+    Thread(target=dispatcher.start).start()
     socketio.run(app, debug=debug, host=host, port=port)

--- a/listenbrainz/websockets/websockets.py
+++ b/listenbrainz/websockets/websockets.py
@@ -1,4 +1,5 @@
 import eventlet
+from threading import Thread
 
 from flask_login import current_user
 from flask_socketio import SocketIO, join_room, emit, disconnect
@@ -51,5 +52,5 @@ def joined(data):
 
 def run_websockets(host='0.0.0.0', port=8082, debug=True):
     dispatcher = ListensDispatcher(app, socketio)
-    dispatcher.start()
+    Thread(target=dispatcher.start).start()
     socketio.run(app, debug=debug, host=host, port=port)

--- a/listenbrainz/websockets/websockets.py
+++ b/listenbrainz/websockets/websockets.py
@@ -52,5 +52,5 @@ def joined(data):
 
 def run_websockets(host='0.0.0.0', port=8082, debug=True):
     dispatcher = ListensDispatcher(app, socketio)
-    Thread(target=dispatcher.start).start()
+    dispatcher.start()
     socketio.run(app, debug=debug, host=host, port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,5 +49,5 @@ google-auth==1.30.0
 pandas==1.3.0
 pyarrow==4.0.1
 more-itertools==8.8.0
-librabbitmq
+pyamqp
 kombu==5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,5 +49,5 @@ google-auth==1.30.0
 pandas==1.3.0
 pyarrow==4.0.1
 more-itertools==8.8.0
-pyamqp
+librabbitmq
 kombu==5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ google-auth==1.30.0
 pandas==1.3.0
 pyarrow==4.0.1
 more-itertools==8.8.0
+librabbitmq
+kombu==5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,5 +49,5 @@ google-auth==1.30.0
 pandas==1.3.0
 pyarrow==4.0.1
 more-itertools==8.8.0
-librabbitmq
+librabbitmq-fork==2.0.2.dev1
 kombu==5.1.0


### PR DESCRIPTION
We intend to replace pika with kombu in LB because kombu is easier to work with in general. To iron out issues, we begin with moving websockets off to kombu because those are a non-essential part of the infra.