### PR TITLE
Add missing MBIDs to UserChartEntity items for display

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserEntityChart.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/src/stats/__snapshots__/UserEntityChart.test.tsx.snap
@@ -5765,7 +5765,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                       "track_metadata": Object {
                         "additional_info": Object {
                           "artist_mbids": Array [],
-                          "recording_mbid": "",
+                          "recording_mbid": undefined,
                           "release_mbid": "",
                         },
                         "artist_name": "Ritviz",
@@ -5843,7 +5843,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                               "track_metadata": Object {
                                 "additional_info": Object {
                                   "artist_mbids": Array [],
-                                  "recording_mbid": "",
+                                  "recording_mbid": undefined,
                                   "release_mbid": "",
                                 },
                                 "artist_name": "Ritviz",
@@ -6950,7 +6950,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                       "track_metadata": Object {
                         "additional_info": Object {
                           "artist_mbids": Array [],
-                          "recording_mbid": "",
+                          "recording_mbid": undefined,
                           "release_mbid": "",
                         },
                         "artist_name": "OneRepublic",
@@ -7028,7 +7028,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                               "track_metadata": Object {
                                 "additional_info": Object {
                                   "artist_mbids": Array [],
-                                  "recording_mbid": "",
+                                  "recording_mbid": undefined,
                                   "release_mbid": "",
                                 },
                                 "artist_name": "OneRepublic",
@@ -7280,7 +7280,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                       "track_metadata": Object {
                         "additional_info": Object {
                           "artist_mbids": Array [],
-                          "recording_mbid": "",
+                          "recording_mbid": undefined,
                           "release_mbid": "",
                         },
                         "artist_name": "Tommee Profitt",
@@ -7358,7 +7358,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                               "track_metadata": Object {
                                 "additional_info": Object {
                                   "artist_mbids": Array [],
-                                  "recording_mbid": "",
+                                  "recording_mbid": undefined,
                                   "release_mbid": "",
                                 },
                                 "artist_name": "Tommee Profitt",
@@ -7610,7 +7610,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                       "track_metadata": Object {
                         "additional_info": Object {
                           "artist_mbids": Array [],
-                          "recording_mbid": "",
+                          "recording_mbid": undefined,
                           "release_mbid": "",
                         },
                         "artist_name": "Maroon 5",
@@ -7688,7 +7688,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                               "track_metadata": Object {
                                 "additional_info": Object {
                                   "artist_mbids": Array [],
-                                  "recording_mbid": "",
+                                  "recording_mbid": undefined,
                                   "release_mbid": "",
                                 },
                                 "artist_name": "Maroon 5",
@@ -7940,7 +7940,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                       "track_metadata": Object {
                         "additional_info": Object {
                           "artist_mbids": Array [],
-                          "recording_mbid": "",
+                          "recording_mbid": undefined,
                           "release_mbid": "",
                         },
                         "artist_name": "Sia",
@@ -8018,7 +8018,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                               "track_metadata": Object {
                                 "additional_info": Object {
                                   "artist_mbids": Array [],
-                                  "recording_mbid": "",
+                                  "recording_mbid": undefined,
                                   "release_mbid": "",
                                 },
                                 "artist_name": "Sia",
@@ -8954,7 +8954,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                       "track_metadata": Object {
                         "additional_info": Object {
                           "artist_mbids": Array [],
-                          "recording_mbid": "",
+                          "recording_mbid": undefined,
                           "release_mbid": "",
                         },
                         "artist_name": "The Local train",
@@ -9032,7 +9032,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                               "track_metadata": Object {
                                 "additional_info": Object {
                                   "artist_mbids": Array [],
-                                  "recording_mbid": "",
+                                  "recording_mbid": undefined,
                                   "release_mbid": "",
                                 },
                                 "artist_name": "The Local train",
@@ -9455,7 +9455,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                       "track_metadata": Object {
                         "additional_info": Object {
                           "artist_mbids": Array [],
-                          "recording_mbid": "",
+                          "recording_mbid": undefined,
                           "release_mbid": "",
                         },
                         "artist_name": "Ellie Goulding",
@@ -9533,7 +9533,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                               "track_metadata": Object {
                                 "additional_info": Object {
                                   "artist_mbids": Array [],
-                                  "recording_mbid": "",
+                                  "recording_mbid": undefined,
                                   "release_mbid": "",
                                 },
                                 "artist_name": "Ellie Goulding",
@@ -10382,7 +10382,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 "track_metadata": Object {
                   "additional_info": Object {
                     "artist_mbids": Array [],
-                    "recording_mbid": "",
+                    "recording_mbid": undefined,
                     "release_mbid": "",
                   },
                   "artist_name": "Ritviz",
@@ -10473,7 +10473,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 "track_metadata": Object {
                   "additional_info": Object {
                     "artist_mbids": Array [],
-                    "recording_mbid": "",
+                    "recording_mbid": undefined,
                     "release_mbid": "",
                   },
                   "artist_name": "OneRepublic",
@@ -10499,7 +10499,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 "track_metadata": Object {
                   "additional_info": Object {
                     "artist_mbids": Array [],
-                    "recording_mbid": "",
+                    "recording_mbid": undefined,
                     "release_mbid": "",
                   },
                   "artist_name": "Tommee Profitt",
@@ -10525,7 +10525,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 "track_metadata": Object {
                   "additional_info": Object {
                     "artist_mbids": Array [],
-                    "recording_mbid": "",
+                    "recording_mbid": undefined,
                     "release_mbid": "",
                   },
                   "artist_name": "Maroon 5",
@@ -10551,7 +10551,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 "track_metadata": Object {
                   "additional_info": Object {
                     "artist_mbids": Array [],
-                    "recording_mbid": "",
+                    "recording_mbid": undefined,
                     "release_mbid": "",
                   },
                   "artist_name": "Sia",
@@ -10629,7 +10629,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 "track_metadata": Object {
                   "additional_info": Object {
                     "artist_mbids": Array [],
-                    "recording_mbid": "",
+                    "recording_mbid": undefined,
                     "release_mbid": "",
                   },
                   "artist_name": "The Local train",
@@ -10668,7 +10668,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
                 "track_metadata": Object {
                   "additional_info": Object {
                     "artist_mbids": Array [],
-                    "recording_mbid": "",
+                    "recording_mbid": undefined,
                     "release_mbid": "",
                   },
                   "artist_name": "Ellie Goulding",

--- a/listenbrainz/webserver/static/js/src/stats/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/utils.tsx
@@ -44,9 +44,10 @@ export function userChartEntityToListen(
       artist_name: artistName ?? "",
       release_name: releaseName ?? "",
       additional_info: {
-        artist_mbids: artistMBIDs,
+        artist_mbids:
+          entityType === "artist" ? ([entityMBID] as string[]) : artistMBIDs,
         recording_mbid: entityType === "recording" ? entityMBID : undefined,
-        release_mbid: releaseMBID,
+        release_mbid: entityType === "release" ? entityMBID : releaseMBID,
       },
     },
   };

--- a/listenbrainz/webserver/static/js/src/stats/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/utils.tsx
@@ -37,6 +37,18 @@ export function userChartEntityToListen(
   const trackName = entityType === "recording" ? entityName : "";
   const artistName = entityType === "artist" ? entityName : artist;
   const releaseName = entityType === "release" ? entityName : release;
+  let artist_mbids = artistMBIDs;
+  let release_mbid = releaseMBID;
+  let recording_mbid;
+  if (entityType === "artist" && entityMBID) {
+    artist_mbids = [entityMBID] as string[];
+  }
+  if (entityType === "release" && entityMBID) {
+    release_mbid = entityMBID;
+  }
+  if (entityType === "recording" && entityMBID) {
+    recording_mbid = entityMBID;
+  }
   return {
     listened_at: -1,
     track_metadata: {
@@ -44,10 +56,9 @@ export function userChartEntityToListen(
       artist_name: artistName ?? "",
       release_name: releaseName ?? "",
       additional_info: {
-        artist_mbids:
-          entityType === "artist" ? ([entityMBID] as string[]) : artistMBIDs,
-        recording_mbid: entityType === "recording" ? entityMBID : undefined,
-        release_mbid: entityType === "release" ? entityMBID : releaseMBID,
+        artist_mbids,
+        recording_mbid,
+        release_mbid,
       },
     },
   };


### PR DESCRIPTION
When transforming UserChartEntity items to listens, the format was not what I thought it was.

For an item of type "release", the 'release_mbid' field will be undefined, but the 'entityMBID' will contain the release's MBID.
So we need to reconstruct our MBIDs for each entity type.

We use those MBIDs down the line in the ListenCard for example, to fetch covert art and other features.