### PR TITLE
Validate that payload in submission json is a list

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -199,6 +199,19 @@ class APITestCase(ListenAPIIntegrationTestCase):
             response = self.send_data(payload)
             self.assert400(response)
 
+    def test_payload_is_not_list(self):
+        """ Test that API returns 400 for payloads with no listens
+        """
+        for listen_type in ('single', 'playing_now', 'import'):
+            data = {
+                'listen_type': listen_type,
+                'payload': {},
+            }
+            response = self.send_data(data)
+            self.assert400(response)
+            self.assertEqual('The payload in the JSON document should be'
+                             ' a list of listens.', response.json['error'])
+
     def test_unauthorized_submission(self):
         """ Test for checking that unauthorized submissions return 401
         """

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -65,6 +65,10 @@ def submit_listen():
 
     try:
         payload = data['payload']
+
+        if not isinstance(payload, list):
+            raise APIBadRequest("The payload in the JSON document should be a list of listens.", payload)
+
         if len(payload) == 0:
             log_raise_400(
                 "JSON document does not contain any listens", payload)


### PR DESCRIPTION
The payload in submission json has to be a list. If it is a dict, each key is treated as a listen by the code. If payload is a string,
each character is treated as a listen. In both of these cases, we get a 500 error because the later performed listen checks do not expect this. For instance, https://sentry.metabrainz.org/organizations/metabrainz/issues/42133/