### PR TITLE
LB-1001 : Show playlist title in newly created playlist alert message

### DIFF
--- a/listenbrainz/webserver/static/js/src/playlists/CreateOrEditPlaylistModal.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/CreateOrEditPlaylistModal.tsx
@@ -9,7 +9,7 @@ import GlobalAppContext from "../GlobalAppContext";
 type CreateOrEditPlaylistModalProps = {
   playlist?: JSPFPlaylist;
   onSubmit: (
-    name: string,
+    title: string,
     description: string,
     isPublic: boolean,
     collaborators: string[],

--- a/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlist.tsx
@@ -266,12 +266,17 @@ export default class PlaylistPage extends React.Component<
         currentUser.auth_token,
         getPlaylistId(playlist)
       );
+      // Fetch the newly created playlist and add it to the state if it's the current user's page
+      const JSPFObject: JSPFObject = await this.APIService.getPlaylist(
+        newPlaylistId,
+        currentUser.auth_token
+      );
       newAlert(
         "success",
         "Duplicated playlist",
         <>
           Duplicated to playlist&ensp;
-          <a href={`/playlist/${newPlaylistId}`}>{newPlaylistId}</a>
+          <a href={`/playlist/${newPlaylistId}`}>{JSPFObject.playlist.title}</a>
         </>
       );
     } catch (error) {

--- a/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
@@ -162,20 +162,20 @@ export default class UserPlaylists extends React.Component<
         currentUser.auth_token,
         playlistId
       );
+      // Fetch the newly created playlist and add it to the state if it's the current user's page
+      const JSPFObject: JSPFObject = await this.APIService.getPlaylist(
+        newPlaylistId,
+        currentUser.auth_token
+      );
       newAlert(
         "success",
         "Duplicated playlist",
         <>
           Duplicated to playlist&ensp;
-          <a href={`/playlist/${newPlaylistId}`}>Copy of {playlistTitle}</a>
+          <a href={`/playlist/${newPlaylistId}`}>{JSPFObject.playlist.title}</a>
         </>
       );
-      // Fetch the newly created playlist and add it to the state if it's the current user's page
       if (this.isCurrentUserPage()) {
-        const JSPFObject: JSPFObject = await this.APIService.getPlaylist(
-          newPlaylistId,
-          currentUser.auth_token
-        );
         this.setState((prevState) => ({
           playlists: [JSPFObject.playlist, ...prevState.playlists],
         }));

--- a/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/Playlists.tsx
@@ -143,7 +143,10 @@ export default class UserPlaylists extends React.Component<
     );
   };
 
-  copyPlaylist = async (playlistId: string): Promise<void> => {
+  copyPlaylist = async (
+    playlistId: string,
+    playlistTitle: string
+  ): Promise<void> => {
     const { newAlert } = this.props;
     const { currentUser } = this.context;
     if (!currentUser?.auth_token) {
@@ -164,7 +167,7 @@ export default class UserPlaylists extends React.Component<
         "Duplicated playlist",
         <>
           Duplicated to playlist&ensp;
-          <a href={`/playlist/${newPlaylistId}`}>{newPlaylistId}</a>
+          <a href={`/playlist/${newPlaylistId}`}>Copy of {playlistTitle}</a>
         </>
       );
       // Fetch the newly created playlist and add it to the state if it's the current user's page
@@ -229,7 +232,7 @@ export default class UserPlaylists extends React.Component<
   };
 
   createPlaylist = async (
-    name: string,
+    title: string,
     description: string,
     isPublic: boolean,
     // Not sure what to do with those yet
@@ -273,7 +276,7 @@ export default class UserPlaylists extends React.Component<
           date: "",
           track: [],
 
-          title: name,
+          title,
           annotation: description,
           extension: {
             [MUSICBRAINZ_JSPF_PLAYLIST_EXTENSION]: {
@@ -291,8 +294,8 @@ export default class UserPlaylists extends React.Component<
         "success",
         "Created playlist",
         <>
-          Created new playlist{" "}
-          <a href={`/playlist/${newPlaylistId}`}>{newPlaylistId}</a>
+          Created new {isPublic ? "public" : "private"} playlist{" "}
+          <a href={`/playlist/${newPlaylistId}`}>{title}</a>
         </>
       );
       // Fetch the newly created playlist and add it to the state
@@ -512,7 +515,11 @@ export default class UserPlaylists extends React.Component<
                 {isRecommendations ? (
                   <button
                     className="playlist-card-action-button"
-                    onClick={this.copyPlaylist.bind(this, playlistId)}
+                    onClick={this.copyPlaylist.bind(
+                      this,
+                      playlistId,
+                      playlist.title
+                    )}
                     type="button"
                   >
                     <FontAwesomeIcon
@@ -548,7 +555,11 @@ export default class UserPlaylists extends React.Component<
                       >
                         <li>
                           <button
-                            onClick={this.copyPlaylist.bind(this, playlistId)}
+                            onClick={this.copyPlaylist.bind(
+                              this,
+                              playlistId,
+                              playlist.title
+                            )}
                             type="button"
                           >
                             Duplicate


### PR DESCRIPTION
I've added a quick mention of whether the playlist is public/private in the message, too.
+ Same mechanism applied to duplicating a playlist.

<img width="414" alt="playlist_name" src="https://user-images.githubusercontent.com/6179856/142615401-f6a77020-bd1e-48a2-9b9d-0ed4659f53da.png">

