### PR TITLE
AISOTT: Minor mapping fixes and new index on listen table

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -3,6 +3,7 @@ BEGIN;
 CREATE INDEX listened_at_user_name_ndx_listen ON listen (listened_at DESC, user_name);
 CREATE INDEX created_ndx_listen ON listen (created);
 CREATE UNIQUE INDEX listened_at_track_name_user_name_ndx_listen ON listen (listened_at DESC, track_name, user_name);
+CREATE INDEX recording_msid_ndx_listen on listen ((data->'track_metadata'->'additional_info'->>'recording_msid'));
 
 -- View indexes are created in listenbrainz/db/timescale.py
 

--- a/listenbrainz/mbid_mapping_writer/job_queue.py
+++ b/listenbrainz/mbid_mapping_writer/job_queue.py
@@ -260,8 +260,7 @@ class MappingJobQueue(threading.Thread):
                         low_quality_rate=stats["low_quality"] - stats["last_low_quality"],
                         no_match_rate=stats["no_match"] - stats["last_no_match"],
                         listens_per_sec=listens_per_sec,
-                        listen_count=stats["listen_count"],
-                        listens_matched=stats["listens_matched"],
+                        listens_matched_p=stats["listens_matched"] / stats["listen_count"] * 100.0,
                         legacy_index_date=datetime.date.fromtimestamp(self.legacy_listens_index_date).strftime("%Y-%m-%d"))
 
             stats["last_exact_match"] = stats["exact_match"]

--- a/listenbrainz/mbid_mapping_writer/job_queue.py
+++ b/listenbrainz/mbid_mapping_writer/job_queue.py
@@ -268,6 +268,9 @@ class MappingJobQueue(threading.Thread):
             stats["last_med_quality"] = stats["med_quality"]
             stats["last_low_quality"] = stats["low_quality"]
             stats["last_no_match"] = stats["no_match"]
+            stats["listens_matched"] = 0
+            stats["listen_count"] = 0
+
 
     def run(self):
         """ main thread entry point"""

--- a/listenbrainz/mbid_mapping_writer/job_queue.py
+++ b/listenbrainz/mbid_mapping_writer/job_queue.py
@@ -260,7 +260,7 @@ class MappingJobQueue(threading.Thread):
                         low_quality_rate=stats["low_quality"] - stats["last_low_quality"],
                         no_match_rate=stats["no_match"] - stats["last_no_match"],
                         listens_per_sec=listens_per_sec,
-                        listens_matched_p=stats["listens_matched"] / stats["listen_count"] * 100.0,
+                        listens_matched_p=stats["listens_matched"] / (stats["listen_count"] or .000001) * 100.0,
                         legacy_index_date=datetime.date.fromtimestamp(self.legacy_listens_index_date).strftime("%Y-%m-%d"))
 
             stats["last_exact_match"] = stats["exact_match"]

--- a/listenbrainz/mbid_mapping_writer/matcher.py
+++ b/listenbrainz/mbid_mapping_writer/matcher.py
@@ -36,7 +36,7 @@ def process_listens(app, listens, is_legacy_listen=False):
         # Remove msids for which we already have a match, unless
         # its timestamp is 0, which means we should re-check the item
         with timescale.engine.connect() as connection:
-            query = """SELECT recording_msid 
+            query = """SELECT recording_msid, match_type
                          FROM mbid_mapping
                         WHERE recording_msid IN :msids
                           AND last_updated != '1970-01-01'"""
@@ -48,6 +48,8 @@ def process_listens(app, listens, is_legacy_listen=False):
                     break
                 del msids[str(result[0])]
                 stats["processed"] += 1
+                if result[1] != 'no_match':
+                    stats["listens_matched"] += 1
                 skipped += 1
 
         if len(msids) == 0:


### PR DESCRIPTION
This PR fixes a couple of minor issues that were not right with the latest mapping refactoring:

1. Fix the incoming listens match rate
2. Add an index on recording_msid (JSONB) on listens -- this becomes more important as we do more re-checks.