### PR TITLE
Add sitewide release stats

### DIFF
--- a/data/model/sitewide_entity.py
+++ b/data/model/sitewide_entity.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Union
 import pydantic
 
 from data.model.sitewide_artist_stat import SitewideArtistRecord
+from data.model.user_entity import UserEntityRecord
 
 
 class SitewideEntityStatMessage(pydantic.BaseModel):
@@ -15,4 +16,4 @@ class SitewideEntityStatMessage(pydantic.BaseModel):
     count: int
     # Order of the records in union is important and should be from more specific to less specific
     # For more info read https://pydantic-docs.helpmanual.io/usage/types/#unions
-    data: List[SitewideArtistRecord]
+    data: List[UserEntityRecord]

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -113,7 +113,7 @@ def handle_sitewide_entity(data):
     entity = data['entity']
 
     try:
-        db_stats.insert_sitewide_jsonb_data(entity, StatRange[SitewideArtistRecord](**data))
+        db_stats.insert_sitewide_jsonb_data(entity, StatRange[UserEntityRecord](**data))
     except ValidationError:
         current_app.logger.error(f"""ValidationError while inserting {stats_range} sitewide top {entity}.
         Data: {json.dumps(data, indent=3)}""", exc_info=True)

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -117,7 +117,7 @@ def request_user_stats(type_, range_, entity):
 @cli.command(name="request_sitewide_stats")
 @click.option("--range", 'range_', type=click.Choice(ALLOWED_STATISTICS_RANGE),
               help="Time range of statistics to calculate", required=True)
-@click.option("--entity", type=click.Choice(['artists']),
+@click.option("--entity", type=click.Choice(['artists', 'releases']),
               help="Entity for which statistics should be calculated")
 def request_sitewide_stats(range_, entity):
     """ Send request to calculate sitewide stats to the spark cluster

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -594,7 +594,65 @@ def get_sitewide_artist():
 @crossdomain()
 @ratelimit()
 def get_sitewide_release():
-    """ TODO: Add documentation """
+    """
+    A sample response from the endpoint may look like:
+
+    .. code-block:: json
+
+        {
+            "payload": {
+                "releases": [
+                    {
+                        "artist_mbids": [],
+                        "artist_name": "Coldplay",
+                        "listen_count": 26,
+                        "release_mbid": "",
+                        "release_name": "Live in Buenos Aires"
+                    },
+                    {
+                        "artist_mbids": [],
+                        "artist_name": "Ellie Goulding",
+                        "listen_count": 25,
+                        "release_mbid": "",
+                        "release_name": "Delirium (Deluxe)"
+                    },
+                    {
+                        "artist_mbids": [],
+                        "artist_name": "The Fray",
+                        "listen_count": 25,
+                        "release_mbid": "",
+                        "release_name": "How to Save a Life"
+                    },
+                ],
+                "offset": 0,
+                "count": 2,
+                "range": "year",
+                "last_updated": 1588494361,
+                "from_ts": 1009823400,
+                "to_ts": 1590029157
+            }
+        }
+
+    .. note::
+        - This endpoint is currently in beta
+        - ``artist_mbids``, ``artist_msid``, ``release_mbid`` and ``release_msid`` are optional fields and
+          may not be present in all the responses
+
+    :param count: Optional, number of artists to return for each time range,
+        Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET`
+        Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
+    :type count: ``int``
+    :param offset: Optional, number of artists to skip from the beginning, for pagination.
+        Ex. An offset of 5 means the top 5 artists will be skipped, defaults to 0
+    :type offset: ``int``
+    :param range: Optional, time interval for which statistics should be returned, possible values are
+        :data:`~data.model.common_stat.ALLOWED_STATISTICS_RANGE`, defaults to ``all_time``
+    :type range: ``str``
+    :statuscode 200: Successful query, you have data!
+    :statuscode 204: Statistics haven't been calculated, empty response will be returned
+    :statuscode 400: Bad request, check ``response['error']`` for more details
+    :resheader Content-Type: *application/json*
+    """
     return _get_sitewide_stats("releases")
 
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -587,21 +587,33 @@ def get_sitewide_artist():
     :statuscode 400: Bad request, check ``response['error']`` for more details
     :resheader Content-Type: *application/json*
     """
-    stats_range = request.args.get('range', default='all_time')
+    return _get_sitewide_stats("artists")
+
+
+@stats_api_bp.route("/sitewide/releases")
+@crossdomain()
+@ratelimit()
+def get_sitewide_release():
+    """ TODO: Add documentation """
+    return _get_sitewide_stats("releases")
+
+
+def _get_sitewide_stats(entity: str):
+    stats_range = request.args.get("range", default="all_time")
     if not _is_valid_range(stats_range):
-        raise APIBadRequest("Invalid range: {}".format(stats_range))
+        raise APIBadRequest(f"Invalid range: {stats_range}")
 
-    offset = get_non_negative_param('offset', default=0)
-    count = get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
+    offset = get_non_negative_param("offset", default=0)
+    count = get_non_negative_param("count", default=DEFAULT_ITEMS_PER_GET)
 
-    stats = db_stats.get_sitewide_stats(stats_range, 'artists')
+    stats = db_stats.get_sitewide_stats(stats_range, entity)
     if stats is None:
-        raise APINoContent('')
+        raise APINoContent("")
 
     entity_list, total_entity_count = _process_user_entity(stats, offset, count)
     return jsonify({
         "payload": {
-            "artists": entity_list,
+            entity: entity_list,
             "range": stats_range,
             "offset": offset,
             "count": total_entity_count,

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -5,8 +5,11 @@ from typing import List, Optional
 
 from data.model.sitewide_artist_stat import SitewideArtistRecord
 from data.model.sitewide_entity import SitewideEntityStatMessage
+from data.model.user_artist_stat import UserArtistRecord
+from data.model.user_release_stat import UserReleaseRecord
 from listenbrainz_spark.stats import get_dates_for_stats_range
 from listenbrainz_spark.stats.sitewide.artist import get_artists
+from listenbrainz_spark.stats.sitewide.release import get_releases
 from listenbrainz_spark.utils import get_listens_from_new_dump
 from pydantic import ValidationError
 
@@ -16,10 +19,12 @@ logger = logging.getLogger(__name__)
 
 entity_handler_map = {
     "artists": get_artists,
+    "releases": get_releases
 }
 
 entity_model_map = {
-    "artists": SitewideArtistRecord
+    "artists": UserArtistRecord,
+    "releases": UserReleaseRecord
 }
 
 

--- a/listenbrainz_spark/stats/sitewide/release.py
+++ b/listenbrainz_spark/stats/sitewide/release.py
@@ -1,0 +1,61 @@
+from listenbrainz_spark.stats import run_query, SITEWIDE_STATS_ENTITY_LIMIT
+
+
+def get_releases(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
+    """
+    Get release information (release_name, release_mbid etc) ordered by
+    listen count (number of times listened to tracks which belong to a
+    particular release).
+
+    Args:
+        table: name of the temporary table
+        limit: number of top releases to retain
+    Returns:
+        iterator: an iterator over result, contains only 1 row
+                {
+                    [
+                        {
+                            'release_name': str
+                            'release_msid': str,
+                            'release_mbid': str,
+                            'artist_name': str,
+                            'artist_msid': str,
+                            'artist_mbids': list(str),
+                            'listen_count': int
+                        },
+                        ...
+                    ],
+                }
+    """
+    result = run_query(f"""
+        WITH intermediate_table as (
+            SELECT first(release_name) AS any_release_name
+                 , release_mbid
+                 , first(artist_name) AS any_artist_name
+                 , artist_credit_mbids
+                 , count(*) as listen_count
+              FROM {table}
+             WHERE release_name != ''
+          GROUP BY lower(release_name)
+                 , release_mbid
+                 , lower(artist_name)
+                 , artist_credit_mbids
+          ORDER BY listen_count DESC
+             LIMIT {limit}
+        )
+        SELECT sort_array(
+                    collect_list(
+                        struct(
+                            listen_count
+                          , any_release_name AS release_name
+                          , release_mbid
+                          , any_artist_name AS artist_name
+                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                        )
+                    )
+                   , false
+                ) as stats
+          FROM intermediate_table
+        """)
+
+    return result.toLocalIterator()


### PR DESCRIPTION
Add sitewide release statistics. Most of the code is copy paste from existing sitewide artist stats, only the Spark SQL query is the new code added. Tests are pending will add in a separate PR later.