### PR TITLE
Fix sitewide artists casing and sorting

### DIFF
--- a/listenbrainz_spark/stats/__init__.py
+++ b/listenbrainz_spark/stats/__init__.py
@@ -12,6 +12,8 @@ from pyspark.sql.utils import *
 
 from listenbrainz_spark.utils import get_latest_listen_ts
 
+SITEWIDE_STATS_ENTITY_LIMIT = 1000  # number of top artists to retain in sitewide stats
+
 
 def run_query(query):
     """ Returns dataframe that results from running the query.

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -17,11 +17,11 @@ def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
     # with sort_array.
     result = run_query(f"""
         WITH intermediate_table as (
-            SELECT artist_name
+            SELECT first(artist_name) AS any_artist_name
                  , artist_credit_mbids
                  , count(*) as listen_count
               FROM {table}
-          GROUP BY artist_name
+          GROUP BY lower(artist_name)
                  , artist_credit_mbids
           ORDER BY listen_count DESC
              LIMIT {limit}
@@ -30,7 +30,7 @@ def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
                     collect_list(
                         struct(
                             listen_count
-                          , artist_name
+                          , any_artist_name AS artist_name
                           , coalesce(artist_credit_mbids, array()) AS artist_mbids
                         )
                     )

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -1,6 +1,4 @@
-from listenbrainz_spark.stats import run_query
-
-SITEWIDE_STATS_ENTITY_LIMIT = 1000  # number of top artists to retain in sitewide stats
+from listenbrainz_spark.stats import run_query, SITEWIDE_STATS_ENTITY_LIMIT
 
 
 def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
@@ -13,7 +11,10 @@ def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
         Returns:
             iterator (iter): An iterator over result
     """
-
+    # we sort twice, the ORDER BY in CTE sorts to eliminate all
+    # but top LIMIT results. collect_list's docs mention that the
+    # order of collected results is not guaranteed so sort again
+    # with sort_array.
     result = run_query(f"""
         WITH intermediate_table as (
             SELECT artist_name
@@ -25,12 +26,15 @@ def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
           ORDER BY listen_count DESC
              LIMIT {limit}
         )
-        SELECT collect_list(
-                    struct(
-                        artist_name
-                      , coalesce(artist_credit_mbids, array()) AS artist_mbids
-                      , listen_count
+        SELECT sort_array(
+                    collect_list(
+                        struct(
+                            listen_count
+                          , artist_name
+                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                        )
                     )
+                    , false
                ) AS stats
           FROM intermediate_table
     """)

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_artist.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_artist.py
@@ -6,7 +6,6 @@ from listenbrainz_spark.stats.user.tests import StatsTestCase
 class SitewideArtistTestCase(StatsTestCase):
 
     def test_get_artist(self):
-        self.maxDiff = None
         with open(self.path_to_data_file('sitewide_top_artists_output.json')) as f:
             expected = json.load(f)
         received = list(entity.get_entity_stats('artists', 'all_time'))

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_artist.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_artist.py
@@ -6,6 +6,7 @@ from listenbrainz_spark.stats.user.tests import StatsTestCase
 class SitewideArtistTestCase(StatsTestCase):
 
     def test_get_artist(self):
+        self.maxDiff = None
         with open(self.path_to_data_file('sitewide_top_artists_output.json')) as f:
             expected = json.load(f)
         received = list(entity.get_entity_stats('artists', 'all_time'))

--- a/listenbrainz_spark/testdata/sitewide_top_artists_output.json
+++ b/listenbrainz_spark/testdata/sitewide_top_artists_output.json
@@ -15,7 +15,15 @@
                 "artist_name": "Portishead"
             },
             {
-                "artist_mbids": [],
+                "artist_mbids": [
+                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+                ],
+                "listen_count": 5,
+                "artist_name": "Massive Attack"
+            },
+            {
+                "artist_mbids": [
+                ],
                 "listen_count": 5,
                 "artist_name": "Lucifer Cast, Tom Ellis"
             },
@@ -35,18 +43,6 @@
             },
             {
                 "artist_mbids": [
-                    "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
-                ],
-                "listen_count": 5,
-                "artist_name": "Massive Attack"
-            },
-            {
-                "artist_mbids": [],
-                "listen_count": 4,
-                "artist_name": "Future, Marshmello"
-            },
-            {
-                "artist_mbids": [
                     "b014d579-b549-4b21-b90d-5264e0433988"
                 ],
                 "listen_count": 4,
@@ -54,10 +50,37 @@
             },
             {
                 "artist_mbids": [
+                ],
+                "listen_count": 4,
+                "artist_name": "Future, Marshmello"
+            },
+            {
+                "artist_mbids": [
                     "c44ff36b-651f-4c20-98ee-519cf4ed07e7"
                 ],
                 "listen_count": 4,
                 "artist_name": "Aether"
+            },
+            {
+                "artist_mbids": [
+                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+                ],
+                "listen_count": 3,
+                "artist_name": "Vangelis"
+            },
+            {
+                "artist_mbids": [
+                    "78c94cba-761f-4212-8508-a24bda2e57dc"
+                ],
+                "listen_count": 3,
+                "artist_name": "Little People"
+            },
+            {
+                "artist_mbids": [
+                    "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"
+                ],
+                "listen_count": 3,
+                "artist_name": "Jon Bellion"
             },
             {
                 "artist_mbids": [
@@ -79,33 +102,7 @@
                     "859d0860-d480-4efd-970c-c05d5f1776b8"
                 ],
                 "listen_count": 3,
-                "artist_name": "Beyonc\u00e9"
-            },
-            {
-                "artist_mbids": [
-                    "78c94cba-761f-4212-8508-a24bda2e57dc"
-                ],
-                "listen_count": 3,
-                "artist_name": "Little People"
-            },
-            {
-                "artist_mbids": [
-                    "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
-                ],
-                "listen_count": 3,
-                "artist_name": "Vangelis"
-            },
-            {
-                "artist_mbids": [
-                    "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e"
-                ],
-                "listen_count": 3,
-                "artist_name": "Jon Bellion"
-            },
-            {
-                "artist_mbids": [],
-                "listen_count": 2,
-                "artist_name": "Kalabi"
+                "artist_name": "Beyoncé"
             },
             {
                 "artist_mbids": [
@@ -130,16 +127,17 @@
                 "artist_name": "The Polish Ambassador"
             },
             {
-                "artist_mbids": [],
-                "listen_count": 2,
-                "artist_name": "Bo Burnham"
-            },
-            {
                 "artist_mbids": [
                     "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
                 ],
                 "listen_count": 2,
                 "artist_name": "Olivia Rodrigo"
+            },
+            {
+                "artist_mbids": [
+                ],
+                "listen_count": 2,
+                "artist_name": "Kalabi"
             },
             {
                 "artist_mbids": [
@@ -149,16 +147,39 @@
                 "artist_name": "Dua Lipa"
             },
             {
-                "artist_mbids": [],
-                "listen_count": 1,
-                "artist_name": "Brazilian Girls"
+                "artist_mbids": [
+                ],
+                "listen_count": 2,
+                "artist_name": "Bo Burnham"
             },
             {
                 "artist_mbids": [
-                    "a8b39181-6939-451e-9641-2db231b73706"
+                    "6fe91ae9-8ddb-47b0-a2d7-252833ce5500"
                 ],
                 "listen_count": 1,
-                "artist_name": "Abakus"
+                "artist_name": "The Egg"
+            },
+            {
+                "artist_mbids": [
+                    "9806e551-9a63-4a9d-be1b-5297b2ac0e76"
+                ],
+                "listen_count": 1,
+                "artist_name": "Sounds From The Ground"
+            },
+            {
+                "artist_mbids": [
+                    "4f29ecd7-21a5-4c03-b9ba-d0cfe9488f8c",
+                    "bf24ca37-25f4-4e34-9aec-460b94364cfc"
+                ],
+                "listen_count": 1,
+                "artist_name": "Shakira"
+            },
+            {
+                "artist_mbids": [
+                    "1a40f886-0877-4bab-9ab1-761147dadb89"
+                ],
+                "listen_count": 1,
+                "artist_name": "Ott"
             },
             {
                 "artist_mbids": [
@@ -166,13 +187,6 @@
                 ],
                 "listen_count": 1,
                 "artist_name": "New Order"
-            },
-            {
-                "artist_mbids": [
-                    "056e4f3e-d505-4dad-8ec1-d04f521cbb56"
-                ],
-                "listen_count": 1,
-                "artist_name": "Daft Punk"
             },
             {
                 "artist_mbids": [
@@ -192,42 +206,6 @@
             },
             {
                 "artist_mbids": [
-                    "603ba565-3967-4be1-931e-9cb945394e86"
-                ],
-                "listen_count": 1,
-                "artist_name": "*NSYNC"
-            },
-            {
-                "artist_mbids": [
-                    "7eb1ce54-a355-41f9-8d68-e018b096d427"
-                ],
-                "listen_count": 1,
-                "artist_name": "Harry Styles"
-            },
-            {
-                "artist_mbids": [
-                    "4f29ecd7-21a5-4c03-b9ba-d0cfe9488f8c",
-                    "bf24ca37-25f4-4e34-9aec-460b94364cfc"
-                ],
-                "listen_count": 1,
-                "artist_name": "Shakira"
-            },
-            {
-                "artist_mbids": [
-                    "9806e551-9a63-4a9d-be1b-5297b2ac0e76"
-                ],
-                "listen_count": 1,
-                "artist_name": "Sounds From The Ground"
-            },
-            {
-                "artist_mbids": [
-                    "1a40f886-0877-4bab-9ab1-761147dadb89"
-                ],
-                "listen_count": 1,
-                "artist_name": "Ott"
-            },
-            {
-                "artist_mbids": [
                     "3252542b-98a7-48ba-9861-7a612b16c227"
                 ],
                 "listen_count": 1,
@@ -243,10 +221,23 @@
             },
             {
                 "artist_mbids": [
-                    "6fe91ae9-8ddb-47b0-a2d7-252833ce5500"
+                    "7eb1ce54-a355-41f9-8d68-e018b096d427"
                 ],
                 "listen_count": 1,
-                "artist_name": "The Egg"
+                "artist_name": "Harry Styles"
+            },
+            {
+                "artist_mbids": [
+                    "056e4f3e-d505-4dad-8ec1-d04f521cbb56"
+                ],
+                "listen_count": 1,
+                "artist_name": "Daft Punk"
+            },
+            {
+                "artist_mbids": [
+                ],
+                "listen_count": 1,
+                "artist_name": "Brazilian Girls"
             },
             {
                 "artist_mbids": [
@@ -254,6 +245,20 @@
                 ],
                 "listen_count": 1,
                 "artist_name": "All India Radio"
+            },
+            {
+                "artist_mbids": [
+                    "a8b39181-6939-451e-9641-2db231b73706"
+                ],
+                "listen_count": 1,
+                "artist_name": "Abakus"
+            },
+            {
+                "artist_mbids": [
+                    "603ba565-3967-4be1-931e-9cb945394e86"
+                ],
+                "listen_count": 1,
+                "artist_name": "*NSYNC"
             }
         ]
     }


### PR DESCRIPTION
#1623 fixed a casing bug where different casing of artist/recording/release name caused duplicates in stats. This is the same fix for sitewide stats. Note that during dumping listens, we prefer data from MusicBrainz so a lot of data has consistent and "correct" case but all listens are not mapped so we still need this fix and the unmapped listens may still have bad casing.

Other change is make the order of items in the struct consitent with user stats. Note that sorting is done on the first column of the struct. Here it doesn't matter much because we have an explicit ORDER BY in the CTE but I changed the order anyways for consistency with user stats where the order does matter (because we need to sort within each group not the overall selection).