### PR TITLE
Update spotify reader imported listen counts more frequently

### DIFF
--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -387,9 +387,9 @@ def process_all_spotify_users():
                                         u['musicbrainz_id'], exc_info=True)
             failure += 1
 
-    if time.monotonic() > _metric_submission_time:
-        _metric_submission_time += METRIC_UPDATE_INTERVAL
-        metrics.set("spotify_reader", imported_listens=_listens_imported_since_start)
+        if time.monotonic() > _metric_submission_time:
+            _metric_submission_time += METRIC_UPDATE_INTERVAL
+            metrics.set("spotify_reader", imported_listens=_listens_imported_since_start)
 
     current_app.logger.info('Processed %d users successfully!', success)
     current_app.logger.info('Encountered errors while processing %d users.', failure)


### PR DESCRIPTION
Move the import listen count update code inside the loop so that it is checked after every user. If outside the loop, the condition won't be checked till all users in the batch have been processed (which currently takes ~7 mins). Therefore, updates to the metric are infrequent. Updating the metric at the same frequency (every 60s) as elsewhere (e.g: ts writer) helps simplify writing alerts in the grafana dashboard.

