### PR TITLE
Simplify spark request manage

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -30,7 +30,7 @@ def _get_possible_queries():
         return ujson.load(f)
 
 
-def _prepare_query_message(query, /, **params):
+def _prepare_query_message(query, **params):
     """ Prepare the JSON message that needs to be sent to the
     spark cluster based on the query and the parameters the
     query needs
@@ -62,7 +62,7 @@ def _prepare_query_message(query, /, **params):
     return ujson.dumps(message)
 
 
-def send_request_to_spark_cluster(query, /, **params):
+def send_request_to_spark_cluster(query, **params):
     message = _prepare_query_message(query, **params)
 
     with create_app().app_context():

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -65,7 +65,8 @@ def _prepare_query_message(query, params=None):
     return ujson.dumps(message)
 
 
-def send_request_to_spark_cluster(message):
+def send_request_to_spark_cluster(query, params=None):
+    message = _prepare_query_message(query, params)
     with create_app().app_context():
         rabbitmq_connection = utils.connect_to_rabbitmq(
             username=current_app.config['RABBITMQ_USERNAME'],
@@ -108,8 +109,7 @@ def request_user_stats(type_, range_, entity):
     if type_ == "entity" and entity:
         params["entity"] = entity
     try:
-        send_request_to_spark_cluster(_prepare_query_message(
-            f"stats.user.{type_}", params=params))
+        send_request_to_spark_cluster(f"stats.user.{type_}", params=params)
     except InvalidSparkRequestError:
         click.echo("Incorrect arguments provided")
 
@@ -143,8 +143,7 @@ def request_import_new_full_dump(id_: int):
         send_request_to_spark_cluster(_prepare_query_message(
             'import.dump.full_id', params={'dump_id': id_}))
     else:
-        send_request_to_spark_cluster(
-            _prepare_query_message('import.dump.full_newest'))
+        send_request_to_spark_cluster('import.dump.full_newest')
 
 
 @cli.command(name="request_import_incremental")
@@ -154,11 +153,9 @@ def request_import_new_incremental_dump(id_: int):
     """ Send the cluster a request to import a new incremental data dump
     """
     if id_:
-        send_request_to_spark_cluster(_prepare_query_message(
-            'import.dump.incremental_id', params={'dump_id': id_}))
+        send_request_to_spark_cluster('import.dump.incremental_id', params={'dump_id': id_})
     else:
-        send_request_to_spark_cluster(
-            _prepare_query_message('import.dump.incremental_newest'))
+        send_request_to_spark_cluster('import.dump.incremental_newest')
 
 
 @cli.command(name="request_dataframes")
@@ -178,8 +175,7 @@ def request_dataframes(days, job_type, listens_threshold):
         'job_type': job_type,
         'minimum_listens_threshold': listens_threshold
     }
-    send_request_to_spark_cluster(_prepare_query_message(
-        'cf.recommendations.recording.create_dataframes', params=params))
+    send_request_to_spark_cluster('cf.recommendations.recording.create_dataframes', params=params)
 
 
 def parse_list(ctx, args):
@@ -202,8 +198,7 @@ def request_model(rank, itr, lmbda, alpha):
         'alpha': alpha,
     }
 
-    send_request_to_spark_cluster(_prepare_query_message(
-        'cf.recommendations.recording.train_model', params=params))
+    send_request_to_spark_cluster('cf.recommendations.recording.train_model', params=params)
 
 
 @cli.command(name='request_candidate_sets')
@@ -223,8 +218,7 @@ def request_candidate_sets(days, top, similar, users, html):
         "users": users,
         "html_flag": html
     }
-    send_request_to_spark_cluster(_prepare_query_message(
-        'cf.recommendations.recording.candidate_sets', params=params))
+    send_request_to_spark_cluster('cf.recommendations.recording.candidate_sets', params=params)
 
 
 @cli.command(name='request_recommendations')
@@ -240,8 +234,7 @@ def request_recommendations(top, similar, users):
         'recommendation_similar_artist_limit': similar,
         'users': users
     }
-    send_request_to_spark_cluster(_prepare_query_message(
-        'cf.recommendations.recording.recommendations', params=params))
+    send_request_to_spark_cluster('cf.recommendations.recording.recommendations', params=params)
 
 
 @cli.command(name='request_import_artist_relation')
@@ -249,8 +242,7 @@ def request_import_artist_relation():
     """ Send the spark cluster a request to import artist relation.
     """
 
-    send_request_to_spark_cluster(
-        _prepare_query_message('import.artist_relation'))
+    send_request_to_spark_cluster('import.artist_relation')
 
 
 @cli.command(name='request_similar_users')
@@ -261,8 +253,7 @@ def request_similar_users(max_num_users):
     params = {
         'max_num_users': max_num_users
     }
-    send_request_to_spark_cluster(_prepare_query_message(
-        'similarity.similar_users', params=params))
+    send_request_to_spark_cluster('similarity.similar_users', params=params)
 
 
 # Some useful commands to keep our crontabs manageable. These commands do not add new functionality

--- a/listenbrainz/spark/test_request_manage.py
+++ b/listenbrainz/spark/test_request_manage.py
@@ -46,83 +46,83 @@ class RequestManageTestCase(unittest.TestCase):
 
         # extra parameter given
         with self.assertRaises(request_manage.InvalidSparkRequestError):
-            request_manage._prepare_query_message('stats.user.listening_activity.week', {'musicbrainz_id': 'wtf'})
+            request_manage._prepare_query_message('stats.user.listening_activity.week', musicbrainz_id='wtf')
 
         # invalid parameter given
         with self.assertRaises(request_manage.InvalidSparkRequestError):
-            request_manage._prepare_query_message('stats.user.entity', {'invalid_param': 'wtf'})
+            request_manage._prepare_query_message('stats.user.entity', invalid_param='wtf')
 
         # extra (unexpected) parameter passed
         with self.assertRaises(request_manage.InvalidSparkRequestError):
-            request_manage._prepare_query_message('stats.user.entity', {'entity': 'recordings', 'param2': 'bbq'})
+            request_manage._prepare_query_message('stats.user.entity', entity='recordings', param2='bbq')
 
         # expected parameter not passed
         with self.assertRaises(request_manage.InvalidSparkRequestError):
-            request_manage._prepare_query_message('stats.user.entity', {})
+            request_manage._prepare_query_message('stats.user.entity')
 
     def test_prepare_query_message_happy_path(self):
         expected_message = ujson.dumps({'query': 'stats.user.entity', 'params': {'entity': 'test', 'stats_range': 'week'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity', params={'entity': 'test', 'stats_range': 'week'})
+        received_message = request_manage._prepare_query_message('stats.user.entity', entity='test', stats_range='week')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.entity', 'params': {'entity': 'test', 'stats_range': 'month'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity', params={'entity': 'test', 'stats_range': 'month'})
+        received_message = request_manage._prepare_query_message('stats.user.entity', entity='test', stats_range='month')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.entity', 'params': {'entity': 'test', 'stats_range': 'year'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity', params={'entity': 'test', 'stats_range': 'year'})
+        received_message = request_manage._prepare_query_message('stats.user.entity', entity='test', stats_range='year')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.entity', 'params': {'entity': 'test', 'stats_range': 'all_time'}})
-        received_message = request_manage._prepare_query_message('stats.user.entity', params={'entity': 'test', 'stats_range': 'all_time'})
+        received_message = request_manage._prepare_query_message('stats.user.entity', entity='test', stats_range='all_time')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.listening_activity', 'params': {'stats_range': 'week'}})
-        received_message = request_manage._prepare_query_message('stats.user.listening_activity', params={'stats_range': 'week'})
+        received_message = request_manage._prepare_query_message('stats.user.listening_activity', stats_range='week')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.listening_activity', 'params': {'stats_range': 'month'}})
-        received_message = request_manage._prepare_query_message('stats.user.listening_activity', params={'stats_range': 'month'})
+        received_message = request_manage._prepare_query_message('stats.user.listening_activity', stats_range='month')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.listening_activity', 'params': {'stats_range': 'year'}})
-        received_message = request_manage._prepare_query_message('stats.user.listening_activity', params={'stats_range': 'year'})
+        received_message = request_manage._prepare_query_message('stats.user.listening_activity', stats_range='year')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.listening_activity', 'params': {'stats_range': 'all_time'}})
-        received_message = request_manage._prepare_query_message('stats.user.listening_activity', params={'stats_range': 'all_time'})
+        received_message = request_manage._prepare_query_message('stats.user.listening_activity', stats_range='all_time')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.daily_activity', 'params': {'stats_range': 'week'}})
-        received_message = request_manage._prepare_query_message('stats.user.daily_activity', params={'stats_range': 'week'})
+        received_message = request_manage._prepare_query_message('stats.user.daily_activity', stats_range='week')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.daily_activity', 'params': {'stats_range': 'month'}})
-        received_message = request_manage._prepare_query_message('stats.user.daily_activity', params={'stats_range': 'month'})
+        received_message = request_manage._prepare_query_message('stats.user.daily_activity', stats_range='month')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.daily_activity', 'params': {'stats_range': 'year'}})
-        received_message = request_manage._prepare_query_message('stats.user.daily_activity', params={'stats_range': 'year'})
+        received_message = request_manage._prepare_query_message('stats.user.daily_activity', stats_range='year')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.user.daily_activity', 'params': {'stats_range': 'all_time'}})
-        received_message = request_manage._prepare_query_message('stats.user.daily_activity', params={'stats_range': 'all_time'})
+        received_message = request_manage._prepare_query_message('stats.user.daily_activity', stats_range='all_time')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.sitewide.entity', 'params': {'entity': 'test', 'stats_range': 'week'}})
-        received_message = request_manage._prepare_query_message('stats.sitewide.entity', params={'entity': 'test', 'stats_range': 'week'})
+        received_message = request_manage._prepare_query_message('stats.sitewide.entity', entity='test', stats_range='week')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.sitewide.entity', 'params': {'entity': 'test', 'stats_range': 'month'}})
-        received_message = request_manage._prepare_query_message('stats.sitewide.entity', params={'entity': 'test', 'stats_range': 'month'})
+        received_message = request_manage._prepare_query_message('stats.sitewide.entity', entity='test', stats_range='month')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.sitewide.entity', 'params': {'entity': 'test', 'stats_range': 'year'}})
-        received_message = request_manage._prepare_query_message('stats.sitewide.entity', params={'entity': 'test', 'stats_range': 'year'})
+        received_message = request_manage._prepare_query_message('stats.sitewide.entity', entity='test', stats_range='year')
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'stats.sitewide.entity', 'params': {'entity': 'test', 'stats_range': 'all_time'}})
-        received_message = request_manage._prepare_query_message('stats.sitewide.entity', params={'entity': 'test', 'stats_range': 'all_time'})
+        received_message = request_manage._prepare_query_message('stats.sitewide.entity', entity='test', stats_range='all_time')
         self.assertEqual(expected_message, received_message)
 
         message = {
@@ -135,7 +135,7 @@ class RequestManageTestCase(unittest.TestCase):
         }
         expected_message = ujson.dumps(message)
         received_message = request_manage._prepare_query_message('cf.recommendations.recording.create_dataframes',
-                                                                 message['params'])
+                                                                 **message['params'])
         self.assertEqual(expected_message, received_message)
 
         message = {
@@ -149,7 +149,7 @@ class RequestManageTestCase(unittest.TestCase):
         }
         expected_message = ujson.dumps(message)
         received_message = request_manage._prepare_query_message('cf.recommendations.recording.train_model',
-                                                                 message['params'])
+                                                                 **message['params'])
         self.assertEqual(expected_message, received_message)
 
         message = {
@@ -164,7 +164,7 @@ class RequestManageTestCase(unittest.TestCase):
         }
         expected_message = ujson.dumps(message)
         received_message = request_manage._prepare_query_message('cf.recommendations.recording.candidate_sets',
-                                                                 message['params'])
+                                                                 **message['params'])
         self.assertEqual(expected_message, received_message)
 
         message = {
@@ -177,7 +177,7 @@ class RequestManageTestCase(unittest.TestCase):
         }
         expected_message = ujson.dumps(message)
         received_message = request_manage._prepare_query_message('cf.recommendations.recording.recommendations',
-                                                                 message['params'])
+                                                                 **message['params'])
         self.assertEqual(expected_message, received_message)
 
         expected_message = ujson.dumps({'query': 'import.artist_relation'})
@@ -191,6 +191,5 @@ class RequestManageTestCase(unittest.TestCase):
             }
         }
         expected_message = ujson.dumps(message)
-        received_message = request_manage._prepare_query_message('similarity.similar_users',
-                                                                 message['params'])
+        received_message = request_manage._prepare_query_message('similarity.similar_users', max_num_users=25)
         self.assertEqual(expected_message, received_message)


### PR DESCRIPTION
We never really send a request to spark without calling prepare_query_message on it so makes sense to deduplicate this. Also, use kwargs to avoid dicts everytime.

(Making these changes to because facing lot of repitition while adding new commands for year in music stuff)