### PR TITLE
Run sitewide top recordings and top releases stats during regular cron run

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -255,7 +255,7 @@ def cron_request_all_stats(ctx):
         for stat in ["listening_activity", "daily_activity"]:
             ctx.invoke(request_user_stats, type_=stat, range_=stats_range)
 
-        for entity in ["artists"]:
+        for entity in ["artists", "releases", "recordings"]:
             ctx.invoke(request_sitewide_stats, range_=stats_range, entity=entity)
 
 


### PR DESCRIPTION
The change got dropped during a merge. So adding again.