### PR TITLE
Correction of Brainzplayer playNextTrack mechanism

### DIFF
--- a/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/BrainzPlayer.tsx
@@ -281,7 +281,8 @@ export default class BrainzPlayer extends React.Component<
     if (currentListenIndex === -1) {
       // No current listen index found, default to first item
       nextListenIndex = 0;
-    } else if (invert) {
+    } else if (invert === true) {
+      // Invert means "play previous track" instead of next track
       // `|| 0` constrains to positive numbers
       nextListenIndex = currentListenIndex - 1 || 0;
     } else {


### PR DESCRIPTION
In the process of refactoring Brainzplayer in #1728 , we broke the mechanism a bit and clicking on "next" in BrainzPlayer does the same thing as clicking "previous".
That is because we are checking if a condition is truthy instead of checking specifically if the condition === true