### PR TITLE
Fix broken feed due to incorrect dict access

### DIFF
--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -457,7 +457,7 @@ def get_recording_pin_events(users_for_events: List[dict], min_ts: int, max_ts: 
                     additional_info=AdditionalInfo(
                         recording_msid=pin.recording_msid,
                         recording_mbid=pin.recording_mbid,
-                        artist_msid=pin.track_metadata["artist_msid"],
+                        artist_msid=pin.track_metadata["additional_info"]["artist_msid"],
                     )
                 )
             )


### PR DESCRIPTION
artist_msid is a part of additional_info inside track_metadata and not a top level key. Hence, fixing access of artist_msid key. The feed page is also not loading for any user due to an ISE occuring as a result of this error. 
