### PR TITLE
Cap listen counts for sitewide stats

### DIFF
--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -20,7 +20,7 @@ def get_artists(table: str, user_listen_count_limit, top_artists_limit: int = SI
         WITH intermediate_table as (
             SELECT first(artist_name) AS any_artist_name
                  , artist_credit_mbids
-                 , count(*) as listen_count
+                 , LEAST(count(*), {user_listen_count_limit}) as listen_count
               FROM {table}
           GROUP BY lower(artist_name)
                  , artist_credit_mbids

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -1,13 +1,14 @@
 from listenbrainz_spark.stats import run_query, SITEWIDE_STATS_ENTITY_LIMIT
 
 
-def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
+def get_artists(table: str, user_listen_count_limit, top_artists_limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
     """ Get artist information (artist_name, artist_msid etc) for every time range specified
         the "time_range" table ordered by listen count
 
         Args:
-            table: Name of the temporary table.
-            limit: number of top artists to retain
+            table: name of the temporary table
+            user_listen_count_limit: per user per entity listen count above which it should be capped
+            top_artists_limit: number of top artists to retain
         Returns:
             iterator (iter): An iterator over result
     """
@@ -24,7 +25,7 @@ def get_artists(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
           GROUP BY lower(artist_name)
                  , artist_credit_mbids
           ORDER BY listen_count DESC
-             LIMIT {limit}
+             LIMIT {top_artists_limit}
         )
         SELECT sort_array(
                     collect_list(

--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -19,7 +19,7 @@ def get_artists(table: str, user_listen_count_limit, top_artists_limit: int = SI
     result = run_query(f"""
         WITH user_counts as (
             SELECT user_name
-                 , first(artist_name) AS any_artist_name
+                 , first(artist_name) AS artist_name
                  , artist_credit_mbids
                  , LEAST(count(*), {user_listen_count_limit}) as listen_count
               FROM {table}
@@ -27,7 +27,7 @@ def get_artists(table: str, user_listen_count_limit, top_artists_limit: int = SI
                  , lower(artist_name)
                  , artist_credit_mbids
         ), intermediate_table AS (
-            SELECT first(artist_name) AS any_artist_name
+            SELECT first(artist_name) AS artist_name
                  , artist_credit_mbids
                  , SUM(listen_count) as total_listen_count
               FROM user_counts
@@ -40,7 +40,7 @@ def get_artists(table: str, user_listen_count_limit, top_artists_limit: int = SI
                     collect_list(
                         struct(
                             total_listen_count AS listen_count
-                          , any_artist_name AS artist_name
+                          , artist_name
                           , coalesce(artist_credit_mbids, array()) AS artist_mbids
                         )
                     )

--- a/listenbrainz_spark/stats/sitewide/recording.py
+++ b/listenbrainz_spark/stats/sitewide/recording.py
@@ -24,7 +24,7 @@ def get_recordings(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
                  , artist_credit_mbids
                  , nullif(first(release_name), '') as any_release_name
                  , release_mbid
-                 , count(*) as listen_count
+                 , LEAST(count(*), 500) as listen_count
               FROM {table}
           GROUP BY lower(recording_name)
                  , recording_mbid

--- a/listenbrainz_spark/stats/sitewide/release.py
+++ b/listenbrainz_spark/stats/sitewide/release.py
@@ -34,7 +34,7 @@ def get_releases(table: str, user_listen_count_limit, top_releases_limit: int = 
                  , release_mbid
                  , first(artist_name) AS any_artist_name
                  , artist_credit_mbids
-                 , count(*) as listen_count
+                 , LEAST(count(*), {user_listen_count_limit}) as listen_count
               FROM {table}
              WHERE release_name != ''
           GROUP BY lower(release_name)

--- a/listenbrainz_spark/stats/sitewide/release.py
+++ b/listenbrainz_spark/stats/sitewide/release.py
@@ -1,7 +1,7 @@
 from listenbrainz_spark.stats import run_query, SITEWIDE_STATS_ENTITY_LIMIT
 
 
-def get_releases(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
+def get_releases(table: str, user_listen_count_limit, top_releases_limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
     """
     Get release information (release_name, release_mbid etc) ordered by
     listen count (number of times listened to tracks which belong to a
@@ -9,7 +9,8 @@ def get_releases(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
 
     Args:
         table: name of the temporary table
-        limit: number of top releases to retain
+        user_listen_count_limit: per user per entity listen count above which it should be capped
+        top_releases_limit: number of top releases to retain
     Returns:
         iterator: an iterator over result, contains only 1 row
                 {
@@ -41,7 +42,7 @@ def get_releases(table: str, limit: int = SITEWIDE_STATS_ENTITY_LIMIT):
                  , lower(artist_name)
                  , artist_credit_mbids
           ORDER BY listen_count DESC
-             LIMIT {limit}
+             LIMIT {top_releases_limit}
         )
         SELECT sort_array(
                     collect_list(


### PR DESCRIPTION
We witnessed that a few users' listen counts were dominating the entire sitewide stats. So, we decided to impose a per user per recording listen count limit. This improved the sitewide stats by a lot.

For now only recording stats use the capped limit, I'll modify the artist and release stats once the recording query is reviewed and finalized.