### PR TITLE
Update test.sh commands to run as the local user

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -24,6 +24,8 @@ services:
     image: listenbrainz
     volumes:
       - ..:/code/listenbrainz:z
+    environment:
+      PYTHONDONTWRITEBYTECODE: 1
     depends_on:
       - redis
       - lb_db

--- a/docker/docker-compose.spark.yml
+++ b/docker/docker-compose.spark.yml
@@ -30,3 +30,5 @@ services:
     command: dockerize -wait tcp://namenode:9000 -timeout 60s bash -c "cp listenbrainz_spark/config.py.sample listenbrainz_spark/config.py; PYTHONDONTWRITEBYTECODE=1 python -m pytest -c pytest.spark.ini"
     volumes:
       - ..:/rec
+    environment:
+      PYTHONDONTWRITEBYTECODE: 1

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -25,6 +25,8 @@ services:
       target: listenbrainz-dev
     volumes:
       - ..:/code/listenbrainz:z
+    environment:
+      PYTHONDONTWRITEBYTECODE: 1
     depends_on:
       - redis
       - lb_db

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "eslint ./static/js/src --ext .js,.jsx,.ts,.tsx --fix --quiet",
     "format:ci": "eslint ./static/js/src --ext .js,.jsx,.ts,.tsx --max-warnings 0 --color",
     "test": "TZ='Europe/London' jest",
-    "test:ci": "TZ='Europe/London' jest --ci --reporters=default --reporters=jest-junit",
+    "test:ci": "JEST_JUNIT_OUTPUT_DIR=/tmp TZ='Europe/London' jest --ci --reporters=default --reporters=jest-junit",
     "test:watch": "TZ='Europe/London' jest --watch",
     "test:update-snapshots": "TZ='Europe/London' jest -u",
     "test:coverage": "TZ='Europe/London' jest --coverage --colors",

--- a/test.sh
+++ b/test.sh
@@ -66,7 +66,9 @@ function docker_compose_run {
 }
 
 function docker_compose_run_spark {
-    invoke_docker_compose_spark run --rm --user `id -u`:`id -g` "$@"
+    # We run spark tests as root and not the local user due to the requirement for
+    # the uid to exist as a real user
+    invoke_docker_compose_spark run --rm "$@"
 }
 
 function docker_compose_run_int {

--- a/test.sh
+++ b/test.sh
@@ -43,24 +43,48 @@ if [[ ! -d "docker" ]]; then
     exit 255
 fi
 
-function build_unit_containers {
+function invoke_docker_compose {
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                build lb_db redis rabbitmq listenbrainz
+                   "$@"
+}
+
+function invoke_docker_compose_spark {
+    docker-compose -f $SPARK_COMPOSE_FILE_LOC \
+                   -p $SPARK_COMPOSE_PROJECT_NAME \
+                   "$@"
+}
+
+function invoke_docker_compose_int {
+    docker-compose -f $INT_COMPOSE_FILE_LOC \
+                   -p $INT_COMPOSE_PROJECT_NAME \
+                   "$@"
+}
+
+function docker_compose_run {
+    invoke_docker_compose run --rm --user `id -u`:`id -g` "$@"
+}
+
+function docker_compose_run_spark {
+    invoke_docker_compose_spark run --rm --user `id -u`:`id -g` "$@"
+}
+
+function docker_compose_run_int {
+    invoke_docker_compose_int run --rm --user `id -u`:`id -g` "$@"
+}
+
+function build_unit_containers {
+    invoke_docker_compose build lb_db redis rabbitmq listenbrainz
 }
 
 function bring_up_unit_db {
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                up -d lb_db redis rabbitmq
+    invoke_docker_compose up -d lb_db redis rabbitmq
 }
 
 function unit_setup {
     echo "Running setup"
     # PostgreSQL Database initialization
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                run --rm listenbrainz dockerize \
+    docker_compose_run listenbrainz dockerize \
                   -wait tcp://lb_db:5432 -timeout 60s \
                   -wait tcp://rabbitmq:5672 -timeout 60s \
                 bash -c "python3 manage.py init_db --create-db && \
@@ -91,28 +115,20 @@ function is_unit_db_exists {
 
 function unit_stop {
     # Stopping all unit test containers associated with this project
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                stop
+    invoke_docker_compose stop
 }
 
 function unit_dcdown {
     # Shutting down all unit test containers associated with this project
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                down
+    invoke_docker_compose down
 }
 
 function build_frontend_containers {
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                build frontend_tester
+    invoke_docker_compose build frontend_tester
 }
 
 function update_snapshots {
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                run --rm frontend_tester npm run test:update-snapshots
+    docker_compose_run frontend_tester npm run test:update-snapshots
 }
 
 function run_lint_check {
@@ -122,9 +138,7 @@ function run_lint_check {
         command="format"
     fi
 
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                run --rm frontend_tester npm run $command
+    docker_compose_run frontend_tester npm run $command
 }
 
 function run_frontend_tests {
@@ -133,55 +147,39 @@ function run_frontend_tests {
     else
         command="test"
     fi
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                run --rm frontend_tester npm run $command
+    docker_compose_run frontend_tester npm run $command
 }
 
 function run_type_check {
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                run --rm frontend_tester npm run type-check
+    docker_compose_run frontend_tester npm run type-check
 }
 
 function spark_setup {
     echo "Running spark test setup"
-    docker-compose -f $SPARK_COMPOSE_FILE_LOC \
-                   -p $SPARK_COMPOSE_PROJECT_NAME \
-                  up -d namenode datanode
+    invoke_docker_compose_spark up -d namenode datanode
 }
 
 function build_spark_containers {
-    docker-compose -f $SPARK_COMPOSE_FILE_LOC \
-                   -p $SPARK_COMPOSE_PROJECT_NAME \
-                build namenode
+    invoke_docker_compose_spark build namenode
 }
 
 function spark_dcdown {
     # Shutting down all spark test containers associated with this project
-    docker-compose -f $SPARK_COMPOSE_FILE_LOC \
-                   -p $SPARK_COMPOSE_PROJECT_NAME \
-                down
+    invoke_docker_compose_spark down
 }
 
 function int_build {
-    docker-compose -f $INT_COMPOSE_FILE_LOC \
-                   -p $INT_COMPOSE_PROJECT_NAME \
-                build
+    invoke_docker_compose_int build
 }
 
 function int_dcdown {
     # Shutting down all integration test containers associated with this project
-    docker-compose -f $INT_COMPOSE_FILE_LOC \
-                   -p $INT_COMPOSE_PROJECT_NAME \
-                down
+    invoke_docker_compose_int down
 }
 
 function int_setup {
     echo "Running setup"
-    docker-compose -f $INT_COMPOSE_FILE_LOC \
-                   -p $INT_COMPOSE_PROJECT_NAME \
-                run --rm listenbrainz dockerize \
+    docker_compose_run_int listenbrainz dockerize \
                   -wait tcp://lb_db:5432 -timeout 60s \
                 bash -c "python3 manage.py init_db --create-db && \
                          python3 manage.py init_msb_db --create-db && \
@@ -189,9 +187,7 @@ function int_setup {
 }
 
 function bring_up_int_containers {
-    docker-compose -f $INT_COMPOSE_FILE_LOC \
-                   -p $INT_COMPOSE_PROJECT_NAME \
-                up -d lb_db redis timescale_writer rabbitmq
+    invoke_docker_compose_int up -d lb_db redis timescale_writer rabbitmq
 }
 
 # Exit immediately if a command exits with a non-zero status.
@@ -207,9 +203,7 @@ if [ "$1" == "spark" ]; then
 
     spark_setup
     echo "Running tests"
-    docker-compose -f $SPARK_COMPOSE_FILE_LOC \
-                   -p $SPARK_COMPOSE_PROJECT_NAME \
-                run --rm request_consumer
+    docker_compose_run_spark request_consumer
     RET=$?
     spark_dcdown
     exit $RET
@@ -232,9 +226,7 @@ if [ "$1" == "int" ]; then
     fi
     echo "Running tests $TESTS_TO_RUN"
 
-    docker-compose -f $INT_COMPOSE_FILE_LOC \
-                   -p $INT_COMPOSE_PROJECT_NAME \
-                run --rm listenbrainz dockerize \
+    docker_compose_run_int listenbrainz dockerize \
                   -wait tcp://lb_db:5432 -timeout 60s \
                   -wait tcp://redis:6379 -timeout 60s \
                   -wait tcp://rabbitmq:5672 -timeout 60s \
@@ -315,17 +307,13 @@ if [ $DB_EXISTS -eq 1 -a $DB_RUNNING -eq 1 ]; then
     bring_up_unit_db
     unit_setup
     echo "Running tests"
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                run --rm listenbrainz pytest "$@"
+    docker_compose_run listenbrainz pytest "$@"
     RET=$?
     unit_dcdown
     exit $RET
 else
     # Else, we have containers, just run tests
     echo "Running tests"
-    docker-compose -f $COMPOSE_FILE_LOC \
-                   -p $COMPOSE_PROJECT_NAME \
-                run --rm listenbrainz pytest "$@"
+    docker_compose_run listenbrainz pytest "$@"
     exit $?
 fi


### PR DESCRIPTION

# Problem

When running some test commands on linux + docker, the test process runs as root sometimes resulting in the creation of files owned by root (pyc files, jest snapshots), making it hard to clean up again when using your local user.

Also, there is a lot of duplication of `docker-compose -f .... -p .....`

# Solution

Use `docker-compose run --user` flag to run the process as your local user. This should have no effect on macos. We use the same process in develop.sh


# Action

I tested unit, int, fe tests (along with supporting commands) and they all succeeded.
Spark tests failed, but I don't think it was related to my change. @amCap1712, can you take a look at these and see if anything looks weird?

