### PR TITLE
Standardise all LB ports to start with 7

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     image: timescale/timescaledb:2.2.0-pg11
     volumes:
       - timescaledb:/var/lib/postgresql/data:z
+    ports:
+      - "127.0.0.1:7432:5432"
     environment:
       POSTGRES_PASSWORD: 'postgres'
 
@@ -55,9 +57,9 @@ services:
 
   api_compat:
     image: web
-    command: python3 /code/listenbrainz/manage.py run_api_compat_server -h 0.0.0.0 -p 8080 -d
+    command: python3 /code/listenbrainz/manage.py run_api_compat_server -h 0.0.0.0 -p 7080 -d
     ports:
-      - "8080:8080"
+      - "7080:7080"
     volumes:
       - ..:/code/listenbrainz:z
     depends_on:
@@ -87,9 +89,9 @@ services:
     image: web
     volumes:
       - ..:/code/listenbrainz:z
-    command: python manage.py run_websockets -h 0.0.0.0 -p 8082
+    command: python manage.py run_websockets -h 0.0.0.0 -p 7082
     ports:
-      - "8082:8082"
+      - "7082:7082"
     depends_on:
       - redis
       - rabbitmq

--- a/docs/dev/api-compat.rst
+++ b/docs/dev/api-compat.rst
@@ -53,7 +53,7 @@ For development
 #. In Audacious, go to File > Settings > Plugins > Scrobbler2.0 and enable it. Now open its settings and then authenticate.
 
 #. When you get a URL from your application which look like this ``http://last.fm/api/auth/?api_key=as3..234&..``, replace it with ``http://<HOSTURL>/api/auth/?api_key=as3..234&..``.
-    - If you are running a local server, then ``HOSTURL`` should be similar to "localhost:8080".
+    - If you are running a local server, then ``HOSTURL`` should be similar to "localhost:7080".
     - If you are not running the server, then ``HOSTURL`` should be "api.listenbrainz.org".
 
 

--- a/listenbrainz/api_compat.py
+++ b/listenbrainz/api_compat.py
@@ -12,8 +12,8 @@ if __name__ == "__main__":
                              "in config file.")
     parser.add_argument("-t", "--host", default="0.0.0.0", type=str,
                         help="Which interfaces to listen on. Default: 0.0.0.0.")
-    parser.add_argument("-p", "--port", default="8080", type=int,
-                        help="Which port to listen on. Default: 8080.")
+    parser.add_argument("-p", "--port", default="7080", type=int,
+                        help="Which port to listen on. Default: 7080.")
     args = parser.parse_args()
     application.run(debug=True if args.debug else None,
                     host=args.host, port=args.port)

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -115,11 +115,11 @@ UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 
 # Set to "https://api.listenbrainz.org" if you want to work on frontend for user statistics
 # without going through the process of generating the stats in local environment. Otherwise,
-# set it to "http://localhost"
+# set it to "http://localhost:7000"
 API_URL = 'https://api.listenbrainz.org'
-LASTFM_PROXY_URL = 'http://localhost:8080/'
-SERVER_ROOT_URL = 'http://localhost'
-WEBSOCKETS_SERVER_URL = 'http://localhost:8082'
+LASTFM_PROXY_URL = 'http://localhost:7080/'
+SERVER_ROOT_URL = 'http://localhost:7000'
+WEBSOCKETS_SERVER_URL = 'http://localhost:7082'
 MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'
 LISTENBRAINZ_LABS_API_URL = 'https://labs.api.listenbrainz.org'
 

--- a/listenbrainz/rtd_config.py
+++ b/listenbrainz/rtd_config.py
@@ -71,7 +71,7 @@ MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB
 UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 
 API_URL = 'https://api.listenbrainz.org'
-LASTFM_PROXY_URL = 'http://0.0.0.0:8080/'
+LASTFM_PROXY_URL = 'http://0.0.0.0:7080/'
 MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'
 SPOTIFY_CLIENT_ID = ''
 SPOTIFY_CLIENT_SECRET = ''

--- a/listenbrainz/webserver/static/js/src/__mocks__/playlistPageProps.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/playlistPageProps.json
@@ -36,6 +36,6 @@
             ]
         }
     },
-    "webSocketsServerUrl": "http://localhost:8082",
+    "webSocketsServerUrl": "http://localhost:7082",
     "labsApiUrl": "http://0.0.0.0"
 }

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsOneListen.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsOneListen.json
@@ -32,7 +32,7 @@
     "access_token": "access token",
     "permission": ["streaming", "user-read-email", "user-read-private"]
   },
-  "webSocketsServerUrl": "http://localhost:8082",
+  "webSocketsServerUrl": "http://localhost:7082",
   "searchLargerTimeRange": 0
 }
 

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsPlayingNow.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsPlayingNow.json
@@ -42,7 +42,7 @@
     "access_token": "access token",
     "permission": ["streaming", "user-read-email", "user-read-private"]
   },
-  "webSocketsServerUrl": "http://localhost:8082",
+  "webSocketsServerUrl": "http://localhost:7082",
   "searchLargerTimeRange": 0
 }
 

--- a/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsTooManyListens.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recentListensPropsTooManyListens.json
@@ -841,7 +841,7 @@
 	  "access_token": "access token",
 	  "permission": ["streaming", "user-read-email", "user-read-private"]
 	},
-	"webSocketsServerUrl": "http://localhost:8082",
+	"webSocketsServerUrl": "http://localhost:7082",
 	"searchLargerTimeRange": 0
   }
   

--- a/listenbrainz/webserver/static/js/src/__mocks__/recommendationPropsOne.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recommendationPropsOne.json
@@ -25,7 +25,7 @@
         }
       }
     ],
-    "webSocketsServerUrl": "http://localhost:8082",
+    "webSocketsServerUrl": "http://localhost:7082",
     "spotify": {
       "access_token": "access token",
       "permission": ["streaming", "user-read-email", "user-read-private"]

--- a/listenbrainz/webserver/static/js/src/__mocks__/recommendations.json
+++ b/listenbrainz/webserver/static/js/src/__mocks__/recommendations.json
@@ -725,7 +725,7 @@
 		}
 	  }
 	],
-	"webSocketsServerUrl": "http://localhost:8082",
+	"webSocketsServerUrl": "http://localhost:7082",
 	"spotify": {
 	  "access_token": "access token",
 	  "permission": ["streaming", "user-read-email", "user-read-private"]

--- a/listenbrainz/webserver/static/js/src/follow/__mocks__/userSocialNetworkProps.json
+++ b/listenbrainz/webserver/static/js/src/follow/__mocks__/userSocialNetworkProps.json
@@ -7,5 +7,5 @@
         "id": 2,
         "name": "bob"
     },
-    "webSocketsServerUrl": "http://localhost:8082"
+    "webSocketsServerUrl": "http://localhost:7082"
 }

--- a/listenbrainz/websockets/websockets.py
+++ b/listenbrainz/websockets/websockets.py
@@ -50,7 +50,7 @@ def joined(data):
         disconnect()
 
 
-def run_websockets(host='0.0.0.0', port=8082, debug=True):
+def run_websockets(host='0.0.0.0', port=7082, debug=True):
     dispatcher = ListensDispatcher(app, socketio)
     Thread(target=dispatcher.start).start()
     socketio.run(app, debug=debug, host=host, port=port)

--- a/manage.py
+++ b/manage.py
@@ -33,7 +33,7 @@ TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(
 
 @cli.command(name="run_api_compat_server")
 @click.option("--host", "-h", default="0.0.0.0", show_default=True)
-@click.option("--port", "-p", default=8080, show_default=True)
+@click.option("--port", "-p", default=7080, show_default=True)
 @click.option("--debug", "-d", is_flag=True,
               help="Turns debugging mode on or off. If specified, overrides "
                    "'DEBUG' value in the config file.")
@@ -51,7 +51,7 @@ def run_api_compat_server(host, port, debug=False):
 
 @cli.command(name="run_websockets")
 @click.option("--host", "-h", default="0.0.0.0", show_default=True)
-@click.option("--port", "-p", default=8082, show_default=True)
+@click.option("--port", "-p", default=7082, show_default=True)
 @click.option("--debug", "-d", is_flag=True,
               help="Turns debugging mode on or off. If specified, overrides "
                    "'DEBUG' value in the config file.")


### PR DESCRIPTION
# Problem

In order to prevent conflicts when running multiple MeB projects, we
decided to isolate ports for each project. Continues from bcc5836d

# Solution

* Don't just update the published port, also update the default port for the service inside each container
* Also update api compat and websockets to use a 7 port
* publish postgres (on 127.0.0.1)
* Update config, documentation, and startup scripts


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


