### PR TITLE
Remove load_recordings_from_mbids

### DIFF
--- a/listenbrainz/messybrainz/__init__.py
+++ b/listenbrainz/messybrainz/__init__.py
@@ -99,19 +99,6 @@ def load_recordings_from_msids(msids):
         return data.load_recordings_from_msids(connection, msids)
 
 
-def load_recordings_from_mbids(mbids):
-    """ Returns data for a recording with specified MusicBrainz ID.
-
-    Args:
-        mbid (uuid): the MusicBrainz ID of the recording
-    Returns:
-        A dict containing the recording data for the recording with specified MusicBrainz ID
-    """
-
-    with engine.begin() as connection:
-        return data.load_recordings_from_mbids(connection, mbids)
-
-
 def insert_single(connection, recording):
     """ Inserts a single recording into MessyBrainz.
 

--- a/listenbrainz/messybrainz/tests/test_data.py
+++ b/listenbrainz/messybrainz/tests/test_data.py
@@ -94,12 +94,6 @@ class DataTestCase(MessyBrainzTestCase):
             result = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertDictEqual(result['payload'], recording)
 
-    def test_load_recordings_from_mbids(self):
-        with messybrainz.engine.connect() as connection:
-            data.submit_recording(connection, recording)
-            result = data.load_recordings_from_mbids(connection, [recording["recording_mbid"]])[0]
-            self.assertDictEqual(result['payload'], recording)
-
     def test_convert_to_messybrainz_json(self):
         sorted_keys, transformed_json = data.convert_to_messybrainz_json(recording)
         result = json.loads(transformed_json)


### PR DESCRIPTION
We don't use this method anywhere currently. We should use mbid data from mapping tables wherever needed so removing this.