### PR TITLE
Remove artist_msid from recommending track event

### DIFF
--- a/data/model/listen.py
+++ b/data/model/listen.py
@@ -23,7 +23,7 @@ from data.model.validators import check_valid_uuid
 
 class AdditionalInfo(BaseModel):
     artist_mbids: Optional[List[str]]
-    artist_msid: constr(min_length=1)
+    artist_msid: Optional[constr(min_length=1)]
     discnumber: Optional[NonNegativeInt]
     duration_ms: Optional[NonNegativeInt]
     isrc: Optional[str]

--- a/listenbrainz/db/tests/test_user_timeline_event.py
+++ b/listenbrainz/db/tests/test_user_timeline_event.py
@@ -48,7 +48,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         events = db_user_timeline_event.get_user_track_recommendation_events(
@@ -70,7 +69,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                     track_name="Sunflower",
                     artist_name="Swae Lee & Post Malone",
                     recording_msid=str(uuid.uuid4()),
-                    artist_msid=str(uuid.uuid4()),
                 )
             )
 
@@ -81,7 +79,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         self.assertEqual(UserTimelineEventType.RECORDING_RECOMMENDATION, event.event_type)
@@ -107,7 +104,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         new_user = db_user.get_or_create(2, 'captain america')
@@ -117,7 +113,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Fade",
                 artist_name="Kanye West",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         events = db_user_timeline_event.get_user_track_recommendation_events(
@@ -133,7 +128,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
 
@@ -144,7 +138,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
 
@@ -166,7 +159,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         db_user_timeline_event.create_user_track_recommendation_event(
@@ -175,7 +167,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Da Funk",
                 artist_name="Daft Punk",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
 
@@ -187,7 +178,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Da Funk",
                 artist_name="Daft Punk",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
 
@@ -216,7 +206,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         db_user_timeline_event.create_user_track_recommendation_event(
@@ -225,7 +214,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="Da Funk",
                 artist_name="Daft Punk",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
 
@@ -248,7 +236,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="All Caps",
                 artist_name="MF DOOM",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         self.assertEqual(UserTimelineEventType.RECORDING_RECOMMENDATION, event_rec.event_type)
@@ -299,7 +286,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 track_name="All Caps",
                 artist_name="MF DOOM",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
         with mock.patch("listenbrainz.db.engine.connect", side_effect=Exception):

--- a/listenbrainz/webserver/static/js/src/APIService.test.ts
+++ b/listenbrainz/webserver/static/js/src/APIService.test.ts
@@ -783,7 +783,6 @@ describe("recommendTrackToFollowers", () => {
     const metadata: UserTrackRecommendationMetadata = {
       artist_name: "Hans Zimmer",
       track_name: "Flight",
-      artist_msid: "artist_msid",
       recording_msid: "recording_msid",
     };
     await apiService.recommendTrackToFollowers(
@@ -808,7 +807,6 @@ describe("recommendTrackToFollowers", () => {
     const metadata: UserTrackRecommendationMetadata = {
       artist_name: "Hans Zimmer",
       track_name: "Flight",
-      artist_msid: "artist_msid",
       recording_msid: "recording_msid",
     };
     await apiService.recommendTrackToFollowers(
@@ -823,7 +821,6 @@ describe("recommendTrackToFollowers", () => {
     const metadata: UserTrackRecommendationMetadata = {
       artist_name: "Hans Zimmer",
       track_name: "Flight",
-      artist_msid: "artist_msid",
       recording_msid: "recording_msid",
     };
     await expect(

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -166,7 +166,6 @@ export default class ListenCard extends React.Component<
           listen,
           "track_metadata.additional_info.recording_msid"
         ),
-        artist_msid: _get(listen, "track_metadata.additional_info.artist_msid"),
       };
       try {
         const status = await APIService.recommendTrackToFollowers(

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -497,7 +497,6 @@ declare type UserTrackRecommendationMetadata = {
   release_name?: string;
   recording_mbid?: string;
   recording_msid: string;
-  artist_msid: string;
 };
 
 declare type PinEventMetadata = Listen & {

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -151,10 +151,9 @@ def get_pins_for_user(user_name):
                     "recording_mbid": null,
                     "recording_msid": "fd7d9162-a284-4a10-906c-faae4f1e166b"
                     "track_metadata": {
-                        "artist_msid": "8c7b4641-e363-4598-ae70-7709840fb934",
                         "artist_name": "Rick Astley",
                         "track_name": "Never Gonna Give You Up"
-                        }
+                    }
                 },
                 "-- more pinned recording items here ---"
             ],
@@ -229,9 +228,8 @@ def get_pins_for_user_following(user_name):
                 "recording_mbid": null,
                 "recording_msid": "40ef0ae1-5626-43eb-838f-1b34187519bf",
                 "track_metadata": {
-                        "artist_msid": "8c7b4641-e363-4598-ae70-7709840fb934",
-                        "artist_name": "Rick Astley",
-                        "track_name": "Never Gonna Give You Up"
+                    "artist_name": "Rick Astley",
+                    "track_name": "Never Gonna Give You Up"
                 },
                 "user_name": "-- the MusicBrainz ID of the user who pinned this recording --"
                 },

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -63,7 +63,6 @@ def create_user_recording_recommendation_event(user_name):
             "metadata": {
                 "artist_name": "<The name of the artist, required>",
                 "track_name": "<The name of the track, required>",
-                "artist_msid": "<The MessyBrainz ID of the artist, required>",
                 "recording_msid": "<The MessyBrainz ID of the recording, required>",
                 "release_name": "<The name of the release, optional>",
                 "recording_mbid": "<The MusicBrainz ID of the recording, optional>"
@@ -414,7 +413,6 @@ def get_recording_recommendation_events(users_for_events: List[dict], min_ts: in
                     additional_info=AdditionalInfo(
                         recording_msid=event.metadata.recording_msid,
                         recording_mbid=event.metadata.recording_mbid,
-                        artist_msid=event.metadata.artist_msid,
                     )
                 ),
             )
@@ -457,7 +455,6 @@ def get_recording_pin_events(users_for_events: List[dict], min_ts: int, max_ts: 
                     additional_info=AdditionalInfo(
                         recording_msid=pin.recording_msid,
                         recording_mbid=pin.recording_mbid,
-                        artist_msid=pin.track_metadata["additional_info"]["artist_msid"],
                     )
                 )
             )


### PR DESCRIPTION
We do not use artist msid anywhere in recommending track event. The frontend also does not use this info. Hence, removing this. This makes having optional recording_msids easier because then we no longer need to lookup messybrainz db for each item. Currently, we lookup messybrainz for each pin because artist msid is required to recommend anything. Now that we do not need artist msid for this event, we can go ahead and make msids optional elsewhere.
