### PR TITLE
Add API support for getting and fetching the algorithm_metadata field.

### DIFF
--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -3,6 +3,7 @@ import datetime
 from typing import List, Optional
 
 import sqlalchemy
+import ujson
 
 from listenbrainz.db.model import playlist as model_playlist
 from listenbrainz.db import timescale as ts
@@ -405,7 +406,9 @@ def create(playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist
                              RETURNING id, mbid, created
     """)
     fields = playlist.dict(include={'creator_id', 'name', 'description', 'public',
-                                    'copied_from_id', 'created_for_id', 'algorithm_metadata'})
+                                    'copied_from_id', 'created_for_id'})
+    fields["algorithm_metadata"] = ujson.dumps(playlist.algorithm_metadata or {})
+
     with ts.engine.connect() as connection:
         result = connection.execute(query, fields)
         row = dict(result.fetchone())

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -21,7 +21,8 @@ def get_test_data():
           "annotation": "your lame <i>80s</i> music",
           "extension": {
               PLAYLIST_EXTENSION_URI: {
-                  "public": True
+                  "public": True,
+                  "algorithm_metadata": { "give_you_up": "never" }
               }
           },
           "track": [
@@ -104,6 +105,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["playlist"]["annotation"], "your lame <i>80s</i> music")
         self.assertEqual(response.json["playlist"]["track"][0]["identifier"],
                          playlist["playlist"]["track"][0]["identifier"])
+        self.assertNotIn("algorithm_metadata", response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI])
         try:
             dateutil.parser.isoparse(response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["last_modified_at"])
         except ValueError:
@@ -131,6 +133,9 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["created_for"], self.user["musicbrainz_id"])
+        self.assertEqual(response.json["playlist"]["extension"]
+                         [PLAYLIST_EXTENSION_URI]["algorithm_metadata"],
+                         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["algorithm_metadata"])
 
         # Try to submit a playlist on a different users's behalf without the right perms
         # (a user must be part of config. APPROVED_PLAYLIST_BOTS to be able to create playlists

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -16,21 +16,21 @@ from listenbrainz.webserver.views.playlist_api import PLAYLIST_TRACK_URI_PREFIX,
 
 def get_test_data():
     return {
-       "playlist": {
-          "title": "1980s flashback jams",
-          "annotation": "your lame <i>80s</i> music",
-          "extension": {
-              PLAYLIST_EXTENSION_URI: {
-                  "public": True,
-                  "algorithm_metadata": { "give_you_up": "never" }
-              }
-          },
-          "track": [
-             {
-                "identifier": "https://musicbrainz.org/recording/e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
-             }
-          ],
-       }
+        "playlist": {
+            "title": "1980s flashback jams",
+            "annotation": "your lame <i>80s</i> music",
+            "extension": {
+                PLAYLIST_EXTENSION_URI: {
+                    "public": True,
+                    "algorithm_metadata": {"give_you_up": "never"}
+                }
+            },
+            "track": [
+                {
+                    "identifier": "https://musicbrainz.org/recording/e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
+                }
+            ],
+        }
     }
 
 
@@ -184,14 +184,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
         """ Test to ensure creating an empty playlist works """
 
         playlist = {
-           "playlist": {
-              "title": "yer dreams suck!",
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "title": "yer dreams suck!",
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
 
         response = self.client.post(
@@ -211,18 +211,18 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # submit a playlist without title
         playlist = {
-           "playlist": {
-              "track": [
-                 {
-                    "identifier": "https://musicbrainz.org/recording/e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
-                 }
-              ],
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "track": [
+                   {
+                       "identifier": "https://musicbrainz.org/recording/e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
+                   }
+                ],
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
 
         response = self.client.post(
@@ -235,14 +235,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # submit a playlist without public defined
         playlist = {
-           "playlist": {
-              "title": "no, you're a douche!",
-              "track": [
-                 {
-                    "identifier": "https://musicbrainz.org/recording/e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
-                 }
-              ],
-           }
+            "playlist": {
+                "title": "no, you're a douche!",
+                "track": [
+                    {
+                        "identifier": "https://musicbrainz.org/recording/e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
+                    }
+                ],
+            }
         }
 
         response = self.client.post(
@@ -251,7 +251,8 @@ class PlaylistAPITestCase(IntegrationTestCase):
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert400(response)
-        self.assertEqual(response.json["error"], "JSPF playlist.extension.https://musicbrainz.org/doc/jspf#playlist.public field must be given.")
+        self.assertEqual(
+            response.json["error"], "JSPF playlist.extension.https://musicbrainz.org/doc/jspf#playlist.public field must be given.")
 
         # submit a playlist with non-boolean public
         playlist = {
@@ -366,7 +367,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         )
         self.assert200(response)
         self.assertEqual(response.json["playlist_count"], 1)
-        self.assertEqual(response.json["playlists"][0]["playlist"]["extension"] \
+        self.assertEqual(response.json["playlists"][0]["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["collaborators"], [self.user2["musicbrainz_id"]])
 
         # Check private too
@@ -450,18 +451,18 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Add a track to the playlist
         add_recording = {
-           "playlist": {
-              "track": [
-                 {
-                    "identifier": PLAYLIST_TRACK_URI_PREFIX + "4a77a078-e91a-4522-a409-3b58aa7de3ae"
-                 }
-              ],
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "track": [
+                    {
+                        "identifier": PLAYLIST_TRACK_URI_PREFIX + "4a77a078-e91a-4522-a409-3b58aa7de3ae"
+                    }
+                ],
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
         response = self.client.post(
             url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
@@ -483,13 +484,13 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Add an invalid track id to the playlist
         add_recording = {
-           "playlist": {
-              "track": [
-                 {
-                    "identifier": "4a77a078-e91a-4522-a409-3b58aa7de3ae"
-                 }
-              ],
-           }
+            "playlist": {
+                "track": [
+                    {
+                        "identifier": "4a77a078-e91a-4522-a409-3b58aa7de3ae"
+                    }
+                ],
+            }
         }
         response = self.client.post(
             url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
@@ -501,22 +502,22 @@ class PlaylistAPITestCase(IntegrationTestCase):
     def test_playlist_recording_move(self):
 
         playlist = {
-           "playlist": {
-              "title": "1980s flashback jams",
-              "track": [
-                 {
-                    "identifier": PLAYLIST_TRACK_URI_PREFIX + "e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
-                 },
-                 {
-                    "identifier": PLAYLIST_TRACK_URI_PREFIX + "57ef4803-5181-4b3d-8dd6-8b9d9ca83e2a"
-                 }
-              ],
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "title": "1980s flashback jams",
+                "track": [
+                    {
+                        "identifier": PLAYLIST_TRACK_URI_PREFIX + "e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
+                    },
+                    {
+                        "identifier": PLAYLIST_TRACK_URI_PREFIX + "57ef4803-5181-4b3d-8dd6-8b9d9ca83e2a"
+                    }
+                ],
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
 
         response = self.client.post(
@@ -548,22 +549,22 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
     def test_playlist_recording_delete(self):
         playlist = {
-           "playlist": {
-              "title": "1980s flashback jams",
-              "track": [
-                 {
-                    "identifier": PLAYLIST_TRACK_URI_PREFIX + "e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
-                 },
-                 {
-                    "identifier": PLAYLIST_TRACK_URI_PREFIX + "57ef4803-5181-4b3d-8dd6-8b9d9ca83e2a"
-                 }
-              ],
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "title": "1980s flashback jams",
+                "track": [
+                    {
+                        "identifier": PLAYLIST_TRACK_URI_PREFIX + "e8f9b188-f819-4e43-ab0f-4bd26ce9ff56"
+                    },
+                    {
+                        "identifier": PLAYLIST_TRACK_URI_PREFIX + "57ef4803-5181-4b3d-8dd6-8b9d9ca83e2a"
+                    }
+                ],
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
 
         response = self.client.post(
@@ -594,14 +595,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
     def test_playlist_delete_playlist(self):
 
         playlist = {
-           "playlist": {
-              "title": "yer dreams suck!",
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "title": "yer dreams suck!",
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
 
         response = self.client.post(
@@ -628,16 +629,16 @@ class PlaylistAPITestCase(IntegrationTestCase):
     def test_playlist_copy_public_playlist(self):
 
         playlist = {
-           "playlist": {
-              "title": "my stupid playlist",
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True,
-                      "collaborators": [self.user2["musicbrainz_id"],
-                                        self.user3["musicbrainz_id"]]
-                  }
-              },
-           }
+            "playlist": {
+                "title": "my stupid playlist",
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True,
+                        "collaborators": [self.user2["musicbrainz_id"],
+                                          self.user3["musicbrainz_id"]]
+                    }
+                },
+            }
         }
 
         response = self.client.post(
@@ -663,10 +664,10 @@ class PlaylistAPITestCase(IntegrationTestCase):
         )
         self.assert200(response)
         self.assertEqual(response.json["playlist"]["identifier"], PLAYLIST_URI_PREFIX + new_playlist_mbid)
-        self.assertEqual(response.json["playlist"]["extension"] \
-                         [PLAYLIST_EXTENSION_URI]["copied_from_mbid"], \
+        self.assertEqual(response.json["playlist"]["extension"]
+                         [PLAYLIST_EXTENSION_URI]["copied_from_mbid"],
                          PLAYLIST_URI_PREFIX + playlist_mbid)
-        self.assertEqual(response.json["playlist"]["extension"] \
+        self.assertEqual(response.json["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["public"], True)
         self.assertEqual(response.json["playlist"]["title"], "Copy of my stupid playlist")
         self.assertEqual(response.json["playlist"]["creator"], "anothertestuserpleaseignore")
@@ -689,18 +690,17 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["copied_from_deleted"], True)
 
-
     def test_playlist_copy_private_playlist(self):
 
         playlist = {
-           "playlist": {
-              "title": "my stupid playlist",
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": False
-                  }
-              },
-           }
+            "playlist": {
+                "title": "my stupid playlist",
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": False
+                    }
+                },
+            }
         }
 
         response = self.client.post(
@@ -814,18 +814,18 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Add recording to playlist
         add_recording = {
-           "playlist": {
-              "track": [
-                 {
-                    "identifier": PLAYLIST_TRACK_URI_PREFIX + "4a77a078-e91a-4522-a409-3b58aa7de3ae"
-                 }
-              ],
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "track": [
+                    {
+                        "identifier": PLAYLIST_TRACK_URI_PREFIX + "4a77a078-e91a-4522-a409-3b58aa7de3ae"
+                    }
+                ],
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
         response = self.client.post(
             url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
@@ -917,23 +917,23 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["playlist_count"], 2)
         self.assertEqual(response.json["count"], DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL)
         self.assertEqual(response.json["offset"], 0)
-        self.assertEqual(response.json["playlists"][0]["playlist"]["extension"] \
+        self.assertEqual(response.json["playlists"][0]["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["creator"], self.user4["musicbrainz_id"])
         self.assertEqual(response.json["playlists"][0]["playlist"]["identifier"], PLAYLIST_URI_PREFIX + public_playlist_mbid)
         self.assertEqual(response.json["playlists"][0]["playlist"]["title"], "1980s flashback jams")
         self.assertEqual(response.json["playlists"][0]["playlist"]["annotation"], "your lame <i>80s</i> music")
-        self.assertEqual(response.json["playlists"][0]["playlist"]["extension"] \
+        self.assertEqual(response.json["playlists"][0]["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["public"], True)
         try:
             dateutil.parser.isoparse(response.json["playlists"][0]["playlist"]["date"])
         except ValueError:
             assert False
-        self.assertEqual(response.json["playlists"][1]["playlist"]["extension"] \
+        self.assertEqual(response.json["playlists"][1]["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["creator"], self.user4["musicbrainz_id"])
         self.assertEqual(response.json["playlists"][1]["playlist"]["identifier"], PLAYLIST_URI_PREFIX + private_playlist_mbid)
         self.assertEqual(response.json["playlists"][1]["playlist"]["title"], "1980s flashback jams")
         self.assertEqual(response.json["playlists"][1]["playlist"]["annotation"], "your lame <i>80s</i> music")
-        self.assertEqual(response.json["playlists"][1]["playlist"]["extension"] \
+        self.assertEqual(response.json["playlists"][1]["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["public"], False)
         try:
             dateutil.parser.isoparse(response.json["playlists"][1]["playlist"]["date"])
@@ -960,7 +960,6 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["playlist_count"], 2)
         self.assertEqual(response.json["count"], 1)
         self.assertEqual(response.json["offset"], 1)
-
 
     def test_playlist_unauthorized_access(self):
         """ Test for checking that unauthorized access return 401 """
@@ -1018,14 +1017,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
         """ Test for checking that forbidden access returns 403 """
 
         playlist = {
-           "playlist": {
-              "title": "my stupid playlist",
-              "extension": {
-                  PLAYLIST_EXTENSION_URI: {
-                      "public": True
-                  }
-              },
-           }
+            "playlist": {
+                "title": "my stupid playlist",
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True
+                    }
+                },
+            }
         }
 
         response = self.client.post(

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -114,6 +114,8 @@ def serialize_jspf(playlist: Playlist):
         extension['created_for'] = playlist.created_for
     if playlist.collaborators:
         extension['collaborators'] = playlist.collaborators
+    if playlist.algorithm_metadata:
+        extension['algorithm_metadata'] = playlist.algorithm_metadata
 
     pl["extension"] = {PLAYLIST_EXTENSION_URI: extension}
 
@@ -284,12 +286,23 @@ def create_playlist():
     if description is not None:
         description = _filter_description_html(description)
 
+
+    # Check to see if the submitted playlist has algorithm_metadata defined and the current user an approved
+    # playlist submitter; if so, load the metadata from the JSPF playlist and add to the new playlist
+    algorithm_metadata = None
+    if user["musicbrainz_id"] in current_app.config["APPROVED_PLAYLIST_BOTS"]:
+        try:
+            algorithm_metadata = data["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["algorithm_metadata"]
+        except KeyError:
+            pass
+    
     playlist = WritablePlaylist(name=data['playlist']['title'],
                                 creator_id=user["id"],
                                 description=description,
                                 collaborator_ids=collaborator_ids,
                                 collaborators=collaborators,
-                                public=public)
+                                public=public,
+                                algorithm_metadata=algorithm_metadata)
 
     if data["playlist"].get("created_for", None):
         if user["musicbrainz_id"] not in current_app.config["APPROVED_PLAYLIST_BOTS"]:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -98,7 +98,7 @@ def serialize_jspf(playlist: Playlist):
           "title": playlist.name,
           "identifier": PLAYLIST_URI_PREFIX + str(playlist.mbid),
           "date": playlist.created.astimezone(datetime.timezone.utc).isoformat()
-    }
+          }
     if playlist.description:
         pl["annotation"] = playlist.description
 
@@ -286,7 +286,6 @@ def create_playlist():
     if description is not None:
         description = _filter_description_html(description)
 
-
     # Check to see if the submitted playlist has algorithm_metadata defined and the current user an approved
     # playlist submitter; if so, load the metadata from the JSPF playlist and add to the new playlist
     algorithm_metadata = None
@@ -295,7 +294,7 @@ def create_playlist():
             algorithm_metadata = data["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["algorithm_metadata"]
         except KeyError:
             pass
-    
+
     playlist = WritablePlaylist(name=data['playlist']['title'],
                                 creator_id=user["id"],
                                 description=description,
@@ -316,7 +315,7 @@ def create_playlist():
         for track in data["playlist"]["track"]:
             try:
                 playlist.recordings.append(WritablePlaylistRecording(mbid=UUID(track['identifier'][len(PLAYLIST_TRACK_URI_PREFIX):]),
-                                           added_by_id=user["id"]))
+                                                                     added_by_id=user["id"]))
             except ValueError:
                 log_raise_400("Invalid recording MBID found in submitted recordings")
 


### PR DESCRIPTION
This PR adds support for submitting algorithm_metadata with a playlist if the submitter is an approved playlist submitter. This functionality is needed for troi-bot to submit metadata about playlists so that periodic playlists can be updated in sane and predictable manner. Playlists will be given a slug to identify them as belonging to a given patch that was run for a given time period, so that they may be periodically updated. 

NOTE: This will need to be deployed before we can delivery the YIM playlists.