### PR TITLE
LB-296: Disable root logger configuration in listenstore causing duplicate messages

### DIFF
--- a/listenbrainz/__init__.py
+++ b/listenbrainz/__init__.py
@@ -7,11 +7,10 @@ DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)
                                       'db', 'licenses', 'COPYING-PublicDomain')
 
 _handler = logging.StreamHandler()
-_handler.setLevel(logging.INFO)
 _formatter = logging.Formatter("%(asctime)s %(name)-20s %(levelname)-8s %(message)s")
 _handler.setFormatter(_formatter)
 
 _logger = logging.getLogger("listenbrainz")
+# This level is set to DEBUG in listenbrainz.webserver.gen_app if Flask DEBUG=True
 _logger.setLevel(logging.INFO)
 _logger.addHandler(_handler)
-

--- a/listenbrainz/listenstore/__init__.py
+++ b/listenbrainz/listenstore/__init__.py
@@ -1,5 +1,3 @@
-import logging
-
 ORDER_DESC = 0
 ORDER_ASC = 1
 ORDER_TEXT = [ "DESC", "ASC" ]
@@ -13,13 +11,6 @@ from listenbrainz.listenstore import listenstore
 import listenbrainz.listen as listen
 ListenStore = listenstore.ListenStore
 Listen = listen.Listen
-
-
-# Certain modules configure logging on a module-level context, so we have to
-# configure logging as early as possible or some loggers will be disabled by
-# reconfiguring logging.
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s %(levelname)s %(message)s')
 
 
 # ╭∩╮

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pprint
 import sys
@@ -77,6 +78,7 @@ def gen_app(debug=None):
 
     In the Flask app returned, blueprints are not registered.
     """
+
     app = CustomFlask(
         import_name=__name__,
         use_flask_uuid=True,
@@ -85,6 +87,11 @@ def gen_app(debug=None):
     load_config(app)
     if debug is not None:
         app.debug = debug
+    # As early as possible, if debug is True, set the log level of our 'listenbrainz' logger to DEBUG
+    # to prevent flask from creating a new log handler
+    if app.debug:
+        logger = logging.getLogger('listenbrainz')
+        logger.setLevel(logging.DEBUG)
 
     # initialize Flask-DebugToolbar if the debug option is True
     if app.debug and app.config['SECRET_KEY']:


### PR DESCRIPTION
# Problem

All log messages were appearing twice:

> spotify_reader_1    | 2021-12-07 15:05:09,784 listenbrainz.webserver INFO     Processed 1 users successfully!
> spotify_reader_1    | 2021-12-07 15:05:09,784 INFO Processed 1 users successfully!

We specifically [set up a `listenbrainz` logger](https://github.com/metabrainz/listenbrainz-server/blob/dfb0fcff6bef52195b3c5fd9a2bea0804420a0b4/listenbrainz/__init__.py#L14) for all LB packages, but somehow messages were being sent to a root logger too which was mysteriously being created.

# Solution

Turns out it wasn't much of a mystery. The root logger was implicitly created in listenstore, way back in one of the earliest LB commits


# Action

Now that we don't have a root logger, there may be some messages that will get lost, however the only instance of logging that I can find outside of the `listenbrainz` package is in the spark package, and we already set up a root logger for that, so everything should be fine.