### PR TITLE
LB-1033: Fix doc comment for listenbrainz.webserver.views.api_tools.MAX_LISTEN_SIZE

### DIFF
--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -20,9 +20,9 @@ from listenbrainz.webserver import API_LISTENED_AT_ALLOWED_SKEW
 from listenbrainz.webserver.errors import APIServiceUnavailable, APIBadRequest, APIUnauthorized, \
     ListenValidationError
 
-#: Maximum overall listen size in bytes, to prevent egregious spamming.
 from listenbrainz.webserver.models import SubmitListenUserMetadata
 
+#: Maximum overall listen size in bytes, to prevent egregious spamming.
 MAX_LISTEN_SIZE = 10240
 
 #: The maximum number of tags per listen.


### PR DESCRIPTION
Fixes documentation for `MAX_LISTEN_SIZE` for LB-1033