### PR TITLE
Use LEFT JOINs for medium format in mapping because it can be NULL

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
+++ b/listenbrainz/mbid_mapping/mapping/mbid_mapping.py
@@ -99,15 +99,15 @@ def create_temp_release_table(conn):
                                   JOIN musicbrainz.release r ON rg.id = r.release_group
                              LEFT JOIN musicbrainz.release_country rc ON rc.release = r.id
                                   JOIN musicbrainz.medium m ON m.release = r.id
-                                  JOIN musicbrainz.medium_format mf ON m.format = mf.id
-                                  JOIN mapping.format_sort fs ON mf.id = fs.format
+                             LEFT JOIN musicbrainz.medium_format mf ON m.format = mf.id
+                             LEFT JOIN mapping.format_sort fs ON mf.id = fs.format
                                   JOIN musicbrainz.artist_credit ac ON rg.artist_credit = ac.id
                                   JOIN musicbrainz.release_group_primary_type rgpt ON rg.type = rgpt.id
                              LEFT JOIN musicbrainz.release_group_secondary_type_join rgstj ON rg.id = rgstj.release_group
                              LEFT JOIN musicbrainz.release_group_secondary_type rgst ON rgstj.secondary_type = rgst.id
                                  WHERE rg.artist_credit %s 1
                                        %s
-                                 ORDER BY rg.type, rgst.id desc, fs.sort,
+                                 ORDER BY rg.type, rgst.id desc, fs.sort NULLS LAST,
                                           to_date(date_year::TEXT || '-' ||
                                                   COALESCE(date_month,12)::TEXT || '-' ||
                                                   COALESCE(date_day,28)::TEXT, 'YYYY-MM-DD'),


### PR DESCRIPTION
We found that some releases (eg: https://musicbrainz.org/release/a4be0448-accc-4f12-bf23-08122434270e) were not being mapped and digging deeper discovered it was because medium_format is nullable. To include these releases in the mapping use a LEFT JOIN but order by NULLS LAST so that releases with a medium format available are preferred.