### PR TITLE
Add auth-token whitelist support

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -181,6 +181,9 @@ ADMINS = [
 APPROVED_PLAYLIST_BOTS = [
     {{template "KEY_ARRAY" "approved_playlist_bots"}}
 ]
+WHITELISTED_AUTH_TOKENS = [
+    {{template "KEY_ARRAY" "whitelisted_auth_tokens"}}
+]
 
 # SPOTIFY
 SPOTIFY_CLIENT_ID = '''{{template "KEY" "spotify/client_id"}}'''

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -132,6 +132,9 @@ ADMINS = []
 # Users who are allowed to submit playlists made for someone else.
 APPROVED_PLAYLIST_BOTS = ['troi-bot']
 
+# Auth tokens that are not subject to rate limits:
+WHITELISTED_AUTH_TOKENS = []
+
 # SPOTIFY
 SPOTIFY_CLIENT_ID = 'needs a non empty default value for tests, change this'
 SPOTIFY_CLIENT_SECRET = 'needs a non empty default value for tests, change this'

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -72,6 +72,15 @@ def load_config(app):
         print('Unable to retrieve git commit. Error: %s', str(e))
 
 
+def check_ratelimit_token_whitelist(auth_token):
+    """
+        Check to see if the given auth_token is a whitelisted auth token.
+    """
+
+    from flask import current_app
+    return if auth_token in current_app.config["WHITELISTED_AUTH_TOKENS"]
+
+
 def gen_app(debug=None):
     """ Generate a Flask app for LB with all configurations done and connections established.
 
@@ -134,7 +143,8 @@ def gen_app(debug=None):
     from listenbrainz.webserver.errors import init_error_handlers
     init_error_handlers(app)
 
-    from brainzutils.ratelimit import inject_x_rate_headers
+    from brainzutils.ratelimit import inject_x_rate_headers, set_user_validation_function
+    set_user_validation_function(check_ratelimit_token_whitelist)
     @app.after_request
     def after_request_callbacks(response):
         return inject_x_rate_headers(response)

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -78,7 +78,7 @@ def check_ratelimit_token_whitelist(auth_token):
     """
 
     from flask import current_app
-    return if auth_token in current_app.config["WHITELISTED_AUTH_TOKENS"]
+    return auth_token in current_app.config["WHITELISTED_AUTH_TOKENS"]
 
 
 def gen_app(debug=None):


### PR DESCRIPTION
At times the LB team needs to have unlimited access to the LB API, but that is difficult because we have no means to exempt any clients from rate limits. This PR allows WHITELISTED_AUTH_TOKENS to be set in config.py/consul config to specify the tokens that should not be subjected to rate limiting.

related configs PR: https://github.com/metabrainz/docker-server-configs/pull/198