### PR TITLE
Add support for importing troi generated playlist excerpts

### DIFF
--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -326,13 +326,17 @@ def create_test_parquet_files():
 @cli.command(name="import_yim_playlists")
 @click.argument('patch-slug', type=str)
 @click.argument('dump-file', type=str)
-def create_full(patch_slug, dump_file):
+def import_yim_playlists(patch_slug, dump_file):
     """ Import playlist excerpts into the YIM data table from a dump file.
 
         Args:
             patch_slug (str): The slug of the troi patch that generated these playlists.
             dump_file (str): The dump file to import. For each user, it should contain
                              three lines: user_name, playlist_mbid, JSPF data.
+
+        .. note::
+
+            First copy the dump to inside the container from which the script is to be run.
     """
     app = create_app()
     with app.app_context():

--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -176,7 +176,6 @@ def insert_playlists(troi_patch_slug, import_file):
       DO UPDATE SET data = statistics.year_in_music.data || EXCLUDED.data
         """
 
-    print("start playlist import")
     data = []
     with open(import_file, "r") as f:
         while True:
@@ -199,8 +198,6 @@ def insert_playlists(troi_patch_slug, import_file):
         with connection.cursor() as cursor:
             execute_values(cursor, query, data)
         connection.commit()
-        print("playlists imported.")
     except psycopg2.errors.OperationalError:
         connection.rollback()
         current_app.logger.error("Error while inserting playlist/%s:" % troi_patch_slug, exc_info=True)
-        print("playlists import failed.")

--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -188,7 +188,12 @@ def insert_playlists(troi_patch_slug, import_file):
             playlist_mbid = f.readline().strip()
             jspf = f.readline().strip()
 
-            data.append((user_name, ujson.dumps({troi_patch_slug: {"mbid": playlist_mbid, "jspf": jspf}})))
+            data.append((user_name, ujson.dumps({
+                troi_patch_slug: {
+                    "mbid": playlist_mbid,
+                    "jspf": ujson.loads(jspf)
+                }
+            })))
 
     for user_name, js in data:
         print("%s %s" % (user_name, js[:20]))

--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -168,7 +168,7 @@ def insert_playlists(troi_patch_slug, import_file):
     query = """
         INSERT INTO statistics.year_in_music(user_id, data)
              SELECT "user".id
-                  , jsonb_build_object('playlists', playlists::jsonb)
+                  , playlists::jsonb
                FROM (VALUES %s) AS t(user_name, playlists)
                JOIN "user"
                  ON "user".musicbrainz_id = user_name
@@ -189,14 +189,11 @@ def insert_playlists(troi_patch_slug, import_file):
             jspf = f.readline().strip()
 
             data.append((user_name, ujson.dumps({
-                troi_patch_slug: {
+                f"playlist-{troi_patch_slug}": {
                     "mbid": playlist_mbid,
                     "jspf": ujson.loads(jspf)
                 }
             })))
-
-    for user_name, js in data:
-        print("%s %s" % (user_name, js[:20]))
 
     try:
         with connection.cursor() as cursor:
@@ -205,5 +202,5 @@ def insert_playlists(troi_patch_slug, import_file):
         print("playlists imported.")
     except psycopg2.errors.OperationalError:
         connection.rollback()
-        current_app.logger.error("Error while inserting playlist/%s:" % playlist_slug, exc_info=True)
+        current_app.logger.error("Error while inserting playlist/%s:" % troi_patch_slug, exc_info=True)
         print("playlists import failed.")


### PR DESCRIPTION
This PR is based off @amCap1712's year-in-music branch and should first be merged into that branch!

This PR adds support for taking playlist excerpt dumps created by troi and import them into the LB database. Each dump should be formatted as follows:

<user_name>\n
<playlist_mbid>\n
<playlist_JSPF>\n

To import the file use:

manage.py dump import_yim_playlists 