### PR TITLE
Add coverart to playlist items

### DIFF
--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -247,7 +247,7 @@ def get_coverart_for_playlist(playlist_jspf):
             recording_mbid = row["recording_mbid"]
             release_mbid = row["release_mbid"]
             recording_mbid_to_release_mbid[recording_mbid] = release_mbid
-    
+
     coverart = get_coverart_for_top_releases(list(recording_mbid_to_release_mbid.values()))
     recording_mbid_to_coverart = {}
     for recording_mbid, release_mbid in recording_mbid_to_release_mbid.items():

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -383,8 +383,9 @@ def handle_top_stats(message):
 
     # for top_releases, look up cover art
     if message["entity"] == "releases":
-        coverart = year_in_music.get_coverart_for_top_releases(message["data"])
-        year_in_music.handle_coverart(user["id"], coverart)
+        release_mbids = [rel["release_mbid"] for rel in message["data"] if "release_mbid" in rel]
+        coverart = year_in_music.get_coverart_for_top_releases(release_mbids)
+        year_in_music.handle_coverart(user["id"], "top_releases_coverart", coverart)
 
 
 def handle_listens_per_day(message):

--- a/listenbrainz/webserver/static/js/src/playlists/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/utils.tsx
@@ -80,6 +80,10 @@ export function JSPFTrackToListen(track: JSPFTrack): Listen {
   if (customFields?.added_at) {
     listen.listened_at_iso = customFields.added_at;
   }
+  if (listen.track_metadata.additional_info) {
+    listen.track_metadata.additional_info.artist_mbids =
+      customFields?.artist_mbids || customFields?.artist_identifier;
+  }
   return listen;
 }
 

--- a/listenbrainz/webserver/static/js/src/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/types.d.ts
@@ -433,6 +433,7 @@ declare type JSPFPlaylistExtension = {
 declare type JSPFTrackExtension = {
   added_by: string;
   artist_identifier: string[]; // Full MusicBrainz artist URIs
+  artist_mbids?: string[]; // Full MusicBrainz artist URIs
   added_at: string; // ISO date string
   release_identifier?: string; // Full MusicBrainz release URI
 };

--- a/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
+++ b/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
@@ -132,7 +132,7 @@ export default class YearInMusic extends React.Component<
           if (found) {
             const recording_mbid = found[0];
             newTrack.id = recording_mbid;
-            const recording_coverart = coverArt[recording_mbid];
+            const recording_coverart = coverArt?.[recording_mbid];
             if (recording_coverart) {
               newTrack.image = recording_coverart;
             }

--- a/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
+++ b/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
@@ -30,7 +30,10 @@ import ComponentToImage from "./ComponentToImage";
 import fakeData from "./year-in-music-data.json";
 import ListenCard from "../listens/ListenCard";
 import UserListModalEntry from "../follow/UserListModalEntry";
-import { JSPFTrackToListen } from "../playlists/utils";
+import {
+  JSPFTrackToListen,
+  MUSICBRAINZ_JSPF_TRACK_EXTENSION,
+} from "../playlists/utils";
 
 export type YearInMusicProps = {
   user: ListenBrainzUser;
@@ -108,6 +111,8 @@ export default class YearInMusic extends React.Component<
     description?: string
   ): { jspf: JSPFObject; mbid: string; description?: string } | undefined {
     const uuidMatch = /[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}/g;
+    /* We generated some playlists with this incorrect value as the track extension key, rewrite it if it exists */
+    const badPlaylistTrackExtensionValue = "https://musicbrainz.org/recording/";
     const { yearInMusicData } = this.props;
     let playlist;
     try {
@@ -131,6 +136,13 @@ export default class YearInMusic extends React.Component<
             if (recording_coverart) {
               newTrack.image = recording_coverart;
             }
+          }
+          if (
+            newTrack.extension &&
+            track.extension?.[badPlaylistTrackExtensionValue]
+          ) {
+            newTrack.extension[MUSICBRAINZ_JSPF_TRACK_EXTENSION] =
+              track.extension[badPlaylistTrackExtensionValue];
           }
           return newTrack;
         }


### PR DESCRIPTION
# Problem

Playlist items looked a bit boring

# Solution
Use mapping to go from recording -> release and then look up coverart


# Action

- [ ] need to test that top releases lookup still works
- [ ] add coverart lookup to the playlist import code
- [ ] add artist mbid to listen card to make artist names links to MB

