### PR TITLE
Deduplicate new releases of top artists

### DIFF
--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -76,7 +76,7 @@ def _get_releases_for_year(year):
 def _get_new_releases_of_top_artists():
     return """
         SELECT user_name
-             , collect_list(
+             , collect_set(
                     struct(
                        title
                      , release_mbid


### PR DESCRIPTION
If a release has multiple artist credits, the release may duplicated when joined with the top artists. To avoid duplication, use collect_set. However, this does not prevent multiple releases of a release group released in the same year from appearing in the list again.
