### PR TITLE
YIM: Fix coverflow navigation

### DIFF
--- a/listenbrainz/webserver/static/css/year-in-music.less
+++ b/listenbrainz/webserver/static/css/year-in-music.less
@@ -71,6 +71,13 @@
 		box-shadow: 0 20px 40px rgb(0 0 0 / 30%);
 		-webkit-box-reflect: below 1px -webkit-linear-gradient(bottom, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0) 20%, rgba(0, 0, 0, 0));
 	}
+	div[class*="coverflow__text__"]{
+		font-size: .6em;
+		@media(max-width:@screen-tablet) {
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
 	div[class*="coverflow__left__"]{
 		left:calc(45%) !important;
 		transform: translateZ(70px);

--- a/listenbrainz/webserver/static/css/year-in-music.less
+++ b/listenbrainz/webserver/static/css/year-in-music.less
@@ -72,23 +72,16 @@
 		-webkit-box-reflect: below 1px -webkit-linear-gradient(bottom, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0) 20%, rgba(0, 0, 0, 0));
 	}
 	div[class*="coverflow__left__"]{
-		left:calc(50% - 300px) !important;
-		transform: translateZ(30px);
-		@media(min-width:@screen-desktop) {
-			left:calc(50% - 500px) !important;
-		}
+		left:calc(45%) !important;
+		transform: translateZ(70px);
 	}
 	div[class*="coverflow__right__"]{
-		right:calc(50% - 300px) !important;
-		transform: translateZ(30px);
-		@media(min-width:@screen-desktop) {
-			right:calc(50% - 500px) !important;
-		}
+		right:calc(45%) !important;
+		transform: translateZ(70px);
 	}
 	div[class*="coverflow__arrow__"]{
 		&:before, &:after{
 			height: 3px;
-			box-shadow: 2px 2px 3px rgb(0 0 0 / 50%);
 		}
 	}
 	/* "Save as image" component */

--- a/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
+++ b/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
@@ -477,6 +477,7 @@ export default class YearInMusic extends React.Component<
                   displayQuantityOfSide={3}
                   currentFigureScale={2}
                   otherFigureScale={1}
+                  navigation
                   enableScroll
                   infiniteScroll
                   enableHeading
@@ -499,7 +500,7 @@ export default class YearInMusic extends React.Component<
                       data-action={
                         release.release_mbid
                           ? `https://musicbrainz.org/release/${release.release_mbid}/`
-                          : ""
+                          : undefined
                       }
                       src={
                         yearInMusicData.top_releases_coverart?.[

--- a/listenbrainz/webserver/static/js/src/year-in-music/year-in-music-data.json
+++ b/listenbrainz/webserver/static/js/src/year-in-music/year-in-music-data.json
@@ -1,4101 +1,4096 @@
 {
-	"payload": {
-		"data": {
-			"day_of_week": "Friday",
-			"listens_per_day": [
-				{
-					"from_ts": 1609459200,
-					"listen_count": 0,
-					"time_range": "01 January 2021",
-					"to_ts": 1609545599
-				},
-				{
-					"from_ts": 1609545600,
-					"listen_count": 0,
-					"time_range": "02 January 2021",
-					"to_ts": 1609631999
-				},
-				{
-					"from_ts": 1609632000,
-					"listen_count": 41,
-					"time_range": "03 January 2021",
-					"to_ts": 1609718399
-				},
-				{
-					"from_ts": 1609718400,
-					"listen_count": 1,
-					"time_range": "04 January 2021",
-					"to_ts": 1609804799
-				},
-				{
-					"from_ts": 1609804800,
-					"listen_count": 0,
-					"time_range": "05 January 2021",
-					"to_ts": 1609891199
-				},
-				{
-					"from_ts": 1609891200,
-					"listen_count": 2,
-					"time_range": "06 January 2021",
-					"to_ts": 1609977599
-				},
-				{
-					"from_ts": 1609977600,
-					"listen_count": 1,
-					"time_range": "07 January 2021",
-					"to_ts": 1610063999
-				},
-				{
-					"from_ts": 1610064000,
-					"listen_count": 0,
-					"time_range": "08 January 2021",
-					"to_ts": 1610150399
-				},
-				{
-					"from_ts": 1610150400,
-					"listen_count": 0,
-					"time_range": "09 January 2021",
-					"to_ts": 1610236799
-				},
-				{
-					"from_ts": 1610236800,
-					"listen_count": 51,
-					"time_range": "10 January 2021",
-					"to_ts": 1610323199
-				},
-				{
-					"from_ts": 1610323200,
-					"listen_count": 7,
-					"time_range": "11 January 2021",
-					"to_ts": 1610409599
-				},
-				{
-					"from_ts": 1610409600,
-					"listen_count": 0,
-					"time_range": "12 January 2021",
-					"to_ts": 1610495999
-				},
-				{
-					"from_ts": 1610496000,
-					"listen_count": 21,
-					"time_range": "13 January 2021",
-					"to_ts": 1610582399
-				},
-				{
-					"from_ts": 1610582400,
-					"listen_count": 1,
-					"time_range": "14 January 2021",
-					"to_ts": 1610668799
-				},
-				{
-					"from_ts": 1610668800,
-					"listen_count": 27,
-					"time_range": "15 January 2021",
-					"to_ts": 1610755199
-				},
-				{
-					"from_ts": 1610755200,
-					"listen_count": 0,
-					"time_range": "16 January 2021",
-					"to_ts": 1610841599
-				},
-				{
-					"from_ts": 1610841600,
-					"listen_count": 0,
-					"time_range": "17 January 2021",
-					"to_ts": 1610927999
-				},
-				{
-					"from_ts": 1610928000,
-					"listen_count": 0,
-					"time_range": "18 January 2021",
-					"to_ts": 1611014399
-				},
-				{
-					"from_ts": 1611014400,
-					"listen_count": 0,
-					"time_range": "19 January 2021",
-					"to_ts": 1611100799
-				},
-				{
-					"from_ts": 1611100800,
-					"listen_count": 1,
-					"time_range": "20 January 2021",
-					"to_ts": 1611187199
-				},
-				{
-					"from_ts": 1611187200,
-					"listen_count": 6,
-					"time_range": "21 January 2021",
-					"to_ts": 1611273599
-				},
-				{
-					"from_ts": 1611273600,
-					"listen_count": 46,
-					"time_range": "22 January 2021",
-					"to_ts": 1611359999
-				},
-				{
-					"from_ts": 1611360000,
-					"listen_count": 44,
-					"time_range": "23 January 2021",
-					"to_ts": 1611446399
-				},
-				{
-					"from_ts": 1611446400,
-					"listen_count": 0,
-					"time_range": "24 January 2021",
-					"to_ts": 1611532799
-				},
-				{
-					"from_ts": 1611532800,
-					"listen_count": 23,
-					"time_range": "25 January 2021",
-					"to_ts": 1611619199
-				},
-				{
-					"from_ts": 1611619200,
-					"listen_count": 1,
-					"time_range": "26 January 2021",
-					"to_ts": 1611705599
-				},
-				{
-					"from_ts": 1611705600,
-					"listen_count": 0,
-					"time_range": "27 January 2021",
-					"to_ts": 1611791999
-				},
-				{
-					"from_ts": 1611792000,
-					"listen_count": 1,
-					"time_range": "28 January 2021",
-					"to_ts": 1611878399
-				},
-				{
-					"from_ts": 1611878400,
-					"listen_count": 0,
-					"time_range": "29 January 2021",
-					"to_ts": 1611964799
-				},
-				{
-					"from_ts": 1611964800,
-					"listen_count": 13,
-					"time_range": "30 January 2021",
-					"to_ts": 1612051199
-				},
-				{
-					"from_ts": 1612051200,
-					"listen_count": 0,
-					"time_range": "31 January 2021",
-					"to_ts": 1612137599
-				},
-				{
-					"from_ts": 1612137600,
-					"listen_count": 1,
-					"time_range": "01 February 2021",
-					"to_ts": 1612223999
-				},
-				{
-					"from_ts": 1612224000,
-					"listen_count": 0,
-					"time_range": "02 February 2021",
-					"to_ts": 1612310399
-				},
-				{
-					"from_ts": 1612310400,
-					"listen_count": 0,
-					"time_range": "03 February 2021",
-					"to_ts": 1612396799
-				},
-				{
-					"from_ts": 1612396800,
-					"listen_count": 0,
-					"time_range": "04 February 2021",
-					"to_ts": 1612483199
-				},
-				{
-					"from_ts": 1612483200,
-					"listen_count": 35,
-					"time_range": "05 February 2021",
-					"to_ts": 1612569599
-				},
-				{
-					"from_ts": 1612569600,
-					"listen_count": 0,
-					"time_range": "06 February 2021",
-					"to_ts": 1612655999
-				},
-				{
-					"from_ts": 1612656000,
-					"listen_count": 18,
-					"time_range": "07 February 2021",
-					"to_ts": 1612742399
-				},
-				{
-					"from_ts": 1612742400,
-					"listen_count": 0,
-					"time_range": "08 February 2021",
-					"to_ts": 1612828799
-				},
-				{
-					"from_ts": 1612828800,
-					"listen_count": 0,
-					"time_range": "09 February 2021",
-					"to_ts": 1612915199
-				},
-				{
-					"from_ts": 1612915200,
-					"listen_count": 14,
-					"time_range": "10 February 2021",
-					"to_ts": 1613001599
-				},
-				{
-					"from_ts": 1613001600,
-					"listen_count": 1,
-					"time_range": "11 February 2021",
-					"to_ts": 1613087999
-				},
-				{
-					"from_ts": 1613088000,
-					"listen_count": 44,
-					"time_range": "12 February 2021",
-					"to_ts": 1613174399
-				},
-				{
-					"from_ts": 1613174400,
-					"listen_count": 2,
-					"time_range": "13 February 2021",
-					"to_ts": 1613260799
-				},
-				{
-					"from_ts": 1613260800,
-					"listen_count": 46,
-					"time_range": "14 February 2021",
-					"to_ts": 1613347199
-				},
-				{
-					"from_ts": 1613347200,
-					"listen_count": 3,
-					"time_range": "15 February 2021",
-					"to_ts": 1613433599
-				},
-				{
-					"from_ts": 1613433600,
-					"listen_count": 21,
-					"time_range": "16 February 2021",
-					"to_ts": 1613519999
-				},
-				{
-					"from_ts": 1613520000,
-					"listen_count": 33,
-					"time_range": "17 February 2021",
-					"to_ts": 1613606399
-				},
-				{
-					"from_ts": 1613606400,
-					"listen_count": 0,
-					"time_range": "18 February 2021",
-					"to_ts": 1613692799
-				},
-				{
-					"from_ts": 1613692800,
-					"listen_count": 19,
-					"time_range": "19 February 2021",
-					"to_ts": 1613779199
-				},
-				{
-					"from_ts": 1613779200,
-					"listen_count": 0,
-					"time_range": "20 February 2021",
-					"to_ts": 1613865599
-				},
-				{
-					"from_ts": 1613865600,
-					"listen_count": 19,
-					"time_range": "21 February 2021",
-					"to_ts": 1613951999
-				},
-				{
-					"from_ts": 1613952000,
-					"listen_count": 0,
-					"time_range": "22 February 2021",
-					"to_ts": 1614038399
-				},
-				{
-					"from_ts": 1614038400,
-					"listen_count": 0,
-					"time_range": "23 February 2021",
-					"to_ts": 1614124799
-				},
-				{
-					"from_ts": 1614124800,
-					"listen_count": 0,
-					"time_range": "24 February 2021",
-					"to_ts": 1614211199
-				},
-				{
-					"from_ts": 1614211200,
-					"listen_count": 19,
-					"time_range": "25 February 2021",
-					"to_ts": 1614297599
-				},
-				{
-					"from_ts": 1614297600,
-					"listen_count": 3,
-					"time_range": "26 February 2021",
-					"to_ts": 1614383999
-				},
-				{
-					"from_ts": 1614384000,
-					"listen_count": 16,
-					"time_range": "27 February 2021",
-					"to_ts": 1614470399
-				},
-				{
-					"from_ts": 1614470400,
-					"listen_count": 29,
-					"time_range": "28 February 2021",
-					"to_ts": 1614556799
-				},
-				{
-					"from_ts": 1614556800,
-					"listen_count": 7,
-					"time_range": "01 March 2021",
-					"to_ts": 1614643199
-				},
-				{
-					"from_ts": 1614643200,
-					"listen_count": 15,
-					"time_range": "02 March 2021",
-					"to_ts": 1614729599
-				},
-				{
-					"from_ts": 1614729600,
-					"listen_count": 7,
-					"time_range": "03 March 2021",
-					"to_ts": 1614815999
-				},
-				{
-					"from_ts": 1614816000,
-					"listen_count": 5,
-					"time_range": "04 March 2021",
-					"to_ts": 1614902399
-				},
-				{
-					"from_ts": 1614902400,
-					"listen_count": 4,
-					"time_range": "05 March 2021",
-					"to_ts": 1614988799
-				},
-				{
-					"from_ts": 1614988800,
-					"listen_count": 13,
-					"time_range": "06 March 2021",
-					"to_ts": 1615075199
-				},
-				{
-					"from_ts": 1615075200,
-					"listen_count": 7,
-					"time_range": "07 March 2021",
-					"to_ts": 1615161599
-				},
-				{
-					"from_ts": 1615161600,
-					"listen_count": 20,
-					"time_range": "08 March 2021",
-					"to_ts": 1615247999
-				},
-				{
-					"from_ts": 1615248000,
-					"listen_count": 7,
-					"time_range": "09 March 2021",
-					"to_ts": 1615334399
-				},
-				{
-					"from_ts": 1615334400,
-					"listen_count": 18,
-					"time_range": "10 March 2021",
-					"to_ts": 1615420799
-				},
-				{
-					"from_ts": 1615420800,
-					"listen_count": 26,
-					"time_range": "11 March 2021",
-					"to_ts": 1615507199
-				},
-				{
-					"from_ts": 1615507200,
-					"listen_count": 10,
-					"time_range": "12 March 2021",
-					"to_ts": 1615593599
-				},
-				{
-					"from_ts": 1615593600,
-					"listen_count": 0,
-					"time_range": "13 March 2021",
-					"to_ts": 1615679999
-				},
-				{
-					"from_ts": 1615680000,
-					"listen_count": 7,
-					"time_range": "14 March 2021",
-					"to_ts": 1615766399
-				},
-				{
-					"from_ts": 1615766400,
-					"listen_count": 0,
-					"time_range": "15 March 2021",
-					"to_ts": 1615852799
-				},
-				{
-					"from_ts": 1615852800,
-					"listen_count": 0,
-					"time_range": "16 March 2021",
-					"to_ts": 1615939199
-				},
-				{
-					"from_ts": 1615939200,
-					"listen_count": 31,
-					"time_range": "17 March 2021",
-					"to_ts": 1616025599
-				},
-				{
-					"from_ts": 1616025600,
-					"listen_count": 8,
-					"time_range": "18 March 2021",
-					"to_ts": 1616111999
-				},
-				{
-					"from_ts": 1616112000,
-					"listen_count": 0,
-					"time_range": "19 March 2021",
-					"to_ts": 1616198399
-				},
-				{
-					"from_ts": 1616198400,
-					"listen_count": 1,
-					"time_range": "20 March 2021",
-					"to_ts": 1616284799
-				},
-				{
-					"from_ts": 1616284800,
-					"listen_count": 0,
-					"time_range": "21 March 2021",
-					"to_ts": 1616371199
-				},
-				{
-					"from_ts": 1616371200,
-					"listen_count": 0,
-					"time_range": "22 March 2021",
-					"to_ts": 1616457599
-				},
-				{
-					"from_ts": 1616457600,
-					"listen_count": 0,
-					"time_range": "23 March 2021",
-					"to_ts": 1616543999
-				},
-				{
-					"from_ts": 1616544000,
-					"listen_count": 12,
-					"time_range": "24 March 2021",
-					"to_ts": 1616630399
-				},
-				{
-					"from_ts": 1616630400,
-					"listen_count": 0,
-					"time_range": "25 March 2021",
-					"to_ts": 1616716799
-				},
-				{
-					"from_ts": 1616716800,
-					"listen_count": 14,
-					"time_range": "26 March 2021",
-					"to_ts": 1616803199
-				},
-				{
-					"from_ts": 1616803200,
-					"listen_count": 0,
-					"time_range": "27 March 2021",
-					"to_ts": 1616889599
-				},
-				{
-					"from_ts": 1616889600,
-					"listen_count": 0,
-					"time_range": "28 March 2021",
-					"to_ts": 1616975999
-				},
-				{
-					"from_ts": 1616976000,
-					"listen_count": 0,
-					"time_range": "29 March 2021",
-					"to_ts": 1617062399
-				},
-				{
-					"from_ts": 1617062400,
-					"listen_count": 3,
-					"time_range": "30 March 2021",
-					"to_ts": 1617148799
-				},
-				{
-					"from_ts": 1617148800,
-					"listen_count": 0,
-					"time_range": "31 March 2021",
-					"to_ts": 1617235199
-				},
-				{
-					"from_ts": 1617235200,
-					"listen_count": 8,
-					"time_range": "01 April 2021",
-					"to_ts": 1617321599
-				},
-				{
-					"from_ts": 1617321600,
-					"listen_count": 18,
-					"time_range": "02 April 2021",
-					"to_ts": 1617407999
-				},
-				{
-					"from_ts": 1617408000,
-					"listen_count": 3,
-					"time_range": "03 April 2021",
-					"to_ts": 1617494399
-				},
-				{
-					"from_ts": 1617494400,
-					"listen_count": 41,
-					"time_range": "04 April 2021",
-					"to_ts": 1617580799
-				},
-				{
-					"from_ts": 1617580800,
-					"listen_count": 0,
-					"time_range": "05 April 2021",
-					"to_ts": 1617667199
-				},
-				{
-					"from_ts": 1617667200,
-					"listen_count": 11,
-					"time_range": "06 April 2021",
-					"to_ts": 1617753599
-				},
-				{
-					"from_ts": 1617753600,
-					"listen_count": 8,
-					"time_range": "07 April 2021",
-					"to_ts": 1617839999
-				},
-				{
-					"from_ts": 1617840000,
-					"listen_count": 9,
-					"time_range": "08 April 2021",
-					"to_ts": 1617926399
-				},
-				{
-					"from_ts": 1617926400,
-					"listen_count": 27,
-					"time_range": "09 April 2021",
-					"to_ts": 1618012799
-				},
-				{
-					"from_ts": 1618012800,
-					"listen_count": 0,
-					"time_range": "10 April 2021",
-					"to_ts": 1618099199
-				},
-				{
-					"from_ts": 1618099200,
-					"listen_count": 1,
-					"time_range": "11 April 2021",
-					"to_ts": 1618185599
-				},
-				{
-					"from_ts": 1618185600,
-					"listen_count": 13,
-					"time_range": "12 April 2021",
-					"to_ts": 1618271999
-				},
-				{
-					"from_ts": 1618272000,
-					"listen_count": 103,
-					"time_range": "13 April 2021",
-					"to_ts": 1618358399
-				},
-				{
-					"from_ts": 1618358400,
-					"listen_count": 2,
-					"time_range": "14 April 2021",
-					"to_ts": 1618444799
-				},
-				{
-					"from_ts": 1618444800,
-					"listen_count": 2,
-					"time_range": "15 April 2021",
-					"to_ts": 1618531199
-				},
-				{
-					"from_ts": 1618531200,
-					"listen_count": 41,
-					"time_range": "16 April 2021",
-					"to_ts": 1618617599
-				},
-				{
-					"from_ts": 1618617600,
-					"listen_count": 0,
-					"time_range": "17 April 2021",
-					"to_ts": 1618703999
-				},
-				{
-					"from_ts": 1618704000,
-					"listen_count": 0,
-					"time_range": "18 April 2021",
-					"to_ts": 1618790399
-				},
-				{
-					"from_ts": 1618790400,
-					"listen_count": 18,
-					"time_range": "19 April 2021",
-					"to_ts": 1618876799
-				},
-				{
-					"from_ts": 1618876800,
-					"listen_count": 23,
-					"time_range": "20 April 2021",
-					"to_ts": 1618963199
-				},
-				{
-					"from_ts": 1618963200,
-					"listen_count": 0,
-					"time_range": "21 April 2021",
-					"to_ts": 1619049599
-				},
-				{
-					"from_ts": 1619049600,
-					"listen_count": 0,
-					"time_range": "22 April 2021",
-					"to_ts": 1619135999
-				},
-				{
-					"from_ts": 1619136000,
-					"listen_count": 6,
-					"time_range": "23 April 2021",
-					"to_ts": 1619222399
-				},
-				{
-					"from_ts": 1619222400,
-					"listen_count": 0,
-					"time_range": "24 April 2021",
-					"to_ts": 1619308799
-				},
-				{
-					"from_ts": 1619308800,
-					"listen_count": 0,
-					"time_range": "25 April 2021",
-					"to_ts": 1619395199
-				},
-				{
-					"from_ts": 1619395200,
-					"listen_count": 0,
-					"time_range": "26 April 2021",
-					"to_ts": 1619481599
-				},
-				{
-					"from_ts": 1619481600,
-					"listen_count": 28,
-					"time_range": "27 April 2021",
-					"to_ts": 1619567999
-				},
-				{
-					"from_ts": 1619568000,
-					"listen_count": 8,
-					"time_range": "28 April 2021",
-					"to_ts": 1619654399
-				},
-				{
-					"from_ts": 1619654400,
-					"listen_count": 16,
-					"time_range": "29 April 2021",
-					"to_ts": 1619740799
-				},
-				{
-					"from_ts": 1619740800,
-					"listen_count": 0,
-					"time_range": "30 April 2021",
-					"to_ts": 1619827199
-				},
-				{
-					"from_ts": 1619827200,
-					"listen_count": 0,
-					"time_range": "01 May 2021",
-					"to_ts": 1619913599
-				},
-				{
-					"from_ts": 1619913600,
-					"listen_count": 12,
-					"time_range": "02 May 2021",
-					"to_ts": 1619999999
-				},
-				{
-					"from_ts": 1620000000,
-					"listen_count": 35,
-					"time_range": "03 May 2021",
-					"to_ts": 1620086399
-				},
-				{
-					"from_ts": 1620086400,
-					"listen_count": 7,
-					"time_range": "04 May 2021",
-					"to_ts": 1620172799
-				},
-				{
-					"from_ts": 1620172800,
-					"listen_count": 0,
-					"time_range": "05 May 2021",
-					"to_ts": 1620259199
-				},
-				{
-					"from_ts": 1620259200,
-					"listen_count": 43,
-					"time_range": "06 May 2021",
-					"to_ts": 1620345599
-				},
-				{
-					"from_ts": 1620345600,
-					"listen_count": 2,
-					"time_range": "07 May 2021",
-					"to_ts": 1620431999
-				},
-				{
-					"from_ts": 1620432000,
-					"listen_count": 0,
-					"time_range": "08 May 2021",
-					"to_ts": 1620518399
-				},
-				{
-					"from_ts": 1620518400,
-					"listen_count": 5,
-					"time_range": "09 May 2021",
-					"to_ts": 1620604799
-				},
-				{
-					"from_ts": 1620604800,
-					"listen_count": 29,
-					"time_range": "10 May 2021",
-					"to_ts": 1620691199
-				},
-				{
-					"from_ts": 1620691200,
-					"listen_count": 19,
-					"time_range": "11 May 2021",
-					"to_ts": 1620777599
-				},
-				{
-					"from_ts": 1620777600,
-					"listen_count": 44,
-					"time_range": "12 May 2021",
-					"to_ts": 1620863999
-				},
-				{
-					"from_ts": 1620864000,
-					"listen_count": 34,
-					"time_range": "13 May 2021",
-					"to_ts": 1620950399
-				},
-				{
-					"from_ts": 1620950400,
-					"listen_count": 51,
-					"time_range": "14 May 2021",
-					"to_ts": 1621036799
-				},
-				{
-					"from_ts": 1621036800,
-					"listen_count": 0,
-					"time_range": "15 May 2021",
-					"to_ts": 1621123199
-				},
-				{
-					"from_ts": 1621123200,
-					"listen_count": 0,
-					"time_range": "16 May 2021",
-					"to_ts": 1621209599
-				},
-				{
-					"from_ts": 1621209600,
-					"listen_count": 12,
-					"time_range": "17 May 2021",
-					"to_ts": 1621295999
-				},
-				{
-					"from_ts": 1621296000,
-					"listen_count": 0,
-					"time_range": "18 May 2021",
-					"to_ts": 1621382399
-				},
-				{
-					"from_ts": 1621382400,
-					"listen_count": 19,
-					"time_range": "19 May 2021",
-					"to_ts": 1621468799
-				},
-				{
-					"from_ts": 1621468800,
-					"listen_count": 0,
-					"time_range": "20 May 2021",
-					"to_ts": 1621555199
-				},
-				{
-					"from_ts": 1621555200,
-					"listen_count": 0,
-					"time_range": "21 May 2021",
-					"to_ts": 1621641599
-				},
-				{
-					"from_ts": 1621641600,
-					"listen_count": 0,
-					"time_range": "22 May 2021",
-					"to_ts": 1621727999
-				},
-				{
-					"from_ts": 1621728000,
-					"listen_count": 9,
-					"time_range": "23 May 2021",
-					"to_ts": 1621814399
-				},
-				{
-					"from_ts": 1621814400,
-					"listen_count": 18,
-					"time_range": "24 May 2021",
-					"to_ts": 1621900799
-				},
-				{
-					"from_ts": 1621900800,
-					"listen_count": 17,
-					"time_range": "25 May 2021",
-					"to_ts": 1621987199
-				},
-				{
-					"from_ts": 1621987200,
-					"listen_count": 0,
-					"time_range": "26 May 2021",
-					"to_ts": 1622073599
-				},
-				{
-					"from_ts": 1622073600,
-					"listen_count": 80,
-					"time_range": "27 May 2021",
-					"to_ts": 1622159999
-				},
-				{
-					"from_ts": 1622160000,
-					"listen_count": 0,
-					"time_range": "28 May 2021",
-					"to_ts": 1622246399
-				},
-				{
-					"from_ts": 1622246400,
-					"listen_count": 0,
-					"time_range": "29 May 2021",
-					"to_ts": 1622332799
-				},
-				{
-					"from_ts": 1622332800,
-					"listen_count": 0,
-					"time_range": "30 May 2021",
-					"to_ts": 1622419199
-				},
-				{
-					"from_ts": 1622419200,
-					"listen_count": 0,
-					"time_range": "31 May 2021",
-					"to_ts": 1622505599
-				},
-				{
-					"from_ts": 1622505600,
-					"listen_count": 5,
-					"time_range": "01 June 2021",
-					"to_ts": 1622591999
-				},
-				{
-					"from_ts": 1622592000,
-					"listen_count": 0,
-					"time_range": "02 June 2021",
-					"to_ts": 1622678399
-				},
-				{
-					"from_ts": 1622678400,
-					"listen_count": 0,
-					"time_range": "03 June 2021",
-					"to_ts": 1622764799
-				},
-				{
-					"from_ts": 1622764800,
-					"listen_count": 24,
-					"time_range": "04 June 2021",
-					"to_ts": 1622851199
-				},
-				{
-					"from_ts": 1622851200,
-					"listen_count": 0,
-					"time_range": "05 June 2021",
-					"to_ts": 1622937599
-				},
-				{
-					"from_ts": 1622937600,
-					"listen_count": 0,
-					"time_range": "06 June 2021",
-					"to_ts": 1623023999
-				},
-				{
-					"from_ts": 1623024000,
-					"listen_count": 0,
-					"time_range": "07 June 2021",
-					"to_ts": 1623110399
-				},
-				{
-					"from_ts": 1623110400,
-					"listen_count": 0,
-					"time_range": "08 June 2021",
-					"to_ts": 1623196799
-				},
-				{
-					"from_ts": 1623196800,
-					"listen_count": 6,
-					"time_range": "09 June 2021",
-					"to_ts": 1623283199
-				},
-				{
-					"from_ts": 1623283200,
-					"listen_count": 17,
-					"time_range": "10 June 2021",
-					"to_ts": 1623369599
-				},
-				{
-					"from_ts": 1623369600,
-					"listen_count": 0,
-					"time_range": "11 June 2021",
-					"to_ts": 1623455999
-				},
-				{
-					"from_ts": 1623456000,
-					"listen_count": 0,
-					"time_range": "12 June 2021",
-					"to_ts": 1623542399
-				},
-				{
-					"from_ts": 1623542400,
-					"listen_count": 0,
-					"time_range": "13 June 2021",
-					"to_ts": 1623628799
-				},
-				{
-					"from_ts": 1623628800,
-					"listen_count": 0,
-					"time_range": "14 June 2021",
-					"to_ts": 1623715199
-				},
-				{
-					"from_ts": 1623715200,
-					"listen_count": 0,
-					"time_range": "15 June 2021",
-					"to_ts": 1623801599
-				},
-				{
-					"from_ts": 1623801600,
-					"listen_count": 1,
-					"time_range": "16 June 2021",
-					"to_ts": 1623887999
-				},
-				{
-					"from_ts": 1623888000,
-					"listen_count": 4,
-					"time_range": "17 June 2021",
-					"to_ts": 1623974399
-				},
-				{
-					"from_ts": 1623974400,
-					"listen_count": 0,
-					"time_range": "18 June 2021",
-					"to_ts": 1624060799
-				},
-				{
-					"from_ts": 1624060800,
-					"listen_count": 0,
-					"time_range": "19 June 2021",
-					"to_ts": 1624147199
-				},
-				{
-					"from_ts": 1624147200,
-					"listen_count": 0,
-					"time_range": "20 June 2021",
-					"to_ts": 1624233599
-				},
-				{
-					"from_ts": 1624233600,
-					"listen_count": 1,
-					"time_range": "21 June 2021",
-					"to_ts": 1624319999
-				},
-				{
-					"from_ts": 1624320000,
-					"listen_count": 0,
-					"time_range": "22 June 2021",
-					"to_ts": 1624406399
-				},
-				{
-					"from_ts": 1624406400,
-					"listen_count": 0,
-					"time_range": "23 June 2021",
-					"to_ts": 1624492799
-				},
-				{
-					"from_ts": 1624492800,
-					"listen_count": 0,
-					"time_range": "24 June 2021",
-					"to_ts": 1624579199
-				},
-				{
-					"from_ts": 1624579200,
-					"listen_count": 0,
-					"time_range": "25 June 2021",
-					"to_ts": 1624665599
-				},
-				{
-					"from_ts": 1624665600,
-					"listen_count": 0,
-					"time_range": "26 June 2021",
-					"to_ts": 1624751999
-				},
-				{
-					"from_ts": 1624752000,
-					"listen_count": 25,
-					"time_range": "27 June 2021",
-					"to_ts": 1624838399
-				},
-				{
-					"from_ts": 1624838400,
-					"listen_count": 0,
-					"time_range": "28 June 2021",
-					"to_ts": 1624924799
-				},
-				{
-					"from_ts": 1624924800,
-					"listen_count": 0,
-					"time_range": "29 June 2021",
-					"to_ts": 1625011199
-				},
-				{
-					"from_ts": 1625011200,
-					"listen_count": 0,
-					"time_range": "30 June 2021",
-					"to_ts": 1625097599
-				},
-				{
-					"from_ts": 1625097600,
-					"listen_count": 0,
-					"time_range": "01 July 2021",
-					"to_ts": 1625183999
-				},
-				{
-					"from_ts": 1625184000,
-					"listen_count": 1,
-					"time_range": "02 July 2021",
-					"to_ts": 1625270399
-				},
-				{
-					"from_ts": 1625270400,
-					"listen_count": 0,
-					"time_range": "03 July 2021",
-					"to_ts": 1625356799
-				},
-				{
-					"from_ts": 1625356800,
-					"listen_count": 0,
-					"time_range": "04 July 2021",
-					"to_ts": 1625443199
-				},
-				{
-					"from_ts": 1625443200,
-					"listen_count": 0,
-					"time_range": "05 July 2021",
-					"to_ts": 1625529599
-				},
-				{
-					"from_ts": 1625529600,
-					"listen_count": 0,
-					"time_range": "06 July 2021",
-					"to_ts": 1625615999
-				},
-				{
-					"from_ts": 1625616000,
-					"listen_count": 0,
-					"time_range": "07 July 2021",
-					"to_ts": 1625702399
-				},
-				{
-					"from_ts": 1625702400,
-					"listen_count": 2,
-					"time_range": "08 July 2021",
-					"to_ts": 1625788799
-				},
-				{
-					"from_ts": 1625788800,
-					"listen_count": 11,
-					"time_range": "09 July 2021",
-					"to_ts": 1625875199
-				},
-				{
-					"from_ts": 1625875200,
-					"listen_count": 13,
-					"time_range": "10 July 2021",
-					"to_ts": 1625961599
-				},
-				{
-					"from_ts": 1625961600,
-					"listen_count": 0,
-					"time_range": "11 July 2021",
-					"to_ts": 1626047999
-				},
-				{
-					"from_ts": 1626048000,
-					"listen_count": 0,
-					"time_range": "12 July 2021",
-					"to_ts": 1626134399
-				},
-				{
-					"from_ts": 1626134400,
-					"listen_count": 0,
-					"time_range": "13 July 2021",
-					"to_ts": 1626220799
-				},
-				{
-					"from_ts": 1626220800,
-					"listen_count": 0,
-					"time_range": "14 July 2021",
-					"to_ts": 1626307199
-				},
-				{
-					"from_ts": 1626307200,
-					"listen_count": 0,
-					"time_range": "15 July 2021",
-					"to_ts": 1626393599
-				},
-				{
-					"from_ts": 1626393600,
-					"listen_count": 13,
-					"time_range": "16 July 2021",
-					"to_ts": 1626479999
-				},
-				{
-					"from_ts": 1626480000,
-					"listen_count": 0,
-					"time_range": "17 July 2021",
-					"to_ts": 1626566399
-				},
-				{
-					"from_ts": 1626566400,
-					"listen_count": 0,
-					"time_range": "18 July 2021",
-					"to_ts": 1626652799
-				},
-				{
-					"from_ts": 1626652800,
-					"listen_count": 4,
-					"time_range": "19 July 2021",
-					"to_ts": 1626739199
-				},
-				{
-					"from_ts": 1626739200,
-					"listen_count": 4,
-					"time_range": "20 July 2021",
-					"to_ts": 1626825599
-				},
-				{
-					"from_ts": 1626825600,
-					"listen_count": 29,
-					"time_range": "21 July 2021",
-					"to_ts": 1626911999
-				},
-				{
-					"from_ts": 1626912000,
-					"listen_count": 3,
-					"time_range": "22 July 2021",
-					"to_ts": 1626998399
-				},
-				{
-					"from_ts": 1626998400,
-					"listen_count": 3,
-					"time_range": "23 July 2021",
-					"to_ts": 1627084799
-				},
-				{
-					"from_ts": 1627084800,
-					"listen_count": 0,
-					"time_range": "24 July 2021",
-					"to_ts": 1627171199
-				},
-				{
-					"from_ts": 1627171200,
-					"listen_count": 0,
-					"time_range": "25 July 2021",
-					"to_ts": 1627257599
-				},
-				{
-					"from_ts": 1627257600,
-					"listen_count": 0,
-					"time_range": "26 July 2021",
-					"to_ts": 1627343999
-				},
-				{
-					"from_ts": 1627344000,
-					"listen_count": 0,
-					"time_range": "27 July 2021",
-					"to_ts": 1627430399
-				},
-				{
-					"from_ts": 1627430400,
-					"listen_count": 0,
-					"time_range": "28 July 2021",
-					"to_ts": 1627516799
-				},
-				{
-					"from_ts": 1627516800,
-					"listen_count": 0,
-					"time_range": "29 July 2021",
-					"to_ts": 1627603199
-				},
-				{
-					"from_ts": 1627603200,
-					"listen_count": 0,
-					"time_range": "30 July 2021",
-					"to_ts": 1627689599
-				},
-				{
-					"from_ts": 1627689600,
-					"listen_count": 0,
-					"time_range": "31 July 2021",
-					"to_ts": 1627775999
-				},
-				{
-					"from_ts": 1627776000,
-					"listen_count": 0,
-					"time_range": "01 August 2021",
-					"to_ts": 1627862399
-				},
-				{
-					"from_ts": 1627862400,
-					"listen_count": 0,
-					"time_range": "02 August 2021",
-					"to_ts": 1627948799
-				},
-				{
-					"from_ts": 1627948800,
-					"listen_count": 0,
-					"time_range": "03 August 2021",
-					"to_ts": 1628035199
-				},
-				{
-					"from_ts": 1628035200,
-					"listen_count": 0,
-					"time_range": "04 August 2021",
-					"to_ts": 1628121599
-				},
-				{
-					"from_ts": 1628121600,
-					"listen_count": 0,
-					"time_range": "05 August 2021",
-					"to_ts": 1628207999
-				},
-				{
-					"from_ts": 1628208000,
-					"listen_count": 0,
-					"time_range": "06 August 2021",
-					"to_ts": 1628294399
-				},
-				{
-					"from_ts": 1628294400,
-					"listen_count": 0,
-					"time_range": "07 August 2021",
-					"to_ts": 1628380799
-				},
-				{
-					"from_ts": 1628380800,
-					"listen_count": 0,
-					"time_range": "08 August 2021",
-					"to_ts": 1628467199
-				},
-				{
-					"from_ts": 1628467200,
-					"listen_count": 0,
-					"time_range": "09 August 2021",
-					"to_ts": 1628553599
-				},
-				{
-					"from_ts": 1628553600,
-					"listen_count": 0,
-					"time_range": "10 August 2021",
-					"to_ts": 1628639999
-				},
-				{
-					"from_ts": 1628640000,
-					"listen_count": 0,
-					"time_range": "11 August 2021",
-					"to_ts": 1628726399
-				},
-				{
-					"from_ts": 1628726400,
-					"listen_count": 0,
-					"time_range": "12 August 2021",
-					"to_ts": 1628812799
-				},
-				{
-					"from_ts": 1628812800,
-					"listen_count": 0,
-					"time_range": "13 August 2021",
-					"to_ts": 1628899199
-				},
-				{
-					"from_ts": 1628899200,
-					"listen_count": 0,
-					"time_range": "14 August 2021",
-					"to_ts": 1628985599
-				},
-				{
-					"from_ts": 1628985600,
-					"listen_count": 0,
-					"time_range": "15 August 2021",
-					"to_ts": 1629071999
-				},
-				{
-					"from_ts": 1629072000,
-					"listen_count": 0,
-					"time_range": "16 August 2021",
-					"to_ts": 1629158399
-				},
-				{
-					"from_ts": 1629158400,
-					"listen_count": 0,
-					"time_range": "17 August 2021",
-					"to_ts": 1629244799
-				},
-				{
-					"from_ts": 1629244800,
-					"listen_count": 0,
-					"time_range": "18 August 2021",
-					"to_ts": 1629331199
-				},
-				{
-					"from_ts": 1629331200,
-					"listen_count": 0,
-					"time_range": "19 August 2021",
-					"to_ts": 1629417599
-				},
-				{
-					"from_ts": 1629417600,
-					"listen_count": 0,
-					"time_range": "20 August 2021",
-					"to_ts": 1629503999
-				},
-				{
-					"from_ts": 1629504000,
-					"listen_count": 0,
-					"time_range": "21 August 2021",
-					"to_ts": 1629590399
-				},
-				{
-					"from_ts": 1629590400,
-					"listen_count": 0,
-					"time_range": "22 August 2021",
-					"to_ts": 1629676799
-				},
-				{
-					"from_ts": 1629676800,
-					"listen_count": 0,
-					"time_range": "23 August 2021",
-					"to_ts": 1629763199
-				},
-				{
-					"from_ts": 1629763200,
-					"listen_count": 0,
-					"time_range": "24 August 2021",
-					"to_ts": 1629849599
-				},
-				{
-					"from_ts": 1629849600,
-					"listen_count": 0,
-					"time_range": "25 August 2021",
-					"to_ts": 1629935999
-				},
-				{
-					"from_ts": 1629936000,
-					"listen_count": 4,
-					"time_range": "26 August 2021",
-					"to_ts": 1630022399
-				},
-				{
-					"from_ts": 1630022400,
-					"listen_count": 1,
-					"time_range": "27 August 2021",
-					"to_ts": 1630108799
-				},
-				{
-					"from_ts": 1630108800,
-					"listen_count": 0,
-					"time_range": "28 August 2021",
-					"to_ts": 1630195199
-				},
-				{
-					"from_ts": 1630195200,
-					"listen_count": 0,
-					"time_range": "29 August 2021",
-					"to_ts": 1630281599
-				},
-				{
-					"from_ts": 1630281600,
-					"listen_count": 2,
-					"time_range": "30 August 2021",
-					"to_ts": 1630367999
-				},
-				{
-					"from_ts": 1630368000,
-					"listen_count": 0,
-					"time_range": "31 August 2021",
-					"to_ts": 1630454399
-				},
-				{
-					"from_ts": 1630454400,
-					"listen_count": 14,
-					"time_range": "01 September 2021",
-					"to_ts": 1630540799
-				},
-				{
-					"from_ts": 1630540800,
-					"listen_count": 0,
-					"time_range": "02 September 2021",
-					"to_ts": 1630627199
-				},
-				{
-					"from_ts": 1630627200,
-					"listen_count": 29,
-					"time_range": "03 September 2021",
-					"to_ts": 1630713599
-				},
-				{
-					"from_ts": 1630713600,
-					"listen_count": 0,
-					"time_range": "04 September 2021",
-					"to_ts": 1630799999
-				},
-				{
-					"from_ts": 1630800000,
-					"listen_count": 0,
-					"time_range": "05 September 2021",
-					"to_ts": 1630886399
-				},
-				{
-					"from_ts": 1630886400,
-					"listen_count": 27,
-					"time_range": "06 September 2021",
-					"to_ts": 1630972799
-				},
-				{
-					"from_ts": 1630972800,
-					"listen_count": 5,
-					"time_range": "07 September 2021",
-					"to_ts": 1631059199
-				},
-				{
-					"from_ts": 1631059200,
-					"listen_count": 0,
-					"time_range": "08 September 2021",
-					"to_ts": 1631145599
-				},
-				{
-					"from_ts": 1631145600,
-					"listen_count": 13,
-					"time_range": "09 September 2021",
-					"to_ts": 1631231999
-				},
-				{
-					"from_ts": 1631232000,
-					"listen_count": 4,
-					"time_range": "10 September 2021",
-					"to_ts": 1631318399
-				},
-				{
-					"from_ts": 1631318400,
-					"listen_count": 0,
-					"time_range": "11 September 2021",
-					"to_ts": 1631404799
-				},
-				{
-					"from_ts": 1631404800,
-					"listen_count": 0,
-					"time_range": "12 September 2021",
-					"to_ts": 1631491199
-				},
-				{
-					"from_ts": 1631491200,
-					"listen_count": 0,
-					"time_range": "13 September 2021",
-					"to_ts": 1631577599
-				},
-				{
-					"from_ts": 1631577600,
-					"listen_count": 14,
-					"time_range": "14 September 2021",
-					"to_ts": 1631663999
-				},
-				{
-					"from_ts": 1631664000,
-					"listen_count": 7,
-					"time_range": "15 September 2021",
-					"to_ts": 1631750399
-				},
-				{
-					"from_ts": 1631750400,
-					"listen_count": 4,
-					"time_range": "16 September 2021",
-					"to_ts": 1631836799
-				},
-				{
-					"from_ts": 1631836800,
-					"listen_count": 0,
-					"time_range": "17 September 2021",
-					"to_ts": 1631923199
-				},
-				{
-					"from_ts": 1631923200,
-					"listen_count": 0,
-					"time_range": "18 September 2021",
-					"to_ts": 1632009599
-				},
-				{
-					"from_ts": 1632009600,
-					"listen_count": 0,
-					"time_range": "19 September 2021",
-					"to_ts": 1632095999
-				},
-				{
-					"from_ts": 1632096000,
-					"listen_count": 2,
-					"time_range": "20 September 2021",
-					"to_ts": 1632182399
-				},
-				{
-					"from_ts": 1632182400,
-					"listen_count": 0,
-					"time_range": "21 September 2021",
-					"to_ts": 1632268799
-				},
-				{
-					"from_ts": 1632268800,
-					"listen_count": 0,
-					"time_range": "22 September 2021",
-					"to_ts": 1632355199
-				},
-				{
-					"from_ts": 1632355200,
-					"listen_count": 11,
-					"time_range": "23 September 2021",
-					"to_ts": 1632441599
-				},
-				{
-					"from_ts": 1632441600,
-					"listen_count": 15,
-					"time_range": "24 September 2021",
-					"to_ts": 1632527999
-				},
-				{
-					"from_ts": 1632528000,
-					"listen_count": 1,
-					"time_range": "25 September 2021",
-					"to_ts": 1632614399
-				},
-				{
-					"from_ts": 1632614400,
-					"listen_count": 0,
-					"time_range": "26 September 2021",
-					"to_ts": 1632700799
-				},
-				{
-					"from_ts": 1632700800,
-					"listen_count": 6,
-					"time_range": "27 September 2021",
-					"to_ts": 1632787199
-				},
-				{
-					"from_ts": 1632787200,
-					"listen_count": 17,
-					"time_range": "28 September 2021",
-					"to_ts": 1632873599
-				},
-				{
-					"from_ts": 1632873600,
-					"listen_count": 18,
-					"time_range": "29 September 2021",
-					"to_ts": 1632959999
-				},
-				{
-					"from_ts": 1632960000,
-					"listen_count": 2,
-					"time_range": "30 September 2021",
-					"to_ts": 1633046399
-				},
-				{
-					"from_ts": 1633046400,
-					"listen_count": 0,
-					"time_range": "01 October 2021",
-					"to_ts": 1633132799
-				},
-				{
-					"from_ts": 1633132800,
-					"listen_count": 0,
-					"time_range": "02 October 2021",
-					"to_ts": 1633219199
-				},
-				{
-					"from_ts": 1633219200,
-					"listen_count": 49,
-					"time_range": "03 October 2021",
-					"to_ts": 1633305599
-				},
-				{
-					"from_ts": 1633305600,
-					"listen_count": 27,
-					"time_range": "04 October 2021",
-					"to_ts": 1633391999
-				},
-				{
-					"from_ts": 1633392000,
-					"listen_count": 13,
-					"time_range": "05 October 2021",
-					"to_ts": 1633478399
-				},
-				{
-					"from_ts": 1633478400,
-					"listen_count": 17,
-					"time_range": "06 October 2021",
-					"to_ts": 1633564799
-				},
-				{
-					"from_ts": 1633564800,
-					"listen_count": 13,
-					"time_range": "07 October 2021",
-					"to_ts": 1633651199
-				},
-				{
-					"from_ts": 1633651200,
-					"listen_count": 1,
-					"time_range": "08 October 2021",
-					"to_ts": 1633737599
-				},
-				{
-					"from_ts": 1633737600,
-					"listen_count": 0,
-					"time_range": "09 October 2021",
-					"to_ts": 1633823999
-				},
-				{
-					"from_ts": 1633824000,
-					"listen_count": 2,
-					"time_range": "10 October 2021",
-					"to_ts": 1633910399
-				},
-				{
-					"from_ts": 1633910400,
-					"listen_count": 0,
-					"time_range": "11 October 2021",
-					"to_ts": 1633996799
-				},
-				{
-					"from_ts": 1633996800,
-					"listen_count": 0,
-					"time_range": "12 October 2021",
-					"to_ts": 1634083199
-				},
-				{
-					"from_ts": 1634083200,
-					"listen_count": 0,
-					"time_range": "13 October 2021",
-					"to_ts": 1634169599
-				},
-				{
-					"from_ts": 1634169600,
-					"listen_count": 2,
-					"time_range": "14 October 2021",
-					"to_ts": 1634255999
-				},
-				{
-					"from_ts": 1634256000,
-					"listen_count": 0,
-					"time_range": "15 October 2021",
-					"to_ts": 1634342399
-				},
-				{
-					"from_ts": 1634342400,
-					"listen_count": 2,
-					"time_range": "16 October 2021",
-					"to_ts": 1634428799
-				},
-				{
-					"from_ts": 1634428800,
-					"listen_count": 1,
-					"time_range": "17 October 2021",
-					"to_ts": 1634515199
-				},
-				{
-					"from_ts": 1634515200,
-					"listen_count": 8,
-					"time_range": "18 October 2021",
-					"to_ts": 1634601599
-				},
-				{
-					"from_ts": 1634601600,
-					"listen_count": 0,
-					"time_range": "19 October 2021",
-					"to_ts": 1634687999
-				},
-				{
-					"from_ts": 1634688000,
-					"listen_count": 17,
-					"time_range": "20 October 2021",
-					"to_ts": 1634774399
-				},
-				{
-					"from_ts": 1634774400,
-					"listen_count": 2,
-					"time_range": "21 October 2021",
-					"to_ts": 1634860799
-				},
-				{
-					"from_ts": 1634860800,
-					"listen_count": 13,
-					"time_range": "22 October 2021",
-					"to_ts": 1634947199
-				},
-				{
-					"from_ts": 1634947200,
-					"listen_count": 5,
-					"time_range": "23 October 2021",
-					"to_ts": 1635033599
-				},
-				{
-					"from_ts": 1635033600,
-					"listen_count": 1,
-					"time_range": "24 October 2021",
-					"to_ts": 1635119999
-				},
-				{
-					"from_ts": 1635120000,
-					"listen_count": 12,
-					"time_range": "25 October 2021",
-					"to_ts": 1635206399
-				},
-				{
-					"from_ts": 1635206400,
-					"listen_count": 3,
-					"time_range": "26 October 2021",
-					"to_ts": 1635292799
-				},
-				{
-					"from_ts": 1635292800,
-					"listen_count": 1,
-					"time_range": "27 October 2021",
-					"to_ts": 1635379199
-				},
-				{
-					"from_ts": 1635379200,
-					"listen_count": 1,
-					"time_range": "28 October 2021",
-					"to_ts": 1635465599
-				},
-				{
-					"from_ts": 1635465600,
-					"listen_count": 6,
-					"time_range": "29 October 2021",
-					"to_ts": 1635551999
-				},
-				{
-					"from_ts": 1635552000,
-					"listen_count": 2,
-					"time_range": "30 October 2021",
-					"to_ts": 1635638399
-				},
-				{
-					"from_ts": 1635638400,
-					"listen_count": 0,
-					"time_range": "31 October 2021",
-					"to_ts": 1635724799
-				},
-				{
-					"from_ts": 1635724800,
-					"listen_count": 4,
-					"time_range": "01 November 2021",
-					"to_ts": 1635811199
-				},
-				{
-					"from_ts": 1635811200,
-					"listen_count": 30,
-					"time_range": "02 November 2021",
-					"to_ts": 1635897599
-				},
-				{
-					"from_ts": 1635897600,
-					"listen_count": 2,
-					"time_range": "03 November 2021",
-					"to_ts": 1635983999
-				},
-				{
-					"from_ts": 1635984000,
-					"listen_count": 0,
-					"time_range": "04 November 2021",
-					"to_ts": 1636070399
-				},
-				{
-					"from_ts": 1636070400,
-					"listen_count": 0,
-					"time_range": "05 November 2021",
-					"to_ts": 1636156799
-				},
-				{
-					"from_ts": 1636156800,
-					"listen_count": 0,
-					"time_range": "06 November 2021",
-					"to_ts": 1636243199
-				},
-				{
-					"from_ts": 1636243200,
-					"listen_count": 0,
-					"time_range": "07 November 2021",
-					"to_ts": 1636329599
-				},
-				{
-					"from_ts": 1636329600,
-					"listen_count": 0,
-					"time_range": "08 November 2021",
-					"to_ts": 1636415999
-				},
-				{
-					"from_ts": 1636416000,
-					"listen_count": 56,
-					"time_range": "09 November 2021",
-					"to_ts": 1636502399
-				},
-				{
-					"from_ts": 1636502400,
-					"listen_count": 2,
-					"time_range": "10 November 2021",
-					"to_ts": 1636588799
-				},
-				{
-					"from_ts": 1636588800,
-					"listen_count": 1,
-					"time_range": "11 November 2021",
-					"to_ts": 1636675199
-				},
-				{
-					"from_ts": 1636675200,
-					"listen_count": 4,
-					"time_range": "12 November 2021",
-					"to_ts": 1636761599
-				},
-				{
-					"from_ts": 1636761600,
-					"listen_count": 0,
-					"time_range": "13 November 2021",
-					"to_ts": 1636847999
-				},
-				{
-					"from_ts": 1636848000,
-					"listen_count": 0,
-					"time_range": "14 November 2021",
-					"to_ts": 1636934399
-				},
-				{
-					"from_ts": 1636934400,
-					"listen_count": 18,
-					"time_range": "15 November 2021",
-					"to_ts": 1637020799
-				},
-				{
-					"from_ts": 1637020800,
-					"listen_count": 8,
-					"time_range": "16 November 2021",
-					"to_ts": 1637107199
-				},
-				{
-					"from_ts": 1637107200,
-					"listen_count": 10,
-					"time_range": "17 November 2021",
-					"to_ts": 1637193599
-				},
-				{
-					"from_ts": 1637193600,
-					"listen_count": 6,
-					"time_range": "18 November 2021",
-					"to_ts": 1637279999
-				},
-				{
-					"from_ts": 1637280000,
-					"listen_count": 8,
-					"time_range": "19 November 2021",
-					"to_ts": 1637366399
-				},
-				{
-					"from_ts": 1637366400,
-					"listen_count": 0,
-					"time_range": "20 November 2021",
-					"to_ts": 1637452799
-				},
-				{
-					"from_ts": 1637452800,
-					"listen_count": 0,
-					"time_range": "21 November 2021",
-					"to_ts": 1637539199
-				},
-				{
-					"from_ts": 1637539200,
-					"listen_count": 13,
-					"time_range": "22 November 2021",
-					"to_ts": 1637625599
-				},
-				{
-					"from_ts": 1637625600,
-					"listen_count": 13,
-					"time_range": "23 November 2021",
-					"to_ts": 1637711999
-				},
-				{
-					"from_ts": 1637712000,
-					"listen_count": 48,
-					"time_range": "24 November 2021",
-					"to_ts": 1637798399
-				},
-				{
-					"from_ts": 1637798400,
-					"listen_count": 16,
-					"time_range": "25 November 2021",
-					"to_ts": 1637884799
-				},
-				{
-					"from_ts": 1637884800,
-					"listen_count": 35,
-					"time_range": "26 November 2021",
-					"to_ts": 1637971199
-				},
-				{
-					"from_ts": 1637971200,
-					"listen_count": 0,
-					"time_range": "27 November 2021",
-					"to_ts": 1638057599
-				},
-				{
-					"from_ts": 1638057600,
-					"listen_count": 13,
-					"time_range": "28 November 2021",
-					"to_ts": 1638143999
-				},
-				{
-					"from_ts": 1638144000,
-					"listen_count": 47,
-					"time_range": "29 November 2021",
-					"to_ts": 1638230399
-				},
-				{
-					"from_ts": 1638230400,
-					"listen_count": 0,
-					"time_range": "30 November 2021",
-					"to_ts": 1638316799
-				},
-				{
-					"from_ts": 1638316800,
-					"listen_count": 29,
-					"time_range": "01 December 2021",
-					"to_ts": 1638403199
-				},
-				{
-					"from_ts": 1638403200,
-					"listen_count": 48,
-					"time_range": "02 December 2021",
-					"to_ts": 1638489599
-				},
-				{
-					"from_ts": 1638489600,
-					"listen_count": 20,
-					"time_range": "03 December 2021",
-					"to_ts": 1638575999
-				},
-				{
-					"from_ts": 1638576000,
-					"listen_count": 0,
-					"time_range": "04 December 2021",
-					"to_ts": 1638662399
-				},
-				{
-					"from_ts": 1638662400,
-					"listen_count": 0,
-					"time_range": "05 December 2021",
-					"to_ts": 1638748799
-				},
-				{
-					"from_ts": 1638748800,
-					"listen_count": 7,
-					"time_range": "06 December 2021",
-					"to_ts": 1638835199
-				},
-				{
-					"from_ts": 1638835200,
-					"listen_count": 0,
-					"time_range": "07 December 2021",
-					"to_ts": 1638921599
-				},
-				{
-					"from_ts": 1638921600,
-					"listen_count": 16,
-					"time_range": "08 December 2021",
-					"to_ts": 1639007999
-				},
-				{
-					"from_ts": 1639008000,
-					"listen_count": 1,
-					"time_range": "09 December 2021",
-					"to_ts": 1639094399
-				},
-				{
-					"from_ts": 1639094400,
-					"listen_count": 31,
-					"time_range": "10 December 2021",
-					"to_ts": 1639180799
-				},
-				{
-					"from_ts": 1639180800,
-					"listen_count": 5,
-					"time_range": "11 December 2021",
-					"to_ts": 1639267199
-				},
-				{
-					"from_ts": 1639267200,
-					"listen_count": 0,
-					"time_range": "12 December 2021",
-					"to_ts": 1639353599
-				},
-				{
-					"from_ts": 1639353600,
-					"listen_count": 5,
-					"time_range": "13 December 2021",
-					"to_ts": 1639439999
-				},
-				{
-					"from_ts": 1639440000,
-					"listen_count": 37,
-					"time_range": "14 December 2021",
-					"to_ts": 1639526399
-				},
-				{
-					"from_ts": 1639526400,
-					"listen_count": 2,
-					"time_range": "15 December 2021",
-					"to_ts": 1639612799
-				},
-				{
-					"from_ts": 1639612800,
-					"listen_count": 0,
-					"time_range": "16 December 2021",
-					"to_ts": 1639699199
-				}
-			],
-			"most_listened_year": {
-				"1958": 1,
-				"1962": 4,
-				"1964": 1,
-				"1965": 2,
-				"1966": 4,
-				"1967": 11,
-				"1968": 10,
-				"1969": 3,
-				"1970": 13,
-				"1971": 11,
-				"1972": 14,
-				"1973": 12,
-				"1974": 14,
-				"1975": 9,
-				"1976": 13,
-				"1977": 1,
-				"1978": 8,
-				"1979": 5,
-				"1981": 2,
-				"1982": 3,
-				"1983": 6,
-				"1984": 6,
-				"1985": 1,
-				"1986": 2,
-				"1987": 7,
-				"1988": 8,
-				"1989": 8,
-				"1990": 4,
-				"1991": 6,
-				"1992": 26,
-				"1993": 39,
-				"1994": 27,
-				"1995": 12,
-				"1996": 23,
-				"1997": 17,
-				"1998": 32,
-				"1999": 23,
-				"2000": 13,
-				"2001": 17,
-				"2002": 30,
-				"2003": 39,
-				"2004": 33,
-				"2005": 30,
-				"2006": 49,
-				"2007": 37,
-				"2008": 49,
-				"2009": 65,
-				"2010": 44,
-				"2011": 61,
-				"2012": 46,
-				"2013": 68,
-				"2014": 112,
-				"2015": 99,
-				"2016": 150,
-				"2017": 114,
-				"2018": 202,
-				"2019": 155,
-				"2020": 395,
-				"2021": 325
-			},
-			"most_prominent_color": "(165, 166, 156)",
-			"new_releases_of_top_artists": [
-				{
-					"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_credit_names": ["Mdou Moctar"],
-					"first_release_date": "2021-05-21",
-					"release_mbid": "48afcf02-f396-4c13-bdef-222965474094",
-					"title": "Afrique Victime",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["9f930ddf-be2f-4de5-a39f-7ae47305752e"],
-					"artist_credit_names": ["The Psychedelic Furs"],
-					"first_release_date": "2021-09-01",
-					"release_mbid": "1c6a4d54-dfac-4f0e-8502-0ca21b3c40f9",
-					"title": "Evergreen",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-04-12",
-					"release_mbid": "08f57b3b-61fd-49a3-b05d-0d6d9912ddd0",
-					"title": "True",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4", "bc880664-6751-4998-984d-ebdbff15d229"],
-					"artist_credit_names": ["Danny Elfman", "Trent Reznor"],
-					"first_release_date": "2021-08-11",
-					"release_mbid": "63090666-48e7-40b7-8a32-e408346771d8",
-					"title": "True",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-06-11",
-					"release_mbid": "793e1cc3-f568-4b5c-b160-b39ecd5ac007",
-					"title": "Butterfly 3000",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-01-11",
-					"release_mbid": "27fdab3f-8ed6-4935-9693-9e02865e4a20",
-					"title": "Sorry",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-02-26",
-					"release_mbid": "f04e0d01-77bf-4d8c-b6b6-e0efb27da1ae",
-					"title": "L.W.",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
-					"artist_credit_names": ["Goat"],
-					"first_release_date": "2021-08-27",
-					"release_mbid": "8297858b-eed6-43bd-b429-79b2f8a8625c",
-					"title": "Headsoup",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
-					"artist_credit_names": ["Green Lung"],
-					"first_release_date": "2021-08-27",
-					"release_mbid": "5998e6f1-6970-4d3e-ab1f-f6a7857cccce",
-					"title": "Graveyard Sun",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_credit_names": ["Mdou Moctar"],
-					"first_release_date": "2021-05-21",
-					"release_mbid": "9439ce5e-0b57-431a-b2a8-58be26c3abc2",
-					"title": "Afrique Victime",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-02-18",
-					"release_mbid": "eea6587b-6ef9-4124-9e23-8a52d8459ed6",
-					"title": "Pleura",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": [
-						"c266a7ab-7b9f-478f-a26d-91c5f8f04c7c", "42dd1862-7255-47ed-8584-651abce3bf53",
-						"62b29e5c-d717-4586-87bc-ade74a6a9fe8"
-					],
-					"artist_credit_names": ["DJ Yoda", "Nubya Garcia", "Edo.G"],
-					"first_release_date": "2021-03-05",
-					"release_mbid": "fa634c8f-3710-4d73-903c-5b8200c6e80c",
-					"title": "Roxbury",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
-					"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
-					"first_release_date": "2021-06-11",
-					"release_mbid": "bb7d4f1d-3a47-42ee-b450-ba0b763c68b7",
-					"title": "Dark Mark (Theme)",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-03-19",
-					"release_mbid": "0ef0d03c-418e-48fb-8444-bb2bdaaa862c",
-					"title": "Live in Melbourne ‘21",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
-					"artist_credit_names": ["Green Lung"],
-					"first_release_date": "2021-10-22",
-					"release_mbid": "7a00a638-d77a-4da7-8c6e-d9f01a59bebb",
-					"title": "Black Harvest",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
-					"artist_credit_names": ["Green Lung"],
-					"first_release_date": "2021-10-22",
-					"release_mbid": "edf26b54-36c9-43c7-918b-884711ba9dd1",
-					"title": "Black Harvest",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["cb331ec3-72af-4d8c-825a-63f79d56a651"],
-					"artist_credit_names": ["Movie Club"],
-					"first_release_date": "2021-07-08",
-					"release_mbid": "503f6e83-e5b6-4b17-8e4a-621ce201d00e",
-					"title": "Trap Door",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["c3aeb863-7b26-4388-94e8-5a240f2be21b"],
-					"artist_credit_names": ["Tom Waits"],
-					"first_release_date": "2021-01-12",
-					"release_mbid": "545fdd9c-a696-4ea3-87f8-46e9082b266c",
-					"title": "Sharp as a Razor and Soft as a Prayer (Live 1977)",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-05-29",
-					"release_mbid": "2a6d3e8d-f5ce-4633-afea-87e046a0758e",
-					"title": "Live in Sydney ‘21",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
-					"artist_credit_names": ["Goat"],
-					"first_release_date": "2021-07-05",
-					"release_mbid": "3de4b3c3-1747-4a75-a394-846aa754ed7b",
-					"title": "Queen of the Underground (edit)",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
-					"artist_credit_names": ["The Longest Johns"],
-					"first_release_date": "2021",
-					"release_mbid": "57f7b40d-f13b-498f-981d-6b6323727a8e",
-					"title": "Land Shanties",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["bded3a41-acd7-42ff-9402-cb59e35be8f4"],
-					"artist_credit_names": ["Endless Boogie"],
-					"first_release_date": "2021-11-12",
-					"release_mbid": "534fb7ec-c530-4a49-aa9b-02f6560d6fed",
-					"title": "Admonitions",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["795d12c3-099e-4195-8f40-6764472db494", "3a605eba-b6a1-4298-855d-b3033df0bf8b"],
-					"artist_credit_names": ["Ryley Walker", "幾何学模様"],
-					"first_release_date": "2021-02-05",
-					"release_mbid": "760acd46-eab1-4c25-bffc-c5dc7da69364",
-					"title": "Deep Fried Grandeur",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_credit_names": ["Slift"],
-					"first_release_date": "2021-06-18",
-					"release_mbid": "b2c565b3-f103-4bf5-aee4-31422cfd5838",
-					"title": "Levitation Sessions",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-05-25",
-					"release_mbid": "0edab12a-33ca-4751-b574-dfcba95410a3",
-					"title": "Insects",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
-					"artist_credit_names": ["The Longest Johns"],
-					"first_release_date": "2021-12-06",
-					"release_mbid": "8ab24647-90eb-474b-b604-92e0d77aad36",
-					"title": "Commodore 1864",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": [
-						"c266a7ab-7b9f-478f-a26d-91c5f8f04c7c", "42dd1862-7255-47ed-8584-651abce3bf53",
-						"62b29e5c-d717-4586-87bc-ade74a6a9fe8"
-					],
-					"artist_credit_names": ["DJ Yoda", "Nubya Garcia", "Edo.G"],
-					"first_release_date": "2021-03-05",
-					"release_mbid": "715631dd-f796-4def-981b-d60d00d4e37d",
-					"title": "Roxbury",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-01-28",
-					"release_mbid": "36c762d3-d0b8-4349-89e2-37da14e83531",
-					"title": "O.N.E.",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-06-11",
-					"release_mbid": "99517c21-0583-45c5-96e6-b90575090e45",
-					"title": "Butterfly 3000",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
-					"artist_credit_names": ["Nubya Garcia"],
-					"first_release_date": "2021-10-22",
-					"release_mbid": "849aa6f7-d155-4d12-878a-df5b571bab0a",
-					"title": "SOURCE ⧺ WE MOVE",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-02-26",
-					"release_mbid": "61c386be-c0b0-41f8-8290-aede50a046b0",
-					"title": "L.W.",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
-					"artist_credit_names": ["Goat"],
-					"first_release_date": "2021-08-27",
-					"release_mbid": "d6971aa7-545e-4ce8-8b5d-300868b57cf4",
-					"title": "Headsoup",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["22e6f8d3-2d7e-4abb-8a77-1a6d581cd560"],
-					"artist_credit_names": ["Wolves Like Me"],
-					"first_release_date": "2021-01-28",
-					"release_mbid": "bf04a661-b7f2-40c9-b8e6-276ff3602997",
-					"title": "Who's Afraid?",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
-					"artist_credit_names": ["Les Filles de Illighadad"],
-					"first_release_date": "2021-07-09",
-					"release_mbid": "0ad08d1a-24f7-4cda-9d01-6cddc889ed2e",
-					"title": "At Pioneer Works",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
-					"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
-					"first_release_date": "2021-06-11",
-					"release_mbid": "f2352415-9aa1-4962-afeb-e336c290b8e1",
-					"title": "Dark Mark (Theme)",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["248c71ae-de8a-4246-8435-d0a19e0ebf41", "a9126556-f555-4920-9617-6e013f8228a7"],
-					"artist_credit_names": ["Kira Skov", "Mark Lanegan"],
-					"first_release_date": "2021-04-09",
-					"release_mbid": "51cf73a8-c06c-4fb8-b7d8-a4d83a0db8ff",
-					"title": "Idea of Love",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
-					"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
-					"first_release_date": "2021-10-15",
-					"release_mbid": "4fbbd214-aba9-4922-a34e-09c02ffe20e2",
-					"title": "Dark Mark vs. Skeleton Joe",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_credit_names": ["Mdou Moctar"],
-					"first_release_date": "2021-05-21",
-					"release_mbid": "01c0affe-3c70-4433-892f-80f6a1e74982",
-					"title": "Afrique Victime",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
-					"artist_credit_names": ["Black Sky Giant"],
-					"first_release_date": "2021-06-10",
-					"release_mbid": "9da22f1c-ceeb-401f-8dd2-acca823ec1eb",
-					"title": "Falling Mothership",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_credit_names": ["Slift"],
-					"first_release_date": "2021-01-08",
-					"release_mbid": "ebe43918-bd5d-4f80-bbca-926752d01d59",
-					"title": "Space Is the Key / La Planète inexplorée",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-04-01",
-					"release_mbid": "a06b33c1-39fb-483b-83ec-a1a497531fef",
-					"title": "Kick Me (Zach Hill remix)",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["eb3b3201-d6d5-4143-bd30-c50e719c138e"],
-					"artist_credit_names": ["Dust Mice"],
-					"first_release_date": "2021-04-16",
-					"release_mbid": "e5f194c0-3ee9-46f2-a7e4-78b6f642d6d9",
-					"title": "Earth III",
-					"type": null
-				},
-				{
-					"artist_credit_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
-					"artist_credit_names": ["Kraftwerk"],
-					"first_release_date": "2021-05-11",
-					"release_mbid": "dcbeb0bc-9601-40bc-895f-ca7a7a641b5c",
-					"title": "Heimcomputer",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-06-11",
-					"release_mbid": "a1fc45f0-d4b3-4462-b54f-108e59f404cd",
-					"title": "Big Mess",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-12-10",
-					"release_mbid": "4d7093d9-0a7f-4b35-a6c6-292991828c0a",
-					"title": "Live at Levitation ‘16",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
-					"artist_credit_names": ["Green Lung"],
-					"first_release_date": "2021-10-22",
-					"release_mbid": "a0796b13-b7b2-45d4-8375-7a65d384d279",
-					"title": "Black Harvest",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["795d12c3-099e-4195-8f40-6764472db494", "3a605eba-b6a1-4298-855d-b3033df0bf8b"],
-					"artist_credit_names": ["Ryley Walker", "幾何学模様"],
-					"first_release_date": "2021-02-05",
-					"release_mbid": "30b5db7d-cb62-4c09-938c-01e75da359e9",
-					"title": "Deep Fried Grandeur",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_credit_names": ["Mdou Moctar"],
-					"first_release_date": "2021-05-21",
-					"release_mbid": "60377f9b-98b5-4304-aeb4-e1835889482f",
-					"title": "Afrique Victime",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
-					"artist_credit_names": ["Kraftwerk"],
-					"first_release_date": "2021-05-11",
-					"release_mbid": "9e8dbe4e-9316-47e1-96c6-f8a08451ce9e",
-					"title": "Heimcomputer",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-12-10",
-					"release_mbid": "8d9e8021-09e2-48ab-9a04-e358bba7cacb",
-					"title": "Live at Levitation ‘14",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["bded3a41-acd7-42ff-9402-cb59e35be8f4"],
-					"artist_credit_names": ["Endless Boogie"],
-					"first_release_date": "2021-11-12",
-					"release_mbid": "75d7e92c-45e2-4c6e-930c-5d9f1c73af1d",
-					"title": "Admonitions",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-10-01",
-					"release_mbid": "381e305a-ebef-4372-821b-68fef45d7778",
-					"title": "Live in Milwaukee ‘19",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["795d12c3-099e-4195-8f40-6764472db494", "3a605eba-b6a1-4298-855d-b3033df0bf8b"],
-					"artist_credit_names": ["Ryley Walker", "幾何学模様"],
-					"first_release_date": "2021-02-05",
-					"release_mbid": "489fa3c2-5894-4cb6-a006-0506b851f3a3",
-					"title": "Deep Fried Grandeur",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
-					"artist_credit_names": ["Black Sky Giant"],
-					"first_release_date": "2021-01-16",
-					"release_mbid": "de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746",
-					"title": "Planet Terror",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
-					"artist_credit_names": ["José Carlos Schwarz"],
-					"first_release_date": "2021-04-09",
-					"release_mbid": "0d698584-4c46-46ce-9781-e394d81450bd",
-					"title": "Lua Ki Di Nos",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["425bd6b7-dccf-4a03-9a4c-40f28fb5792d"],
-					"artist_credit_names": ["The Ossuary"],
-					"first_release_date": "2021-05-28",
-					"release_mbid": "6d77c3fa-44aa-4814-abdf-82d66a167370",
-					"title": "Oltretomba",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["3a605eba-b6a1-4298-855d-b3033df0bf8b"],
-					"artist_credit_names": ["幾何学模様"],
-					"first_release_date": "2021-01-15",
-					"release_mbid": "6b0fbd5a-5027-450a-9fc0-5fdd567ffdff",
-					"title": "Live at Levitation",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-03-11",
-					"release_mbid": "bc8153d4-352a-4744-904e-c37ff49b1f27",
-					"title": "Kick Me",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-06-11",
-					"release_mbid": "e8a18bc7-1de7-4515-b2f3-2974286d8657",
-					"title": "Butterfly 3000",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-02-11",
-					"release_mbid": "6f675815-a096-4119-8847-cf255c5040b4",
-					"title": "Love in the Time of Covid",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-09-10",
-					"release_mbid": "ed6072a4-0533-4824-bb93-b43fd5e75c30",
-					"title": "We Belong (Squarepusher remix)",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
-					"first_release_date": "2021-02-26",
-					"release_mbid": "c3a1f0f6-4039-4ae1-a516-2a438ac6c88c",
-					"title": "L.W.",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_credit_names": ["Mdou Moctar"],
-					"first_release_date": "2021-04-01",
-					"release_mbid": "d3989eb1-f6b7-4cc0-a645-3d2e50dca060",
-					"title": "Afrique Victime",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
-					"artist_credit_names": ["Nubya Garcia"],
-					"first_release_date": "2021-09-02",
-					"release_mbid": "eb628f72-d946-4310-be8f-a25f9e65e946",
-					"title": "Pace (Moses Boyd remix)",
-					"type": "Single"
-				},
-				{
-					"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
-					"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
-					"first_release_date": "2021-10-15",
-					"release_mbid": "7da68b56-723e-445e-a354-a549c23dd443",
-					"title": "Dark Mark vs Skeleton Joe",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_credit_names": ["Danny Elfman"],
-					"first_release_date": "2021-06-11",
-					"release_mbid": "7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19",
-					"title": "Big Mess",
-					"type": "Album"
-				},
-				{
-					"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
-					"artist_credit_names": ["Goat"],
-					"first_release_date": "2021-08-03",
-					"release_mbid": "8ceb3338-7c74-4329-b04a-a2749683cd37",
-					"title": "Fill My Mouth",
-					"type": "Single"
-				}
-			],
-			"playlist-top-discoveries-for-year": {
-				"jspf": {
-					"playlist": {
-						"annotation": "<p>\n              This playlist highlights tracks that mr_monkey first listened to in 2021 and listened to more than once.\n              </p>\n              <p>\n              We generated this playlist from mr_monkey's listens and chose all the recordings\n              that they first listened to this year and they listened to more than once. We removed\n              recordings from duplicate artists so that ideally no artist (or an artist in a collaboration) appears\n              more than twice in this playlist, although that may not always be possible. \n              Finally we randomized the order of the recordings so that two of the same artists hopefully\n              won't appear in a row.\n              </p>\n              <p>\n              Please remember that ListenBrainz may not know about all the times this user listened to a recording\n              before they started sharing their listening history with us, so we apologize if recordings appear that\n              this user listened to in the past. Also, we have attempted to match all of the listens to MusicBrainz\n              IDs in order for them to be included in this playlist, but we may not have been able to match them all,\n              so some recordings may be missing from this list.\n              </p>\n              <p>\n              This is a review playlist that we hope will give insights into the listening habits of the year.\n              </p>\n           ",
-						"creator": "ListenBrainz Troi",
-						"extension": {
-							"https://musicbrainz.org/doc/jspf#playlist": {
-								"algorithm_metadata": {"source_patch": "top-discoveries-for-year"},
-								"public": true
-							}
-						},
-						"title": "Top Discoveries of 2021 for mr_monkey",
-						"track": [
-							{
-								"album": "",
-								"creator": "Sergeant Thunderhoof",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/1110726a-05da-4ad3-8d39-5c184c2206c8",
-								"title": "Another Plane"
-							},
-							{
-								"album": "",
-								"creator": "Nubya Garcia",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/84b9fdb2-1ce6-4420-92b3-13679f71dcfe",
-								"title": "When We Are"
-							},
-							{
-								"album": "",
-								"creator": "Raúl Monsalve y los Forajidos",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/afa6d740-452a-4cc2-b24e-16d6d143b763",
-								"title": "Malembe"
-							},
-							{
-								"album": "",
-								"creator": "Mdou Moctar",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/2d743c39-4ce4-4af0-ae9b-067019ca4029",
-								"title": "A Fleur Tamgak"
-							},
-							{
-								"album": "",
-								"creator": "Koichi Sakai / Alfa Sackey",
-								"extension": {
-									"https://musicbrainz.org/recording/": {
-										"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"]
-									}
-								},
-								"identifier": "https://musicbrainz.org/recording/dbb8196d-d1c1-4fa7-a198-98a49aa6f260",
-								"title": "Atenteben Blues"
-							}
-						]
-					}
-				},
-				"mbid": "51a7c3b7-4045-49bc-8f5d-496c7ca3e119"
-			},
-			"playlist-top-missed-recordings-for-year": {
-				"jspf": {
-					"playlist": {
-						"annotation": "<p>\n              This playlist is made from recordings that mr_monkey's most similar users listened to this year, but that\n              mr_monkey didn't listen to this year.\n              </p>\n              <p>\n              We determined the top 3 most similar users to mr_monkey and selected all of the recordings\n              they listened to this year. We then removed all of the recordings that mr_monkey listened to from\n              this list of recordings, leaving only those that they didn't listen to. We removed recordings from\n              duplicate artists so that ideally no artist (or an artist in a collaboration) appears\n              more than twice in this playlist, although that may not always be possible. Finally we\n              randomized the order of the recordings so that two of the same artists hopefully won't appear\n              in a row.\n              </p>\n              <p>\n              We have attempted to match all of the listens to MusicBrainz\n              IDs in order for them to be included in this playlist, but we may not have been able to match them all,\n              so some recordings may be missing from this list.\n              </p>\n              <p>\n              This is a discovery playlist that will hopefully introduce the user to some new recordings\n              that other similar users love. Because this is a discovery playlist, it may require\n              more active listening since it may contain tracks that are not fully to the taste of the user.\n              </p>\n           ",
-						"creator": "ListenBrainz Troi",
-						"extension": {
-							"https://musicbrainz.org/doc/jspf#playlist": {
-								"algorithm_metadata": {"source_patch": "top-missed-recordings-for-year"},
-								"public": true
-							}
-						},
-						"title": "Top Missed Recordings of 2021 for mr_monkey",
-						"track": [
-							{
-								"album": "",
-								"creator": "Infinity Frequencies",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["80c29427-3fdf-47e4-a4a4-ea180d8c9072"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/22c93b09-3cb5-49cb-a510-f9ada3b3c1c8",
-								"title": "The descent"
-							},
-							{
-								"album": "",
-								"creator": "Ängie",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["2785996d-a14a-464f-9887-16268cc4dfed"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/dfc822a5-06a6-4bc3-9fa6-7f709f63e168",
-								"title": "Sad Sex"
-							},
-							{
-								"album": "",
-								"creator": "Cœur",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["23305753-d03c-4c66-a6f0-6df41135d2dd"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/0cd84991-b754-4a0f-990c-24fe9ac902c7",
-								"title": "Chrysanthème"
-							},
-							{
-								"album": "",
-								"creator": "Hubert-Félix Thiéfaine",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["29e9c7d7-e79a-41d5-a255-c19ff04d5065"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/e994acc9-2405-4c55-8b12-47df113339f8",
-								"title": "Page noire"
-							},
-							{
-								"album": "",
-								"creator": "Brain Damage meets Big Youth",
-								"extension": {
-									"https://musicbrainz.org/recording/": {
-										"artist_mbids": ["9d19a058-3bb8-4858-937b-39dc2b817fc8", "6e4cbcf5-1b18-4719-98c2-7a2c9eccaa6d"]
-									}
-								},
-								"identifier": "https://musicbrainz.org/recording/6f6cc2db-a49d-46e5-949e-d54e951db0d4",
-								"title": "Educated Fools"
-							}
-						]
-					}
-				},
-				"mbid": "4657f3d1-b795-4733-b957-24edca7f2729"
-			},
-			"playlist-top-new-recordings-for-year": {
-				"jspf": {
-					"playlist": {
-						"annotation": "<p>\n              This playlist highlights recordings released in 2021 that mr_monkey listened to the most.\n              </p>\n              <p>\n              We generated this playlist from the user's listens and chose all the recordings\n              that were released this year and that the user listened to often. We removed recordings\n              from duplicate artists so that ideally no artist (or an artist in a collaboration) appears\n              more than twice in this playlist, although that may not always be possible. Finally we randomized\n              the order of the recordings so that two of the same artists hopefully won't appear in a row.\n              </p>\n              <p>\n              We have attempted to match all of the listens to MusicBrainz\n              IDs in order for them to be included in this playlist, but we may not have been able to match them all,\n              so some recordings may be missing from this list.\n              </p>\n              <p>\n              This is a review playlist that we hope will give insights the music released during the year.\n              </p>",
-						"creator": "ListenBrainz Troi",
-						"extension": {
-							"https://musicbrainz.org/doc/jspf#playlist": {
-								"algorithm_metadata": {"source_patch": "top-new-recordings-for-year"},
-								"public": true
-							}
-						},
-						"title": "Top New Releases in 2021 for mr_monkey",
-						"track": [
-							{
-								"album": "",
-								"creator": ":nepaal",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["7c50724d-92e2-45eb-b7a7-2b3d612a3b06"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/928c26f4-bc9d-4c8d-84c7-00848bc1879f",
-								"title": "Pharisaismic Plebeian Bureaucracism"
-							},
-							{
-								"album": "",
-								"creator": "Liquid Sound Company",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["5eb16ca3-8475-4d0c-a439-daecd807778a"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/ae1e2c92-5870-423d-9f63-9421cc5b106a",
-								"title": "Blacklight Corridor"
-							},
-							{
-								"album": "",
-								"creator": "KOKOROKO",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["2650f0e7-3879-4b2c-8908-d025113cbece"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/763b2206-0110-413a-9e87-9cd7b53f77cc",
-								"title": "Uman"
-							},
-							{
-								"album": "",
-								"creator": "Taxi Caveman",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["5f643039-147a-4fcd-b112-c0f60530a253"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/050c8872-a7cf-4805-8ea5-616376d272b8",
-								"title": "I, The Witch"
-							},
-							{
-								"album": "",
-								"creator": "Brain Damage meets Big Youth",
-								"extension": {
-									"https://musicbrainz.org/recording/": {
-										"artist_mbids": ["6e4cbcf5-1b18-4719-98c2-7a2c9eccaa6d", "9d19a058-3bb8-4858-937b-39dc2b817fc8"]
-									}
-								},
-								"identifier": "https://musicbrainz.org/recording/7ca4ffd9-6d3e-4194-9856-834f7dfbd508",
-								"title": "Good to Talk"
-							}
-						]
-					}
-				},
-				"mbid": "8ba58c32-de1e-47d1-8e3d-2e931e79b629"
-			},
-			"playlist-top-recordings-for-year": {
-				"jspf": {
-					"playlist": {
-						"annotation": "<p>\n              This playlist is made from mr_monkey's Top Recordings for 2021 statistics.\n              </p>\n              <p>\n              We selected the top tracks from this user’s statistics and removed those recordings that we could not\n              match to entries in MusicBrainz. (This is a requirement to make this list playable.)\n              </p>\n              <p>\n              This is a review playlist that we hope will give insights into the listening habits of the year.\n              </p>\n           ",
-						"creator": "ListenBrainz Troi",
-						"extension": {
-							"https://musicbrainz.org/doc/jspf#playlist": {
-								"algorithm_metadata": {"source_patch": "top-recordings-for-year"},
-								"public": true
-							}
-						},
-						"title": "Top Recordings of 2021 for mr_monkey",
-						"track": [
-							{
-								"album": "Fever Ray",
-								"creator": "Fever Ray",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/55a6d83f-af43-449e-a6b4-1b8fa24b4039",
-								"title": "If I Had a Heart"
-							},
-							{
-								"album": "Grown",
-								"creator": "Waaju",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/72586151-9800-44d6-8732-6b8491808651",
-								"title": "Listening Glasses"
-							},
-							{
-								"album": "The Two Sides of Fela: Jazz & Dance",
-								"creator": "Fela Kuti",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["6514cffa-fbe0-4965-ad88-e998ead8a82a"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/a106cc67-0fa7-45f8-b894-e4f89624ed20",
-								"title": "Eko Ile"
-							},
-							{
-								"album": "Grown",
-								"creator": "Waaju",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/7edc2546-2288-4004-af22-e5e1325ee311",
-								"title": "Wassoulou"
-							},
-							{
-								"album": "Grown",
-								"creator": "Waaju",
-								"extension": {
-									"https://musicbrainz.org/recording/": { "artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"] }
-								},
-								"identifier": "https://musicbrainz.org/recording/98ebe88f-f72e-4b52-8402-7a01b88f3826",
-								"title": "Moleman"
-							}
-						]
-					}
-				},
-				"mbid": "548715b7-2fbc-45d9-a0a7-001786eada9d"
-			},
-			"similar_users": {
-				"ALERTua": 0.3757489101,
-				"A_Galoot": 0.3684194592,
-				"Anandamide": 0.7084108003,
-				"BlueCoke": 0.3271148878,
-				"DeepSlackerJazz": 0.3837503434,
-				"OverFjell": 1,
-				"Paoleddu": 0.3539377078,
-				"Peter-K": 0.465846533,
-				"Shrike": 0.3735010094,
-				"TyriGen": 0.4253733387,
-				"Zas": 0.9159547887,
-				"a_beautiful_war": 0.328987247,
-				"an.archi": 0.3145100724,
-				"doctorworm": 0.4375715465,
-				"itsthenewmeta": 0.4837755275,
-				"malguinis": 0.3441075518,
-				"misterplanty": 0.3357076275,
-				"mystictim": 0.3223334487,
-				"nihilix": 0.3757889275,
-				"nkundiushuti": 0.3441078783,
-				"rpaxon": 0.3477923015,
-				"shanksk": 0.5536979994,
-				"weirditude": 0.3547205253,
-				"y7kko": 0.4977883018,
-				"zehmurilo": 0.8895062542
-			},
-			"top_artists": [
-				{
-					"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_name": "Mdou Moctar",
-					"listen_count": 64
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 55
-				},
-				{
-					"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_name": "Slift",
-					"listen_count": 52
-				},
-				{
-					"artist_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
-					"artist_name": "The Longest Johns",
-					"listen_count": 46
-				},
-				{
-					"artist_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
-					"artist_name": "Goat",
-					"listen_count": 41
-				},
-				{
-					"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
-					"artist_name": "Raúl Monsalve y los Forajidos",
-					"listen_count": 36
-				},
-				{
-					"artist_mbids": ["8ed78ccf-7a3f-4717-b84c-1606627124bd"],
-					"artist_name": "Hey Colossus",
-					"listen_count": 29
-				},
-				{
-					"artist_mbids": ["3a605eba-b6a1-4298-855d-b3033df0bf8b"],
-					"artist_name": "Kikagaku Moyo",
-					"listen_count": 28
-				},
-				{
-					"artist_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_name": "King Gizzard & The Lizard Wizard",
-					"listen_count": 27
-				},
-				{
-					"artist_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
-					"artist_name": "Les Filles de Illighadad",
-					"listen_count": 25
-				},
-				{
-					"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
-					"artist_name": "Fever Ray",
-					"listen_count": 25
-				},
-				{
-					"artist_mbids": ["42689657-cbec-4f66-a9ed-80f939ea23ed"],
-					"artist_name": "Morphine",
-					"listen_count": 24
-				},
-				{
-					"artist_mbids": ["72fd7688-8394-43b6-8f41-278657648a45"],
-					"artist_name": "Yussef Kamaal",
-					"listen_count": 23
-				},
-				{
-					"artist_mbids": ["9219acc3-6234-4aee-8633-fe438daee3b2"],
-					"artist_name": "Anna Scionti",
-					"listen_count": 23
-				},
-				{
-					"artist_mbids": ["7a6506cc-6f12-442d-9d3e-149bc838792e"],
-					"artist_name": "79.5",
-					"listen_count": 23
-				},
-				{
-					"artist_mbids": ["d1ccc60e-45d5-4176-a328-47cd5984e55b"],
-					"artist_name": "Tidiane Thiam",
-					"listen_count": 22
-				},
-				{
-					"artist_mbids": ["c10e38ae-d06f-4bf4-8b54-8e19236a94f4"],
-					"artist_name": "Mohama Saz",
-					"listen_count": 21
-				},
-				{
-					"artist_mbids": ["22e6f8d3-2d7e-4abb-8a77-1a6d581cd560"],
-					"artist_name": "Wolves Like Me",
-					"listen_count": 20
-				},
-				{
-					"artist_mbids": ["8067c102-4996-42bc-9980-06ce2e644eae"],
-					"artist_name": "Soul Coughing",
-					"listen_count": 20
-				},
-				{
-					"artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"],
-					"artist_name": "Sergeant Thunderhoof",
-					"listen_count": 20
-				},
-				{
-					"artist_mbids": ["edf62daa-1425-44bb-8fe3-07499b519472"],
-					"artist_name": "Imarhan",
-					"listen_count": 20
-				},
-				{
-					"artist_mbids": ["7e9d3899-9de2-4741-973c-6147238bb2f1"],
-					"artist_name": "Koudede",
-					"listen_count": 19
-				},
-				{
-					"artist_mbids": ["c3aeb863-7b26-4388-94e8-5a240f2be21b"],
-					"artist_name": "Tom Waits",
-					"listen_count": 18
-				},
-				{
-					"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
-					"artist_name": "Nubya Garcia",
-					"listen_count": 18
-				},
-				{
-					"artist_mbids": ["052b43c2-2f6a-4e60-92ea-18b4de2be0d9"],
-					"artist_name": "Naxatras",
-					"listen_count": 18
-				},
-				{
-					"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"],
-					"artist_name": "Koichi Sakai / Afla Sackey",
-					"listen_count": 18
-				},
-				{
-					"artist_mbids": ["d675ed3f-bee2-40e0-8386-2960f477ad35"],
-					"artist_name": "Buried Feather",
-					"listen_count": 18
-				},
-				{
-					"artist_mbids": ["2c180037-0af5-4f9d-a29d-9512544a3064"],
-					"artist_name": "Afla Sackey & Afrik Bawantu",
-					"listen_count": 18
-				},
-				{
-					"artist_mbids": ["6ce5eca0-4ad6-49e0-a5ab-e11482d85324"],
-					"artist_name": "Sudan Archives",
-					"listen_count": 17
-				},
-				{
-					"artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_name": "Danny Elfman",
-					"listen_count": 17
-				},
-				{
-					"artist_mbids": ["cb331ec3-72af-4d8c-825a-63f79d56a651"],
-					"artist_name": "Movie Club",
-					"listen_count": 16
-				},
-				{
-					"artist_mbids": ["a9126556-f555-4920-9617-6e013f8228a7"],
-					"artist_name": "Mark Lanegan",
-					"listen_count": 16
-				},
-				{
-					"artist_mbids": ["2a67f9e5-8b94-4929-b74c-236b4c1a70c3"],
-					"artist_name": "Mantra Machine",
-					"listen_count": 16
-				},
-				{
-					"artist_mbids": ["e5963d26-01fa-40f5-b200-e0127f410a45"],
-					"artist_name": "Harry Nilsson",
-					"listen_count": 16
-				},
-				{
-					"artist_mbids": ["425bd6b7-dccf-4a03-9a4c-40f28fb5792d"],
-					"artist_name": "The Ossuary",
-					"listen_count": 15
-				},
-				{
-					"artist_mbids": ["a18c09f4-6b6f-4f9c-a4bb-ae2db7cab657"],
-					"artist_name": "Samsara Blues Experiment",
-					"listen_count": 15
-				},
-				{
-					"artist_mbids": ["aeb7af5b-fef8-479d-b5b4-f9b3c4fb95d4"],
-					"artist_name": "Masters of Reality",
-					"listen_count": 15
-				},
-				{
-					"artist_mbids": ["67f0c7ca-14e8-47a3-be0e-bd2f2ffe25bb", "ed8a131a-3ec7-4410-a848-40aa670111e0"],
-					"artist_name": "Mulatu Astatke & Black Jesus Experience",
-					"listen_count": 14
-				},
-				{
-					"artist_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
-					"artist_name": "Kraftwerk",
-					"listen_count": 14
-				},
-				{
-					"artist_mbids": ["1bdc2715-507c-41cb-9e06-021a8ecd6c8e"],
-					"artist_name": "Karkara",
-					"listen_count": 14
-				},
-				{
-					"artist_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
-					"artist_name": "Black Sky Giant",
-					"listen_count": 14
-				},
-				{
-					"artist_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
-					"artist_name": "Green Lung",
-					"listen_count": 13
-				},
-				{
-					"artist_mbids": ["5c98fc12-be83-4246-ae5b-2184192913b9"],
-					"artist_name": "Tinariwen",
-					"listen_count": 12
-				},
-				{
-					"artist_mbids": ["9f930ddf-be2f-4de5-a39f-7ae47305752e"],
-					"artist_name": "The Psychedelic Furs",
-					"listen_count": 12
-				},
-				{
-					"artist_mbids": ["231ff972-4e8e-4157-95e2-12f963cb478c"],
-					"artist_name": "Seasick Steve",
-					"listen_count": 12
-				},
-				{
-					"artist_mbids": ["eb3b3201-d6d5-4143-bd30-c50e719c138e"],
-					"artist_name": "Dust Mice",
-					"listen_count": 12
-				},
-				{
-					"artist_mbids": [],
-					"artist_name": "Anne-Sophie Mutter & Herbert Von Karajan",
-					"listen_count": 12
-				},
-				{"artist_mbids": [], "artist_name": "Roswell Rudd", "listen_count": 11},
-				{
-					"artist_mbids": ["2650f0e7-3879-4b2c-8908-d025113cbece"],
-					"artist_name": "KOKOROKO",
-					"listen_count": 11
-				},
-				{
-					"artist_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
-					"artist_name": "José Carlos Schwarz & Le Cobiana Djazz",
-					"listen_count": 11
-				}
-			],
-			"top_recordings": [
-				{
-					"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
-					"artist_name": "Fever Ray",
-					"listen_count": 10,
-					"recording_mbid": "55a6d83f-af43-449e-a6b4-1b8fa24b4039",
-					"release_mbid": "dba22fc0-9772-49c9-baaa-937d7914278a",
-					"release_name": "Fever Ray",
-					"track_name": "If I Had a Heart"
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 9,
-					"recording_mbid": "72586151-9800-44d6-8732-6b8491808651",
-					"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
-					"release_name": "Grown",
-					"track_name": "Listening Glasses"
-				},
-				{
-					"artist_mbids": ["6514cffa-fbe0-4965-ad88-e998ead8a82a"],
-					"artist_name": "Fela Kuti",
-					"listen_count": 9,
-					"recording_mbid": "a106cc67-0fa7-45f8-b894-e4f89624ed20",
-					"release_mbid": "371f9461-d100-4627-a863-eee42019f2a2",
-					"release_name": "The Two Sides of Fela: Jazz & Dance",
-					"track_name": "Eko Ile"
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 8,
-					"recording_mbid": "7edc2546-2288-4004-af22-e5e1325ee311",
-					"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
-					"release_name": "Grown",
-					"track_name": "Wassoulou"
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 8,
-					"recording_mbid": "98ebe88f-f72e-4b52-8402-7a01b88f3826",
-					"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
-					"release_name": "Grown",
-					"track_name": "Moleman"
-				},
-				{
-					"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_name": "Mdou Moctar",
-					"listen_count": 8,
-					"recording_mbid": "b376d4e6-8f05-43d4-97a2-44984931fcaa",
-					"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
-					"release_name": "Ilana: The Creator",
-					"track_name": "Inizgam"
-				},
-				{
-					"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_name": "Mdou Moctar",
-					"listen_count": 7,
-					"recording_mbid": "69532d98-67e9-495f-a7ac-a95fa976064a",
-					"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
-					"release_name": "Ilana: The Creator",
-					"track_name": "Tumastin"
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 7,
-					"recording_mbid": "88e8b728-2964-405b-94ad-0f005dde4aea",
-					"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
-					"release_name": "Grown",
-					"track_name": "Time’s Got A Hold"
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 7,
-					"recording_mbid": "9b41165e-73ad-4e2b-aec1-4aa62eb69d16",
-					"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
-					"release_name": "Grown",
-					"track_name": "Rollando"
-				},
-				{
-					"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
-					"artist_name": "Raúl Monsalve y los Forajidos",
-					"listen_count": 7,
-					"recording_mbid": "ac57c873-aea2-4f4a-873d-51cb8f4e12da",
-					"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
-					"release_name": "Bichos",
-					"track_name": "Mosquito"
-				},
-				{
-					"artist_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
-					"artist_name": "Les Filles de Illighadad",
-					"listen_count": 7,
-					"recording_mbid": "da9df919-8a3d-426e-9c68-d49b1d644110",
-					"release_mbid": "bc3e00b2-49f9-4e17-b4b6-7d1ccd1ea3c4",
-					"release_name": "Eghass Malan",
-					"track_name": "Inssegh Inssegh"
-				},
-				{
-					"artist_mbids": ["c33643b1-b62b-4834-8cd5-709ac45b6ae0"],
-					"artist_name": "TaxiWars",
-					"listen_count": 7,
-					"recording_mbid": "5b1a00ae-0a2a-4c0b-bd92-be4e9fcf58eb",
-					"release_mbid": "816c5c61-0184-41fb-9ee7-a6833df9e25d",
-					"release_name": "TaxiWars",
-					"track_name": "Death Ride Through Wet Snow"
-				},
-				{
-					"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
-					"artist_name": "Fever Ray",
-					"listen_count": 6,
-					"recording_mbid": "a62817d2-a7d2-4e1a-8c64-b225076eef8d",
-					"release_mbid": "dba22fc0-9772-49c9-baaa-937d7914278a",
-					"release_name": "Fever Ray",
-					"track_name": "When I Grow Up"
-				},
-				{
-					"artist_mbids": ["bded3a41-acd7-42ff-9402-cb59e35be8f4"],
-					"artist_name": "Endless Boogie",
-					"listen_count": 6,
-					"recording_mbid": "385f4381-0f6d-47a0-bc56-07570374f650",
-					"release_mbid": "a1bbc1d4-f2d3-4de9-a6b6-307f86d20ba3",
-					"release_name": "Vibe Killer",
-					"track_name": "Vibe Killer"
-				},
-				{
-					"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_name": "Slift",
-					"listen_count": 6,
-					"recording_mbid": "38851005-c0f5-4a59-a623-3589ae86db11",
-					"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
-					"release_name": "Ummon",
-					"track_name": "Ummon"
-				},
-				{
-					"artist_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
-					"artist_name": "Kraftwerk",
-					"listen_count": 6,
-					"recording_mbid": "fc7112f9-a06d-4f32-9bd3-c86eeb0cf288",
-					"release_mbid": "ee5f888d-2734-3ace-a25b-b6f9f39ca147",
-					"release_name": "Tour de France Soundtracks",
-					"track_name": "Tour de France"
-				},
-				{
-					"artist_mbids": ["1bdc2715-507c-41cb-9e06-021a8ecd6c8e"],
-					"artist_name": "Karkara",
-					"listen_count": 6,
-					"recording_mbid": "81583b4d-c881-499f-868e-20bf55312a1b",
-					"release_mbid": "cca29976-fea4-445a-be77-13b789dcdb81",
-					"release_name": "Nowhere Land",
-					"track_name": "Space Caravan"
-				},
-				{
-					"artist_mbids": ["d2b50525-1111-4906-aab6-4553f035f679"],
-					"artist_name": "Adriano Celentano",
-					"listen_count": 6,
-					"recording_mbid": "1460126d-5c9b-4e25-9968-b740d4796da0",
-					"release_mbid": "85393d0b-acdb-3d2c-b755-a4e0a7da3fc5",
-					"release_name": "Nostalrock",
-					"track_name": "Prisencolinensinainciusol"
-				},
-				{
-					"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
-					"artist_name": "Raúl Monsalve y los Forajidos",
-					"listen_count": 6,
-					"recording_mbid": "afa6d740-452a-4cc2-b24e-16d6d143b763",
-					"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
-					"release_name": "Bichos",
-					"track_name": "Malembe"
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 6,
-					"recording_mbid": "d3d524ac-1db2-4e48-acbd-ea29cd0b21d6",
-					"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
-					"release_name": "Grown",
-					"track_name": "Grown"
-				},
-				{
-					"artist_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_name": "King Gizzard & The Lizard Wizard",
-					"listen_count": 6,
-					"recording_mbid": "86d60ccc-c28d-40b3-9e53-b8468a7b8447",
-					"release_mbid": "db1c268c-39bd-4a86-bc02-2d514e205a42",
-					"release_name": "Nonagon Infinity",
-					"track_name": "Gamma Knife"
-				},
-				{
-					"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
-					"artist_name": "Nubya Garcia",
-					"listen_count": 6,
-					"recording_mbid": "d14b9cf0-1f05-434f-a2b3-16540e53e42a",
-					"release_mbid": "3ed914b0-9552-4258-9823-196ebbebfbf6",
-					"release_name": "Nubya’s 5ive",
-					"track_name": "Fly Free"
-				},
-				{
-					"artist_mbids": ["0b8dff0b-ce42-4cc6-afd1-1841f7781ed4"],
-					"artist_name": "Moondog",
-					"listen_count": 6,
-					"recording_mbid": "25f7c11a-d6df-4f02-b653-a6e7d7eab540",
-					"release_mbid": "f655e246-7b8a-44aa-a82e-73d37679a3d7",
-					"release_name": "DJ-Kicks: Henrik Schwarz",
-					"track_name": "Bird's Lament"
-				},
-				{
-					"artist_mbids": ["b7be7cdc-d77d-48a2-8d5f-f273e6545dd7"],
-					"artist_name": "Batmobile",
-					"listen_count": 5,
-					"recording_mbid": "4d4da953-9610-4786-947a-d99eeede33b0",
-					"release_mbid": "69223aed-432b-4652-9e03-840961fae89f",
-					"release_name": "Blast From the Past: The Worst and the Best",
-					"track_name": "Transsylvanian Express"
-				},
-				{
-					"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_name": "Slift",
-					"listen_count": 5,
-					"recording_mbid": "2ff15000-fe23-4a2f-bd70-a28c4dc32d48",
-					"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
-					"release_name": "Ummon",
-					"track_name": "Thousand Helmets of Gold"
-				},
-				{
-					"artist_mbids": ["67f0c7ca-14e8-47a3-be0e-bd2f2ffe25bb"],
-					"artist_name": "Mulatu Astatqé",
-					"listen_count": 5,
-					"recording_mbid": "fa5575af-be0c-4108-a392-6923bf56222d",
-					"release_mbid": "f85a03b1-efb8-4558-86ac-f23945a94853",
-					"release_name": "Ethiopiques 4: Ethio Jazz & Musique Instrumentale, 1969-1974",
-					"track_name": "Mètché dershé"
-				},
-				{
-					"artist_mbids": ["5971a238-30c7-4e9d-8716-5aec17628802", "fd673bd4-0168-47b6-80ba-96cc3ba1a1e2"],
-					"artist_name": "Tintura + Arno Tamm",
-					"listen_count": 5,
-					"recording_mbid": "99a2ec4b-5d0a-4736-b2af-1f317ba36dcd",
-					"release_mbid": "566a4c9f-55ca-4d01-93db-1b0a386d7d84",
-					"release_name": "Kaugel üksi võõra rahva hulgas",
-					"track_name": "Kust on tulnud muodike"
-				},
-				{
-					"artist_mbids": ["a5120e5e-0cb5-4212-8de0-fda40639007b", "f3ef765f-b7bf-4454-a007-c3468796dd24"],
-					"artist_name": "Homayoun Shajarian & Sohrab Pournazeri",
-					"listen_count": 5,
-					"recording_mbid": "5ec1413c-6aa7-4f17-93d8-a3c2a315d68a",
-					"release_mbid": "db717c45-448a-4b7e-b84d-fd0e14c36f12",
-					"release_name": "Iran",
-					"track_name": "Iran"
-				},
-				{
-					"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_name": "Slift",
-					"listen_count": 5,
-					"recording_mbid": "d95fa492-a834-4013-9102-03bd184d917a",
-					"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
-					"release_name": "Ummon",
-					"track_name": "Hyperion"
-				},
-				{
-					"artist_mbids": ["e193397d-a888-4b4d-b11d-2a602c24b023"],
-					"artist_name": "Dhafer Youssef",
-					"listen_count": 5,
-					"recording_mbid": "88616ac8-cbc6-4bc5-8b1b-74bd2bfde803",
-					"release_mbid": "5f2c7e20-fc50-44f4-a8a1-4acb35ddd486",
-					"release_name": "Diwan of Beauty and Odd",
-					"track_name": "Delightfully Odd"
-				},
-				{
-					"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
-					"artist_name": "Raúl Monsalve y los Forajidos",
-					"listen_count": 5,
-					"recording_mbid": "47709a9a-7691-4818-b62d-d0d58c352a2a",
-					"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
-					"release_name": "Bichos",
-					"track_name": "Bocón"
-				},
-				{
-					"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"],
-					"artist_name": "Koichi Sakai / Afla Sackey",
-					"listen_count": 5,
-					"recording_mbid": "dbb8196d-d1c1-4fa7-a198-98a49aa6f260",
-					"release_mbid": "790fe3d0-6c19-4b2e-9067-a6b66ce00bfe",
-					"release_name": "Wono LP",
-					"track_name": "Atenteben Blues"
-				},
-				{
-					"artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"],
-					"artist_name": "Sergeant Thunderhoof",
-					"listen_count": 5,
-					"recording_mbid": "1110726a-05da-4ad3-8d39-5c184c2206c8",
-					"release_mbid": "a49acda6-2a0f-4ce5-b009-f86f8fb33644",
-					"release_name": "Terra Solus",
-					"track_name": "Another Plane"
-				},
-				{
-					"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
-					"artist_name": "Nubya Garcia",
-					"listen_count": 4,
-					"recording_mbid": "84b9fdb2-1ce6-4420-92b3-13679f71dcfe",
-					"release_mbid": "18b916a9-7e58-485a-b972-32b6960b55db",
-					"release_name": "When We Are",
-					"track_name": "When We Are"
-				},
-				{
-					"artist_mbids": ["92f7110a-0d26-4d01-8d5d-a400e9b7145f"],
-					"artist_name": "Creature With the Atom Brain",
-					"listen_count": 4,
-					"recording_mbid": "0953c6df-422e-442a-be97-84079c883f49",
-					"release_mbid": "4d2d9802-7eb7-4ef3-b7e4-3ed6ea001382",
-					"release_name": "Transylvania",
-					"track_name": "Transylvania"
-				},
-				{
-					"artist_mbids": ["5c98fc12-be83-4246-ae5b-2184192913b9"],
-					"artist_name": "Tinariwen",
-					"listen_count": 4,
-					"recording_mbid": "b8cb2270-ef98-4010-8cfe-f00cc999bbd0",
-					"release_mbid": "07037dca-b814-4d01-9ded-096a06826d75",
-					"release_name": "Emmaar",
-					"track_name": "Toumast Tincha"
-				},
-				{
-					"artist_mbids": ["4ced64a4-1731-43c2-aaed-dbb3725fab9d"],
-					"artist_name": "The Parlor Mob",
-					"listen_count": 4,
-					"recording_mbid": "de08b36e-d8c8-4051-8316-f067688de858",
-					"release_mbid": "c9e0db11-6225-4479-ad30-f4ab983fae1b",
-					"release_name": "And You Were a Crow",
-					"track_name": "Tide of Tears"
-				},
-				{
-					"artist_mbids": ["2650f0e7-3879-4b2c-8908-d025113cbece"],
-					"artist_name": "KOKOROKO",
-					"listen_count": 4,
-					"recording_mbid": "b26bc064-fb52-433e-af02-fc2ab58e6bb0",
-					"release_mbid": "d7104546-c08d-4c6e-b14b-d4b7b00d4462",
-					"release_name": "KOKOROKO",
-					"track_name": "Ti-de"
-				},
-				{
-					"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_name": "Mdou Moctar",
-					"listen_count": 4,
-					"recording_mbid": "9bcd7c08-0548-4fe3-873b-a23b75c9f264",
-					"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
-					"release_name": "Ilana: The Creator",
-					"track_name": "Tarhatazed"
-				},
-				{
-					"artist_mbids": ["04cd0cfd-bfd1-4c36-bc38-95c35e2c045f"],
-					"artist_name": "Cream",
-					"listen_count": 4,
-					"recording_mbid": "2d5ae8c3-0db6-4354-a8ce-e530a58fd2b9",
-					"release_mbid": "ff44b5ec-ac04-3a6a-aad4-a26e9591e332",
-					"release_name": "Disraeli Gears",
-					"track_name": "Tales of Brave Ulysses"
-				},
-				{
-					"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_name": "Mdou Moctar",
-					"listen_count": 4,
-					"recording_mbid": "775f4f57-6a17-40cb-b79e-8df957af3428",
-					"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
-					"release_name": "Ilana: The Creator",
-					"track_name": "Takamba"
-				},
-				{
-					"artist_mbids": ["4d593ee9-d16a-41fd-89f9-fddd48af1dd7", "62e1043b-07e6-440e-bdf6-227ea2876e81"],
-					"artist_name": "Scotch Rolex ft. Lord Spikeheart",
-					"listen_count": 4,
-					"recording_mbid": "5656bce7-25dc-4176-b3e3-8a477a542da2",
-					"release_mbid": "40d6c86f-d3e5-4bb4-93bd-22631315a3b0",
-					"release_name": "TEWARI",
-					"track_name": "Success"
-				},
-				{
-					"artist_mbids": ["42689657-cbec-4f66-a9ed-80f939ea23ed"],
-					"artist_name": "Morphine",
-					"listen_count": 4,
-					"recording_mbid": "d8a213c8-d692-4d54-91de-25ac68b67a49",
-					"release_mbid": "c6f2297e-4083-439e-b141-f947de988576",
-					"release_name": "Cure for Pain",
-					"track_name": "Sheila"
-				},
-				{
-					"artist_mbids": ["3d49e36a-cc9e-411e-93c6-d1646ba5bd3a"],
-					"artist_name": "The Staple Singers",
-					"listen_count": 4,
-					"recording_mbid": "d5037427-7317-4c14-9540-fda40ad2ea5c",
-					"release_mbid": "bc517b5e-9262-4d5a-bf4f-7d22ccd51bdf",
-					"release_name": "City in the Sky",
-					"track_name": "Respect Yourself"
-				},
-				{
-					"artist_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
-					"artist_name": "José Carlos Schwarz & Le Cobiana Djazz",
-					"listen_count": 4,
-					"recording_mbid": "525a03ac-5b08-47bc-9e42-97fddf20f073",
-					"release_mbid": "0d698584-4c46-46ce-9781-e394d81450bd",
-					"release_name": "Lua Ki Di Nos",
-					"track_name": "Na Kolonia"
-				},
-				{
-					"artist_mbids": ["b0a7716f-9e14-4114-825a-1cadadfd7817"],
-					"artist_name": "General Midi",
-					"listen_count": 4,
-					"recording_mbid": "5e58c67c-ee7e-4a89-9fda-3dde3ef8152f",
-					"release_mbid": "e7266b15-6353-4c9e-b9ba-0a283b9c74e8",
-					"release_name": "Operation Overdrive",
-					"track_name": "Milton"
-				},
-				{
-					"artist_mbids": ["02177ee9-4415-4f31-a166-fc57a9016d4f", "7682d624-9e0b-45b2-b7d0-d1b18b3ebd05"],
-					"artist_name": "Vieux Farka Touré & Julia Easterlin",
-					"listen_count": 4,
-					"recording_mbid": "1b2f42c5-eb1d-4db8-b18f-200b94410140",
-					"release_mbid": "ee40241c-c48d-4a79-b9d9-6a8b903ea93c",
-					"release_name": "Touristes",
-					"track_name": "Masters of War"
-				},
-				{
-					"artist_mbids": ["5182c1d9-c7d2-4dad-afa0-ccfeada921a8"],
-					"artist_name": "Black Sabbath",
-					"listen_count": 4,
-					"recording_mbid": "c825b3da-2573-4007-b042-90a4edb6acd1",
-					"release_mbid": "0b4d5359-6ecb-4c09-b36a-f56b70d101a2",
-					"release_name": "Master of Reality",
-					"track_name": "Lord of This World"
-				},
-				{
-					"artist_mbids": ["2c180037-0af5-4f9d-a29d-9512544a3064"],
-					"artist_name": "Afla Sackey & Afrik Bawantu",
-					"listen_count": 4,
-					"recording_mbid": "56b13aee-0ca7-47cc-95b5-78a156a2d867",
-					"release_mbid": "7a08a7ce-4621-42c7-b85c-a7eea4d041df",
-					"release_name": "Life On The Street",
-					"track_name": "Life On The Street"
-				},
-				{
-					"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_name": "Slift",
-					"listen_count": 4,
-					"recording_mbid": "90f23763-acf4-4b58-8ad1-992c0146814f",
-					"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
-					"release_name": "Ummon",
-					"track_name": "It’s Coming…"
-				}
-			],
-			"top_releases": [
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 45,
-					"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
-					"release_name": "Grown"
-				},
-				{
-					"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
-					"artist_name": "Slift",
-					"listen_count": 43,
-					"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
-					"release_name": "Ummon"
-				},
-				{
-					"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_name": "Mdou Moctar",
-					"listen_count": 36,
-					"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
-					"release_name": "Ilana: The Creator"
-				},
-				{
-					"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
-					"artist_name": "Raúl Monsalve y los Forajidos",
-					"listen_count": 36,
-					"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
-					"release_name": "Bichos"
-				},
-				{
-					"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
-					"artist_name": "Fever Ray",
-					"listen_count": 25,
-					"release_mbid": "dba22fc0-9772-49c9-baaa-937d7914278a",
-					"release_name": "Fever Ray"
-				},
-				{
-					"artist_mbids": ["7a6506cc-6f12-442d-9d3e-149bc838792e"],
-					"artist_name": "79.5",
-					"listen_count": 23,
-					"release_mbid": "14bec13f-5656-4f41-9e9c-71cafbb43b5d",
-					"release_name": "Predictions"
-				},
-				{
-					"artist_mbids": ["3a605eba-b6a1-4298-855d-b3033df0bf8b"],
-					"artist_name": "Kikagaku Moyo",
-					"listen_count": 23,
-					"release_mbid": "b0509ae0-782c-49f2-9deb-96fee10d52c5",
-					"release_name": "House in the Tall Grass"
-				},
-				{
-					"artist_mbids": ["72fd7688-8394-43b6-8f41-278657648a45"],
-					"artist_name": "Yussef Kamaal",
-					"listen_count": 23,
-					"release_mbid": "e6a5e707-7782-4258-8b22-9364629810bf",
-					"release_name": "Black Focus"
-				},
-				{
-					"artist_mbids": ["d1ccc60e-45d5-4176-a328-47cd5984e55b"],
-					"artist_name": "Tidiane Thiam",
-					"listen_count": 22,
-					"release_mbid": "30d789a0-fbfc-4e1d-9afc-a40aad08ca75",
-					"release_name": "Siftorde"
-				},
-				{
-					"artist_mbids": ["42689657-cbec-4f66-a9ed-80f939ea23ed"],
-					"artist_name": "Morphine",
-					"listen_count": 22,
-					"release_mbid": "c6f2297e-4083-439e-b141-f947de988576",
-					"release_name": "Cure for Pain"
-				},
-				{
-					"artist_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
-					"artist_name": "The Longest Johns",
-					"listen_count": 22,
-					"release_mbid": "a36fc551-0b52-4e76-a990-29a95e10a6d5",
-					"release_name": "Between Wind and Water"
-				},
-				{
-					"artist_mbids": ["22e6f8d3-2d7e-4abb-8a77-1a6d581cd560"],
-					"artist_name": "Wolves Like Me",
-					"listen_count": 20,
-					"release_mbid": "bf04a661-b7f2-40c9-b8e6-276ff3602997",
-					"release_name": "Who's Afraid?"
-				},
-				{
-					"artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"],
-					"artist_name": "Sergeant Thunderhoof",
-					"listen_count": 20,
-					"release_mbid": "a49acda6-2a0f-4ce5-b009-f86f8fb33644",
-					"release_name": "Terra Solus"
-				},
-				{
-					"artist_mbids": ["9219acc3-6234-4aee-8633-fe438daee3b2"],
-					"artist_name": "Anna Scionti",
-					"listen_count": 20,
-					"release_mbid": "dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0",
-					"release_name": "Junkbox Racket"
-				},
-				{
-					"artist_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
-					"artist_name": "King Gizzard & The Lizard Wizard",
-					"listen_count": 19,
-					"release_mbid": "db1c268c-39bd-4a86-bc02-2d514e205a42",
-					"release_name": "Nonagon Infinity"
-				},
-				{
-					"artist_mbids": ["c10e38ae-d06f-4bf4-8b54-8e19236a94f4"],
-					"artist_name": "Mohama Saz",
-					"listen_count": 19,
-					"release_mbid": "525dd70b-9614-477c-bd5a-1f8cfe547fe3",
-					"release_name": "Negro es el poder"
-				},
-				{
-					"artist_mbids": ["8ed78ccf-7a3f-4717-b84c-1606627124bd"],
-					"artist_name": "Hey Colossus",
-					"listen_count": 19,
-					"release_mbid": "882d8b34-42bc-4c10-b66e-5d87211a783a",
-					"release_name": "Dances / Curses"
-				},
-				{
-					"artist_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
-					"artist_name": "Goat",
-					"listen_count": 19,
-					"release_mbid": "4aef4248-31eb-44ea-95e3-c3706fd14ebe",
-					"release_name": "Commune"
-				},
-				{
-					"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"],
-					"artist_name": "Koichi Sakai / Afla Sackey",
-					"listen_count": 18,
-					"release_mbid": "790fe3d0-6c19-4b2e-9067-a6b66ce00bfe",
-					"release_name": "Wono LP"
-				},
-				{
-					"artist_mbids": ["2c180037-0af5-4f9d-a29d-9512544a3064"],
-					"artist_name": "Afla Sackey & Afrik Bawantu",
-					"listen_count": 18,
-					"release_mbid": "7a08a7ce-4621-42c7-b85c-a7eea4d041df",
-					"release_name": "Life On The Street"
-				},
-				{
-					"artist_mbids": ["052b43c2-2f6a-4e60-92ea-18b4de2be0d9"],
-					"artist_name": "Naxatras",
-					"listen_count": 18,
-					"release_mbid": "fd2c2f03-91d2-4ef0-a4c2-b22a141b8305",
-					"release_name": "III"
-				},
-				{
-					"artist_mbids": ["d675ed3f-bee2-40e0-8386-2960f477ad35"],
-					"artist_name": "Buried Feather",
-					"listen_count": 18,
-					"release_mbid": "0aaa7ecf-c117-4fc3-8f87-27dd8063010d",
-					"release_name": "Cloudberry Dreamshake"
-				},
-				{
-					"artist_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
-					"artist_name": "Les Filles de Illighadad",
-					"listen_count": 17,
-					"release_mbid": "bc3e00b2-49f9-4e17-b4b6-7d1ccd1ea3c4",
-					"release_name": "Eghass Malan"
-				},
-				{
-					"artist_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
-					"artist_name": "The Longest Johns",
-					"listen_count": 16,
-					"release_mbid": "12590c2f-fc17-4ea8-a7d0-6105e9192519",
-					"release_name": "Written in Salt"
-				},
-				{
-					"artist_mbids": ["cb331ec3-72af-4d8c-825a-63f79d56a651"],
-					"artist_name": "Movie Club",
-					"listen_count": 16,
-					"release_mbid": "43da4da0-f2cd-4e49-8bae-b334e2a71245",
-					"release_name": "Black Flamingo"
-				},
-				{
-					"artist_mbids": ["7e9d3899-9de2-4741-973c-6147238bb2f1"],
-					"artist_name": "Koudede",
-					"listen_count": 15,
-					"release_mbid": "d3a8492f-3130-4b34-9e8e-c0d5a3bff25e",
-					"release_name": "Taghlamt"
-				},
-				{
-					"artist_mbids": ["aeb7af5b-fef8-479d-b5b4-f9b3c4fb95d4"],
-					"artist_name": "Masters of Reality",
-					"listen_count": 15,
-					"release_mbid": "a9967f3c-d767-447f-b50d-96adfc6b1d1f",
-					"release_name": "Sunrise on the Sufferbus"
-				},
-				{
-					"artist_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
-					"artist_name": "Goat",
-					"listen_count": 15,
-					"release_mbid": "c27b9ce0-d30a-4793-b290-7cb0568a7289",
-					"release_name": "Requiem"
-				},
-				{
-					"artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
-					"artist_name": "Danny Elfman",
-					"listen_count": 15,
-					"release_mbid": "7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19",
-					"release_name": "Big Mess"
-				},
-				{
-					"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
-					"artist_name": "Mdou Moctar",
-					"listen_count": 15,
-					"release_mbid": "3b4e94a4-a148-4291-8f37-98b646e29e35",
-					"release_name": "Afelan"
-				},
-				{
-					"artist_mbids": ["67f0c7ca-14e8-47a3-be0e-bd2f2ffe25bb", "ed8a131a-3ec7-4410-a848-40aa670111e0"],
-					"artist_name": "Mulatu Astatke & Black Jesus Experience",
-					"listen_count": 14,
-					"release_mbid": "17697121-bbb5-4af9-8fab-a835a81889b5",
-					"release_name": "To Know Without Knowing"
-				},
-				{
-					"artist_mbids": ["6ce5eca0-4ad6-49e0-a5ab-e11482d85324"],
-					"artist_name": "Sudan Archives",
-					"listen_count": 14,
-					"release_mbid": "555fce2e-44b4-464c-bb70-40f2ac39ba00",
-					"release_name": "Sudan Archives"
-				},
-				{
-					"artist_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
-					"artist_name": "Black Sky Giant",
-					"listen_count": 14,
-					"release_mbid": "de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746",
-					"release_name": "Planet Terror"
-				},
-				{
-					"artist_mbids": ["1bdc2715-507c-41cb-9e06-021a8ecd6c8e"],
-					"artist_name": "Karkara",
-					"listen_count": 14,
-					"release_mbid": "cca29976-fea4-445a-be77-13b789dcdb81",
-					"release_name": "Nowhere Land"
-				},
-				{
-					"artist_mbids": ["2a67f9e5-8b94-4929-b74c-236b4c1a70c3"],
-					"artist_name": "Mantra Machine",
-					"listen_count": 14,
-					"release_mbid": "e3987f3b-0913-4917-9345-a7d1b0743131",
-					"release_name": "Nitrogen"
-				},
-				{
-					"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
-					"artist_name": "Nubya Garcia",
-					"listen_count": 13,
-					"release_mbid": "3ed914b0-9552-4258-9823-196ebbebfbf6",
-					"release_name": "Nubya’s 5ive"
-				},
-				{
-					"artist_mbids": ["8067c102-4996-42bc-9980-06ce2e644eae"],
-					"artist_name": "Soul Coughing",
-					"listen_count": 13,
-					"release_mbid": "95cfa680-5f12-4f6a-b56b-6464b23a51d7",
-					"release_name": "Irresistible Bliss"
-				},
-				{
-					"artist_mbids": ["a9126556-f555-4920-9617-6e013f8228a7"],
-					"artist_name": "Mark Lanegan",
-					"listen_count": 13,
-					"release_mbid": "cf637081-1868-4dac-a4ba-b57ac329459d",
-					"release_name": "Bubblegum"
-				},
-				{
-					"artist_mbids": ["eb3b3201-d6d5-4143-bd30-c50e719c138e"],
-					"artist_name": "Dust Mice",
-					"listen_count": 12,
-					"release_mbid": "0f055f1b-5ee0-473a-9c1c-3ada4d326b22",
-					"release_name": "Super Moon Fetus"
-				},
-				{
-					"artist_mbids": ["425bd6b7-dccf-4a03-9a4c-40f28fb5792d"],
-					"artist_name": "The Ossuary",
-					"listen_count": 12,
-					"release_mbid": "6d77c3fa-44aa-4814-abdf-82d66a167370",
-					"release_name": "Oltretomba"
-				},
-				{
-					"artist_mbids": ["c3aeb863-7b26-4388-94e8-5a240f2be21b"],
-					"artist_name": "Tom Waits",
-					"listen_count": 12,
-					"release_mbid": "dbd7788b-d83b-3fca-9a1e-ef477fbef18b",
-					"release_name": "Blood Money"
-				},
-				{
-					"artist_mbids": [],
-					"artist_name": "Anne-Sophie Mutter & Herbert Von Karajan",
-					"listen_count": 12,
-					"release_name": "Antonio Vivaldi - The Four Seasons(DTS)"
-				},
-				{
-					"artist_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
-					"artist_name": "Kraftwerk",
-					"listen_count": 11,
-					"release_mbid": "ee5f888d-2734-3ace-a25b-b6f9f39ca147",
-					"release_name": "Tour de France Soundtracks"
-				},
-				{
-					"artist_mbids": [],
-					"artist_name": "Roswell Rudd",
-					"listen_count": 11,
-					"release_name": "Malicool"
-				},
-				{
-					"artist_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
-					"artist_name": "José Carlos Schwarz & Le Cobiana Djazz",
-					"listen_count": 11,
-					"release_mbid": "0d698584-4c46-46ce-9781-e394d81450bd",
-					"release_name": "Lua Ki Di Nos"
-				},
-				{
-					"artist_mbids": ["dc041361-3440-4c8a-a91d-730c0a30617b"],
-					"artist_name": "I Mitomani Beat",
-					"listen_count": 11,
-					"release_mbid": "f92a777c-e972-4f35-af16-1c52d5475ed5",
-					"release_name": "Fuori Dal Tempo"
-				},
-				{
-					"artist_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
-					"artist_name": "Green Lung",
-					"listen_count": 11,
-					"release_mbid": "82a4ad46-2b60-44c3-91a9-58fc18eaa8d0",
-					"release_name": "Free the Witch"
-				},
-				{
-					"artist_mbids": ["a18c09f4-6b6f-4f9c-a4bb-ae2db7cab657"],
-					"artist_name": "Samsara Blues Experiment",
-					"listen_count": 11,
-					"release_mbid": "4ae759b4-3887-4e09-b731-a0fc95827f7e",
-					"release_name": "End of Forever"
-				},
-				{
-					"artist_mbids": ["350bddf0-fa3c-4b7c-98e5-afabaa8e630f"],
-					"artist_name": "TisDass",
-					"listen_count": 10,
-					"release_mbid": "76b95291-ca09-4ce4-be26-f53a94f2530b",
-					"release_name": "Yamedan"
-				},
-				{
-					"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
-					"artist_name": "Waaju",
-					"listen_count": 10,
-					"release_mbid": "5e366076-7842-465f-8f66-4f4ac48dd582",
-					"release_name": "Waaju"
-				}
-			],
-			"top_releases_coverart": {
-				"0aaa7ecf-c117-4fc3-8f87-27dd8063010d": "https://archive.org/download/mbid-0aaa7ecf-c117-4fc3-8f87-27dd8063010d/mbid-0aaa7ecf-c117-4fc3-8f87-27dd8063010d-24818898237_thumb500.jpg",
-				"0d698584-4c46-46ce-9781-e394d81450bd": "https://archive.org/download/mbid-0d698584-4c46-46ce-9781-e394d81450bd/mbid-0d698584-4c46-46ce-9781-e394d81450bd-29260797648_thumb500.jpg",
-				"0f055f1b-5ee0-473a-9c1c-3ada4d326b22": "https://archive.org/download/mbid-0f055f1b-5ee0-473a-9c1c-3ada4d326b22/mbid-0f055f1b-5ee0-473a-9c1c-3ada4d326b22-28528635378_thumb500.jpg",
-				"12590c2f-fc17-4ea8-a7d0-6105e9192519": "https://archive.org/download/mbid-9ff59752-ae14-436d-9cfa-538c3a277a49/mbid-9ff59752-ae14-436d-9cfa-538c3a277a49-28508253308_thumb500.jpg",
-				"14bec13f-5656-4f41-9e9c-71cafbb43b5d": "https://archive.org/download/mbid-14bec13f-5656-4f41-9e9c-71cafbb43b5d/mbid-14bec13f-5656-4f41-9e9c-71cafbb43b5d-21132449540_thumb500.jpg",
-				"17697121-bbb5-4af9-8fab-a835a81889b5": "https://archive.org/download/mbid-17697121-bbb5-4af9-8fab-a835a81889b5/mbid-17697121-bbb5-4af9-8fab-a835a81889b5-28321745116_thumb500.jpg",
-				"30d789a0-fbfc-4e1d-9afc-a40aad08ca75": "https://archive.org/download/mbid-30d789a0-fbfc-4e1d-9afc-a40aad08ca75/mbid-30d789a0-fbfc-4e1d-9afc-a40aad08ca75-26101187098_thumb500.jpg",
-				"3b4e94a4-a148-4291-8f37-98b646e29e35": "https://archive.org/download/mbid-3b4e94a4-a148-4291-8f37-98b646e29e35/mbid-3b4e94a4-a148-4291-8f37-98b646e29e35-22567406586_thumb500.jpg",
-				"3ed914b0-9552-4258-9823-196ebbebfbf6": "https://archive.org/download/mbid-3ed914b0-9552-4258-9823-196ebbebfbf6/mbid-3ed914b0-9552-4258-9823-196ebbebfbf6-30548125375_thumb500.jpg",
-				"43da4da0-f2cd-4e49-8bae-b334e2a71245": "https://archive.org/download/mbid-43da4da0-f2cd-4e49-8bae-b334e2a71245/mbid-43da4da0-f2cd-4e49-8bae-b334e2a71245-29837533510_thumb500.jpg",
-				"4ae759b4-3887-4e09-b731-a0fc95827f7e": "https://archive.org/download/mbid-4ae759b4-3887-4e09-b731-a0fc95827f7e/mbid-4ae759b4-3887-4e09-b731-a0fc95827f7e-28171732498_thumb500.jpg",
-				"4aef4248-31eb-44ea-95e3-c3706fd14ebe": "https://archive.org/download/mbid-991de6ef-018f-4cc1-804e-694d6ed0ac60/mbid-991de6ef-018f-4cc1-804e-694d6ed0ac60-30098225803_thumb500.jpg",
-				"525dd70b-9614-477c-bd5a-1f8cfe547fe3": "https://archive.org/download/mbid-525dd70b-9614-477c-bd5a-1f8cfe547fe3/mbid-525dd70b-9614-477c-bd5a-1f8cfe547fe3-16146216234_thumb500.jpg",
-				"555fce2e-44b4-464c-bb70-40f2ac39ba00": "https://archive.org/download/mbid-555fce2e-44b4-464c-bb70-40f2ac39ba00/mbid-555fce2e-44b4-464c-bb70-40f2ac39ba00-17275675545_thumb500.jpg",
-				"57b16096-5ab0-453b-9f6c-9ba6752a07c1": "https://archive.org/download/mbid-6f821b32-d742-4855-a92b-e4307a71d328/mbid-6f821b32-d742-4855-a92b-e4307a71d328-25157253217_thumb500.jpg",
-				"5e366076-7842-465f-8f66-4f4ac48dd582": "https://archive.org/download/mbid-5e366076-7842-465f-8f66-4f4ac48dd582/mbid-5e366076-7842-465f-8f66-4f4ac48dd582-27111713202_thumb500.jpg",
-				"6d77c3fa-44aa-4814-abdf-82d66a167370": "https://archive.org/download/mbid-6d77c3fa-44aa-4814-abdf-82d66a167370/mbid-6d77c3fa-44aa-4814-abdf-82d66a167370-31023875910_thumb500.jpg",
-				"76b95291-ca09-4ce4-be26-f53a94f2530b": "https://archive.org/download/mbid-76b95291-ca09-4ce4-be26-f53a94f2530b/mbid-76b95291-ca09-4ce4-be26-f53a94f2530b-12215908866_thumb500.jpg",
-				"790fe3d0-6c19-4b2e-9067-a6b66ce00bfe": "https://archive.org/download/mbid-790fe3d0-6c19-4b2e-9067-a6b66ce00bfe/mbid-790fe3d0-6c19-4b2e-9067-a6b66ce00bfe-31016686916_thumb500.jpg",
-				"7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19": "https://archive.org/download/mbid-7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19/mbid-7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19-29690912729_thumb500.jpg",
-				"82a4ad46-2b60-44c3-91a9-58fc18eaa8d0": "https://archive.org/download/mbid-82a4ad46-2b60-44c3-91a9-58fc18eaa8d0/mbid-82a4ad46-2b60-44c3-91a9-58fc18eaa8d0-19151416676_thumb500.jpg",
-				"882d8b34-42bc-4c10-b66e-5d87211a783a": "https://archive.org/download/mbid-c169b6b9-f8a8-4223-a27b-d54f779e23d6/mbid-c169b6b9-f8a8-4223-a27b-d54f779e23d6-27699726096_thumb500.jpg",
-				"8f4d033b-336f-49e4-9fee-3ea9828bc3d9": "https://archive.org/download/mbid-8f4d033b-336f-49e4-9fee-3ea9828bc3d9/mbid-8f4d033b-336f-49e4-9fee-3ea9828bc3d9-26952123955_thumb500.jpg",
-				"95cfa680-5f12-4f6a-b56b-6464b23a51d7": "https://archive.org/download/mbid-95cfa680-5f12-4f6a-b56b-6464b23a51d7/mbid-95cfa680-5f12-4f6a-b56b-6464b23a51d7-5722139475_thumb500.jpg",
-				"a36fc551-0b52-4e76-a990-29a95e10a6d5": "https://archive.org/download/mbid-90ab2dbb-a73f-433f-af08-86480569d052/mbid-90ab2dbb-a73f-433f-af08-86480569d052-28561345452_thumb500.jpg",
-				"a49acda6-2a0f-4ce5-b009-f86f8fb33644": "https://archive.org/download/mbid-a49acda6-2a0f-4ce5-b009-f86f8fb33644/mbid-a49acda6-2a0f-4ce5-b009-f86f8fb33644-31016437738_thumb500.jpg",
-				"a9967f3c-d767-447f-b50d-96adfc6b1d1f": "https://archive.org/download/mbid-a9967f3c-d767-447f-b50d-96adfc6b1d1f/mbid-a9967f3c-d767-447f-b50d-96adfc6b1d1f-4697744998_thumb500.jpg",
-				"b0509ae0-782c-49f2-9deb-96fee10d52c5": "https://archive.org/download/mbid-b0509ae0-782c-49f2-9deb-96fee10d52c5/mbid-b0509ae0-782c-49f2-9deb-96fee10d52c5-13685812868_thumb500.jpg",
-				"b32fdb57-591a-423c-94bd-2ecc11dd529d": "https://archive.org/download/mbid-b32fdb57-591a-423c-94bd-2ecc11dd529d/mbid-b32fdb57-591a-423c-94bd-2ecc11dd529d-27595765927_thumb500.jpg",
-				"bc3e00b2-49f9-4e17-b4b6-7d1ccd1ea3c4": "https://archive.org/download/mbid-83bb5d9b-8028-4e8a-b366-e552788251ac/mbid-83bb5d9b-8028-4e8a-b366-e552788251ac-18529426891_thumb500.jpg",
-				"bf04a661-b7f2-40c9-b8e6-276ff3602997": "https://archive.org/download/mbid-bf04a661-b7f2-40c9-b8e6-276ff3602997/mbid-bf04a661-b7f2-40c9-b8e6-276ff3602997-31016387153_thumb500.jpg",
-				"c20f3a9b-bdc3-474a-a5ba-0e1b819bb777": "https://archive.org/download/mbid-f2456b58-1365-41a2-ad4a-e7f93b4ef24c/mbid-f2456b58-1365-41a2-ad4a-e7f93b4ef24c-23111873482_thumb500.jpg",
-				"c27b9ce0-d30a-4793-b290-7cb0568a7289": "https://archive.org/download/mbid-3dd71efa-4a6f-4035-b473-704cbc5d3905/mbid-3dd71efa-4a6f-4035-b473-704cbc5d3905-30098155000_thumb500.jpg",
-				"c6f2297e-4083-439e-b141-f947de988576": "https://archive.org/download/mbid-c6f2297e-4083-439e-b141-f947de988576/mbid-c6f2297e-4083-439e-b141-f947de988576-14670890955_thumb500.jpg",
-				"cca29976-fea4-445a-be77-13b789dcdb81": "https://archive.org/download/mbid-cca29976-fea4-445a-be77-13b789dcdb81/mbid-cca29976-fea4-445a-be77-13b789dcdb81-27317413245_thumb500.jpg",
-				"cf637081-1868-4dac-a4ba-b57ac329459d": "https://archive.org/download/mbid-864236f5-29bd-3075-893c-1614da2a760a/mbid-864236f5-29bd-3075-893c-1614da2a760a-10445104137_thumb500.jpg",
-				"d3a8492f-3130-4b34-9e8e-c0d5a3bff25e": "https://archive.org/download/mbid-d3a8492f-3130-4b34-9e8e-c0d5a3bff25e/mbid-d3a8492f-3130-4b34-9e8e-c0d5a3bff25e-31024382371_thumb500.jpg",
-				"db1c268c-39bd-4a86-bc02-2d514e205a42": "https://archive.org/download/mbid-db1c268c-39bd-4a86-bc02-2d514e205a42/mbid-db1c268c-39bd-4a86-bc02-2d514e205a42-28715709130_thumb500.jpg",
-				"dba22fc0-9772-49c9-baaa-937d7914278a": "https://archive.org/download/mbid-dba22fc0-9772-49c9-baaa-937d7914278a/mbid-dba22fc0-9772-49c9-baaa-937d7914278a-3694245478_thumb500.jpg",
-				"dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0": "https://archive.org/download/mbid-dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0/mbid-dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0-28501559665_thumb500.jpg",
-				"dbd7788b-d83b-3fca-9a1e-ef477fbef18b": "https://archive.org/download/mbid-fe24ae45-4a90-3baa-9b92-d9008c6fbfed/mbid-fe24ae45-4a90-3baa-9b92-d9008c6fbfed-29377113010_thumb500.jpg",
-				"de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746": "https://archive.org/download/mbid-de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746/mbid-de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746-28346397129_thumb500.jpg",
-				"e3987f3b-0913-4917-9345-a7d1b0743131": "https://archive.org/download/mbid-e3987f3b-0913-4917-9345-a7d1b0743131/mbid-e3987f3b-0913-4917-9345-a7d1b0743131-9088922725_thumb500.jpg",
-				"e6a5e707-7782-4258-8b22-9364629810bf": "https://archive.org/download/mbid-e6a5e707-7782-4258-8b22-9364629810bf/mbid-e6a5e707-7782-4258-8b22-9364629810bf-17570747724_thumb500.jpg",
-				"ee5f888d-2734-3ace-a25b-b6f9f39ca147": "https://archive.org/download/mbid-ee5f888d-2734-3ace-a25b-b6f9f39ca147/mbid-ee5f888d-2734-3ace-a25b-b6f9f39ca147-2541564114_thumb500.jpg",
-				"f92a777c-e972-4f35-af16-1c52d5475ed5": "https://archive.org/download/mbid-f92a777c-e972-4f35-af16-1c52d5475ed5/mbid-f92a777c-e972-4f35-af16-1c52d5475ed5-30833685382_thumb500.jpg",
-				"fd2c2f03-91d2-4ef0-a4c2-b22a141b8305": "https://archive.org/download/mbid-fd2c2f03-91d2-4ef0-a4c2-b22a141b8305/mbid-fd2c2f03-91d2-4ef0-a4c2-b22a141b8305-19125183916_thumb500.jpg"
-			},
-			"total_listen_count": 2742
+	"day_of_week": "Friday",
+	"listens_per_day": [
+		{
+			"from_ts": 1609459200,
+			"listen_count": 0,
+			"time_range": "01 January 2021",
+			"to_ts": 1609545599
 		},
-		"user_name": "mr_monkey"
-	}
+		{
+			"from_ts": 1609545600,
+			"listen_count": 0,
+			"time_range": "02 January 2021",
+			"to_ts": 1609631999
+		},
+		{
+			"from_ts": 1609632000,
+			"listen_count": 41,
+			"time_range": "03 January 2021",
+			"to_ts": 1609718399
+		},
+		{
+			"from_ts": 1609718400,
+			"listen_count": 1,
+			"time_range": "04 January 2021",
+			"to_ts": 1609804799
+		},
+		{
+			"from_ts": 1609804800,
+			"listen_count": 0,
+			"time_range": "05 January 2021",
+			"to_ts": 1609891199
+		},
+		{
+			"from_ts": 1609891200,
+			"listen_count": 2,
+			"time_range": "06 January 2021",
+			"to_ts": 1609977599
+		},
+		{
+			"from_ts": 1609977600,
+			"listen_count": 1,
+			"time_range": "07 January 2021",
+			"to_ts": 1610063999
+		},
+		{
+			"from_ts": 1610064000,
+			"listen_count": 0,
+			"time_range": "08 January 2021",
+			"to_ts": 1610150399
+		},
+		{
+			"from_ts": 1610150400,
+			"listen_count": 0,
+			"time_range": "09 January 2021",
+			"to_ts": 1610236799
+		},
+		{
+			"from_ts": 1610236800,
+			"listen_count": 51,
+			"time_range": "10 January 2021",
+			"to_ts": 1610323199
+		},
+		{
+			"from_ts": 1610323200,
+			"listen_count": 7,
+			"time_range": "11 January 2021",
+			"to_ts": 1610409599
+		},
+		{
+			"from_ts": 1610409600,
+			"listen_count": 0,
+			"time_range": "12 January 2021",
+			"to_ts": 1610495999
+		},
+		{
+			"from_ts": 1610496000,
+			"listen_count": 21,
+			"time_range": "13 January 2021",
+			"to_ts": 1610582399
+		},
+		{
+			"from_ts": 1610582400,
+			"listen_count": 1,
+			"time_range": "14 January 2021",
+			"to_ts": 1610668799
+		},
+		{
+			"from_ts": 1610668800,
+			"listen_count": 27,
+			"time_range": "15 January 2021",
+			"to_ts": 1610755199
+		},
+		{
+			"from_ts": 1610755200,
+			"listen_count": 0,
+			"time_range": "16 January 2021",
+			"to_ts": 1610841599
+		},
+		{
+			"from_ts": 1610841600,
+			"listen_count": 0,
+			"time_range": "17 January 2021",
+			"to_ts": 1610927999
+		},
+		{
+			"from_ts": 1610928000,
+			"listen_count": 0,
+			"time_range": "18 January 2021",
+			"to_ts": 1611014399
+		},
+		{
+			"from_ts": 1611014400,
+			"listen_count": 0,
+			"time_range": "19 January 2021",
+			"to_ts": 1611100799
+		},
+		{
+			"from_ts": 1611100800,
+			"listen_count": 1,
+			"time_range": "20 January 2021",
+			"to_ts": 1611187199
+		},
+		{
+			"from_ts": 1611187200,
+			"listen_count": 6,
+			"time_range": "21 January 2021",
+			"to_ts": 1611273599
+		},
+		{
+			"from_ts": 1611273600,
+			"listen_count": 46,
+			"time_range": "22 January 2021",
+			"to_ts": 1611359999
+		},
+		{
+			"from_ts": 1611360000,
+			"listen_count": 44,
+			"time_range": "23 January 2021",
+			"to_ts": 1611446399
+		},
+		{
+			"from_ts": 1611446400,
+			"listen_count": 0,
+			"time_range": "24 January 2021",
+			"to_ts": 1611532799
+		},
+		{
+			"from_ts": 1611532800,
+			"listen_count": 23,
+			"time_range": "25 January 2021",
+			"to_ts": 1611619199
+		},
+		{
+			"from_ts": 1611619200,
+			"listen_count": 1,
+			"time_range": "26 January 2021",
+			"to_ts": 1611705599
+		},
+		{
+			"from_ts": 1611705600,
+			"listen_count": 0,
+			"time_range": "27 January 2021",
+			"to_ts": 1611791999
+		},
+		{
+			"from_ts": 1611792000,
+			"listen_count": 1,
+			"time_range": "28 January 2021",
+			"to_ts": 1611878399
+		},
+		{
+			"from_ts": 1611878400,
+			"listen_count": 0,
+			"time_range": "29 January 2021",
+			"to_ts": 1611964799
+		},
+		{
+			"from_ts": 1611964800,
+			"listen_count": 13,
+			"time_range": "30 January 2021",
+			"to_ts": 1612051199
+		},
+		{
+			"from_ts": 1612051200,
+			"listen_count": 0,
+			"time_range": "31 January 2021",
+			"to_ts": 1612137599
+		},
+		{
+			"from_ts": 1612137600,
+			"listen_count": 1,
+			"time_range": "01 February 2021",
+			"to_ts": 1612223999
+		},
+		{
+			"from_ts": 1612224000,
+			"listen_count": 0,
+			"time_range": "02 February 2021",
+			"to_ts": 1612310399
+		},
+		{
+			"from_ts": 1612310400,
+			"listen_count": 0,
+			"time_range": "03 February 2021",
+			"to_ts": 1612396799
+		},
+		{
+			"from_ts": 1612396800,
+			"listen_count": 0,
+			"time_range": "04 February 2021",
+			"to_ts": 1612483199
+		},
+		{
+			"from_ts": 1612483200,
+			"listen_count": 35,
+			"time_range": "05 February 2021",
+			"to_ts": 1612569599
+		},
+		{
+			"from_ts": 1612569600,
+			"listen_count": 0,
+			"time_range": "06 February 2021",
+			"to_ts": 1612655999
+		},
+		{
+			"from_ts": 1612656000,
+			"listen_count": 18,
+			"time_range": "07 February 2021",
+			"to_ts": 1612742399
+		},
+		{
+			"from_ts": 1612742400,
+			"listen_count": 0,
+			"time_range": "08 February 2021",
+			"to_ts": 1612828799
+		},
+		{
+			"from_ts": 1612828800,
+			"listen_count": 0,
+			"time_range": "09 February 2021",
+			"to_ts": 1612915199
+		},
+		{
+			"from_ts": 1612915200,
+			"listen_count": 14,
+			"time_range": "10 February 2021",
+			"to_ts": 1613001599
+		},
+		{
+			"from_ts": 1613001600,
+			"listen_count": 1,
+			"time_range": "11 February 2021",
+			"to_ts": 1613087999
+		},
+		{
+			"from_ts": 1613088000,
+			"listen_count": 44,
+			"time_range": "12 February 2021",
+			"to_ts": 1613174399
+		},
+		{
+			"from_ts": 1613174400,
+			"listen_count": 2,
+			"time_range": "13 February 2021",
+			"to_ts": 1613260799
+		},
+		{
+			"from_ts": 1613260800,
+			"listen_count": 46,
+			"time_range": "14 February 2021",
+			"to_ts": 1613347199
+		},
+		{
+			"from_ts": 1613347200,
+			"listen_count": 3,
+			"time_range": "15 February 2021",
+			"to_ts": 1613433599
+		},
+		{
+			"from_ts": 1613433600,
+			"listen_count": 21,
+			"time_range": "16 February 2021",
+			"to_ts": 1613519999
+		},
+		{
+			"from_ts": 1613520000,
+			"listen_count": 33,
+			"time_range": "17 February 2021",
+			"to_ts": 1613606399
+		},
+		{
+			"from_ts": 1613606400,
+			"listen_count": 0,
+			"time_range": "18 February 2021",
+			"to_ts": 1613692799
+		},
+		{
+			"from_ts": 1613692800,
+			"listen_count": 19,
+			"time_range": "19 February 2021",
+			"to_ts": 1613779199
+		},
+		{
+			"from_ts": 1613779200,
+			"listen_count": 0,
+			"time_range": "20 February 2021",
+			"to_ts": 1613865599
+		},
+		{
+			"from_ts": 1613865600,
+			"listen_count": 19,
+			"time_range": "21 February 2021",
+			"to_ts": 1613951999
+		},
+		{
+			"from_ts": 1613952000,
+			"listen_count": 0,
+			"time_range": "22 February 2021",
+			"to_ts": 1614038399
+		},
+		{
+			"from_ts": 1614038400,
+			"listen_count": 0,
+			"time_range": "23 February 2021",
+			"to_ts": 1614124799
+		},
+		{
+			"from_ts": 1614124800,
+			"listen_count": 0,
+			"time_range": "24 February 2021",
+			"to_ts": 1614211199
+		},
+		{
+			"from_ts": 1614211200,
+			"listen_count": 19,
+			"time_range": "25 February 2021",
+			"to_ts": 1614297599
+		},
+		{
+			"from_ts": 1614297600,
+			"listen_count": 3,
+			"time_range": "26 February 2021",
+			"to_ts": 1614383999
+		},
+		{
+			"from_ts": 1614384000,
+			"listen_count": 16,
+			"time_range": "27 February 2021",
+			"to_ts": 1614470399
+		},
+		{
+			"from_ts": 1614470400,
+			"listen_count": 29,
+			"time_range": "28 February 2021",
+			"to_ts": 1614556799
+		},
+		{
+			"from_ts": 1614556800,
+			"listen_count": 7,
+			"time_range": "01 March 2021",
+			"to_ts": 1614643199
+		},
+		{
+			"from_ts": 1614643200,
+			"listen_count": 15,
+			"time_range": "02 March 2021",
+			"to_ts": 1614729599
+		},
+		{
+			"from_ts": 1614729600,
+			"listen_count": 7,
+			"time_range": "03 March 2021",
+			"to_ts": 1614815999
+		},
+		{
+			"from_ts": 1614816000,
+			"listen_count": 5,
+			"time_range": "04 March 2021",
+			"to_ts": 1614902399
+		},
+		{
+			"from_ts": 1614902400,
+			"listen_count": 4,
+			"time_range": "05 March 2021",
+			"to_ts": 1614988799
+		},
+		{
+			"from_ts": 1614988800,
+			"listen_count": 13,
+			"time_range": "06 March 2021",
+			"to_ts": 1615075199
+		},
+		{
+			"from_ts": 1615075200,
+			"listen_count": 7,
+			"time_range": "07 March 2021",
+			"to_ts": 1615161599
+		},
+		{
+			"from_ts": 1615161600,
+			"listen_count": 20,
+			"time_range": "08 March 2021",
+			"to_ts": 1615247999
+		},
+		{
+			"from_ts": 1615248000,
+			"listen_count": 7,
+			"time_range": "09 March 2021",
+			"to_ts": 1615334399
+		},
+		{
+			"from_ts": 1615334400,
+			"listen_count": 18,
+			"time_range": "10 March 2021",
+			"to_ts": 1615420799
+		},
+		{
+			"from_ts": 1615420800,
+			"listen_count": 26,
+			"time_range": "11 March 2021",
+			"to_ts": 1615507199
+		},
+		{
+			"from_ts": 1615507200,
+			"listen_count": 10,
+			"time_range": "12 March 2021",
+			"to_ts": 1615593599
+		},
+		{
+			"from_ts": 1615593600,
+			"listen_count": 0,
+			"time_range": "13 March 2021",
+			"to_ts": 1615679999
+		},
+		{
+			"from_ts": 1615680000,
+			"listen_count": 7,
+			"time_range": "14 March 2021",
+			"to_ts": 1615766399
+		},
+		{
+			"from_ts": 1615766400,
+			"listen_count": 0,
+			"time_range": "15 March 2021",
+			"to_ts": 1615852799
+		},
+		{
+			"from_ts": 1615852800,
+			"listen_count": 0,
+			"time_range": "16 March 2021",
+			"to_ts": 1615939199
+		},
+		{
+			"from_ts": 1615939200,
+			"listen_count": 31,
+			"time_range": "17 March 2021",
+			"to_ts": 1616025599
+		},
+		{
+			"from_ts": 1616025600,
+			"listen_count": 8,
+			"time_range": "18 March 2021",
+			"to_ts": 1616111999
+		},
+		{
+			"from_ts": 1616112000,
+			"listen_count": 0,
+			"time_range": "19 March 2021",
+			"to_ts": 1616198399
+		},
+		{
+			"from_ts": 1616198400,
+			"listen_count": 1,
+			"time_range": "20 March 2021",
+			"to_ts": 1616284799
+		},
+		{
+			"from_ts": 1616284800,
+			"listen_count": 0,
+			"time_range": "21 March 2021",
+			"to_ts": 1616371199
+		},
+		{
+			"from_ts": 1616371200,
+			"listen_count": 0,
+			"time_range": "22 March 2021",
+			"to_ts": 1616457599
+		},
+		{
+			"from_ts": 1616457600,
+			"listen_count": 0,
+			"time_range": "23 March 2021",
+			"to_ts": 1616543999
+		},
+		{
+			"from_ts": 1616544000,
+			"listen_count": 12,
+			"time_range": "24 March 2021",
+			"to_ts": 1616630399
+		},
+		{
+			"from_ts": 1616630400,
+			"listen_count": 0,
+			"time_range": "25 March 2021",
+			"to_ts": 1616716799
+		},
+		{
+			"from_ts": 1616716800,
+			"listen_count": 14,
+			"time_range": "26 March 2021",
+			"to_ts": 1616803199
+		},
+		{
+			"from_ts": 1616803200,
+			"listen_count": 0,
+			"time_range": "27 March 2021",
+			"to_ts": 1616889599
+		},
+		{
+			"from_ts": 1616889600,
+			"listen_count": 0,
+			"time_range": "28 March 2021",
+			"to_ts": 1616975999
+		},
+		{
+			"from_ts": 1616976000,
+			"listen_count": 0,
+			"time_range": "29 March 2021",
+			"to_ts": 1617062399
+		},
+		{
+			"from_ts": 1617062400,
+			"listen_count": 3,
+			"time_range": "30 March 2021",
+			"to_ts": 1617148799
+		},
+		{
+			"from_ts": 1617148800,
+			"listen_count": 0,
+			"time_range": "31 March 2021",
+			"to_ts": 1617235199
+		},
+		{
+			"from_ts": 1617235200,
+			"listen_count": 8,
+			"time_range": "01 April 2021",
+			"to_ts": 1617321599
+		},
+		{
+			"from_ts": 1617321600,
+			"listen_count": 18,
+			"time_range": "02 April 2021",
+			"to_ts": 1617407999
+		},
+		{
+			"from_ts": 1617408000,
+			"listen_count": 3,
+			"time_range": "03 April 2021",
+			"to_ts": 1617494399
+		},
+		{
+			"from_ts": 1617494400,
+			"listen_count": 41,
+			"time_range": "04 April 2021",
+			"to_ts": 1617580799
+		},
+		{
+			"from_ts": 1617580800,
+			"listen_count": 0,
+			"time_range": "05 April 2021",
+			"to_ts": 1617667199
+		},
+		{
+			"from_ts": 1617667200,
+			"listen_count": 11,
+			"time_range": "06 April 2021",
+			"to_ts": 1617753599
+		},
+		{
+			"from_ts": 1617753600,
+			"listen_count": 8,
+			"time_range": "07 April 2021",
+			"to_ts": 1617839999
+		},
+		{
+			"from_ts": 1617840000,
+			"listen_count": 9,
+			"time_range": "08 April 2021",
+			"to_ts": 1617926399
+		},
+		{
+			"from_ts": 1617926400,
+			"listen_count": 27,
+			"time_range": "09 April 2021",
+			"to_ts": 1618012799
+		},
+		{
+			"from_ts": 1618012800,
+			"listen_count": 0,
+			"time_range": "10 April 2021",
+			"to_ts": 1618099199
+		},
+		{
+			"from_ts": 1618099200,
+			"listen_count": 1,
+			"time_range": "11 April 2021",
+			"to_ts": 1618185599
+		},
+		{
+			"from_ts": 1618185600,
+			"listen_count": 13,
+			"time_range": "12 April 2021",
+			"to_ts": 1618271999
+		},
+		{
+			"from_ts": 1618272000,
+			"listen_count": 103,
+			"time_range": "13 April 2021",
+			"to_ts": 1618358399
+		},
+		{
+			"from_ts": 1618358400,
+			"listen_count": 2,
+			"time_range": "14 April 2021",
+			"to_ts": 1618444799
+		},
+		{
+			"from_ts": 1618444800,
+			"listen_count": 2,
+			"time_range": "15 April 2021",
+			"to_ts": 1618531199
+		},
+		{
+			"from_ts": 1618531200,
+			"listen_count": 41,
+			"time_range": "16 April 2021",
+			"to_ts": 1618617599
+		},
+		{
+			"from_ts": 1618617600,
+			"listen_count": 0,
+			"time_range": "17 April 2021",
+			"to_ts": 1618703999
+		},
+		{
+			"from_ts": 1618704000,
+			"listen_count": 0,
+			"time_range": "18 April 2021",
+			"to_ts": 1618790399
+		},
+		{
+			"from_ts": 1618790400,
+			"listen_count": 18,
+			"time_range": "19 April 2021",
+			"to_ts": 1618876799
+		},
+		{
+			"from_ts": 1618876800,
+			"listen_count": 23,
+			"time_range": "20 April 2021",
+			"to_ts": 1618963199
+		},
+		{
+			"from_ts": 1618963200,
+			"listen_count": 0,
+			"time_range": "21 April 2021",
+			"to_ts": 1619049599
+		},
+		{
+			"from_ts": 1619049600,
+			"listen_count": 0,
+			"time_range": "22 April 2021",
+			"to_ts": 1619135999
+		},
+		{
+			"from_ts": 1619136000,
+			"listen_count": 6,
+			"time_range": "23 April 2021",
+			"to_ts": 1619222399
+		},
+		{
+			"from_ts": 1619222400,
+			"listen_count": 0,
+			"time_range": "24 April 2021",
+			"to_ts": 1619308799
+		},
+		{
+			"from_ts": 1619308800,
+			"listen_count": 0,
+			"time_range": "25 April 2021",
+			"to_ts": 1619395199
+		},
+		{
+			"from_ts": 1619395200,
+			"listen_count": 0,
+			"time_range": "26 April 2021",
+			"to_ts": 1619481599
+		},
+		{
+			"from_ts": 1619481600,
+			"listen_count": 28,
+			"time_range": "27 April 2021",
+			"to_ts": 1619567999
+		},
+		{
+			"from_ts": 1619568000,
+			"listen_count": 8,
+			"time_range": "28 April 2021",
+			"to_ts": 1619654399
+		},
+		{
+			"from_ts": 1619654400,
+			"listen_count": 16,
+			"time_range": "29 April 2021",
+			"to_ts": 1619740799
+		},
+		{
+			"from_ts": 1619740800,
+			"listen_count": 0,
+			"time_range": "30 April 2021",
+			"to_ts": 1619827199
+		},
+		{
+			"from_ts": 1619827200,
+			"listen_count": 0,
+			"time_range": "01 May 2021",
+			"to_ts": 1619913599
+		},
+		{
+			"from_ts": 1619913600,
+			"listen_count": 12,
+			"time_range": "02 May 2021",
+			"to_ts": 1619999999
+		},
+		{
+			"from_ts": 1620000000,
+			"listen_count": 35,
+			"time_range": "03 May 2021",
+			"to_ts": 1620086399
+		},
+		{
+			"from_ts": 1620086400,
+			"listen_count": 7,
+			"time_range": "04 May 2021",
+			"to_ts": 1620172799
+		},
+		{
+			"from_ts": 1620172800,
+			"listen_count": 0,
+			"time_range": "05 May 2021",
+			"to_ts": 1620259199
+		},
+		{
+			"from_ts": 1620259200,
+			"listen_count": 43,
+			"time_range": "06 May 2021",
+			"to_ts": 1620345599
+		},
+		{
+			"from_ts": 1620345600,
+			"listen_count": 2,
+			"time_range": "07 May 2021",
+			"to_ts": 1620431999
+		},
+		{
+			"from_ts": 1620432000,
+			"listen_count": 0,
+			"time_range": "08 May 2021",
+			"to_ts": 1620518399
+		},
+		{
+			"from_ts": 1620518400,
+			"listen_count": 5,
+			"time_range": "09 May 2021",
+			"to_ts": 1620604799
+		},
+		{
+			"from_ts": 1620604800,
+			"listen_count": 29,
+			"time_range": "10 May 2021",
+			"to_ts": 1620691199
+		},
+		{
+			"from_ts": 1620691200,
+			"listen_count": 19,
+			"time_range": "11 May 2021",
+			"to_ts": 1620777599
+		},
+		{
+			"from_ts": 1620777600,
+			"listen_count": 44,
+			"time_range": "12 May 2021",
+			"to_ts": 1620863999
+		},
+		{
+			"from_ts": 1620864000,
+			"listen_count": 34,
+			"time_range": "13 May 2021",
+			"to_ts": 1620950399
+		},
+		{
+			"from_ts": 1620950400,
+			"listen_count": 51,
+			"time_range": "14 May 2021",
+			"to_ts": 1621036799
+		},
+		{
+			"from_ts": 1621036800,
+			"listen_count": 0,
+			"time_range": "15 May 2021",
+			"to_ts": 1621123199
+		},
+		{
+			"from_ts": 1621123200,
+			"listen_count": 0,
+			"time_range": "16 May 2021",
+			"to_ts": 1621209599
+		},
+		{
+			"from_ts": 1621209600,
+			"listen_count": 12,
+			"time_range": "17 May 2021",
+			"to_ts": 1621295999
+		},
+		{
+			"from_ts": 1621296000,
+			"listen_count": 0,
+			"time_range": "18 May 2021",
+			"to_ts": 1621382399
+		},
+		{
+			"from_ts": 1621382400,
+			"listen_count": 19,
+			"time_range": "19 May 2021",
+			"to_ts": 1621468799
+		},
+		{
+			"from_ts": 1621468800,
+			"listen_count": 0,
+			"time_range": "20 May 2021",
+			"to_ts": 1621555199
+		},
+		{
+			"from_ts": 1621555200,
+			"listen_count": 0,
+			"time_range": "21 May 2021",
+			"to_ts": 1621641599
+		},
+		{
+			"from_ts": 1621641600,
+			"listen_count": 0,
+			"time_range": "22 May 2021",
+			"to_ts": 1621727999
+		},
+		{
+			"from_ts": 1621728000,
+			"listen_count": 9,
+			"time_range": "23 May 2021",
+			"to_ts": 1621814399
+		},
+		{
+			"from_ts": 1621814400,
+			"listen_count": 18,
+			"time_range": "24 May 2021",
+			"to_ts": 1621900799
+		},
+		{
+			"from_ts": 1621900800,
+			"listen_count": 17,
+			"time_range": "25 May 2021",
+			"to_ts": 1621987199
+		},
+		{
+			"from_ts": 1621987200,
+			"listen_count": 0,
+			"time_range": "26 May 2021",
+			"to_ts": 1622073599
+		},
+		{
+			"from_ts": 1622073600,
+			"listen_count": 80,
+			"time_range": "27 May 2021",
+			"to_ts": 1622159999
+		},
+		{
+			"from_ts": 1622160000,
+			"listen_count": 0,
+			"time_range": "28 May 2021",
+			"to_ts": 1622246399
+		},
+		{
+			"from_ts": 1622246400,
+			"listen_count": 0,
+			"time_range": "29 May 2021",
+			"to_ts": 1622332799
+		},
+		{
+			"from_ts": 1622332800,
+			"listen_count": 0,
+			"time_range": "30 May 2021",
+			"to_ts": 1622419199
+		},
+		{
+			"from_ts": 1622419200,
+			"listen_count": 0,
+			"time_range": "31 May 2021",
+			"to_ts": 1622505599
+		},
+		{
+			"from_ts": 1622505600,
+			"listen_count": 5,
+			"time_range": "01 June 2021",
+			"to_ts": 1622591999
+		},
+		{
+			"from_ts": 1622592000,
+			"listen_count": 0,
+			"time_range": "02 June 2021",
+			"to_ts": 1622678399
+		},
+		{
+			"from_ts": 1622678400,
+			"listen_count": 0,
+			"time_range": "03 June 2021",
+			"to_ts": 1622764799
+		},
+		{
+			"from_ts": 1622764800,
+			"listen_count": 24,
+			"time_range": "04 June 2021",
+			"to_ts": 1622851199
+		},
+		{
+			"from_ts": 1622851200,
+			"listen_count": 0,
+			"time_range": "05 June 2021",
+			"to_ts": 1622937599
+		},
+		{
+			"from_ts": 1622937600,
+			"listen_count": 0,
+			"time_range": "06 June 2021",
+			"to_ts": 1623023999
+		},
+		{
+			"from_ts": 1623024000,
+			"listen_count": 0,
+			"time_range": "07 June 2021",
+			"to_ts": 1623110399
+		},
+		{
+			"from_ts": 1623110400,
+			"listen_count": 0,
+			"time_range": "08 June 2021",
+			"to_ts": 1623196799
+		},
+		{
+			"from_ts": 1623196800,
+			"listen_count": 6,
+			"time_range": "09 June 2021",
+			"to_ts": 1623283199
+		},
+		{
+			"from_ts": 1623283200,
+			"listen_count": 17,
+			"time_range": "10 June 2021",
+			"to_ts": 1623369599
+		},
+		{
+			"from_ts": 1623369600,
+			"listen_count": 0,
+			"time_range": "11 June 2021",
+			"to_ts": 1623455999
+		},
+		{
+			"from_ts": 1623456000,
+			"listen_count": 0,
+			"time_range": "12 June 2021",
+			"to_ts": 1623542399
+		},
+		{
+			"from_ts": 1623542400,
+			"listen_count": 0,
+			"time_range": "13 June 2021",
+			"to_ts": 1623628799
+		},
+		{
+			"from_ts": 1623628800,
+			"listen_count": 0,
+			"time_range": "14 June 2021",
+			"to_ts": 1623715199
+		},
+		{
+			"from_ts": 1623715200,
+			"listen_count": 0,
+			"time_range": "15 June 2021",
+			"to_ts": 1623801599
+		},
+		{
+			"from_ts": 1623801600,
+			"listen_count": 1,
+			"time_range": "16 June 2021",
+			"to_ts": 1623887999
+		},
+		{
+			"from_ts": 1623888000,
+			"listen_count": 4,
+			"time_range": "17 June 2021",
+			"to_ts": 1623974399
+		},
+		{
+			"from_ts": 1623974400,
+			"listen_count": 0,
+			"time_range": "18 June 2021",
+			"to_ts": 1624060799
+		},
+		{
+			"from_ts": 1624060800,
+			"listen_count": 0,
+			"time_range": "19 June 2021",
+			"to_ts": 1624147199
+		},
+		{
+			"from_ts": 1624147200,
+			"listen_count": 0,
+			"time_range": "20 June 2021",
+			"to_ts": 1624233599
+		},
+		{
+			"from_ts": 1624233600,
+			"listen_count": 1,
+			"time_range": "21 June 2021",
+			"to_ts": 1624319999
+		},
+		{
+			"from_ts": 1624320000,
+			"listen_count": 0,
+			"time_range": "22 June 2021",
+			"to_ts": 1624406399
+		},
+		{
+			"from_ts": 1624406400,
+			"listen_count": 0,
+			"time_range": "23 June 2021",
+			"to_ts": 1624492799
+		},
+		{
+			"from_ts": 1624492800,
+			"listen_count": 0,
+			"time_range": "24 June 2021",
+			"to_ts": 1624579199
+		},
+		{
+			"from_ts": 1624579200,
+			"listen_count": 0,
+			"time_range": "25 June 2021",
+			"to_ts": 1624665599
+		},
+		{
+			"from_ts": 1624665600,
+			"listen_count": 0,
+			"time_range": "26 June 2021",
+			"to_ts": 1624751999
+		},
+		{
+			"from_ts": 1624752000,
+			"listen_count": 25,
+			"time_range": "27 June 2021",
+			"to_ts": 1624838399
+		},
+		{
+			"from_ts": 1624838400,
+			"listen_count": 0,
+			"time_range": "28 June 2021",
+			"to_ts": 1624924799
+		},
+		{
+			"from_ts": 1624924800,
+			"listen_count": 0,
+			"time_range": "29 June 2021",
+			"to_ts": 1625011199
+		},
+		{
+			"from_ts": 1625011200,
+			"listen_count": 0,
+			"time_range": "30 June 2021",
+			"to_ts": 1625097599
+		},
+		{
+			"from_ts": 1625097600,
+			"listen_count": 0,
+			"time_range": "01 July 2021",
+			"to_ts": 1625183999
+		},
+		{
+			"from_ts": 1625184000,
+			"listen_count": 1,
+			"time_range": "02 July 2021",
+			"to_ts": 1625270399
+		},
+		{
+			"from_ts": 1625270400,
+			"listen_count": 0,
+			"time_range": "03 July 2021",
+			"to_ts": 1625356799
+		},
+		{
+			"from_ts": 1625356800,
+			"listen_count": 0,
+			"time_range": "04 July 2021",
+			"to_ts": 1625443199
+		},
+		{
+			"from_ts": 1625443200,
+			"listen_count": 0,
+			"time_range": "05 July 2021",
+			"to_ts": 1625529599
+		},
+		{
+			"from_ts": 1625529600,
+			"listen_count": 0,
+			"time_range": "06 July 2021",
+			"to_ts": 1625615999
+		},
+		{
+			"from_ts": 1625616000,
+			"listen_count": 0,
+			"time_range": "07 July 2021",
+			"to_ts": 1625702399
+		},
+		{
+			"from_ts": 1625702400,
+			"listen_count": 2,
+			"time_range": "08 July 2021",
+			"to_ts": 1625788799
+		},
+		{
+			"from_ts": 1625788800,
+			"listen_count": 11,
+			"time_range": "09 July 2021",
+			"to_ts": 1625875199
+		},
+		{
+			"from_ts": 1625875200,
+			"listen_count": 13,
+			"time_range": "10 July 2021",
+			"to_ts": 1625961599
+		},
+		{
+			"from_ts": 1625961600,
+			"listen_count": 0,
+			"time_range": "11 July 2021",
+			"to_ts": 1626047999
+		},
+		{
+			"from_ts": 1626048000,
+			"listen_count": 0,
+			"time_range": "12 July 2021",
+			"to_ts": 1626134399
+		},
+		{
+			"from_ts": 1626134400,
+			"listen_count": 0,
+			"time_range": "13 July 2021",
+			"to_ts": 1626220799
+		},
+		{
+			"from_ts": 1626220800,
+			"listen_count": 0,
+			"time_range": "14 July 2021",
+			"to_ts": 1626307199
+		},
+		{
+			"from_ts": 1626307200,
+			"listen_count": 0,
+			"time_range": "15 July 2021",
+			"to_ts": 1626393599
+		},
+		{
+			"from_ts": 1626393600,
+			"listen_count": 13,
+			"time_range": "16 July 2021",
+			"to_ts": 1626479999
+		},
+		{
+			"from_ts": 1626480000,
+			"listen_count": 0,
+			"time_range": "17 July 2021",
+			"to_ts": 1626566399
+		},
+		{
+			"from_ts": 1626566400,
+			"listen_count": 0,
+			"time_range": "18 July 2021",
+			"to_ts": 1626652799
+		},
+		{
+			"from_ts": 1626652800,
+			"listen_count": 4,
+			"time_range": "19 July 2021",
+			"to_ts": 1626739199
+		},
+		{
+			"from_ts": 1626739200,
+			"listen_count": 4,
+			"time_range": "20 July 2021",
+			"to_ts": 1626825599
+		},
+		{
+			"from_ts": 1626825600,
+			"listen_count": 29,
+			"time_range": "21 July 2021",
+			"to_ts": 1626911999
+		},
+		{
+			"from_ts": 1626912000,
+			"listen_count": 3,
+			"time_range": "22 July 2021",
+			"to_ts": 1626998399
+		},
+		{
+			"from_ts": 1626998400,
+			"listen_count": 3,
+			"time_range": "23 July 2021",
+			"to_ts": 1627084799
+		},
+		{
+			"from_ts": 1627084800,
+			"listen_count": 0,
+			"time_range": "24 July 2021",
+			"to_ts": 1627171199
+		},
+		{
+			"from_ts": 1627171200,
+			"listen_count": 0,
+			"time_range": "25 July 2021",
+			"to_ts": 1627257599
+		},
+		{
+			"from_ts": 1627257600,
+			"listen_count": 0,
+			"time_range": "26 July 2021",
+			"to_ts": 1627343999
+		},
+		{
+			"from_ts": 1627344000,
+			"listen_count": 0,
+			"time_range": "27 July 2021",
+			"to_ts": 1627430399
+		},
+		{
+			"from_ts": 1627430400,
+			"listen_count": 0,
+			"time_range": "28 July 2021",
+			"to_ts": 1627516799
+		},
+		{
+			"from_ts": 1627516800,
+			"listen_count": 0,
+			"time_range": "29 July 2021",
+			"to_ts": 1627603199
+		},
+		{
+			"from_ts": 1627603200,
+			"listen_count": 0,
+			"time_range": "30 July 2021",
+			"to_ts": 1627689599
+		},
+		{
+			"from_ts": 1627689600,
+			"listen_count": 0,
+			"time_range": "31 July 2021",
+			"to_ts": 1627775999
+		},
+		{
+			"from_ts": 1627776000,
+			"listen_count": 0,
+			"time_range": "01 August 2021",
+			"to_ts": 1627862399
+		},
+		{
+			"from_ts": 1627862400,
+			"listen_count": 0,
+			"time_range": "02 August 2021",
+			"to_ts": 1627948799
+		},
+		{
+			"from_ts": 1627948800,
+			"listen_count": 0,
+			"time_range": "03 August 2021",
+			"to_ts": 1628035199
+		},
+		{
+			"from_ts": 1628035200,
+			"listen_count": 0,
+			"time_range": "04 August 2021",
+			"to_ts": 1628121599
+		},
+		{
+			"from_ts": 1628121600,
+			"listen_count": 0,
+			"time_range": "05 August 2021",
+			"to_ts": 1628207999
+		},
+		{
+			"from_ts": 1628208000,
+			"listen_count": 0,
+			"time_range": "06 August 2021",
+			"to_ts": 1628294399
+		},
+		{
+			"from_ts": 1628294400,
+			"listen_count": 0,
+			"time_range": "07 August 2021",
+			"to_ts": 1628380799
+		},
+		{
+			"from_ts": 1628380800,
+			"listen_count": 0,
+			"time_range": "08 August 2021",
+			"to_ts": 1628467199
+		},
+		{
+			"from_ts": 1628467200,
+			"listen_count": 0,
+			"time_range": "09 August 2021",
+			"to_ts": 1628553599
+		},
+		{
+			"from_ts": 1628553600,
+			"listen_count": 0,
+			"time_range": "10 August 2021",
+			"to_ts": 1628639999
+		},
+		{
+			"from_ts": 1628640000,
+			"listen_count": 0,
+			"time_range": "11 August 2021",
+			"to_ts": 1628726399
+		},
+		{
+			"from_ts": 1628726400,
+			"listen_count": 0,
+			"time_range": "12 August 2021",
+			"to_ts": 1628812799
+		},
+		{
+			"from_ts": 1628812800,
+			"listen_count": 0,
+			"time_range": "13 August 2021",
+			"to_ts": 1628899199
+		},
+		{
+			"from_ts": 1628899200,
+			"listen_count": 0,
+			"time_range": "14 August 2021",
+			"to_ts": 1628985599
+		},
+		{
+			"from_ts": 1628985600,
+			"listen_count": 0,
+			"time_range": "15 August 2021",
+			"to_ts": 1629071999
+		},
+		{
+			"from_ts": 1629072000,
+			"listen_count": 0,
+			"time_range": "16 August 2021",
+			"to_ts": 1629158399
+		},
+		{
+			"from_ts": 1629158400,
+			"listen_count": 0,
+			"time_range": "17 August 2021",
+			"to_ts": 1629244799
+		},
+		{
+			"from_ts": 1629244800,
+			"listen_count": 0,
+			"time_range": "18 August 2021",
+			"to_ts": 1629331199
+		},
+		{
+			"from_ts": 1629331200,
+			"listen_count": 0,
+			"time_range": "19 August 2021",
+			"to_ts": 1629417599
+		},
+		{
+			"from_ts": 1629417600,
+			"listen_count": 0,
+			"time_range": "20 August 2021",
+			"to_ts": 1629503999
+		},
+		{
+			"from_ts": 1629504000,
+			"listen_count": 0,
+			"time_range": "21 August 2021",
+			"to_ts": 1629590399
+		},
+		{
+			"from_ts": 1629590400,
+			"listen_count": 0,
+			"time_range": "22 August 2021",
+			"to_ts": 1629676799
+		},
+		{
+			"from_ts": 1629676800,
+			"listen_count": 0,
+			"time_range": "23 August 2021",
+			"to_ts": 1629763199
+		},
+		{
+			"from_ts": 1629763200,
+			"listen_count": 0,
+			"time_range": "24 August 2021",
+			"to_ts": 1629849599
+		},
+		{
+			"from_ts": 1629849600,
+			"listen_count": 0,
+			"time_range": "25 August 2021",
+			"to_ts": 1629935999
+		},
+		{
+			"from_ts": 1629936000,
+			"listen_count": 4,
+			"time_range": "26 August 2021",
+			"to_ts": 1630022399
+		},
+		{
+			"from_ts": 1630022400,
+			"listen_count": 1,
+			"time_range": "27 August 2021",
+			"to_ts": 1630108799
+		},
+		{
+			"from_ts": 1630108800,
+			"listen_count": 0,
+			"time_range": "28 August 2021",
+			"to_ts": 1630195199
+		},
+		{
+			"from_ts": 1630195200,
+			"listen_count": 0,
+			"time_range": "29 August 2021",
+			"to_ts": 1630281599
+		},
+		{
+			"from_ts": 1630281600,
+			"listen_count": 2,
+			"time_range": "30 August 2021",
+			"to_ts": 1630367999
+		},
+		{
+			"from_ts": 1630368000,
+			"listen_count": 0,
+			"time_range": "31 August 2021",
+			"to_ts": 1630454399
+		},
+		{
+			"from_ts": 1630454400,
+			"listen_count": 14,
+			"time_range": "01 September 2021",
+			"to_ts": 1630540799
+		},
+		{
+			"from_ts": 1630540800,
+			"listen_count": 0,
+			"time_range": "02 September 2021",
+			"to_ts": 1630627199
+		},
+		{
+			"from_ts": 1630627200,
+			"listen_count": 29,
+			"time_range": "03 September 2021",
+			"to_ts": 1630713599
+		},
+		{
+			"from_ts": 1630713600,
+			"listen_count": 0,
+			"time_range": "04 September 2021",
+			"to_ts": 1630799999
+		},
+		{
+			"from_ts": 1630800000,
+			"listen_count": 0,
+			"time_range": "05 September 2021",
+			"to_ts": 1630886399
+		},
+		{
+			"from_ts": 1630886400,
+			"listen_count": 27,
+			"time_range": "06 September 2021",
+			"to_ts": 1630972799
+		},
+		{
+			"from_ts": 1630972800,
+			"listen_count": 5,
+			"time_range": "07 September 2021",
+			"to_ts": 1631059199
+		},
+		{
+			"from_ts": 1631059200,
+			"listen_count": 0,
+			"time_range": "08 September 2021",
+			"to_ts": 1631145599
+		},
+		{
+			"from_ts": 1631145600,
+			"listen_count": 13,
+			"time_range": "09 September 2021",
+			"to_ts": 1631231999
+		},
+		{
+			"from_ts": 1631232000,
+			"listen_count": 4,
+			"time_range": "10 September 2021",
+			"to_ts": 1631318399
+		},
+		{
+			"from_ts": 1631318400,
+			"listen_count": 0,
+			"time_range": "11 September 2021",
+			"to_ts": 1631404799
+		},
+		{
+			"from_ts": 1631404800,
+			"listen_count": 0,
+			"time_range": "12 September 2021",
+			"to_ts": 1631491199
+		},
+		{
+			"from_ts": 1631491200,
+			"listen_count": 0,
+			"time_range": "13 September 2021",
+			"to_ts": 1631577599
+		},
+		{
+			"from_ts": 1631577600,
+			"listen_count": 14,
+			"time_range": "14 September 2021",
+			"to_ts": 1631663999
+		},
+		{
+			"from_ts": 1631664000,
+			"listen_count": 7,
+			"time_range": "15 September 2021",
+			"to_ts": 1631750399
+		},
+		{
+			"from_ts": 1631750400,
+			"listen_count": 4,
+			"time_range": "16 September 2021",
+			"to_ts": 1631836799
+		},
+		{
+			"from_ts": 1631836800,
+			"listen_count": 0,
+			"time_range": "17 September 2021",
+			"to_ts": 1631923199
+		},
+		{
+			"from_ts": 1631923200,
+			"listen_count": 0,
+			"time_range": "18 September 2021",
+			"to_ts": 1632009599
+		},
+		{
+			"from_ts": 1632009600,
+			"listen_count": 0,
+			"time_range": "19 September 2021",
+			"to_ts": 1632095999
+		},
+		{
+			"from_ts": 1632096000,
+			"listen_count": 2,
+			"time_range": "20 September 2021",
+			"to_ts": 1632182399
+		},
+		{
+			"from_ts": 1632182400,
+			"listen_count": 0,
+			"time_range": "21 September 2021",
+			"to_ts": 1632268799
+		},
+		{
+			"from_ts": 1632268800,
+			"listen_count": 0,
+			"time_range": "22 September 2021",
+			"to_ts": 1632355199
+		},
+		{
+			"from_ts": 1632355200,
+			"listen_count": 11,
+			"time_range": "23 September 2021",
+			"to_ts": 1632441599
+		},
+		{
+			"from_ts": 1632441600,
+			"listen_count": 15,
+			"time_range": "24 September 2021",
+			"to_ts": 1632527999
+		},
+		{
+			"from_ts": 1632528000,
+			"listen_count": 1,
+			"time_range": "25 September 2021",
+			"to_ts": 1632614399
+		},
+		{
+			"from_ts": 1632614400,
+			"listen_count": 0,
+			"time_range": "26 September 2021",
+			"to_ts": 1632700799
+		},
+		{
+			"from_ts": 1632700800,
+			"listen_count": 6,
+			"time_range": "27 September 2021",
+			"to_ts": 1632787199
+		},
+		{
+			"from_ts": 1632787200,
+			"listen_count": 17,
+			"time_range": "28 September 2021",
+			"to_ts": 1632873599
+		},
+		{
+			"from_ts": 1632873600,
+			"listen_count": 18,
+			"time_range": "29 September 2021",
+			"to_ts": 1632959999
+		},
+		{
+			"from_ts": 1632960000,
+			"listen_count": 2,
+			"time_range": "30 September 2021",
+			"to_ts": 1633046399
+		},
+		{
+			"from_ts": 1633046400,
+			"listen_count": 0,
+			"time_range": "01 October 2021",
+			"to_ts": 1633132799
+		},
+		{
+			"from_ts": 1633132800,
+			"listen_count": 0,
+			"time_range": "02 October 2021",
+			"to_ts": 1633219199
+		},
+		{
+			"from_ts": 1633219200,
+			"listen_count": 49,
+			"time_range": "03 October 2021",
+			"to_ts": 1633305599
+		},
+		{
+			"from_ts": 1633305600,
+			"listen_count": 27,
+			"time_range": "04 October 2021",
+			"to_ts": 1633391999
+		},
+		{
+			"from_ts": 1633392000,
+			"listen_count": 13,
+			"time_range": "05 October 2021",
+			"to_ts": 1633478399
+		},
+		{
+			"from_ts": 1633478400,
+			"listen_count": 17,
+			"time_range": "06 October 2021",
+			"to_ts": 1633564799
+		},
+		{
+			"from_ts": 1633564800,
+			"listen_count": 13,
+			"time_range": "07 October 2021",
+			"to_ts": 1633651199
+		},
+		{
+			"from_ts": 1633651200,
+			"listen_count": 1,
+			"time_range": "08 October 2021",
+			"to_ts": 1633737599
+		},
+		{
+			"from_ts": 1633737600,
+			"listen_count": 0,
+			"time_range": "09 October 2021",
+			"to_ts": 1633823999
+		},
+		{
+			"from_ts": 1633824000,
+			"listen_count": 2,
+			"time_range": "10 October 2021",
+			"to_ts": 1633910399
+		},
+		{
+			"from_ts": 1633910400,
+			"listen_count": 0,
+			"time_range": "11 October 2021",
+			"to_ts": 1633996799
+		},
+		{
+			"from_ts": 1633996800,
+			"listen_count": 0,
+			"time_range": "12 October 2021",
+			"to_ts": 1634083199
+		},
+		{
+			"from_ts": 1634083200,
+			"listen_count": 0,
+			"time_range": "13 October 2021",
+			"to_ts": 1634169599
+		},
+		{
+			"from_ts": 1634169600,
+			"listen_count": 2,
+			"time_range": "14 October 2021",
+			"to_ts": 1634255999
+		},
+		{
+			"from_ts": 1634256000,
+			"listen_count": 0,
+			"time_range": "15 October 2021",
+			"to_ts": 1634342399
+		},
+		{
+			"from_ts": 1634342400,
+			"listen_count": 2,
+			"time_range": "16 October 2021",
+			"to_ts": 1634428799
+		},
+		{
+			"from_ts": 1634428800,
+			"listen_count": 1,
+			"time_range": "17 October 2021",
+			"to_ts": 1634515199
+		},
+		{
+			"from_ts": 1634515200,
+			"listen_count": 8,
+			"time_range": "18 October 2021",
+			"to_ts": 1634601599
+		},
+		{
+			"from_ts": 1634601600,
+			"listen_count": 0,
+			"time_range": "19 October 2021",
+			"to_ts": 1634687999
+		},
+		{
+			"from_ts": 1634688000,
+			"listen_count": 17,
+			"time_range": "20 October 2021",
+			"to_ts": 1634774399
+		},
+		{
+			"from_ts": 1634774400,
+			"listen_count": 2,
+			"time_range": "21 October 2021",
+			"to_ts": 1634860799
+		},
+		{
+			"from_ts": 1634860800,
+			"listen_count": 13,
+			"time_range": "22 October 2021",
+			"to_ts": 1634947199
+		},
+		{
+			"from_ts": 1634947200,
+			"listen_count": 5,
+			"time_range": "23 October 2021",
+			"to_ts": 1635033599
+		},
+		{
+			"from_ts": 1635033600,
+			"listen_count": 1,
+			"time_range": "24 October 2021",
+			"to_ts": 1635119999
+		},
+		{
+			"from_ts": 1635120000,
+			"listen_count": 12,
+			"time_range": "25 October 2021",
+			"to_ts": 1635206399
+		},
+		{
+			"from_ts": 1635206400,
+			"listen_count": 3,
+			"time_range": "26 October 2021",
+			"to_ts": 1635292799
+		},
+		{
+			"from_ts": 1635292800,
+			"listen_count": 1,
+			"time_range": "27 October 2021",
+			"to_ts": 1635379199
+		},
+		{
+			"from_ts": 1635379200,
+			"listen_count": 1,
+			"time_range": "28 October 2021",
+			"to_ts": 1635465599
+		},
+		{
+			"from_ts": 1635465600,
+			"listen_count": 6,
+			"time_range": "29 October 2021",
+			"to_ts": 1635551999
+		},
+		{
+			"from_ts": 1635552000,
+			"listen_count": 2,
+			"time_range": "30 October 2021",
+			"to_ts": 1635638399
+		},
+		{
+			"from_ts": 1635638400,
+			"listen_count": 0,
+			"time_range": "31 October 2021",
+			"to_ts": 1635724799
+		},
+		{
+			"from_ts": 1635724800,
+			"listen_count": 4,
+			"time_range": "01 November 2021",
+			"to_ts": 1635811199
+		},
+		{
+			"from_ts": 1635811200,
+			"listen_count": 30,
+			"time_range": "02 November 2021",
+			"to_ts": 1635897599
+		},
+		{
+			"from_ts": 1635897600,
+			"listen_count": 2,
+			"time_range": "03 November 2021",
+			"to_ts": 1635983999
+		},
+		{
+			"from_ts": 1635984000,
+			"listen_count": 0,
+			"time_range": "04 November 2021",
+			"to_ts": 1636070399
+		},
+		{
+			"from_ts": 1636070400,
+			"listen_count": 0,
+			"time_range": "05 November 2021",
+			"to_ts": 1636156799
+		},
+		{
+			"from_ts": 1636156800,
+			"listen_count": 0,
+			"time_range": "06 November 2021",
+			"to_ts": 1636243199
+		},
+		{
+			"from_ts": 1636243200,
+			"listen_count": 0,
+			"time_range": "07 November 2021",
+			"to_ts": 1636329599
+		},
+		{
+			"from_ts": 1636329600,
+			"listen_count": 0,
+			"time_range": "08 November 2021",
+			"to_ts": 1636415999
+		},
+		{
+			"from_ts": 1636416000,
+			"listen_count": 56,
+			"time_range": "09 November 2021",
+			"to_ts": 1636502399
+		},
+		{
+			"from_ts": 1636502400,
+			"listen_count": 2,
+			"time_range": "10 November 2021",
+			"to_ts": 1636588799
+		},
+		{
+			"from_ts": 1636588800,
+			"listen_count": 1,
+			"time_range": "11 November 2021",
+			"to_ts": 1636675199
+		},
+		{
+			"from_ts": 1636675200,
+			"listen_count": 4,
+			"time_range": "12 November 2021",
+			"to_ts": 1636761599
+		},
+		{
+			"from_ts": 1636761600,
+			"listen_count": 0,
+			"time_range": "13 November 2021",
+			"to_ts": 1636847999
+		},
+		{
+			"from_ts": 1636848000,
+			"listen_count": 0,
+			"time_range": "14 November 2021",
+			"to_ts": 1636934399
+		},
+		{
+			"from_ts": 1636934400,
+			"listen_count": 18,
+			"time_range": "15 November 2021",
+			"to_ts": 1637020799
+		},
+		{
+			"from_ts": 1637020800,
+			"listen_count": 8,
+			"time_range": "16 November 2021",
+			"to_ts": 1637107199
+		},
+		{
+			"from_ts": 1637107200,
+			"listen_count": 10,
+			"time_range": "17 November 2021",
+			"to_ts": 1637193599
+		},
+		{
+			"from_ts": 1637193600,
+			"listen_count": 6,
+			"time_range": "18 November 2021",
+			"to_ts": 1637279999
+		},
+		{
+			"from_ts": 1637280000,
+			"listen_count": 8,
+			"time_range": "19 November 2021",
+			"to_ts": 1637366399
+		},
+		{
+			"from_ts": 1637366400,
+			"listen_count": 0,
+			"time_range": "20 November 2021",
+			"to_ts": 1637452799
+		},
+		{
+			"from_ts": 1637452800,
+			"listen_count": 0,
+			"time_range": "21 November 2021",
+			"to_ts": 1637539199
+		},
+		{
+			"from_ts": 1637539200,
+			"listen_count": 13,
+			"time_range": "22 November 2021",
+			"to_ts": 1637625599
+		},
+		{
+			"from_ts": 1637625600,
+			"listen_count": 13,
+			"time_range": "23 November 2021",
+			"to_ts": 1637711999
+		},
+		{
+			"from_ts": 1637712000,
+			"listen_count": 48,
+			"time_range": "24 November 2021",
+			"to_ts": 1637798399
+		},
+		{
+			"from_ts": 1637798400,
+			"listen_count": 16,
+			"time_range": "25 November 2021",
+			"to_ts": 1637884799
+		},
+		{
+			"from_ts": 1637884800,
+			"listen_count": 35,
+			"time_range": "26 November 2021",
+			"to_ts": 1637971199
+		},
+		{
+			"from_ts": 1637971200,
+			"listen_count": 0,
+			"time_range": "27 November 2021",
+			"to_ts": 1638057599
+		},
+		{
+			"from_ts": 1638057600,
+			"listen_count": 13,
+			"time_range": "28 November 2021",
+			"to_ts": 1638143999
+		},
+		{
+			"from_ts": 1638144000,
+			"listen_count": 47,
+			"time_range": "29 November 2021",
+			"to_ts": 1638230399
+		},
+		{
+			"from_ts": 1638230400,
+			"listen_count": 0,
+			"time_range": "30 November 2021",
+			"to_ts": 1638316799
+		},
+		{
+			"from_ts": 1638316800,
+			"listen_count": 29,
+			"time_range": "01 December 2021",
+			"to_ts": 1638403199
+		},
+		{
+			"from_ts": 1638403200,
+			"listen_count": 48,
+			"time_range": "02 December 2021",
+			"to_ts": 1638489599
+		},
+		{
+			"from_ts": 1638489600,
+			"listen_count": 20,
+			"time_range": "03 December 2021",
+			"to_ts": 1638575999
+		},
+		{
+			"from_ts": 1638576000,
+			"listen_count": 0,
+			"time_range": "04 December 2021",
+			"to_ts": 1638662399
+		},
+		{
+			"from_ts": 1638662400,
+			"listen_count": 0,
+			"time_range": "05 December 2021",
+			"to_ts": 1638748799
+		},
+		{
+			"from_ts": 1638748800,
+			"listen_count": 7,
+			"time_range": "06 December 2021",
+			"to_ts": 1638835199
+		},
+		{
+			"from_ts": 1638835200,
+			"listen_count": 0,
+			"time_range": "07 December 2021",
+			"to_ts": 1638921599
+		},
+		{
+			"from_ts": 1638921600,
+			"listen_count": 16,
+			"time_range": "08 December 2021",
+			"to_ts": 1639007999
+		},
+		{
+			"from_ts": 1639008000,
+			"listen_count": 1,
+			"time_range": "09 December 2021",
+			"to_ts": 1639094399
+		},
+		{
+			"from_ts": 1639094400,
+			"listen_count": 31,
+			"time_range": "10 December 2021",
+			"to_ts": 1639180799
+		},
+		{
+			"from_ts": 1639180800,
+			"listen_count": 5,
+			"time_range": "11 December 2021",
+			"to_ts": 1639267199
+		},
+		{
+			"from_ts": 1639267200,
+			"listen_count": 0,
+			"time_range": "12 December 2021",
+			"to_ts": 1639353599
+		},
+		{
+			"from_ts": 1639353600,
+			"listen_count": 5,
+			"time_range": "13 December 2021",
+			"to_ts": 1639439999
+		},
+		{
+			"from_ts": 1639440000,
+			"listen_count": 37,
+			"time_range": "14 December 2021",
+			"to_ts": 1639526399
+		},
+		{
+			"from_ts": 1639526400,
+			"listen_count": 2,
+			"time_range": "15 December 2021",
+			"to_ts": 1639612799
+		},
+		{
+			"from_ts": 1639612800,
+			"listen_count": 0,
+			"time_range": "16 December 2021",
+			"to_ts": 1639699199
+		}
+	],
+	"most_listened_year": {
+		"1958": 1,
+		"1962": 4,
+		"1964": 1,
+		"1965": 2,
+		"1966": 4,
+		"1967": 11,
+		"1968": 10,
+		"1969": 3,
+		"1970": 13,
+		"1971": 11,
+		"1972": 14,
+		"1973": 12,
+		"1974": 14,
+		"1975": 9,
+		"1976": 13,
+		"1977": 1,
+		"1978": 8,
+		"1979": 5,
+		"1981": 2,
+		"1982": 3,
+		"1983": 6,
+		"1984": 6,
+		"1985": 1,
+		"1986": 2,
+		"1987": 7,
+		"1988": 8,
+		"1989": 8,
+		"1990": 4,
+		"1991": 6,
+		"1992": 26,
+		"1993": 39,
+		"1994": 27,
+		"1995": 12,
+		"1996": 23,
+		"1997": 17,
+		"1998": 32,
+		"1999": 23,
+		"2000": 13,
+		"2001": 17,
+		"2002": 30,
+		"2003": 39,
+		"2004": 33,
+		"2005": 30,
+		"2006": 49,
+		"2007": 37,
+		"2008": 49,
+		"2009": 65,
+		"2010": 44,
+		"2011": 61,
+		"2012": 46,
+		"2013": 68,
+		"2014": 112,
+		"2015": 99,
+		"2016": 150,
+		"2017": 114,
+		"2018": 202,
+		"2019": 155,
+		"2020": 395,
+		"2021": 325
+	},
+	"most_prominent_color": "(165, 166, 156)",
+	"new_releases_of_top_artists": [
+		{
+			"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_credit_names": ["Mdou Moctar"],
+			"first_release_date": "2021-05-21",
+			"release_mbid": "48afcf02-f396-4c13-bdef-222965474094",
+			"title": "Afrique Victime",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["9f930ddf-be2f-4de5-a39f-7ae47305752e"],
+			"artist_credit_names": ["The Psychedelic Furs"],
+			"first_release_date": "2021-09-01",
+			"release_mbid": "1c6a4d54-dfac-4f0e-8502-0ca21b3c40f9",
+			"title": "Evergreen",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-04-12",
+			"release_mbid": "08f57b3b-61fd-49a3-b05d-0d6d9912ddd0",
+			"title": "True",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4", "bc880664-6751-4998-984d-ebdbff15d229"],
+			"artist_credit_names": ["Danny Elfman", "Trent Reznor"],
+			"first_release_date": "2021-08-11",
+			"release_mbid": "63090666-48e7-40b7-8a32-e408346771d8",
+			"title": "True",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-06-11",
+			"release_mbid": "793e1cc3-f568-4b5c-b160-b39ecd5ac007",
+			"title": "Butterfly 3000",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-01-11",
+			"release_mbid": "27fdab3f-8ed6-4935-9693-9e02865e4a20",
+			"title": "Sorry",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-02-26",
+			"release_mbid": "f04e0d01-77bf-4d8c-b6b6-e0efb27da1ae",
+			"title": "L.W.",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
+			"artist_credit_names": ["Goat"],
+			"first_release_date": "2021-08-27",
+			"release_mbid": "8297858b-eed6-43bd-b429-79b2f8a8625c",
+			"title": "Headsoup",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
+			"artist_credit_names": ["Green Lung"],
+			"first_release_date": "2021-08-27",
+			"release_mbid": "5998e6f1-6970-4d3e-ab1f-f6a7857cccce",
+			"title": "Graveyard Sun",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_credit_names": ["Mdou Moctar"],
+			"first_release_date": "2021-05-21",
+			"release_mbid": "9439ce5e-0b57-431a-b2a8-58be26c3abc2",
+			"title": "Afrique Victime",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-02-18",
+			"release_mbid": "eea6587b-6ef9-4124-9e23-8a52d8459ed6",
+			"title": "Pleura",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": [
+				"c266a7ab-7b9f-478f-a26d-91c5f8f04c7c", "42dd1862-7255-47ed-8584-651abce3bf53",
+				"62b29e5c-d717-4586-87bc-ade74a6a9fe8"
+			],
+			"artist_credit_names": ["DJ Yoda", "Nubya Garcia", "Edo.G"],
+			"first_release_date": "2021-03-05",
+			"release_mbid": "fa634c8f-3710-4d73-903c-5b8200c6e80c",
+			"title": "Roxbury",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
+			"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
+			"first_release_date": "2021-06-11",
+			"release_mbid": "bb7d4f1d-3a47-42ee-b450-ba0b763c68b7",
+			"title": "Dark Mark (Theme)",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-03-19",
+			"release_mbid": "0ef0d03c-418e-48fb-8444-bb2bdaaa862c",
+			"title": "Live in Melbourne ‘21",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
+			"artist_credit_names": ["Green Lung"],
+			"first_release_date": "2021-10-22",
+			"release_mbid": "7a00a638-d77a-4da7-8c6e-d9f01a59bebb",
+			"title": "Black Harvest",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
+			"artist_credit_names": ["Green Lung"],
+			"first_release_date": "2021-10-22",
+			"release_mbid": "edf26b54-36c9-43c7-918b-884711ba9dd1",
+			"title": "Black Harvest",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["cb331ec3-72af-4d8c-825a-63f79d56a651"],
+			"artist_credit_names": ["Movie Club"],
+			"first_release_date": "2021-07-08",
+			"release_mbid": "503f6e83-e5b6-4b17-8e4a-621ce201d00e",
+			"title": "Trap Door",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["c3aeb863-7b26-4388-94e8-5a240f2be21b"],
+			"artist_credit_names": ["Tom Waits"],
+			"first_release_date": "2021-01-12",
+			"release_mbid": "545fdd9c-a696-4ea3-87f8-46e9082b266c",
+			"title": "Sharp as a Razor and Soft as a Prayer (Live 1977)",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-05-29",
+			"release_mbid": "2a6d3e8d-f5ce-4633-afea-87e046a0758e",
+			"title": "Live in Sydney ‘21",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
+			"artist_credit_names": ["Goat"],
+			"first_release_date": "2021-07-05",
+			"release_mbid": "3de4b3c3-1747-4a75-a394-846aa754ed7b",
+			"title": "Queen of the Underground (edit)",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
+			"artist_credit_names": ["The Longest Johns"],
+			"first_release_date": "2021",
+			"release_mbid": "57f7b40d-f13b-498f-981d-6b6323727a8e",
+			"title": "Land Shanties",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["bded3a41-acd7-42ff-9402-cb59e35be8f4"],
+			"artist_credit_names": ["Endless Boogie"],
+			"first_release_date": "2021-11-12",
+			"release_mbid": "534fb7ec-c530-4a49-aa9b-02f6560d6fed",
+			"title": "Admonitions",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["795d12c3-099e-4195-8f40-6764472db494", "3a605eba-b6a1-4298-855d-b3033df0bf8b"],
+			"artist_credit_names": ["Ryley Walker", "幾何学模様"],
+			"first_release_date": "2021-02-05",
+			"release_mbid": "760acd46-eab1-4c25-bffc-c5dc7da69364",
+			"title": "Deep Fried Grandeur",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_credit_names": ["Slift"],
+			"first_release_date": "2021-06-18",
+			"release_mbid": "b2c565b3-f103-4bf5-aee4-31422cfd5838",
+			"title": "Levitation Sessions",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-05-25",
+			"release_mbid": "0edab12a-33ca-4751-b574-dfcba95410a3",
+			"title": "Insects",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
+			"artist_credit_names": ["The Longest Johns"],
+			"first_release_date": "2021-12-06",
+			"release_mbid": "8ab24647-90eb-474b-b604-92e0d77aad36",
+			"title": "Commodore 1864",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": [
+				"c266a7ab-7b9f-478f-a26d-91c5f8f04c7c", "42dd1862-7255-47ed-8584-651abce3bf53",
+				"62b29e5c-d717-4586-87bc-ade74a6a9fe8"
+			],
+			"artist_credit_names": ["DJ Yoda", "Nubya Garcia", "Edo.G"],
+			"first_release_date": "2021-03-05",
+			"release_mbid": "715631dd-f796-4def-981b-d60d00d4e37d",
+			"title": "Roxbury",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-01-28",
+			"release_mbid": "36c762d3-d0b8-4349-89e2-37da14e83531",
+			"title": "O.N.E.",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-06-11",
+			"release_mbid": "99517c21-0583-45c5-96e6-b90575090e45",
+			"title": "Butterfly 3000",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
+			"artist_credit_names": ["Nubya Garcia"],
+			"first_release_date": "2021-10-22",
+			"release_mbid": "849aa6f7-d155-4d12-878a-df5b571bab0a",
+			"title": "SOURCE ⧺ WE MOVE",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-02-26",
+			"release_mbid": "61c386be-c0b0-41f8-8290-aede50a046b0",
+			"title": "L.W.",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
+			"artist_credit_names": ["Goat"],
+			"first_release_date": "2021-08-27",
+			"release_mbid": "d6971aa7-545e-4ce8-8b5d-300868b57cf4",
+			"title": "Headsoup",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["22e6f8d3-2d7e-4abb-8a77-1a6d581cd560"],
+			"artist_credit_names": ["Wolves Like Me"],
+			"first_release_date": "2021-01-28",
+			"release_mbid": "bf04a661-b7f2-40c9-b8e6-276ff3602997",
+			"title": "Who's Afraid?",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
+			"artist_credit_names": ["Les Filles de Illighadad"],
+			"first_release_date": "2021-07-09",
+			"release_mbid": "0ad08d1a-24f7-4cda-9d01-6cddc889ed2e",
+			"title": "At Pioneer Works",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
+			"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
+			"first_release_date": "2021-06-11",
+			"release_mbid": "f2352415-9aa1-4962-afeb-e336c290b8e1",
+			"title": "Dark Mark (Theme)",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["248c71ae-de8a-4246-8435-d0a19e0ebf41", "a9126556-f555-4920-9617-6e013f8228a7"],
+			"artist_credit_names": ["Kira Skov", "Mark Lanegan"],
+			"first_release_date": "2021-04-09",
+			"release_mbid": "51cf73a8-c06c-4fb8-b7d8-a4d83a0db8ff",
+			"title": "Idea of Love",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
+			"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
+			"first_release_date": "2021-10-15",
+			"release_mbid": "4fbbd214-aba9-4922-a34e-09c02ffe20e2",
+			"title": "Dark Mark vs. Skeleton Joe",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_credit_names": ["Mdou Moctar"],
+			"first_release_date": "2021-05-21",
+			"release_mbid": "01c0affe-3c70-4433-892f-80f6a1e74982",
+			"title": "Afrique Victime",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
+			"artist_credit_names": ["Black Sky Giant"],
+			"first_release_date": "2021-06-10",
+			"release_mbid": "9da22f1c-ceeb-401f-8dd2-acca823ec1eb",
+			"title": "Falling Mothership",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_credit_names": ["Slift"],
+			"first_release_date": "2021-01-08",
+			"release_mbid": "ebe43918-bd5d-4f80-bbca-926752d01d59",
+			"title": "Space Is the Key / La Planète inexplorée",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-04-01",
+			"release_mbid": "a06b33c1-39fb-483b-83ec-a1a497531fef",
+			"title": "Kick Me (Zach Hill remix)",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["eb3b3201-d6d5-4143-bd30-c50e719c138e"],
+			"artist_credit_names": ["Dust Mice"],
+			"first_release_date": "2021-04-16",
+			"release_mbid": "e5f194c0-3ee9-46f2-a7e4-78b6f642d6d9",
+			"title": "Earth III",
+			"type": null
+		},
+		{
+			"artist_credit_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
+			"artist_credit_names": ["Kraftwerk"],
+			"first_release_date": "2021-05-11",
+			"release_mbid": "dcbeb0bc-9601-40bc-895f-ca7a7a641b5c",
+			"title": "Heimcomputer",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-06-11",
+			"release_mbid": "a1fc45f0-d4b3-4462-b54f-108e59f404cd",
+			"title": "Big Mess",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-12-10",
+			"release_mbid": "4d7093d9-0a7f-4b35-a6c6-292991828c0a",
+			"title": "Live at Levitation ‘16",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
+			"artist_credit_names": ["Green Lung"],
+			"first_release_date": "2021-10-22",
+			"release_mbid": "a0796b13-b7b2-45d4-8375-7a65d384d279",
+			"title": "Black Harvest",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["795d12c3-099e-4195-8f40-6764472db494", "3a605eba-b6a1-4298-855d-b3033df0bf8b"],
+			"artist_credit_names": ["Ryley Walker", "幾何学模様"],
+			"first_release_date": "2021-02-05",
+			"release_mbid": "30b5db7d-cb62-4c09-938c-01e75da359e9",
+			"title": "Deep Fried Grandeur",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_credit_names": ["Mdou Moctar"],
+			"first_release_date": "2021-05-21",
+			"release_mbid": "60377f9b-98b5-4304-aeb4-e1835889482f",
+			"title": "Afrique Victime",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
+			"artist_credit_names": ["Kraftwerk"],
+			"first_release_date": "2021-05-11",
+			"release_mbid": "9e8dbe4e-9316-47e1-96c6-f8a08451ce9e",
+			"title": "Heimcomputer",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-12-10",
+			"release_mbid": "8d9e8021-09e2-48ab-9a04-e358bba7cacb",
+			"title": "Live at Levitation ‘14",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["bded3a41-acd7-42ff-9402-cb59e35be8f4"],
+			"artist_credit_names": ["Endless Boogie"],
+			"first_release_date": "2021-11-12",
+			"release_mbid": "75d7e92c-45e2-4c6e-930c-5d9f1c73af1d",
+			"title": "Admonitions",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-10-01",
+			"release_mbid": "381e305a-ebef-4372-821b-68fef45d7778",
+			"title": "Live in Milwaukee ‘19",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["795d12c3-099e-4195-8f40-6764472db494", "3a605eba-b6a1-4298-855d-b3033df0bf8b"],
+			"artist_credit_names": ["Ryley Walker", "幾何学模様"],
+			"first_release_date": "2021-02-05",
+			"release_mbid": "489fa3c2-5894-4cb6-a006-0506b851f3a3",
+			"title": "Deep Fried Grandeur",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
+			"artist_credit_names": ["Black Sky Giant"],
+			"first_release_date": "2021-01-16",
+			"release_mbid": "de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746",
+			"title": "Planet Terror",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
+			"artist_credit_names": ["José Carlos Schwarz"],
+			"first_release_date": "2021-04-09",
+			"release_mbid": "0d698584-4c46-46ce-9781-e394d81450bd",
+			"title": "Lua Ki Di Nos",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["425bd6b7-dccf-4a03-9a4c-40f28fb5792d"],
+			"artist_credit_names": ["The Ossuary"],
+			"first_release_date": "2021-05-28",
+			"release_mbid": "6d77c3fa-44aa-4814-abdf-82d66a167370",
+			"title": "Oltretomba",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["3a605eba-b6a1-4298-855d-b3033df0bf8b"],
+			"artist_credit_names": ["幾何学模様"],
+			"first_release_date": "2021-01-15",
+			"release_mbid": "6b0fbd5a-5027-450a-9fc0-5fdd567ffdff",
+			"title": "Live at Levitation",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-03-11",
+			"release_mbid": "bc8153d4-352a-4744-904e-c37ff49b1f27",
+			"title": "Kick Me",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-06-11",
+			"release_mbid": "e8a18bc7-1de7-4515-b2f3-2974286d8657",
+			"title": "Butterfly 3000",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-02-11",
+			"release_mbid": "6f675815-a096-4119-8847-cf255c5040b4",
+			"title": "Love in the Time of Covid",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-09-10",
+			"release_mbid": "ed6072a4-0533-4824-bb93-b43fd5e75c30",
+			"title": "We Belong (Squarepusher remix)",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_credit_names": ["King Gizzard & The Lizard Wizard"],
+			"first_release_date": "2021-02-26",
+			"release_mbid": "c3a1f0f6-4039-4ae1-a516-2a438ac6c88c",
+			"title": "L.W.",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_credit_names": ["Mdou Moctar"],
+			"first_release_date": "2021-04-01",
+			"release_mbid": "d3989eb1-f6b7-4cc0-a645-3d2e50dca060",
+			"title": "Afrique Victime",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
+			"artist_credit_names": ["Nubya Garcia"],
+			"first_release_date": "2021-09-02",
+			"release_mbid": "eb628f72-d946-4310-be8f-a25f9e65e946",
+			"title": "Pace (Moses Boyd remix)",
+			"type": "Single"
+		},
+		{
+			"artist_credit_mbids": ["a9126556-f555-4920-9617-6e013f8228a7", "1cc84f76-5a48-45b8-a96d-a93cc12194e0"],
+			"artist_credit_names": ["Mark Lanegan", "Joe Cardamone"],
+			"first_release_date": "2021-10-15",
+			"release_mbid": "7da68b56-723e-445e-a354-a549c23dd443",
+			"title": "Dark Mark vs Skeleton Joe",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_credit_names": ["Danny Elfman"],
+			"first_release_date": "2021-06-11",
+			"release_mbid": "7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19",
+			"title": "Big Mess",
+			"type": "Album"
+		},
+		{
+			"artist_credit_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
+			"artist_credit_names": ["Goat"],
+			"first_release_date": "2021-08-03",
+			"release_mbid": "8ceb3338-7c74-4329-b04a-a2749683cd37",
+			"title": "Fill My Mouth",
+			"type": "Single"
+		}
+	],
+	"playlist-top-discoveries-for-year": {
+		"jspf": {
+			"playlist": {
+				"annotation": "<p>\n              This playlist highlights tracks that mr_monkey first listened to in 2021 and listened to more than once.\n              </p>\n              <p>\n              We generated this playlist from mr_monkey's listens and chose all the recordings\n              that they first listened to this year and they listened to more than once. We removed\n              recordings from duplicate artists so that ideally no artist (or an artist in a collaboration) appears\n              more than twice in this playlist, although that may not always be possible. \n              Finally we randomized the order of the recordings so that two of the same artists hopefully\n              won't appear in a row.\n              </p>\n              <p>\n              Please remember that ListenBrainz may not know about all the times this user listened to a recording\n              before they started sharing their listening history with us, so we apologize if recordings appear that\n              this user listened to in the past. Also, we have attempted to match all of the listens to MusicBrainz\n              IDs in order for them to be included in this playlist, but we may not have been able to match them all,\n              so some recordings may be missing from this list.\n              </p>\n              <p>\n              This is a review playlist that we hope will give insights into the listening habits of the year.\n              </p>\n           ",
+				"creator": "ListenBrainz Troi",
+				"extension": {
+					"https://musicbrainz.org/doc/jspf#playlist": {
+						"algorithm_metadata": {"source_patch": "top-discoveries-for-year"},
+						"public": true
+					}
+				},
+				"title": "Top Discoveries of 2021 for mr_monkey",
+				"track": [
+					{
+						"album": "",
+						"creator": "Sergeant Thunderhoof",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/1110726a-05da-4ad3-8d39-5c184c2206c8",
+						"title": "Another Plane"
+					},
+					{
+						"album": "",
+						"creator": "Nubya Garcia",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/84b9fdb2-1ce6-4420-92b3-13679f71dcfe",
+						"title": "When We Are"
+					},
+					{
+						"album": "",
+						"creator": "Raúl Monsalve y los Forajidos",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/afa6d740-452a-4cc2-b24e-16d6d143b763",
+						"title": "Malembe"
+					},
+					{
+						"album": "",
+						"creator": "Mdou Moctar",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/2d743c39-4ce4-4af0-ae9b-067019ca4029",
+						"title": "A Fleur Tamgak"
+					},
+					{
+						"album": "",
+						"creator": "Koichi Sakai / Alfa Sackey",
+						"extension": {
+							"https://musicbrainz.org/recording/": {
+								"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"]
+							}
+						},
+						"identifier": "https://musicbrainz.org/recording/dbb8196d-d1c1-4fa7-a198-98a49aa6f260",
+						"title": "Atenteben Blues"
+					}
+				]
+			}
+		},
+		"mbid": "51a7c3b7-4045-49bc-8f5d-496c7ca3e119"
+	},
+	"playlist-top-missed-recordings-for-year": {
+		"jspf": {
+			"playlist": {
+				"annotation": "<p>\n              This playlist is made from recordings that mr_monkey's most similar users listened to this year, but that\n              mr_monkey didn't listen to this year.\n              </p>\n              <p>\n              We determined the top 3 most similar users to mr_monkey and selected all of the recordings\n              they listened to this year. We then removed all of the recordings that mr_monkey listened to from\n              this list of recordings, leaving only those that they didn't listen to. We removed recordings from\n              duplicate artists so that ideally no artist (or an artist in a collaboration) appears\n              more than twice in this playlist, although that may not always be possible. Finally we\n              randomized the order of the recordings so that two of the same artists hopefully won't appear\n              in a row.\n              </p>\n              <p>\n              We have attempted to match all of the listens to MusicBrainz\n              IDs in order for them to be included in this playlist, but we may not have been able to match them all,\n              so some recordings may be missing from this list.\n              </p>\n              <p>\n              This is a discovery playlist that will hopefully introduce the user to some new recordings\n              that other similar users love. Because this is a discovery playlist, it may require\n              more active listening since it may contain tracks that are not fully to the taste of the user.\n              </p>\n           ",
+				"creator": "ListenBrainz Troi",
+				"extension": {
+					"https://musicbrainz.org/doc/jspf#playlist": {
+						"algorithm_metadata": {"source_patch": "top-missed-recordings-for-year"},
+						"public": true
+					}
+				},
+				"title": "Top Missed Recordings of 2021 for mr_monkey",
+				"track": [
+					{
+						"album": "",
+						"creator": "Infinity Frequencies",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["80c29427-3fdf-47e4-a4a4-ea180d8c9072"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/22c93b09-3cb5-49cb-a510-f9ada3b3c1c8",
+						"title": "The descent"
+					},
+					{
+						"album": "",
+						"creator": "Ängie",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["2785996d-a14a-464f-9887-16268cc4dfed"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/dfc822a5-06a6-4bc3-9fa6-7f709f63e168",
+						"title": "Sad Sex"
+					},
+					{
+						"album": "",
+						"creator": "Cœur",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["23305753-d03c-4c66-a6f0-6df41135d2dd"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/0cd84991-b754-4a0f-990c-24fe9ac902c7",
+						"title": "Chrysanthème"
+					},
+					{
+						"album": "",
+						"creator": "Hubert-Félix Thiéfaine",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["29e9c7d7-e79a-41d5-a255-c19ff04d5065"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/e994acc9-2405-4c55-8b12-47df113339f8",
+						"title": "Page noire"
+					},
+					{
+						"album": "",
+						"creator": "Brain Damage meets Big Youth",
+						"extension": {
+							"https://musicbrainz.org/recording/": {
+								"artist_mbids": ["9d19a058-3bb8-4858-937b-39dc2b817fc8", "6e4cbcf5-1b18-4719-98c2-7a2c9eccaa6d"]
+							}
+						},
+						"identifier": "https://musicbrainz.org/recording/6f6cc2db-a49d-46e5-949e-d54e951db0d4",
+						"title": "Educated Fools"
+					}
+				]
+			}
+		},
+		"mbid": "4657f3d1-b795-4733-b957-24edca7f2729"
+	},
+	"playlist-top-new-recordings-for-year": {
+		"jspf": {
+			"playlist": {
+				"annotation": "<p>\n              This playlist highlights recordings released in 2021 that mr_monkey listened to the most.\n              </p>\n              <p>\n              We generated this playlist from the user's listens and chose all the recordings\n              that were released this year and that the user listened to often. We removed recordings\n              from duplicate artists so that ideally no artist (or an artist in a collaboration) appears\n              more than twice in this playlist, although that may not always be possible. Finally we randomized\n              the order of the recordings so that two of the same artists hopefully won't appear in a row.\n              </p>\n              <p>\n              We have attempted to match all of the listens to MusicBrainz\n              IDs in order for them to be included in this playlist, but we may not have been able to match them all,\n              so some recordings may be missing from this list.\n              </p>\n              <p>\n              This is a review playlist that we hope will give insights the music released during the year.\n              </p>",
+				"creator": "ListenBrainz Troi",
+				"extension": {
+					"https://musicbrainz.org/doc/jspf#playlist": {
+						"algorithm_metadata": {"source_patch": "top-new-recordings-for-year"},
+						"public": true
+					}
+				},
+				"title": "Top New Releases in 2021 for mr_monkey",
+				"track": [
+					{
+						"album": "",
+						"creator": ":nepaal",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["7c50724d-92e2-45eb-b7a7-2b3d612a3b06"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/928c26f4-bc9d-4c8d-84c7-00848bc1879f",
+						"title": "Pharisaismic Plebeian Bureaucracism"
+					},
+					{
+						"album": "",
+						"creator": "Liquid Sound Company",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["5eb16ca3-8475-4d0c-a439-daecd807778a"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/ae1e2c92-5870-423d-9f63-9421cc5b106a",
+						"title": "Blacklight Corridor"
+					},
+					{
+						"album": "",
+						"creator": "KOKOROKO",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["2650f0e7-3879-4b2c-8908-d025113cbece"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/763b2206-0110-413a-9e87-9cd7b53f77cc",
+						"title": "Uman"
+					},
+					{
+						"album": "",
+						"creator": "Taxi Caveman",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["5f643039-147a-4fcd-b112-c0f60530a253"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/050c8872-a7cf-4805-8ea5-616376d272b8",
+						"title": "I, The Witch"
+					},
+					{
+						"album": "",
+						"creator": "Brain Damage meets Big Youth",
+						"extension": {
+							"https://musicbrainz.org/recording/": {
+								"artist_mbids": ["6e4cbcf5-1b18-4719-98c2-7a2c9eccaa6d", "9d19a058-3bb8-4858-937b-39dc2b817fc8"]
+							}
+						},
+						"identifier": "https://musicbrainz.org/recording/7ca4ffd9-6d3e-4194-9856-834f7dfbd508",
+						"title": "Good to Talk"
+					}
+				]
+			}
+		},
+		"mbid": "8ba58c32-de1e-47d1-8e3d-2e931e79b629"
+	},
+	"playlist-top-recordings-for-year": {
+		"jspf": {
+			"playlist": {
+				"annotation": "<p>\n              This playlist is made from mr_monkey's Top Recordings for 2021 statistics.\n              </p>\n              <p>\n              We selected the top tracks from this user’s statistics and removed those recordings that we could not\n              match to entries in MusicBrainz. (This is a requirement to make this list playable.)\n              </p>\n              <p>\n              This is a review playlist that we hope will give insights into the listening habits of the year.\n              </p>\n           ",
+				"creator": "ListenBrainz Troi",
+				"extension": {
+					"https://musicbrainz.org/doc/jspf#playlist": {
+						"algorithm_metadata": {"source_patch": "top-recordings-for-year"},
+						"public": true
+					}
+				},
+				"title": "Top Recordings of 2021 for mr_monkey",
+				"track": [
+					{
+						"album": "Fever Ray",
+						"creator": "Fever Ray",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/55a6d83f-af43-449e-a6b4-1b8fa24b4039",
+						"title": "If I Had a Heart"
+					},
+					{
+						"album": "Grown",
+						"creator": "Waaju",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/72586151-9800-44d6-8732-6b8491808651",
+						"title": "Listening Glasses"
+					},
+					{
+						"album": "The Two Sides of Fela: Jazz & Dance",
+						"creator": "Fela Kuti",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["6514cffa-fbe0-4965-ad88-e998ead8a82a"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/a106cc67-0fa7-45f8-b894-e4f89624ed20",
+						"title": "Eko Ile"
+					},
+					{
+						"album": "Grown",
+						"creator": "Waaju",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/7edc2546-2288-4004-af22-e5e1325ee311",
+						"title": "Wassoulou"
+					},
+					{
+						"album": "Grown",
+						"creator": "Waaju",
+						"extension": {
+							"https://musicbrainz.org/recording/": { "artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"] }
+						},
+						"identifier": "https://musicbrainz.org/recording/98ebe88f-f72e-4b52-8402-7a01b88f3826",
+						"title": "Moleman"
+					}
+				]
+			}
+		},
+		"mbid": "548715b7-2fbc-45d9-a0a7-001786eada9d"
+	},
+	"similar_users": {
+		"ALERTua": 0.3757489101,
+		"A_Galoot": 0.3684194592,
+		"Anandamide": 0.7084108003,
+		"BlueCoke": 0.3271148878,
+		"DeepSlackerJazz": 0.3837503434,
+		"OverFjell": 1,
+		"Paoleddu": 0.3539377078,
+		"Peter-K": 0.465846533,
+		"Shrike": 0.3735010094,
+		"TyriGen": 0.4253733387,
+		"Zas": 0.9159547887,
+		"a_beautiful_war": 0.328987247,
+		"an.archi": 0.3145100724,
+		"doctorworm": 0.4375715465,
+		"itsthenewmeta": 0.4837755275,
+		"malguinis": 0.3441075518,
+		"misterplanty": 0.3357076275,
+		"mystictim": 0.3223334487,
+		"nihilix": 0.3757889275,
+		"nkundiushuti": 0.3441078783,
+		"rpaxon": 0.3477923015,
+		"shanksk": 0.5536979994,
+		"weirditude": 0.3547205253,
+		"y7kko": 0.4977883018,
+		"zehmurilo": 0.8895062542
+	},
+	"top_artists": [
+		{
+			"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_name": "Mdou Moctar",
+			"listen_count": 64
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 55
+		},
+		{
+			"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_name": "Slift",
+			"listen_count": 52
+		},
+		{
+			"artist_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
+			"artist_name": "The Longest Johns",
+			"listen_count": 46
+		},
+		{
+			"artist_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
+			"artist_name": "Goat",
+			"listen_count": 41
+		},
+		{
+			"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
+			"artist_name": "Raúl Monsalve y los Forajidos",
+			"listen_count": 36
+		},
+		{
+			"artist_mbids": ["8ed78ccf-7a3f-4717-b84c-1606627124bd"],
+			"artist_name": "Hey Colossus",
+			"listen_count": 29
+		},
+		{
+			"artist_mbids": ["3a605eba-b6a1-4298-855d-b3033df0bf8b"],
+			"artist_name": "Kikagaku Moyo",
+			"listen_count": 28
+		},
+		{
+			"artist_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_name": "King Gizzard & The Lizard Wizard",
+			"listen_count": 27
+		},
+		{
+			"artist_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
+			"artist_name": "Les Filles de Illighadad",
+			"listen_count": 25
+		},
+		{
+			"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
+			"artist_name": "Fever Ray",
+			"listen_count": 25
+		},
+		{
+			"artist_mbids": ["42689657-cbec-4f66-a9ed-80f939ea23ed"],
+			"artist_name": "Morphine",
+			"listen_count": 24
+		},
+		{
+			"artist_mbids": ["72fd7688-8394-43b6-8f41-278657648a45"],
+			"artist_name": "Yussef Kamaal",
+			"listen_count": 23
+		},
+		{
+			"artist_mbids": ["9219acc3-6234-4aee-8633-fe438daee3b2"],
+			"artist_name": "Anna Scionti",
+			"listen_count": 23
+		},
+		{
+			"artist_mbids": ["7a6506cc-6f12-442d-9d3e-149bc838792e"],
+			"artist_name": "79.5",
+			"listen_count": 23
+		},
+		{
+			"artist_mbids": ["d1ccc60e-45d5-4176-a328-47cd5984e55b"],
+			"artist_name": "Tidiane Thiam",
+			"listen_count": 22
+		},
+		{
+			"artist_mbids": ["c10e38ae-d06f-4bf4-8b54-8e19236a94f4"],
+			"artist_name": "Mohama Saz",
+			"listen_count": 21
+		},
+		{
+			"artist_mbids": ["22e6f8d3-2d7e-4abb-8a77-1a6d581cd560"],
+			"artist_name": "Wolves Like Me",
+			"listen_count": 20
+		},
+		{
+			"artist_mbids": ["8067c102-4996-42bc-9980-06ce2e644eae"],
+			"artist_name": "Soul Coughing",
+			"listen_count": 20
+		},
+		{
+			"artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"],
+			"artist_name": "Sergeant Thunderhoof",
+			"listen_count": 20
+		},
+		{
+			"artist_mbids": ["edf62daa-1425-44bb-8fe3-07499b519472"],
+			"artist_name": "Imarhan",
+			"listen_count": 20
+		},
+		{
+			"artist_mbids": ["7e9d3899-9de2-4741-973c-6147238bb2f1"],
+			"artist_name": "Koudede",
+			"listen_count": 19
+		},
+		{
+			"artist_mbids": ["c3aeb863-7b26-4388-94e8-5a240f2be21b"],
+			"artist_name": "Tom Waits",
+			"listen_count": 18
+		},
+		{
+			"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
+			"artist_name": "Nubya Garcia",
+			"listen_count": 18
+		},
+		{
+			"artist_mbids": ["052b43c2-2f6a-4e60-92ea-18b4de2be0d9"],
+			"artist_name": "Naxatras",
+			"listen_count": 18
+		},
+		{
+			"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"],
+			"artist_name": "Koichi Sakai / Afla Sackey",
+			"listen_count": 18
+		},
+		{
+			"artist_mbids": ["d675ed3f-bee2-40e0-8386-2960f477ad35"],
+			"artist_name": "Buried Feather",
+			"listen_count": 18
+		},
+		{
+			"artist_mbids": ["2c180037-0af5-4f9d-a29d-9512544a3064"],
+			"artist_name": "Afla Sackey & Afrik Bawantu",
+			"listen_count": 18
+		},
+		{
+			"artist_mbids": ["6ce5eca0-4ad6-49e0-a5ab-e11482d85324"],
+			"artist_name": "Sudan Archives",
+			"listen_count": 17
+		},
+		{
+			"artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_name": "Danny Elfman",
+			"listen_count": 17
+		},
+		{
+			"artist_mbids": ["cb331ec3-72af-4d8c-825a-63f79d56a651"],
+			"artist_name": "Movie Club",
+			"listen_count": 16
+		},
+		{
+			"artist_mbids": ["a9126556-f555-4920-9617-6e013f8228a7"],
+			"artist_name": "Mark Lanegan",
+			"listen_count": 16
+		},
+		{
+			"artist_mbids": ["2a67f9e5-8b94-4929-b74c-236b4c1a70c3"],
+			"artist_name": "Mantra Machine",
+			"listen_count": 16
+		},
+		{
+			"artist_mbids": ["e5963d26-01fa-40f5-b200-e0127f410a45"],
+			"artist_name": "Harry Nilsson",
+			"listen_count": 16
+		},
+		{
+			"artist_mbids": ["425bd6b7-dccf-4a03-9a4c-40f28fb5792d"],
+			"artist_name": "The Ossuary",
+			"listen_count": 15
+		},
+		{
+			"artist_mbids": ["a18c09f4-6b6f-4f9c-a4bb-ae2db7cab657"],
+			"artist_name": "Samsara Blues Experiment",
+			"listen_count": 15
+		},
+		{
+			"artist_mbids": ["aeb7af5b-fef8-479d-b5b4-f9b3c4fb95d4"],
+			"artist_name": "Masters of Reality",
+			"listen_count": 15
+		},
+		{
+			"artist_mbids": ["67f0c7ca-14e8-47a3-be0e-bd2f2ffe25bb", "ed8a131a-3ec7-4410-a848-40aa670111e0"],
+			"artist_name": "Mulatu Astatke & Black Jesus Experience",
+			"listen_count": 14
+		},
+		{
+			"artist_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
+			"artist_name": "Kraftwerk",
+			"listen_count": 14
+		},
+		{
+			"artist_mbids": ["1bdc2715-507c-41cb-9e06-021a8ecd6c8e"],
+			"artist_name": "Karkara",
+			"listen_count": 14
+		},
+		{
+			"artist_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
+			"artist_name": "Black Sky Giant",
+			"listen_count": 14
+		},
+		{
+			"artist_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
+			"artist_name": "Green Lung",
+			"listen_count": 13
+		},
+		{
+			"artist_mbids": ["5c98fc12-be83-4246-ae5b-2184192913b9"],
+			"artist_name": "Tinariwen",
+			"listen_count": 12
+		},
+		{
+			"artist_mbids": ["9f930ddf-be2f-4de5-a39f-7ae47305752e"],
+			"artist_name": "The Psychedelic Furs",
+			"listen_count": 12
+		},
+		{
+			"artist_mbids": ["231ff972-4e8e-4157-95e2-12f963cb478c"],
+			"artist_name": "Seasick Steve",
+			"listen_count": 12
+		},
+		{
+			"artist_mbids": ["eb3b3201-d6d5-4143-bd30-c50e719c138e"],
+			"artist_name": "Dust Mice",
+			"listen_count": 12
+		},
+		{
+			"artist_mbids": [],
+			"artist_name": "Anne-Sophie Mutter & Herbert Von Karajan",
+			"listen_count": 12
+		},
+		{"artist_mbids": [], "artist_name": "Roswell Rudd", "listen_count": 11},
+		{
+			"artist_mbids": ["2650f0e7-3879-4b2c-8908-d025113cbece"],
+			"artist_name": "KOKOROKO",
+			"listen_count": 11
+		},
+		{
+			"artist_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
+			"artist_name": "José Carlos Schwarz & Le Cobiana Djazz",
+			"listen_count": 11
+		}
+	],
+	"top_recordings": [
+		{
+			"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
+			"artist_name": "Fever Ray",
+			"listen_count": 10,
+			"recording_mbid": "55a6d83f-af43-449e-a6b4-1b8fa24b4039",
+			"release_mbid": "dba22fc0-9772-49c9-baaa-937d7914278a",
+			"release_name": "Fever Ray",
+			"track_name": "If I Had a Heart"
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 9,
+			"recording_mbid": "72586151-9800-44d6-8732-6b8491808651",
+			"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
+			"release_name": "Grown",
+			"track_name": "Listening Glasses"
+		},
+		{
+			"artist_mbids": ["6514cffa-fbe0-4965-ad88-e998ead8a82a"],
+			"artist_name": "Fela Kuti",
+			"listen_count": 9,
+			"recording_mbid": "a106cc67-0fa7-45f8-b894-e4f89624ed20",
+			"release_mbid": "371f9461-d100-4627-a863-eee42019f2a2",
+			"release_name": "The Two Sides of Fela: Jazz & Dance",
+			"track_name": "Eko Ile"
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 8,
+			"recording_mbid": "7edc2546-2288-4004-af22-e5e1325ee311",
+			"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
+			"release_name": "Grown",
+			"track_name": "Wassoulou"
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 8,
+			"recording_mbid": "98ebe88f-f72e-4b52-8402-7a01b88f3826",
+			"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
+			"release_name": "Grown",
+			"track_name": "Moleman"
+		},
+		{
+			"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_name": "Mdou Moctar",
+			"listen_count": 8,
+			"recording_mbid": "b376d4e6-8f05-43d4-97a2-44984931fcaa",
+			"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
+			"release_name": "Ilana: The Creator",
+			"track_name": "Inizgam"
+		},
+		{
+			"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_name": "Mdou Moctar",
+			"listen_count": 7,
+			"recording_mbid": "69532d98-67e9-495f-a7ac-a95fa976064a",
+			"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
+			"release_name": "Ilana: The Creator",
+			"track_name": "Tumastin"
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 7,
+			"recording_mbid": "88e8b728-2964-405b-94ad-0f005dde4aea",
+			"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
+			"release_name": "Grown",
+			"track_name": "Time’s Got A Hold"
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 7,
+			"recording_mbid": "9b41165e-73ad-4e2b-aec1-4aa62eb69d16",
+			"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
+			"release_name": "Grown",
+			"track_name": "Rollando"
+		},
+		{
+			"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
+			"artist_name": "Raúl Monsalve y los Forajidos",
+			"listen_count": 7,
+			"recording_mbid": "ac57c873-aea2-4f4a-873d-51cb8f4e12da",
+			"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
+			"release_name": "Bichos",
+			"track_name": "Mosquito"
+		},
+		{
+			"artist_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
+			"artist_name": "Les Filles de Illighadad",
+			"listen_count": 7,
+			"recording_mbid": "da9df919-8a3d-426e-9c68-d49b1d644110",
+			"release_mbid": "bc3e00b2-49f9-4e17-b4b6-7d1ccd1ea3c4",
+			"release_name": "Eghass Malan",
+			"track_name": "Inssegh Inssegh"
+		},
+		{
+			"artist_mbids": ["c33643b1-b62b-4834-8cd5-709ac45b6ae0"],
+			"artist_name": "TaxiWars",
+			"listen_count": 7,
+			"recording_mbid": "5b1a00ae-0a2a-4c0b-bd92-be4e9fcf58eb",
+			"release_mbid": "816c5c61-0184-41fb-9ee7-a6833df9e25d",
+			"release_name": "TaxiWars",
+			"track_name": "Death Ride Through Wet Snow"
+		},
+		{
+			"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
+			"artist_name": "Fever Ray",
+			"listen_count": 6,
+			"recording_mbid": "a62817d2-a7d2-4e1a-8c64-b225076eef8d",
+			"release_mbid": "dba22fc0-9772-49c9-baaa-937d7914278a",
+			"release_name": "Fever Ray",
+			"track_name": "When I Grow Up"
+		},
+		{
+			"artist_mbids": ["bded3a41-acd7-42ff-9402-cb59e35be8f4"],
+			"artist_name": "Endless Boogie",
+			"listen_count": 6,
+			"recording_mbid": "385f4381-0f6d-47a0-bc56-07570374f650",
+			"release_mbid": "a1bbc1d4-f2d3-4de9-a6b6-307f86d20ba3",
+			"release_name": "Vibe Killer",
+			"track_name": "Vibe Killer"
+		},
+		{
+			"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_name": "Slift",
+			"listen_count": 6,
+			"recording_mbid": "38851005-c0f5-4a59-a623-3589ae86db11",
+			"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
+			"release_name": "Ummon",
+			"track_name": "Ummon"
+		},
+		{
+			"artist_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
+			"artist_name": "Kraftwerk",
+			"listen_count": 6,
+			"recording_mbid": "fc7112f9-a06d-4f32-9bd3-c86eeb0cf288",
+			"release_mbid": "ee5f888d-2734-3ace-a25b-b6f9f39ca147",
+			"release_name": "Tour de France Soundtracks",
+			"track_name": "Tour de France"
+		},
+		{
+			"artist_mbids": ["1bdc2715-507c-41cb-9e06-021a8ecd6c8e"],
+			"artist_name": "Karkara",
+			"listen_count": 6,
+			"recording_mbid": "81583b4d-c881-499f-868e-20bf55312a1b",
+			"release_mbid": "cca29976-fea4-445a-be77-13b789dcdb81",
+			"release_name": "Nowhere Land",
+			"track_name": "Space Caravan"
+		},
+		{
+			"artist_mbids": ["d2b50525-1111-4906-aab6-4553f035f679"],
+			"artist_name": "Adriano Celentano",
+			"listen_count": 6,
+			"recording_mbid": "1460126d-5c9b-4e25-9968-b740d4796da0",
+			"release_mbid": "85393d0b-acdb-3d2c-b755-a4e0a7da3fc5",
+			"release_name": "Nostalrock",
+			"track_name": "Prisencolinensinainciusol"
+		},
+		{
+			"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
+			"artist_name": "Raúl Monsalve y los Forajidos",
+			"listen_count": 6,
+			"recording_mbid": "afa6d740-452a-4cc2-b24e-16d6d143b763",
+			"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
+			"release_name": "Bichos",
+			"track_name": "Malembe"
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 6,
+			"recording_mbid": "d3d524ac-1db2-4e48-acbd-ea29cd0b21d6",
+			"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
+			"release_name": "Grown",
+			"track_name": "Grown"
+		},
+		{
+			"artist_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_name": "King Gizzard & The Lizard Wizard",
+			"listen_count": 6,
+			"recording_mbid": "86d60ccc-c28d-40b3-9e53-b8468a7b8447",
+			"release_mbid": "db1c268c-39bd-4a86-bc02-2d514e205a42",
+			"release_name": "Nonagon Infinity",
+			"track_name": "Gamma Knife"
+		},
+		{
+			"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
+			"artist_name": "Nubya Garcia",
+			"listen_count": 6,
+			"recording_mbid": "d14b9cf0-1f05-434f-a2b3-16540e53e42a",
+			"release_mbid": "3ed914b0-9552-4258-9823-196ebbebfbf6",
+			"release_name": "Nubya’s 5ive",
+			"track_name": "Fly Free"
+		},
+		{
+			"artist_mbids": ["0b8dff0b-ce42-4cc6-afd1-1841f7781ed4"],
+			"artist_name": "Moondog",
+			"listen_count": 6,
+			"recording_mbid": "25f7c11a-d6df-4f02-b653-a6e7d7eab540",
+			"release_mbid": "f655e246-7b8a-44aa-a82e-73d37679a3d7",
+			"release_name": "DJ-Kicks: Henrik Schwarz",
+			"track_name": "Bird's Lament"
+		},
+		{
+			"artist_mbids": ["b7be7cdc-d77d-48a2-8d5f-f273e6545dd7"],
+			"artist_name": "Batmobile",
+			"listen_count": 5,
+			"recording_mbid": "4d4da953-9610-4786-947a-d99eeede33b0",
+			"release_mbid": "69223aed-432b-4652-9e03-840961fae89f",
+			"release_name": "Blast From the Past: The Worst and the Best",
+			"track_name": "Transsylvanian Express"
+		},
+		{
+			"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_name": "Slift",
+			"listen_count": 5,
+			"recording_mbid": "2ff15000-fe23-4a2f-bd70-a28c4dc32d48",
+			"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
+			"release_name": "Ummon",
+			"track_name": "Thousand Helmets of Gold"
+		},
+		{
+			"artist_mbids": ["67f0c7ca-14e8-47a3-be0e-bd2f2ffe25bb"],
+			"artist_name": "Mulatu Astatqé",
+			"listen_count": 5,
+			"recording_mbid": "fa5575af-be0c-4108-a392-6923bf56222d",
+			"release_mbid": "f85a03b1-efb8-4558-86ac-f23945a94853",
+			"release_name": "Ethiopiques 4: Ethio Jazz & Musique Instrumentale, 1969-1974",
+			"track_name": "Mètché dershé"
+		},
+		{
+			"artist_mbids": ["5971a238-30c7-4e9d-8716-5aec17628802", "fd673bd4-0168-47b6-80ba-96cc3ba1a1e2"],
+			"artist_name": "Tintura + Arno Tamm",
+			"listen_count": 5,
+			"recording_mbid": "99a2ec4b-5d0a-4736-b2af-1f317ba36dcd",
+			"release_mbid": "566a4c9f-55ca-4d01-93db-1b0a386d7d84",
+			"release_name": "Kaugel üksi võõra rahva hulgas",
+			"track_name": "Kust on tulnud muodike"
+		},
+		{
+			"artist_mbids": ["a5120e5e-0cb5-4212-8de0-fda40639007b", "f3ef765f-b7bf-4454-a007-c3468796dd24"],
+			"artist_name": "Homayoun Shajarian & Sohrab Pournazeri",
+			"listen_count": 5,
+			"recording_mbid": "5ec1413c-6aa7-4f17-93d8-a3c2a315d68a",
+			"release_mbid": "db717c45-448a-4b7e-b84d-fd0e14c36f12",
+			"release_name": "Iran",
+			"track_name": "Iran"
+		},
+		{
+			"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_name": "Slift",
+			"listen_count": 5,
+			"recording_mbid": "d95fa492-a834-4013-9102-03bd184d917a",
+			"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
+			"release_name": "Ummon",
+			"track_name": "Hyperion"
+		},
+		{
+			"artist_mbids": ["e193397d-a888-4b4d-b11d-2a602c24b023"],
+			"artist_name": "Dhafer Youssef",
+			"listen_count": 5,
+			"recording_mbid": "88616ac8-cbc6-4bc5-8b1b-74bd2bfde803",
+			"release_mbid": "5f2c7e20-fc50-44f4-a8a1-4acb35ddd486",
+			"release_name": "Diwan of Beauty and Odd",
+			"track_name": "Delightfully Odd"
+		},
+		{
+			"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
+			"artist_name": "Raúl Monsalve y los Forajidos",
+			"listen_count": 5,
+			"recording_mbid": "47709a9a-7691-4818-b62d-d0d58c352a2a",
+			"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
+			"release_name": "Bichos",
+			"track_name": "Bocón"
+		},
+		{
+			"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"],
+			"artist_name": "Koichi Sakai / Afla Sackey",
+			"listen_count": 5,
+			"recording_mbid": "dbb8196d-d1c1-4fa7-a198-98a49aa6f260",
+			"release_mbid": "790fe3d0-6c19-4b2e-9067-a6b66ce00bfe",
+			"release_name": "Wono LP",
+			"track_name": "Atenteben Blues"
+		},
+		{
+			"artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"],
+			"artist_name": "Sergeant Thunderhoof",
+			"listen_count": 5,
+			"recording_mbid": "1110726a-05da-4ad3-8d39-5c184c2206c8",
+			"release_mbid": "a49acda6-2a0f-4ce5-b009-f86f8fb33644",
+			"release_name": "Terra Solus",
+			"track_name": "Another Plane"
+		},
+		{
+			"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
+			"artist_name": "Nubya Garcia",
+			"listen_count": 4,
+			"recording_mbid": "84b9fdb2-1ce6-4420-92b3-13679f71dcfe",
+			"release_mbid": "18b916a9-7e58-485a-b972-32b6960b55db",
+			"release_name": "When We Are",
+			"track_name": "When We Are"
+		},
+		{
+			"artist_mbids": ["92f7110a-0d26-4d01-8d5d-a400e9b7145f"],
+			"artist_name": "Creature With the Atom Brain",
+			"listen_count": 4,
+			"recording_mbid": "0953c6df-422e-442a-be97-84079c883f49",
+			"release_mbid": "4d2d9802-7eb7-4ef3-b7e4-3ed6ea001382",
+			"release_name": "Transylvania",
+			"track_name": "Transylvania"
+		},
+		{
+			"artist_mbids": ["5c98fc12-be83-4246-ae5b-2184192913b9"],
+			"artist_name": "Tinariwen",
+			"listen_count": 4,
+			"recording_mbid": "b8cb2270-ef98-4010-8cfe-f00cc999bbd0",
+			"release_mbid": "07037dca-b814-4d01-9ded-096a06826d75",
+			"release_name": "Emmaar",
+			"track_name": "Toumast Tincha"
+		},
+		{
+			"artist_mbids": ["4ced64a4-1731-43c2-aaed-dbb3725fab9d"],
+			"artist_name": "The Parlor Mob",
+			"listen_count": 4,
+			"recording_mbid": "de08b36e-d8c8-4051-8316-f067688de858",
+			"release_mbid": "c9e0db11-6225-4479-ad30-f4ab983fae1b",
+			"release_name": "And You Were a Crow",
+			"track_name": "Tide of Tears"
+		},
+		{
+			"artist_mbids": ["2650f0e7-3879-4b2c-8908-d025113cbece"],
+			"artist_name": "KOKOROKO",
+			"listen_count": 4,
+			"recording_mbid": "b26bc064-fb52-433e-af02-fc2ab58e6bb0",
+			"release_mbid": "d7104546-c08d-4c6e-b14b-d4b7b00d4462",
+			"release_name": "KOKOROKO",
+			"track_name": "Ti-de"
+		},
+		{
+			"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_name": "Mdou Moctar",
+			"listen_count": 4,
+			"recording_mbid": "9bcd7c08-0548-4fe3-873b-a23b75c9f264",
+			"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
+			"release_name": "Ilana: The Creator",
+			"track_name": "Tarhatazed"
+		},
+		{
+			"artist_mbids": ["04cd0cfd-bfd1-4c36-bc38-95c35e2c045f"],
+			"artist_name": "Cream",
+			"listen_count": 4,
+			"recording_mbid": "2d5ae8c3-0db6-4354-a8ce-e530a58fd2b9",
+			"release_mbid": "ff44b5ec-ac04-3a6a-aad4-a26e9591e332",
+			"release_name": "Disraeli Gears",
+			"track_name": "Tales of Brave Ulysses"
+		},
+		{
+			"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_name": "Mdou Moctar",
+			"listen_count": 4,
+			"recording_mbid": "775f4f57-6a17-40cb-b79e-8df957af3428",
+			"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
+			"release_name": "Ilana: The Creator",
+			"track_name": "Takamba"
+		},
+		{
+			"artist_mbids": ["4d593ee9-d16a-41fd-89f9-fddd48af1dd7", "62e1043b-07e6-440e-bdf6-227ea2876e81"],
+			"artist_name": "Scotch Rolex ft. Lord Spikeheart",
+			"listen_count": 4,
+			"recording_mbid": "5656bce7-25dc-4176-b3e3-8a477a542da2",
+			"release_mbid": "40d6c86f-d3e5-4bb4-93bd-22631315a3b0",
+			"release_name": "TEWARI",
+			"track_name": "Success"
+		},
+		{
+			"artist_mbids": ["42689657-cbec-4f66-a9ed-80f939ea23ed"],
+			"artist_name": "Morphine",
+			"listen_count": 4,
+			"recording_mbid": "d8a213c8-d692-4d54-91de-25ac68b67a49",
+			"release_mbid": "c6f2297e-4083-439e-b141-f947de988576",
+			"release_name": "Cure for Pain",
+			"track_name": "Sheila"
+		},
+		{
+			"artist_mbids": ["3d49e36a-cc9e-411e-93c6-d1646ba5bd3a"],
+			"artist_name": "The Staple Singers",
+			"listen_count": 4,
+			"recording_mbid": "d5037427-7317-4c14-9540-fda40ad2ea5c",
+			"release_mbid": "bc517b5e-9262-4d5a-bf4f-7d22ccd51bdf",
+			"release_name": "City in the Sky",
+			"track_name": "Respect Yourself"
+		},
+		{
+			"artist_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
+			"artist_name": "José Carlos Schwarz & Le Cobiana Djazz",
+			"listen_count": 4,
+			"recording_mbid": "525a03ac-5b08-47bc-9e42-97fddf20f073",
+			"release_mbid": "0d698584-4c46-46ce-9781-e394d81450bd",
+			"release_name": "Lua Ki Di Nos",
+			"track_name": "Na Kolonia"
+		},
+		{
+			"artist_mbids": ["b0a7716f-9e14-4114-825a-1cadadfd7817"],
+			"artist_name": "General Midi",
+			"listen_count": 4,
+			"recording_mbid": "5e58c67c-ee7e-4a89-9fda-3dde3ef8152f",
+			"release_mbid": "e7266b15-6353-4c9e-b9ba-0a283b9c74e8",
+			"release_name": "Operation Overdrive",
+			"track_name": "Milton"
+		},
+		{
+			"artist_mbids": ["02177ee9-4415-4f31-a166-fc57a9016d4f", "7682d624-9e0b-45b2-b7d0-d1b18b3ebd05"],
+			"artist_name": "Vieux Farka Touré & Julia Easterlin",
+			"listen_count": 4,
+			"recording_mbid": "1b2f42c5-eb1d-4db8-b18f-200b94410140",
+			"release_mbid": "ee40241c-c48d-4a79-b9d9-6a8b903ea93c",
+			"release_name": "Touristes",
+			"track_name": "Masters of War"
+		},
+		{
+			"artist_mbids": ["5182c1d9-c7d2-4dad-afa0-ccfeada921a8"],
+			"artist_name": "Black Sabbath",
+			"listen_count": 4,
+			"recording_mbid": "c825b3da-2573-4007-b042-90a4edb6acd1",
+			"release_mbid": "0b4d5359-6ecb-4c09-b36a-f56b70d101a2",
+			"release_name": "Master of Reality",
+			"track_name": "Lord of This World"
+		},
+		{
+			"artist_mbids": ["2c180037-0af5-4f9d-a29d-9512544a3064"],
+			"artist_name": "Afla Sackey & Afrik Bawantu",
+			"listen_count": 4,
+			"recording_mbid": "56b13aee-0ca7-47cc-95b5-78a156a2d867",
+			"release_mbid": "7a08a7ce-4621-42c7-b85c-a7eea4d041df",
+			"release_name": "Life On The Street",
+			"track_name": "Life On The Street"
+		},
+		{
+			"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_name": "Slift",
+			"listen_count": 4,
+			"recording_mbid": "90f23763-acf4-4b58-8ad1-992c0146814f",
+			"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
+			"release_name": "Ummon",
+			"track_name": "It’s Coming…"
+		}
+	],
+	"top_releases": [
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 45,
+			"release_mbid": "8f4d033b-336f-49e4-9fee-3ea9828bc3d9",
+			"release_name": "Grown"
+		},
+		{
+			"artist_mbids": ["3d303095-020a-4b65-9419-b91a574c8c9b"],
+			"artist_name": "Slift",
+			"listen_count": 43,
+			"release_mbid": "57b16096-5ab0-453b-9f6c-9ba6752a07c1",
+			"release_name": "Ummon"
+		},
+		{
+			"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_name": "Mdou Moctar",
+			"listen_count": 36,
+			"release_mbid": "c20f3a9b-bdc3-474a-a5ba-0e1b819bb777",
+			"release_name": "Ilana: The Creator"
+		},
+		{
+			"artist_mbids": ["7d8dd77c-f433-42ad-9b99-9da904485eb0"],
+			"artist_name": "Raúl Monsalve y los Forajidos",
+			"listen_count": 36,
+			"release_mbid": "b32fdb57-591a-423c-94bd-2ecc11dd529d",
+			"release_name": "Bichos"
+		},
+		{
+			"artist_mbids": ["f7df5df4-4dfa-459d-972b-1ba051c15ddc"],
+			"artist_name": "Fever Ray",
+			"listen_count": 25,
+			"release_mbid": "dba22fc0-9772-49c9-baaa-937d7914278a",
+			"release_name": "Fever Ray"
+		},
+		{
+			"artist_mbids": ["7a6506cc-6f12-442d-9d3e-149bc838792e"],
+			"artist_name": "79.5",
+			"listen_count": 23,
+			"release_mbid": "14bec13f-5656-4f41-9e9c-71cafbb43b5d",
+			"release_name": "Predictions"
+		},
+		{
+			"artist_mbids": ["3a605eba-b6a1-4298-855d-b3033df0bf8b"],
+			"artist_name": "Kikagaku Moyo",
+			"listen_count": 23,
+			"release_mbid": "b0509ae0-782c-49f2-9deb-96fee10d52c5",
+			"release_name": "House in the Tall Grass"
+		},
+		{
+			"artist_mbids": ["72fd7688-8394-43b6-8f41-278657648a45"],
+			"artist_name": "Yussef Kamaal",
+			"listen_count": 23,
+			"release_mbid": "e6a5e707-7782-4258-8b22-9364629810bf",
+			"release_name": "Black Focus"
+		},
+		{
+			"artist_mbids": ["d1ccc60e-45d5-4176-a328-47cd5984e55b"],
+			"artist_name": "Tidiane Thiam",
+			"listen_count": 22,
+			"release_mbid": "30d789a0-fbfc-4e1d-9afc-a40aad08ca75",
+			"release_name": "Siftorde"
+		},
+		{
+			"artist_mbids": ["42689657-cbec-4f66-a9ed-80f939ea23ed"],
+			"artist_name": "Morphine",
+			"listen_count": 22,
+			"release_mbid": "c6f2297e-4083-439e-b141-f947de988576",
+			"release_name": "Cure for Pain"
+		},
+		{
+			"artist_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
+			"artist_name": "The Longest Johns",
+			"listen_count": 22,
+			"release_mbid": "a36fc551-0b52-4e76-a990-29a95e10a6d5",
+			"release_name": "Between Wind and Water"
+		},
+		{
+			"artist_mbids": ["22e6f8d3-2d7e-4abb-8a77-1a6d581cd560"],
+			"artist_name": "Wolves Like Me",
+			"listen_count": 20,
+			"release_mbid": "bf04a661-b7f2-40c9-b8e6-276ff3602997",
+			"release_name": "Who's Afraid?"
+		},
+		{
+			"artist_mbids": ["339b406e-4907-4a0f-b84a-9bac08e0947a"],
+			"artist_name": "Sergeant Thunderhoof",
+			"listen_count": 20,
+			"release_mbid": "a49acda6-2a0f-4ce5-b009-f86f8fb33644",
+			"release_name": "Terra Solus"
+		},
+		{
+			"artist_mbids": ["9219acc3-6234-4aee-8633-fe438daee3b2"],
+			"artist_name": "Anna Scionti",
+			"listen_count": 20,
+			"release_mbid": "dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0",
+			"release_name": "Junkbox Racket"
+		},
+		{
+			"artist_mbids": ["f58384a4-2ad2-4f24-89c5-c7b74ae1cce7"],
+			"artist_name": "King Gizzard & The Lizard Wizard",
+			"listen_count": 19,
+			"release_mbid": "db1c268c-39bd-4a86-bc02-2d514e205a42",
+			"release_name": "Nonagon Infinity"
+		},
+		{
+			"artist_mbids": ["c10e38ae-d06f-4bf4-8b54-8e19236a94f4"],
+			"artist_name": "Mohama Saz",
+			"listen_count": 19,
+			"release_mbid": "525dd70b-9614-477c-bd5a-1f8cfe547fe3",
+			"release_name": "Negro es el poder"
+		},
+		{
+			"artist_mbids": ["8ed78ccf-7a3f-4717-b84c-1606627124bd"],
+			"artist_name": "Hey Colossus",
+			"listen_count": 19,
+			"release_mbid": "882d8b34-42bc-4c10-b66e-5d87211a783a",
+			"release_name": "Dances / Curses"
+		},
+		{
+			"artist_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
+			"artist_name": "Goat",
+			"listen_count": 19,
+			"release_mbid": "4aef4248-31eb-44ea-95e3-c3706fd14ebe",
+			"release_name": "Commune"
+		},
+		{
+			"artist_mbids": ["1cacb864-e06f-4cf9-8105-508184c4168e", "2c180037-0af5-4f9d-a29d-9512544a3064"],
+			"artist_name": "Koichi Sakai / Afla Sackey",
+			"listen_count": 18,
+			"release_mbid": "790fe3d0-6c19-4b2e-9067-a6b66ce00bfe",
+			"release_name": "Wono LP"
+		},
+		{
+			"artist_mbids": ["2c180037-0af5-4f9d-a29d-9512544a3064"],
+			"artist_name": "Afla Sackey & Afrik Bawantu",
+			"listen_count": 18,
+			"release_mbid": "7a08a7ce-4621-42c7-b85c-a7eea4d041df",
+			"release_name": "Life On The Street"
+		},
+		{
+			"artist_mbids": ["052b43c2-2f6a-4e60-92ea-18b4de2be0d9"],
+			"artist_name": "Naxatras",
+			"listen_count": 18,
+			"release_mbid": "fd2c2f03-91d2-4ef0-a4c2-b22a141b8305",
+			"release_name": "III"
+		},
+		{
+			"artist_mbids": ["d675ed3f-bee2-40e0-8386-2960f477ad35"],
+			"artist_name": "Buried Feather",
+			"listen_count": 18,
+			"release_mbid": "0aaa7ecf-c117-4fc3-8f87-27dd8063010d",
+			"release_name": "Cloudberry Dreamshake"
+		},
+		{
+			"artist_mbids": ["981669c1-696b-450a-9594-4f59be20cd86"],
+			"artist_name": "Les Filles de Illighadad",
+			"listen_count": 17,
+			"release_mbid": "bc3e00b2-49f9-4e17-b4b6-7d1ccd1ea3c4",
+			"release_name": "Eghass Malan"
+		},
+		{
+			"artist_mbids": ["6a125082-74c4-4a1b-bf4b-d91d9cafde4c"],
+			"artist_name": "The Longest Johns",
+			"listen_count": 16,
+			"release_mbid": "12590c2f-fc17-4ea8-a7d0-6105e9192519",
+			"release_name": "Written in Salt"
+		},
+		{
+			"artist_mbids": ["cb331ec3-72af-4d8c-825a-63f79d56a651"],
+			"artist_name": "Movie Club",
+			"listen_count": 16,
+			"release_mbid": "43da4da0-f2cd-4e49-8bae-b334e2a71245",
+			"release_name": "Black Flamingo"
+		},
+		{
+			"artist_mbids": ["7e9d3899-9de2-4741-973c-6147238bb2f1"],
+			"artist_name": "Koudede",
+			"listen_count": 15,
+			"release_mbid": "d3a8492f-3130-4b34-9e8e-c0d5a3bff25e",
+			"release_name": "Taghlamt"
+		},
+		{
+			"artist_mbids": ["aeb7af5b-fef8-479d-b5b4-f9b3c4fb95d4"],
+			"artist_name": "Masters of Reality",
+			"listen_count": 15,
+			"release_mbid": "a9967f3c-d767-447f-b50d-96adfc6b1d1f",
+			"release_name": "Sunrise on the Sufferbus"
+		},
+		{
+			"artist_mbids": ["6738d800-5160-4959-b78a-ae12c5dba3d0"],
+			"artist_name": "Goat",
+			"listen_count": 15,
+			"release_mbid": "c27b9ce0-d30a-4793-b290-7cb0568a7289",
+			"release_name": "Requiem"
+		},
+		{
+			"artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+			"artist_name": "Danny Elfman",
+			"listen_count": 15,
+			"release_mbid": "7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19",
+			"release_name": "Big Mess"
+		},
+		{
+			"artist_mbids": ["d85defaf-b82e-48be-beb5-2672099e392e"],
+			"artist_name": "Mdou Moctar",
+			"listen_count": 15,
+			"release_mbid": "3b4e94a4-a148-4291-8f37-98b646e29e35",
+			"release_name": "Afelan"
+		},
+		{
+			"artist_mbids": ["67f0c7ca-14e8-47a3-be0e-bd2f2ffe25bb", "ed8a131a-3ec7-4410-a848-40aa670111e0"],
+			"artist_name": "Mulatu Astatke & Black Jesus Experience",
+			"listen_count": 14,
+			"release_mbid": "17697121-bbb5-4af9-8fab-a835a81889b5",
+			"release_name": "To Know Without Knowing"
+		},
+		{
+			"artist_mbids": ["6ce5eca0-4ad6-49e0-a5ab-e11482d85324"],
+			"artist_name": "Sudan Archives",
+			"listen_count": 14,
+			"release_mbid": "555fce2e-44b4-464c-bb70-40f2ac39ba00",
+			"release_name": "Sudan Archives"
+		},
+		{
+			"artist_mbids": ["77e5c5bb-f35b-4573-964d-6c5f7e73e06b"],
+			"artist_name": "Black Sky Giant",
+			"listen_count": 14,
+			"release_mbid": "de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746",
+			"release_name": "Planet Terror"
+		},
+		{
+			"artist_mbids": ["1bdc2715-507c-41cb-9e06-021a8ecd6c8e"],
+			"artist_name": "Karkara",
+			"listen_count": 14,
+			"release_mbid": "cca29976-fea4-445a-be77-13b789dcdb81",
+			"release_name": "Nowhere Land"
+		},
+		{
+			"artist_mbids": ["2a67f9e5-8b94-4929-b74c-236b4c1a70c3"],
+			"artist_name": "Mantra Machine",
+			"listen_count": 14,
+			"release_mbid": "e3987f3b-0913-4917-9345-a7d1b0743131",
+			"release_name": "Nitrogen"
+		},
+		{
+			"artist_mbids": ["42dd1862-7255-47ed-8584-651abce3bf53"],
+			"artist_name": "Nubya Garcia",
+			"listen_count": 13,
+			"release_mbid": "3ed914b0-9552-4258-9823-196ebbebfbf6",
+			"release_name": "Nubya’s 5ive"
+		},
+		{
+			"artist_mbids": ["8067c102-4996-42bc-9980-06ce2e644eae"],
+			"artist_name": "Soul Coughing",
+			"listen_count": 13,
+			"release_mbid": "95cfa680-5f12-4f6a-b56b-6464b23a51d7",
+			"release_name": "Irresistible Bliss"
+		},
+		{
+			"artist_mbids": ["a9126556-f555-4920-9617-6e013f8228a7"],
+			"artist_name": "Mark Lanegan",
+			"listen_count": 13,
+			"release_mbid": "cf637081-1868-4dac-a4ba-b57ac329459d",
+			"release_name": "Bubblegum"
+		},
+		{
+			"artist_mbids": ["eb3b3201-d6d5-4143-bd30-c50e719c138e"],
+			"artist_name": "Dust Mice",
+			"listen_count": 12,
+			"release_mbid": "0f055f1b-5ee0-473a-9c1c-3ada4d326b22",
+			"release_name": "Super Moon Fetus"
+		},
+		{
+			"artist_mbids": ["425bd6b7-dccf-4a03-9a4c-40f28fb5792d"],
+			"artist_name": "The Ossuary",
+			"listen_count": 12,
+			"release_mbid": "6d77c3fa-44aa-4814-abdf-82d66a167370",
+			"release_name": "Oltretomba"
+		},
+		{
+			"artist_mbids": ["c3aeb863-7b26-4388-94e8-5a240f2be21b"],
+			"artist_name": "Tom Waits",
+			"listen_count": 12,
+			"release_mbid": "dbd7788b-d83b-3fca-9a1e-ef477fbef18b",
+			"release_name": "Blood Money"
+		},
+		{
+			"artist_mbids": [],
+			"artist_name": "Anne-Sophie Mutter & Herbert Von Karajan",
+			"listen_count": 12,
+			"release_name": "Antonio Vivaldi - The Four Seasons(DTS)"
+		},
+		{
+			"artist_mbids": ["5700dcd4-c139-4f31-aa3e-6382b9af9032"],
+			"artist_name": "Kraftwerk",
+			"listen_count": 11,
+			"release_mbid": "ee5f888d-2734-3ace-a25b-b6f9f39ca147",
+			"release_name": "Tour de France Soundtracks"
+		},
+		{
+			"artist_mbids": [],
+			"artist_name": "Roswell Rudd",
+			"listen_count": 11,
+			"release_name": "Malicool"
+		},
+		{
+			"artist_mbids": ["d5fb82c9-ea77-4b4b-87d7-6912f5bd4a5c"],
+			"artist_name": "José Carlos Schwarz & Le Cobiana Djazz",
+			"listen_count": 11,
+			"release_mbid": "0d698584-4c46-46ce-9781-e394d81450bd",
+			"release_name": "Lua Ki Di Nos"
+		},
+		{
+			"artist_mbids": ["dc041361-3440-4c8a-a91d-730c0a30617b"],
+			"artist_name": "I Mitomani Beat",
+			"listen_count": 11,
+			"release_mbid": "f92a777c-e972-4f35-af16-1c52d5475ed5",
+			"release_name": "Fuori Dal Tempo"
+		},
+		{
+			"artist_mbids": ["36274201-f583-4859-83b8-5b8778dcb9f7"],
+			"artist_name": "Green Lung",
+			"listen_count": 11,
+			"release_mbid": "82a4ad46-2b60-44c3-91a9-58fc18eaa8d0",
+			"release_name": "Free the Witch"
+		},
+		{
+			"artist_mbids": ["a18c09f4-6b6f-4f9c-a4bb-ae2db7cab657"],
+			"artist_name": "Samsara Blues Experiment",
+			"listen_count": 11,
+			"release_mbid": "4ae759b4-3887-4e09-b731-a0fc95827f7e",
+			"release_name": "End of Forever"
+		},
+		{
+			"artist_mbids": ["350bddf0-fa3c-4b7c-98e5-afabaa8e630f"],
+			"artist_name": "TisDass",
+			"listen_count": 10,
+			"release_mbid": "76b95291-ca09-4ce4-be26-f53a94f2530b",
+			"release_name": "Yamedan"
+		},
+		{
+			"artist_mbids": ["25c86f9e-bf61-4f4a-896e-4f6c8a04c14b"],
+			"artist_name": "Waaju",
+			"listen_count": 10,
+			"release_mbid": "5e366076-7842-465f-8f66-4f4ac48dd582",
+			"release_name": "Waaju"
+		}
+	],
+	"top_releases_coverart": {
+		"0aaa7ecf-c117-4fc3-8f87-27dd8063010d": "https://archive.org/download/mbid-0aaa7ecf-c117-4fc3-8f87-27dd8063010d/mbid-0aaa7ecf-c117-4fc3-8f87-27dd8063010d-24818898237_thumb500.jpg",
+		"0d698584-4c46-46ce-9781-e394d81450bd": "https://archive.org/download/mbid-0d698584-4c46-46ce-9781-e394d81450bd/mbid-0d698584-4c46-46ce-9781-e394d81450bd-29260797648_thumb500.jpg",
+		"0f055f1b-5ee0-473a-9c1c-3ada4d326b22": "https://archive.org/download/mbid-0f055f1b-5ee0-473a-9c1c-3ada4d326b22/mbid-0f055f1b-5ee0-473a-9c1c-3ada4d326b22-28528635378_thumb500.jpg",
+		"12590c2f-fc17-4ea8-a7d0-6105e9192519": "https://archive.org/download/mbid-9ff59752-ae14-436d-9cfa-538c3a277a49/mbid-9ff59752-ae14-436d-9cfa-538c3a277a49-28508253308_thumb500.jpg",
+		"14bec13f-5656-4f41-9e9c-71cafbb43b5d": "https://archive.org/download/mbid-14bec13f-5656-4f41-9e9c-71cafbb43b5d/mbid-14bec13f-5656-4f41-9e9c-71cafbb43b5d-21132449540_thumb500.jpg",
+		"17697121-bbb5-4af9-8fab-a835a81889b5": "https://archive.org/download/mbid-17697121-bbb5-4af9-8fab-a835a81889b5/mbid-17697121-bbb5-4af9-8fab-a835a81889b5-28321745116_thumb500.jpg",
+		"30d789a0-fbfc-4e1d-9afc-a40aad08ca75": "https://archive.org/download/mbid-30d789a0-fbfc-4e1d-9afc-a40aad08ca75/mbid-30d789a0-fbfc-4e1d-9afc-a40aad08ca75-26101187098_thumb500.jpg",
+		"3b4e94a4-a148-4291-8f37-98b646e29e35": "https://archive.org/download/mbid-3b4e94a4-a148-4291-8f37-98b646e29e35/mbid-3b4e94a4-a148-4291-8f37-98b646e29e35-22567406586_thumb500.jpg",
+		"3ed914b0-9552-4258-9823-196ebbebfbf6": "https://archive.org/download/mbid-3ed914b0-9552-4258-9823-196ebbebfbf6/mbid-3ed914b0-9552-4258-9823-196ebbebfbf6-30548125375_thumb500.jpg",
+		"43da4da0-f2cd-4e49-8bae-b334e2a71245": "https://archive.org/download/mbid-43da4da0-f2cd-4e49-8bae-b334e2a71245/mbid-43da4da0-f2cd-4e49-8bae-b334e2a71245-29837533510_thumb500.jpg",
+		"4ae759b4-3887-4e09-b731-a0fc95827f7e": "https://archive.org/download/mbid-4ae759b4-3887-4e09-b731-a0fc95827f7e/mbid-4ae759b4-3887-4e09-b731-a0fc95827f7e-28171732498_thumb500.jpg",
+		"4aef4248-31eb-44ea-95e3-c3706fd14ebe": "https://archive.org/download/mbid-991de6ef-018f-4cc1-804e-694d6ed0ac60/mbid-991de6ef-018f-4cc1-804e-694d6ed0ac60-30098225803_thumb500.jpg",
+		"525dd70b-9614-477c-bd5a-1f8cfe547fe3": "https://archive.org/download/mbid-525dd70b-9614-477c-bd5a-1f8cfe547fe3/mbid-525dd70b-9614-477c-bd5a-1f8cfe547fe3-16146216234_thumb500.jpg",
+		"555fce2e-44b4-464c-bb70-40f2ac39ba00": "https://archive.org/download/mbid-555fce2e-44b4-464c-bb70-40f2ac39ba00/mbid-555fce2e-44b4-464c-bb70-40f2ac39ba00-17275675545_thumb500.jpg",
+		"57b16096-5ab0-453b-9f6c-9ba6752a07c1": "https://archive.org/download/mbid-6f821b32-d742-4855-a92b-e4307a71d328/mbid-6f821b32-d742-4855-a92b-e4307a71d328-25157253217_thumb500.jpg",
+		"5e366076-7842-465f-8f66-4f4ac48dd582": "https://archive.org/download/mbid-5e366076-7842-465f-8f66-4f4ac48dd582/mbid-5e366076-7842-465f-8f66-4f4ac48dd582-27111713202_thumb500.jpg",
+		"6d77c3fa-44aa-4814-abdf-82d66a167370": "https://archive.org/download/mbid-6d77c3fa-44aa-4814-abdf-82d66a167370/mbid-6d77c3fa-44aa-4814-abdf-82d66a167370-31023875910_thumb500.jpg",
+		"76b95291-ca09-4ce4-be26-f53a94f2530b": "https://archive.org/download/mbid-76b95291-ca09-4ce4-be26-f53a94f2530b/mbid-76b95291-ca09-4ce4-be26-f53a94f2530b-12215908866_thumb500.jpg",
+		"790fe3d0-6c19-4b2e-9067-a6b66ce00bfe": "https://archive.org/download/mbid-790fe3d0-6c19-4b2e-9067-a6b66ce00bfe/mbid-790fe3d0-6c19-4b2e-9067-a6b66ce00bfe-31016686916_thumb500.jpg",
+		"7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19": "https://archive.org/download/mbid-7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19/mbid-7d9f61f8-e6dc-42c1-a40c-bdc2bc494e19-29690912729_thumb500.jpg",
+		"82a4ad46-2b60-44c3-91a9-58fc18eaa8d0": "https://archive.org/download/mbid-82a4ad46-2b60-44c3-91a9-58fc18eaa8d0/mbid-82a4ad46-2b60-44c3-91a9-58fc18eaa8d0-19151416676_thumb500.jpg",
+		"882d8b34-42bc-4c10-b66e-5d87211a783a": "https://archive.org/download/mbid-c169b6b9-f8a8-4223-a27b-d54f779e23d6/mbid-c169b6b9-f8a8-4223-a27b-d54f779e23d6-27699726096_thumb500.jpg",
+		"8f4d033b-336f-49e4-9fee-3ea9828bc3d9": "https://archive.org/download/mbid-8f4d033b-336f-49e4-9fee-3ea9828bc3d9/mbid-8f4d033b-336f-49e4-9fee-3ea9828bc3d9-26952123955_thumb500.jpg",
+		"95cfa680-5f12-4f6a-b56b-6464b23a51d7": "https://archive.org/download/mbid-95cfa680-5f12-4f6a-b56b-6464b23a51d7/mbid-95cfa680-5f12-4f6a-b56b-6464b23a51d7-5722139475_thumb500.jpg",
+		"a36fc551-0b52-4e76-a990-29a95e10a6d5": "https://archive.org/download/mbid-90ab2dbb-a73f-433f-af08-86480569d052/mbid-90ab2dbb-a73f-433f-af08-86480569d052-28561345452_thumb500.jpg",
+		"a49acda6-2a0f-4ce5-b009-f86f8fb33644": "https://archive.org/download/mbid-a49acda6-2a0f-4ce5-b009-f86f8fb33644/mbid-a49acda6-2a0f-4ce5-b009-f86f8fb33644-31016437738_thumb500.jpg",
+		"a9967f3c-d767-447f-b50d-96adfc6b1d1f": "https://archive.org/download/mbid-a9967f3c-d767-447f-b50d-96adfc6b1d1f/mbid-a9967f3c-d767-447f-b50d-96adfc6b1d1f-4697744998_thumb500.jpg",
+		"b0509ae0-782c-49f2-9deb-96fee10d52c5": "https://archive.org/download/mbid-b0509ae0-782c-49f2-9deb-96fee10d52c5/mbid-b0509ae0-782c-49f2-9deb-96fee10d52c5-13685812868_thumb500.jpg",
+		"b32fdb57-591a-423c-94bd-2ecc11dd529d": "https://archive.org/download/mbid-b32fdb57-591a-423c-94bd-2ecc11dd529d/mbid-b32fdb57-591a-423c-94bd-2ecc11dd529d-27595765927_thumb500.jpg",
+		"bc3e00b2-49f9-4e17-b4b6-7d1ccd1ea3c4": "https://archive.org/download/mbid-83bb5d9b-8028-4e8a-b366-e552788251ac/mbid-83bb5d9b-8028-4e8a-b366-e552788251ac-18529426891_thumb500.jpg",
+		"bf04a661-b7f2-40c9-b8e6-276ff3602997": "https://archive.org/download/mbid-bf04a661-b7f2-40c9-b8e6-276ff3602997/mbid-bf04a661-b7f2-40c9-b8e6-276ff3602997-31016387153_thumb500.jpg",
+		"c20f3a9b-bdc3-474a-a5ba-0e1b819bb777": "https://archive.org/download/mbid-f2456b58-1365-41a2-ad4a-e7f93b4ef24c/mbid-f2456b58-1365-41a2-ad4a-e7f93b4ef24c-23111873482_thumb500.jpg",
+		"c27b9ce0-d30a-4793-b290-7cb0568a7289": "https://archive.org/download/mbid-3dd71efa-4a6f-4035-b473-704cbc5d3905/mbid-3dd71efa-4a6f-4035-b473-704cbc5d3905-30098155000_thumb500.jpg",
+		"c6f2297e-4083-439e-b141-f947de988576": "https://archive.org/download/mbid-c6f2297e-4083-439e-b141-f947de988576/mbid-c6f2297e-4083-439e-b141-f947de988576-14670890955_thumb500.jpg",
+		"cca29976-fea4-445a-be77-13b789dcdb81": "https://archive.org/download/mbid-cca29976-fea4-445a-be77-13b789dcdb81/mbid-cca29976-fea4-445a-be77-13b789dcdb81-27317413245_thumb500.jpg",
+		"cf637081-1868-4dac-a4ba-b57ac329459d": "https://archive.org/download/mbid-864236f5-29bd-3075-893c-1614da2a760a/mbid-864236f5-29bd-3075-893c-1614da2a760a-10445104137_thumb500.jpg",
+		"d3a8492f-3130-4b34-9e8e-c0d5a3bff25e": "https://archive.org/download/mbid-d3a8492f-3130-4b34-9e8e-c0d5a3bff25e/mbid-d3a8492f-3130-4b34-9e8e-c0d5a3bff25e-31024382371_thumb500.jpg",
+		"db1c268c-39bd-4a86-bc02-2d514e205a42": "https://archive.org/download/mbid-db1c268c-39bd-4a86-bc02-2d514e205a42/mbid-db1c268c-39bd-4a86-bc02-2d514e205a42-28715709130_thumb500.jpg",
+		"dba22fc0-9772-49c9-baaa-937d7914278a": "https://archive.org/download/mbid-dba22fc0-9772-49c9-baaa-937d7914278a/mbid-dba22fc0-9772-49c9-baaa-937d7914278a-3694245478_thumb500.jpg",
+		"dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0": "https://archive.org/download/mbid-dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0/mbid-dbd690ab-1cd4-46e4-ae6e-f7e72e6ce0e0-28501559665_thumb500.jpg",
+		"dbd7788b-d83b-3fca-9a1e-ef477fbef18b": "https://archive.org/download/mbid-fe24ae45-4a90-3baa-9b92-d9008c6fbfed/mbid-fe24ae45-4a90-3baa-9b92-d9008c6fbfed-29377113010_thumb500.jpg",
+		"de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746": "https://archive.org/download/mbid-de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746/mbid-de3f6b4a-a5f7-4f7b-9d1b-92c0aa210746-28346397129_thumb500.jpg",
+		"e3987f3b-0913-4917-9345-a7d1b0743131": "https://archive.org/download/mbid-e3987f3b-0913-4917-9345-a7d1b0743131/mbid-e3987f3b-0913-4917-9345-a7d1b0743131-9088922725_thumb500.jpg",
+		"e6a5e707-7782-4258-8b22-9364629810bf": "https://archive.org/download/mbid-e6a5e707-7782-4258-8b22-9364629810bf/mbid-e6a5e707-7782-4258-8b22-9364629810bf-17570747724_thumb500.jpg",
+		"ee5f888d-2734-3ace-a25b-b6f9f39ca147": "https://archive.org/download/mbid-ee5f888d-2734-3ace-a25b-b6f9f39ca147/mbid-ee5f888d-2734-3ace-a25b-b6f9f39ca147-2541564114_thumb500.jpg",
+		"f92a777c-e972-4f35-af16-1c52d5475ed5": "https://archive.org/download/mbid-f92a777c-e972-4f35-af16-1c52d5475ed5/mbid-f92a777c-e972-4f35-af16-1c52d5475ed5-30833685382_thumb500.jpg",
+		"fd2c2f03-91d2-4ef0-a4c2-b22a141b8305": "https://archive.org/download/mbid-fd2c2f03-91d2-4ef0-a4c2-b22a141b8305/mbid-fd2c2f03-91d2-4ef0-a4c2-b22a141b8305-19125183916_thumb500.jpg"
+	},
+	"total_listen_count": 2742
 }


### PR DESCRIPTION
Puts the navigation arrows back and visible on the Coverflow

Note: This disables clicking on the covers to right/left of the middle one to navigate, unfortunately

![image](https://user-images.githubusercontent.com/6179856/146550972-20268fac-aea6-40ac-82bf-db0ae6d513bd.png)
