### PR TITLE
Fix OutOfMemory error in site wide listening activity stats

### DIFF
--- a/listenbrainz_spark/stats/common/listening_activity.py
+++ b/listenbrainz_spark/stats/common/listening_activity.py
@@ -55,9 +55,15 @@ def get_two_quarters_ago_offset(_date: date) -> relativedelta:
         return relativedelta(month=4, day=1)
 
 
-def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta, str]:
-    """ Returns the start time, end time, segment step size and date format to use for
-    calculating the listening activity stats
+def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta, str, str]:
+    """ Returns the start time, end time, segment step size, python date format and spark
+     date format to use for calculating the listening activity stats
+
+     We need both python date and spark date format because site wide listening activity uses
+     it. See the site wide listening activity query for details.
+
+     Python date format reference: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+     Spark date format reference: https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html
 
     .. note::
 
@@ -73,7 +79,8 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
         from_ts = datetime.combine(from_date, time.min)
         step = relativedelta(days=+1)
         date_format = "%d %B %Y"
-        return from_ts, to_ts, step, date_format
+        spark_date_format = "d MMMM y"
+        return from_ts, to_ts, step, date_format, spark_date_format
 
     if stats_range == "all_time":
         # all_time stats range is easy, just return time from LASTFM founding
@@ -83,7 +90,8 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
         # compute listening activity on annual basis
         step = relativedelta(years=+1)
         date_format = "%Y"
-        return from_date, to_date, step, date_format
+        spark_date_format = "y"
+        return from_date, to_date, step, date_format, spark_date_format
 
     # If we had used datetime.now or date.today here and the data in spark
     # became outdated due to some reason, empty stats would be sent to LB.
@@ -100,12 +108,14 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
             # compute listening activity for each day, include weekday in date format
             step = relativedelta(days=+1)
             date_format = "%A %d %B %Y"
+            spark_date_format = "EEEE d MMMM y"
         elif stats_range == "this_month":
             # if today is 1st then 1st of 2 months ago otherwise the 1st of last month
             from_offset = relativedelta(months=-2) if latest_listen_date.day == 1 else relativedelta(months=-1, day=1)
             # compute listening activity for each day but no weekday
             step = relativedelta(days=+1)
             date_format = "%d %B %Y"
+            spark_date_format = "d MMMM y"
         else:
             # if today is the 1st of the year, then still show last year stats
             if latest_listen_date.day == 1 and latest_listen_date.month == 1:
@@ -115,13 +125,14 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
             step = relativedelta(months=+1)
             # compute listening activity for each month
             date_format = "%B %Y"
+            spark_date_format = "MMMM y"
 
         from_date = latest_listen_date + from_offset
 
         # set time to 00:00
         from_date = datetime.combine(from_date, time.min)
         to_date = datetime.combine(latest_listen_date, time.min)
-        return from_date, to_date, step, date_format
+        return from_date, to_date, step, date_format, spark_date_format
 
     # following are "last" week/month/year stats, here we want the stats of the
     # previous week/month/year and *not* from 7 days ago to today so on.
@@ -134,29 +145,34 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
         # compute listening activity for each day, include weekday in date format
         step = relativedelta(days=+1)
         date_format = "%A %d %B %Y"
+        spark_date_format = "EEEE d MMMM y"
     elif stats_range == "month":
         from_offset = relativedelta(months=-2, day=1)  # start of the previous to previous month
         to_offset = relativedelta(months=+2)
         # compute listening activity for each day but no weekday
         step = relativedelta(days=+1)
         date_format = "%d %B %Y"
+        spark_date_format = "d MMMM y"
     elif stats_range == "quarter":
         from_offset = get_two_quarters_ago_offset(latest_listen_date)
         to_offset = relativedelta(months=+6)
         # compute listening activity for each week with date format as day
         step = relativedelta(weeks=+1)
         date_format = "%d %B %Y"
+        spark_date_format = "d MMMM y"
     elif stats_range == "half_yearly":
         from_offset = _get_half_year_offset(latest_listen_date)
         to_offset = relativedelta(months=+12)
         step = relativedelta(months=+1)
         date_format = "%B %Y"
+        spark_date_format = "MMMM y"
     else:  # year
         from_offset = relativedelta(years=-2, month=1, day=1)  # start of the previous to previous year
         to_offset = relativedelta(years=+2)
         step = relativedelta(months=+1)
         # compute listening activity for each month
         date_format = "%B %Y"
+        spark_date_format = "MMMM y"
 
     from_date = latest_listen_date + from_offset
     to_date = from_date + to_offset
@@ -165,10 +181,10 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
     from_date = datetime.combine(from_date, time.min)
     to_date = datetime.combine(to_date, time.min)
 
-    return from_date, to_date, step, date_format
+    return from_date, to_date, step, date_format, spark_date_format
 
 
-def setup_time_range(stats_range: str) -> Tuple[datetime, datetime]:
+def setup_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta, str, str]:
     """
     Sets up time range buckets needed to calculate listening activity stats and
     returns the start and end time of the time range.
@@ -181,7 +197,7 @@ def setup_time_range(stats_range: str) -> Tuple[datetime, datetime]:
     will return 1st of last year as the start time and the current date as the
     end time in this example.
     """
-    from_date, to_date, step, date_format = get_time_range(stats_range)
+    from_date, to_date, step, date_format, spark_date_format = get_time_range(stats_range)
     time_range = []
 
     segment_start = from_date
@@ -196,4 +212,4 @@ def setup_time_range(stats_range: str) -> Tuple[datetime, datetime]:
     time_range_df = listenbrainz_spark.session.createDataFrame(time_range, time_range_schema)
     time_range_df.createOrReplaceTempView("time_range")
 
-    return from_date, to_date
+    return from_date, to_date, step, date_format, spark_date_format

--- a/listenbrainz_spark/stats/common/listening_activity.py
+++ b/listenbrainz_spark/stats/common/listening_activity.py
@@ -156,8 +156,7 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
     elif stats_range == "quarter":
         from_offset = get_two_quarters_ago_offset(latest_listen_date)
         to_offset = relativedelta(months=+6)
-        # compute listening activity for each week with date format as day
-        step = relativedelta(weeks=+1)
+        step = relativedelta(days=+1)
         date_format = "%d %B %Y"
         spark_date_format = "d MMMM y"
     elif stats_range == "half_yearly":

--- a/listenbrainz_spark/stats/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/sitewide/listening_activity.py
@@ -54,7 +54,7 @@ def calculate_listening_activity(spark_date_format):
                                   to_unix_timestamp(start) AS from_ts
                                 , to_unix_timestamp(end) AS to_ts
                                 , time_range
-                                , listen_count
+                                , COALESCE(listen_count, 0) AS listen_count
                             )
                         )
                     ) AS listening_activity

--- a/listenbrainz_spark/stats/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/sitewide/listening_activity.py
@@ -41,7 +41,7 @@ def calculate_listening_activity(spark_date_format):
     # much cheaper than joining with a separate time range table. We still join the grouped data with
     # a separate time range table to fill any gaps i.e. time ranges with no listens get a value of 0
     # instead of being completely omitted from the final result.
-    result = run_query(f""" 
+    result = run_query(f"""
         WITH bucket_listen_counts AS (
             SELECT date_format(listened_at, '{spark_date_format}') AS time_range
                  , count(listened_at) AS listen_count
@@ -60,7 +60,7 @@ def calculate_listening_activity(spark_date_format):
                     ) AS listening_activity
               FROM time_range
          LEFT JOIN bucket_listen_counts
-             USING (time_range) 
+             USING (time_range)
     """)
     return result.toLocalIterator()
 

--- a/listenbrainz_spark/stats/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/sitewide/listening_activity.py
@@ -50,7 +50,12 @@ def calculate_listening_activity(spark_date_format):
         )
             SELECT sort_array(
                        collect_list(
-                           struct(start AS from_ts, end AS to_ts, time_range, listen_count)
+                            struct(
+                                  to_unix_timestamp(start) AS from_ts
+                                , to_unix_timestamp(end) AS to_ts
+                                , time_range
+                                , listen_count
+                            )
                         )
                     ) AS listening_activity
               FROM time_range

--- a/listenbrainz_spark/stats/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/sitewide/listening_activity.py
@@ -22,33 +22,40 @@ time_range_schema = StructType([
 logger = logging.getLogger(__name__)
 
 
-def calculate_listening_activity():
+def calculate_listening_activity(spark_date_format):
     """ Calculate number of listens for each user in time ranges given in the "time_range" table.
     The time ranges are as follows:
         1) week - each day with weekday name of the past 2 weeks.
         2) month - each day the past 2 months.
         3) year - each month of the past 2 years.
         4) all_time - each year starting from LAST_FM_FOUNDING_YEAR (2002)
+
+    Args:
+        spark_date_format: the date format
     """
-    # calculates the number of listens in each time range for each user, count(listen.listened_at) so that
+    # calculates the number of listens in each time range for each user, count(listened_at) so that
     # group without listens are counted as 0, count(*) gives 1.
-    result = run_query(""" 
-        WITH intermediate_table AS (
-            SELECT to_unix_timestamp(first(time_range.start)) as from_ts
-                 , to_unix_timestamp(first(time_range.end)) as to_ts
-                 , time_range.time_range AS time_range
-                 , count(listens.listened_at) as listen_count
-              FROM time_range
-         LEFT JOIN listens
-                ON listens.listened_at BETWEEN time_range.start AND time_range.end
-          GROUP BY time_range.time_range
+    # this query is much different that the user listening activity stats query because an earlier
+    # version of this query which was similar to that caused OutOfMemory on yearly and all time
+    # ranges. It turns converting each listened_at to the needed date format and grouping by it is
+    # much cheaper than joining with a separate time range table. We still join the grouped data with
+    # a separate time range table to fill any gaps i.e. time ranges with no listens get a value of 0
+    # instead of being completely omitted from the final result.
+    result = run_query(f""" 
+        WITH bucket_listen_counts AS (
+            SELECT date_format(listened_at, {spark_date_format}) AS time_range
+                 , count(listened_at) AS listen_count
+              FROM listens
+          GROUP BY time_range
         )
             SELECT sort_array(
                        collect_list(
-                           struct(from_ts, to_ts, time_range, listen_count)
+                           struct(start AS from_ts, end AS to_ts, time_range, listen_count)
                         )
                     ) AS listening_activity
-              FROM intermediate_table
+              FROM time_range
+         LEFT JOIN bucket_listen_counts
+             USING (time_range) 
     """)
     return result.toLocalIterator()
 
@@ -63,9 +70,9 @@ def get_listening_activity(stats_range: str):
     details). These values are used on the listening activity reports.
     """
     logger.debug(f"Calculating listening_activity_{stats_range}")
-    from_date, to_date = setup_time_range(stats_range)
+    from_date, to_date, _, _, spark_date_format = setup_time_range(stats_range)
     get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView("listens")
-    data = calculate_listening_activity()
+    data = calculate_listening_activity(spark_date_format)
     messages = create_messages(data=data, stats_range=stats_range, from_date=from_date, to_date=to_date)
     logger.debug("Done!")
     return messages

--- a/listenbrainz_spark/stats/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/sitewide/listening_activity.py
@@ -43,7 +43,7 @@ def calculate_listening_activity(spark_date_format):
     # instead of being completely omitted from the final result.
     result = run_query(f""" 
         WITH bucket_listen_counts AS (
-            SELECT date_format(listened_at, {spark_date_format}) AS time_range
+            SELECT date_format(listened_at, '{spark_date_format}') AS time_range
                  , count(listened_at) AS listen_count
               FROM listens
           GROUP BY time_range

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -65,7 +65,7 @@ def get_listening_activity(stats_range: str, message_type="user_listening_activi
     details). These values are used on the listening activity reports.
     """
     logger.debug(f"Calculating listening_activity_{stats_range}")
-    from_date, to_date = setup_time_range(stats_range)
+    from_date, to_date, _, _, _ = setup_time_range(stats_range)
     get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView("listens")
     data = calculate_listening_activity()
     messages = create_messages(data=data, stats_range=stats_range,

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -92,7 +92,7 @@ class ListeningActivityTestCase(StatsTestCase):
             datetime(2021, 7, 1),
             datetime(2021, 10, 1)
         ]
-        step = relativedelta(weeks=+1)
+        step = relativedelta(days=+1)
         fmt = "%d %B %Y"
         spark_fmt = "d MMMM y"
 

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -116,9 +116,9 @@ class ListeningActivityTestCase(StatsTestCase):
         spark_fmt = "MMMM y"
 
         mock_listen_ts.return_value = datetime(2021, 3, 5, 2, 3, 0)
-        self.assertEqual((periods[0], periods[2], step, fmt, spark_fmt, spark_fmt), listening_activity_utils.get_time_range("half_yearly"))
+        self.assertEqual((periods[0], periods[2], step, fmt, spark_fmt), listening_activity_utils.get_time_range("half_yearly"))
         mock_listen_ts.return_value = datetime(2021, 9, 7, 2, 3, 0)
-        self.assertEqual((periods[1], periods[3], step, fmt, spark_fmt, spark_fmt), listening_activity_utils.get_time_range("half_yearly"))
+        self.assertEqual((periods[1], periods[3], step, fmt, spark_fmt), listening_activity_utils.get_time_range("half_yearly"))
 
         step = relativedelta(days=+1)
         fmt = "%A %d %B %Y"

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -94,14 +94,16 @@ class ListeningActivityTestCase(StatsTestCase):
         ]
         step = relativedelta(weeks=+1)
         fmt = "%d %B %Y"
+        spark_fmt = "d MMMM y"
+
         mock_listen_ts.return_value = datetime(2021, 1, 5, 2, 3, 0)
-        self.assertEqual((quarters[0], quarters[2], step, fmt), listening_activity_utils.get_time_range("quarter"))
+        self.assertEqual((quarters[0], quarters[2], step, fmt, spark_fmt), listening_activity_utils.get_time_range("quarter"))
         mock_listen_ts.return_value = datetime(2021, 5, 7, 2, 3, 0)
-        self.assertEqual((quarters[1], quarters[3], step, fmt), listening_activity_utils.get_time_range("quarter"))
+        self.assertEqual((quarters[1], quarters[3], step, fmt, spark_fmt), listening_activity_utils.get_time_range("quarter"))
         mock_listen_ts.return_value = datetime(2021, 8, 9, 2, 3, 0)
-        self.assertEqual((quarters[2], quarters[4], step, fmt), listening_activity_utils.get_time_range("quarter"))
+        self.assertEqual((quarters[2], quarters[4], step, fmt, spark_fmt), listening_activity_utils.get_time_range("quarter"))
         mock_listen_ts.return_value = datetime(2021, 11, 8, 2, 3, 0)
-        self.assertEqual((quarters[3], quarters[5], step, fmt), listening_activity_utils.get_time_range("quarter"))
+        self.assertEqual((quarters[3], quarters[5], step, fmt, spark_fmt), listening_activity_utils.get_time_range("quarter"))
 
         periods = [
             datetime(2020, 1, 1),
@@ -111,88 +113,86 @@ class ListeningActivityTestCase(StatsTestCase):
         ]
         step = relativedelta(months=+1)
         fmt = "%B %Y"
+        spark_fmt = "MMMM y"
+
         mock_listen_ts.return_value = datetime(2021, 3, 5, 2, 3, 0)
-        self.assertEqual((periods[0], periods[2], step, fmt), listening_activity_utils.get_time_range("half_yearly"))
+        self.assertEqual((periods[0], periods[2], step, fmt, spark_fmt, spark_fmt), listening_activity_utils.get_time_range("half_yearly"))
         mock_listen_ts.return_value = datetime(2021, 9, 7, 2, 3, 0)
-        self.assertEqual((periods[1], periods[3], step, fmt), listening_activity_utils.get_time_range("half_yearly"))
+        self.assertEqual((periods[1], periods[3], step, fmt, spark_fmt, spark_fmt), listening_activity_utils.get_time_range("half_yearly"))
 
         step = relativedelta(days=+1)
         fmt = "%A %d %B %Y"
+        spark_fmt = "EEEE d MMMM y"
 
         mock_listen_ts.return_value = datetime(2021, 11, 24, 2, 3, 0)
         self.assertEqual(
-            (datetime(2021, 11, 15), datetime(2021, 11, 24), step, fmt),
+            (datetime(2021, 11, 15), datetime(2021, 11, 24), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("this_week")
         )
-
         mock_listen_ts.return_value = datetime(2021, 11, 22, 3, 0, 0)
         self.assertEqual(
-            (datetime(2021, 11, 8), datetime(2021, 11, 22), step, fmt),
+            (datetime(2021, 11, 8), datetime(2021, 11, 22), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("this_week")
         )
 
         mock_listen_ts.return_value = datetime(2021, 11, 24, 2, 3, 0)
         self.assertEqual(
-            (datetime(2021, 11, 8), datetime(2021, 11, 22), step, fmt),
+            (datetime(2021, 11, 8), datetime(2021, 11, 22), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("week")
         )
-
         mock_listen_ts.return_value = datetime(2021, 11, 22, 3, 0, 0)
         self.assertEqual(
-            (datetime(2021, 11, 8), datetime(2021, 11, 22), step, fmt),
+            (datetime(2021, 11, 8), datetime(2021, 11, 22), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("week")
         )
 
         step = relativedelta(days=+1)
         fmt = "%d %B %Y"
+        spark_fmt = "d MMMM y"
 
         mock_listen_ts.return_value = datetime(2021, 11, 21, 2, 3, 0)
         self.assertEqual(
-            (datetime(2021, 10, 1), datetime(2021, 11, 21), step, fmt),
+            (datetime(2021, 10, 1), datetime(2021, 11, 21), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("this_month")
         )
-
         mock_listen_ts.return_value = datetime(2021, 11, 1, 3, 0, 0)
         self.assertEqual(
-            (datetime(2021, 9, 1), datetime(2021, 11, 1), step, fmt),
+            (datetime(2021, 9, 1), datetime(2021, 11, 1), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("this_month")
         )
 
         mock_listen_ts.return_value = datetime(2021, 11, 21, 2, 3, 0)
         self.assertEqual(
-            (datetime(2021, 9, 1), datetime(2021, 11, 1), step, fmt),
+            (datetime(2021, 9, 1), datetime(2021, 11, 1), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("month")
         )
-
         mock_listen_ts.return_value = datetime(2021, 11, 1, 3, 0, 0)
         self.assertEqual(
-            (datetime(2021, 9, 1), datetime(2021, 11, 1), step, fmt),
+            (datetime(2021, 9, 1), datetime(2021, 11, 1), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("month")
         )
 
         step = relativedelta(months=+1)
         fmt = "%B %Y"
+        spark_fmt = "MMMM y"
 
         mock_listen_ts.return_value = datetime(2021, 11, 21, 2, 3, 0)
         self.assertEqual(
-            (datetime(2019, 1, 1), datetime(2021, 1, 1), step, fmt),
+            (datetime(2019, 1, 1), datetime(2021, 1, 1), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("year")
         )
-
         mock_listen_ts.return_value = datetime(2021, 1, 1, 2, 3, 0)
         self.assertEqual(
-            (datetime(2019, 1, 1), datetime(2021, 1, 1), step, fmt),
+            (datetime(2019, 1, 1), datetime(2021, 1, 1), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("year")
         )
-
         mock_listen_ts.return_value = datetime(2021, 1, 1, 2, 1, 0)
         self.assertEqual(
-            (datetime(2019, 1, 1), datetime(2021, 1, 1), step, fmt),
+            (datetime(2019, 1, 1), datetime(2021, 1, 1), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("this_year")
         )
-
         mock_listen_ts.return_value = datetime(2021, 11, 1, 3, 0, 0)
         self.assertEqual(
-            (datetime(2020, 1, 1), datetime(2021, 11, 1), step, fmt),
+            (datetime(2020, 1, 1), datetime(2021, 11, 1), step, fmt, spark_fmt),
             listening_activity_utils.get_time_range("this_year")
         )


### PR DESCRIPTION
Empirical testing has shown that joining time_range table with listens table before grouping is more expensive than converting each listen's listened_at to the desired date format, grouping on that and then joining with time_range table to fill any gaps. The first approach is so much more expensive that it causes a OOM in the Spark Driver.