### PR TITLE
Add recording mbid to recording feedback

### DIFF
--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -36,6 +36,7 @@ CREATE UNIQUE INDEX user_id_service_ndx_listens_importer ON listens_importer (us
 CREATE INDEX latest_listened_at_ndx_listens_importer ON listens_importer (latest_listened_at DESC NULLS LAST);
 
 CREATE UNIQUE INDEX user_id_rec_msid_ndx_feedback ON recording_feedback (user_id, recording_msid);
+CREATE UNIQUE INDEX user_id_rec_mbid_ndx_feedback ON recording_feedback (user_id, recording_mbid);
 
 -- NOTE: If the indexes for the similar_user table changes, update the code in listenbrainz/db/similar_users.py !
 CREATE UNIQUE INDEX user_id_ndx_similar_user ON recommendation.similar_user (user_id);

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -36,7 +36,7 @@ CREATE UNIQUE INDEX user_id_service_ndx_listens_importer ON listens_importer (us
 CREATE INDEX latest_listened_at_ndx_listens_importer ON listens_importer (latest_listened_at DESC NULLS LAST);
 
 CREATE UNIQUE INDEX user_id_rec_msid_ndx_feedback ON recording_feedback (user_id, recording_msid);
-CREATE UNIQUE INDEX user_id_rec_mbid_ndx_feedback ON recording_feedback (user_id, recording_mbid);
+CREATE UNIQUE INDEX user_id_mbid_ndx_rec_feedback ON recording_feedback (user_id, recording_mbid);
 
 -- NOTE: If the indexes for the similar_user table changes, update the code in listenbrainz/db/similar_users.py !
 CREATE UNIQUE INDEX user_id_ndx_similar_user ON recommendation.similar_user (user_id);

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -213,10 +213,15 @@ CREATE TABLE recommendation_feedback (
 CREATE TABLE recording_feedback (
     id                      SERIAL, -- PK
     user_id                 INTEGER NOT NULL, -- FK to "user".id
-    recording_msid          UUID NOT NULL,
+    recording_msid          UUID,
+    recording_mbid          UUID,
     score                   SMALLINT NOT NULL,
     created                 TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE recording_feedback
+    ADD CONSTRAINT feedback_recording_msid_or_recording_mbid_check
+    CHECK ( recording_msid IS NOT NULL OR recording_mbid IS NOT NULL );
 
 CREATE TABLE release_color(
     id                      SERIAL, -- PK

--- a/admin/sql/updates/2021-12-20-add-mbid-to-recording-feedback.sql
+++ b/admin/sql/updates/2021-12-20-add-mbid-to-recording-feedback.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE recording_feedback ALTER COLUMN recording_msid DROP NOT NULL;
+
+ALTER TABLE recording_feedback ADD COLUMN recording_mbid UUID;
+
+ALTER TABLE recording_feedback
+    ADD CONSTRAINT feedback_recording_msid_or_recording_mbid_check
+    CHECK ( recording_msid IS NOT NULL OR recording_mbid IS NOT NULL );
+
+COMMIT;

--- a/admin/sql/updates/2021-12-20-add-mbid-to-recording-feedback.sql
+++ b/admin/sql/updates/2021-12-20-add-mbid-to-recording-feedback.sql
@@ -8,4 +8,6 @@ ALTER TABLE recording_feedback
     ADD CONSTRAINT feedback_recording_msid_or_recording_mbid_check
     CHECK ( recording_msid IS NOT NULL OR recording_mbid IS NOT NULL );
 
+CREATE UNIQUE INDEX user_id_rec_mbid_ndx_feedback ON recording_feedback (user_id, recording_mbid);
+
 COMMIT;

--- a/admin/sql/updates/2021-12-20-add-mbid-to-recording-feedback.sql
+++ b/admin/sql/updates/2021-12-20-add-mbid-to-recording-feedback.sql
@@ -8,6 +8,6 @@ ALTER TABLE recording_feedback
     ADD CONSTRAINT feedback_recording_msid_or_recording_mbid_check
     CHECK ( recording_msid IS NOT NULL OR recording_mbid IS NOT NULL );
 
-CREATE UNIQUE INDEX user_id_rec_mbid_ndx_feedback ON recording_feedback (user_id, recording_mbid);
+CREATE UNIQUE INDEX user_id_mbid_ndx_rec_feedback ON recording_feedback (user_id, recording_mbid);
 
 COMMIT;

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -1,5 +1,5 @@
 import sqlalchemy
-from sqlalchemy import text
+from sqlalchemy import text, select
 
 from listenbrainz import db
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
@@ -67,7 +67,7 @@ def delete(feedback: Feedback):
         Args:
             feedback: An object of class Feedback
     """
-    conditions = [text("user_id = :user_id")]
+    conditions = ["user_id = :user_id"]
     args = {"user_id": feedback.user_id}
 
     if feedback.recording_msid:
@@ -79,9 +79,8 @@ def delete(feedback: Feedback):
         args["recording_mbid"] = feedback.recording_mbid
 
     where_clause = " AND ".join(conditions)
-
     with db.engine.connect() as connection:
-        connection.execute(text("DELETE FROM recording_feedback WHERE ") + where_clause, args)
+        connection.execute(text("DELETE FROM recording_feedback WHERE " + where_clause), args)
 
 
 def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = None, metadata: bool = False) -> List[Feedback]:

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -2,13 +2,9 @@ import sqlalchemy
 from sqlalchemy import text
 
 from listenbrainz import db
-from listenbrainz.db import timescale
-from listenbrainz.db.mapping import fetch_track_metadata_for_items
+from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
 from listenbrainz.db.model.feedback import Feedback
-from listenbrainz import messybrainz as msb_db
-from listenbrainz.messybrainz.data import load_recordings_from_msids
 from typing import List
-from listenbrainz.messybrainz.exceptions import NoDataFoundException
 
 
 def insert(feedback: Feedback):

--- a/listenbrainz/db/model/feedback.py
+++ b/listenbrainz/db/model/feedback.py
@@ -1,10 +1,11 @@
 from copy import copy
 
 from datetime import datetime
-from pydantic import BaseModel, NonNegativeInt, validator, constr
-from data.model.validators import check_valid_uuid
+from pydantic import NonNegativeInt, validator
+from listenbrainz.db.mapping import MsidMbidModel
 
-class Feedback(BaseModel):
+
+class Feedback(MsidMbidModel):
     """ Represents a feedback object
         Args:
             user_id: the row id of the user in the DB
@@ -16,10 +17,8 @@ class Feedback(BaseModel):
 
     user_id: NonNegativeInt
     user_name: str = None
-    recording_msid: constr(min_length=1)
     score: int
     created: datetime = None
-    track_metadata: dict = None
 
     def to_api(self) -> dict:
         fb = copy(self)
@@ -35,5 +34,3 @@ class Feedback(BaseModel):
         if scr not in [-1, 0, 1]:
             raise ValueError('Score can have a value of 1, 0 or -1.')
         return scr
-
-    _is_recording_msid_valid: classmethod = validator("recording_msid", allow_reuse=True)(check_valid_uuid)

--- a/listenbrainz/db/model/feedback.py
+++ b/listenbrainz/db/model/feedback.py
@@ -2,7 +2,7 @@ from copy import copy
 
 from datetime import datetime
 from pydantic import NonNegativeInt, validator
-from listenbrainz.db.mapping import MsidMbidModel
+from listenbrainz.db.msid_mbid_mapping import MsidMbidModel
 
 
 class Feedback(MsidMbidModel):

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -100,7 +100,7 @@ def fetch_track_metadata_for_items(items: List[ModelT]) -> List[ModelT]:
 
     mapping_mbid_metadata, mapping_msid_metadata = load_recordings_from_mapping(mbid_item_map.keys(), msid_item_map.keys())
     _update_items_from_map(mbid_item_map, mapping_mbid_metadata)
-    _update_items_from_map(msid_item_map, mapping_mbid_metadata)
+    _update_items_from_map(msid_item_map, mapping_msid_metadata)
     return items
 
 

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -216,7 +216,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
         fb_msid_1 = self.sample_feedback[0]["recording_msid"]
 
         self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0)
+        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -227,7 +227,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
         user2 = db_user.get_or_create(2, "recording_feedback_other_user")
         self.insert_test_data(user2["id"])
 
-        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0)
+        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0)
         self.assertEqual(len(result), 2)
 
         self.assertEqual(result[0].user_id, user2["id"])
@@ -241,33 +241,33 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
         self.assertEqual(result[1].score, self.sample_feedback[0]["score"])
 
         # test the score argument
-        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0, score=1)
+        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0, score=1)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].score, 1)
         self.assertEqual(result[1].score, 1)
 
-        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0, score=-1)
+        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0, score=-1)
         self.assertEqual(len(result), 0)
 
         # test the limit argument
-        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=1, offset=0)
+        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=1, offset=0)
         self.assertEqual(len(result), 1)
 
         # test the offset argument
-        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=1)
+        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=1)
         self.assertEqual(len(result), 1)
 
     def test_get_feedback_count_for_recording(self):
         fb_msid_1 = self.sample_feedback[0]["recording_msid"]
 
         self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_count_for_recording(recording_msid=fb_msid_1)
+        result = db_feedback.get_feedback_count_for_recording("recording_msid", fb_msid_1)
         self.assertEqual(result, 1)
 
         user2 = db_user.get_or_create(2, "recording_feedback_other_user")
         self.insert_test_data(user2["id"])
 
-        result = db_feedback.get_feedback_count_for_recording(recording_msid=fb_msid_1)
+        result = db_feedback.get_feedback_count_for_recording("recording_msid", fb_msid_1)
         self.assertEqual(result, 2)
 
     def test_get_feedback_for_multiple_recordings_for_user(self):

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -216,7 +216,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
         fb_msid_1 = self.sample_feedback[0]["recording_msid"]
 
         self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0)
+        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -227,7 +227,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
         user2 = db_user.get_or_create(2, "recording_feedback_other_user")
         self.insert_test_data(user2["id"])
 
-        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0)
+        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0)
         self.assertEqual(len(result), 2)
 
         self.assertEqual(result[0].user_id, user2["id"])
@@ -241,20 +241,20 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
         self.assertEqual(result[1].score, self.sample_feedback[0]["score"])
 
         # test the score argument
-        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0, score=1)
+        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0, score=1)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].score, 1)
         self.assertEqual(result[1].score, 1)
 
-        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=0, score=-1)
+        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=0, score=-1)
         self.assertEqual(len(result), 0)
 
         # test the limit argument
-        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=1, offset=0)
+        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=1, offset=0)
         self.assertEqual(len(result), 1)
 
         # test the offset argument
-        result = db_feedback.get_feedback_for_recording(recording_msid=fb_msid_1, limit=25, offset=1)
+        result = db_feedback.get_feedback_for_recording(recording=fb_msid_1, limit=25, offset=1)
         self.assertEqual(len(result), 1)
 
     def test_get_feedback_count_for_recording(self):
@@ -284,7 +284,9 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
 
         result = db_feedback.get_feedback_for_multiple_recordings_for_user(
             user_id=self.user["id"],
-            recording_list=recording_list
+            user_name=self.user["musicbrainz_id"],
+            recording_msids=recording_list,
+            recording_mbids=[]
         )
         self.assertEqual(len(result), len(recording_list))
 

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -48,7 +48,19 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "recording_msid": "7babc9be-ca2b-4544-b932-7c9ab38770d6",
             "score": 1
         }
+        response = self.client.post(
+            url_for("feedback_api_v1.recording_feedback"),
+            data=json.dumps(feedback),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+            content_type="application/json"
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["status"], "ok")
 
+        feedback = {
+            "recording_mbid": "7babc9be-ca2b-4544-b932-7c9ab38770d6",
+            "score": -1
+        }
         response = self.client.post(
             url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -5,6 +5,7 @@ from flask import url_for
 
 import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.user as db_user
+from listenbrainz import messybrainz
 from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.tests.integration import IntegrationTestCase
 
@@ -461,7 +462,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1))
         self.assert200(response)
         data = json.loads(response.data)
@@ -483,9 +484,9 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_recording_invalid_recording_msid(self):
         """ Test to make sure that the API sends 404 if recording_msid is invalid. """
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording", recording_msid="invalid_recording_msid"))
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid", recording_msid="invalid_recording_msid"))
         self.assert400(response)
-        self.assertEqual(response.json["error"], "invalid_recording_msid MSID format invalid.")
+        self.assertEqual(response.json["error"], "invalid_recording_msid msid format invalid.")
 
     def test_get_feedback_for_recording_with_score_param(self):
         """ Test to make sure valid response is received when score param is passed """
@@ -495,7 +496,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass score = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"score": 1})
         self.assert200(response)
         data = json.loads(response.data)
@@ -516,7 +517,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[0]["score"], inserted_rows[0]["score"])
 
         # pass score = -1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"score": -1})
         self.assert200(response)
         data = json.loads(response.data)
@@ -536,13 +537,13 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass non-int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"score": "invalid_score"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Invalid score argument: invalid_score")
 
         # pass invalid int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"score": 10})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Score can have a value of 1 or -1.")
@@ -555,7 +556,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"count": 1})
         self.assert200(response)
         data = json.loads(response.data)
@@ -579,13 +580,13 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass non-int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"count": "invalid_count"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
         # pass negative int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"count": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
@@ -598,7 +599,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"offset": 1})
         self.assert200(response)
         data = json.loads(response.data)
@@ -622,13 +623,13 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass non-int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"offset": "invalid_offset"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
         # pass negative int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording",
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"offset": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
@@ -677,13 +678,13 @@ class FeedbackAPITestCase(IntegrationTestCase):
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
                                            user_name=self.user["musicbrainz_id"]))  # missing recordings param
         self.assert400(response)
-        self.assertEqual(response.json["error"], "'recordings' has no valid recording MSID.")
+        self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
 
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
                                            user_name=self.user["musicbrainz_id"]),
                                    query_string={"recordings": ""})  # empty string
         self.assert400(response)
-        self.assertEqual(response.json["error"], "'recordings' has no valid recording MSID.")
+        self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
 
     def test_get_feedback_for_recordings_for_user_invalid_recording(self):
         """ Test to make sure that the API sends 400 if params recordings has invalid recording_msid. """
@@ -704,8 +705,45 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
+    def _insert_feedback_with_metadata(self, user_id):
+        recordings = [
+            {
+                "title": "Strangers",
+                "artist": "Portishead",
+                "release": "Dummy"
+            },
+            {
+                "title": "Wicked Game",
+                "artist": "Tom Ellis",
+                "release": "Lucifer"
+            }
+        ]
+        submitted_data = messybrainz.insert_all_in_transaction(recordings)
+
+        sample_feedback = [
+            {
+                "recording_msid": submitted_data[0]["ids"]["recording_msid"],
+                "score": 1
+            },
+            {
+                "recording_msid": submitted_data[1]["ids"]["recording_msid"],
+                "score": -1
+            }
+        ]
+        for fb in sample_feedback:
+            db_feedback.insert(
+                Feedback(
+                    user_id=user_id,
+                    recording_msid=fb["recording_msid"],
+                    score=fb["score"]
+                )
+            )
+        return sample_feedback
+
     def test_feedback_view(self):
-        inserted_rows = self.insert_test_data(self.user["id"])
+        # user.feedback endpoint queries recording feedback with metadata which loads
+        # data from msb so insert recordings into msb as well, otherwise the test will fail
+        inserted_rows = self._insert_feedback_with_metadata(self.user["id"])
 
         # Fetch loved page
         r = self.client.get(url_for('user.feedback', user_name=self.user['musicbrainz_id']))

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -42,6 +42,36 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
         return sample_feedback
 
+    def insert_test_data_with_mbid(self, user_id):
+        sample_feedback = [
+            {
+                "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                "score": 1
+            },
+            {
+                "recording_msid": "222eb00d-9ead-42de-aec9-8f8c1509413d",
+                "score": -1
+            },
+            {
+                "recording_mbid": "076255b4-1575-11ec-ac84-135bf6a670e3",
+                "score": 1
+            },
+            {
+                "recording_mbid": "1fd178b4-1575-11ec-b98a-d72392cd8c97",
+                "score": -1
+            }
+        ]
+        for fb in sample_feedback:
+            db_feedback.insert(
+                Feedback(
+                    user_id=user_id,
+                    recording_msid=fb.get("recording_msid"),
+                    recording_mbid=fb.get("recording_mbid"),
+                    score=fb["score"]
+                )
+            )
+        return sample_feedback
+
     def test_recording_feedback(self):
         """ Test for submission of valid feedback """
         feedback = {
@@ -58,7 +88,21 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         feedback = {
-            "recording_mbid": "7babc9be-ca2b-4544-b932-7c9ab38770d6",
+            "recording_mbid": "e7ebbb99-7346-4323-9541-dffae9e1003b",
+            "score": -1
+        }
+        response = self.client.post(
+            url_for("feedback_api_v1.recording_feedback"),
+            data=json.dumps(feedback),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+            content_type="application/json"
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["status"], "ok")
+
+        feedback = {
+            "recording_mbid": "9d008211-c920-4ff7-a17f-b86e4246c58c",
+            "recording_msid": "9541592c-0102-4b94-93cc-ee0f3cf83d64",
             "score": -1
         }
         response = self.client.post(
@@ -175,7 +219,20 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "recording_msid": "invalid_recording_msid",
             "score": 1
         }
+        response = self.client.post(
+            url_for("feedback_api_v1.recording_feedback"),
+            data=json.dumps(invalid_feedback),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+            content_type="application/json"
+        )
+        self.assert400(response)
+        self.assertEqual(response.json["code"], 400)
 
+        # submit feedback with invalid recording_mbid
+        invalid_feedback = {
+            "recording_mbid": "invalid_recording_mbid",
+            "score": 1
+        }
         response = self.client.post(
             url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(invalid_feedback),
@@ -190,7 +247,6 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "recording_msid": "7babc9be-ca2b-4544-b932-7c9ab38770d6",
             "score": 5
         }
-
         response = self.client.post(
             url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(invalid_feedback),
@@ -215,7 +271,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
-    def test_recording_feedback_update_score(self):
+    def test_recording_msid_feedback_update_score(self):
         """
         Test to check that score gets updated when a user changes feedback score for a recording_msid
         i.e love to hate or vice-versa
@@ -264,6 +320,55 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(result[0].recording_msid, updated_feedback["recording_msid"])
         self.assertEqual(result[0].score, updated_feedback["score"])
 
+    def test_recording_mbid_feedback_update_score(self):
+        """
+        Test to check that score gets updated when a user changes feedback score for a recording_mbid
+        i.e love to hate or vice-versa
+        """
+
+        # submit a feedback with score = 1
+        feedback = {
+            "recording_mbid": "076255b4-1575-11ec-ac84-135bf6a670e3",
+            "score": 1
+        }
+
+        response = self.client.post(
+            url_for("feedback_api_v1.recording_feedback"),
+            data=json.dumps(feedback),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+            content_type="application/json"
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["status"], "ok")
+
+        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].user_id, self.user["id"])
+        self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
+        self.assertEqual(result[0].score, feedback["score"])
+
+        # submit an updated feedback for the same recording_mbid with new score = -1
+        updated_feedback = {
+            "recording_mbid": "076255b4-1575-11ec-ac84-135bf6a670e3",
+            "score": -1
+        }
+
+        response = self.client.post(
+            url_for("feedback_api_v1.recording_feedback"),
+            data=json.dumps(updated_feedback),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+            content_type="application/json"
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["status"], "ok")
+
+        # check that the record gets updated
+        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].user_id, self.user["id"])
+        self.assertEqual(result[0].recording_mbid, updated_feedback["recording_mbid"])
+        self.assertEqual(result[0].score, updated_feedback["score"])
+
     def test_recording_feedback_delete_when_score_is_zero(self):
         """
         Test to check that the feedback record gets deleted when a user removes feedback for a recording_msid
@@ -294,6 +399,52 @@ class FeedbackAPITestCase(IntegrationTestCase):
         # submit an updated feedback for the same recording_msid with new score = 0
         updated_feedback = {
             "recording_msid": "7babc9be-ca2b-4544-b932-7c9ab38770d6",
+            "score": 0
+        }
+
+        response = self.client.post(
+            url_for("feedback_api_v1.recording_feedback"),
+            data=json.dumps(updated_feedback),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+            content_type="application/json"
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["status"], "ok")
+
+        # check that the record gets deleted
+        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), 0)
+
+    def test_recording_mbid_feedback_delete_when_score_is_zero(self):
+        """
+        Test to check that the feedback record gets deleted when a user removes feedback for a recording_mbid
+        by submitting a score = 0
+        """
+
+        # submit a feedback with score = 1
+        feedback = {
+            "recording_mbid": "076255b4-1575-11ec-ac84-135bf6a670e3",
+            "score": 1
+        }
+
+        response = self.client.post(
+            url_for("feedback_api_v1.recording_feedback"),
+            data=json.dumps(feedback),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+            content_type="application/json"
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["status"], "ok")
+
+        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].user_id, self.user["id"])
+        self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
+        self.assertEqual(result[0].score, feedback["score"])
+
+        # submit an updated feedback for the same recording_mbid with new score = 0
+        updated_feedback = {
+            "recording_mbid": "076255b4-1575-11ec-ac84-135bf6a670e3",
             "score": 0
         }
 
@@ -341,7 +492,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_user_with_score_param(self):
         """ Test to make sure valid response is received when score param is passed """
-        inserted_rows = self.insert_test_data(self.user["id"])
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
 
         # pass score = 1
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
@@ -349,16 +500,22 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         data = json.loads(response.data)
 
-        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["count"], 2)
         self.assertEqual(data["total_count"], len(inserted_rows))
         self.assertEqual(data["offset"], 0)
 
         feedback = data["feedback"]  # sorted in descending order of their creation
-        self.assertEqual(len(feedback), 1)
+        self.assertEqual(len(feedback), 2)
 
         self.assertEqual(feedback[0]["user_id"], self.user["musicbrainz_id"])
-        self.assertEqual(feedback[0]["recording_msid"], inserted_rows[0]["recording_msid"])
+        self.assertEqual(feedback[0]["recording_msid"], None)
+        self.assertEqual(feedback[0]["recording_mbid"], inserted_rows[2]["recording_mbid"])
         self.assertEqual(feedback[0]["score"], 1)
+
+        self.assertEqual(feedback[1]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[1]["recording_msid"], inserted_rows[0]["recording_msid"])
+        self.assertEqual(feedback[1]["recording_mbid"], None)
+        self.assertEqual(feedback[1]["score"], 1)
 
         # pass score = -1
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
@@ -366,16 +523,22 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         data = json.loads(response.data)
 
-        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["count"], 2)
         self.assertEqual(data["total_count"], len(inserted_rows))
         self.assertEqual(data["offset"], 0)
 
         feedback = data["feedback"]  # sorted in descending order of their creation
-        self.assertEqual(len(feedback), 1)
+        self.assertEqual(len(feedback), 2)
 
         self.assertEqual(feedback[0]["user_id"], self.user["musicbrainz_id"])
-        self.assertEqual(feedback[0]["recording_msid"], inserted_rows[1]["recording_msid"])
+        self.assertEqual(feedback[0]["recording_msid"], None)
+        self.assertEqual(feedback[0]["recording_mbid"], inserted_rows[3]["recording_mbid"])
         self.assertEqual(feedback[0]["score"], -1)
+
+        self.assertEqual(feedback[1]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[1]["recording_msid"], inserted_rows[1]["recording_msid"])
+        self.assertEqual(feedback[1]["recording_mbid"], None)
+        self.assertEqual(feedback[1]["score"], -1)
 
     def test_get_feedback_for_user_with_invalid_score_param(self):
         """ Test to make sure 400 response is received if score argument is not valid """
@@ -395,7 +558,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_user_with_count_param(self):
         """ Test to make sure valid response is received when count param is passed """
-        inserted_rows = self.insert_test_data(self.user["id"])
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
 
         # pass count = 1
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
@@ -411,8 +574,9 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(len(feedback), 1)
 
         self.assertEqual(feedback[0]["user_id"], self.user["musicbrainz_id"])
-        self.assertEqual(feedback[0]["recording_msid"], inserted_rows[1]["recording_msid"])
-        self.assertEqual(feedback[0]["score"], inserted_rows[1]["score"])
+        self.assertEqual(feedback[0]["recording_msid"], None)
+        self.assertEqual(feedback[0]["recording_mbid"], inserted_rows[3]["recording_mbid"])
+        self.assertEqual(feedback[0]["score"], inserted_rows[3]["score"])
 
     def test_get_feedback_for_user_with_invalid_count_param(self):
         """ Test to make sure 400 response is received if count argument is not valid """
@@ -494,11 +658,46 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[1]["recording_msid"], rec_msid_1)
         self.assertEqual(feedback[0]["score"], inserted_rows[0]["score"])
 
+    def test_get_feedback_for_recording_mbid(self):
+        """ Test to make sure valid response is received for recording mbid feedback """
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+        inserted_rows = self.insert_test_data_with_mbid(self.user2["id"])
+
+        rec_mbid = inserted_rows[2]["recording_mbid"]
+
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid))
+        self.assert200(response)
+        data = json.loads(response.data)
+
+        self.assertEqual(data["count"], 2)
+        self.assertEqual(data["total_count"], 2)
+        self.assertEqual(data["offset"], 0)
+
+        feedback = data["feedback"]  # sorted in descending order of their creation
+        self.assertEqual(len(feedback), 2)
+
+        self.assertEqual(feedback[0]["user_id"], self.user2["musicbrainz_id"])
+        self.assertEqual(feedback[0]["recording_msid"], None)
+        self.assertEqual(feedback[0]["recording_mbid"], rec_mbid)
+        self.assertEqual(feedback[0]["score"], inserted_rows[2]["score"])
+
+        self.assertEqual(feedback[1]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[1]["recording_msid"], None)
+        self.assertEqual(feedback[1]["recording_mbid"], rec_mbid)
+        self.assertEqual(feedback[1]["score"], inserted_rows[2]["score"])
+
     def test_get_feedback_for_recording_invalid_recording_msid(self):
         """ Test to make sure that the API sends 404 if recording_msid is invalid. """
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid", recording_msid="invalid_recording_msid"))
         self.assert400(response)
         self.assertEqual(response.json["error"], "invalid_recording_msid msid format invalid.")
+
+    def test_get_feedback_for_recording_mbid_invalid_recording_msid(self):
+        """ Test to make sure that the API sends 404 if recording_mbid is invalid. """
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid", recording_mbid="invalid_recording_mbid"))
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "invalid_recording_mbid mbid format invalid.")
 
     def test_get_feedback_for_recording_with_score_param(self):
         """ Test to make sure valid response is received when score param is passed """
@@ -541,6 +740,47 @@ class FeedbackAPITestCase(IntegrationTestCase):
         feedback = data["feedback"]  # sorted in descending order of their creation
         self.assertEqual(len(feedback), 0)
 
+    def test_get_feedback_for_recording_mbid_with_score_param(self):
+        """ Test to make sure valid response is received when score param is passed """
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+        inserted_rows = self.insert_test_data_with_mbid(self.user2["id"])
+
+        rec_mbid_1 = inserted_rows[2]["recording_mbid"]
+
+        # pass score = 1
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"score": 1})
+        self.assert200(response)
+        data = json.loads(response.data)
+
+        self.assertEqual(data["count"], 2)
+        self.assertEqual(data["total_count"], 2)
+        self.assertEqual(data["offset"], 0)
+
+        feedback = data["feedback"]  # sorted in descending order of their creation
+        self.assertEqual(len(feedback), 2)
+
+        self.assertEqual(feedback[0]["user_id"], self.user2["musicbrainz_id"])
+        self.assertEqual(feedback[0]["recording_mbid"], rec_mbid_1)
+        self.assertEqual(feedback[0]["score"], inserted_rows[2]["score"])
+
+        self.assertEqual(feedback[1]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[1]["recording_mbid"], rec_mbid_1)
+        self.assertEqual(feedback[1]["score"], inserted_rows[2]["score"])
+
+        # pass score = -1
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"score": -1})
+        self.assert200(response)
+        data = json.loads(response.data)
+
+        self.assertEqual(data["count"], 0)
+        self.assertEqual(data["total_count"], 2)
+        self.assertEqual(data["offset"], 0)
+
+        feedback = data["feedback"]  # sorted in descending order of their creation
+        self.assertEqual(len(feedback), 0)
+
     def test_get_feedback_for_recording_with_invalid_score_param(self):
         """ Test to make sure 400 response is received if score argument is not valid """
         inserted_rows = self.insert_test_data(self.user["id"])
@@ -557,6 +797,25 @@ class FeedbackAPITestCase(IntegrationTestCase):
         # pass invalid int value to score
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"score": 10})
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "Score can have a value of 1 or -1.")
+
+    def test_get_feedback_for_recording_mbid_with_invalid_score_param(self):
+        """ Test to make sure 400 response is received if score argument is not valid """
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+        inserted_rows = self.insert_test_data_with_mbid(self.user2["id"])
+
+        rec_mbid_1 = inserted_rows[2]["recording_mbid"]
+
+        # pass non-int value to score
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"score": "invalid_score"})
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "Invalid score argument: invalid_score")
+
+        # pass invalid int value to score
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"score": 10})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Score can have a value of 1 or -1.")
 
@@ -584,6 +843,30 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[0]["recording_msid"], rec_msid_1)
         self.assertEqual(feedback[0]["score"], inserted_rows[0]["score"])
 
+    def test_get_feedback_for_recording_mbid_with_count_param(self):
+        """ Test to make sure valid response is received when count param is passed """
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+        inserted_rows = self.insert_test_data_with_mbid(self.user2["id"])
+
+        rec_mbid_1 = inserted_rows[3]["recording_mbid"]
+
+        # pass count = 1
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"count": 1})
+        self.assert200(response)
+        data = json.loads(response.data)
+
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["total_count"], 2)
+        self.assertEqual(data["offset"], 0)
+
+        feedback = data["feedback"]  # sorted in descending order of their creation
+        self.assertEqual(len(feedback), 1)
+
+        self.assertEqual(feedback[0]["user_id"], self.user2["musicbrainz_id"])
+        self.assertEqual(feedback[0]["recording_mbid"], rec_mbid_1)
+        self.assertEqual(feedback[0]["score"], inserted_rows[3]["score"])
+
     def test_get_feedback_for_recording_with_invalid_count_param(self):
         """ Test to make sure 400 response is received if count argument is not valid """
         inserted_rows = self.insert_test_data(self.user["id"])
@@ -600,6 +883,24 @@ class FeedbackAPITestCase(IntegrationTestCase):
         # pass negative int value to count
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
                                            recording_msid=rec_msid_1), query_string={"count": -1})
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
+
+    def test_get_feedback_for_recording_mbid_with_invalid_count_param(self):
+        """ Test to make sure 400 response is received if count argument is not valid """
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+
+        rec_mbid_1 = inserted_rows[2]["recording_mbid"]
+
+        # pass non-int value to count
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"count": "invalid_count"})
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
+
+        # pass negative int value to count
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"count": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
@@ -627,6 +928,30 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[0]["recording_msid"], rec_msid_1)
         self.assertEqual(feedback[0]["score"], inserted_rows[0]["score"])
 
+    def test_get_feedback_for_recording_mbid_with_offset_param(self):
+        """ Test to make sure valid response is received when offset param is passed """
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+        inserted_rows = self.insert_test_data_with_mbid(self.user2["id"])
+
+        rec_mbid_1 = inserted_rows[3]["recording_mbid"]
+
+        # pass count = 1
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"offset": 1})
+        self.assert200(response)
+        data = json.loads(response.data)
+
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["total_count"], 2)
+        self.assertEqual(data["offset"], 1)
+
+        feedback = data["feedback"]  # sorted in descending order of their creation
+        self.assertEqual(len(feedback), 1)
+
+        self.assertEqual(feedback[0]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[0]["recording_mbid"], rec_mbid_1)
+        self.assertEqual(feedback[0]["score"], inserted_rows[3]["score"])
+
     def test_get_feedback_for_recording_with_invalid_offset_param(self):
         """ Test to make sure 400 response is received if offset argument is not valid """
         inserted_rows = self.insert_test_data(self.user["id"])
@@ -646,21 +971,37 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
-    def test_get_feedback_for_recordings_for_user(self):
-        """ Test to make sure valid response is received """
+    def test_get_feedback_for_recording_mbid_with_invalid_offset_param(self):
+        """ Test to make sure 400 response is received if offset argument is not valid """
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+
+        rec_mbid_1 = inserted_rows[3]["recording_mbid"]
+
+        # pass non-int value to offset
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"offset": "invalid_offset"})
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
+
+        # pass negative int value to offset
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                           recording_mbid=rec_mbid_1), query_string={"offset": -1})
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
+
+    def _test_get_feedback_for_recordings_for_user_valid(self, fallback):
+        param = "recordings" if fallback else "recording_msids"
         inserted_rows = self.insert_test_data(self.user["id"])
 
-        recordings = ""
         # recording_msids for which feedback records are inserted
-        for row in inserted_rows:
-            recordings += row["recording_msid"] + ","
+        recordings = inserted_rows[0]["recording_msid"] + "," + inserted_rows[1]["recording_msid"]
 
         # recording_msid for which feedback record doesn't exist
         non_existing_rec_msid = "b83fd3c3-449c-49be-a874-31d7cf26d946"
-        recordings += non_existing_rec_msid
+        recordings = recordings + "," + non_existing_rec_msid
 
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]), query_string={"recordings": recordings})
+                                           user_name=self.user["musicbrainz_id"]), query_string={param: recordings})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -678,6 +1019,70 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[2]["user_id"], self.user["musicbrainz_id"])
         self.assertEqual(feedback[2]["recording_msid"], non_existing_rec_msid)
         self.assertEqual(feedback[2]["score"], 0)
+
+    def test_get_feedback_for_recordings_for_user(self):
+        """ Test to make sure valid response is received when recording_msids is used and when fallback recordings
+         parameter used """
+        self._test_get_feedback_for_recordings_for_user_valid(True)
+        self._test_get_feedback_for_recordings_for_user_valid(False)
+
+    def test_get_feedback_for_recordings_for_user_valid_mbids(self):
+        inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
+
+        # recording_msids for which feedback records are inserted
+        recordings = inserted_rows[0]["recording_msid"] + "," + inserted_rows[1]["recording_msid"]
+
+        # recording_msid for which feedback record doesn't exist
+        non_existing_rec_msid = "b83fd3c3-449c-49be-a874-31d7cf26d946"
+        recordings = recordings + "," + non_existing_rec_msid
+
+        # recording_msids for which feedback records are inserted
+        recording_mbids = inserted_rows[2]["recording_mbid"] + "," + inserted_rows[3]["recording_mbid"]
+
+        # recording_mbid for which feedback record doesn't exist
+        non_existing_rec_mbid = "6a221fda-2200-11ec-ac7d-dfa16a57158f"
+        recording_mbids = recording_mbids + "," + non_existing_rec_mbid
+
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                           user_name=self.user["musicbrainz_id"]),
+                                   query_string={"recording_msids": recordings, "recording_mbids": recording_mbids})
+        self.assert200(response)
+        data = json.loads(response.data)
+
+        feedback = data["feedback"]
+        self.assertEqual(len(feedback), 6)
+
+        self.assertEqual(feedback[0]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[0]["recording_msid"], None)
+        self.assertEqual(feedback[0]["recording_mbid"], inserted_rows[3]["recording_mbid"])
+        self.assertEqual(feedback[0]["score"], inserted_rows[3]["score"])
+
+        self.assertEqual(feedback[1]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[1]["recording_msid"], None)
+        self.assertEqual(feedback[1]["recording_mbid"], inserted_rows[2]["recording_mbid"])
+        self.assertEqual(feedback[1]["score"], inserted_rows[2]["score"])
+
+        self.assertEqual(feedback[2]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[2]["recording_msid"], None)
+        self.assertEqual(feedback[2]["recording_mbid"], non_existing_rec_mbid)
+        self.assertEqual(feedback[2]["score"], 0)
+
+        self.assertEqual(feedback[3]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[3]["recording_msid"], non_existing_rec_msid)
+        self.assertEqual(feedback[3]["recording_mbid"], None)
+        self.assertEqual(feedback[3]["score"], 0)
+
+        self.assertEqual(feedback[4]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[4]["recording_msid"], inserted_rows[0]["recording_msid"])
+        self.assertEqual(feedback[4]["recording_mbid"], None)
+        self.assertEqual(feedback[4]["score"], inserted_rows[0]["score"])
+
+        self.assertEqual(feedback[5]["user_id"], self.user["musicbrainz_id"])
+        self.assertEqual(feedback[5]["recording_msid"], inserted_rows[1]["recording_msid"])
+        self.assertEqual(feedback[5]["recording_mbid"], None)
+        self.assertEqual(feedback[5]["score"], inserted_rows[1]["score"])
+
+
 
     def test_get_feedback_for_recordings_for_user_invalid_user(self):
         """ Test to make sure that the API sends 404 if user does not exist. """
@@ -698,6 +1103,18 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
 
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                           user_name=self.user["musicbrainz_id"]),
+                                   query_string={"recording_msids": ""})  # empty string
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
+
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                           user_name=self.user["musicbrainz_id"]),
+                                   query_string={"recording_mbidss": ""})  # empty string
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
+
     def test_get_feedback_for_recordings_for_user_invalid_recording(self):
         """ Test to make sure that the API sends 400 if params recordings has invalid recording_msid. """
         inserted_rows = self.insert_test_data(self.user["id"])
@@ -713,7 +1130,13 @@ class FeedbackAPITestCase(IntegrationTestCase):
         recordings += invalid_rec_msid
         response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
                                            user_name=self.user["musicbrainz_id"]),
-                                   query_string={"recordings": recordings})  # recordings has invalid recording_msid
+                                   query_string={"recording_msids": recordings})  # recording_msids has invalid recording_msid
+        self.assert400(response)
+        self.assertEqual(response.json["code"], 400)
+
+        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                           user_name=self.user["musicbrainz_id"]),
+                                   query_string={"recording_mbids": recordings})  # recording_mbids has invalid recording_msid
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -15,6 +15,9 @@ from listenbrainz.webserver.views.api_tools import log_raise_400, is_valid_uuid,
 
 feedback_api_bp = Blueprint('feedback_api_v1', __name__)
 
+# default feedback score if the user the hasn't given feedback on a recording
+FEEDBACK_DEFAULT_SCORE = 0
+
 
 @feedback_api_bp.route("/recording-feedback", methods=["POST", "OPTIONS"])
 @crossdomain(headers="Authorization, Content-Type")
@@ -57,7 +60,7 @@ def recording_feedback():
         log_raise_400("Invalid JSON document submitted: %s" % str(e).replace("\n ", ":").replace("\n", " "),
                       data)
 
-    if feedback.score == 0:
+    if feedback.score == FEEDBACK_DEFAULT_SCORE:
         db_feedback.delete(feedback)
     else:
         db_feedback.insert(feedback)

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -248,7 +248,6 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertDictEqual(results[0], {
             'inserted_at': 0,
             'listened_at': 1539509881,
-            'recording_mbid': None,
             'recording_msid': '6c617681-281e-4dae-af59-8e00f93c4376',
             'user_name': None,
             'track_metadata': {
@@ -263,7 +262,6 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertDictEqual(results[1], {
             'inserted_at': 0,
             'listened_at': 1539441702,
-            'recording_mbid': None,
             'recording_msid': '7ad53fd7-5b40-4e13-b680-52716fb86d5f',
             'user_name': None,
             'track_metadata': {
@@ -278,7 +276,6 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertDictEqual(results[2], {
             'inserted_at': 0,
             'listened_at': 1539441531,
-            'recording_mbid': None,
             'recording_msid': None,
             'user_name': None,
             'track_metadata': {

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -248,6 +248,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertDictEqual(results[0], {
             'inserted_at': 0,
             'listened_at': 1539509881,
+            'recording_mbid': None,
             'recording_msid': '6c617681-281e-4dae-af59-8e00f93c4376',
             'user_name': None,
             'track_metadata': {
@@ -262,6 +263,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertDictEqual(results[1], {
             'inserted_at': 0,
             'listened_at': 1539441702,
+            'recording_mbid': None,
             'recording_msid': '7ad53fd7-5b40-4e13-b680-52716fb86d5f',
             'user_name': None,
             'track_metadata': {
@@ -276,6 +278,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertDictEqual(results[2], {
             'inserted_at': 0,
             'listened_at': 1539441531,
+            'recording_mbid': None,
             'recording_msid': None,
             'user_name': None,
             'track_metadata': {
@@ -322,6 +325,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         results = ujson.loads(r.data.decode('utf-8'))
 
         self.assertDictEqual(results[0], {
+            'recording_mbid': None,
             'recording_msid': '6c617681-281e-4dae-af59-8e00f93c4376',
             'score': 1,
             'user_id': None,
@@ -329,6 +333,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
             'track_metadata': None,
         })
         self.assertDictEqual(results[1], {
+            'recording_mbid': None,
             'recording_msid': '7ad53fd7-5b40-4e13-b680-52716fb86d5f',
             'score': 1,
             'user_id': None,
@@ -336,6 +341,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
             'track_metadata': None,
         })
         self.assertDictEqual(results[2], {
+            'recording_mbid': None,
             'recording_msid': '7816411a-2cc6-4e43-b7a1-60ad093c2c31',
             'score': -1,
             'user_id': None,


### PR DESCRIPTION
Adds support to give feedback using recording mbid only. The feedback endpoints till now only accepted recording msid, however we now want to support recording msids and recording mbids both. This creates issues if we want to maintain backward compatibility, we either need to add uglish workarounds to the existing endpoints and default to the current behaviour to maintain compat. Otherwise, we need to add separate endpoints. Also, in future we probably want to remove the support for msids so many of these measures will look redundant at that time. 

For example:

1) `GET /user/<user_name>/get-feedback-for-recordings?recordings=[foobar]` accepts a recordings param which should be a list of recording msids. We need to add another param to support recording mbids. I think it would be nice if the returned json contained two top level keys - mbids and msids to denote the feedback for each but that json structure will probably be incompatible with existing. 

2) `GET /recording/<recording_msid>/get-feedback` accepts a recording msid in the path. It should still work if we a mbid is sent but need a way to differentiate whether its a msid or mbid. Maybe add a query param `is_mbid` but uhhh?