### PR TITLE
LB-676: Listenbrainz reports git commit error on startup

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -63,7 +63,7 @@ def load_config(app):
 
     app.config.from_pyfile(config_file)
     # Output config values and some other info
-    if deploy_env in ['prod', 'beta' 'test']:
+    if deploy_env in ['prod', 'beta', 'test']:
         print('Configuration values are as follows: ')
         print(pprint.pformat(app.config, indent=4))
 

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -63,14 +63,15 @@ def load_config(app):
 
     app.config.from_pyfile(config_file)
     # Output config values and some other info
-    if deploy_env in ['prod', 'test']:
+    if deploy_env in ['prod', 'beta' 'test']:
         print('Configuration values are as follows: ')
         print(pprint.pformat(app.config, indent=4))
-    try:
-        with open('.git-version') as git_version_file:
-            print('Running on git commit: %s' % git_version_file.read().strip())
-    except IOError as e:
-        print('Unable to retrieve git commit. Error: %s', str(e))
+
+        try:
+            with open('.git-version') as git_version_file:
+                print('Running on git commit: %s' % git_version_file.read().strip())
+        except IOError as e:
+            print('Unable to retrieve git commit. Error: %s', str(e))
 
 
 def check_ratelimit_token_whitelist(auth_token):


### PR DESCRIPTION
LB-676

Only perform .git-version check in prod where the file will always be present. For local development, this probably doesn't make much sense anyway because we can run git normally.