### PR TITLE
LB-993: Increase buffer-size to avoid 502 errors

### DIFF
--- a/docker/services/uwsgi/uwsgi.ini
+++ b/docker/services/uwsgi/uwsgi.ini
@@ -14,3 +14,5 @@ disable-logging = true
 need-app = true
 ; when uwsgi gets a sighup, quit completely and let runit restart us
 exit-on-reload = true
+; increase buffer size for requests that send a lot of mbids in query params
+buffer-size = 8192


### PR DESCRIPTION
LB-993

When the user feedback endpoint is queried with too many recordings, it errors with 502. This is because the recording mbids are sent as a part of the query params in the URL and cause the size of request to exceed uwsgi buffer size. Double the buffer size to allow us to do ~100 mbids in one go.

Tested the fix on test.lb to confirm it works.