### PR TITLE
LB-985, LB-994, LB-986, LB-877, LB-996, LB-997: Fix multiple api compat bugs

### DIFF
--- a/listenbrainz/db/lastfm_session.py
+++ b/listenbrainz/db/lastfm_session.py
@@ -66,7 +66,7 @@ class Session(object):
         """ Create a new session for the user by consuming the token.
             If session already exists for the user then renew the session_key(sid).
         """
-        sid = binascii.b2a_hex(os.urandom(20))
+        sid = os.urandom(20).hex()
         session = Session.generate(token.user.id, sid, token.api_key)
         token.consume()
         return session

--- a/listenbrainz/db/lastfm_token.py
+++ b/listenbrainz/db/lastfm_token.py
@@ -59,7 +59,7 @@ class Token(object):
 
     @staticmethod
     def generate(api_key):
-        token = str(binascii.b2a_hex(os.urandom(20)))
+        token = os.urandom(20).hex()
         with db.engine.connect() as connection:
             q = """ INSERT INTO api_compat.token (token, api_key) VALUES (:token, :api_key)
                     ON CONFLICT(api_key) DO UPDATE SET token = EXCLUDED.token, ts = EXCLUDED.ts

--- a/listenbrainz/db/lastfm_user.py
+++ b/listenbrainz/db/lastfm_user.py
@@ -62,7 +62,7 @@ class User(object):
             })
             row = result.fetchone()
             if row:
-                return User(row['"user".id'], row['"user".created'], row['"user".musicbrainz_id'], row['"user".auth_token'])
+                return User(row['id'], row['created'], row['musicbrainz_id'], row['auth_token'])
             return None
 
     @staticmethod

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -373,7 +373,7 @@ def format_response(data, format="xml"):
     elif format == 'json':
         # Remove the <lfm> tag and its attributes
         jsonData = xmltodict.parse(data)['lfm']
-        for k in jsonData.keys():
+        for k in list(jsonData.keys()):
             if k[0] == '@':
                 jsonData.pop(k)
 

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -225,7 +225,7 @@ def _to_native_api(lookup, method="track.scrobble", output_format="xml"):
         if 'trackNumber' in data:
             listen['track_metadata']['additional_info']['tracknumber'] = data['trackNumber']
         if 'mbid' in data:
-            listen['track_metadata']['release_mbid'] = data['mbid']
+            listen['track_metadata']['track_mbid'] = data['mbid']
         if 'duration' in data:
             listen['track_metadata']['additional_info']['duration'] = data['duration']
         # Choosen_by_user is 1 by default

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -168,6 +168,9 @@ def _to_native_api(data, append_key):
         except (KeyError, ValueError, ListenValidationError):
             return None
 
+    # Source has special meaning in LFM api. e.g.: if you see a listen with
+    # "source": "P", in the database it is a listen from API compat deprecated.
+    # https://web.archive.org/web/20090217162831/http://last.fm/api/submissions
     if 'o{}'.format(append_key) in data:
         listen['track_metadata']['additional_info']['source'] = data['o{}'.format(append_key)]
 


### PR DESCRIPTION
- LB-985: Potential bug in lastfm proxy API - mbid field
- LB-994: RuntimeError: OrderedDict mutated during iteration
- LB-986: Bad additional_info.source field in submission from lfm compat api
- LB-877: lfm compat api user.getInfo doesn't work
- LB-996: method=auth.getsession returns string with \x prefix
- LB-997: method=auth.gettoken returns bytes repr (b'token')