### PR TITLE
Spotify mapping

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -29,4 +29,6 @@ CREATE INDEX recording_mbid_ndx_mbid_mapping ON mbid_mapping (recording_mbid);
 CREATE INDEX match_type_ndx_mbid_mapping ON mbid_mapping (match_type);
 CREATE INDEX last_updated_ndx_mbid_mapping ON mbid_mapping (last_updated);
 
+CREATE UNIQUE INDEX recording_msid_ndx_spotify_mapping ON spotify_mapping (recording_msid);
+
 COMMIT;

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -82,4 +82,18 @@ ALTER TABLE mbid_mapping
         )
     );
 
+CREATE TABLE spotify_mapping (
+    recording_msid      UUID NOT NULL,
+    track               TEXT,
+    album               TEXT,
+    artist              TEXT[],
+    album_artist        TEXT[],
+    isrc                TEXT
+);
+
+-- postgres does not enforce dimensionality of arrays. add explicit check to avoid regressions (once burnt, twice shy!).
+ALTER TABLE spotify_mapping_metadata
+    ADD CONSTRAINT spotify_mapping_metadata_ndims_check
+    CHECK ( array_ndims(artist) = 1 AND array_ndims(album_artist) = 1 );
+
 COMMIT;

--- a/listenbrainz/mbid_mapping/mapping/spotify_mapping.py
+++ b/listenbrainz/mbid_mapping/mapping/spotify_mapping.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from sqlalchemy import text
+
+from listenbrainz.db import timescale
+
+base_query_begin = text("""
+    INSERT INTO spotify_mapping
+         SELECT data->'track_metadata'->'additional_info'->>'recording_msid'::UUID
+              , data->'track_metadata'->'additional_info'->>'spotify_id'
+              , data->'track_metadata'->'additional_info'->>'spotify_album_id'
+              , data->'track_metadata'->'additional_info'->>'spotify_artist_ids'
+              , data->'track_metadata'->'additional_info'->>'spotify_album_artist_ids'
+              , data->'track_metadata'->'additional_info'->>'isrc'
+           FROM listen
+          WHERE data->'track_metadata'->'additional_info'->>'recording_msid' IS NOT NULL
+            AND data->'track_metadata'->'additional_info'->>'spotify_id' IS NOT NULL
+            AND """)
+initial_query = text("listened_at >= :start AND listened_at < :end")
+incremental_query = text("created >= :watermark")
+# spotify_id field is considered while calculating a msid, so one msid can only have
+# one spotify track id associated with it. Assuming, given a spotify track id other
+# spotify ids do not change all ids for a given msid will be fixed. Thus, ignoring rows
+# if msid is already present in mapping is enough to avoid duplicates and not lose data.
+base_query_end = text(" ON CONFLICT (recording_msid) DO NOTHING")
+
+LISTEN_MINIMUM_TS = int(datetime(2002, 10, 1).timestamp())
+CHUNK_SECONDS = 432000
+
+
+# TODO: decide what to do with watermark - run for last time period or store last run timestamp somewhere
+def _incremental_run(start):
+    final_query = base_query_begin + incremental_query
+    with timescale.engine.connect() as connection:
+        connection.execute(final_query, watermark=start)
+
+
+def _initial_run():
+    final_query = base_query_begin + initial_query
+    start = LISTEN_MINIMUM_TS
+    end = int(datetime.now().timestamp())
+    with timescale.engine.connect() as connection:
+        while start < end:
+            connection.execute(final_query, start=start, end=start + CHUNK_SECONDS)
+            start += CHUNK_SECONDS


### PR DESCRIPTION
First rough cut of spotify mapping. We originally intended to use continous aggregates for this but when I tried to implement the mapping using it I hit a few issues.

-  Continous aggregates need to include the time column of the hypertable but we don't have the use of listened_at column here. 
- Already materialized chunks are not refreshed automatically we need to refresh them manually like we do for listen count 30 day  view currently.
- When a chunk is refreshed from which listens have been deleted, some data may get removed from the mapping table.
- Normal postgres materialized views can be a solution but the issue with those is that those cannot be updated incrementally.

This PR currently creates the mapping by processing each chunk and putting data in a mapping table. After initial run, process all listens since the last run. To be added: a cron job to run this periodically (daily?).