### PR TITLE
Fix deserialization of json payloads in websockets

### DIFF
--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -36,7 +36,6 @@ class ListensDispatcher(ConsumerMixin):
         listens = json.loads(message.body.decode("utf-8"))
         for data in listens:
             if event_name == "playing_now":
-                current_app.logger.error("Websockets Now Playing Data: %s", json.dumps(data))
                 listen = NowPlayingListen(user_id=data["user_id"], user_name=data["user_name"], data=data["track_metadata"])
             else:
                 data["track_metadata"] = data["data"]

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -1,6 +1,7 @@
 import json
 import time
 
+from flask import current_app
 from kombu.mixins import ConsumerMixin
 
 import ujson
@@ -37,6 +38,7 @@ class ListensDispatcher(ConsumerMixin):
             if event_name == "playing_now":
                 listen = NowPlayingListen(user_id=data["user_id"], user_name=data["user_name"], data=data["data"])
             else:
+                current_app.logger.error("Websockets Listen Data: %s", json.dumps(data))
                 listen = Listen.from_json(data)
             self.socketio.emit(event_name, json.dumps(listen.to_api()), to=listen.user_name)
         message.ack()

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -36,11 +36,11 @@ class ListensDispatcher(ConsumerMixin):
         listens = json.loads(message.body.decode("utf-8"))
         for data in listens:
             if event_name == "playing_now":
-                listen = NowPlayingListen(user_id=data["user_id"], user_name=data["user_name"], data=data["data"])
+                current_app.logger.error("Websockets Now Playing Data: %s", json.dumps(data))
+                listen = NowPlayingListen(user_id=data["user_id"], user_name=data["user_name"], data=data["track_metadata"])
             else:
                 data["track_metadata"] = data["data"]
                 del data["data"]
-                current_app.logger.error("Websockets Listen Data: %s", json.dumps(data))
                 listen = Listen.from_json(data)
             self.socketio.emit(event_name, json.dumps(listen.to_api()), to=listen.user_name)
         message.ack()

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -38,6 +38,8 @@ class ListensDispatcher(ConsumerMixin):
             if event_name == "playing_now":
                 listen = NowPlayingListen(user_id=data["user_id"], user_name=data["user_name"], data=data["data"])
             else:
+                data["track_metadata"] = data["data"]
+                del data["data"]
                 current_app.logger.error("Websockets Listen Data: %s", json.dumps(data))
                 listen = Listen.from_json(data)
             self.socketio.emit(event_name, json.dumps(listen.to_api()), to=listen.user_name)


### PR DESCRIPTION
This has been broken for some time now so the websockets container was running an older release version. With this PR, the keys are fixed so websockets can be brought to the latest release. It probably also makes sense the key names more uniform but that needs more extensive changes so for another day.