### PR TITLE
LB-1000: Missing headers in API error responses

### DIFF
--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -140,7 +140,6 @@ def init_error_handlers(app):
         if current_app.config.get('IS_API_COMPAT_APP') or request.path.startswith(API_PREFIX):
             response = make_response(jsonify({'code': code, 'error': error.description}), code)
             response.headers["Access-Control-Allow-Origin"] = "*"
-            response.headers["Access-Control-Expose-Headers"] = "X-RateLimit-Remaining,X-RateLimit-Limit,X-RateLimit-Reset,X-RateLimit-Reset-In"
             return response
         return error_wrapper('errors/{code}.html'.format(code=code), error, code)
 

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -138,7 +138,10 @@ def init_error_handlers(app):
                 otherwise
         """
         if current_app.config.get('IS_API_COMPAT_APP') or request.path.startswith(API_PREFIX):
-            return crossdomain(jsonify({'code': code, 'error': error.description})), code
+            response = make_response(jsonify({'code': code, 'error': error.description}), code)
+            response.headers["Access-Control-Allow-Origin"] = "*"
+            response.headers["Access-Control-Expose-Headers"] = "X-RateLimit-Remaining,X-RateLimit-Limit,X-RateLimit-Reset,X-RateLimit-Reset-In"
+            return response
         return error_wrapper('errors/{code}.html'.format(code=code), error, code)
 
     @app.errorhandler(400)

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -138,7 +138,7 @@ def init_error_handlers(app):
                 otherwise
         """
         if current_app.config.get('IS_API_COMPAT_APP') or request.path.startswith(API_PREFIX):
-            return jsonify({'code': code, 'error': error.description}), code
+            return crossdomain(jsonify({'code': code, 'error': error.description}), code)
         return error_wrapper('errors/{code}.html'.format(code=code), error, code)
 
     @app.errorhandler(400)

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -138,9 +138,9 @@ def init_error_handlers(app):
                 otherwise
         """
         if current_app.config.get('IS_API_COMPAT_APP') or request.path.startswith(API_PREFIX):
-            response = make_response(jsonify({'code': code, 'error': error.description}), code)
+            response = jsonify({'code': code, 'error': error.description})
             response.headers["Access-Control-Allow-Origin"] = "*"
-            return response
+            return response, code
         return error_wrapper('errors/{code}.html'.format(code=code), error, code)
 
     @app.errorhandler(400)

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -138,7 +138,7 @@ def init_error_handlers(app):
                 otherwise
         """
         if current_app.config.get('IS_API_COMPAT_APP') or request.path.startswith(API_PREFIX):
-            return crossdomain(jsonify({'code': code, 'error': error.description}), code)
+            return crossdomain(jsonify({'code': code, 'error': error.description})), code
         return error_wrapper('errors/{code}.html'.format(code=code), error, code)
 
     @app.errorhandler(400)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
In LB-1000, there was mention of rate limit headers not passing through. Personally I had experienced CORS headers not passing through because of ISE. So this is an attempt to fix both of these issues
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Hence implemented error handling in only the `crossdomain()` decorator, since in all APIs (at least in all the ones I checked), `crossdomain()` was being called first.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
Should some sort of logging need to be implemented in this PR?
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


