### PR TITLE
Remove unused utility methods

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -23,30 +23,24 @@ https://listenbrainz.readthedocs.io/en/production/dev/listenbrainz-dumps.html
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-import logging
 import os
 import shutil
+import subprocess
+import tarfile
+import tempfile
+from datetime import datetime, timedelta
 from ftplib import FTP
 
 import sqlalchemy
-import subprocess
-import sys
-import tarfile
-import tempfile
-import time
 import ujson
-
-from datetime import datetime, timedelta
-
 from brainzutils.mail import send_mail
 from flask import current_app, render_template
-from listenbrainz import DUMP_LICENSE_FILE_PATH
-import listenbrainz.db as db
-from listenbrainz.db import timescale
-from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
-from listenbrainz.utils import create_path, log_ioerrors
 
-from listenbrainz import config
+import listenbrainz.db as db
+from listenbrainz import DUMP_LICENSE_FILE_PATH
+from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
+from listenbrainz.db import timescale
+from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app
 
 MAIN_FTP_SERVER_URL = "ftp.eu.metabrainz.org"

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -1,12 +1,9 @@
 # coding=utf-8
 import calendar
-import time
-import ujson
-import yaml
 from copy import deepcopy
-
 from datetime import datetime
-from listenbrainz.utils import escape
+
+import ujson
 
 
 def flatten_dict(d, seperator='', parent_key=''):

--- a/listenbrainz/listen_writer.py
+++ b/listenbrainz/listen_writer.py
@@ -1,9 +1,9 @@
 import sys
-import listenbrainz.utils as utils
-
 import time
-utils.safely_import_config()
+
 from flask import current_app
+
+import listenbrainz.utils as utils
 
 
 class ListenWriter:

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -1,31 +1,25 @@
 #!/usr/bin/python3
 import time
+from typing import Dict, List
 
 import spotipy
 from brainzutils import metrics
-from typing import Dict, List
+from brainzutils.mail import send_mail
+from dateutil import parser
+from flask import current_app, render_template
+from spotipy import SpotifyException
+from werkzeug.exceptions import InternalServerError, ServiceUnavailable
 
 import listenbrainz.webserver
-
-from listenbrainz.utils import safely_import_config
-from listenbrainz.webserver.models import SubmitListenUserMetadata
-
-safely_import_config()
-
+from listenbrainz.db import user as db_user
+from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.domain.external_service import ExternalServiceError, ExternalServiceAPIError, \
     ExternalServiceInvalidGrantError
 from listenbrainz.domain.spotify import SpotifyService
-
 from listenbrainz.webserver.errors import APIBadRequest
-
-from dateutil import parser
-from flask import current_app, render_template
-from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
-from listenbrainz.db import user as db_user
-from listenbrainz.db.exceptions import DatabaseException
-from spotipy import SpotifyException
-from werkzeug.exceptions import InternalServerError, ServiceUnavailable
-from brainzutils.mail import send_mail
+from listenbrainz.webserver.models import SubmitListenUserMetadata
+from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, LISTEN_TYPE_IMPORT, \
+    LISTEN_TYPE_PLAYING_NOW
 
 METRIC_UPDATE_INTERVAL = 60  # seconds
 _listens_imported_since_last_update = 0  # number of listens imported since last metric update was submitted

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -1,17 +1,10 @@
 import errno
 import os
 import socket
+import time
+from datetime import datetime, timezone
 
 import pika
-import time
-
-from datetime import datetime, timezone
-from redis import Redis
-
-def escape(value):
-    """ Escapes backslashes, quotes and new lines present in the string value
-    """
-    return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
 
 
 def create_path(path):

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -92,30 +92,6 @@ def create_channel_to_consume(connection, exchange: str, queue: str, callback_fu
     return ch
 
 
-def connect_to_redis(host, port, log=print):
-    """ Create a connection to redis and return it
-
-    Note: This is a blocking function which keeps trying to connect to redis until
-    it establishes a connection
-
-    Args:
-        host: the hostname of the redis server
-        port: the port of the redis server
-        log: the function to use for error logging
-
-    Returns:
-        Redis object
-    """
-    while True:
-        try:
-            redis = Redis(host=host, port=port)
-            redis.ping()
-            return redis
-        except Exception as err:
-            log("Cannot connect to redis: %s. Retrying in 3 seconds and trying again." % str(err))
-            time.sleep(3)
-
-
 def unix_timestamp_to_datetime(timestamp):
     """ Converts expires_at timestamp received from Spotify to a datetime object
 
@@ -126,6 +102,7 @@ def unix_timestamp_to_datetime(timestamp):
         A datetime object with timezone UTC corresponding to the provided timestamp
     """
     return datetime.utcfromtimestamp(timestamp).replace(tzinfo=timezone.utc)
+
 
 def get_fallback_connection_name():
     """ Get a connection name friendlier than docker gateway ip during connecting

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -123,18 +123,6 @@ def connect_to_redis(host, port, log=print):
             log("Cannot connect to redis: %s. Retrying in 3 seconds and trying again." % str(err))
             time.sleep(3)
 
-def safely_import_config():
-    """ 
-        Safely import config.py. If config.py is not found, wait 2 seconds and try again.
-    """
-
-    while True:
-        try:
-            from listenbrainz import config
-            break
-        except ImportError:
-            print("Cannot import config.py. Waiting and retrying...")
-            time.sleep(2)
 
 def unix_timestamp_to_datetime(timestamp):
     """ Converts expires_at timestamp received from Spotify to a datetime object

--- a/listenbrainz/utils.py
+++ b/listenbrainz/utils.py
@@ -24,14 +24,6 @@ def create_path(path):
                             (path, exception))
 
 
-def log_ioerrors(logger, e):
-    """ Logs IOErrors that occur in case we run out of disk space.
-        This is used in data dumps and is a placeholder while Sentry support
-        is added.
-    """
-    logger.error('IOError while creating dump: %s', str(e))
-
-
 def connect_to_rabbitmq(username, password,
                         host, port, virtual_host,
                         connection_type=pika.BlockingConnection,

--- a/manage.py
+++ b/manage.py
@@ -1,24 +1,19 @@
-from datetime import datetime
+import os
+from time import sleep
+
+import click
+import sqlalchemy
+from werkzeug.serving import run_simple
 
 import listenbrainz.db.dump_manager as dump_manager
 import listenbrainz.spark.request_manage as spark_request_manage
+from listenbrainz import db
+from listenbrainz import webserver
+from listenbrainz.db import timescale as ts
 from listenbrainz.listenstore import timescale_fill_userid
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data as ts_recalculate_all_user_data, \
     refresh_listen_count_aggregate as ts_refresh_listen_count_aggregate
-
-from listenbrainz import db
-from listenbrainz.db import timescale as ts
-from listenbrainz import webserver
-from werkzeug.serving import run_simple
-import os
-import click
-import sqlalchemy
-from time import sleep
-
-from listenbrainz.utils import safely_import_config
 from listenbrainz.webserver import create_app
-
-safely_import_config()
 
 
 @click.group()


### PR DESCRIPTION
We have some unused utilty methods, removing them.

- safely_import_config 

We use configuration through flask, instead of directly import config.py (except in tests). There will be errors when the app creation happens if the config is missing which is effectively the same use case and happens for all places opposed to this method which is only used at a few places.

- log_ioerrors 

The method is unused anyways but we have some sentry support in dumps now and there are likely telegram alerts setup for low disk space.

- connect_to_redis and escape
