### PR TITLE
Simplify redis connection initializations

### DIFF
--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -1,14 +1,12 @@
 from datetime import datetime
-from time import time
+from typing import Optional
 
 import redis
-from typing import Optional
 import ujson
+from brainzutils import cache
 
 from listenbrainz.listen import Listen, NowPlayingListen
 from listenbrainz.listenstore import ListenStore
-from brainzutils import cache
-from listenbrainz.utils import create_path, init_cache
 
 
 class RedisListenStore(ListenStore):
@@ -18,16 +16,6 @@ class RedisListenStore(ListenStore):
     PLAYING_NOW_KEY = "pn."
     LISTEN_COUNT_PER_DAY_EXPIRY_TIME = 3 * 24 * 60 * 60  # 3 days in seconds
     LISTEN_COUNT_PER_DAY_KEY = "lc-day-"
-
-
-    def __init__(self, log, conf):
-        super(RedisListenStore, self).__init__(log)
-
-        # Initialize brainzutils cache
-        init_cache(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'],
-                   namespace=conf['REDIS_NAMESPACE'])
-        # This is used in tests. Leave for cleanup in LB-879
-        self.redis = cache._r
 
     def get_playing_now(self, user_id):
         """ Return the current playing song of the user

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -31,7 +31,6 @@ class RedisListenStoreTestCase(DatabaseTestCase):
 
     def tearDown(self):
         cache._r.flushdb()
-        cache._r.connection.disconnect()
         super(RedisListenStoreTestCase, self).tearDown()
 
     def test_get_and_put_playing_now(self):

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -13,6 +13,7 @@ import listenbrainz.db.user as db_user
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz import config
 from listenbrainz.listen import Listen, NowPlayingListen
+from listenbrainz.utils import init_cache
 from listenbrainz.webserver.redis_connection import init_redis_connection
 from listenbrainz.listenstore.redis_listenstore import RedisListenStore
 
@@ -21,9 +22,11 @@ class RedisListenStoreTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(RedisListenStoreTestCase, self).setUp()
-        self.log = logging.getLogger()
         # TODO: Ideally this would use a config from a flask app, but this test case doesn't create an app
-        self._redis = init_redis_connection(self.log, config.REDIS_HOST, config.REDIS_PORT, config.REDIS_NAMESPACE)
+        init_cache(config.REDIS_HOST, config.REDIS_PORT, config.REDIS_NAMESPACE)
+
+        self.log = logging.getLogger()
+        self._redis = init_redis_connection(self.log)
         self.testuser = db_user.get_or_create(1, "test")
 
     def tearDown(self):

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -30,8 +30,8 @@ class RedisListenStoreTestCase(DatabaseTestCase):
         self.testuser = db_user.get_or_create(1, "test")
 
     def tearDown(self):
-        self._redis.redis.flushdb()
-        Connection(self._redis.redis).disconnect()
+        cache._r.flushdb()
+        cache._r.connection.disconnect()
         super(RedisListenStoreTestCase, self).tearDown()
 
     def test_get_and_put_playing_now(self):

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -1,36 +1,35 @@
 # coding=utf-8
 
 import os
+import shutil
 import subprocess
 import tarfile
 import tempfile
 import time
-import shutil
 import uuid
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
-import ujson
+from typing import List, Dict
+import pandas as pd
 import psycopg2
 import psycopg2.sql
-from psycopg2.extras import execute_values
-from psycopg2.errors import UntranslatableCharacter
-from typing import List, Dict
-import sqlalchemy
-import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-
+import sqlalchemy
+import ujson
 from brainzutils import cache
+from psycopg2.errors import UntranslatableCharacter
+from psycopg2.extras import execute_values
 
-from listenbrainz.db import timescale
 from listenbrainz import DUMP_LICENSE_FILE_PATH, db
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
+from listenbrainz.db import timescale
 from listenbrainz.db.dump import SchemaMismatchException
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore import ListenStore
 from listenbrainz.listenstore import ORDER_ASC, ORDER_TEXT, LISTENS_DUMP_SCHEMA_VERSION, LISTEN_MINIMUM_DATE
-from listenbrainz.utils import create_path, init_cache
+from listenbrainz.utils import create_path
 
 # Append the user name for both of these keys
 REDIS_USER_LISTEN_COUNT = "lc."
@@ -71,11 +70,7 @@ class TimescaleListenStore(ListenStore):
 
         timescale.init_db_connection(conf['SQLALCHEMY_TIMESCALE_URI'])
 
-        # Initialize brainzutils cache
-        init_cache(host=conf['REDIS_HOST'], port=conf['REDIS_PORT'],
-                   namespace=conf['REDIS_NAMESPACE'])
-        self.dump_temp_dir_root = conf.get(
-            'LISTEN_DUMP_TEMP_DIR_ROOT', tempfile.mkdtemp())
+        self.dump_temp_dir_root = conf.get('LISTEN_DUMP_TEMP_DIR_ROOT', tempfile.mkdtemp())
 
     def set_empty_values_for_user(self, user_id: int):
         """When a user is created, set the timestamp keys and insert an entry in the listen count

--- a/listenbrainz/tests/integration/test_profile_views.py
+++ b/listenbrainz/tests/integration/test_profile_views.py
@@ -1,14 +1,12 @@
 import json
 import time
 
-from flask import url_for, current_app, g
-from redis import Redis
 from brainzutils import cache
+from flask import url_for, g
 
 import listenbrainz.db.user as db_user
-from listenbrainz.tests.integration import IntegrationTestCase
 from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT
-from listenbrainz.utils import init_cache
+from listenbrainz.tests.integration import IntegrationTestCase
 
 
 class ProfileViewsTestCase(IntegrationTestCase):
@@ -16,11 +14,6 @@ class ProfileViewsTestCase(IntegrationTestCase):
         super().setUp()
         self.user = db_user.get_or_create(1, 'iliekcomputers')
         db_user.agree_to_gdpr(self.user['musicbrainz_id'])
-
-        # Initialize brainzutils cache
-        init_cache(host=current_app.config['REDIS_HOST'],
-                   port=current_app.config['REDIS_PORT'],
-                   namespace=current_app.config['REDIS_NAMESPACE'])
         self.redis = cache._r
 
     def tearDown(self):

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -6,7 +6,7 @@ from time import sleep, monotonic
 import pika
 import psycopg2
 import ujson
-from brainzutils import metrics
+from brainzutils import metrics, cache
 from flask import current_app
 from more_itertools import chunked
 from redis import Redis
@@ -16,7 +16,7 @@ from listenbrainz.listen import Listen
 from listenbrainz.listen_writer import ListenWriter
 from listenbrainz.listenstore import RedisListenStore
 from listenbrainz.listenstore import TimescaleListenStore
-from listenbrainz.webserver import create_app
+from listenbrainz.webserver import create_app, redis_connection
 from listenbrainz.webserver.views.api_tools import MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP
 
 METRIC_UPDATE_INTERVAL = 60  # seconds

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -1,23 +1,22 @@
 #!/usr/bin/env python3
 import sys
-from time import sleep, monotonic
 from datetime import datetime
+from time import sleep, monotonic
 
 import pika
+import psycopg2
 import ujson
+from brainzutils import metrics
 from flask import current_app
 from more_itertools import chunked
 from redis import Redis
-import psycopg2
-
-from listenbrainz.listen import Listen
-from listenbrainz.listenstore import RedisListenStore
-from listenbrainz.listen_writer import ListenWriter
-from listenbrainz.listenstore import TimescaleListenStore
-from listenbrainz.webserver import create_app
-from brainzutils import metrics
 
 from listenbrainz import messybrainz
+from listenbrainz.listen import Listen
+from listenbrainz.listen_writer import ListenWriter
+from listenbrainz.listenstore import RedisListenStore
+from listenbrainz.listenstore import TimescaleListenStore
+from listenbrainz.webserver import create_app
 from listenbrainz.webserver.views.api_tools import MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP
 
 METRIC_UPDATE_INTERVAL = 60  # seconds
@@ -236,10 +235,8 @@ class TimescaleWriterSubscriber(ListenWriter):
 
                 while True:
                     try:
-                        self.redis = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'],
-                                           decode_responses=True)
-                        self.redis.ping()
-                        self.redis_listenstore = RedisListenStore(current_app.logger, current_app.config)
+                        cache._r.ping()
+                        self.redis_listenstore = redis_connection._redis
                         break
                     except Exception as err:
                         current_app.logger.error("Cannot connect to redis: %s. Retrying in 2 seconds and trying again." %

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -34,7 +34,7 @@ def create_timescale(app):
 
 def create_redis(app):
     from listenbrainz.webserver.redis_connection import init_redis_connection
-    init_redis_connection(app.logger, app.config['REDIS_HOST'], app.config['REDIS_PORT'], app.config['REDIS_NAMESPACE'])
+    init_redis_connection(app.logger)
 
 
 def create_rabbitmq(app):

--- a/listenbrainz/webserver/redis_connection.py
+++ b/listenbrainz/webserver/redis_connection.py
@@ -1,9 +1,11 @@
-from redis import Redis
-import redis
 import time
+from typing import Optional
+
+import redis
+
 from listenbrainz.listenstore import RedisListenStore
 
-_redis = None
+_redis: Optional[RedisListenStore] = None
 
 
 def init_redis_connection(logger):

--- a/listenbrainz/webserver/redis_connection.py
+++ b/listenbrainz/webserver/redis_connection.py
@@ -6,17 +6,13 @@ from listenbrainz.listenstore import RedisListenStore
 _redis = None
 
 
-def init_redis_connection(logger, host, port, namespace):
+def init_redis_connection(logger):
     """Create a connection to the Redis server."""
 
     global _redis
     while True:
         try:
-            _redis = RedisListenStore(logger, {
-                'REDIS_HOST': host,
-                'REDIS_PORT': port,
-                'REDIS_NAMESPACE': namespace
-            })
+            _redis = RedisListenStore(logger)
             _redis.check_connection()
             break
         except redis.exceptions.ConnectionError as e:


### PR DESCRIPTION
During of creation of flask app, we initialize cache so there's no need to do it again in listenstore's which are created after cache has been initialized. There are a couple of places where we still init_cache manually (in mbid mapping writer and recalculate user data cron job because we don't create a flask app there