### PR TITLE
Use gen_app over create_app where possible

### DIFF
--- a/listenbrainz/server.py
+++ b/listenbrainz/server.py
@@ -1,3 +1,3 @@
-from listenbrainz.webserver import create_app
+from listenbrainz.webserver import create_web_app
 
-application = create_app()
+application = create_web_app()

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -82,7 +82,7 @@ def check_ratelimit_token_whitelist(auth_token):
     return auth_token in current_app.config["WHITELISTED_AUTH_TOKENS"]
 
 
-def gen_app(debug=None):
+def create_app(debug=None):
     """ Generate a Flask app for LB with all configurations done and connections established.
 
     In the Flask app returned, blueprints are not registered.
@@ -165,8 +165,9 @@ def gen_app(debug=None):
     return app
 
 
-def create_app(debug=None):
-    app = gen_app(debug=debug)
+def create_web_app(debug=None):
+    """ Generate a Flask app for LB with all configurations done, connections established and endpoints added."""
+    app = create_app(debug=debug)
 
     # Static files
     import listenbrainz.webserver.static_manager
@@ -230,7 +231,7 @@ def create_api_compat_app(debug=None):
     need to create a different app and only register the api_compat blueprints
     """
 
-    app = gen_app(debug=debug)
+    app = create_app(debug=debug)
 
     from listenbrainz.webserver.views.api_compat import api_bp as api_compat_bp
     from listenbrainz.webserver.views.api_compat_deprecated import api_compat_old_bp

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -1,12 +1,12 @@
 import flask_testing
 
-from listenbrainz.webserver import create_app, create_api_compat_app
+from listenbrainz.webserver import create_api_compat_app, create_web_app
 
 
 class ServerTestCase(flask_testing.TestCase):
 
     def create_app(self):
-        app = create_app(debug=False)
+        app = create_web_app(debug=False)
         app.config['TESTING'] = True
         return app
 

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -1,19 +1,17 @@
-import ujson
 from unittest import mock
 from unittest.mock import MagicMock
 
+import ujson
 from flask import url_for
-from flask_login import login_required, AnonymousUserMixin
+from flask_login import login_required
 from requests.exceptions import HTTPError
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
-from pika.exceptions import ConnectionClosed, ChannelClosed
 
 import listenbrainz.db.user as db_user
 import listenbrainz.webserver.login
 from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.webserver import create_app
+from listenbrainz.webserver import create_web_app
 from listenbrainz.webserver.testing import ServerTestCase
-
 
 
 class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
@@ -73,9 +71,8 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
         Creating an app with default config so that debug is True
         and SECRET_KEY is defined.
         """
-        app = create_app(debug=True)
-        client = app.test_client()
-        resp = client.get('/data/')
+        app = create_web_app()
+        resp = app.test_client().get('/data/')
         self.assert200(resp)
         self.assertIn('flDebug', str(resp.data))
 

--- a/listenbrainz/websockets/websockets.py
+++ b/listenbrainz/websockets/websockets.py
@@ -5,13 +5,13 @@ from flask_login import current_user
 from flask_socketio import SocketIO, join_room, emit, disconnect
 from werkzeug.exceptions import BadRequest
 
-from listenbrainz.webserver import gen_app
+from listenbrainz.webserver import create_app
 from listenbrainz.db import playlist as db_playlist
 from listenbrainz.websockets.listens_dispatcher import ListensDispatcher
 
 eventlet.monkey_patch()
 
-app = gen_app()
+app = create_app()
 app.init_loggers(
     file_config=app.config.get('LOG_FILE'),
     sentry_config=app.config.get('LOG_SENTRY')


### PR DESCRIPTION
Almost all LB services run inside a flask app context, we use create_app to create flask app instances for use there. However, create_app also registers endpoints and related jinja stuff in the flask app. This is not needed at most of those places, only configurations and connections are. We also have a gen_app method which does exactly that so we should be using gen_app at all places except the LB web api app.

However, there are many places to replace create_app with gen_app and we are habitual of using create_app everywhere so we'll forget this and end up using the create_app instead gen_app again. For this reason, I am renaming create_app to create_web_app because it registers web blueprints. gen_app is renamed to create_app and so using create_app is fine now. If
someone uses create_app and gets an error about missing endpoints, then use create_web_app at that place instead.