### PR TITLE
LB-866 (II): Use user_id column to fetch/delete listens

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -1,8 +1,8 @@
 BEGIN;
 
-CREATE INDEX listened_at_user_name_ndx_listen ON listen (listened_at DESC, user_name);
+CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id);
 CREATE INDEX created_ndx_listen ON listen (created);
-CREATE UNIQUE INDEX listened_at_track_name_user_name_ndx_listen ON listen (listened_at DESC, track_name, user_name);
+CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id);
 
 -- View indexes are created in listenbrainz/db/timescale.py
 

--- a/admin/timescale/updates/2022-01-13-add-user-id-indexes.sql
+++ b/admin/timescale/updates/2022-01-13-add-user-id-indexes.sql
@@ -5,3 +5,9 @@
 -- This operation doesn't support being run inside a transaction.
 CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id) WITH (timescaledb.transaction_per_chunk);
 CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id) WITH (timescaledb.transaction_per_chunk);
+
+-- the user_id was initially set to DEFAULT to 0 while a background process updated user ids
+-- according to the user name now the process is complete so a default is no longer needed.
+BEGIN;
+ALTER TABLE listen ALTER COLUMN user_id DROP DEFAULT;
+COMMIT;

--- a/admin/timescale/updates/2022-01-13-add-user-id-indexes.sql
+++ b/admin/timescale/updates/2022-01-13-add-user-id-indexes.sql
@@ -1,0 +1,7 @@
+-- CREATE INDEX will lock the whole table, which means that it'll be unavailable while the index
+-- is building. Timescale doesn't support CREATE INDEX CONCURRENTLY. The best we can do is this
+-- extension which opens a transaction and creates the index one chunk at a time.
+-- This lets inserts and selects work on the table while it's running
+-- This operation doesn't support being run inside a transaction.
+CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id) WITH (timescaledb.transaction_per_chunk);
+CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id) WITH (timescaledb.transaction_per_chunk);

--- a/admin/timescale/updates/2022-01-13-add-user-id-indexes.sql
+++ b/admin/timescale/updates/2022-01-13-add-user-id-indexes.sql
@@ -4,7 +4,9 @@
 -- This lets inserts and selects work on the table while it's running
 -- This operation doesn't support being run inside a transaction.
 CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id) WITH (timescaledb.transaction_per_chunk);
-CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id) WITH (timescaledb.transaction_per_chunk);
+
+-- unique index cannot be created using transaction_per_chunk
+CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id);
 
 -- the user_id was initially set to DEFAULT to 0 while a background process updated user ids
 -- according to the user name now the process is complete so a default is no longer needed.

--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -56,7 +56,7 @@ class ListenStore(object):
         """
         raise NotImplementedError()
 
-    def fetch_listens(self, user_name, from_ts=None, to_ts=None, limit=DEFAULT_LISTENS_PER_FETCH):
+    def fetch_listens(self, user_id, from_ts=None, to_ts=None, limit=DEFAULT_LISTENS_PER_FETCH):
         """ Check from_ts, to_ts, and limit for fetching listens
             and set them to default values if not given.
         """
@@ -67,4 +67,4 @@ class ListenStore(object):
         else:
             order = ORDER_DESC
 
-        return self.fetch_listens_from_storage(user_name, from_ts, to_ts, limit, order)
+        return self.fetch_listens_from_storage(user_id, from_ts, to_ts, limit, order)

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -63,9 +63,8 @@ class RedisListenStore(ListenStore):
             self.log.error("Redis ping didn't work: {}".format(str(e)))
             raise
 
-
     def update_recent_listens(self, unique):
-        """ 
+        """
             Store the most recent listens in redis so we can fetch them easily for a recent listens page. This
             is not a critical action, so if it fails, it fails. Let's live with it.
         """
@@ -78,11 +77,10 @@ class RedisListenStore(ListenStore):
         if recent:
             cache._r.zadd(cache._prep_key(self.RECENT_LISTENS_KEY), recent, nx=True)
 
-            # Don't prune the sorted list each time, but only when it reaches twice the desired size 
+            # Don't prune the sorted list each time, but only when it reaches twice the desired size
             count = cache._r.zcard(cache._prep_key(self.RECENT_LISTENS_KEY))
             if count > (self.RECENT_LISTENS_MAX * 2):
                 cache._r.zpopmin(cache._prep_key(self.RECENT_LISTENS_KEY), count - self.RECENT_LISTENS_MAX - 1)
-
 
     def get_recent_listens(self, max = RECENT_LISTENS_MAX):
         """

--- a/listenbrainz/listenstore/tests/test_test.py
+++ b/listenbrainz/listenstore/tests/test_test.py
@@ -70,7 +70,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         super(TestTimescaleListenStore, self).tearDown()
 
     def _create_test_data(self, user_name, test_data_file_name=None):
-        test_data = create_test_data_for_timescalelistenstore(user_name, test_data_file_name)
+        test_data = create_test_data_for_timescalelistenstore(user_name, 1, test_data_file_name)
         self.logstore.insert(test_data)
         return len(test_data)
 

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -108,7 +108,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
         query = """INSERT INTO listen (listened_at, track_name, user_name, user_id, data, created)
                         VALUES %s
-                   ON CONFLICT (listened_at, track_name, user_name)
+                   ON CONFLICT (listened_at, track_name, user_id)
                     DO NOTHING
                 """
 
@@ -229,7 +229,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         testuser_name = testuser['musicbrainz_id']
 
         count = self._create_test_data(testuser_name)
-        listen_count = self.logstore.get_listen_count_for_user(user_id=testuser["id"])
+        listen_count = self.logstore.get_listen_count_for_user(testuser_name)
         self.assertEqual(count, listen_count)
 
     def test_fetch_recent_listens(self):
@@ -432,8 +432,8 @@ class TestTimescaleListenStore(DatabaseTestCase):
         testuser = db_user.get_or_create(uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         count = self._create_test_data(testuser_name)
-        user_key = REDIS_USER_LISTEN_COUNT + testuser["id"]
-        self.assertEqual(count, self.logstore.get_listen_count_for_user(testuser["id"]))
+        user_key = REDIS_USER_LISTEN_COUNT + testuser_name
+        self.assertEqual(count, self.logstore.get_listen_count_for_user(testuser_name))
         self.assertEqual(count, int(cache.get(user_key, decode=False) or 0))
 
         batch = generate_data(uid, testuser_name, int(time()), 1)
@@ -453,7 +453,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        self.logstore.delete(testuser["id"])
+        self.logstore.delete(testuser_name, testuser["id"])
         listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=testuser["id"], to_ts=1400000300)
         self.assertEqual(len(listens), 0)
 
@@ -470,7 +470,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        self.logstore.delete_listen(1400000050, testuser["id"], "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
+        self.logstore.delete_listen(1400000050, testuser_name, testuser["id"], "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
         listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=testuser["id"], to_ts=1400000300)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -478,7 +478,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[2].ts_since_epoch, 1400000100)
         self.assertEqual(listens[3].ts_since_epoch, 1400000000)
 
-        self.assertEqual(self.logstore.get_listen_count_for_user(testuser["id"]), 4)
+        self.assertEqual(self.logstore.get_listen_count_for_user(testuser_name), 4)
         min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser["id"])
         self.assertEqual(min_ts, 1400000000)
         self.assertEqual(max_ts, 1400000200)

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -139,12 +139,12 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
     def test_insert_timescale(self):
         count = self._create_test_data(self.testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1399999999)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1399999999)
         self.assertEqual(len(listens), count)
 
     def test_fetch_listens_0(self):
         self._create_test_data(self.testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000000, limit=1)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1400000000, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].ts_since_epoch, 1400000050)
         self.assertEqual(min_ts, 1400000000)
@@ -152,7 +152,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
     def test_fetch_listens_1(self):
         self._create_test_data(self.testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000000)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1400000000)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -161,14 +161,14 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
     def test_fetch_listens_2(self):
         self._create_test_data(self.testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000100)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1400000100)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
 
     def test_fetch_listens_3(self):
         self._create_test_data(self.testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, to_ts=1400000300)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -178,7 +178,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
     def test_fetch_listens_4(self):
         self._create_test_data(self.testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000049, to_ts=1400000101)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1400000049, to_ts=1400000101)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1400000100)
         self.assertEqual(listens[1].ts_since_epoch, 1400000050)
@@ -186,14 +186,14 @@ class TestTimescaleListenStore(DatabaseTestCase):
     def test_fetch_listens_5(self):
         self._create_test_data(self.testuser_name)
         with self.assertRaises(ValueError):
-            self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000101, to_ts=1400000001)
+            self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1400000101, to_ts=1400000001)
 
     def test_fetch_listens_with_gaps(self):
         self._create_test_data(self.testuser_name,
                                test_data_file_name='timescale_listenstore_test_listens_over_greater_time_range.json')
 
         # test from_ts with gaps
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1399999999)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1399999999)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1420000050)
         self.assertEqual(listens[1].ts_since_epoch, 1420000000)
@@ -201,13 +201,13 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000000)
 
         # test from_ts and to_ts with gaps
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000049, to_ts=1420000001)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1400000049, to_ts=1420000001)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1420000000)
         self.assertEqual(listens[1].ts_since_epoch, 1400000050)
 
         # test to_ts with gaps
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=1420000051)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, to_ts=1420000051)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1420000050)
         self.assertEqual(listens[1].ts_since_epoch, 1420000000)
@@ -217,7 +217,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
     def test_fetch_listens_with_mapping(self):
         self._create_test_data(self.testuser_name)
         self._insert_mapping_metadata("c7a41965-9f1e-456c-8b1d-27c0f0dde280")
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, from_ts=1400000000, limit=1)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, from_ts=1400000000, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].data["mbid_mapping"]["artist_mbids"], ['6a221fda-2200-11ec-ac7d-dfa16a57158f'])
         self.assertEqual(listens[0].data["mbid_mapping"]["release_mbid"], '1fd178b4-1575-11ec-b98a-d72392cd8c97')
@@ -229,7 +229,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         testuser_name = testuser['musicbrainz_id']
 
         count = self._create_test_data(testuser_name)
-        listen_count = self.logstore.get_listen_count_for_user(user_name=testuser_name)
+        listen_count = self.logstore.get_listen_count_for_user(user_id=testuser["id"])
         self.assertEqual(count, listen_count)
 
     def test_fetch_recent_listens(self):
@@ -241,13 +241,13 @@ class TestTimescaleListenStore(DatabaseTestCase):
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], limit=1, max_age=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user["id"], user2["id"]], limit=1, max_age=10000000000)
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name, user_name2], max_age=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user["id"], user2["id"]], max_age=10000000000)
         self.assertEqual(len(recent), 4)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user_name], max_age=int(time()) -
+        recent = self.logstore.fetch_recent_listens_for_users([user["id"]], max_age=int(time()) -
                                                               recent[0].ts_since_epoch + 1)
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)
@@ -279,7 +279,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertTrue(os.path.isfile(dump_location))
         self.reset_timescale_db()
         self.logstore.import_listens_dump(dump_location)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=base + 11)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, to_ts=base + 11)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, base + 5)
         self.assertEqual(listens[1].ts_since_epoch, base + 4)
@@ -303,7 +303,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertTrue(os.path.isfile(dump_location))
         self.reset_timescale_db()
         self.logstore.import_listens_dump(dump_location)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=base + 11)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, to_ts=base + 11)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, base + 5)
         self.assertEqual(listens[1].ts_since_epoch, base + 4)
@@ -328,7 +328,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertTrue(os.path.isfile(dump_location))
         self.reset_timescale_db()
         self.logstore.import_listens_dump(dump_location)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, to_ts=1400000300)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -354,7 +354,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
         self.logstore.import_listens_dump(dump_location)
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=user['musicbrainz_id'], to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=user['id'], to_ts=1400000300)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -362,7 +362,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=self.testuser_name, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=self.testuser_id, to_ts=1400000300)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -432,8 +432,8 @@ class TestTimescaleListenStore(DatabaseTestCase):
         testuser = db_user.get_or_create(uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         count = self._create_test_data(testuser_name)
-        user_key = REDIS_USER_LISTEN_COUNT + testuser_name
-        self.assertEqual(count, self.logstore.get_listen_count_for_user(testuser_name))
+        user_key = REDIS_USER_LISTEN_COUNT + testuser["id"]
+        self.assertEqual(count, self.logstore.get_listen_count_for_user(testuser["id"]))
         self.assertEqual(count, int(cache.get(user_key, decode=False) or 0))
 
         batch = generate_data(uid, testuser_name, int(time()), 1)
@@ -445,7 +445,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         testuser = db_user.get_or_create(uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=testuser_name, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=testuser["id"], to_ts=1400000300)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -453,8 +453,8 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        self.logstore.delete(testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=testuser_name, to_ts=1400000300)
+        self.logstore.delete(testuser["id"])
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=testuser["id"], to_ts=1400000300)
         self.assertEqual(len(listens), 0)
 
     def test_delete_single_listen(self):
@@ -462,7 +462,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         testuser = db_user.get_or_create(uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=testuser_name, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=testuser["id"], to_ts=1400000300)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -470,16 +470,16 @@ class TestTimescaleListenStore(DatabaseTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        self.logstore.delete_listen(1400000050, testuser_name, "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user_name=testuser_name, to_ts=1400000300)
+        self.logstore.delete_listen(1400000050, testuser["id"], "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user_id=testuser["id"], to_ts=1400000300)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
         self.assertEqual(listens[2].ts_since_epoch, 1400000100)
         self.assertEqual(listens[3].ts_since_epoch, 1400000000)
 
-        self.assertEqual(self.logstore.get_listen_count_for_user(testuser_name), 4)
-        min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser_name)
+        self.assertEqual(self.logstore.get_listen_count_for_user(testuser["id"]), 4)
+        min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser["id"])
         self.assertEqual(min_ts, 1400000000)
         self.assertEqual(max_ts, 1400000200)
 
@@ -490,8 +490,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
         """
         uid = random.randint(2000, 1 << 31)
         testuser = db_user.get_or_create(uid, "user_%d" % uid)
-        testuser_name = testuser['musicbrainz_id']
-        min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser_name)
+        min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser["id"])
         self.assertEqual(min_ts, 0)
         self.assertEqual(max_ts, 0)
-        self.assertEqual(cache.get(REDIS_USER_TIMESTAMPS + testuser_name), "0,0")
+        self.assertEqual(cache.get(REDIS_USER_TIMESTAMPS + testuser["id"]), "0,0")

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -493,4 +493,4 @@ class TestTimescaleListenStore(DatabaseTestCase):
         min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser["id"])
         self.assertEqual(min_ts, 0)
         self.assertEqual(max_ts, 0)
-        self.assertEqual(cache.get(REDIS_USER_TIMESTAMPS + testuser["id"]), "0,0")
+        self.assertEqual(cache.get(REDIS_USER_TIMESTAMPS + str(testuser["id"])), "0,0")

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -71,6 +71,7 @@ class TestTimescaleListenStore(DatabaseTestCase):
 
     def tearDown(self):
         self.logstore = None
+        cache._r.flushdb()
         super(TestTimescaleListenStore, self).tearDown()
 
     def _create_test_data(self, user_name, user_id, test_data_file_name=None):

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -46,14 +46,15 @@ def to_epoch(date):
     return int((date - datetime.utcfromtimestamp(0)).total_seconds())
 
 
-def create_test_data_for_timescalelistenstore(user_name, test_data_file_name=None):
+def create_test_data_for_timescalelistenstore(user_name: str, user_id: int, test_data_file_name: str = None):
     """Create listens for timescalelistenstore tests.
 
     From a json file in testdata it creates Listen objects with a specified user_name for tests.
 
     Args:
-        user_name (str): MusicBrainz username of a user.
-        test_data_file_name (str): If specified use the given file to create Listen objects.
+        user_name: MusicBrainz username of a user.
+        user_id: listenbrainz row id of the user
+        test_data_file_name: If specified use the given file to create Listen objects.
                                    DEFAULT = 'timescale_listenstore_test_listens.json'
 
     Returns:
@@ -69,6 +70,7 @@ def create_test_data_for_timescalelistenstore(user_name, test_data_file_name=Non
     test_data = []
     for listen in listens['payload']:
         listen['user_name'] = user_name
+        listen['user_id'] = user_id
         test_data.append(Listen().from_json(listen))
 
     return test_data

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -75,22 +75,22 @@ class TimescaleListenStore(ListenStore):
         self.dump_temp_dir_root = conf.get(
             'LISTEN_DUMP_TEMP_DIR_ROOT', tempfile.mkdtemp())
 
-    def set_empty_cache_values_for_user(self, user_name):
+    def set_empty_cache_values_for_user(self, user_id):
         """When a user is created, set the listen_count and timestamp keys so that we
            can avoid the expensive lookup for a brand new user."""
 
-        cache.set(REDIS_USER_LISTEN_COUNT + user_name, 0, expirein=0, encode=False)
-        cache.set(REDIS_USER_TIMESTAMPS + user_name, "0,0", expirein=0)
+        cache.set(REDIS_USER_LISTEN_COUNT + user_id, 0, expirein=0, encode=False)
+        cache.set(REDIS_USER_TIMESTAMPS + user_id, "0,0", expirein=0)
 
-    def get_listen_count_for_user(self, user_name):
+    def get_listen_count_for_user(self, user_id):
         """Get the total number of listens for a user. The number of listens comes from
            brainzutils cache unless an exact number is asked for.
 
         Args:
-            user_name: the user to get listens for
+            user_id: the user to get listens for
         """
 
-        count = cache.get(REDIS_USER_LISTEN_COUNT + user_name, decode=False)
+        count = cache.get(REDIS_USER_LISTEN_COUNT + user_id, decode=False)
         # count < 0, yeah that's possible. when a user imports from last.fm,
         # we call set_listen_count_expiry_for_user to set a TTL on the count.
         # the intent is that when the key expires and the listen counts will
@@ -107,23 +107,23 @@ class TimescaleListenStore(ListenStore):
         # inserted a listen. redis would create a key with value 0 and increment it
         # by 1. only now we don't have a way to detect this.
         if count is None or int(count) < 0:
-            return self.reset_listen_count(user_name)
+            return self.reset_listen_count(user_id)
         else:
             return int(count)
 
-    def reset_listen_count(self, user_name):
+    def reset_listen_count(self, user_id):
         """ Reset the listen count of a user from cache and put in a new calculated value.
             returns the re-calculated listen count.
 
             Args:
-                user_name: the musicbrainz id of user whose listen count needs to be reset
+                user_id: the musicbrainz id of user whose listen count needs to be reset
         """
-        query = "SELECT SUM(count) FROM listen_count_30day WHERE user_name = :user_name"
+        query = "SELECT SUM(count) FROM listen_count_30day WHERE user_id = :user_id"
         t0 = time.monotonic()
         try:
             with timescale.engine.connect() as connection:
                 result = connection.execute(sqlalchemy.text(query), {
-                    "user_name": user_name,
+                    "user_id": user_id,
                 })
                 count = int(result.fetchone()[0] or 0)
 
@@ -133,24 +133,23 @@ class TimescaleListenStore(ListenStore):
             raise
 
         # intended for production monitoring
-        self.log.info("listen counts %s %.2fs" % (user_name, time.monotonic() - t0))
+        self.log.info("listen counts %s %.2fs" % (user_id, time.monotonic() - t0))
         # put this value into brainzutils cache without an expiry time
-        cache.set(REDIS_USER_LISTEN_COUNT + user_name,
-                  count, expirein=0, encode=False)
+        cache.set(REDIS_USER_LISTEN_COUNT + user_id, count, expirein=0, encode=False)
         return count
 
-    def set_listen_count_expiry_for_user(self, user_name):
+    def set_listen_count_expiry_for_user(self, user_id):
         """ Set an expire time for the listen count cache item. This is called after
             a bulk import which allows for timescale continuous aggregates to catch up
             to listen counts. Once the key expires, the correct value can be calculated
             from the aggregate.
 
             Args:
-                user_name: the musicbrainz id of user whose listen count needs an expiry time
+                user_id: the musicbrainz id of user whose listen count needs an expiry time
         """
-        cache._r.expire(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name), REDIS_POST_IMPORT_LISTEN_COUNT_EXPIRY)
+        cache._r.expire(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_id), REDIS_POST_IMPORT_LISTEN_COUNT_EXPIRY)
 
-    def update_timestamps_for_user(self, user_name, min_ts, max_ts):
+    def update_timestamps_for_user(self, user_id, min_ts, max_ts):
         """
             If any code adds/removes listens it should update the timestamps for the user
             using this function, so that they values in redis are always current.
@@ -159,40 +158,39 @@ class TimescaleListenStore(ListenStore):
             saved in the cache, otherwise the user timestamps remain unchanged.
         """
 
-        cached_min_ts, cached_max_ts = self.get_timestamps_for_user(user_name)
+        cached_min_ts, cached_max_ts = self.get_timestamps_for_user(user_id)
         if min_ts < cached_min_ts or max_ts > cached_max_ts:
             if min_ts < cached_min_ts:
                 cached_min_ts = min_ts
             if max_ts > cached_max_ts:
                 cached_max_ts = max_ts
-            cache.set(REDIS_USER_TIMESTAMPS + user_name, "%d,%d" %
+            cache.set(REDIS_USER_TIMESTAMPS + user_id, "%d,%d" %
                       (cached_min_ts, cached_max_ts), expirein=0)
 
-    def get_timestamps_for_user(self, user_name):
+    def get_timestamps_for_user(self, user_id):
         """ Return the max_ts and min_ts for a given user and cache the result in brainzutils cache
         """
-
-        tss = cache.get(REDIS_USER_TIMESTAMPS + user_name)
+        tss = cache.get(REDIS_USER_TIMESTAMPS + user_id)
         if tss:
             (min_ts, max_ts) = tss.split(",")
             min_ts = int(min_ts)
             max_ts = int(max_ts)
         else:
             t0 = time.monotonic()
-            min_ts = self._select_single_timestamp(True, user_name)
-            max_ts = self._select_single_timestamp(False, user_name)
-            cache.set(REDIS_USER_TIMESTAMPS + user_name, "%d,%d" % (min_ts, max_ts), expirein=0)
+            min_ts = self._select_single_timestamp(True, user_id)
+            max_ts = self._select_single_timestamp(False, user_id)
+            cache.set(REDIS_USER_TIMESTAMPS + user_id, "%d,%d" % (min_ts, max_ts), expirein=0)
             # intended for production monitoring
-            self.log.info("timestamps %s %.2fs" % (user_name, time.monotonic() - t0))
+            self.log.info("timestamps %s %.2fs" % (user_id, time.monotonic() - t0))
 
         return min_ts, max_ts
 
-    def _select_single_timestamp(self, select_min_timestamp, user_name):
+    def _select_single_timestamp(self, select_min_timestamp, user_id):
         """ Fetch a single timestamp (min or max) from the listenstore for a given user.
 
             Args:
                 select_min_timestamp: boolean. Select the min timestamp if true, max if false.
-                user_name: the user for whom to fetch the timestamp.
+                user_id: the user for whom to fetch the timestamp.
 
             Returns:
 
@@ -205,11 +203,11 @@ class TimescaleListenStore(ListenStore):
 
         query = """SELECT %s(listened_at) AS ts
                      FROM listen
-                     WHERE user_name = :user_name""" % function
+                     WHERE user_id = :user_id""" % function
         try:
             with timescale.engine.connect() as connection:
                 result = connection.execute(sqlalchemy.text(query), {
-                    "user_name": user_name
+                    "user_id": user_id
                 })
                 row = result.fetchone()
                 if row is None or row['ts'] is None:
@@ -250,7 +248,7 @@ class TimescaleListenStore(ListenStore):
 
     def insert(self, listens):
         """
-            Insert a batch of listens. Returns a list of (listened_at, track_name, user_name) that indicates
+            Insert a batch of listens. Returns a list of (listened_at, track_name, user_id) that indicates
             which rows were inserted into the DB. If the row is not listed in the return values, it was a duplicate.
         """
 
@@ -258,11 +256,11 @@ class TimescaleListenStore(ListenStore):
         for listen in listens:
             submit.append(listen.to_timescale())
 
-        query = """INSERT INTO listen (listened_at, track_name, user_name, user_id, data)
+        query = """INSERT INTO listen (listened_at, track_name, user_id, user_id, data)
                         VALUES %s
-                   ON CONFLICT (listened_at, track_name, user_name)
+                   ON CONFLICT (listened_at, track_name, user_id)
                     DO NOTHING
-                     RETURNING listened_at, track_name, user_name"""
+                     RETURNING listened_at, track_name, user_id"""
 
         inserted_rows = []
         conn = timescale.engine.raw_connection()
@@ -283,19 +281,19 @@ class TimescaleListenStore(ListenStore):
         # update the listen counts and timestamps for the users
         user_timestamps = {}
         user_counts = defaultdict(int)
-        for ts, _, user_name in inserted_rows:
-            if user_name in user_timestamps:
-                if ts < user_timestamps[user_name][0]:
-                    user_timestamps[user_name][0] = ts
-                if ts > user_timestamps[user_name][1]:
-                    user_timestamps[user_name][1] = ts
+        for ts, _, user_id in inserted_rows:
+            if user_id in user_timestamps:
+                if ts < user_timestamps[user_id][0]:
+                    user_timestamps[user_id][0] = ts
+                if ts > user_timestamps[user_id][1]:
+                    user_timestamps[user_id][1] = ts
             else:
-                user_timestamps[user_name] = [ts, ts]
+                user_timestamps[user_id] = [ts, ts]
 
-            user_counts[user_name] += 1
+            user_counts[user_id] += 1
 
-        for user_name in user_counts:
-            cache.increment(REDIS_USER_LISTEN_COUNT + user_name, amount=user_counts[user_name])
+        for user_id in user_counts:
+            cache.increment(REDIS_USER_LISTEN_COUNT + user_id, amount=user_counts[user_id])
 
         for user in user_timestamps:
             self.update_timestamps_for_user(
@@ -303,7 +301,7 @@ class TimescaleListenStore(ListenStore):
 
         return inserted_rows
 
-    def fetch_listens_from_storage(self, user_name, from_ts, to_ts, limit, order):
+    def fetch_listens_from_storage(self, user_id, from_ts, to_ts, limit, order):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
             the value they are converted to the local server's timezone. So to compare
             datetime object we need to create a object in the same timezone as the server.
@@ -317,9 +315,9 @@ class TimescaleListenStore(ListenStore):
             order: 0 for ASCending order, 1 for DESCending order
         """
 
-        return self.fetch_listens_for_multiple_users_from_storage([user_name], from_ts, to_ts, limit, order)
+        return self.fetch_listens_for_multiple_users_from_storage([user_id], from_ts, to_ts, limit, order)
 
-    def fetch_listens_for_multiple_users_from_storage(self, user_names: List[str], from_ts: float, to_ts: float, limit: int, order: int):
+    def fetch_listens_for_multiple_users_from_storage(self, user_ids: List[int], from_ts: float, to_ts: float, limit: int, order: int):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
             the value they are converted to the local server's timezone. So to compare
             datetime object we need to create a object in the same timezone as the server.
@@ -334,8 +332,8 @@ class TimescaleListenStore(ListenStore):
         """
 
         min_user_ts = max_user_ts = None
-        for user_name in user_names:
-            min_ts, max_ts = self.get_timestamps_for_user(user_name)
+        for user_id in user_ids:
+            min_ts, max_ts = self.get_timestamps_for_user(user_id)
             min_user_ts = min(min_ts, min_user_ts or min_ts)
             max_user_ts = max(max_ts, max_user_ts or max_ts)
 
@@ -343,7 +341,7 @@ class TimescaleListenStore(ListenStore):
             to_ts = max_user_ts + 1
 
         if min_user_ts == 0 and max_user_ts == 0:
-            return ([], min_user_ts, max_user_ts)
+            return [], min_user_ts, max_user_ts
 
         window_size = DEFAULT_FETCH_WINDOW
         query = """SELECT listened_at, track_name, user_name, created, data, mm.recording_mbid, release_mbid, artist_mbids
@@ -352,7 +350,7 @@ class TimescaleListenStore(ListenStore):
                        ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = mm.recording_msid
           FULL OUTER JOIN mbid_mapping_metadata m
                        ON mm.recording_mbid = m.recording_mbid
-                    WHERE user_name IN :user_names
+                    WHERE user_id IN :user_ids
                       AND listened_at > :from_ts
                       AND listened_at < :to_ts
                  ORDER BY listened_at """ + ORDER_TEXT[order] + " LIMIT :limit"
@@ -383,7 +381,7 @@ class TimescaleListenStore(ListenStore):
                     done = True
                     break
 
-                curs = connection.execute(sqlalchemy.text(query), user_names=tuple(user_names),
+                curs = connection.execute(sqlalchemy.text(query), user_ids=tuple(user_ids),
                                           from_ts=from_ts, to_ts=to_ts, limit=limit)
                 while True:
                     result = curs.fetchone()
@@ -426,9 +424,9 @@ class TimescaleListenStore(ListenStore):
             listens.reverse()
 
         self.log.info("fetch listens %s %.2fs (%d passes)" %
-                      (str(user_names), fetch_listens_time, passes))
+                      (str(user_ids), fetch_listens_time, passes))
 
-        return (listens, min_user_ts, max_user_ts)
+        return listens, min_user_ts, max_user_ts
 
     def fetch_recent_listens_for_users(self, user_list, limit=2, max_age=3600):
         """ Fetch recent listens for a list of users, given a limit which applies per user. If you
@@ -449,7 +447,7 @@ class TimescaleListenStore(ListenStore):
                                   ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = m.recording_msid
                      FULL OUTER JOIN mbid_mapping_metadata mm
                                   ON mm.recording_mbid = m.recording_mbid
-                               WHERE user_name IN :user_list
+                               WHERE user_id IN :user_list
                                  AND listened_at > :ts
                             GROUP BY user_name, listened_at, track_name, created, data, mm.recording_mbid, release_mbid, artist_mbids
                             ORDER BY listened_at DESC) tmp
@@ -987,20 +985,20 @@ class TimescaleListenStore(ListenStore):
 
         return total_imported
 
-    def delete(self, musicbrainz_id):
+    def delete(self, user_id):
         """ Delete all listens for user with specified MusicBrainz ID.
 
         Note: this method tries to delete the user 5 times before giving up.
 
         Args:
-            musicbrainz_id (str): the MusicBrainz ID of the user
+            user_id: the MusicBrainz ID of the user
 
         Raises: Exception if unable to delete the user in 5 retries
         """
 
-        self.set_empty_cache_values_for_user(musicbrainz_id)
-        args = {'user_name': musicbrainz_id}
-        query = "DELETE FROM listen WHERE user_name = :user_name"
+        self.set_empty_cache_values_for_user(user_id)
+        args = {'user_id': user_id}
+        query = "DELETE FROM listen WHERE user_id = :user_id"
 
         try:
             with timescale.engine.connect() as connection:
@@ -1009,27 +1007,30 @@ class TimescaleListenStore(ListenStore):
             self.log.error("Cannot delete listens for user: %s" % str(e))
             raise
 
-    def delete_listen(self, listened_at: int, user_name: str, recording_msid: str):
+    def delete_listen(self, listened_at: int, user_id: str, recording_msid: str):
         """ Delete a particular listen for user with specified MusicBrainz ID.
         Args:
             listened_at: The timestamp of the listen
-            user_name: the username of the user
+            user_id: the username of the user
             recording_msid: the MessyBrainz ID of the recording
         Raises: TimescaleListenStoreException if unable to delete the listen
         """
 
-        args = {'listened_at': listened_at, 'user_name': user_name,
-                'recording_msid': recording_msid}
+        args = {
+            'listened_at': listened_at,
+            'user_id': user_id,
+            'recording_msid': recording_msid
+        }
         query = """DELETE FROM listen
                     WHERE listened_at = :listened_at
-                      AND user_name = :user_name
+                      AND user_id = :user_id
                       AND data -> 'track_metadata' -> 'additional_info' ->> 'recording_msid' = :recording_msid """
 
         try:
             with timescale.engine.connect() as connection:
                 connection.execute(sqlalchemy.text(query), args)
 
-            cache._r.decrby(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_name))
+            cache._r.decrby(cache._prep_key(REDIS_USER_LISTEN_COUNT + user_id))
         except psycopg2.OperationalError as e:
             self.log.error("Cannot delete listen for user: %s" % str(e))
             raise TimescaleListenStoreException

--- a/listenbrainz/testdata/timescale_listenstore_test_listens.json
+++ b/listenbrainz/testdata/timescale_listenstore_test_listens.json
@@ -1,75 +1,70 @@
 {
-    "listen_type": "single",
-    "payload":[
-	{
+    "listen_type": "import",
+    "payload": [
+        {
             "track_metadata": {
-		"track_name": "Immigrant Song 0",
-		"additional_info": {
-		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-		    "release_msid": null
-		},
-		"artist_name": "Led Zeppelin"
+                "track_name": "Immigrant Song 0",
+                "additional_info": {
+                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+                    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+                    "release_msid": null
+                },
+                "artist_name": "Led Zeppelin"
             },
-            "user_id": 1,
             "listened_at": "1400000000",
             "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-	},
-	{
+        },
+        {
             "track_metadata": {
-		"track_name": "Immigrant Song 50",
-		"additional_info": {
-		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-		    "release_msid": null
-		},
-		"artist_name": "Led Zeppelin"
+                "track_name": "Immigrant Song 50",
+                "additional_info": {
+                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+                    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+                    "release_msid": null
+                },
+                "artist_name": "Led Zeppelin"
             },
-            "user_id": 1,
             "listened_at": "1400000050",
             "recording_msid": "c7a41965-9f1e-456c-8b1d-27c0f0dde280"
-	},
-	{
+        },
+        {
             "track_metadata": {
-		"track_name": "Immigrant Song 100",
-		"additional_info": {
-		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-		    "release_msid": null
-		},
-		"artist_name": "Led Zeppelin"
+                "track_name": "Immigrant Song 100",
+                "additional_info": {
+                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+                    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+                    "release_msid": null
+                },
+                "artist_name": "Led Zeppelin"
             },
-            "user_id": 1,
             "listened_at": "1400000100",
             "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-	},
-	{
+        },
+        {
             "track_metadata": {
-		"track_name": "Immigrant Song 150",
-		"additional_info": {
-		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-		    "release_msid": null
-		},
-		"artist_name": "Led Zeppelin"
+                "track_name": "Immigrant Song 150",
+                "additional_info": {
+                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+                    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+                    "release_msid": null
+                },
+                "artist_name": "Led Zeppelin"
             },
-            "user_id": 1,
             "listened_at": "1400000150",
             "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-	},
-	{
+        },
+        {
             "track_metadata": {
-		"track_name": "Immigrant Song 200",
-		"additional_info": {
-		    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
-		    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
-		    "release_msid": null
-		},
-		"artist_name": "Led Zeppelin"
+                "track_name": "Immigrant Song 200",
+                "additional_info": {
+                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59",
+                    "artist_msid": "e229c8fa-7450-4916-8848-4535a40dc151",
+                    "release_msid": null
+                },
+                "artist_name": "Led Zeppelin"
             },
-            "user_id": 1,
             "listened_at": "1400000200",
             "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
-	}
+        }
     ]
 }

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -74,11 +74,12 @@ class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):
         )
 
 
-class APICompatIntegrationTestCase(APICompatServerTestCase, DatabaseTestCase):
+class APICompatIntegrationTestCase(APICompatServerTestCase, DatabaseTestCase, TimescaleTestCase):
 
     def setUp(self):
         APICompatServerTestCase.setUp(self)
         DatabaseTestCase.setUp(self)
+        TimescaleTestCase.setUp(self)
 
     def tearDown(self):
         APICompatServerTestCase.tearDown(self)

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -189,7 +189,7 @@ class APICompatTestCase(APICompatIntegrationTestCase):
 
         # Check if listen reached the timescale listenstore
         time.sleep(2)
-        listens, _, _ = self.ls.fetch_listens(self.lb_user['musicbrainz_id'], from_ts=timestamp-1)
+        listens, _, _ = self.ls.fetch_listens(self.lb_user['id'], from_ts=timestamp-1)
         self.assertEqual(len(listens), 1)
 
     def test_record_invalid_listen(self):
@@ -248,7 +248,7 @@ class APICompatTestCase(APICompatIntegrationTestCase):
 
         # Check if listens reached the timescale listenstore
         time.sleep(1)
-        listens, _, _ = self.ls.fetch_listens(self.lb_user['musicbrainz_id'], from_ts=timestamp-1)
+        listens, _, _ = self.ls.fetch_listens(self.lb_user['id'], from_ts=timestamp-1)
         self.assertEqual(len(listens), 2)
 
     def test_create_response_for_single_listen(self):

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -157,7 +157,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
         time.sleep(1)
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(self.user['musicbrainz_id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(self.user['id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -4,6 +4,7 @@ import os
 import uuid
 from random import randint
 
+from listenbrainz.db.testing import TimescaleTestCase
 from listenbrainz.tests.integration import IntegrationTestCase
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore import TimescaleListenStore
@@ -17,10 +18,11 @@ from listenbrainz import config
 from datetime import datetime
 
 
-class TimescaleWriterTestCase(IntegrationTestCase):
+class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
 
     def setUp(self):
-        super(TimescaleWriterTestCase, self).setUp()
+        IntegrationTestCase.setUp(self)
+        TimescaleTestCase.setUp(self)
         self.ls = TimescaleListenStore({'REDIS_HOST': config.REDIS_HOST,
                                        'REDIS_PORT': config.REDIS_PORT,
                                        'REDIS_NAMESPACE': config.REDIS_NAMESPACE,

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -76,7 +76,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
 
         self.assertEqual(1, self.rs.get_listen_count_for_day(datetime.utcnow()))
 
-        (min_ts, max_ts) = self.ls.get_timestamps_for_user(user_name=user.musicbrainz_id)
+        (min_ts, max_ts) = self.ls.get_timestamps_for_user(user["id"])
         self.assertEqual(min_ts, 1486449409)
         self.assertEqual(max_ts, 1486449409)
 

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -55,7 +55,7 @@ class TimescaleWriterTestCase(IntegrationTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
         recent = self.rs.get_recent_listens(4)
@@ -92,7 +92,7 @@ class TimescaleWriterTestCase(IntegrationTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 
@@ -104,7 +104,7 @@ class TimescaleWriterTestCase(IntegrationTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 
@@ -125,10 +125,10 @@ class TimescaleWriterTestCase(IntegrationTestCase):
         time.sleep(2)  # sleep to allow timescale-writer to do its thing
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user1['musicbrainz_id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user1['id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
-        listens, _, _ = self.ls.fetch_listens(user2['musicbrainz_id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user2['id'], to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 
@@ -154,5 +154,5 @@ class TimescaleWriterTestCase(IntegrationTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['musicbrainz_id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
         self.assertEqual(len(listens), 4)

--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -70,7 +70,7 @@ def get_user():
             raise MusicBrainzAuthNoEmailError()
         db_user.create(musicbrainz_row_id, musicbrainz_id, email=user_email)
         user = db_user.get_by_mb_id(musicbrainz_id, fetch_email=True)
-        ts.set_empty_cache_values_for_user(musicbrainz_id)
+        ts.set_empty_cache_values_for_user(musicbrainz_id, user["id"])
     else:  # an existing user is trying to log in
         # Other option is to change the return type of get_by_mb_row_id to a dict
         # but its used so widely that we would modifying huge number of tests

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -247,7 +247,7 @@ def get_recent_listens_for_user_list(user_list):
 
     db_conn = webserver.create_timescale(current_app)
     users = db_user.get_many_users_by_mb_id(users)
-    user_ids = [user["id"] for user in users]
+    user_ids = [user["id"] for user in users.values()]
     listens = db_conn.fetch_recent_listens_for_users(user_ids, limit=limit)
 
     listen_data = []

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -520,7 +520,8 @@ def delete_listen():
         log_raise_400("%s: Recording MSID format invalid." % recording_msid)
 
     try:
-        _ts.delete_listen(listened_at=listened_at, recording_msid=recording_msid, user_id=user["id"])
+        _ts.delete_listen(listened_at=listened_at, recording_msid=recording_msid,
+                          user_id=user["id"], user_name=user["musicbrainz_id"])
     except TimescaleListenStoreException as e:
         current_app.logger.error("Cannot delete listen for user: %s" % str(e))
         raise APIServiceUnavailable(

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -134,7 +134,7 @@ def get_listens(user_name):
         raise APIBadRequest("min_ts should be less than max_ts")
 
     listens, _, max_ts_per_user = db_conn.fetch_listens(
-        user_name,
+        user["id"],
         limit=count,
         from_ts=min_ts,
         to_ts=max_ts
@@ -246,10 +246,10 @@ def get_recent_listens_for_user_list(user_list):
         raise APIBadRequest("user_list is empty or invalid.")
 
     db_conn = webserver.create_timescale(current_app)
-    listens = db_conn.fetch_recent_listens_for_users(
-        users,
-        limit=limit
-    )
+    users = db_user.get_many_users_by_mb_id(users)
+    user_ids = [user["id"] for user in users]
+    listens = db_conn.fetch_recent_listens_for_users(user_ids, limit=limit)
+
     listen_data = []
     for listen in listens:
         listen_data.append(listen.to_api())
@@ -520,8 +520,7 @@ def delete_listen():
         log_raise_400("%s: Recording MSID format invalid." % recording_msid)
 
     try:
-        _ts.delete_listen(listened_at=listened_at,
-                          recording_msid=recording_msid, user_name=user["musicbrainz_id"])
+        _ts.delete_listen(listened_at=listened_at, recording_msid=recording_msid, user_id=user["id"])
     except TimescaleListenStoreException as e:
         current_app.logger.error("Cannot delete listen for user: %s" % str(e))
         raise APIServiceUnavailable(

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -127,7 +127,7 @@ def fetch_listens(musicbrainz_id, to_ts):
     """
     db_conn = webserver.create_timescale(current_app)
     while True:
-        batch, _, _ = db_conn.fetch_listens(current_user.musicbrainz_id, to_ts=to_ts, limit=EXPORT_FETCH_COUNT)
+        batch, _, _ = db_conn.fetch_listens(current_user.id, to_ts=to_ts, limit=EXPORT_FETCH_COUNT)
         if not batch:
             break
         yield from batch

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -197,26 +197,26 @@ class UserViewsTestCase(IntegrationTestCase):
 
         # If no parameter is given, use current time as the to_ts
         self.client.get(url_for('user.profile', user_name='iliekcomputers'))
-        req_call = mock.call('iliekcomputers', limit=25, from_ts=None)
+        req_call = mock.call(1, limit=25, from_ts=None)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # max_ts query param -> to_ts timescale param
         self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'max_ts': 1520946000})
-        req_call = mock.call('iliekcomputers', limit=25, to_ts=1520946000)
+        req_call = mock.call(1, limit=25, to_ts=1520946000)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # min_ts query param -> from_ts timescale param
         self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'min_ts': 1520941000})
-        req_call = mock.call('iliekcomputers', limit=25, from_ts=1520941000)
+        req_call = mock.call(1, limit=25, from_ts=1520941000)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # If max_ts and min_ts set, only max_ts is used
         self.client.get(url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'min_ts': 1520941000, 'max_ts': 1520946000})
-        req_call = mock.call('iliekcomputers', limit=25, to_ts=1520946000)
+        req_call = mock.call(1, limit=25, to_ts=1520946000)
         timescale.assert_has_calls([req_call])
 
     @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -168,7 +168,7 @@ class UserViewsTestCase(IntegrationTestCase):
     def _create_test_data(self, user_name):
         min_ts = -1
         max_ts = -1
-        self.test_data = create_test_data_for_timescalelistenstore(user_name)
+        self.test_data = create_test_data_for_timescalelistenstore(user_name, 1)
         for listen in self.test_data:
             if min_ts < 0 or listen.ts_since_epoch < min_ts:
                 min_ts = listen.ts_since_epoch

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -424,7 +424,7 @@ def delete_user(musicbrainz_id):
     """
 
     user = _get_user(musicbrainz_id)
-    timescale_connection._ts.delete(musicbrainz_id, user.id)
+    timescale_connection._ts.delete(user.musicbrainz_id, user.id)
     db_user.delete(user.id)
 
 
@@ -437,8 +437,8 @@ def delete_listens_history(musicbrainz_id):
     """
 
     user = _get_user(musicbrainz_id)
-    timescale_connection._ts.delete(musicbrainz_id, user.id)
-    timescale_connection._ts.reset_listen_count(musicbrainz_id)
+    timescale_connection._ts.delete(user.musicbrainz_id, user.id)
+    timescale_connection._ts.reset_listen_count(user.musicbrainz_id)
     listens_importer.update_latest_listened_at(user.id, ExternalServiceType.LASTFM, 0)
     db_stats.delete_user_stats(user.id)
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -424,7 +424,7 @@ def delete_user(musicbrainz_id):
     """
 
     user = _get_user(musicbrainz_id)
-    timescale_connection._ts.delete(user.musicbrainz_id)
+    timescale_connection._ts.delete(user.id)
     db_user.delete(user.id)
 
 
@@ -437,10 +437,9 @@ def delete_listens_history(musicbrainz_id):
     """
 
     user = _get_user(musicbrainz_id)
-    timescale_connection._ts.delete(user.musicbrainz_id)
-    timescale_connection._ts.reset_listen_count(user.musicbrainz_id)
-    listens_importer.update_latest_listened_at(
-        user.id, ExternalServiceType.LASTFM, 0)
+    timescale_connection._ts.delete(user.id)
+    timescale_connection._ts.reset_listen_count(user.id)
+    listens_importer.update_latest_listened_at(user.id, ExternalServiceType.LASTFM, 0)
     db_stats.delete_user_stats(user.id)
 
 

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -99,7 +99,7 @@ def profile(user_name):
     else:
         args['from_ts'] = min_ts
     data, min_ts_per_user, max_ts_per_user = db_conn.fetch_listens(
-        user_name, limit=LISTENS_PER_PAGE, **args)
+        user.id, limit=LISTENS_PER_PAGE, **args)
 
     listens = []
     for listen in data:

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -424,7 +424,7 @@ def delete_user(musicbrainz_id):
     """
 
     user = _get_user(musicbrainz_id)
-    timescale_connection._ts.delete(user.id)
+    timescale_connection._ts.delete(musicbrainz_id, user.id)
     db_user.delete(user.id)
 
 
@@ -437,8 +437,8 @@ def delete_listens_history(musicbrainz_id):
     """
 
     user = _get_user(musicbrainz_id)
-    timescale_connection._ts.delete(user.id)
-    timescale_connection._ts.reset_listen_count(user.id)
+    timescale_connection._ts.delete(musicbrainz_id, user.id)
+    timescale_connection._ts.reset_listen_count(musicbrainz_id)
     listens_importer.update_latest_listened_at(user.id, ExternalServiceType.LASTFM, 0)
     db_stats.delete_user_stats(user.id)
 

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -187,7 +187,7 @@ def user_feed(user_name: str):
     users_following = db_user_relationship.get_following_for_user(user['id'])
 
     # get all listen events
-    user_ids = [user['user_id'] for user in users_following]
+    user_ids = [user['id'] for user in users_following]
     if len(users_following) == 0:
         listen_events = []
     else:

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -187,11 +187,11 @@ def user_feed(user_name: str):
     users_following = db_user_relationship.get_following_for_user(user['id'])
 
     # get all listen events
-    musicbrainz_ids = [user['musicbrainz_id'] for user in users_following]
+    user_ids = [user['user_id'] for user in users_following]
     if len(users_following) == 0:
         listen_events = []
     else:
-        listen_events = get_listen_events(db_conn, musicbrainz_ids, min_ts, max_ts, count)
+        listen_events = get_listen_events(db_conn, user_ids, min_ts, max_ts, count)
 
     # for events like "follow" and "recording recommendations", we want to show the user
     # their own events as well
@@ -297,7 +297,7 @@ def delete_feed_events(user_name):
 
 def get_listen_events(
     db_conn: TimescaleListenStore,
-    musicbrainz_ids: List[str],
+    user_ids: List[int],
     min_ts: int,
     max_ts: int,
     count: int,
@@ -311,7 +311,7 @@ def get_listen_events(
     # but I'm happy with this heuristic for now and we can change later.
     db_conn = webserver.create_timescale(current_app)
     listens, _, _ = db_conn.fetch_listens_for_multiple_users_from_storage(
-        musicbrainz_ids,
+        user_ids,
         limit=count,
         from_ts=min_ts,
         to_ts=max_ts,


### PR DESCRIPTION
#1574 added user ids to the listen table. This PR migrates the code to fetch and delete listens to use user ids instead. 

- Listen counts also have a user name column so those can't use user ids yet. #1700 will overhaul listen counts anyways so the intent is to make the user id switch for counts there. At a few places, both user ids and user names are needed currently for this reason. All references to user names will go away in the long run.

- I haven't updated the dumps yet to use usernames from "user" table instead of the listen table because currently we haven't removed the user name column, will do that shift in a separate PR.

- When deploying this, the cache keys for user timestamps will change so we should need to regenerate those in advance to avoid slowdowns in prod. My suggestion is stop ts writer prod, run a script from web beta to generate new redis keys, update ts writer prod to use new keys, bring up new ts writer and web.