### PR TITLE
Fix bug in artist country code api endpoint

### DIFF
--- a/listenbrainz/labs_api/labs/api/artist_country_from_artist_mbid.py
+++ b/listenbrainz/labs_api/labs/api/artist_country_from_artist_mbid.py
@@ -59,7 +59,7 @@ class ArtistCountryFromArtistMBIDQuery(Query):
 
                     r = dict(row)
                     areas.append(r['area_id'])
-                    mapping.append(row)
+                    mapping.append(r)
 
                 if not areas:
                     return []


### PR DESCRIPTION
In #1818, artist_name was added to the artist country code api. In that , the intent was probably to append r instead of row. Due to not calling dict on the result row, it is appended as an array to json. Due to this artist map endpoint which calls this labs api endpoint errors and returns a 500. Weird that the labs api test didn't catch this bug.

