### PR TITLE
Fix LB server local development

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         GIT_COMMIT_SHA: HEAD
     environment:
-      FLASK_APP: listenbrainz.webserver
+      FLASK_APP: listenbrainz.webserver:create_web_app()
       FLASK_ENV: development
     command: flask run -h 0.0.0.0 -p 80
     image: web

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,10 @@ services:
 
   api_compat:
     image: web
-    command: python3 /code/listenbrainz/manage.py run_api_compat_server -h 0.0.0.0 -p 7080 -d
+    environment:
+      FLASK_APP: listenbrainz.webserver:create_api_compat_app()
+      FLASK_ENV: development
+    command: flask run -h 0.0.0.0 -p 7080
     ports:
       - "7080:7080"
     volumes:

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -5,8 +5,6 @@ import click
 import sqlalchemy
 from werkzeug.serving import run_simple
 
-import listenbrainz.db.dump_manager as dump_manager
-import listenbrainz.spark.request_manage as spark_request_manage
 from listenbrainz import db
 from listenbrainz import webserver
 from listenbrainz.db import timescale as ts
@@ -27,24 +25,6 @@ MSB_ADMIN_SQL_DIR = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', 'admin', 'messybrainz', 'sql')
 TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), '..', 'admin', 'timescale')
-
-
-@cli.command(name="run_api_compat_server")
-@click.option("--host", "-h", default="0.0.0.0", show_default=True)
-@click.option("--port", "-p", default=7080, show_default=True)
-@click.option("--debug", "-d", is_flag=True,
-              help="Turns debugging mode on or off. If specified, overrides "
-                   "'DEBUG' value in the config file.")
-def run_api_compat_server(host, port, debug=False):
-    application = webserver.create_api_compat_app()
-    run_simple(
-        hostname=host,
-        port=port,
-        application=application,
-        use_debugger=debug,
-        use_reloader=debug,
-        processes=5
-    )
 
 
 @cli.command(name="run_websockets")


### PR DESCRIPTION
Due to the changes in #1816, local development broke. Flask by default creates application using create_app but we want to use create_web_app so need to specify it manually. The other option is to create a command in manage.py like run_api_compat_server, I didn't go for that version because werkzeug.run_simple's defaults are different from flask run's
so need more work to make sure it works as desired. We can go that way later if we think it has advantages but currently need to get local development working again.