### PR TITLE
Do not run CI on draft PRs

### DIFF
--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '*' ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - 'listenbrainz_spark/**'
       - 'requirements_spark.txt'
@@ -19,6 +20,8 @@ jobs:
   prod:
 
       runs-on: ubuntu-latest
+
+      if: github.event.pull_request.draft == false
 
       steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '*' ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths:
       - '**.jsx?'
       - '**.tsx?'
@@ -20,6 +21,8 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+
+    if: github.event.pull_request.draft == false
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '*' ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - 'listenbrainz_spark/**'
       - 'requirements_spark.txt'
@@ -23,6 +24,8 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+
+    if: github.event.pull_request.draft == false
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -19,6 +19,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    if: github.event.pull_request.draft == false
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '*' ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - 'listenbrainz_spark/**'
       - 'requirements_spark.txt'
@@ -23,6 +24,8 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+
+    if: github.event.pull_request.draft == false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We probably do not want CI to be run for draft PRs. I think its fine to disable it for all workflows but we can configure this on a per workflow basis if we want some jobs to run for draft PRs.