### PR TITLE
Fix handling of multiple items (pinned recordings) having same mbid/msid

### DIFF
--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -93,8 +93,7 @@ def fetch_track_metadata_for_items(items: List[ModelT]) -> List[ModelT]:
     msid_metadatas = load_recordings_from_msids(msid_item_map.keys())
     for metadata in msid_metadatas:
         msid = metadata["ids"]["recording_msid"]
-        items = msid_item_map[msid]
-        for item in items:
+        for item in msid_item_map[msid]:
             item.track_metadata = {
                 "track_name": metadata["payload"]["title"],
                 "artist_name": metadata["payload"]["artist"],
@@ -127,5 +126,3 @@ def _update_items_from_map(models: Dict[str, Iterable[ModelT]], metadatas: Dict)
                     "artist_mbids": metadata["artist_mbids"]
                 }
             }
-
-    return models

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -80,7 +80,7 @@ def fetch_track_metadata_for_items(items: List[ModelT]) -> List[ModelT]:
         Returns:
             The given list of MsidMbidModel objects with updated track_metadata.
     """
-    # it is possible to that multiple items have same msid/mbid. for example, pinning the
+    # it is possible that multiple items have same msid/mbid. for example, pinning the
     # same recording twice. since the dict is keyed by mbid/msid the corresponding value
     # should be a iterable of all items having that mbid
     msid_item_map, mbid_item_map = defaultdict(list), defaultdict(list)
@@ -109,6 +109,7 @@ def fetch_track_metadata_for_items(items: List[ModelT]) -> List[ModelT]:
 
 
 def _update_items_from_map(models: Dict[str, Iterable[ModelT]], metadatas: Dict):
+    """ The models are updated in place with data of the corresponding mbid/msid from the metadatas. """
     for _id, items in models.items():
         if _id not in metadatas:
             continue

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -124,3 +124,21 @@ class MappingTestCase(TimescaleTestCase):
             self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
             self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
             self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
+
+    def test_fetch_track_metadata_for_items_with_same_mbid(self):
+        recording = self.insert_recordings()[0]
+        models = [
+            MsidMbidModel(recording_msid=recording["recording_msid"], recording_mbid=recording["recording_mbid"]),
+            MsidMbidModel(recording_msid=recording["recording_msid"], recording_mbid=recording["recording_mbid"]),
+        ]
+        models = fetch_track_metadata_for_items(models)
+        for model in models:
+            metadata = model.track_metadata
+            self.assertEqual(metadata["track_name"], recording["title"])
+            self.assertEqual(metadata["artist_name"], recording["artist"])
+            self.assertEqual(metadata["release_name"], recording["release"])
+            self.assertEqual(metadata["additional_info"]["recording_mbid"], recording["recording_mbid"])
+            self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
+            self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
+            self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
+


### PR DESCRIPTION
It is possible to that multiple items have same msid/mbid. for example, pinning the same recording twice. Since the dict is keyed by mbid/msid the corresponding value should be a iterable of all items having that mbid so that such items are handled. Added test for the same.