### PR TITLE
Update listen additional_info metadata added to spotify listens

### DIFF
--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -99,7 +99,6 @@ def _convert_spotify_play_to_listen(play, listen_type):
         'tracknumber': track.get('track_number'),
         'spotify_artist_ids': spotify_artist_ids,
         'artist_names': artist_names,
-        'listening_from': 'spotify',
         'discnumber': track.get('disc_number'),
         'duration_ms': track.get('duration_ms'),
         'spotify_album_id': album.get('external_urls', {}).get('spotify'),
@@ -108,6 +107,8 @@ def _convert_spotify_play_to_listen(play, listen_type):
         'release_artist_names': release_artist_names,
         # Named 'album_*' because Spotify calls it album and this is spotify-specific
         'spotify_album_artist_ids': spotify_album_artist_ids,
+        'submission_client': 'listenbrainz',
+        'music_service': 'spotify.com'
     }
     isrc = track.get('external_ids', {}).get('isrc')
     spotify_url = track.get('external_urls', {}).get('spotify')
@@ -115,6 +116,7 @@ def _convert_spotify_play_to_listen(play, listen_type):
         additional['isrc'] = isrc
     if spotify_url:
         additional['spotify_id'] = spotify_url
+        additional['origin_url'] = spotify_url
 
     listen['track_metadata'] = {
         'artist_name': artist_name,

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -45,13 +45,15 @@ class ConvertListensTestCase(DatabaseTestCase):
                     'discnumber': 1,
                     'spotify_artist_ids': ['https://open.spotify.com/artist/6waa8mKu91GjzD4NlONlNJ'],
                     'artist_names': ['The Hollies'],
-                    'listening_from': 'spotify',
                     'duration_ms': 392080,
                     'spotify_album_id': 'https://open.spotify.com/album/2XoKFlFYe5Cy2Zt8gSHsWH',
                     'release_artist_name': 'The San Sebastian Strings',
                     'release_artist_names': ['The San Sebastian Strings'],
                     'spotify_album_artist_ids': ['https://open.spotify.com/artist/5SPV5qSO1UNNwwBCzrNfum'],
-                    'spotify_id': 'https://open.spotify.com/track/5SvAa2E5qyvZzfFlVtnXsQ'
+                    'spotify_id': 'https://open.spotify.com/track/5SvAa2E5qyvZzfFlVtnXsQ',
+                    'origin_url': 'https://open.spotify.com/track/5SvAa2E5qyvZzfFlVtnXsQ',
+                    'submission_client': 'listenbrainz',
+                    'music_service': 'spotify.com'
                 }
             }
         }
@@ -79,14 +81,16 @@ class ConvertListensTestCase(DatabaseTestCase):
                     'spotify_artist_ids': ['https://open.spotify.com/artist/1OwarW4LEHnoep20ixRA0y',
                                            'https://open.spotify.com/artist/5J6L7N6B4nI1M5cwa29mQG'],
                     'artist_names': ['Robert Plant', 'Alison Krauss'],
-                    'listening_from': 'spotify',
                     'duration_ms': 243480,
                     'spotify_album_id': 'https://open.spotify.com/album/3Z5nkL4z2Tsa3b79vv6LXb',
                     'release_artist_name': 'Robert Plant, Alison Krauss',
                     'release_artist_names': ['Robert Plant', 'Alison Krauss'],
                     'spotify_album_artist_ids': ['https://open.spotify.com/artist/1OwarW4LEHnoep20ixRA0y',
                                                  'https://open.spotify.com/artist/5J6L7N6B4nI1M5cwa29mQG'],
-                    'spotify_id': 'https://open.spotify.com/track/6bnmRsdxYacqLSlS36EJT6'
+                    'spotify_id': 'https://open.spotify.com/track/6bnmRsdxYacqLSlS36EJT6',
+                    'origin_url': 'https://open.spotify.com/track/6bnmRsdxYacqLSlS36EJT6',
+                    'submission_client': 'listenbrainz',
+                    'music_service': 'spotify.com'
                 }
             }
         }

--- a/listenbrainz/testdata/empty_artist_name.json
+++ b/listenbrainz/testdata/empty_artist_name.json
@@ -8,7 +8,7 @@
                 "track_name": "Duuuuuuude!",
                 "release_name": "The Life of Pablo",
                 "additional_info": {
-                    "listening_from": "spotify",
+                    "music_service": "spotify.com",
                     "recording_msid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
                 }
             }

--- a/listenbrainz/testdata/empty_track_name.json
+++ b/listenbrainz/testdata/empty_track_name.json
@@ -8,7 +8,7 @@
                 "track_name": "",
                 "release_name": "The Life of Pablo",
                 "additional_info": {
-                    "listening_from": "spotify",
+                    "music_service": "spotify.com",
                     "recording_msid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
                 }
             }

--- a/listenbrainz/testdata/spotify_recently_played_expected.json
+++ b/listenbrainz/testdata/spotify_recently_played_expected.json
@@ -16,7 +16,9 @@
                         "discnumber": 1,
                         "duration_ms": 238805,
                         "isrc": "GBUM72000433",
-                        "listening_from": "spotify",
+                        "music_service": "spotify.com",
+                        "submission_client": "listenbrainz",
+                        "origin_url": "https://open.spotify.com/track/02MWAaffLxlfxAUY7c5dvx",
                         "recording_msid": "dce97a5f-09ad-4605-a239-4532abe7c8b2",
                         "release_artist_name": "Glass Animals",
                         "release_artist_names": [

--- a/listenbrainz/testdata/valid_single.json
+++ b/listenbrainz/testdata/valid_single.json
@@ -8,7 +8,7 @@
                 "track_name": "Fade",
                 "release_name": "The Life of Pablo",
                 "additional_info": {
-                    "listening_from": "spotify",
+                    "music_service": "spotify.com",
                     "recording_msid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
                 }
             }

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -82,7 +82,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(data['listens'][0]['track_metadata']
                          ['release_name'], 'The Life of Pablo')
         self.assertEqual(data['listens'][0]['track_metadata']
-                         ['additional_info']['listening_from'], 'spotify')
+                         ['additional_info']['music_service'], 'spotify.com')
 
         # make sure that artist msid, release msid and recording msid are present in data
         self.assertTrue(is_valid_uuid(data['listens'][0]['recording_msid']))

--- a/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -69,12 +69,18 @@ export default class SpotifyPlayer
   };
 
   static isListenFromThisService = (listen: Listen | JSPFTrack): boolean => {
+    // Retro-compatibility: listening_from has been deprecated in favor of music_service
     const listeningFrom = _get(
       listen,
       "track_metadata.additional_info.listening_from"
     );
+    const musicService = _get(
+      listen,
+      "track_metadata.additional_info.music_service"
+    );
     return (
       (isString(listeningFrom) && listeningFrom.toLowerCase() === "spotify") ||
+      (isString(musicService) && musicService.toLowerCase() === "spotify.com") ||
       Boolean(SpotifyPlayer.getSpotifyURLFromListen(listen))
     );
   };
@@ -119,7 +125,8 @@ export default class SpotifyPlayer
   static getSpotifyURLFromListen(
     listen: Listen | JSPFTrack
   ): string | undefined {
-    return _get(listen, "track_metadata.additional_info.spotify_id");
+    return _get(listen, "track_metadata.additional_info.spotify_id") ??
+    _get(listen, "track_metadata.additional_info.origin_url");
   }
 
   static getSpotifyTrackIDFromListen(listen: Listen | JSPFTrack): string {
@@ -255,17 +262,6 @@ export default class SpotifyPlayer
     } catch (error) {
       handleError(error.message);
     }
-  };
-
-  isListenFromThisService = (listen: Listen | JSPFTrack): boolean => {
-    const listeningFrom = _get(
-      listen,
-      "track_metadata.additional_info.listening_from"
-    );
-    return (
-      (isString(listeningFrom) && listeningFrom.toLowerCase() === "spotify") ||
-      Boolean(SpotifyPlayer.getSpotifyURLFromListen(listen))
-    );
   };
 
   canSearchAndPlayTracks = (): boolean => {

--- a/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -80,7 +80,8 @@ export default class SpotifyPlayer
     );
     return (
       (isString(listeningFrom) && listeningFrom.toLowerCase() === "spotify") ||
-      (isString(musicService) && musicService.toLowerCase() === "spotify.com") ||
+      (isString(musicService) &&
+        musicService.toLowerCase() === "spotify.com") ||
       Boolean(SpotifyPlayer.getSpotifyURLFromListen(listen))
     );
   };
@@ -125,8 +126,15 @@ export default class SpotifyPlayer
   static getSpotifyURLFromListen(
     listen: Listen | JSPFTrack
   ): string | undefined {
-    return _get(listen, "track_metadata.additional_info.spotify_id") ??
-    _get(listen, "track_metadata.additional_info.origin_url");
+    const spotifyId = _get(listen, "track_metadata.additional_info.spotify_id");
+    if (spotifyId) {
+      return spotifyId;
+    }
+    const originURL = _get(listen, "track_metadata.additional_info.origin_url");
+    if (originURL && /open\.spotify\.com\/track\//.test(originURL)) {
+      return originURL;
+    }
+    return undefined;
   }
 
   static getSpotifyTrackIDFromListen(listen: Listen | JSPFTrack): string {

--- a/listenbrainz/webserver/static/js/src/utils/Scrobble.ts
+++ b/listenbrainz/webserver/static/js/src/utils/Scrobble.ts
@@ -90,7 +90,7 @@ export default class Scrobble {
         artist_name: this.artistName(),
         release_name: this.releaseName(),
         additional_info: {
-          listening_from: "lastfm",
+          submission_client: "ListenBrainz lastfm importer",
           lastfm_track_mbid: this.trackMBID(),
           lastfm_release_mbid: this.releaseMBID(),
           lastfm_artist_mbid: this.artistMBID(),

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -37,6 +37,7 @@ interface AdditionalInfo {
   spotify_album_id?: string | null;
   spotify_artist_ids?: Array<string> | null;
   spotify_id?: string | null;
+  submission_client?: string | null;
   youtube_id?: string | null;
   origin_url?: string | null;
   tags?: Array<string> | null;

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -22,6 +22,7 @@ interface AdditionalInfo {
   artist_msid?: string | null;
   discnumber?: number | null;
   duration_ms?: number | null;
+  duration?: number | null;
   isrc?: string | null;
   listening_from?: string | null; // Deprecated
   music_service?: string | null;

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -23,7 +23,8 @@ interface AdditionalInfo {
   discnumber?: number | null;
   duration_ms?: number | null;
   isrc?: string | null;
-  listening_from?: string | null;
+  listening_from?: string | null; // Deprecated
+  music_service?: string | null;
   recording_mbid?: string | null;
   recording_msid?: string | null;
   release_artist_name?: string | null;

--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -147,6 +147,7 @@ const getTrackName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
 
 const getTrackDuration = (listen?: Listen | JSPFTrack): number =>
   _.get(listen, "track_metadata.additional_info.duration_ms", "") ||
+  _.get(listen, "track_metadata.additional_info.duration", "") ||
   _.get(listen, "duration", "");
 
 const getArtistName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>

--- a/listenbrainz/webserver/static/js/tests/__mocks__/encodeScrobbleOutput.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/encodeScrobbleOutput.json
@@ -5,7 +5,7 @@
       "artist_name": "Coldplay",
       "release_name": "A Head Full Of Dreams",
       "additional_info": {
-        "listening_from": "lastfm",
+        "submission_client": "ListenBrainz lastfm importer",
         "lastfm_track_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
         "lastfm_release_mbid": "002183a5-c087-4c0a-9c47-65ef79261dd2",
         "lastfm_artist_mbid": "cc197bad-dc9c-440d-a5b5-d52ba2e14234"
@@ -19,7 +19,7 @@
       "artist_name": "Imagine Dragons",
       "release_name": "Evolve",
       "additional_info": {
-        "listening_from": "lastfm",
+        "submission_client": "ListenBrainz lastfm importer",
         "lastfm_track_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9",
         "lastfm_release_mbid": "25c11880-bc5e-43db-927b-522eb871dc9e",
         "lastfm_artist_mbid": "012151a8-0f9a-44c9-997f-ebd68b5389f9"
@@ -33,7 +33,7 @@
       "artist_name": "Imagine Dragons",
       "release_name": "Evolve",
       "additional_info": {
-        "listening_from": "lastfm",
+        "submission_client": "ListenBrainz lastfm importer",
         "lastfm_track_mbid": "022d6bfb-2a57-486b-a784-2af9b4b93fa9"
       }
     },

--- a/listenbrainz/webserver/static/js/tests/__mocks__/feedProps.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/feedProps.json
@@ -19,7 +19,7 @@
 						"discnumber": 1,
 						"duration_ms": 254815,
 						"isrc": "EEVC11700034",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "45ddbea4-79ee-4462-be9c-20a55bb5c20d",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -60,7 +60,7 @@
 						"discnumber": 1,
 						"duration_ms": 231351,
 						"isrc": "EEVC11700033",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "866818d9-a17b-43fc-b32a-3d9fbdc59fdb",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -101,7 +101,7 @@
 						"discnumber": 1,
 						"duration_ms": 325450,
 						"isrc": "EEVC11700032",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "d92c1f4e-b793-4ac5-a697-c2702563abbf",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -170,7 +170,7 @@
 						"discnumber": 1,
 						"duration_ms": 206193,
 						"isrc": "EEVC11700029",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "dc4e6b2c-a2fe-4a5d-a75a-736b87395046",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -211,7 +211,7 @@
 						"discnumber": 1,
 						"duration_ms": 165511,
 						"isrc": "EEVC11700028",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "2d1d1f67-60a5-4558-a5c6-b413c8374df5",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -255,7 +255,7 @@
 						"discnumber": 1,
 						"duration_ms": 200135,
 						"isrc": "FIUM72100016",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "20be8c56-c45e-4d5b-b1fa-9e3880410963",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -302,7 +302,7 @@
 						"discnumber": 1,
 						"duration_ms": 120135,
 						"isrc": "FIUM72100015",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "6a62ea39-5661-4c5a-b6a0-470da1d0f921",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -349,7 +349,7 @@
 						"discnumber": 1,
 						"duration_ms": 129547,
 						"isrc": "FIUM72100014",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "0eb7e0ec-f68b-4981-8d93-523aec9edbbc",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -396,7 +396,7 @@
 						"discnumber": 1,
 						"duration_ms": 162932,
 						"isrc": "FIUM72100013",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "cd51317b-ff6e-4711-98fd-8b25a4c8e730",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -444,7 +444,7 @@
 						"discnumber": 1,
 						"duration_ms": 226421,
 						"isrc": "FIUM72100012",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "efa4a107-7e2a-4519-860d-1ac758357ca9",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -492,7 +492,7 @@
 						"discnumber": 1,
 						"duration_ms": 185092,
 						"isrc": "FIUM72100011",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "5bbefb15-27e8-4b57-b099-88ce9042d191",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -539,7 +539,7 @@
 						"discnumber": 1,
 						"duration_ms": 216720,
 						"isrc": "FIUM72000442",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "411962f8-8dc1-47db-a766-b8f2a2c1a11c",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -586,7 +586,7 @@
 					"discnumber": 1,
 					"duration_ms": 223184,
 					"isrc": "FIUM72100010",
-					"listening_from": "spotify",
+					"music_service": "spotify.com",
 					"recording_msid": "6469fb75-fef4-4c17-8c28-ab7b4f13feba",
 					"release_artist_name": "Pitsa",
 					"release_artist_names": [
@@ -634,7 +634,7 @@
 					"discnumber": 1,
 					"duration_ms": 197278,
 					"isrc": "FIUM72100009",
-					"listening_from": "spotify",
+					"music_service": "spotify.com",
 					"recording_msid": "2a6e8522-21a9-4f76-aed6-90b26e080991",
 					"release_artist_name": "Pitsa",
 					"release_artist_names": [
@@ -682,7 +682,7 @@
 					"discnumber": 1,
 					"duration_ms": 196135,
 					"isrc": "FIUM72000406",
-					"listening_from": "spotify",
+					"music_service": "spotify.com",
 					"recording_msid": "abc41027-81f5-45dc-8a44-6db0992cee26",
 					"release_artist_name": "Pitsa",
 					"release_artist_names": [
@@ -729,7 +729,7 @@
 					"discnumber": 1,
 					"duration_ms": 219134,
 					"isrc": "FIUM72000381",
-					"listening_from": "spotify",
+					"music_service": "spotify.com",
 					"recording_msid": "7989a204-f7f8-430c-8c5a-4028a61d4d9c",
 					"release_artist_name": "Pitsa",
 					"release_artist_names": [

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensProps.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensProps.json
@@ -25,7 +25,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 268629,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "973e5620-829d-46dd-89a8-760d87076287",
               "release_artist_name": "SOHN",
               "release_artist_names": [
@@ -67,7 +67,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 197720,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "1b91585d-7e91-4e16-8ea1-63b32c1c3a71",
               "release_artist_name": "SOHN",
               "release_artist_names": [
@@ -109,7 +109,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 207060,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "aa6469c3-fc7b-4f71-b788-9fe09397599a",
               "release_artist_name": "SOHN",
               "release_artist_names": [
@@ -151,7 +151,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 183467,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "3b25d198-ef1c-477a-9cb4-2f304c68b30e",
               "release_artist_name": "SOHN",
               "release_artist_names": [
@@ -193,7 +193,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 267046,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "f13ccd3f-7969-4c68-a7c8-d941d9dd7792",
               "release_artist_name": "SOHN",
               "release_artist_names": [
@@ -235,7 +235,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 223095,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "f2fb4d7b-ab6c-4f19-9c8c-40c19b9d547e",
               "release_artist_name": "SOHN",
               "release_artist_names": [
@@ -277,7 +277,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 244186,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "3e0ec489-916d-40dd-8230-87dff3615ae9",
               "release_artist_name": "SOHN",
               "release_artist_names": [
@@ -319,7 +319,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 220765,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "5049f89c-6f3c-42af-8425-629463c90d01",
               "release_artist_name": "Ankur Tewari",
               "release_artist_names": [
@@ -361,7 +361,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 191172,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "45fab49f-02d0-46da-92a9-c61fd6538100",
               "release_artist_name": "Ankur Tewari",
               "release_artist_names": [
@@ -404,7 +404,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 250960,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "ec532252-9d27-4905-a51b-259b05f7275c",
               "release_artist_name": "Beyoncé",
               "release_artist_names": [
@@ -448,7 +448,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 266920,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "fdca6309-7995-4ba7-949e-7a90188195a2",
               "release_artist_name": "Beyoncé",
               "release_artist_names": [
@@ -491,7 +491,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 230893,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "e1416ebe-85c8-4c2b-b8df-49bd5f034710",
               "release_artist_name": "Beyoncé",
               "release_artist_names": [
@@ -534,7 +534,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 276560,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "7c903c79-401c-4aec-a55c-62becf7a07d0",
               "release_artist_name": "Beyoncé",
               "release_artist_names": [
@@ -578,7 +578,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 250960,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "ec532252-9d27-4905-a51b-259b05f7275c",
               "release_artist_name": "Beyoncé",
               "release_artist_names": [
@@ -621,7 +621,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 281518,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "933f16fa-25aa-44d2-a683-234bbd3d71d6",
               "release_artist_name": "Drake",
               "release_artist_names": [
@@ -663,7 +663,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 235566,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "454f5461-102b-4b71-bcdf-8aed09e2cbd8",
               "release_artist_name": "Drake",
               "release_artist_names": [
@@ -707,7 +707,7 @@
               ],
               "discnumber": 2,
               "duration_ms": 197652,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "7d27a3e1-0918-4366-9ee8-8ac61cd0c305",
               "release_artist_name": "Rae Sremmurd, Swae Lee, Slim Jxmmi",
               "release_artist_names": [
@@ -757,7 +757,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 250337,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "1836080b-050b-414a-8345-824b600941be",
               "release_artist_name": "Drake",
               "release_artist_names": [
@@ -801,7 +801,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 107673,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "c1c52262-596e-4be4-8ffe-847a48198934",
               "release_artist_name": "Drake",
               "release_artist_names": [
@@ -843,7 +843,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 298940,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "605181e8-1b79-4e17-99ad-f4aa75f1ec23",
               "release_artist_name": "Drake",
               "release_artist_names": [
@@ -885,7 +885,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 223275,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "0c512050-554f-4372-853c-8d81363b8d32",
               "release_artist_name": "Swae Lee",
               "release_artist_names": [
@@ -928,7 +928,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 142273,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "f918904b-ba07-4fd1-aa1e-3d56f361983a",
               "release_artist_name": "Lil Baby",
               "release_artist_names": [
@@ -973,7 +973,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 173973,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "47ca076c-c518-41ec-be3a-100ad1255967",
               "release_artist_name": "Drake",
               "release_artist_names": [
@@ -1017,7 +1017,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 178626,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "2e8dec65-10a6-4fb4-a8dc-fe26dee92ace",
               "release_artist_name": "Ariana Grande",
               "release_artist_names": [
@@ -1059,7 +1059,7 @@
               ],
               "discnumber": 1,
               "duration_ms": 186873,
-              "listening_from": "spotify",
+              "music_service": "spotify.com",
               "recording_msid": "ab8d8149-0032-4f49-a668-1185672585de",
               "release_artist_name": "Prateek Kuhad",
               "release_artist_names": [

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsThreeListens.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsThreeListens.json
@@ -21,7 +21,7 @@
           "discnumber": 1,
           "duration_ms": 203417,
           "isrc": "GBUM71800366",
-          "listening_from": "spotify",
+          "music_service": "spotify.com",
           "recording_msid": "f730bec5-d243-478e-ae46-2c47770ca1f0",
           "release_artist_name": "5 Seconds of Summer",
           "release_artist_names": [
@@ -86,7 +86,7 @@
             "discnumber": 1,
             "duration_ms": 139563,
             "isrc": "FR9W12028036",
-            "listening_from": "spotify",
+            "music_service": "spotify.com",
             "recording_msid": "f16652d3-d9ac-4fc2-973f-047b7f45bee1",
             "release_artist_name": "Ofenbach, Lagique",
             "release_artist_names": [

--- a/listenbrainz/webserver/static/js/tests/__mocks__/timelineProps.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/timelineProps.json
@@ -29,7 +29,7 @@
 						"discnumber": 1,
 						"duration_ms": 254815,
 						"isrc": "EEVC11700034",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "45ddbea4-79ee-4462-be9c-20a55bb5c20d",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -70,7 +70,7 @@
 						"discnumber": 1,
 						"duration_ms": 231351,
 						"isrc": "EEVC11700033",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "866818d9-a17b-43fc-b32a-3d9fbdc59fdb",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -111,7 +111,7 @@
 						"discnumber": 1,
 						"duration_ms": 325450,
 						"isrc": "EEVC11700032",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "d92c1f4e-b793-4ac5-a697-c2702563abbf",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -180,7 +180,7 @@
 						"discnumber": 1,
 						"duration_ms": 206193,
 						"isrc": "EEVC11700029",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "dc4e6b2c-a2fe-4a5d-a75a-736b87395046",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -221,7 +221,7 @@
 						"discnumber": 1,
 						"duration_ms": 165511,
 						"isrc": "EEVC11700028",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "2d1d1f67-60a5-4558-a5c6-b413c8374df5",
 						"release_artist_name": "Tintura + Arno Tamm",
 						"release_artist_names": [
@@ -265,7 +265,7 @@
 						"discnumber": 1,
 						"duration_ms": 200135,
 						"isrc": "FIUM72100016",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "20be8c56-c45e-4d5b-b1fa-9e3880410963",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -312,7 +312,7 @@
 						"discnumber": 1,
 						"duration_ms": 120135,
 						"isrc": "FIUM72100015",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "6a62ea39-5661-4c5a-b6a0-470da1d0f921",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -359,7 +359,7 @@
 						"discnumber": 1,
 						"duration_ms": 129547,
 						"isrc": "FIUM72100014",
-						"listening_from": "spotify",
+						"music_service": "spotify.com",
 						"recording_msid": "0eb7e0ec-f68b-4981-8d93-523aec9edbbc",
 						"release_artist_name": "Pitsa",
 						"release_artist_names": [
@@ -402,7 +402,7 @@
 						"discnumber": null,
 						"duration_ms": null,
 						"isrc": null,
-						"listening_from": null,
+						"music_service": null,
 						"origin_url": null,
 						"recording_mbid": null,
 						"recording_msid": "6aac964a-fbae-425e-9273-06ed38ae1bda",

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -210,7 +210,9 @@ def _to_native_api(lookup, method, output_format="xml"):
     for ind, data in lookup.items():
         listen = {
             'track_metadata': {
-                'additional_info': {}
+                'additional_info': {
+                    'submission_client': 'ListenBrainz lastfm API'
+                }
             }
         }
         if 'artist' in data:


### PR DESCRIPTION
We updated the documentation for what metadata to put in a listen. This PR updates listens added by our spotify reader to follow this format.

We added the following new fields to the documentation, but I didn't add all of them:

* origin_url - added, same as spotify_id
* music_service - added, 'spotify.com' as per our guides
* submission_client - added, set to 'listenbrainz'

Not added:
* media_player, media_player_version - we don't know what client the user is using to listen, so don't fill this in. It's not always going to be the spotify app
* submission_client_version - does it make sense to have a "version" of the spotify reader?
* music_service_name - we proposed music_service (as a domain), and music_service_name only if you are unable to identify a domain, so I skipped this. We could add it in anyway if we wanted, but I don't think it's needed.


Deprecated fields:
* `'listening_from': 'spotify'` because it's replaced by `'music_service': 'spotify.com'`

