### PR TITLE
Do not read user_name from timescale

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -129,8 +129,8 @@ class Listen(object):
         )
 
     @classmethod
-    def from_timescale(cls, listened_at, track_name, user_name, created, j,
-                       recording_mbid=None, release_mbid=None, artist_mbids=None):
+    def from_timescale(cls, listened_at, track_name, user_id, created, j,
+                       recording_mbid=None, release_mbid=None, artist_mbids=None, user_name=None):
         """Factory to make Listen() objects from a timescale dict"""
 
         j['listened_at'] = datetime.utcfromtimestamp(float(listened_at))
@@ -141,7 +141,7 @@ class Listen(object):
                 "release_mbid": str(release_mbid),
                 "artist_mbids": [ str(m) for m in artist_mbids ] }
         return cls(
-            user_id=j.get('user_id'),
+            user_id=user_id,
             user_name=user_name,
             timestamp=j['listened_at'],
             artist_msid=j['track_metadata']['additional_info'].get('artist_msid'),

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -129,27 +129,27 @@ class Listen(object):
         )
 
     @classmethod
-    def from_timescale(cls, listened_at, track_name, user_id, created, j,
+    def from_timescale(cls, listened_at, track_name, user_id, created, data,
                        recording_mbid=None, release_mbid=None, artist_mbids=None, user_name=None):
         """Factory to make Listen() objects from a timescale dict"""
 
-        j['listened_at'] = datetime.utcfromtimestamp(float(listened_at))
-        j['track_metadata']['track_name'] = track_name
+        data['listened_at'] = datetime.utcfromtimestamp(float(listened_at))
+        data['track_metadata']['track_name'] = track_name
         if recording_mbid is not None and release_mbid is not None and artist_mbids is not None:
-            j["track_metadata"]["mbid_mapping"] = {
+            data["track_metadata"]["mbid_mapping"] = {
                 "recording_mbid": str(recording_mbid),
                 "release_mbid": str(release_mbid),
                 "artist_mbids": [ str(m) for m in artist_mbids ] }
         return cls(
             user_id=user_id,
             user_name=user_name,
-            timestamp=j['listened_at'],
-            artist_msid=j['track_metadata']['additional_info'].get('artist_msid'),
-            release_msid=j['track_metadata']['additional_info'].get('release_msid'),
-            recording_msid=j['track_metadata']['additional_info'].get('recording_msid'),
-            dedup_tag=j.get('dedup_tag', 0),
+            timestamp=data['listened_at'],
+            artist_msid=data['track_metadata']['additional_info'].get('artist_msid'),
+            release_msid=data['track_metadata']['additional_info'].get('release_msid'),
+            recording_msid=data['track_metadata']['additional_info'].get('recording_msid'),
+            dedup_tag=data.get('dedup_tag', 0),
             inserted_timestamp=created,
-            data=j.get('track_metadata')
+            data=data.get('track_metadata')
         )
 
     def to_api(self):

--- a/listenbrainz/listenstore/listenstore.py
+++ b/listenbrainz/listenstore/listenstore.py
@@ -56,7 +56,7 @@ class ListenStore(object):
         """
         raise NotImplementedError()
 
-    def fetch_listens(self, user_id, from_ts=None, to_ts=None, limit=DEFAULT_LISTENS_PER_FETCH):
+    def fetch_listens(self, user, from_ts=None, to_ts=None, limit=DEFAULT_LISTENS_PER_FETCH):
         """ Check from_ts, to_ts, and limit for fetching listens
             and set them to default values if not given.
         """
@@ -67,4 +67,4 @@ class ListenStore(object):
         else:
             order = ORDER_DESC
 
-        return self.fetch_listens_from_storage(user_id, from_ts, to_ts, limit, order)
+        return self.fetch_listens_from_storage(user, from_ts, to_ts, limit, order)

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -243,13 +243,13 @@ class TestTimescaleListenStore(DatabaseTestCase):
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2, user2["id"])
 
-        recent = self.logstore.fetch_recent_listens_for_users([user["id"], user2["id"]], limit=1, max_age=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, max_age=10000000000)
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user["id"], user2["id"]], max_age=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], max_age=10000000000)
         self.assertEqual(len(recent), 4)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user["id"]], max_age=int(time()) -
+        recent = self.logstore.fetch_recent_listens_for_users([user], max_age=int(time()) -
                                                               recent[0].ts_since_epoch + 1)
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -379,7 +379,17 @@ class TimescaleListenStore(ListenStore):
                         break
 
                     user_name = user_id_map[result["user_id"]]
-                    listens.append(Listen.from_timescale(**result, user_name=user_name))
+                    listens.append(Listen.from_timescale(
+                        listened_at=result["listened_at"],
+                        track_name=result["track_name"],
+                        user_id=result["user_id"],
+                        created=result["created"],
+                        data=result["data"],
+                        recording_mbid=result["recording_mbid"],
+                        release_mbid=result["release_mbid"],
+                        artist_mbids=result["artist_mbids"],
+                        user_name=user_name
+                    ))
 
                     if len(listens) == limit:
                         done = True
@@ -432,8 +442,17 @@ class TimescaleListenStore(ListenStore):
                 if not result:
                     break
                 user_name = user_id_map[result["user_id"]]
-                listens.append(Listen.from_timescale(**result, user_name=user_name))
-
+                listens.append(Listen.from_timescale(
+                    listened_at=result["listened_at"],
+                    track_name=result["track_name"],
+                    user_id=result["user_id"],
+                    created=result["created"],
+                    data=result["data"],
+                    recording_mbid=result["recording_mbid"],
+                    release_mbid=result["release_mbid"],
+                    artist_mbids=result["artist_mbids"],
+                    user_name=user_name
+                ))
         return listens
 
     def get_listens_query_for_dump(self, start_time, end_time):
@@ -595,7 +614,17 @@ class TimescaleListenStore(ListenStore):
                             if not result:
                                 break
                             user_name = user_id_map[result["user_id"]]
-                            listen = Listen.from_timescale(**result, user_name=user_name).to_json()
+                            listen = Listen.from_timescale(
+                                listened_at=result["listened_at"],
+                                track_name=result["track_name"],
+                                user_id=result["user_id"],
+                                created=result["created"],
+                                data=result["data"],
+                                recording_mbid=result["recording_mbid"],
+                                release_mbid=result["release_mbid"],
+                                artist_mbids=result["artist_mbids"],
+                                user_name=user_name
+                            ).to_json()
                             out_file.write(ujson.dumps(listen) + "\n")
                             rows_added += 1
                     tar_file.add(filename, arcname=os.path.join(

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -422,7 +422,7 @@ class TimescaleListenStore(ListenStore):
             time.time()) - max_age, 'limit': limit}
         query = """SELECT * FROM (
                               SELECT listened_at, track_name, user_id, created, data, mm.recording_mbid, release_mbid, artist_mbids,
-                                     row_number() OVER (partition by user_name ORDER BY listened_at DESC) AS rownum
+                                     row_number() OVER (partition by user_id ORDER BY listened_at DESC) AS rownum
                                 FROM listen l
                      FULL OUTER JOIN mbid_mapping m
                                   ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = m.recording_msid
@@ -620,9 +620,6 @@ class TimescaleListenStore(ListenStore):
                                 user_id=result["user_id"],
                                 created=result["created"],
                                 data=result["data"],
-                                recording_mbid=result["recording_mbid"],
-                                release_mbid=result["release_mbid"],
-                                artist_mbids=result["artist_mbids"],
                                 user_name=user_name
                             ).to_json()
                             out_file.write(ujson.dumps(listen) + "\n")

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -420,7 +420,7 @@ class TimescaleListenStore(ListenStore):
                                   ON mm.recording_mbid = m.recording_mbid
                                WHERE user_id IN :user_ids
                                  AND listened_at > :ts
-                            GROUP BY user_name, listened_at, track_name, created, data, mm.recording_mbid, release_mbid, artist_mbids
+                            GROUP BY user_id, listened_at, track_name, created, data, mm.recording_mbid, release_mbid, artist_mbids
                             ORDER BY listened_at DESC) tmp
                                WHERE rownum <= :limit"""
 

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -594,8 +594,8 @@ class TimescaleListenStore(ListenStore):
                             result = curs.fetchone()
                             if not result:
                                 break
-
-                            listen = Listen.from_timescale(**result).to_json()
+                            user_name = user_id_map[result["user_id"]]
+                            listen = Listen.from_timescale(**result, user_name=user_name).to_json()
                             out_file.write(ujson.dumps(listen) + "\n")
                             rows_added += 1
                     tar_file.add(filename, arcname=os.path.join(

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -189,7 +189,7 @@ class APICompatTestCase(APICompatIntegrationTestCase):
 
         # Check if listen reached the timescale listenstore
         time.sleep(2)
-        listens, _, _ = self.ls.fetch_listens(self.lb_user['id'], from_ts=timestamp-1)
+        listens, _, _ = self.ls.fetch_listens(self.lb_user, from_ts=timestamp-1)
         self.assertEqual(len(listens), 1)
 
     def test_record_invalid_listen(self):
@@ -248,7 +248,7 @@ class APICompatTestCase(APICompatIntegrationTestCase):
 
         # Check if listens reached the timescale listenstore
         time.sleep(1)
-        listens, _, _ = self.ls.fetch_listens(self.lb_user['id'], from_ts=timestamp-1)
+        listens, _, _ = self.ls.fetch_listens(self.lb_user, from_ts=timestamp-1)
         self.assertEqual(len(listens), 2)
 
     def test_create_response_for_single_listen(self):

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -157,7 +157,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
         time.sleep(1)
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(self.user['id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(self.user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -57,7 +57,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
         recent = self.rs.get_recent_listens(4)
@@ -94,7 +94,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 
@@ -106,7 +106,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 
@@ -127,10 +127,10 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         time.sleep(2)  # sleep to allow timescale-writer to do its thing
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user1['id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user1, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
-        listens, _, _ = self.ls.fetch_listens(user2['id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user2, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
 
@@ -156,5 +156,5 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         time.sleep(2)
 
         to_ts = int(time.time())
-        listens, _, _ = self.ls.fetch_listens(user['id'], to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 4)

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -15,6 +15,7 @@ class ListenTestCase(unittest.TestCase):
             "created": 1525557084,
             "track_name": "Every Step Every Way",
             "user_name": "iliekcomputers",
+            "user_id": 1,
             "data": {
                 'track_metadata': {
                     "artist_name": "Majid Jordan",
@@ -41,9 +42,10 @@ class ListenTestCase(unittest.TestCase):
 
         listen = Listen.from_timescale(timescale_row['listened_at'],
                                        timescale_row['track_name'],
-                                       timescale_row['user_name'],
+                                       timescale_row['user_id'],
                                        timescale_row['created'],
-                                       timescale_row['data'])
+                                       timescale_row['data'],
+                                       user_name=timescale_row['user_name'])
 
         # Check user name
         self.assertEqual(listen.user_name, timescale_row['user_name'])

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -40,12 +40,7 @@ class ListenTestCase(unittest.TestCase):
             }
         }
 
-        listen = Listen.from_timescale(timescale_row['listened_at'],
-                                       timescale_row['track_name'],
-                                       timescale_row['user_id'],
-                                       timescale_row['created'],
-                                       timescale_row['data'],
-                                       user_name=timescale_row['user_name'])
+        listen = Listen.from_timescale(**timescale_row)
 
         # Check user name
         self.assertEqual(listen.user_name, timescale_row['user_name'])

--- a/listenbrainz/webserver/login/__init__.py
+++ b/listenbrainz/webserver/login/__init__.py
@@ -32,6 +32,16 @@ class User(UserMixin):
             login_id=user['login_id'],
         )
 
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "created": self.created,
+            "musicbrainz_id": self.musicbrainz_id,
+            "auth_token": self.auth_token,
+            "gdpr_agreed": self.gdpr_agreed,
+            "login_id": self.login_id
+        }
+
 @login_manager.user_loader
 def load_user(user_login_id):
     try:

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -134,7 +134,7 @@ def get_listens(user_name):
         raise APIBadRequest("min_ts should be less than max_ts")
 
     listens, _, max_ts_per_user = db_conn.fetch_listens(
-        user["id"],
+        user,
         limit=count,
         from_ts=min_ts,
         to_ts=max_ts

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -247,8 +247,7 @@ def get_recent_listens_for_user_list(user_list):
 
     db_conn = webserver.create_timescale(current_app)
     users = db_user.get_many_users_by_mb_id(users)
-    user_ids = [user["id"] for user in users.values()]
-    listens = db_conn.fetch_recent_listens_for_users(user_ids, limit=limit)
+    listens = db_conn.fetch_recent_listens_for_users(users, limit=limit)
 
     listen_data = []
     for listen in listens:

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -247,7 +247,7 @@ def get_recent_listens_for_user_list(user_list):
 
     db_conn = webserver.create_timescale(current_app)
     users = db_user.get_many_users_by_mb_id(users)
-    listens = db_conn.fetch_recent_listens_for_users(users, limit=limit)
+    listens = db_conn.fetch_recent_listens_for_users(users.values(), limit=limit)
 
     listen_data = []
     for listen in listens:

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -127,7 +127,7 @@ def fetch_listens(musicbrainz_id, to_ts):
     """
     db_conn = webserver.create_timescale(current_app)
     while True:
-        batch, _, _ = db_conn.fetch_listens(current_user.id, to_ts=to_ts, limit=EXPORT_FETCH_COUNT)
+        batch, _, _ = db_conn.fetch_listens(current_user.to_dict(), to_ts=to_ts, limit=EXPORT_FETCH_COUNT)
         if not batch:
             break
         yield from batch

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -192,7 +192,7 @@ class UserViewsTestCase(IntegrationTestCase):
     @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')
     def test_ts_filters(self, timescale):
         """Check that max_ts and min_ts are passed to timescale """
-        user = db_user.get(1)
+        user = User.from_dbrow(db_user.get(1)).to_dict()
         timescale.return_value = ([], 0, 0)
 
         # If no parameter is given, use current time as the to_ts

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -192,31 +192,31 @@ class UserViewsTestCase(IntegrationTestCase):
     @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')
     def test_ts_filters(self, timescale):
         """Check that max_ts and min_ts are passed to timescale """
-
+        user = self.user.to_dict()
         timescale.return_value = ([], 0, 0)
 
         # If no parameter is given, use current time as the to_ts
         self.client.get(url_for('user.profile', user_name='iliekcomputers'))
-        req_call = mock.call(1, limit=25, from_ts=None)
+        req_call = mock.call(user, limit=25, from_ts=None)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # max_ts query param -> to_ts timescale param
         self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'max_ts': 1520946000})
-        req_call = mock.call(1, limit=25, to_ts=1520946000)
+        req_call = mock.call(user, limit=25, to_ts=1520946000)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # min_ts query param -> from_ts timescale param
         self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'min_ts': 1520941000})
-        req_call = mock.call(1, limit=25, from_ts=1520941000)
+        req_call = mock.call(user, limit=25, from_ts=1520941000)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # If max_ts and min_ts set, only max_ts is used
         self.client.get(url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'min_ts': 1520941000, 'max_ts': 1520946000})
-        req_call = mock.call(1, limit=25, to_ts=1520946000)
+        req_call = mock.call(user, limit=25, to_ts=1520946000)
         timescale.assert_has_calls([req_call])
 
     @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -192,7 +192,7 @@ class UserViewsTestCase(IntegrationTestCase):
     @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')
     def test_ts_filters(self, timescale):
         """Check that max_ts and min_ts are passed to timescale """
-        user = self.user.to_dict()
+        user = db_user.get(1)
         timescale.return_value = ([], 0, 0)
 
         # If no parameter is given, use current time as the to_ts

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -99,7 +99,7 @@ def profile(user_name):
     else:
         args['from_ts'] = min_ts
     data, min_ts_per_user, max_ts_per_user = db_conn.fetch_listens(
-        user.id, limit=LISTENS_PER_PAGE, **args)
+        user.to_dict(), limit=LISTENS_PER_PAGE, **args)
 
     listens = []
     for listen in data:


### PR DESCRIPTION
The user_name column of listen table will soon go away. So we need to stop reading it from listen table in both dumps and fetch_listens. At both places, we should instead read user_names from primary LB db.