### PR TITLE
Update username whenever user logs in

### DIFF
--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -59,6 +59,14 @@ class UserTestCase(DatabaseTestCase):
         # after update_last_login, the val should be greater than the old value i.e 0
         self.assertGreater(int(user['last_login'].strftime('%s')), 0)
 
+    def test_update_user_details(self):
+        user_id = db_user.create(17, "barbazfoo", "barbaz@foo.com")
+        db_user.update_user_details(user_id, "hello-world", "hello-world@foo.com")
+        user = db_user.get(user_id, fetch_email=True)
+        self.assertEqual(user["id"], user_id)
+        self.assertEqual(user["musicbrainz_id"], "hello-world")
+        self.assertEqual(user["email"], "hello-world@foo.com")
+
     def test_get_all_users(self):
         """ Tests that get_all_users returns ALL users in the db """
 

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -516,7 +516,7 @@ def report_user(reporter_id: int, reported_id: int, reason: str = None):
 
 
 def update_user_details(lb_id: int, musicbrainz_id: str, email: str):
-    """ Update the email field for user with specified MusicBrainz ID
+    """ Update the email field and MusicBrainz ID of the user specified by the lb_id
 
     Args:
         lb_id: listenbrainz row id of the user

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -515,12 +515,13 @@ def report_user(reporter_id: int, reported_id: int, reason: str = None):
         })
 
 
-def update_user_email(musicbrainz_id, email):
+def update_user_details(lb_id: int, musicbrainz_id: str, email: str):
     """ Update the email field for user with specified MusicBrainz ID
 
     Args:
-        musicbrainz_id (str): MusicBrainz username of a user
-        email (str): email of a user
+        lb_id: listenbrainz row id of the user
+        musicbrainz_id: MusicBrainz username of a user
+        email: email of a user
     """
 
     with db.engine.connect() as connection:
@@ -528,8 +529,10 @@ def update_user_email(musicbrainz_id, email):
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
                    SET email = :email
-                 WHERE musicbrainz_id = :musicbrainz_id
+                     , musicbrainz_id = :musicbrainz_id
+                 WHERE id = :lb_id
                 """), {
+                "lb_id": lb_id,
                 "musicbrainz_id": musicbrainz_id,
                 "email": email
             })

--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -77,7 +77,7 @@ def get_user():
         user = dict(user)
         user["email"] = user_email
         # every time a user logs in, update the email in LB.
-        db_user.update_user_email(musicbrainz_id, user_email)
+        db_user.update_user_details(user["id"], musicbrainz_id, user_email)
 
     return user
 


### PR DESCRIPTION
And with this change, we fully support username changes in LB . Earlier PRs migrated various components to use LB user id instead of username. With this, whenever a user logs in their username will be updated in LB so that website uses the new username as well.
