### PR TITLE
Fix usage of InvalidAPIUsage exception

### DIFF
--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -208,7 +208,7 @@ def init_error_handlers(app):
 class InvalidAPIUsage(Exception):
     """ General error class for the API_compat to render errors in multiple formats """
 
-    def __init__(self, api_error, status_code=500, output_format="xml"):
+    def __init__(self, api_error: LastFMError, status_code=500, output_format="xml"):
         Exception.__init__(self)
         self.api_error = api_error
         self.status_code = status_code

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -8,7 +8,7 @@ from flask import Blueprint, request, render_template, current_app
 from flask_login import login_required, current_user
 from brainzutils.ratelimit import ratelimit
 from brainzutils.musicbrainz_db import engine as mb_engine
-from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError, ListenValidationError
+from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError, ListenValidationError, LastFMError
 import xmltodict
 
 from listenbrainz.webserver.models import SubmitListenUserMetadata
@@ -277,7 +277,9 @@ def record_listens(request, data):
     try:
         validated_payload = [validate_listen(listen, listen_type) for listen in native_payload]
     except ListenValidationError as err:
-        raise InvalidAPIUsage(err.message, 400, output_format)
+        # Unsure about which LastFMError code to use but 5 or 6 probably make the most sense.
+        # see listenbrainz.webserver.errors.py for a detailed list of all available codes
+        raise InvalidAPIUsage(LastFMError(code=6, message=err.message), 400, output_format)
 
     user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])
     augmented_listens = insert_payload(validated_payload, user_metadata, listen_type=listen_type)


### PR DESCRIPTION
The first parameter to InvalidAPIUsage should be a LastFMError object. This is case everywhere except during listen validation, fix that by wrapping the message in a LastFMError with a suitable code.