### PR TITLE
Check user_id has a corresponding user_name before accessing

### DIFF
--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -465,6 +465,7 @@ class TimescaleListenStore(ListenStore):
                      FROM listen
                     WHERE listened_at >= :start_time
                       AND listened_at <= :end_time
+                      AND user_id != 0
                  ORDER BY listened_at ASC"""
         args = {
             'start_time': start_time,
@@ -483,6 +484,7 @@ class TimescaleListenStore(ListenStore):
                      FROM listen
                     WHERE created > :start_ts
                       AND created <= :end_ts
+                      AND user_id != 0
                  ORDER BY created ASC"""
 
         args = {
@@ -764,6 +766,7 @@ class TimescaleListenStore(ListenStore):
                        ON mm.recording_mbid = m.recording_mbid
                     WHERE {criteria} > %(start)s
                       AND {criteria} <= %(end)s
+                      AND user_id != 0
                  ORDER BY {criteria} ASC""").format(criteria=psycopg2.sql.Identifier(criteria))
 
         listen_count = 0


### PR DESCRIPTION
I had triggered full dumps after deploying user_id stuff so that spark stuff could be migrated. The normal listens dump at that time failed because a user_id didn't not have a corresponding user_name in the dict. I investigated and discovered that this was the cause:
- All usernames stored in a dict
- New user registers and submit listens
- Query fetches those listens, the user_id does not have a user_name causes a KeyError.

This is possible during incremental dumps too but there dump completes within 2-3 minutes so the issue is rare to occur there but full dumps take over 12 hours to complete so the chances are high. The current fix applies to both queries anyways.

This is a case I haven't previously thought out in depth, what happens when a user registers in the middle of a full dump and submits listen. For normal listens dumps, any behaviour is probably fine but for spark dumps this can cause inconsistent stats for the user for a while. Note that spark dumps are infact not affected by this because there is no use user_name there but still it is worthwhile to know what the current behaviour for this situation is in spark dumps.

For now, let's roll the current fix and keep dumps working.