### PR TITLE
Fix migration of user_name -> user_id in Spark related stuff

### DIFF
--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -130,7 +130,7 @@ def get_top_similar_users(count: int = 200):
             result = connection.execute("""
                 SELECT u.musicbrainz_id AS user_name
                      , ou.musicbrainz_id AS other_user_name
-                     , value->1 AS similarity -- first element of array is similarity, second is global_similarity
+                     , value->2 AS similarity -- first element of array is similarity, second is global_similarity
                   FROM recommendation.similar_user r 
                   JOIN jsonb_each(r.similar_users) j
                     ON TRUE

--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -34,7 +34,7 @@ def import_user_similarities(data):
             curs.execute(
                 """DROP TABLE IF EXISTS recommendation.similar_user_import""")
             curs.execute("""CREATE TABLE recommendation.similar_user_import  (
-                                user_name     VARCHAR NOT NULL,
+                                user_id     INTEGER NOT NULL,
                                 similar_users JSONB)""")
             query = "INSERT INTO recommendation.similar_user_import VALUES %s"
             values = []
@@ -68,7 +68,7 @@ def import_user_similarities(data):
                                         SELECT id AS user_id, similar_users
                                           FROM recommendation.similar_user_import
                                           JOIN "user"
-                                            ON user_name = musicbrainz_id""")
+                                            ON user_id = "user".id""")
 
             curs.execute("""DROP TABLE recommendation.similar_user_import""")
 
@@ -134,7 +134,7 @@ def get_top_similar_users(count: int = 200, global_similarity: bool = False):
     try:
         with conn.cursor() as curs:
             curs.execute("""SELECT musicbrainz_id AS user_name, similar_users
-                             FROM  recommendation.similar_user su
+                              FROM recommendation.similar_user su
                               JOIN "user" u
                                 ON user_id = u.id""")
 

--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -125,10 +125,9 @@ def get_top_similar_users(count: int = 200):
         per user) scale.
     """
     similar_users = {}
-    conn = db.engine.raw_connection()
     try:
-        with conn.cursor() as curs:
-            curs.execute("""
+        with db.engine.connect() as connection:
+            result = connection.execute("""
                 SELECT u.musicbrainz_id AS user_name
                      , ou.musicbrainz_id AS other_user_name
                      , value->1 AS similarity -- first element of array is similarity, second is global_similarity
@@ -141,7 +140,7 @@ def get_top_similar_users(count: int = 200):
                    ON r.user_id = u.id -- user_name of the user_id stored directly in column
             """)
             while True:
-                row = curs.fetchone()
+                row = result.fetchone()
                 if not row:
                     break
                 user = row["user_name"]

--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -130,7 +130,7 @@ def get_top_similar_users(count: int = 200):
             result = connection.execute("""
                 SELECT u.musicbrainz_id AS user_name
                      , ou.musicbrainz_id AS other_user_name
-                     , value->2 AS similarity -- first element of array is similarity, second is global_similarity
+                     , value->1 AS similarity -- first element of array is similarity, second is global_similarity
                   FROM recommendation.similar_user r 
                   JOIN jsonb_each(r.similar_users) j
                     ON TRUE

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -121,7 +121,6 @@ def insert_multiple_user_jsonb_data(data):
     try:
         with connection.cursor() as cursor:
             execute_values(cursor, formatted_query, values)
-            current_app.logger.info("Row Count: %d", cursor.rowcount)
         connection.commit()
     except psycopg2.errors.OperationalError:
         connection.rollback()

--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -19,9 +19,9 @@ class SimilarUserTestCase(DatabaseTestCase):
 
         with db.engine.connect() as connection:
             connection.execute(sqlalchemy.text("""INSERT INTO recommendation.similar_user (user_id, similar_users)
-                                                       VALUES (1, '{ "jerry" : [0.42, 0.01] }')"""))
+                                                       VALUES (1, '{ "2" : [0.42, 0.01] }')"""))
             connection.execute(sqlalchemy.text("""INSERT INTO recommendation.similar_user (user_id, similar_users)
-                                                       VALUES (2, '{ "tom" : [0.42, 0.02] }')"""))
+                                                       VALUES (2, '{ "1" : [0.42, 0.02] }')"""))
 
         similar_users = get_top_similar_users()
         assert len(similar_users) == 1

--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -1,11 +1,5 @@
-# -*- coding: utf-8 -*-
-
 import listenbrainz.db.user as db_user
-import listenbrainz.db.spotify as db_spotify
-import listenbrainz.db.stats as db_stats
 import sqlalchemy
-import time
-import ujson
 
 from listenbrainz import db
 from listenbrainz.db.testing import DatabaseTestCase
@@ -13,15 +7,16 @@ from listenbrainz.db.similar_users import get_top_similar_users
 
 
 class SimilarUserTestCase(DatabaseTestCase):
+
     def test_fetch_top_similar_users(self):
         user_id = db_user.create(1, "tom")
         user_id2 = db_user.create(2, "jerry")
 
         with db.engine.connect() as connection:
-            connection.execute(sqlalchemy.text("""INSERT INTO recommendation.similar_user (user_id, similar_users)
-                                                       VALUES (1, '{ "2" : [0.42, 0.01] }')"""))
-            connection.execute(sqlalchemy.text("""INSERT INTO recommendation.similar_user (user_id, similar_users)
-                                                       VALUES (2, '{ "1" : [0.42, 0.02] }')"""))
+            connection.execute(sqlalchemy.text("""
+                INSERT INTO recommendation.similar_user (user_id, similar_users)
+                     VALUES (1, '{ "2" : [0.42, 0.01] }'), (2, '{ "1" : [0.42, 0.02] }')
+            """))
 
         similar_users = get_top_similar_users()
         assert len(similar_users) == 1
@@ -29,7 +24,7 @@ class SimilarUserTestCase(DatabaseTestCase):
         assert similar_users[0][1] == 'tom'
         assert similar_users[0][2] == "0.420"
 
-        similar_users = get_top_similar_users(global_similarity=True)
+        similar_users = get_top_similar_users()
         assert len(similar_users) == 1
         assert similar_users[0][0] == 'jerry'
         assert similar_users[0][1] == 'tom'

--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -22,10 +22,4 @@ class SimilarUserTestCase(DatabaseTestCase):
         assert len(similar_users) == 1
         assert similar_users[0][0] == 'jerry'
         assert similar_users[0][1] == 'tom'
-        assert similar_users[0][2] == "0.420"
-
-        similar_users = get_top_similar_users()
-        assert len(similar_users) == 1
-        assert similar_users[0][0] == 'jerry'
-        assert similar_users[0][1] == 'tom'
         assert similar_users[0][2] == "0.020"

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -181,14 +181,14 @@ class UserTestCase(DatabaseTestCase):
         user_id_22 = db_user.create(22, "twenty_two")
         user_id_23 = db_user.create(23, "twenty_three")
 
-        similar_users_21 = {"twenty_two": [0.4, .01], "twenty_three": [0.7, 0.001]}
-        similar_users_22 = {"twenty_one": [0.4, .01]}
-        similar_users_23 = {"twenty_one": [0.7, .02]}
+        similar_users_21 = {str(user_id_22): [0.4, .01], str(user_id_23): [0.7, 0.001]}
+        similar_users_22 = {str(user_id_21): [0.4, .01]}
+        similar_users_23 = {str(user_id_21): [0.7, .02]}
 
         similar_users = {
-            "twenty_one": similar_users_21,
-            "twenty_two": similar_users_22,
-            "twenty_three": similar_users_23,
+            str(user_id_21): similar_users_21,
+            str(user_id_22): similar_users_22,
+            str(user_id_23): similar_users_23,
         }
 
         import_user_similarities(similar_users)
@@ -227,16 +227,20 @@ class UserTestCase(DatabaseTestCase):
 
     def test_search(self):
         searcher_id = db_user.create(0, "Cécile")
-        db_user.create(1, "Cecile")
-        db_user.create(2, "lucifer")
-        db_user.create(3, "rob")
+        user_id_c = db_user.create(1, "Cecile")
+        user_id_l = db_user.create(2, "lucifer")
+        user_id_r = db_user.create(3, "rob")
 
         with db.engine.connect() as connection:
-            connection.execute(sqlalchemy.text("""INSERT INTO recommendation.similar_user (user_id, similar_users)
-                                                       VALUES (:user_id, :similar_users)"""), {
-                "user_id": searcher_id,
-                "similar_users": json.dumps({"Cecile": [0.42, 0.20], "lucifer": [0.61, 0.25], "rob": [0.87, 0.43]})
-            })
+            connection.execute(sqlalchemy.text(
+                "INSERT INTO recommendation.similar_user (user_id, similar_users) VALUES (:user_id, :similar_users)"),
+                user_id=searcher_id,
+                similar_users=json.dumps({
+                    str(user_id_c): [0.42, 0.20],
+                    str(user_id_l): [0.61, 0.25],
+                    str(user_id_r): [0.87, 0.43]
+                })
+            )
 
         results = db_user.search("cif", 10, searcher_id)
         self.assertEqual(results, [("Cécile", 0.1, None), ("Cecile", 0.1, 0.42), ("lucifer", 0.0909091, 0.61)])

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -451,7 +451,7 @@ def get_similar_users(user_id: int) -> Optional[SimilarUsers]:
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT musicbrainz_id AS user_name
-                 , value->0 AS similarity -- first element of array is similarity, second is global_similarity
+                 , value->1 AS similarity -- first element of array is local similarity, second is global_similarity
               FROM recommendation.similar_user r 
               JOIN jsonb_each(r.similar_users) j
                 ON TRUE

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -451,7 +451,7 @@ def get_similar_users(user_id: int) -> Optional[SimilarUsers]:
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
             SELECT musicbrainz_id AS user_name
-                 , value->1 AS similarity -- first element of array is local similarity, second is global_similarity
+                 , value->0 AS similarity -- first element of array is local similarity, second is global_similarity
               FROM recommendation.similar_user r 
               JOIN jsonb_each(r.similar_users) j
                 ON TRUE

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -58,16 +58,15 @@ def handle_user_entity(data):
 
 
 def _handle_user_activity_stats(stats_type, stats_model, data):
-    musicbrainz_id = data['musicbrainz_id']
-    user = db_user.get_by_mb_id(musicbrainz_id)
+    user = db_user.get(data['user_id'])
     if not user:
-        current_app.logger.info("Calculated stats for a user that doesn't exist in the Postgres database: %s", musicbrainz_id)
+        current_app.logger.info("Calculated stats for a user that doesn't exist in the Postgres database: %s", data["user_id"])
         return
 
     # send a notification if this is a new batch of stats
     if is_new_user_stats_batch():
         notify_user_stats_update(stat_type=data.get('type', ''))
-    current_app.logger.debug("inserting stats for user %s", musicbrainz_id)
+    current_app.logger.debug("inserting stats for user %s", user["musicbrainz_id"])
     stats_range = data['stats_range']
 
     try:

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -164,7 +164,7 @@ class HandlersTestCase(DatabaseTestCase):
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_handle_user_daily_activity(self, mock_send_mail, mock_new_user_stats, mock_get_by_mb_id, mock_db_insert):
         data = {
-            'musicbrainz_id': 1,
+            'user_id': 1,
             'type': 'daily_activity',
             'stats_range': 'all_time',
             'from_ts': 1,
@@ -247,7 +247,7 @@ class HandlersTestCase(DatabaseTestCase):
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
     def test_handle_recommendations(self, mock_get_by_mb_id, mock_db_insert):
         data = {
-            'musicbrainz_id': 1,
+            'user_id': 1,
             'type': 'cf_recording_recommendations',
             'recommendations': {
                 'top_artist': [
@@ -483,12 +483,14 @@ class HandlersTestCase(DatabaseTestCase):
         with self.app.app_context():
             handle_missing_musicbrainz_data(data)
 
-        mock_db_insert.assert_called_with(1, UserMissingMusicBrainzDataJson(
-            missing_musicbrainz_data=[UserMissingMusicBrainzDataRecord(
-                artist_name="Katty Peri",
-                listened_at="2020-04-29 23:56:23",
-                release_name="No Place Is Home",
-                recording_name="How High"
-            )]),
-                                          'cf'
-                                          )
+        mock_db_insert.assert_called_with(
+            1,
+            UserMissingMusicBrainzDataJson(
+                missing_musicbrainz_data=[UserMissingMusicBrainzDataRecord(
+                    artist_name="Katty Peri",
+                    listened_at="2020-04-29 23:56:23",
+                    release_name="No Place Is Home",
+                    recording_name="How High"
+                )]),
+            'cf'
+        )

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -116,14 +116,13 @@ class HandlersTestCase(DatabaseTestCase):
         )
         self.assertEqual(received, expected)
 
-
     @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_jsonb_data')
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
     @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_handle_user_listening_activity(self, mock_send_mail, mock_new_user_stats, mock_get_by_mb_id, mock_db_insert):
         data = {
-            'musicbrainz_id': 'iliekcomputers',
+            'user_id': 1,
             'type': 'listening_activity',
             'stats_range': 'all_time',
             'from_ts': 1,
@@ -165,7 +164,7 @@ class HandlersTestCase(DatabaseTestCase):
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_handle_user_daily_activity(self, mock_send_mail, mock_new_user_stats, mock_get_by_mb_id, mock_db_insert):
         data = {
-            'musicbrainz_id': 'iliekcomputers',
+            'musicbrainz_id': 1,
             'type': 'daily_activity',
             'stats_range': 'all_time',
             'from_ts': 1,
@@ -248,7 +247,7 @@ class HandlersTestCase(DatabaseTestCase):
     @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
     def test_handle_recommendations(self, mock_get_by_mb_id, mock_db_insert):
         data = {
-            'musicbrainz_id': 'vansika',
+            'musicbrainz_id': 1,
             'type': 'cf_recording_recommendations',
             'recommendations': {
                 'top_artist': [
@@ -467,7 +466,7 @@ class HandlersTestCase(DatabaseTestCase):
     def test_handle_missing_musicbrainz_data(self, mock_get_by_mb_id, mock_db_insert):
         data = {
             'type': 'missing_musicbrainz_data',
-            'musicbrainz_id': 'vansika',
+            'user_id': 1,
             'missing_musicbrainz_data': [
                 {
                     "artist_name": "Katty Peri",

--- a/listenbrainz/spark/test_handlers.py
+++ b/listenbrainz/spark/test_handlers.py
@@ -117,10 +117,10 @@ class HandlersTestCase(DatabaseTestCase):
         self.assertEqual(received, expected)
 
     @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_jsonb_data')
-    @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
+    @mock.patch('listenbrainz.spark.handlers.db_user.get')
     @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
-    def test_handle_user_listening_activity(self, mock_send_mail, mock_new_user_stats, mock_get_by_mb_id, mock_db_insert):
+    def test_handle_user_listening_activity(self, mock_send_mail, mock_new_user_stats, mock_get, mock_db_insert):
         data = {
             'user_id': 1,
             'type': 'listening_activity',
@@ -134,7 +134,7 @@ class HandlersTestCase(DatabaseTestCase):
                 'listen_count': 200,
             }],
         }
-        mock_get_by_mb_id.return_value = {'id': 1, 'musicbrainz_id': 'iliekcomputers'}
+        mock_get.return_value = {'id': 1, 'musicbrainz_id': 'iliekcomputers'}
         mock_new_user_stats.return_value = True
 
         with self.app.app_context():
@@ -159,10 +159,10 @@ class HandlersTestCase(DatabaseTestCase):
         mock_send_mail.assert_called_once()
 
     @mock.patch('listenbrainz.spark.handlers.db_stats.insert_user_jsonb_data')
-    @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
+    @mock.patch('listenbrainz.spark.handlers.db_user.get')
     @mock.patch('listenbrainz.spark.handlers.is_new_user_stats_batch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
-    def test_handle_user_daily_activity(self, mock_send_mail, mock_new_user_stats, mock_get_by_mb_id, mock_db_insert):
+    def test_handle_user_daily_activity(self, mock_send_mail, mock_new_user_stats, mock_get, mock_db_insert):
         data = {
             'user_id': 1,
             'type': 'daily_activity',
@@ -175,7 +175,7 @@ class HandlersTestCase(DatabaseTestCase):
                 'listen_count': 20,
             }],
         }
-        mock_get_by_mb_id.return_value = {'id': 1, 'musicbrainz_id': 'iliekcomputers'}
+        mock_get.return_value = {'id': 1, 'musicbrainz_id': 'iliekcomputers'}
         mock_new_user_stats.return_value = True
 
         with self.app.app_context():
@@ -244,8 +244,8 @@ class HandlersTestCase(DatabaseTestCase):
         self.assertTrue(is_new_user_stats_batch())
 
     @mock.patch('listenbrainz.spark.handlers.db_recommendations_cf_recording.insert_user_recommendation')
-    @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
-    def test_handle_recommendations(self, mock_get_by_mb_id, mock_db_insert):
+    @mock.patch('listenbrainz.spark.handlers.db_user.get')
+    def test_handle_recommendations(self, mock_get, mock_db_insert):
         data = {
             'user_id': 1,
             'type': 'cf_recording_recommendations',
@@ -264,7 +264,7 @@ class HandlersTestCase(DatabaseTestCase):
             }
         }
 
-        mock_get_by_mb_id.return_value = {'id': 1, 'musicbrainz_id': 'vansika'}
+        mock_get.return_value = {'id': 1, 'musicbrainz_id': 'vansika'}
         with self.app.app_context():
             handle_recommendations(data)
 
@@ -462,8 +462,8 @@ class HandlersTestCase(DatabaseTestCase):
             mock_send_mail.assert_called_once()
 
     @mock.patch('listenbrainz.spark.handlers.db_missing_musicbrainz_data.insert_user_missing_musicbrainz_data')
-    @mock.patch('listenbrainz.spark.handlers.db_user.get_by_mb_id')
-    def test_handle_missing_musicbrainz_data(self, mock_get_by_mb_id, mock_db_insert):
+    @mock.patch('listenbrainz.spark.handlers.db_user.get')
+    def test_handle_missing_musicbrainz_data(self, mock_get, mock_db_insert):
         data = {
             'type': 'missing_musicbrainz_data',
             'user_id': 1,
@@ -478,7 +478,7 @@ class HandlersTestCase(DatabaseTestCase):
             'source': 'cf'
         }
 
-        mock_get_by_mb_id.return_value = {'id': 1, 'musicbrainz_id': 'vansika'}
+        mock_get.return_value = {'id': 1, 'musicbrainz_id': 'vansika'}
 
         with self.app.app_context():
             handle_missing_musicbrainz_data(data)

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -583,7 +583,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
         conn = db.engine.raw_connection()
         with conn.cursor() as curs:
-            data = {self.user2['musicbrainz_id']: (.123, 0.01)}
+            data = {self.user2['user_id']: (.123, 0.01)}
             curs.execute("""INSERT INTO recommendation.similar_user VALUES (%s, %s)""",
                          (self.user['id'], json.dumps(data)))
         conn.commit()

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -583,7 +583,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
         conn = db.engine.raw_connection()
         with conn.cursor() as curs:
-            data = {self.user2['user_id']: (.123, 0.01)}
+            data = {self.user2['id']: (.123, 0.01)}
             curs.execute("""INSERT INTO recommendation.similar_user VALUES (%s, %s)""",
                          (self.user['id'], json.dumps(data)))
         conn.commit()

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -286,9 +286,6 @@ def get_similar_users(user_name):
         raise APINotFound("User %s not found" % user_name)
 
     similar_users = db_user.get_similar_users(user['id'])
-    if not similar_users:
-        return jsonify({'payload': []})
-
     response = []
     for user_name in similar_users.similar_users:
         response.append({
@@ -326,7 +323,7 @@ def get_similar_to_user(user_name, other_user_name):
     similar_users = db_user.get_similar_users(user['id'])
     try:
         return jsonify({'payload': {"user_name": other_user_name, "similarity": similar_users.similar_users[other_user_name]}})
-    except KeyError:
+    except (KeyError, AttributeError):
         raise APINotFound("Similar-to user not found")
 
 

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -273,7 +273,7 @@ def similar_users():
         and spammers as well.
     """
 
-    similar_users = get_top_similar_users(global_similarity=True)
+    similar_users = get_top_similar_users()
     return render_template(
         "index/similar-users.html",
         similar_users=similar_users

--- a/listenbrainz_spark/user_similarity/user_similarity.py
+++ b/listenbrainz_spark/user_similarity/user_similarity.py
@@ -38,8 +38,10 @@ def create_messages(similar_users_df: DataFrame) -> dict:
     itr = similar_users_df.toLocalIterator()
     message = {}
     for row in itr:
-        message[row.spark_user_id] = {
-            user.other_spark_user_id: (user.similarity, user.global_similarity) for user in row.similar_users}
+        message[row.user_id] = {
+            user.other_user_id: (user.similarity, user.global_similarity)
+            for user in row.similar_users
+        }
     yield {
         'type': 'similar_users',
         'data': message

--- a/listenbrainz_spark/user_similarity/user_similarity.py
+++ b/listenbrainz_spark/user_similarity/user_similarity.py
@@ -38,8 +38,8 @@ def create_messages(similar_users_df: DataFrame) -> dict:
     itr = similar_users_df.toLocalIterator()
     message = {}
     for row in itr:
-        message[row.user_id] = {
-            user.other_user_id: (user.similarity, user.global_similarity) for user in row.similar_users}
+        message[row.spark_user_id] = {
+            user.other_spark_user_id: (user.similarity, user.global_similarity) for user in row.similar_users}
     yield {
         'type': 'similar_users',
         'data': message
@@ -119,7 +119,7 @@ def threshold_similar_users(matrix: ndarray, max_num_users: int) -> List[Tuple[i
 
 def get_vectors_df(playcounts_df):
     """
-    Each row of playcounts_df has the following columns: recording_id, user_id and a play count denoting how many times
+    Each row of playcounts_df has the following columns: recording_id, spark_user_id and a play count denoting how many times
     a user has played that recording. However, the correlation matrix requires a dataframe having a column of user
     vectors. Spark has various representations built-in for storing sparse matrices. Of these, two are Coordinate
     Matrix and Indexed Row Matrix. A coordinate matrix stores the matrix as tuples of (i, j, x) where matrix[i, j] = x.
@@ -131,7 +131,7 @@ def get_vectors_df(playcounts_df):
     form. Spark ML and MLlib have different representations of vectors, hence we need to manually convert between the
     two. Finally, we take the rows and create a dataframe from them.
     """
-    tuple_mapped_rdd = playcounts_df.rdd.map(lambda x: MatrixEntry(x["recording_id"], x["user_id"], x["count"]))
+    tuple_mapped_rdd = playcounts_df.rdd.map(lambda x: MatrixEntry(x["recording_id"], x["spark_user_id"], x["count"]))
     coordinate_matrix = CoordinateMatrix(tuple_mapped_rdd)
     indexed_row_matrix = coordinate_matrix.toIndexedRowMatrix()
     vectors_mapped_rdd = indexed_row_matrix.rows.map(lambda r: (r.index, r.vector.asML()))
@@ -164,15 +164,17 @@ def get_similar_users_df(max_num_users: int):
     # Due to an unresolved bug in Spark (https://issues.apache.org/jira/browse/SPARK-10925), we cannot join twice on
     # the same dataframe. Hence, we create a modified dataframe with the columns renamed.
     other_users_df = users_df\
-        .withColumnRenamed('user_id', 'other_user_id')\
-        .withColumnRenamed('user_name', 'other_user_name')
+        .withColumnRenamed('spark_user_id', 'other_spark_user_id')\
+        .withColumnRenamed('user_id', 'other_user_id')
 
-    similar_users_df = listenbrainz_spark.session.createDataFrame(similar_users, ['user_id', 'other_user_id',
-        'similarity', 'global_similarity'])\
-        .join(users_df, 'user_id', 'inner')\
-        .join(other_users_df, 'other_user_id', 'inner')\
-        .select('user_name', struct('other_user_name', 'similarity', 'global_similarity').alias('similar_user'))\
-        .groupBy('user_name')\
+    similar_users_df = listenbrainz_spark.session.createDataFrame(
+        similar_users,
+        ['spark_user_id', 'other_spark_user_id', 'similarity', 'global_similarity']
+    )\
+        .join(users_df, 'spark_user_id', 'inner')\
+        .join(other_users_df, 'other_spark_user_id', 'inner')\
+        .select('user_id', struct('other_user_id', 'similarity', 'global_similarity').alias('similar_user'))\
+        .groupBy('user_id')\
         .agg(collect_list('similar_user').alias('similar_users'))
 
     logger.info('Finishing generating similar user matrix')


### PR DESCRIPTION
Looking through sentry errors for the regular spark jobs, I found I had missed multiple places to change user_name -> user_id in spark and spark handlers. These changes are necessary to keep spark jobs working in prod and are currently deployed in prod as well.