### PR TITLE
Refactor fetch_listen methods

### DIFF
--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -184,14 +184,13 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2, user2["id"])
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, min_ts=int(time()) - 10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, min_ts=10000000000)
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=int(time()) - 10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=10000000000)
         self.assertEqual(len(recent), 4)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=int(time()) - recent[0].ts_since_epoch + 1)
-        print(recent)
+        recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=1400000160)
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)
 

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -184,13 +184,13 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2, user2["id"])
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, min_ts=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, min_ts=int(time()) - 10000000000)
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=int(time()) - 10000000000)
         self.assertEqual(len(recent), 4)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=1400000160)
+        recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=recent[0].ts_since_epoch - 1)
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)
 

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -10,7 +10,7 @@ from brainzutils import cache
 import listenbrainz.db.user as db_user
 from listenbrainz.db import timescale as ts
 from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
-from listenbrainz.listenstore.tests.util import create_test_data_for_timescalelistenstore, generate_data
+from listenbrainz.listenstore.tests.util import create_test_data_for_timescalelistenstore
 from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT, REDIS_USER_TIMESTAMPS, \
     TimescaleListenStore
 
@@ -184,14 +184,13 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2, user2["id"])
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, max_age=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, min_ts=int(time()) - 10000000000)
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], max_age=10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=int(time()) - 10000000000)
         self.assertEqual(len(recent), 4)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user], max_age=int(time()) -
-                                                              recent[0].ts_since_epoch + 1)
+        recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=int(time()) - recent[0].ts_since_epoch + 1)
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)
 

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -191,6 +191,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(len(recent), 4)
 
         recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=int(time()) - recent[0].ts_since_epoch + 1)
+        print(recent)
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)
 

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -81,6 +81,8 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         self.assert200(response)
         payload = response.json['payload']
 
+        print(payload)
+
         # the payload contains events for the users we've followed, but we don't care about those
         # for now, so let's remove them for this test.
         payload = self.remove_own_follow_events(payload)
@@ -155,6 +157,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             query_string={'min_ts': ts + 1}
         )
         self.assert200(r)
+        print(payload)
         payload = self.remove_own_follow_events(r.json['payload'])
         self.assertEqual(4, payload['count'])
 
@@ -223,7 +226,6 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(self.main_user['musicbrainz_id'], r.json['payload']['events'][2]['metadata']['user_name_0'])
         self.assertEqual(self.following_user_1['musicbrainz_id'], r.json['payload']['events'][2]['metadata']['user_name_1'])
         self.assertEqual('follow', r.json['payload']['events'][2]['metadata']['relationship_type'])
-
 
     def test_it_returns_recording_recommendation_events(self):
         # create a recording recommendation ourselves

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -81,8 +81,6 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         self.assert200(response)
         payload = response.json['payload']
 
-        print(payload)
-
         # the payload contains events for the users we've followed, but we don't care about those
         # for now, so let's remove them for this test.
         payload = self.remove_own_follow_events(payload)
@@ -157,7 +155,6 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             query_string={'min_ts': ts + 1}
         )
         self.assert200(r)
-        print(payload)
         payload = self.remove_own_follow_events(r.json['payload'])
         self.assertEqual(4, payload['count'])
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -1,3 +1,4 @@
+import time
 from operator import itemgetter
 
 import psycopg2
@@ -242,7 +243,12 @@ def get_recent_listens_for_user_list(user_list):
         raise APIBadRequest("user_list is empty or invalid.")
 
     users = db_user.get_many_users_by_mb_id(users)
-    listens = timescale_connection._ts.fetch_recent_listens_for_users(users.values(), limit=limit)
+    listens = timescale_connection._ts.fetch_recent_listens_for_users(
+        users.values(),
+        min_ts=int(time.time()) - 3600,
+        max_ts=None,
+        limit=limit
+    )
     listen_data = []
     for listen in listens:
         listen_data.append(listen.to_api())

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -298,23 +298,16 @@ def get_listen_events(
 ) -> List[APITimelineEvent]:
     """ Gets all listen events in the feed.
     """
-
-    # NOTE: For now, we get a bunch of listens for the users the current
-    # user is following and take a max of 2 out of them per user. This
-    # could be done better by writing a complex query to get exactly 2 listens for each user,
-    # but I'm happy with this heuristic for now and we can change later.
-    listens, _, _ = timescale_connection._ts.fetch_listens_for_multiple_users_from_storage(
+    listens, _, _ = timescale_connection._ts.fetch_recent_listens_for_users(
         users,
+        min_ts=min_ts,
+        max_ts=max_ts,
         limit=count,
-        from_ts=min_ts,
-        to_ts=max_ts,
-        order=0,  # descending
     )
 
     user_listens_map = defaultdict(list)
     for listen in listens:
-        if len(user_listens_map[listen.user_name]) < MAX_LISTEN_EVENTS_PER_USER:
-            user_listens_map[listen.user_name].append(listen)
+        user_listens_map[listen.user_name].append(listen)
 
     events = []
     for user in user_listens_map:

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -186,7 +186,7 @@ def user_feed(user_name: str):
     if len(users_following) == 0:
         listen_events = []
     else:
-        listen_events = get_listen_events(users_following, min_ts, max_ts, count)
+        listen_events = get_listen_events(users_following, min_ts, max_ts)
 
     # for events like "follow" and "recording recommendations", we want to show the user
     # their own events as well
@@ -294,7 +294,6 @@ def get_listen_events(
     users: List[Dict],
     min_ts: int,
     max_ts: int,
-    count: int,
 ) -> List[APITimelineEvent]:
     """ Gets all listen events in the feed.
     """
@@ -302,7 +301,7 @@ def get_listen_events(
         users,
         min_ts=min_ts,
         max_ts=max_ts,
-        limit=count,
+        limit=MAX_LISTEN_EVENTS_PER_USER,
     )
 
     events = []


### PR DESCRIPTION
We have 3 main entry points to fetch listens: user's get-listens, get-recent-listens endpoint and feed listen events. The first one only fetches the listens of 1 user and the other fetch listens for multiple users.

While working on migrating timestamp stuff, I saw that the feed listen events had a note to use an alternative query in the future. So it happens that query already exists in another name fetch_recent_listens_for_users. Modify the feed endpoint to use that method. Incidentally, this allows to simplify a chain of other fetch_listen methods.