### PR TITLE
Remove get_recent_listens_for_user_list api endpoint

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -129,14 +129,6 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(data['listens'][0]['track_metadata']
                          ['release_name'], 'The Life of Pablo')
 
-        # check that recent listens are fetched correctly
-        url = url_for('api_v1.get_recent_listens_for_user_list',
-                      user_list=self.user['musicbrainz_id'])
-        response = self.client.get(url, query_string={'limit': '1'})
-        self.assert200(response)
-        data = json.loads(response.data)['payload']
-        self.assertEqual(data['count'], 1)
-
         url = url_for('api_v1.get_listen_count',
                       user_name=self.user['musicbrainz_id'])
         response = self.client.get(url)


### PR DESCRIPTION
This endpoint is not used by LB frontend, and we found only a very low number of requests from 2 external users for this endpoint in logs. We reached out to one of those in the IRC channel and found that the requests were being triggered by CI for a client library. The request pattern of the other user also resembles that of a CI, so we believe there are no users for this endpoint and hence removing.