### PR TITLE
Apply overall limit to listen events in feed

### DIFF
--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -184,7 +184,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2, user2["id"])
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], limit=1, min_ts=int(time()) - 10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], per_user_limit=1, min_ts=int(time()) - 10000000000)
         self.assertEqual(len(recent), 2)
 
         recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=int(time()) - 10000000000)

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -360,19 +360,20 @@ class TimescaleListenStore:
 
         return listens, min_user_ts, max_user_ts
 
-    def fetch_recent_listens_for_users(self, users, min_ts: int = None, max_ts: int = None, limit=2):
+    def fetch_recent_listens_for_users(self, users, min_ts: int = None, max_ts: int = None, per_user_limit=2, limit=10):
         """ Fetch recent listens for a list of users, given a limit which applies per user. If you
             have a limit of 3 and 3 users you should get 9 listens if they are available.
 
             user_ids: A list containing the users for which you'd like to retrieve recent listens.
             min_ts: Only return listens with listened_at after this timestamp
             max_ts: Only return listens with listened_at before this timestamp
-            limit: the maximum number of listens for each user to fetch.
+            per_user_limit: the maximum number of listens for each user to fetch
+            limit: the maximum number of listens overall to fetch
         """
         user_id_map = {user["id"]: user["musicbrainz_id"] for user in users}
 
         filters_list = ["user_id IN :user_ids"]
-        args = {"user_ids": tuple(user_id_map.keys()), "limit": limit}
+        args = {"user_ids": tuple(user_id_map.keys()), "per_user_limit": per_user_limit}
         if min_ts:
             filters_list.append("listened_at > :min_ts")
             args["min_ts"] = min_ts
@@ -392,7 +393,9 @@ class TimescaleListenStore:
                                WHERE {filters}
                             GROUP BY user_id, listened_at, track_name, created, data, mm.recording_mbid, release_mbid, artist_mbids
                             ORDER BY listened_at DESC) tmp
-                               WHERE rownum <= :limit"""
+                               WHERE rownum <= :per_user_limit
+                            ORDER BY listened_at DESC   
+                               LIMIT :limit"""
 
         listens = []
         with timescale.engine.connect() as connection:

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -373,7 +373,7 @@ class TimescaleListenStore:
         user_id_map = {user["id"]: user["musicbrainz_id"] for user in users}
 
         filters_list = ["user_id IN :user_ids"]
-        args = {"user_ids": tuple(user_id_map.keys()), "per_user_limit": per_user_limit}
+        args = {"user_ids": tuple(user_id_map.keys()), "per_user_limit": per_user_limit, "limit": limit}
         if min_ts:
             filters_list.append("listened_at > :min_ts")
             args["min_ts"] = min_ts

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -42,7 +42,8 @@ from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError,
 from listenbrainz.webserver.views.api_tools import validate_auth_header, _filter_description_html, \
     _validate_get_endpoint_params
 
-MAX_LISTEN_EVENTS_PER_USER = 2 # the maximum number of listens we want to return in the feed per user
+MAX_LISTEN_EVENTS_PER_USER = 2  # the maximum number of listens we want to return in the feed per user
+MAX_LISTEN_EVENTS_OVERALL = 10  # the maximum number of listens we want to return in the feed overall across users
 DEFAULT_LISTEN_EVENT_WINDOW = 14 * 24 * 60 * 60  # 14 days, to limit the search space of listen events and avoid timeouts
 
 user_timeline_event_api_bp = Blueprint('user_timeline_event_api_bp', __name__)
@@ -316,7 +317,8 @@ def get_listen_events(
         users,
         min_ts=min_ts,
         max_ts=max_ts,
-        limit=MAX_LISTEN_EVENTS_PER_USER,
+        per_user_limit=MAX_LISTEN_EVENTS_PER_USER,
+        limit=MAX_LISTEN_EVENTS_OVERALL
     )
 
     events = []


### PR DESCRIPTION
Currently, feed includes max of 2 listen events per user you are following. If one is following a large number of users, then the
feed will get overwhelmed with just listen events. To avoid this situation, apply an overall limit of max 10 listen events across
users for the feed. Also, sorting it by newer first so that the newer listens are the ones shown if necessary to trim the list.