### PR TITLE
Set custom handler for listenbrainz logger

### DIFF
--- a/listenbrainz/__init__.py
+++ b/listenbrainz/__init__.py
@@ -13,3 +13,4 @@ _handler.setFormatter(_formatter)
 _logger = logging.getLogger("listenbrainz")
 # This level is set to DEBUG in listenbrainz.webserver.gen_app if Flask DEBUG=True
 _logger.setLevel(logging.INFO)
+_logger.addHandler(_handler)


### PR DESCRIPTION
It turns out we forgot to set the handler on the listenbrainz logger. I was tracing why some log messages were missing during testing of the listen delete PR and noticed that adding the handler is missing. After adding it, the earlier missing log messages appear.