### PR TITLE
Allow tracknumber to be str in pydantic model

### DIFF
--- a/data/model/listen.py
+++ b/data/model/listen.py
@@ -43,7 +43,8 @@ class AdditionalInfo(BaseModel):
     origin_url: Optional[str]
     tags: Optional[List[str]]
     track_mbid: Optional[str]
-    tracknumber: Optional[NonNegativeInt]
+    # tracknumber should be int but we don't validate it during submission
+    tracknumber: Optional[str]
     work_mbids: Optional[List[str]]
 
     _validate_uuids: classmethod = validator(


### PR DESCRIPTION
There are a bunch of pydantic errors in sentry due to tracknumber being str but the model requiring it to be an integer. We don't validate tracknumber (see api_compat) to be an integer during submission so try to enforce it here is futile. And we don't use the tracknumber field anywhere anyway.
