### PR TITLE
Add message to inform user of listen deletion policy

### DIFF
--- a/listenbrainz/webserver/static/js/src/user/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/RecentListens.tsx
@@ -478,6 +478,12 @@ export default class RecentListens extends React.Component<
         );
         if (status === 200) {
           this.setState({ deletedListen: listen });
+          newAlert(
+            "info",
+            "Success",
+            "This listen has not been deleted yet, but is scheduled for deletion," +
+              " which usually happens shortly after the hour."
+          );
           // wait for the delete animation to finish
           setTimeout(() => {
             this.removeListenFromListenList(listen);

--- a/listenbrainz/webserver/static/js/tests/user/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/user/RecentListens.test.tsx
@@ -385,7 +385,7 @@ describe("deleteListen", () => {
 
     const wrapper = mount<RecentListens>(
       <GlobalAppContext.Provider value={mountOptions.context}>
-        <RecentListens {...props} />
+        <RecentListens {...props} newAlert={newAlertMock} />
       </GlobalAppContext.Provider>
     );
     const instance = wrapper.instance();

--- a/listenbrainz/webserver/static/js/tests/user/RecentListens.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/user/RecentListens.test.tsx
@@ -5,7 +5,9 @@ import { mount } from "enzyme";
 import * as timeago from "time-ago";
 import fetchMock from "jest-fetch-mock";
 import { io } from "socket.io-client";
-import GlobalAppContext, { GlobalAppContextT } from "../../src/utils/GlobalAppContext";
+import GlobalAppContext, {
+  GlobalAppContextT,
+} from "../../src/utils/GlobalAppContext";
 import APIServiceClass from "../../src/utils/APIService";
 
 import * as recentListensProps from "../__mocks__/recentListensProps.json";
@@ -378,6 +380,7 @@ describe("updateRecordingToPin", () => {
 
 describe("deleteListen", () => {
   it("calls API and removeListenFromListenList correctly, and updates the state", async () => {
+    const newAlertMock = jest.fn();
     jest.useFakeTimers();
 
     const wrapper = mount<RecentListens>(
@@ -411,6 +414,12 @@ describe("deleteListen", () => {
     expect(removeListenCallbackSpy).toHaveBeenCalledWith(listenToDelete);
     expect(instance.state.deletedListen).toEqual(listenToDelete);
     expect(instance.state.listens).not.toContainEqual(listenToDelete);
+    expect(newAlertMock).toHaveBeenCalledWith(
+      "info",
+      "Success",
+      "This listen has not been deleted yet, but is scheduled for deletion," +
+        " which usually happens shortly after the hour."
+    );
   });
 
   it("does nothing if isCurrentUser is false", async () => {

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -433,6 +433,11 @@ def delete_listen():
     Delete a particular listen from a user's listen history.
     This checks for the correct authorization token and deletes the listen.
 
+    .. note::
+
+        This listen has not been deleted yet, but is scheduled for deletion, which
+        usually happens shortly after the hour.
+
     The format of the JSON to be POSTed to this endpoint is:
 
     .. code-block:: json

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -435,7 +435,7 @@ def delete_listen():
 
     .. note::
 
-        This listen has not been deleted yet, but is scheduled for deletion, which
+        The listen is not deleted immediately, but is scheduled for deletion, which
         usually happens shortly after the hour.
 
     The format of the JSON to be POSTed to this endpoint is:


### PR DESCRIPTION
LB website should inform the user that the listen is not deleted immediately but scheduled for deletion when the cron job runs next time. Also, put the error message in delete listen endpoint docs.
