### PR TITLE
 LB-1066: Clarify now playing listens are not persisted in DB

### DIFF
--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -27,6 +27,12 @@ the ``submit-listens`` endpoint. Submit one of three types JSON documents:
 
    - Timestamp must be omitted from a ``playing_now`` submission.
 
+.. note::
+
+    Playing Now listens are only stored temporarily. A playing now listen must be
+    submitted again as a ``single`` or ``import`` for permanent storage.
+
+
 - ``import``: Submit previously saved listens
 
    - ``payload`` should contain information about *at least one* track


### PR DESCRIPTION
An api user suggested on IRC to clarify that playing now listens need to be submitted again as single/import listens.