### PR TITLE
Cleanup mbids lookup in MsB code

### DIFF
--- a/listenbrainz/db/model/pinned_recording.py
+++ b/listenbrainz/db/model/pinned_recording.py
@@ -4,8 +4,7 @@ from typing import Optional, List
 from pydantic import validator, constr, NonNegativeInt
 
 from data.model.validators import check_datetime_has_tzinfo
-from listenbrainz.db.msid_mbid_mapping import MsidMbidModel, load_recordings_from_mapping
-from listenbrainz.messybrainz import load_recordings_from_msids
+from listenbrainz.db.msid_mbid_mapping import MsidMbidModel
 
 DAYS_UNTIL_UNPIN = 7  # default = unpin after one week
 MAX_BLURB_CONTENT_LENGTH = 280  # maximum length of blurb content

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -6,7 +6,6 @@ import listenbrainz.db.user as db_user
 from listenbrainz.db import timescale as ts
 from listenbrainz import messybrainz as msb_db
 from listenbrainz.messybrainz.testing import MessyBrainzTestCase
-from listenbrainz.messybrainz.data import submit_recording, load_recordings_from_msids, get_id_from_meta_hash
 from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
 
 

--- a/listenbrainz/messybrainz/data.py
+++ b/listenbrainz/messybrainz/data.py
@@ -220,15 +220,14 @@ def load_recordings_from_msids(connection, messybrainz_ids):
         if msid not in msid_recording_map:
             raise exceptions.NoDataFoundException
         row = msid_recording_map[msid]
-
-        result = {}
-        result["payload"] = row["data"]
-        result["ids"] = {"artist_mbids": [], "release_mbid": ""}
-        result["ids"]["recording_mbid"] = str(row["data"]["recording_mbid"]) if "recording_mbid" in row["data"] else ""
-        result["ids"]["artist_msid"] = str(row["artist"])
-        result["ids"]["release_msid"] = str(row["release"]) if row["release"] else None
-        result["ids"]["recording_msid"] = str(row["gid"])
-        results.append(result)
+        results.append({
+            "payload": row["data"],
+            "ids": {
+                "artist_msid": str(row["artist"]),
+                "release_msid": str(row["release"]) if row["release"] else None,
+                "recording_msid": str(row["gid"])
+            }
+        })
 
     return results
 

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -111,7 +111,7 @@ class TimescaleWriterSubscriber:
             if 'additional_info' in listen['track_metadata']:
                 ai = listen['track_metadata']['additional_info']
                 if 'artist_mbids' in ai and isinstance(ai['artist_mbids'], list):
-                    messy_dict['artist_mbids'] = ai['artist_mbids']
+                    messy_dict['artist_mbids'] = sorted(ai['artist_mbids'])
                 if 'release_mbid' in ai:
                     messy_dict['release_mbid'] = ai['release_mbid']
                 if 'recording_mbid' in ai:
@@ -149,19 +149,6 @@ class TimescaleWriterSubscriber:
                 listen['track_metadata']['additional_info']['release_msid'] = messybrainz_resp['release_msid']
             except KeyError:
                 pass
-
-            artist_mbids = messybrainz_resp.get('artist_mbids', [])
-            release_mbid = messybrainz_resp.get('release_mbid', None)
-            recording_mbid = messybrainz_resp.get('recording_mbid', None)
-
-            if 'artist_mbids' not in listen['track_metadata']['additional_info'] and \
-                    'release_mbid' not in listen['track_metadata']['additional_info'] and \
-                    'recording_mbid' not in listen['track_metadata']['additional_info']:
-
-                if len(artist_mbids) > 0 and release_mbid and recording_mbid:
-                    listen['track_metadata']['additional_info']['artist_mbids'] = artist_mbids
-                    listen['track_metadata']['additional_info']['release_mbid'] = release_mbid
-                    listen['track_metadata']['additional_info']['recording_mbid'] = recording_mbid
 
             augmented_listens.append(listen)
         return augmented_listens


### PR DESCRIPTION
First, mbid fields are a part of the dict of which hash is calculated when creating msids. Therefore if a listen has the same msid as another, the mbids fields are going to be same or missing in both. So there is no point in assigning mbids from the data  loaded from MsB.

Second, the code to do this lookup is broken. In timescale_writer, we update the listen's additional info with mbids fields. These fields are filled in load_recordings_from_msids where `"artist_mbids": []`. Therefore, the check len(artist_mbids) > 0 in timescale_writer always fails and the mbids are never assigned anyway.

Considering all this, it is better to remove these mbids from "ids". If someone ever needs it, they'll present in the payload key anyway.