### PR TITLE
Some fixes for Last.FM compat API

### DIFF
--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -69,8 +69,11 @@ class CompatError(object):
     INVALID_SERVICE          = LastFMError(code = 2, message = "Invalid service -This service does not exist")
     INVALID_METHOD           = LastFMError(code = 3, message = "Invalid Method - No method with that name in this package")
     INVALID_TOKEN            = LastFMError(code = 4, message = "Invalid Token - Invalid authentication token supplied")
-    NO_EMAIL                 = LastFMError(code = 4, message = REJECT_LISTENS_WITHOUT_EMAIL_ERROR)
+    NO_EMAIL                 = LastFMError(code = 4, message = REJECT_LISTENS_WITHOUT_EMAIL_ERROR)  # custom LB error
     INVALID_FORMAT           = LastFMError(code = 5, message = "Invalid format - This service doesn't exist in that format")
+    INVALID_SCROBBLE_METHOD  = LastFMError(code = 5, message = "Invalid Request Method - track.updatenowplaying and "
+                                                               "track.scrobble are write requests and can only be "
+                                                               "accessed using POST. ")  # custom LB error
     INVALID_PARAMETERS       = LastFMError(code = 6, message = "Invalid parameters - " \
                                                                "Your request is missing a required parameter")
     INVALID_RESOURCE         = LastFMError(code = 7, message = "Invalid resource specified")

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -257,7 +257,7 @@ def record_listens(request, data):
 
     lookup = defaultdict(dict)
     for key, value in data.items():
-        if key in ["sk", "token", "api_key", "method", "api_sig"]:
+        if key in ["sk", "token", "api_key", "method", "api_sig", "format"]:
             continue
         matches = re.match('(.*)\[(\d+)\]', key)
         if matches:

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -90,21 +90,24 @@ def api_methods():
         raise InvalidAPIUsage(CompatError.SERVICE_UNAVAILABLE, output_format=data.get('format', "xml"))
 
     if method in ('track.updatenowplaying', 'track.scrobble'):
-        return record_listens(request, data)
-    elif method == 'auth.getsession':
-        return get_session(request, data)
+        if request.method != 'POST':
+            raise InvalidAPIUsage(CompatError.SERVICE_UNAVAILABLE, output_format=data.get('format', "xml"))
+        return record_listens(data)
+
+    if method == 'auth.getsession':
+        return get_session(data)
     elif method == 'auth.gettoken':
-        return get_token(request, data)
+        return get_token(data)
     elif method == 'user.getinfo':
-        return user_info(request, data)
+        return user_info(data)
     elif method == 'auth.getsessioninfo':
-        return session_info(request, data)
+        return session_info(data)
     else:
         # Invalid Method
         raise InvalidAPIUsage(CompatError.INVALID_METHOD, output_format=data.get('format', "xml"))
 
 
-def session_info(request, data):
+def session_info(data):
     try:
         sk = data['sk']
         api_key = data['api_key']
@@ -136,7 +139,7 @@ def session_info(request, data):
                            output_format)
 
 
-def get_token(request, data):
+def get_token(data):
     """ Issue a token to user after verying his API_KEY
     """
     output_format = data.get('format', 'xml')
@@ -157,7 +160,7 @@ def get_token(request, data):
                            output_format)
 
 
-def get_session(request, data):
+def get_session(data):
     """ Create new session after validating the API_key and token.
     """
     output_format = data.get('format', 'xml')
@@ -192,7 +195,7 @@ def get_session(request, data):
                            data.get('format', "xml"))
 
 
-def _to_native_api(lookup, method="track.scrobble", output_format="xml"):
+def _to_native_api(lookup, method, output_format="xml"):
     """ Converts the list of listens received in the new Last.fm submission format
         to the native ListenBrainz API format.
         Returns: type_of_listen and listen_payload
@@ -235,7 +238,7 @@ def _to_native_api(lookup, method="track.scrobble", output_format="xml"):
     return listen_type, listens
 
 
-def record_listens(request, data):
+def record_listens(data):
     """ Submit the listen in the lastfm format to be inserted in db.
         Accepts listens for both track.updateNowPlaying and track.scrobble methods.
     """
@@ -267,7 +270,7 @@ def record_listens(request, data):
             number = 0
         lookup[number][key] = value
 
-    if request.form['method'].lower() == 'track.updatenowplaying':
+    if data['method'].lower() == 'track.updatenowplaying':
         for i, listen in lookup.items():
             if 'timestamp' not in listen:
                 listen['timestamp'] = calendar.timegm(datetime.now().utctimetuple())
@@ -402,7 +405,7 @@ def format_response(data, format="xml"):
         return json.dumps(remove_attrib_prefix(jsonData), indent=4)
 
 
-def user_info(request, data):
+def user_info(data):
     """ Gives information about the user specified in the parameters.
     """
     try:


### PR DESCRIPTION
The format key is only used to indicate whether the response should be xml or json. If we don't ignore the key, it will get treated as a  separate listen causing listen validation and other errors.

Last.FM API supports both GET/POST requests on many methods but  track.scrobble needs to be accessed using a POST request only because  it is a write method. However, currently we accept both POST and GET for this method. Later during processing we try to access it as a form resulting in an uninformative error. I spent quite some time figuring out what was going on before realising the error. Its better to throw an explicit error about it.

Also, cleanup request data access in various methods.