### PR TITLE
LB-1069: Fix content type header of LFM api compat response

### DIFF
--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -56,7 +56,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         }
         r = self.client.post(url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
-        token = json.loads(r.data)['token']
+        token = r.json['token']
 
         # login as user
         with self.client.session_transaction() as session:
@@ -78,7 +78,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         }
         r = self.client.post(url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
-        sk = json.loads(r.data)['session']['key']
+        sk = r.json['session']['key']
 
         data = {
             'method': 'track.scrobble',
@@ -122,7 +122,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
                 "ignored": "0"
             }
         }
-        self.assertEqual(expected, json.loads(r.data))
+        self.assertEqual(expected, r.json)
 
         # Check if listen reached the timescale listenstore
         time.sleep(1)
@@ -187,6 +187,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         }
         r = self.client.post(url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
+        self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
         response = xmltodict.parse(r.data)
         self.assertEqual(response['lfm']['@status'], 'ok')
@@ -207,6 +208,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         }
         r = self.client.post(url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
+        self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
         response = xmltodict.parse(r.data)
         self.assertEqual(response['lfm']['@status'], 'failed')
@@ -230,6 +232,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
 
         r = self.client.post(url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
+        self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
         expected_message = b"""<?xml version="1.0" encoding="utf-8"?>
 <lfm status="failed">
@@ -258,6 +261,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
 
         r = self.client.post(url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
+        self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
         response = xmltodict.parse(r.data)
         self.assertEqual(response['lfm']['@status'], 'ok')

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -1,4 +1,5 @@
-from flask import render_template, make_response, jsonify, request, has_request_context, _request_ctx_stack, current_app
+from flask import render_template, make_response, jsonify, request, has_request_context, _request_ctx_stack, \
+    current_app, Response
 from yattag import Doc
 import yattag
 import ujson
@@ -219,10 +220,13 @@ class InvalidAPIUsage(Exception):
 
     def render_error(self):
         if self.output_format == "json":
-            return self.to_json()
+            data = self.to_json()
+            content_type = "application/json; charset=utf-8"
         else:
             # default to xml if the output format isn't known or is missing
-            return self.to_xml()
+            data = self.to_xml()
+            content_type = "application/xml; charset=utf-8"
+        return Response(data, mimetype=content_type)
 
     def to_json(self):
         return ujson.dumps({

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -4,7 +4,7 @@ import listenbrainz.db.user as db_user
 from collections import defaultdict
 from yattag import Doc
 import yattag
-from flask import Blueprint, request, render_template, current_app
+from flask import Blueprint, request, render_template, current_app, make_response, Response
 from flask_login import login_required, current_user
 from brainzutils.ratelimit import ratelimit
 from brainzutils.musicbrainz_db import engine as mb_engine
@@ -373,9 +373,7 @@ def format_response(data, format="xml"):
 
         (The #text notation is rarely used in XML responses.)
     """
-    if format == 'xml':
-        return data
-    elif format == 'json':
+    if format == 'json':
         # Remove the <lfm> tag and its attributes
         jsonData = xmltodict.parse(data)['lfm']
         for k in list(jsonData.keys()):
@@ -402,7 +400,13 @@ def format_response(data, format="xml"):
                     print(type(data[k]))
             return data
 
-        return json.dumps(remove_attrib_prefix(jsonData), indent=4)
+        data = json.dumps(remove_attrib_prefix(jsonData), indent=4)
+        content_type = "application/json; charset=utf-8"
+    else:
+        content_type = "application/xml; charset=utf-8"
+
+    response = Response(data, mimetype=content_type)
+    return response
 
 
 def user_info(data):


### PR DESCRIPTION
LB-1069

This is about the newer LFM compat API not the deprecated one. The response from the api are returned with wrong content type header (text/html). It should be instead be application/xml or application/json depending on output format.
