### PR TITLE
Add sitewide stats frontend

### DIFF
--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -241,6 +241,15 @@ def get_sitewide_stats(stats_range: str, stats_type: str) -> Optional[StatApi[En
     return get_user_stats(SITEWIDE_STATS_USER_ID, stats_range, stats_type)
 
 
+def get_sitewide_listening_activity(stats_range: str) -> Optional[StatApi[ListeningActivityRecord]]:
+    """Get sitewide listening activity in the given time range.
+
+        Args:
+            stats_range: the time range to fetch the stats for
+    """
+    return get_user_listening_activity(SITEWIDE_STATS_USER_ID, stats_range)
+
+
 def valid_stats_exist(user_id, days):
     """ Returns True if statistics for a user have been calculated in
     the last X days (where x is passed to the function), and are present in the db

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -12,7 +12,7 @@ import { isInvalidStatRange } from "./utils";
 
 export type UserArtistMapProps = {
   range: UserStatsAPIRange;
-  user: ListenBrainzUser;
+  user?: ListenBrainzUser;
   apiUrl: string;
 };
 
@@ -110,8 +110,13 @@ export default class UserArtistMap extends React.Component<
   getData = async (): Promise<UserArtistMapResponse> => {
     const { range, user } = this.props;
     try {
-      const data = await this.APIService.getUserArtistMap(user.name, range);
-      return data;
+      let data;
+      if (user) {
+        data = this.APIService.getUserArtistMap(user.name, range);
+      } else {
+        data = this.APIService.getSiteWideArtistMap(range);
+      }
+      return await data;
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -110,13 +110,10 @@ export default class UserArtistMap extends React.Component<
   getData = async (): Promise<UserArtistMapResponse> => {
     const { range, user } = this.props;
     try {
-      let data;
-      if (user) {
-        data = this.APIService.getUserArtistMap(user.name, range);
-      } else {
-        data = this.APIService.getSiteWideArtistMap(range);
-      }
-      return await data;
+      return await this.APIService.getUserArtistMap(
+        user ? user.name : undefined,
+        range
+      );
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -110,10 +110,7 @@ export default class UserArtistMap extends React.Component<
   getData = async (): Promise<UserArtistMapResponse> => {
     const { range, user } = this.props;
     try {
-      return await this.APIService.getUserArtistMap(
-        user ? user.name : undefined,
-        range
-      );
+      return await this.APIService.getUserArtistMap(user?.name, range);
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -186,7 +186,7 @@ export default class UserEntityChart extends React.Component<
     const { APIService } = this.context;
     const offset = (page - 1) * this.ROWS_PER_PAGE;
     return APIService.getUserEntity(
-      user ? user.name : undefined,
+      user?.name,
       entity,
       range,
       offset,

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -131,18 +131,13 @@ export default class UserEntityChart extends React.Component<
   }> => {
     const { user } = this.props;
     const { APIService } = this.context;
-    let data;
-    if (user) {
-      data = await APIService.getUserEntity(
-        user.name,
-        entity,
-        range,
-        undefined,
-        1
-      );
-    } else {
-      data = await APIService.getSiteWideEntity(entity, range, undefined, 1);
-    }
+    let data = await APIService.getUserEntity(
+      user ? user.name : undefined,
+      entity,
+      range,
+      undefined,
+      1
+    );
 
     let maxListens = 0;
     let totalPages = 0;
@@ -190,25 +185,13 @@ export default class UserEntityChart extends React.Component<
     const { user } = this.props;
     const { APIService } = this.context;
     const offset = (page - 1) * this.ROWS_PER_PAGE;
-
-    let data;
-    if (user) {
-      data = await APIService.getUserEntity(
-        user.name,
-        entity,
-        range,
-        offset,
-        this.ROWS_PER_PAGE
-      );
-    } else {
-      data = await APIService.getSiteWideEntity(
-        entity,
-        range,
-        offset,
-        this.ROWS_PER_PAGE
-      );
-    }
-    return data;
+    return APIService.getUserEntity(
+      user ? user.name : undefined,
+      entity,
+      range,
+      offset,
+      this.ROWS_PER_PAGE
+    );
   };
 
   processData = (

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -29,7 +29,7 @@ import {
 import ListenCard from "../listens/ListenCard";
 
 export type UserEntityChartProps = {
-  user: ListenBrainzUser;
+  user?: ListenBrainzUser;
   apiUrl: string;
 } & WithAlertNotificationsInjectedProps;
 
@@ -131,13 +131,18 @@ export default class UserEntityChart extends React.Component<
   }> => {
     const { user } = this.props;
     const { APIService } = this.context;
-    let data = await APIService.getUserEntity(
-      user.name,
-      entity,
-      range,
-      undefined,
-      1
-    );
+    let data;
+    if (user) {
+      data = await APIService.getUserEntity(
+        user.name,
+        entity,
+        range,
+        undefined,
+        1
+      );
+    } else {
+      data = await APIService.getSiteWideEntity(entity, range, undefined, 1);
+    }
 
     let maxListens = 0;
     let totalPages = 0;
@@ -186,13 +191,23 @@ export default class UserEntityChart extends React.Component<
     const { APIService } = this.context;
     const offset = (page - 1) * this.ROWS_PER_PAGE;
 
-    const data = await APIService.getUserEntity(
-      user.name,
-      entity,
-      range,
-      offset,
-      this.ROWS_PER_PAGE
-    );
+    let data;
+    if (user) {
+      data = await APIService.getUserEntity(
+        user.name,
+        entity,
+        range,
+        offset,
+        this.ROWS_PER_PAGE
+      );
+    } else {
+      data = await APIService.getSiteWideEntity(
+        entity,
+        range,
+        offset,
+        this.ROWS_PER_PAGE
+      );
+    }
     return data;
   };
 

--- a/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserEntityChart.tsx
@@ -132,7 +132,7 @@ export default class UserEntityChart extends React.Component<
     const { user } = this.props;
     const { APIService } = this.context;
     let data = await APIService.getUserEntity(
-      user ? user.name : undefined,
+      user?.name,
       entity,
       range,
       undefined,

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -129,13 +129,10 @@ export default class UserListeningActivity extends React.Component<
   getData = async (): Promise<UserListeningActivityResponse> => {
     const { range, user } = this.props;
     try {
-      let data;
-      if (user) {
-        data = this.APIService.getUserListeningActivity(user.name, range);
-      } else {
-        data = this.APIService.getSiteWideListeningActivity(range);
-      }
-      return await data;
+      return await this.APIService.getUserListeningActivity(
+        user ? user.name : undefined,
+        range
+      );
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -12,7 +12,7 @@ import { isInvalidStatRange } from "./utils";
 
 export type UserListeningActivityProps = {
   range: UserStatsAPIRange;
-  user: ListenBrainzUser;
+  user?: ListenBrainzUser;
   apiUrl: string;
 };
 
@@ -129,11 +129,13 @@ export default class UserListeningActivity extends React.Component<
   getData = async (): Promise<UserListeningActivityResponse> => {
     const { range, user } = this.props;
     try {
-      const data = await this.APIService.getUserListeningActivity(
-        user.name,
-        range
-      );
-      return data;
+      let data;
+      if (user) {
+        data = this.APIService.getUserListeningActivity(user.name, range);
+      } else {
+        data = this.APIService.getSiteWideListeningActivity(range);
+      }
+      return await data;
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({

--- a/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserListeningActivity.tsx
@@ -129,10 +129,7 @@ export default class UserListeningActivity extends React.Component<
   getData = async (): Promise<UserListeningActivityResponse> => {
     const { range, user } = this.props;
     try {
-      return await this.APIService.getUserListeningActivity(
-        user ? user.name : undefined,
-        range
-      );
+      return await this.APIService.getUserListeningActivity(user?.name, range);
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({

--- a/listenbrainz/webserver/static/js/src/stats/UserReports.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserReports.tsx
@@ -13,7 +13,7 @@ import { getPageProps } from "../utils/utils";
 import { getAllStatRanges } from "./utils";
 
 export type UserReportsProps = {
-  user: ListenBrainzUser;
+  user?: ListenBrainzUser;
   apiUrl: string;
 };
 
@@ -78,7 +78,6 @@ export default class UserReports extends React.Component<
     const { range } = this.state;
     const { apiUrl, user } = this.props;
 
-    type UserStatsPair = [UserStatsAPIRange, string];
     const ranges = getAllStatRanges();
     return (
       <div>
@@ -136,11 +135,13 @@ export default class UserReports extends React.Component<
             </div>
           </div>
         </section>
-        <section id="daily-activity">
-          <ErrorBoundary>
-            <UserDailyActivity range={range} apiUrl={apiUrl} user={user} />
-          </ErrorBoundary>
-        </section>
+        {user && (
+          <section id="daily-activity">
+            <ErrorBoundary>
+              <UserDailyActivity range={range} apiUrl={apiUrl} user={user} />
+            </ErrorBoundary>
+          </section>
+        )}
         <section id="artist-origin">
           <ErrorBoundary>
             <UserArtistMap range={range} apiUrl={apiUrl} user={user} />

--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -72,7 +72,7 @@ export default class UserTopEntity extends React.Component<
     const { entity, range, user } = this.props;
     try {
       return await this.APIService.getUserEntity(
-        user ? user.name : undefined,
+        user?.name,
         entity,
         range,
         0,
@@ -98,10 +98,11 @@ export default class UserTopEntity extends React.Component<
 
     let statsUrl;
     if (user) {
-      statsUrl = `${window.location.origin}/user/${user.name}/charts?range=${range}&entity=${entity}`;
+      statsUrl = `${window.location.origin}/user/${user.name}`;
     } else {
-      statsUrl = `${window.location.origin}/sitewide/charts?range=${range}&entity=${entity}`;
+      statsUrl = `${window.location.origin}/sitewide`;
     }
+    statsUrl += `/charts?range=${range}&entity=${entity}`;
 
     const entityTextOnCard = `${entity}s`;
 

--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -100,7 +100,7 @@ export default class UserTopEntity extends React.Component<
     if (user) {
       statsUrl = `${window.location.origin}/user/${user.name}`;
     } else {
-      statsUrl = `${window.location.origin}/sitewide`;
+      statsUrl = `${window.location.origin}/statistics`;
     }
     statsUrl += `/charts?range=${range}&entity=${entity}`;
 

--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -11,7 +11,7 @@ import { getEntityLink, isInvalidStatRange } from "./utils";
 export type UserTopEntityProps = {
   range: UserStatsAPIRange;
   entity: Entity;
-  user: ListenBrainzUser;
+  user?: ListenBrainzUser;
   apiUrl: string;
 };
 
@@ -71,14 +71,13 @@ export default class UserTopEntity extends React.Component<
   getData = async (): Promise<UserEntityResponse> => {
     const { entity, range, user } = this.props;
     try {
-      const data = await this.APIService.getUserEntity(
-        user.name,
-        entity,
-        range,
-        0,
-        10
-      );
-      return data;
+      let data;
+      if (user) {
+        data = this.APIService.getUserEntity(user.name, entity, range, 0, 10);
+      } else {
+        data = this.APIService.getSiteWideEntity(entity, range, 0, 10);
+      }
+      return await data;
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({
@@ -96,6 +95,13 @@ export default class UserTopEntity extends React.Component<
   render() {
     const { entity, range, user } = this.props;
     const { data, loading, hasError, errorMessage } = this.state;
+
+    let statsUrl;
+    if (user) {
+      statsUrl = `${window.location.origin}/user/${user.name}/charts?range=${range}&entity=${entity}`;
+    } else {
+      statsUrl = `${window.location.origin}/sitewide/charts?range=${range}&entity=${entity}`;
+    }
 
     const entityTextOnCard = `${entity}s`;
 
@@ -285,10 +291,7 @@ export default class UserTopEntity extends React.Component<
             </tbody>
           </table>
           {!hasError && (
-            <a
-              href={`${window.location.origin}/user/${user.name}/charts?range=${range}&entity=${entity}`}
-              className="mt-15"
-            >
+            <a href={statsUrl} className="mt-15">
               View More
             </a>
           )}

--- a/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserTopEntity.tsx
@@ -71,13 +71,13 @@ export default class UserTopEntity extends React.Component<
   getData = async (): Promise<UserEntityResponse> => {
     const { entity, range, user } = this.props;
     try {
-      let data;
-      if (user) {
-        data = this.APIService.getUserEntity(user.name, entity, range, 0, 10);
-      } else {
-        data = this.APIService.getSiteWideEntity(entity, range, 0, 10);
-      }
-      return await data;
+      return await this.APIService.getUserEntity(
+        user ? user.name : undefined,
+        entity,
+        range,
+        0,
+        10
+      );
     } catch (error) {
       if (error.response && error.response.status === 204) {
         this.setState({

--- a/listenbrainz/webserver/static/js/src/utils/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/utils/APIService.ts
@@ -385,11 +385,48 @@ export default class APIService {
     return response.json();
   };
 
+  getSiteWideEntity = async (
+    entity: Entity,
+    range: UserStatsAPIRange = "all_time",
+    offset: number = 0,
+    count?: number
+  ): Promise<UserEntityResponse> => {
+    let url = `${this.APIBaseURI}/stats/sitewide/${entity}s?offset=${offset}&range=${range}`;
+    if (count !== null && count !== undefined) {
+      url += `&count=${count}`;
+    }
+    const response = await fetch(url);
+    await this.checkStatus(response);
+    // if response code is 204, then statistics havent been calculated, send empty object
+    if (response.status === 204) {
+      const error = new APIError(`HTTP Error ${response.statusText}`);
+      error.status = response.statusText;
+      error.response = response;
+      throw error;
+    }
+    return response.json();
+  };
+
   getUserListeningActivity = async (
     userName: string,
     range: UserStatsAPIRange = "all_time"
   ): Promise<UserListeningActivityResponse> => {
     const url = `${this.APIBaseURI}/stats/user/${userName}/listening-activity?range=${range}`;
+    const response = await fetch(url);
+    await this.checkStatus(response);
+    if (response.status === 204) {
+      const error = new APIError(`HTTP Error ${response.statusText}`);
+      error.status = response.statusText;
+      error.response = response;
+      throw error;
+    }
+    return response.json();
+  };
+
+  getSiteWideListeningActivity = async (
+    range: UserStatsAPIRange = "all_time"
+  ): Promise<UserListeningActivityResponse> => {
+    const url = `${this.APIBaseURI}/stats/sitewide/listening-activity?range=${range}`;
     const response = await fetch(url);
     await this.checkStatus(response);
     if (response.status === 204) {
@@ -423,6 +460,22 @@ export default class APIService {
     forceRecalculate: boolean = false
   ) => {
     const url = `${this.APIBaseURI}/stats/user/${userName}/artist-map?range=${range}&force_recalculate=${forceRecalculate}`;
+    const response = await fetch(url);
+    await this.checkStatus(response);
+    if (response.status === 204) {
+      const error = new APIError(`HTTP Error ${response.statusText}`);
+      error.status = response.statusText;
+      error.response = response;
+      throw error;
+    }
+    return response.json();
+  };
+
+  getSiteWideArtistMap = async (
+    range: UserStatsAPIRange = "all_time",
+    forceRecalculate: boolean = false
+  ) => {
+    const url = `${this.APIBaseURI}/stats/sitewide/artist-map?range=${range}&force_recalculate=${forceRecalculate}`;
     const response = await fetch(url);
     await this.checkStatus(response);
     if (response.status === 204) {

--- a/listenbrainz/webserver/static/js/src/utils/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/utils/APIService.ts
@@ -392,7 +392,7 @@ export default class APIService {
   };
 
   getUserListeningActivity = async (
-    userName: string | undefined,
+    userName?: string,
     range: UserStatsAPIRange = "all_time"
   ): Promise<UserListeningActivityResponse> => {
     let url;
@@ -429,7 +429,7 @@ export default class APIService {
   };
 
   getUserArtistMap = async (
-    userName: string | undefined,
+    userName?: string,
     range: UserStatsAPIRange = "all_time",
     forceRecalculate: boolean = false
   ) => {

--- a/listenbrainz/webserver/static/js/src/utils/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/utils/APIService.ts
@@ -363,35 +363,19 @@ export default class APIService {
   };
 
   getUserEntity = async (
-    userName: string,
+    userName: string | undefined,
     entity: Entity,
     range: UserStatsAPIRange = "all_time",
     offset: number = 0,
     count?: number
   ): Promise<UserEntityResponse> => {
-    let url = `${this.APIBaseURI}/stats/user/${userName}/${entity}s?offset=${offset}&range=${range}`;
-    if (count !== null && count !== undefined) {
-      url += `&count=${count}`;
+    let url;
+    if (userName) {
+      url = `${this.APIBaseURI}/stats/user/${userName}/`;
+    } else {
+      url = `${this.APIBaseURI}/stats/sitewide/`;
     }
-    const response = await fetch(url);
-    await this.checkStatus(response);
-    // if response code is 204, then statistics havent been calculated, send empty object
-    if (response.status === 204) {
-      const error = new APIError(`HTTP Error ${response.statusText}`);
-      error.status = response.statusText;
-      error.response = response;
-      throw error;
-    }
-    return response.json();
-  };
-
-  getSiteWideEntity = async (
-    entity: Entity,
-    range: UserStatsAPIRange = "all_time",
-    offset: number = 0,
-    count?: number
-  ): Promise<UserEntityResponse> => {
-    let url = `${this.APIBaseURI}/stats/sitewide/${entity}s?offset=${offset}&range=${range}`;
+    url += `${entity}s?offset=${offset}&range=${range}`;
     if (count !== null && count !== undefined) {
       url += `&count=${count}`;
     }
@@ -408,26 +392,16 @@ export default class APIService {
   };
 
   getUserListeningActivity = async (
-    userName: string,
+    userName: string | undefined,
     range: UserStatsAPIRange = "all_time"
   ): Promise<UserListeningActivityResponse> => {
-    const url = `${this.APIBaseURI}/stats/user/${userName}/listening-activity?range=${range}`;
-    const response = await fetch(url);
-    await this.checkStatus(response);
-    if (response.status === 204) {
-      const error = new APIError(`HTTP Error ${response.statusText}`);
-      error.status = response.statusText;
-      error.response = response;
-      throw error;
+    let url;
+    if (userName) {
+      url = `${this.APIBaseURI}/stats/user/${userName}/listening-activity`;
+    } else {
+      url = `${this.APIBaseURI}/stats/sitewide/listening-activity`;
     }
-    return response.json();
-  };
-
-  getSiteWideListeningActivity = async (
-    range: UserStatsAPIRange = "all_time"
-  ): Promise<UserListeningActivityResponse> => {
-    const url = `${this.APIBaseURI}/stats/sitewide/listening-activity?range=${range}`;
-    const response = await fetch(url);
+    const response = await fetch(`${url}?range=${range}`);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(`HTTP Error ${response.statusText}`);
@@ -455,27 +429,17 @@ export default class APIService {
   };
 
   getUserArtistMap = async (
-    userName: string,
+    userName: string | undefined,
     range: UserStatsAPIRange = "all_time",
     forceRecalculate: boolean = false
   ) => {
-    const url = `${this.APIBaseURI}/stats/user/${userName}/artist-map?range=${range}&force_recalculate=${forceRecalculate}`;
-    const response = await fetch(url);
-    await this.checkStatus(response);
-    if (response.status === 204) {
-      const error = new APIError(`HTTP Error ${response.statusText}`);
-      error.status = response.statusText;
-      error.response = response;
-      throw error;
+    let url;
+    if (userName) {
+      url = `${this.APIBaseURI}/stats/user/${userName}/`;
+    } else {
+      url = `${this.APIBaseURI}/stats/sitewide/`;
     }
-    return response.json();
-  };
-
-  getSiteWideArtistMap = async (
-    range: UserStatsAPIRange = "all_time",
-    forceRecalculate: boolean = false
-  ) => {
-    const url = `${this.APIBaseURI}/stats/sitewide/artist-map?range=${range}&force_recalculate=${forceRecalculate}`;
+    url += `artist-map?range=${range}&force_recalculate=${forceRecalculate}`;
     const response = await fetch(url);
     await this.checkStatus(response);
     if (response.status === 204) {

--- a/listenbrainz/webserver/static/js/tests/stats/UserArtistMap.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/stats/UserArtistMap.test.tsx
@@ -1,13 +1,15 @@
 import * as React from "react";
 import { mount, shallow } from "enzyme";
 
-import UserArtistMap, { UserArtistMapProps } from "../../src/stats/UserArtistMap";
+import UserArtistMap, {
+  UserArtistMapProps,
+} from "../../src/stats/UserArtistMap";
 import APIError from "../../src/utils/APIError";
 import * as userArtistMapResponse from "../__mocks__/userArtistMap.json";
 import * as userArtistMapProcessedDataArtist from "../__mocks__/userArtistMapProcessDataArtist.json";
 import * as userArtistMapProcessedDataListen from "../__mocks__/userArtistMapProcessDataListen.json";
 
-const props: UserArtistMapProps = {
+const userProps: UserArtistMapProps = {
   user: {
     name: "foobar",
   },
@@ -15,241 +17,254 @@ const props: UserArtistMapProps = {
   apiUrl: "barfoo",
 };
 
-describe("UserArtistMap", () => {
-  it("renders correctly", () => {
-    const wrapper = shallow<UserArtistMap>(
-      <UserArtistMap {...{ ...props, range: "all_time" }} />
-    );
+const sitewideProps: UserArtistMapProps = {
+  range: "week",
+  apiUrl: "barfoo",
+};
 
-    wrapper.setState({
-      selectedMetric: "artist",
-      data: userArtistMapProcessedDataArtist,
-      graphContainerWidth: 1200,
-      loading: false,
+describe.each([
+  ["User Stats", userProps],
+  ["Sitewide Stats", sitewideProps],
+])("%s", (name, props) => {
+  describe("UserArtistMap", () => {
+    it("renders correctly", () => {
+      const wrapper = shallow<UserArtistMap>(
+        <UserArtistMap {...{ ...props, range: "all_time" }} />
+      );
+
+      wrapper.setState({
+        selectedMetric: "artist",
+        data: userArtistMapProcessedDataArtist,
+        graphContainerWidth: 1200,
+        loading: false,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
-  });
+    it("renders corectly when range is invalid", () => {
+      const wrapper = mount<UserArtistMap>(<UserArtistMap {...props} />);
 
-  it("renders corectly when range is invalid", () => {
-    const wrapper = mount<UserArtistMap>(<UserArtistMap {...props} />);
+      wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
+      wrapper.update();
 
-    wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
-    wrapper.update();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-});
-
-describe("componentDidMount", () => {
-  it('adds event listener for "resize" event', () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(window, "addEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.handleResize = jest.fn();
-    instance.componentDidMount();
-
-    expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
-  });
-
-  it('calls "handleResize" once', () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
-
-    instance.handleResize = jest.fn();
-    instance.componentDidMount();
-
-    expect(instance.handleResize).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("componentDidUpdate", () => {
-  it("it sets correct state if range is incorrect", () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-
-    wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
-    wrapper.update();
-
-    expect(wrapper.state()).toMatchObject({
-      loading: false,
-      hasError: true,
-      errorMessage: "Invalid range: invalid_range",
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
-  it("calls loadData once if range is valid", () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
+  describe("componentDidMount", () => {
+    it('adds event listener for "resize" event', () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
 
-    instance.loadData = jest.fn();
-    wrapper.setProps({ range: "month" });
-    wrapper.update();
+      const spy = jest.spyOn(window, "addEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.handleResize = jest.fn();
+      instance.componentDidMount();
 
-    expect(instance.loadData).toHaveBeenCalledTimes(1);
-  });
-});
+      expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
+    });
 
-describe("componentWillUnmount", () => {
-  it('removes event listener for "resize" event', () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
+    it('calls "handleResize" once', () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
 
-    const spy = jest.spyOn(window, "removeEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.handleResize = jest.fn();
-    instance.componentWillUnmount();
+      instance.handleResize = jest.fn();
+      instance.componentDidMount();
 
-    expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
-  });
-});
-
-describe("getData", () => {
-  it("calls getUserArtistMap with correct params", async () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.APIService, "getUserArtistMap");
-    spy.mockImplementation(() =>
-      Promise.resolve(userArtistMapResponse as UserArtistMapResponse)
-    );
-    const result = await instance.getData();
-
-    expect(spy).toHaveBeenCalledWith("foobar", "week");
-    expect(result).toEqual(userArtistMapResponse);
-  });
-
-  it("sets state correctly if data is not calculated", async () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.APIService, "getUserArtistMap");
-    const noContentError = new APIError("NO CONTENT");
-    noContentError.response = {
-      status: 204,
-    } as Response;
-    spy.mockImplementation(() => Promise.reject(noContentError));
-    await instance.getData();
-
-    expect(wrapper.state()).toMatchObject({
-      loading: false,
-      hasError: true,
-      errorMessage: "Statistics for the user have not been calculated",
+      expect(instance.handleResize).toHaveBeenCalledTimes(1);
     });
   });
 
-  it("throws error", async () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
+  describe("componentDidUpdate", () => {
+    it("it sets correct state if range is incorrect", () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
 
-    const spy = jest.spyOn(instance.APIService, "getUserArtistMap");
-    const notFoundError = new APIError("NOT FOUND");
-    notFoundError.response = {
-      status: 404,
-    } as Response;
-    spy.mockImplementation(() => Promise.reject(notFoundError));
+      wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
+      wrapper.update();
 
-    await expect(instance.getData()).rejects.toThrow("NOT FOUND");
-  });
-});
+      expect(wrapper.state()).toMatchObject({
+        loading: false,
+        hasError: true,
+        errorMessage: "Invalid range: invalid_range",
+      });
+    });
 
-describe("processData", () => {
-  it("processes data correctly for all_time", () => {
-    const wrapper = shallow<UserArtistMap>(
-      <UserArtistMap {...{ ...props, range: "all_time" }} />
-    );
-    const instance = wrapper.instance();
+    it("calls loadData once if range is valid", () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
 
-    const result = instance.processData(
-      userArtistMapResponse as UserArtistMapResponse,
-      "artist"
-    );
+      instance.loadData = jest.fn();
+      wrapper.setProps({ range: "month" });
+      wrapper.update();
 
-    expect(result).toEqual(userArtistMapProcessedDataArtist);
-  });
-
-  it("processes data correctly for listen", () => {
-    const wrapper = shallow<UserArtistMap>(
-      <UserArtistMap {...{ ...props, range: "all_time" }} />
-    );
-    const instance = wrapper.instance();
-
-    const result = instance.processData(
-      userArtistMapResponse as UserArtistMapResponse,
-      "listen"
-    );
-
-    expect(result).toEqual(userArtistMapProcessedDataListen);
-  });
-  it("returns an empty array if no payload", () => {
-    const wrapper = shallow<UserArtistMap>(
-      <UserArtistMap {...{ ...props, range: "all_time" }} />
-    );
-    const instance = wrapper.instance();
-
-    // When stats haven't been calculated, processData is called with an empty object
-    const result = instance.processData({} as UserArtistMapResponse, "listen");
-
-    expect(result).toEqual([]);
-  });
-});
-
-describe("changeSelectedMetric", () => {
-  it('sets state correctly for "artist"', () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
-
-    instance.rawData = userArtistMapResponse as UserArtistMapResponse;
-
-    instance.changeSelectedMetric("artist");
-    expect(wrapper.state()).toMatchObject({
-      data: userArtistMapProcessedDataArtist,
-      selectedMetric: "artist",
+      expect(instance.loadData).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('sets state correctly for "listen"', () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
+  describe("componentWillUnmount", () => {
+    it('removes event listener for "resize" event', () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
 
-    instance.rawData = userArtistMapResponse as UserArtistMapResponse;
+      const spy = jest.spyOn(window, "removeEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.handleResize = jest.fn();
+      instance.componentWillUnmount();
 
-    instance.changeSelectedMetric("listen");
-    expect(wrapper.state()).toMatchObject({
-      data: userArtistMapProcessedDataListen,
-      selectedMetric: "listen",
+      expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
     });
   });
-});
 
-describe("loadData", () => {
-  it("calls getData once", async () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
+  describe("getData", () => {
+    it("calls getUserArtistMap with correct params", async () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
 
-    instance.getData = jest.fn();
-    instance.processData = jest.fn();
-    await instance.loadData();
+      const spy = jest.spyOn(instance.APIService, "getUserArtistMap");
+      spy.mockImplementation(() =>
+        Promise.resolve(userArtistMapResponse as UserArtistMapResponse)
+      );
+      const result = await instance.getData();
 
-    expect(instance.getData).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(props?.user?.name, "week");
+      expect(result).toEqual(userArtistMapResponse);
+    });
+
+    it("sets state correctly if data is not calculated", async () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserArtistMap");
+      const noContentError = new APIError("NO CONTENT");
+      noContentError.response = {
+        status: 204,
+      } as Response;
+      spy.mockImplementation(() => Promise.reject(noContentError));
+      await instance.getData();
+
+      expect(wrapper.state()).toMatchObject({
+        loading: false,
+        hasError: true,
+        errorMessage: "Statistics for the user have not been calculated",
+      });
+    });
+
+    it("throws error", async () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserArtistMap");
+      const notFoundError = new APIError("NOT FOUND");
+      notFoundError.response = {
+        status: 404,
+      } as Response;
+      spy.mockImplementation(() => Promise.reject(notFoundError));
+
+      await expect(instance.getData()).rejects.toThrow("NOT FOUND");
+    });
   });
 
-  it("set state correctly", async () => {
-    const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
-    const instance = wrapper.instance();
+  describe("processData", () => {
+    it("processes data correctly for all_time", () => {
+      const wrapper = shallow<UserArtistMap>(
+        <UserArtistMap {...{ ...props, range: "all_time" }} />
+      );
+      const instance = wrapper.instance();
 
-    instance.getData = jest
-      .fn()
-      .mockImplementationOnce(() => Promise.resolve(userArtistMapResponse));
-    await instance.loadData();
+      const result = instance.processData(
+        userArtistMapResponse as UserArtistMapResponse,
+        "artist"
+      );
 
-    expect(instance.rawData).toMatchObject(userArtistMapResponse);
+      expect(result).toEqual(userArtistMapProcessedDataArtist);
+    });
 
-    expect(wrapper.state()).toMatchObject({
-      data: userArtistMapProcessedDataArtist,
-      loading: false,
+    it("processes data correctly for listen", () => {
+      const wrapper = shallow<UserArtistMap>(
+        <UserArtistMap {...{ ...props, range: "all_time" }} />
+      );
+      const instance = wrapper.instance();
+
+      const result = instance.processData(
+        userArtistMapResponse as UserArtistMapResponse,
+        "listen"
+      );
+
+      expect(result).toEqual(userArtistMapProcessedDataListen);
+    });
+    it("returns an empty array if no payload", () => {
+      const wrapper = shallow<UserArtistMap>(
+        <UserArtistMap {...{ ...props, range: "all_time" }} />
+      );
+      const instance = wrapper.instance();
+
+      // When stats haven't been calculated, processData is called with an empty object
+      const result = instance.processData(
+        {} as UserArtistMapResponse,
+        "listen"
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("changeSelectedMetric", () => {
+    it('sets state correctly for "artist"', () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
+
+      instance.rawData = userArtistMapResponse as UserArtistMapResponse;
+
+      instance.changeSelectedMetric("artist");
+      expect(wrapper.state()).toMatchObject({
+        data: userArtistMapProcessedDataArtist,
+        selectedMetric: "artist",
+      });
+    });
+
+    it('sets state correctly for "listen"', () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
+
+      instance.rawData = userArtistMapResponse as UserArtistMapResponse;
+
+      instance.changeSelectedMetric("listen");
+      expect(wrapper.state()).toMatchObject({
+        data: userArtistMapProcessedDataListen,
+        selectedMetric: "listen",
+      });
+    });
+  });
+
+  describe("loadData", () => {
+    it("calls getData once", async () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
+
+      instance.getData = jest.fn();
+      instance.processData = jest.fn();
+      await instance.loadData();
+
+      expect(instance.getData).toHaveBeenCalledTimes(1);
+    });
+
+    it("set state correctly", async () => {
+      const wrapper = shallow<UserArtistMap>(<UserArtistMap {...props} />);
+      const instance = wrapper.instance();
+
+      instance.getData = jest
+        .fn()
+        .mockImplementationOnce(() => Promise.resolve(userArtistMapResponse));
+      await instance.loadData();
+
+      expect(instance.rawData).toMatchObject(userArtistMapResponse);
+
+      expect(wrapper.state()).toMatchObject({
+        data: userArtistMapProcessedDataArtist,
+        loading: false,
+      });
     });
   });
 });

--- a/listenbrainz/webserver/static/js/tests/stats/UserEntityChart.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/stats/UserEntityChart.test.tsx
@@ -11,7 +11,7 @@ import * as userReleasesProcessDataOutput from "../__mocks__/userReleasesProcess
 import * as userRecordingsResponse from "../__mocks__/userRecordings.json";
 import * as userRecordingsProcessDataOutput from "../__mocks__/userRecordingsProcessData.json";
 
-const props = {
+const userProps = {
   user: {
     id: 0,
     name: "dummyUser",
@@ -19,6 +19,12 @@ const props = {
   apiUrl: "apiUrl",
   newAlert: jest.fn(),
 };
+
+const sitewideProps = {
+  apiUrl: "apiUrl",
+  newAlert: jest.fn(),
+};
+
 const GlobalContextMock = {
   APIService: new APIService("base-uri"),
   spotifyAuth: {
@@ -34,634 +40,645 @@ const GlobalContextMock = {
   currentUser: { name: "" },
 };
 
-describe("UserEntityChart Page", () => {
-  it("renders correctly for artists", () => {
-    // We don't need to call componentDidMount during "mount" because we are
-    // passing the data manually, so mock the implementation once.
-    jest
-      .spyOn(UserEntityChart.prototype, "componentDidMount")
-      .mockImplementationOnce((): any => {});
+describe.each([
+  ["User Stats", userProps],
+  ["Sitewide Stats", sitewideProps],
+])("%s", (name, props) => {
+  describe("UserEntityChart Page", () => {
+    it("renders correctly for artists", () => {
+      // We don't need to call componentDidMount during "mount" because we are
+      // passing the data manually, so mock the implementation once.
+      jest
+        .spyOn(UserEntityChart.prototype, "componentDidMount")
+        .mockImplementationOnce((): any => {});
 
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
 
-    wrapper.setState({
-      data: userArtistsProcessDataOutput as UserEntityData,
-      startDate: new Date(0),
-      endDate: new Date(10),
-      maxListens: 70,
+      wrapper.setState({
+        data: userArtistsProcessDataOutput as UserEntityData,
+        startDate: new Date(0),
+        endDate: new Date(10),
+        maxListens: 70,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
+    it("renders correctly for releases", () => {
+      // We don't need to call componentDidMount during "mount" because we are
+      // passing the data manually, so mock the implementation once.
+      jest
+        .spyOn(UserEntityChart.prototype, "componentDidMount")
+        .mockImplementationOnce((): any => {});
+
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
+
+      wrapper.setState({
+        data: userReleasesProcessDataOutput as UserEntityData,
+        startDate: new Date(0),
+        endDate: new Date(10),
+        maxListens: 26,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("renders correctly for recording", () => {
+      // We don't need to call componentDidMount during "mount" because we are
+      // passing the data manually, so mock the implementation once.
+      jest
+        .spyOn(UserEntityChart.prototype, "componentDidMount")
+        .mockImplementationOnce((): any => {});
+
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
+
+      wrapper.setState({
+        data: userRecordingsProcessDataOutput as UserEntityData,
+        startDate: new Date(0),
+        endDate: new Date(10),
+        maxListens: 26,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("renders correctly if stats are not calculated", () => {
+      jest
+        .spyOn(UserEntityChart.prototype, "componentDidMount")
+        .mockImplementationOnce((): any => {});
+
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
+      wrapper.setState({
+        hasError: true,
+        errorMessage: "Statistics for the user have not been calculated",
+        entity: "artist",
+        range: "all_time",
+        currPage: 1,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
-  it("renders correctly for releases", () => {
-    // We don't need to call componentDidMount during "mount" because we are
-    // passing the data manually, so mock the implementation once.
-    jest
-      .spyOn(UserEntityChart.prototype, "componentDidMount")
-      .mockImplementationOnce((): any => {});
+  describe("componentDidMount", () => {
+    it('adds event listener for "popstate" event', () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
+      const spy = jest.spyOn(window, "addEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
 
-    wrapper.setState({
-      data: userReleasesProcessDataOutput as UserEntityData,
-      startDate: new Date(0),
-      endDate: new Date(10),
-      maxListens: 26,
+      expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
+    it('adds event listener for "resize" event', () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(window, "addEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.syncStateWithURL = jest.fn();
+      instance.handleResize = jest.fn();
+      instance.componentDidMount();
+
+      expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
+    });
+
+    it("calls getURLParams once", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      instance.getURLParams = jest.fn().mockImplementationOnce(() => {
+        return { page: 1, range: "all_time", entity: "artist" };
+      });
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
+
+      expect(instance.getURLParams).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls replaceState with correct parameters", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(window.history, "replaceState");
+      spy.mockImplementationOnce(() => {});
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
+
+      expect(spy).toHaveBeenCalledWith(
+        null,
+        "",
+        "?page=1&range=all_time&entity=artist"
+      );
+    });
+
+    it("calls syncStateWithURL", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
+
+      expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("renders correctly for recording", () => {
-    // We don't need to call componentDidMount during "mount" because we are
-    // passing the data manually, so mock the implementation once.
-    jest
-      .spyOn(UserEntityChart.prototype, "componentDidMount")
-      .mockImplementationOnce((): any => {});
+  describe("componentWillUnmount", () => {
+    it('removes "popstate" event listener', () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
+      const spy = jest.spyOn(window, "removeEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.syncStateWithURL = jest.fn();
+      instance.componentWillUnmount();
 
-    wrapper.setState({
-      data: userRecordingsProcessDataOutput as UserEntityData,
-      startDate: new Date(0),
-      endDate: new Date(10),
-      maxListens: 26,
+      expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
+    it('removes "resize" event listener', () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(window, "removeEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.handleResize = jest.fn();
+      instance.componentWillUnmount();
+
+      expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
+    });
   });
 
-  it("renders correctly if stats are not calculated", () => {
-    jest
-      .spyOn(UserEntityChart.prototype, "componentDidMount")
-      .mockImplementationOnce((): any => {});
+  describe("changePage", () => {
+    it("calls setURLParams with correct parameters", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />);
-    wrapper.setState({
-      hasError: true,
-      errorMessage: "Statistics for the user have not been calculated",
-      entity: "artist",
-      range: "all_time",
-      currPage: 1,
+      instance.setURLParams = jest.fn();
+      instance.syncStateWithURL = jest.fn();
+      instance.changePage(2);
+
+      expect(instance.setURLParams).toHaveBeenCalledWith(2, "", "");
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
-  });
-});
+    it("calls syncStateWithURL once", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-describe("componentDidMount", () => {
-  it('adds event listener for "popstate" event', () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+      instance.setURLParams = jest.fn();
+      instance.syncStateWithURL = jest.fn();
+      instance.changeRange("week");
+
+      expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
     });
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(window, "addEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
-
-    expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
   });
 
-  it('adds event listener for "resize" event', () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+  describe("changeRange", () => {
+    it("calls setURLParams with correct parameters", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      instance.setURLParams = jest.fn();
+      instance.syncStateWithURL = jest.fn();
+      instance.changeRange("week");
+
+      expect(instance.setURLParams).toHaveBeenCalledWith(1, "week", "");
     });
-    const instance = wrapper.instance();
 
-    const spy = jest.spyOn(window, "addEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.syncStateWithURL = jest.fn();
-    instance.handleResize = jest.fn();
-    instance.componentDidMount();
+    it("calls syncStateWithURL once", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
+      instance.setURLParams = jest.fn();
+      instance.syncStateWithURL = jest.fn();
+      instance.changeRange("week");
+
+      expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("calls getURLParams once", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
+  describe("changeEntity", () => {
+    it("calls setURLParams with correct parameters", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    instance.getURLParams = jest.fn().mockImplementationOnce(() => {
-      return { page: 1, range: "all_time", entity: "artist" };
-    });
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
+      const setURLParamsSpy = jest.spyOn(instance, "setURLParams");
+      instance.changeEntity("release");
 
-    expect(instance.getURLParams).toHaveBeenCalledTimes(1);
+      expect(setURLParamsSpy).toHaveBeenCalledWith(1, "", "release");
+    });
+
+    it("calls syncStateWithURL once", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const syncStateWithURLSpy = jest.spyOn(instance, "syncStateWithURL");
+      instance.changeEntity("release");
+
+      expect(syncStateWithURLSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("calls replaceState with correct parameters", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+  describe("getInitData", () => {
+    it("gets data correctly for artist", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
+      spy.mockImplementation((): any => {
+        return Promise.resolve(userArtistsResponse);
+      });
+
+      const {
+        maxListens,
+        totalPages,
+        entityCount,
+        startDate,
+        endDate,
+      } = await instance.getInitData("all_time", "artist");
+
+      expect(maxListens).toEqual(70);
+      expect(totalPages).toEqual(4);
+      expect(entityCount).toEqual(94);
+      expect(startDate).toEqual(
+        new Date(userArtistsResponse.payload.from_ts * 1000)
+      );
+      expect(endDate).toEqual(
+        new Date(userArtistsResponse.payload.to_ts * 1000)
+      );
     });
-    const instance = wrapper.instance();
 
-    const spy = jest.spyOn(window.history, "replaceState");
-    spy.mockImplementationOnce(() => {});
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
+    it("gets data correctly for release", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    expect(spy).toHaveBeenCalledWith(
-      null,
-      "",
-      "?page=1&range=all_time&entity=artist"
-    );
+      const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
+      spy.mockImplementation((): any => {
+        return Promise.resolve(userReleasesResponse);
+      });
+
+      const {
+        maxListens,
+        totalPages,
+        entityCount,
+        startDate,
+        endDate,
+      } = await instance.getInitData("all_time", "release");
+
+      expect(maxListens).toEqual(26);
+      expect(totalPages).toEqual(7);
+      expect(entityCount).toEqual(164);
+      expect(startDate).toEqual(
+        new Date(userReleasesResponse.payload.from_ts * 1000)
+      );
+      expect(endDate).toEqual(
+        new Date(userReleasesResponse.payload.to_ts * 1000)
+      );
+    });
+
+    it("gets data correctly for recording", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
+      spy.mockImplementation((): any => {
+        return Promise.resolve(userRecordingsResponse);
+      });
+
+      const {
+        maxListens,
+        totalPages,
+        entityCount,
+        startDate,
+        endDate,
+      } = await instance.getInitData("all_time", "recording");
+
+      expect(maxListens).toEqual(25);
+      expect(totalPages).toEqual(10);
+      expect(entityCount).toEqual(227);
+      expect(startDate).toEqual(
+        new Date(userRecordingsResponse.payload.from_ts * 1000)
+      );
+      expect(endDate).toEqual(
+        new Date(userRecordingsResponse.payload.to_ts * 1000)
+      );
+    });
   });
 
-  it("calls syncStateWithURL", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+  describe("getData", () => {
+    it("calls getUserEntity with correct parameters", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
+      spy.mockImplementation((): any => {
+        return Promise.resolve(userArtistsResponse);
+      });
+      await instance.getData(2, "all_time", "release");
+
+      expect(spy).toHaveBeenCalledWith(
+        // @ts-ignore
+        props?.user?.name,
+        "release",
+        "all_time",
+        25,
+        25
+      );
     });
-    const instance = wrapper.instance();
-
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
-
-    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("componentWillUnmount", () => {
-  it('removes "popstate" event listener', () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(window, "removeEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.syncStateWithURL = jest.fn();
-    instance.componentWillUnmount();
-
-    expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
   });
 
-  it('removes "resize" event listener', () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+  describe("processData", () => {
+    it("processes data correctly for top artists", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      wrapper.setState({ entity: "artist" });
+
+      expect(
+        instance.processData(userArtistsResponse as UserArtistsResponse, 1)
+      ).toEqual(userArtistsProcessDataOutput);
     });
-    const instance = wrapper.instance();
 
-    const spy = jest.spyOn(window, "removeEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.handleResize = jest.fn();
-    instance.componentWillUnmount();
+    it("processes data correctly for top releases", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    expect(spy).toHaveBeenCalledWith("resize", instance.handleResize);
-  });
-});
+      wrapper.setState({ entity: "release" });
 
-describe("changePage", () => {
-  it("calls setURLParams with correct parameters", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+      expect(
+        instance.processData(userReleasesResponse as UserReleasesResponse, 1)
+      ).toEqual(userReleasesProcessDataOutput);
     });
-    const instance = wrapper.instance();
 
-    instance.setURLParams = jest.fn();
-    instance.syncStateWithURL = jest.fn();
-    instance.changePage(2);
+    it("processes data correctly for top recordings", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    expect(instance.setURLParams).toHaveBeenCalledWith(2, "", "");
-  });
+      wrapper.setState({ entity: "recording" });
 
-  it("calls syncStateWithURL once", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+      expect(
+        instance.processData(
+          userRecordingsResponse as UserRecordingsResponse,
+          1
+        )
+      ).toEqual(userRecordingsProcessDataOutput);
     });
-    const instance = wrapper.instance();
+    it("returns an empty array if no payload", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    instance.setURLParams = jest.fn();
-    instance.syncStateWithURL = jest.fn();
-    instance.changeRange("week");
+      // When stats haven't been calculated, processData is called with an empty object
+      const result = instance.processData({} as UserRecordingsResponse, 1);
 
-    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("changeRange", () => {
-  it("calls setURLParams with correct parameters", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
+      expect(result).toEqual([]);
     });
-    const instance = wrapper.instance();
-
-    instance.setURLParams = jest.fn();
-    instance.syncStateWithURL = jest.fn();
-    instance.changeRange("week");
-
-    expect(instance.setURLParams).toHaveBeenCalledWith(1, "week", "");
   });
 
-  it("calls syncStateWithURL once", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
+  describe("syncStateWithURL", () => {
+    it("sets state correctly", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
 
-    instance.setURLParams = jest.fn();
-    instance.syncStateWithURL = jest.fn();
-    instance.changeRange("week");
+      jest.spyOn(instance, "getURLParams").mockImplementationOnce(() => ({
+        page: 1,
+        range: "all_time",
+        entity: "artist",
+      }));
+      jest.spyOn(instance, "getInitData").mockImplementationOnce(() =>
+        Promise.resolve({
+          startDate: new Date(0),
+          endDate: new Date(10),
+          totalPages: 2,
+          maxListens: 100,
+          entityCount: 50,
+        })
+      );
+      jest
+        .spyOn(instance, "getData")
+        .mockImplementationOnce(() =>
+          Promise.resolve(userArtistsResponse as UserArtistsResponse)
+        );
+      jest
+        .spyOn(instance, "processData")
+        .mockImplementationOnce(
+          () => userArtistsProcessDataOutput as UserEntityData
+        );
+      await instance.syncStateWithURL();
 
-    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("changeEntity", () => {
-  it("calls setURLParams with correct parameters", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const setURLParamsSpy = jest.spyOn(instance, "setURLParams");
-    instance.changeEntity("release");
-
-    expect(setURLParamsSpy).toHaveBeenCalledWith(1, "", "release");
-  });
-
-  it("calls syncStateWithURL once", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const syncStateWithURLSpy = jest.spyOn(instance, "syncStateWithURL");
-    instance.changeEntity("release");
-
-    expect(syncStateWithURLSpy).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("getInitData", () => {
-  it("gets data correctly for artist", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userArtistsResponse);
-    });
-
-    const {
-      maxListens,
-      totalPages,
-      entityCount,
-      startDate,
-      endDate,
-    } = await instance.getInitData("all_time", "artist");
-
-    expect(maxListens).toEqual(70);
-    expect(totalPages).toEqual(4);
-    expect(entityCount).toEqual(94);
-    expect(startDate).toEqual(
-      new Date(userArtistsResponse.payload.from_ts * 1000)
-    );
-    expect(endDate).toEqual(new Date(userArtistsResponse.payload.to_ts * 1000));
-  });
-
-  it("gets data correctly for release", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userReleasesResponse);
-    });
-
-    const {
-      maxListens,
-      totalPages,
-      entityCount,
-      startDate,
-      endDate,
-    } = await instance.getInitData("all_time", "release");
-
-    expect(maxListens).toEqual(26);
-    expect(totalPages).toEqual(7);
-    expect(entityCount).toEqual(164);
-    expect(startDate).toEqual(
-      new Date(userReleasesResponse.payload.from_ts * 1000)
-    );
-    expect(endDate).toEqual(
-      new Date(userReleasesResponse.payload.to_ts * 1000)
-    );
-  });
-
-  it("gets data correctly for recording", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userRecordingsResponse);
-    });
-
-    const {
-      maxListens,
-      totalPages,
-      entityCount,
-      startDate,
-      endDate,
-    } = await instance.getInitData("all_time", "recording");
-
-    expect(maxListens).toEqual(25);
-    expect(totalPages).toEqual(10);
-    expect(entityCount).toEqual(227);
-    expect(startDate).toEqual(
-      new Date(userRecordingsResponse.payload.from_ts * 1000)
-    );
-    expect(endDate).toEqual(
-      new Date(userRecordingsResponse.payload.to_ts * 1000)
-    );
-  });
-});
-
-describe("getData", () => {
-  it("calls getUserEntity with correct parameters", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.context.APIService, "getUserEntity");
-    spy.mockImplementation((): any => {
-      return Promise.resolve(userArtistsResponse);
-    });
-    await instance.getData(2, "all_time", "release");
-
-    expect(spy).toHaveBeenCalledWith(
-      "dummyUser",
-      "release",
-      "all_time",
-      25,
-      25
-    );
-  });
-});
-
-describe("processData", () => {
-  it("processes data correctly for top artists", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    wrapper.setState({ entity: "artist" });
-
-    expect(
-      instance.processData(userArtistsResponse as UserArtistsResponse, 1)
-    ).toEqual(userArtistsProcessDataOutput);
-  });
-
-  it("processes data correctly for top releases", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    wrapper.setState({ entity: "release" });
-
-    expect(
-      instance.processData(userReleasesResponse as UserReleasesResponse, 1)
-    ).toEqual(userReleasesProcessDataOutput);
-  });
-
-  it("processes data correctly for top recordings", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    wrapper.setState({ entity: "recording" });
-
-    expect(
-      instance.processData(userRecordingsResponse as UserRecordingsResponse, 1)
-    ).toEqual(userRecordingsProcessDataOutput);
-  });
-  it("returns an empty array if no payload", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    // When stats haven't been calculated, processData is called with an empty object
-    const result = instance.processData({} as UserRecordingsResponse, 1);
-
-    expect(result).toEqual([]);
-  });
-});
-
-describe("syncStateWithURL", () => {
-  it("sets state correctly", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    jest.spyOn(instance, "getURLParams").mockImplementationOnce(() => ({
-      page: 1,
-      range: "all_time",
-      entity: "artist",
-    }));
-    jest.spyOn(instance, "getInitData").mockImplementationOnce(() =>
-      Promise.resolve({
+      expect(instance.state).toMatchObject({
+        data: userArtistsProcessDataOutput,
+        currPage: 1,
+        range: "all_time",
+        entity: "artist",
         startDate: new Date(0),
         endDate: new Date(10),
         totalPages: 2,
         maxListens: 100,
         entityCount: 50,
-      })
-    );
-    jest
-      .spyOn(instance, "getData")
-      .mockImplementationOnce(() =>
-        Promise.resolve(userArtistsResponse as UserArtistsResponse)
+        hasError: false,
+      });
+    });
+
+    it("sets state correctly if stats haven't been calculated", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+      instance.getInitData = jest.fn().mockImplementationOnce(() => {
+        const error = new APIError("Not calculated");
+        error.response = {
+          status: 204,
+        } as Response;
+        return Promise.reject(error);
+      });
+
+      await instance.syncStateWithURL();
+      expect(instance.state).toMatchObject({
+        currPage: 1,
+        range: "all_time",
+        entity: "artist",
+        loading: false,
+        entityCount: 0,
+        hasError: true,
+        errorMessage: "Statistics for the user have not been calculated",
+      });
+    });
+
+    it("sets state correctly if range is incorrect", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      instance.getURLParams = jest.fn().mockImplementationOnce(() => {
+        return { range: "invalid_range", entity: "artist", page: 1 };
+      });
+
+      await instance.syncStateWithURL();
+      expect(instance.state).toMatchObject({
+        currPage: 1,
+        range: "invalid_range",
+        entity: "artist",
+        loading: false,
+        hasError: true,
+        errorMessage: "Invalid range: invalid_range",
+      });
+    });
+
+    it("sets state correctly if entity is incorrect", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      instance.getURLParams = jest.fn().mockImplementationOnce(() => {
+        return { range: "all_time", entity: "invalid_entity", page: 1 };
+      });
+
+      await instance.syncStateWithURL();
+      expect(instance.state).toMatchObject({
+        currPage: 1,
+        range: "all_time",
+        entity: "invalid_entity",
+        loading: false,
+        hasError: true,
+        errorMessage: "Invalid entity: invalid_entity",
+      });
+    });
+
+    it("sets state correctly if page is incorrect", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      instance.getURLParams = jest.fn().mockImplementationOnce(() => {
+        return { range: "all_time", entity: "artist", page: 1.5 };
+      });
+
+      await instance.syncStateWithURL();
+      expect(instance.state).toMatchObject({
+        currPage: 1.5,
+        range: "all_time",
+        entity: "artist",
+        loading: false,
+        hasError: true,
+        errorMessage: "Invalid page: 1.5",
+      });
+    });
+    it("throws error if fetch fails", async () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      instance.getInitData = jest
+        .fn()
+        .mockImplementationOnce(() => Promise.reject(Error("failed")));
+
+      await expect(instance.syncStateWithURL()).rejects.toThrowError("failed");
+    });
+  });
+
+  describe("getURLParams", () => {
+    it("gets default parameters if none are provided in the URL", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const { page, range, entity } = instance.getURLParams();
+
+      expect(page).toEqual(1);
+      expect(range).toEqual("all_time");
+      expect(entity).toEqual("artist");
+    });
+
+    it("gets parameters if provided in the URL", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      delete window.location;
+      window.location = {
+        href: "https://foobar.org?page=2&range=week&entity=release",
+      } as Window["location"];
+      const { page, range, entity } = instance.getURLParams();
+
+      expect(page).toEqual(2);
+      expect(range).toEqual("week");
+      expect(entity).toEqual("release");
+    });
+  });
+
+  describe("setURLParams", () => {
+    it("sets URL parameters", () => {
+      const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
+        context: GlobalContextMock,
+      });
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(window.history, "pushState");
+      spy.mockImplementationOnce(() => {});
+
+      instance.setURLParams(2, "all_time", "release");
+      expect(spy).toHaveBeenCalledWith(
+        null,
+        "",
+        "?page=2&range=all_time&entity=release"
       );
-    jest
-      .spyOn(instance, "processData")
-      .mockImplementationOnce(
-        () => userArtistsProcessDataOutput as UserEntityData
-      );
-    await instance.syncStateWithURL();
-
-    expect(instance.state).toMatchObject({
-      data: userArtistsProcessDataOutput,
-      currPage: 1,
-      range: "all_time",
-      entity: "artist",
-      startDate: new Date(0),
-      endDate: new Date(10),
-      totalPages: 2,
-      maxListens: 100,
-      entityCount: 50,
-      hasError: false,
     });
-  });
-
-  it("sets state correctly if stats haven't been calculated", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-    instance.getInitData = jest.fn().mockImplementationOnce(() => {
-      const error = new APIError("Not calculated");
-      error.response = {
-        status: 204,
-      } as Response;
-      return Promise.reject(error);
-    });
-
-    await instance.syncStateWithURL();
-    expect(instance.state).toMatchObject({
-      currPage: 1,
-      range: "all_time",
-      entity: "artist",
-      loading: false,
-      entityCount: 0,
-      hasError: true,
-      errorMessage: "Statistics for the user have not been calculated",
-    });
-  });
-
-  it("sets state correctly if range is incorrect", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    instance.getURLParams = jest.fn().mockImplementationOnce(() => {
-      return { range: "invalid_range", entity: "artist", page: 1 };
-    });
-
-    await instance.syncStateWithURL();
-    expect(instance.state).toMatchObject({
-      currPage: 1,
-      range: "invalid_range",
-      entity: "artist",
-      loading: false,
-      hasError: true,
-      errorMessage: "Invalid range: invalid_range",
-    });
-  });
-
-  it("sets state correctly if entity is incorrect", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    instance.getURLParams = jest.fn().mockImplementationOnce(() => {
-      return { range: "all_time", entity: "invalid_entity", page: 1 };
-    });
-
-    await instance.syncStateWithURL();
-    expect(instance.state).toMatchObject({
-      currPage: 1,
-      range: "all_time",
-      entity: "invalid_entity",
-      loading: false,
-      hasError: true,
-      errorMessage: "Invalid entity: invalid_entity",
-    });
-  });
-
-  it("sets state correctly if page is incorrect", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    instance.getURLParams = jest.fn().mockImplementationOnce(() => {
-      return { range: "all_time", entity: "artist", page: 1.5 };
-    });
-
-    await instance.syncStateWithURL();
-    expect(instance.state).toMatchObject({
-      currPage: 1.5,
-      range: "all_time",
-      entity: "artist",
-      loading: false,
-      hasError: true,
-      errorMessage: "Invalid page: 1.5",
-    });
-  });
-  it("throws error if fetch fails", async () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    instance.getInitData = jest
-      .fn()
-      .mockImplementationOnce(() => Promise.reject(Error("failed")));
-
-    await expect(instance.syncStateWithURL()).rejects.toThrowError("failed");
-  });
-});
-
-describe("getURLParams", () => {
-  it("gets default parameters if none are provided in the URL", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const { page, range, entity } = instance.getURLParams();
-
-    expect(page).toEqual(1);
-    expect(range).toEqual("all_time");
-    expect(entity).toEqual("artist");
-  });
-
-  it("gets parameters if provided in the URL", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    delete window.location;
-    window.location = {
-      href: "https://foobar.org?page=2&range=week&entity=release",
-    } as Window["location"];
-    const { page, range, entity } = instance.getURLParams();
-
-    expect(page).toEqual(2);
-    expect(range).toEqual("week");
-    expect(entity).toEqual("release");
-  });
-});
-
-describe("setURLParams", () => {
-  it("sets URL parameters", () => {
-    const wrapper = mount<UserEntityChart>(<UserEntityChart {...props} />, {
-      context: GlobalContextMock,
-    });
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(window.history, "pushState");
-    spy.mockImplementationOnce(() => {});
-
-    instance.setURLParams(2, "all_time", "release");
-    expect(spy).toHaveBeenCalledWith(
-      null,
-      "",
-      "?page=2&range=all_time&entity=release"
-    );
   });
 });

--- a/listenbrainz/webserver/static/js/tests/stats/UserListeningActivity.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/stats/UserListeningActivity.test.tsx
@@ -14,7 +14,7 @@ import * as userListeningActivityProcessedDataMonth from "../__mocks__/userListe
 import * as userListeningActivityProcessedDataYear from "../__mocks__/userListeningActivityProcessDataYear.json";
 import * as userListeningActivityProcessedDataAllTime from "../__mocks__/userListeningActivityProcessDataAllTime.json";
 
-const props: UserListeningActivityProps = {
+const userProps: UserListeningActivityProps = {
   user: {
     name: "foobar",
   },
@@ -22,314 +22,328 @@ const props: UserListeningActivityProps = {
   apiUrl: "barfoo",
 };
 
-describe("UserListeningActivity", () => {
-  it("renders correctly for week", () => {
-    const wrapper = mount<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
+const sitewideProps: UserListeningActivityProps = {
+  range: "week",
+  apiUrl: "barfoo",
+};
 
-    wrapper.setState({
-      data: userListeningActivityProcessedDataWeek,
-      thisRangePeriod: { start: 1591574400, end: 1592092800 },
-      lastRangePeriod: { start: 1590969600, end: 1591488000 },
-      totalListens: 70,
-      avgListens: 10,
-    });
-    wrapper.update();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("renders correctly for month", () => {
-    const wrapper = mount<UserListeningActivity>(
-      <UserListeningActivity {...{ ...props, range: "month" }} />
-    );
-
-    wrapper.setState({
-      data: userListeningActivityProcessedDataMonth,
-      thisRangePeriod: { start: 1590969600 },
-      lastRangePeriod: { start: 1588291200 },
-      totalListens: 70,
-      avgListens: 10,
-    });
-    wrapper.update();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("renders correctly for year", () => {
-    const wrapper = mount<UserListeningActivity>(
-      <UserListeningActivity {...{ ...props, range: "year" }} />
-    );
-
-    wrapper.setState({
-      data: userListeningActivityProcessedDataYear,
-      thisRangePeriod: { start: 1577836800 },
-      lastRangePeriod: { start: 1546300800 },
-      totalListens: 70,
-      avgListens: 10,
-    });
-    wrapper.update();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("renders correctly for all_time", () => {
-    const wrapper = mount<UserListeningActivity>(
-      <UserListeningActivity {...{ ...props, range: "all_time" }} />
-    );
-
-    wrapper.setState({
-      data: userListeningActivityProcessedDataAllTime,
-      thisRangePeriod: {},
-      lastRangePeriod: {},
-      totalListens: 70,
-      avgListens: 10,
-    });
-    wrapper.update();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("renders corectly when range is invalid", () => {
-    const wrapper = mount<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-
-    wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
-    wrapper.update();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-});
-
-describe("componentDidUpdate", () => {
-  it("it sets correct state if range is incorrect", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-
-    wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
-    wrapper.update();
-
-    expect(wrapper.state()).toMatchObject({
-      loading: false,
-      hasError: true,
-      errorMessage: "Invalid range: invalid_range",
-    });
-  });
-
-  it("calls loadData once if range is valid", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    instance.loadData = jest.fn();
-    wrapper.setProps({ range: "month" });
-    wrapper.update();
-
-    expect(instance.loadData).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("getData", () => {
-  it("calls getUserListeningActivity with correct params", async () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.APIService, "getUserListeningActivity");
-    spy.mockImplementation(() =>
-      Promise.resolve(
-        userListeningActivityResponseWeek as UserListeningActivityResponse
-      )
-    );
-    await instance.getData();
-
-    expect(spy).toHaveBeenCalledWith("foobar", "week");
-  });
-
-  it("sets state correctly if data is not calculated", async () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.APIService, "getUserListeningActivity");
-    const noContentError = new APIError("NO CONTENT");
-    noContentError.response = {
-      status: 204,
-    } as Response;
-    spy.mockImplementation(() => Promise.reject(noContentError));
-    await instance.getData();
-
-    expect(wrapper.state()).toMatchObject({
-      loading: false,
-      hasError: true,
-      errorMessage: "Statistics for the user have not been calculated",
-    });
-  });
-
-  it("throws error", async () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.APIService, "getUserListeningActivity");
-    const notFoundError = new APIError("NOT FOUND");
-    notFoundError.response = {
-      status: 404,
-    } as Response;
-    spy.mockImplementation(() => Promise.reject(notFoundError));
-
-    await expect(instance.getData()).rejects.toThrow("NOT FOUND");
-  });
-});
-
-describe("getNumberOfDaysInMonth", () => {
-  it("calculates correctly for non leap February", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    expect(instance.getNumberOfDaysInMonth(new Date(2019, 1, 1))).toEqual(28);
-  });
-
-  it("calculates correctly for leap February", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    expect(instance.getNumberOfDaysInMonth(new Date(2020, 1, 1))).toEqual(29);
-  });
-
-  it("calculates correctly for December", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    expect(instance.getNumberOfDaysInMonth(new Date(2020, 11, 1))).toEqual(31);
-  });
-
-  it("calculates correctly for November", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    expect(instance.getNumberOfDaysInMonth(new Date(2020, 10, 1))).toEqual(30);
-  });
-});
-
-describe("processData", () => {
-  it("processes data correctly for week", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    const result = instance.processData(
-      userListeningActivityResponseWeek as UserListeningActivityResponse
-    );
-
-    expect(result).toEqual(userListeningActivityProcessedDataWeek);
-  });
-
-  it("processes data correctly for month", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...{ ...props, range: "month" }} />
-    );
-    const instance = wrapper.instance();
-
-    const result = instance.processData(
-      userListeningActivityResponseMonth as UserListeningActivityResponse
-    );
-
-    expect(result).toEqual(userListeningActivityProcessedDataMonth);
-  });
-
-  it("processes data correctly for year", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...{ ...props, range: "year" }} />
-    );
-    const instance = wrapper.instance();
-
-    const result = instance.processData(
-      userListeningActivityResponseYear as UserListeningActivityResponse
-    );
-
-    expect(result).toEqual(userListeningActivityProcessedDataYear);
-  });
-
-  it("processes data correctly for all_time", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...{ ...props, range: "all_time" }} />
-    );
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(Date.prototype, "getFullYear");
-    spy.mockImplementationOnce(() =>
-      new Date(
-        userListeningActivityResponseAllTime.payload.to_ts * 1000
-      ).getFullYear()
-    );
-
-    const result = instance.processData(
-      userListeningActivityResponseAllTime as UserListeningActivityResponse
-    );
-
-    expect(result).toEqual(userListeningActivityProcessedDataAllTime);
-  });
-  it("returns an empty array if no payload", () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...{ ...props, range: "year" }} />
-    );
-    const instance = wrapper.instance();
-
-    // When stats haven't been calculated, processData is called with an empty object
-    const result = instance.processData({} as UserListeningActivityResponse);
-
-    expect(result).toEqual([]);
-  });
-});
-
-describe("loadData", () => {
-  it("calls getData once", async () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    instance.getData = jest.fn();
-    instance.processData = jest.fn();
-    await instance.loadData();
-
-    expect(instance.getData).toHaveBeenCalledTimes(1);
-  });
-
-  it("set state correctly", async () => {
-    const wrapper = shallow<UserListeningActivity>(
-      <UserListeningActivity {...props} />
-    );
-    const instance = wrapper.instance();
-
-    instance.getData = jest
-      .fn()
-      .mockImplementationOnce(() =>
-        Promise.resolve(userListeningActivityResponseWeek)
+describe.each([
+  ["User Stats", userProps],
+  ["Sitewide Stats", sitewideProps],
+])("%s", (name, props) => {
+  describe("UserListeningActivity", () => {
+    it("renders correctly for week", () => {
+      const wrapper = mount<UserListeningActivity>(
+        <UserListeningActivity {...props} />
       );
 
-    await instance.loadData();
+      wrapper.setState({
+        data: userListeningActivityProcessedDataWeek,
+        thisRangePeriod: { start: 1591574400, end: 1592092800 },
+        lastRangePeriod: { start: 1590969600, end: 1591488000 },
+        totalListens: 70,
+        avgListens: 10,
+      });
+      wrapper.update();
 
-    expect(wrapper.state()).toMatchObject({
-      data: userListeningActivityProcessedDataWeek,
-      loading: false,
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("renders correctly for month", () => {
+      const wrapper = mount<UserListeningActivity>(
+        <UserListeningActivity {...{ ...props, range: "month" }} />
+      );
+
+      wrapper.setState({
+        data: userListeningActivityProcessedDataMonth,
+        thisRangePeriod: { start: 1590969600 },
+        lastRangePeriod: { start: 1588291200 },
+        totalListens: 70,
+        avgListens: 10,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("renders correctly for year", () => {
+      const wrapper = mount<UserListeningActivity>(
+        <UserListeningActivity {...{ ...props, range: "year" }} />
+      );
+
+      wrapper.setState({
+        data: userListeningActivityProcessedDataYear,
+        thisRangePeriod: { start: 1577836800 },
+        lastRangePeriod: { start: 1546300800 },
+        totalListens: 70,
+        avgListens: 10,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("renders correctly for all_time", () => {
+      const wrapper = mount<UserListeningActivity>(
+        <UserListeningActivity {...{ ...props, range: "all_time" }} />
+      );
+
+      wrapper.setState({
+        data: userListeningActivityProcessedDataAllTime,
+        thisRangePeriod: {},
+        lastRangePeriod: {},
+        totalListens: 70,
+        avgListens: 10,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("renders corectly when range is invalid", () => {
+      const wrapper = mount<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+
+      wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe("componentDidUpdate", () => {
+    it("it sets correct state if range is incorrect", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+
+      wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
+      wrapper.update();
+
+      expect(wrapper.state()).toMatchObject({
+        loading: false,
+        hasError: true,
+        errorMessage: "Invalid range: invalid_range",
+      });
+    });
+
+    it("calls loadData once if range is valid", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      instance.loadData = jest.fn();
+      wrapper.setProps({ range: "month" });
+      wrapper.update();
+
+      expect(instance.loadData).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getData", () => {
+    it("calls getUserListeningActivity with correct params", async () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserListeningActivity");
+      spy.mockImplementation(() =>
+        Promise.resolve(
+          userListeningActivityResponseWeek as UserListeningActivityResponse
+        )
+      );
+      await instance.getData();
+
+      expect(spy).toHaveBeenCalledWith(props?.user?.name, "week");
+    });
+
+    it("sets state correctly if data is not calculated", async () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserListeningActivity");
+      const noContentError = new APIError("NO CONTENT");
+      noContentError.response = {
+        status: 204,
+      } as Response;
+      spy.mockImplementation(() => Promise.reject(noContentError));
+      await instance.getData();
+
+      expect(wrapper.state()).toMatchObject({
+        loading: false,
+        hasError: true,
+        errorMessage: "Statistics for the user have not been calculated",
+      });
+    });
+
+    it("throws error", async () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserListeningActivity");
+      const notFoundError = new APIError("NOT FOUND");
+      notFoundError.response = {
+        status: 404,
+      } as Response;
+      spy.mockImplementation(() => Promise.reject(notFoundError));
+
+      await expect(instance.getData()).rejects.toThrow("NOT FOUND");
+    });
+  });
+
+  describe("getNumberOfDaysInMonth", () => {
+    it("calculates correctly for non leap February", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      expect(instance.getNumberOfDaysInMonth(new Date(2019, 1, 1))).toEqual(28);
+    });
+
+    it("calculates correctly for leap February", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      expect(instance.getNumberOfDaysInMonth(new Date(2020, 1, 1))).toEqual(29);
+    });
+
+    it("calculates correctly for December", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      expect(instance.getNumberOfDaysInMonth(new Date(2020, 11, 1))).toEqual(
+        31
+      );
+    });
+
+    it("calculates correctly for November", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      expect(instance.getNumberOfDaysInMonth(new Date(2020, 10, 1))).toEqual(
+        30
+      );
+    });
+  });
+
+  describe("processData", () => {
+    it("processes data correctly for week", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      const result = instance.processData(
+        userListeningActivityResponseWeek as UserListeningActivityResponse
+      );
+
+      expect(result).toEqual(userListeningActivityProcessedDataWeek);
+    });
+
+    it("processes data correctly for month", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...{ ...props, range: "month" }} />
+      );
+      const instance = wrapper.instance();
+
+      const result = instance.processData(
+        userListeningActivityResponseMonth as UserListeningActivityResponse
+      );
+
+      expect(result).toEqual(userListeningActivityProcessedDataMonth);
+    });
+
+    it("processes data correctly for year", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...{ ...props, range: "year" }} />
+      );
+      const instance = wrapper.instance();
+
+      const result = instance.processData(
+        userListeningActivityResponseYear as UserListeningActivityResponse
+      );
+
+      expect(result).toEqual(userListeningActivityProcessedDataYear);
+    });
+
+    it("processes data correctly for all_time", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...{ ...props, range: "all_time" }} />
+      );
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(Date.prototype, "getFullYear");
+      spy.mockImplementationOnce(() =>
+        new Date(
+          userListeningActivityResponseAllTime.payload.to_ts * 1000
+        ).getFullYear()
+      );
+
+      const result = instance.processData(
+        userListeningActivityResponseAllTime as UserListeningActivityResponse
+      );
+
+      expect(result).toEqual(userListeningActivityProcessedDataAllTime);
+    });
+    it("returns an empty array if no payload", () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...{ ...props, range: "year" }} />
+      );
+      const instance = wrapper.instance();
+
+      // When stats haven't been calculated, processData is called with an empty object
+      const result = instance.processData({} as UserListeningActivityResponse);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("loadData", () => {
+    it("calls getData once", async () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      instance.getData = jest.fn();
+      instance.processData = jest.fn();
+      await instance.loadData();
+
+      expect(instance.getData).toHaveBeenCalledTimes(1);
+    });
+
+    it("set state correctly", async () => {
+      const wrapper = shallow<UserListeningActivity>(
+        <UserListeningActivity {...props} />
+      );
+      const instance = wrapper.instance();
+
+      instance.getData = jest
+        .fn()
+        .mockImplementationOnce(() =>
+          Promise.resolve(userListeningActivityResponseWeek)
+        );
+
+      await instance.loadData();
+
+      expect(wrapper.state()).toMatchObject({
+        data: userListeningActivityProcessedDataWeek,
+        loading: false,
+      });
     });
   });
 });

--- a/listenbrainz/webserver/static/js/tests/stats/UserReports.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/stats/UserReports.test.tsx
@@ -3,165 +3,174 @@ import { shallow } from "enzyme";
 
 import UserReports, { UserReportsProps } from "../../src/stats/UserReports";
 
-const props: UserReportsProps = {
+const userProps: UserReportsProps = {
   user: {
     name: "test_user",
   },
   apiUrl: "foobar",
 };
 
-describe("UserReports", () => {
-  it("renders without crashing", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
+const sitewideProps: UserReportsProps = {
+  apiUrl: "foobar",
+};
 
-    expect(wrapper).toMatchSnapshot();
-  });
-});
+describe.each([
+  ["User Stats", userProps],
+  ["Sitewide Stats", sitewideProps],
+])("%s", (name, props) => {
+  describe("UserReports", () => {
+    it("renders without crashing", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
 
-describe("ComponentDidMount", () => {
-  it('adds event listener for "popstate" event', () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(window, "addEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
-
-    expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
-  it("calls getURLParams once", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+  describe("ComponentDidMount", () => {
+    it('adds event listener for "popstate" event', () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    instance.getURLParams = jest.fn();
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
+      const spy = jest.spyOn(window, "addEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
 
-    expect(instance.getURLParams).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
+    });
+
+    it("calls getURLParams once", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
+
+      instance.getURLParams = jest.fn();
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
+
+      expect(instance.getURLParams).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls replaceState with correct parameters", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(window.history, "replaceState");
+      spy.mockImplementationOnce(() => {});
+      instance.getURLParams = jest.fn().mockImplementationOnce(() => "week");
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
+
+      expect(spy).toHaveBeenCalledWith(null, "", "?range=week");
+    });
+
+    it("calls syncStateWithURL", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
+
+      instance.syncStateWithURL = jest.fn();
+      instance.componentDidMount();
+
+      expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("calls replaceState with correct parameters", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+  describe("componentWillUnmount", () => {
+    it('removes "popstate" event listener', () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    const spy = jest.spyOn(window.history, "replaceState");
-    spy.mockImplementationOnce(() => {});
-    instance.getURLParams = jest.fn().mockImplementationOnce(() => "week");
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
+      const spy = jest.spyOn(window, "removeEventListener");
+      spy.mockImplementationOnce(() => {});
+      instance.syncStateWithURL = jest.fn();
+      instance.componentWillUnmount();
 
-    expect(spy).toHaveBeenCalledWith(null, "", "?range=week");
+      expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
+    });
   });
 
-  it("calls syncStateWithURL", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+  describe("changeRange", () => {
+    it("calls setURLParams with correct parameters", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    instance.syncStateWithURL = jest.fn();
-    instance.componentDidMount();
+      instance.setURLParams = jest.fn();
+      instance.syncStateWithURL = jest.fn();
+      instance.changeRange("year");
 
-    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
-  });
-});
+      expect(instance.setURLParams).toHaveBeenCalledWith("year");
+    });
 
-describe("componentWillUnmount", () => {
-  it('removes "popstate" event listener', () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+    it("calls syncStateWithURL once", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    const spy = jest.spyOn(window, "removeEventListener");
-    spy.mockImplementationOnce(() => {});
-    instance.syncStateWithURL = jest.fn();
-    instance.componentWillUnmount();
+      instance.syncStateWithURL = jest.fn();
+      instance.changeRange("year");
 
-    expect(spy).toHaveBeenCalledWith("popstate", instance.syncStateWithURL);
-  });
-});
-
-describe("changeRange", () => {
-  it("calls setURLParams with correct parameters", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
-
-    instance.setURLParams = jest.fn();
-    instance.syncStateWithURL = jest.fn();
-    instance.changeRange("year");
-
-    expect(instance.setURLParams).toHaveBeenCalledWith("year");
+      expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("calls syncStateWithURL once", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+  describe("syncStateWithUrl", () => {
+    it("calls getURLParams once", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    instance.syncStateWithURL = jest.fn();
-    instance.changeRange("year");
+      instance.getURLParams = jest.fn();
+      instance.syncStateWithURL();
 
-    expect(instance.syncStateWithURL).toHaveBeenCalledTimes(1);
-  });
-});
+      expect(instance.getURLParams).toHaveBeenCalledTimes(1);
+    });
 
-describe("syncStateWithUrl", () => {
-  it("calls getURLParams once", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+    it("sets state correcty", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    instance.getURLParams = jest.fn();
-    instance.syncStateWithURL();
+      instance.getURLParams = jest.fn().mockImplementationOnce(() => "month");
+      instance.syncStateWithURL();
 
-    expect(instance.getURLParams).toHaveBeenCalledTimes(1);
-  });
-
-  it("sets state correcty", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getURLParams = jest.fn().mockImplementationOnce(() => "month");
-    instance.syncStateWithURL();
-
-    expect(wrapper.state("range")).toEqual("month");
-  });
-});
-
-describe("getURLParams", () => {
-  it("gets default parameters if none are provided in the URL", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
-
-    delete window.location;
-    window.location = {
-      href: "https://foobar.org",
-    } as Window["location"];
-    const range = instance.getURLParams();
-
-    expect(range).toEqual("week");
+      expect(wrapper.state("range")).toEqual("month");
+    });
   });
 
-  it("gets parameters if provided in the URL", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+  describe("getURLParams", () => {
+    it("gets default parameters if none are provided in the URL", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    delete window.location;
-    window.location = {
-      href: "https://foobar.org?range=year",
-    } as Window["location"];
-    const range = instance.getURLParams();
+      delete window.location;
+      window.location = {
+        href: "https://foobar.org",
+      } as Window["location"];
+      const range = instance.getURLParams();
 
-    expect(range).toEqual("year");
+      expect(range).toEqual("week");
+    });
+
+    it("gets parameters if provided in the URL", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
+
+      delete window.location;
+      window.location = {
+        href: "https://foobar.org?range=year",
+      } as Window["location"];
+      const range = instance.getURLParams();
+
+      expect(range).toEqual("year");
+    });
   });
-});
 
-describe("setURLParams", () => {
-  it("sets URL parameters", () => {
-    const wrapper = shallow<UserReports>(<UserReports {...props} />);
-    const instance = wrapper.instance();
+  describe("setURLParams", () => {
+    it("sets URL parameters", () => {
+      const wrapper = shallow<UserReports>(<UserReports {...props} />);
+      const instance = wrapper.instance();
 
-    const spy = jest.spyOn(window.history, "pushState");
-    spy.mockImplementationOnce(() => {});
+      const spy = jest.spyOn(window.history, "pushState");
+      spy.mockImplementationOnce(() => {});
 
-    instance.setURLParams("all_time");
-    expect(spy).toHaveBeenCalledWith(null, "", "?range=all_time");
+      instance.setURLParams("all_time");
+      expect(spy).toHaveBeenCalledWith(null, "", "?range=all_time");
+    });
   });
 });

--- a/listenbrainz/webserver/static/js/tests/stats/UserTopEntity.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/stats/UserTopEntity.test.tsx
@@ -2,12 +2,14 @@ import * as React from "react";
 import { mount, shallow } from "enzyme";
 
 import APIError from "../../src/utils/APIError";
-import UserTopEntity, { UserTopEntityProps } from "../../src/stats/UserTopEntity";
+import UserTopEntity, {
+  UserTopEntityProps,
+} from "../../src/stats/UserTopEntity";
 import * as userArtists from "../__mocks__/userArtists.json";
 import * as userReleases from "../__mocks__/userReleases.json";
 import * as userRecordings from "../__mocks__/userRecordings.json";
 
-const props: UserTopEntityProps = {
+const userProps: UserTopEntityProps = {
   range: "week",
   entity: "artist",
   apiUrl: "foobar",
@@ -16,155 +18,172 @@ const props: UserTopEntityProps = {
   },
 };
 
-describe("UserTopEntity", () => {
-  it("renders correctly for artist", () => {
-    const wrapper = mount<UserTopEntity>(<UserTopEntity {...props} />);
+const sitewideProps: UserTopEntityProps = {
+  range: "week",
+  entity: "artist",
+  apiUrl: "foobar",
+};
 
-    wrapper.setState({
-      data: userArtists as UserArtistsResponse,
-      loading: false,
+describe.each([
+  ["User Stats", userProps],
+  ["Sitewide Stats", sitewideProps],
+])("%s", (name, props) => {
+  describe("UserTopEntity", () => {
+    it("renders correctly for artist", () => {
+      const wrapper = mount<UserTopEntity>(<UserTopEntity {...props} />);
+
+      wrapper.setState({
+        data: userArtists as UserArtistsResponse,
+        loading: false,
+      });
+      wrapper.update();
+
+      expect(wrapper).toMatchSnapshot();
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
-  });
+    it("renders correctly for release", () => {
+      const wrapper = mount<UserTopEntity>(
+        <UserTopEntity {...{ ...props, entity: "release" }} />
+      );
 
-  it("renders correctly for release", () => {
-    const wrapper = mount<UserTopEntity>(
-      <UserTopEntity {...{ ...props, entity: "release" }} />
-    );
+      wrapper.setState({
+        data: userReleases as UserReleasesResponse,
+        loading: false,
+      });
+      wrapper.update();
 
-    wrapper.setState({
-      data: userReleases as UserReleasesResponse,
-      loading: false,
+      expect(wrapper).toMatchSnapshot();
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
-  });
+    it("renders correctly for recording", () => {
+      const wrapper = mount<UserTopEntity>(
+        <UserTopEntity {...{ ...props, entity: "recording" }} />
+      );
 
-  it("renders correctly for recording", () => {
-    const wrapper = mount<UserTopEntity>(
-      <UserTopEntity {...{ ...props, entity: "recording" }} />
-    );
+      wrapper.setState({
+        data: userRecordings as UserRecordingsResponse,
+        loading: false,
+      });
+      wrapper.update();
 
-    wrapper.setState({
-      data: userRecordings as UserRecordingsResponse,
-      loading: false,
+      expect(wrapper).toMatchSnapshot();
     });
-    wrapper.update();
 
-    expect(wrapper).toMatchSnapshot();
-  });
+    it("renders corectly when range is invalid", () => {
+      const wrapper = mount<UserTopEntity>(<UserTopEntity {...props} />);
 
-  it("renders corectly when range is invalid", () => {
-    const wrapper = mount<UserTopEntity>(<UserTopEntity {...props} />);
+      wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
+      wrapper.setState({ loading: false });
+      wrapper.update();
 
-    wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
-    wrapper.setState({ loading: false });
-    wrapper.update();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-});
-
-describe("componentDidUpdate", () => {
-  it("it sets correct state if range is incorrect", () => {
-    const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
-
-    wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
-    wrapper.update();
-
-    expect(wrapper.state()).toMatchObject({
-      loading: false,
-      hasError: true,
-      errorMessage: "Invalid range: invalid_range",
+      expect(wrapper).toMatchSnapshot();
     });
   });
 
-  it("calls loadData once if range is valid", () => {
-    const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
-    const instance = wrapper.instance();
+  describe("componentDidUpdate", () => {
+    it("it sets correct state if range is incorrect", () => {
+      const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
 
-    instance.loadData = jest.fn();
-    wrapper.setProps({ range: "month" });
-    wrapper.update();
+      wrapper.setProps({ range: "invalid_range" as UserStatsAPIRange });
+      wrapper.update();
 
-    expect(instance.loadData).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("loadData", () => {
-  it("calls getData once", async () => {
-    const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest
-      .fn()
-      .mockImplementationOnce(() => Promise.resolve(userArtists));
-    await instance.loadData();
-
-    expect(instance.getData).toHaveBeenCalledTimes(1);
-  });
-
-  it("set state correctly", async () => {
-    const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
-    const instance = wrapper.instance();
-
-    instance.getData = jest
-      .fn()
-      .mockImplementationOnce(() => Promise.resolve(userArtists));
-    await instance.loadData();
-
-    expect(wrapper.state()).toMatchObject({
-      data: userArtists,
-      loading: false,
+      expect(wrapper.state()).toMatchObject({
+        loading: false,
+        hasError: true,
+        errorMessage: "Invalid range: invalid_range",
+      });
     });
-  });
-});
 
-describe("getData", () => {
-  it("calls getUserEntity with correct params", async () => {
-    const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
-    const instance = wrapper.instance();
+    it("calls loadData once if range is valid", () => {
+      const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
+      const instance = wrapper.instance();
 
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    spy.mockImplementation((): any => Promise.resolve(userArtists));
-    await instance.getData();
+      instance.loadData = jest.fn();
+      wrapper.setProps({ range: "month" });
+      wrapper.update();
 
-    expect(spy).toHaveBeenCalledWith("test_user", "artist", "week", 0, 10);
-  });
-
-  it("sets state correctly if data is not calculated", async () => {
-    const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
-    const instance = wrapper.instance();
-
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    const noContentError = new APIError("NO CONTENT");
-    noContentError.response = {
-      status: 204,
-    } as Response;
-    spy.mockImplementation(() => Promise.reject(noContentError));
-    await instance.getData();
-
-    expect(wrapper.state()).toMatchObject({
-      loading: false,
-      hasError: true,
-      errorMessage: "Statistics for the user have not been calculated",
+      expect(instance.loadData).toHaveBeenCalledTimes(1);
     });
   });
 
-  it("throws error", async () => {
-    const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
-    const instance = wrapper.instance();
+  describe("loadData", () => {
+    it("calls getData once", async () => {
+      const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
+      const instance = wrapper.instance();
 
-    const spy = jest.spyOn(instance.APIService, "getUserEntity");
-    const notFoundError = new APIError("NOT FOUND");
-    notFoundError.response = {
-      status: 404,
-    } as Response;
-    spy.mockImplementation(() => Promise.reject(notFoundError));
+      instance.getData = jest
+        .fn()
+        .mockImplementationOnce(() => Promise.resolve(userArtists));
+      await instance.loadData();
 
-    await expect(instance.getData()).rejects.toThrow("NOT FOUND");
+      expect(instance.getData).toHaveBeenCalledTimes(1);
+    });
+
+    it("set state correctly", async () => {
+      const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
+      const instance = wrapper.instance();
+
+      instance.getData = jest
+        .fn()
+        .mockImplementationOnce(() => Promise.resolve(userArtists));
+      await instance.loadData();
+
+      expect(wrapper.state()).toMatchObject({
+        data: userArtists,
+        loading: false,
+      });
+    });
+  });
+
+  describe("getData", () => {
+    it("calls getUserEntity with correct params", async () => {
+      const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserEntity");
+      spy.mockImplementation((): any => Promise.resolve(userArtists));
+      await instance.getData();
+
+      expect(spy).toHaveBeenCalledWith(
+        props?.user?.name,
+        "artist",
+        "week",
+        0,
+        10
+      );
+    });
+
+    it("sets state correctly if data is not calculated", async () => {
+      const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserEntity");
+      const noContentError = new APIError("NO CONTENT");
+      noContentError.response = {
+        status: 204,
+      } as Response;
+      spy.mockImplementation(() => Promise.reject(noContentError));
+      await instance.getData();
+
+      expect(wrapper.state()).toMatchObject({
+        loading: false,
+        hasError: true,
+        errorMessage: "Statistics for the user have not been calculated",
+      });
+    });
+
+    it("throws error", async () => {
+      const wrapper = shallow<UserTopEntity>(<UserTopEntity {...props} />);
+      const instance = wrapper.instance();
+
+      const spy = jest.spyOn(instance.APIService, "getUserEntity");
+      const notFoundError = new APIError("NOT FOUND");
+      notFoundError.response = {
+        status: 404,
+      } as Response;
+      spy.mockImplementation(() => Promise.reject(notFoundError));
+
+      await expect(instance.getData()).rejects.toThrow("NOT FOUND");
+    });
   });
 });

--- a/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserArtistMap.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserArtistMap.test.tsx.snap
@@ -1,6 +1,505 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserArtistMap renders corectly when range is invalid 1`] = `
+exports[`Sitewide Stats UserArtistMap renders corectly when range is invalid 1`] = `
+<UserArtistMap
+  apiUrl="barfoo"
+  range="invalid_range"
+>
+  <ForwardRef
+    style={
+      Object {
+        "marginTop": 20,
+        "minHeight": 600,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "marginTop": 20,
+          "minHeight": 600,
+        }
+      }
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-md-9 col-xs-6"
+        >
+          <h3
+            className="capitalize-bold"
+            style={
+              Object {
+                "marginLeft": 20,
+              }
+            }
+          >
+            Artist Origins
+          </h3>
+        </div>
+        <div
+          className="col-md-2 col-xs-4 text-right"
+          style={
+            Object {
+              "marginTop": 20,
+            }
+          }
+        >
+          <span
+            className="dropdown"
+          >
+            <button
+              className="dropdown-toggle btn-transparent capitalize-bold"
+              data-toggle="dropdown"
+              type="button"
+            >
+              artist
+              s
+              <span
+                className="caret"
+              />
+            </button>
+            <ul
+              className="dropdown-menu"
+              role="menu"
+            >
+              <li>
+                <a
+                  href=""
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Listens
+                </a>
+              </li>
+              <li>
+                <a
+                  href=""
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Artists
+                </a>
+              </li>
+            </ul>
+          </span>
+        </div>
+        <div
+          className="col-md-1 col-xs-2 text-right"
+        >
+          <h4
+            style={
+              Object {
+                "marginTop": 20,
+              }
+            }
+          >
+            <a
+              href="#artist-origin"
+            >
+              <FontAwesomeIcon
+                border={false}
+                className=""
+                color="#000000"
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      512,
+                      512,
+                      Array [],
+                      "f0c1",
+                      "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                    ],
+                    "iconName": "link",
+                    "prefix": "fas",
+                  }
+                }
+                inverse={false}
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                style={
+                  Object {
+                    "marginRight": 20,
+                  }
+                }
+                swapOpacity={false}
+                symbol={false}
+                title=""
+                transform={null}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-link fa-w-16 fa-sm "
+                  color="#000000"
+                  data-icon="link"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={
+                    Object {
+                      "marginRight": 20,
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </FontAwesomeIcon>
+            </a>
+          </h4>
+        </div>
+      </div>
+      <Loader
+        isLoading={false}
+      >
+        <div
+          className="flex-center"
+          style={
+            Object {
+              "minHeight": "inherit",
+            }
+          }
+        >
+          <span
+            className="text-center"
+            style={
+              Object {
+                "fontSize": 24,
+              }
+            }
+          >
+            <FontAwesomeIcon
+              border={false}
+              className=""
+              fixedWidth={false}
+              flip={null}
+              icon={
+                Object {
+                  "icon": Array [
+                    512,
+                    512,
+                    Array [],
+                    "f06a",
+                    "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z",
+                  ],
+                  "iconName": "exclamation-circle",
+                  "prefix": "fas",
+                }
+              }
+              inverse={false}
+              listItem={false}
+              mask={null}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size={null}
+              spin={false}
+              swapOpacity={false}
+              symbol={false}
+              title=""
+              transform={null}
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-exclamation-circle fa-w-16 "
+                data-icon="exclamation-circle"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </FontAwesomeIcon>
+             
+            Invalid range: invalid_range
+          </span>
+        </div>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserArtistMap>
+`;
+
+exports[`Sitewide Stats UserArtistMap renders correctly 1`] = `
+<ForwardRef
+  style={
+    Object {
+      "marginTop": 20,
+      "minHeight": 600,
+    }
+  }
+>
+  <div
+    className="row"
+  >
+    <div
+      className="col-md-9 col-xs-6"
+    >
+      <h3
+        className="capitalize-bold"
+        style={
+          Object {
+            "marginLeft": 20,
+          }
+        }
+      >
+        Artist Origins
+      </h3>
+    </div>
+    <div
+      className="col-md-2 col-xs-4 text-right"
+      style={
+        Object {
+          "marginTop": 20,
+        }
+      }
+    >
+      <span
+        className="dropdown"
+      >
+        <button
+          className="dropdown-toggle btn-transparent capitalize-bold"
+          data-toggle="dropdown"
+          type="button"
+        >
+          artist
+          s
+          <span
+            className="caret"
+          />
+        </button>
+        <ul
+          className="dropdown-menu"
+          role="menu"
+        >
+          <li>
+            <a
+              href=""
+              onClick={[Function]}
+              role="button"
+            >
+              Listens
+            </a>
+          </li>
+          <li>
+            <a
+              href=""
+              onClick={[Function]}
+              role="button"
+            >
+              Artists
+            </a>
+          </li>
+        </ul>
+      </span>
+    </div>
+    <div
+      className="col-md-1 col-xs-2 text-right"
+    >
+      <h4
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <a
+          href="#artist-origin"
+        >
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            color="#000000"
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  512,
+                  512,
+                  Array [],
+                  "f0c1",
+                  "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                ],
+                "iconName": "link",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size="sm"
+            spin={false}
+            style={
+              Object {
+                "marginRight": 20,
+              }
+            }
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          />
+        </a>
+      </h4>
+    </div>
+  </div>
+  <Loader
+    isLoading={false}
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-xs-12"
+      >
+        <CustomChoropleth
+          data={
+            Array [
+              Object {
+                "id": "GBR",
+                "value": 50,
+              },
+              Object {
+                "id": "USA",
+                "value": 135,
+              },
+              Object {
+                "id": "AUS",
+                "value": 6,
+              },
+              Object {
+                "id": "BEL",
+                "value": 2,
+              },
+              Object {
+                "id": "DEU",
+                "value": 10,
+              },
+              Object {
+                "id": "CAN",
+                "value": 10,
+              },
+              Object {
+                "id": "ARG",
+                "value": 1,
+              },
+              Object {
+                "id": "ESP",
+                "value": 1,
+              },
+              Object {
+                "id": "PRT",
+                "value": 1,
+              },
+              Object {
+                "id": "ISL",
+                "value": 3,
+              },
+              Object {
+                "id": "NLD",
+                "value": 6,
+              },
+              Object {
+                "id": "NOR",
+                "value": 2,
+              },
+              Object {
+                "id": "SWE",
+                "value": 10,
+              },
+              Object {
+                "id": "IND",
+                "value": 30,
+              },
+              Object {
+                "id": "IRL",
+                "value": 5,
+              },
+              Object {
+                "id": "FRA",
+                "value": 5,
+              },
+              Object {
+                "id": "URY",
+                "value": 1,
+              },
+              Object {
+                "id": "DNK",
+                "value": 2,
+              },
+              Object {
+                "id": "PAK",
+                "value": 1,
+              },
+              Object {
+                "id": "TUR",
+                "value": 1,
+              },
+              Object {
+                "id": "JAM",
+                "value": 1,
+              },
+              Object {
+                "id": "SGP",
+                "value": 1,
+              },
+              Object {
+                "id": "IDN",
+                "value": 2,
+              },
+              Object {
+                "id": "PHL",
+                "value": 1,
+              },
+              Object {
+                "id": "PRI",
+                "value": 1,
+              },
+              Object {
+                "id": "NZL",
+                "value": 1,
+              },
+              Object {
+                "id": "MYS",
+                "value": 1,
+              },
+            ]
+          }
+          selectedMetric="artist"
+          width={1200}
+        />
+      </div>
+    </div>
+  </Loader>
+</ForwardRef>
+`;
+
+exports[`User Stats UserArtistMap renders corectly when range is invalid 1`] = `
 <UserArtistMap
   apiUrl="barfoo"
   range="invalid_range"
@@ -246,7 +745,7 @@ exports[`UserArtistMap renders corectly when range is invalid 1`] = `
 </UserArtistMap>
 `;
 
-exports[`UserArtistMap renders correctly 1`] = `
+exports[`User Stats UserArtistMap renders correctly 1`] = `
 <ForwardRef
   style={
     Object {

--- a/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserEntityChart.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserEntityChart.test.tsx.snap
@@ -1,6 +1,19061 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserEntityChart Page renders correctly for artists 1`] = `
+exports[`Sitewide Stats UserEntityChart Page renders correctly for artists 1`] = `
+<UserEntityChart
+  apiUrl="apiUrl"
+  newAlert={[MockFunction]}
+>
+  <div
+    role="main"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-8"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": "1em",
+              "minHeight": 500,
+            }
+          }
+        >
+          <Loader
+            isLoading={false}
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Artists
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Releases
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Recordings
+                  </button>
+                </Pill>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <h3>
+                  Top
+                   
+                  <span
+                    style={
+                      Object {
+                        "textTransform": "capitalize",
+                      }
+                    }
+                  />
+                   
+                  of 
+                  the
+                  <span
+                    className="dropdown"
+                    style={
+                      Object {
+                        "fontSize": 22,
+                      }
+                    }
+                  >
+                    <button
+                      className="dropdown-toggle btn-transparent capitalize-bold"
+                      data-toggle="dropdown"
+                      type="button"
+                    >
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li>
+                        <a
+                          href="?page=1&range=this_week&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_month&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_year&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=week&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=month&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=year&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=all_time&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          All time
+                        </a>
+                      </li>
+                    </ul>
+                  </span>
+                  (January 01, 1970 - January 01, 1970)
+                </h3>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <h4
+                  style={
+                    Object {
+                      "textTransform": "capitalize",
+                    }
+                  }
+                >
+                   count - 
+                  <b>
+                    0
+                  </b>
+                </h4>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-6"
+              >
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="2"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Coldplay",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Coldplay"
+                      >
+                        <React.Fragment>
+                          Coldplay
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Coldplay"
+                          >
+                            Coldplay
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Coldplay",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="3"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Ellie Goulding",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Ellie Goulding"
+                      >
+                        <React.Fragment>
+                          Ellie Goulding
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Ellie Goulding"
+                          >
+                            Ellie Goulding
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Ellie Goulding",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="4"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Maroon 5",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Maroon 5"
+                      >
+                        <React.Fragment>
+                          Maroon 5
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Maroon 5"
+                          >
+                            Maroon 5
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Maroon 5",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="5"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "OneRepublic",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="OneRepublic"
+                      >
+                        <React.Fragment>
+                          OneRepublic
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="OneRepublic"
+                          >
+                            OneRepublic
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "OneRepublic",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="6"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Fray",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="The Fray"
+                      >
+                        <React.Fragment>
+                          The Fray
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="The Fray"
+                          >
+                            The Fray
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Fray",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="7"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Ritviz",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Ritviz"
+                      >
+                        <React.Fragment>
+                          Ritviz
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Ritviz"
+                          >
+                            Ritviz
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Ritviz",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="8"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Imagine Dragons",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Imagine Dragons"
+                      >
+                        <React.Fragment>
+                          Imagine Dragons
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Imagine Dragons"
+                          >
+                            Imagine Dragons
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Imagine Dragons",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="9"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Lenka",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Lenka"
+                      >
+                        <React.Fragment>
+                          Lenka
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Lenka"
+                          >
+                            Lenka
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Lenka",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="10"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Vance Joy",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Vance Joy"
+                      >
+                        <React.Fragment>
+                          Vance Joy
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Vance Joy"
+                          >
+                            Vance Joy
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Vance Joy",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="11"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Taylor Swift",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Taylor Swift"
+                      >
+                        <React.Fragment>
+                          Taylor Swift
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Taylor Swift"
+                          >
+                            Taylor Swift
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Taylor Swift",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="12"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Ed Sheeran",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Ed Sheeran"
+                      >
+                        <React.Fragment>
+                          Ed Sheeran
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Ed Sheeran"
+                          >
+                            Ed Sheeran
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Ed Sheeran",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="13"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "George Ezra",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="George Ezra"
+                      >
+                        <React.Fragment>
+                          George Ezra
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="George Ezra"
+                          >
+                            George Ezra
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "George Ezra",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="14"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Christina Perri",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Christina Perri"
+                      >
+                        <React.Fragment>
+                          Christina Perri
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Christina Perri"
+                          >
+                            Christina Perri
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Christina Perri",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="15"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Script",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="The Script"
+                      >
+                        <React.Fragment>
+                          The Script
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="The Script"
+                          >
+                            The Script
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Script",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="16"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Local train",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="The Local train"
+                      >
+                        <React.Fragment>
+                          The Local train
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="The Local train"
+                          >
+                            The Local train
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Local train",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="17"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Tommee Profitt",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Tommee Profitt"
+                      >
+                        <React.Fragment>
+                          Tommee Profitt
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Tommee Profitt"
+                          >
+                            Tommee Profitt
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Tommee Profitt",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="18"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Chainsmokers",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="The Chainsmokers"
+                      >
+                        <React.Fragment>
+                          The Chainsmokers
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="The Chainsmokers"
+                          >
+                            The Chainsmokers
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Chainsmokers",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="19"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Sia",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Sia"
+                      >
+                        <React.Fragment>
+                          Sia
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Sia"
+                          >
+                            Sia
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Sia",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="20"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Of Monsters and Men",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Of Monsters and Men"
+                      >
+                        <React.Fragment>
+                          Of Monsters and Men
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Of Monsters and Men"
+                          >
+                            Of Monsters and Men
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Of Monsters and Men",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="21"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "M.I.A.",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="M.I.A."
+                      >
+                        <React.Fragment>
+                          M.I.A.
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="M.I.A."
+                          >
+                            M.I.A.
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "M.I.A.",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="22"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Linkin Park",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Linkin Park"
+                      >
+                        <React.Fragment>
+                          Linkin Park
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Linkin Park"
+                          >
+                            Linkin Park
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Linkin Park",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="23"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Weeknd",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="The Weeknd"
+                      >
+                        <React.Fragment>
+                          The Weeknd
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="The Weeknd"
+                          >
+                            The Weeknd
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Weeknd",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="24"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Backstreet Boys",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Backstreet Boys"
+                      >
+                        <React.Fragment>
+                          Backstreet Boys
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Backstreet Boys"
+                          >
+                            Backstreet Boys
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Backstreet Boys",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="25"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Train",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Train"
+                      >
+                        <React.Fragment>
+                          Train
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Train"
+                          >
+                            Train
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Train",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="26"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": undefined,
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Lumineers",
+                        "release_name": "",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="The Lumineers"
+                      >
+                        <React.Fragment>
+                          The Lumineers
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title=", "
+                      />
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="The Lumineers"
+                          >
+                            The Lumineers
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title=", "
+                          />
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": undefined,
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Lumineers",
+                                    "release_name": "",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+              </div>
+              <div
+                className="col-xs-6"
+                style={
+                  Object {
+                    "height": "1375px",
+                    "paddingLeft": 0,
+                  }
+                }
+              >
+                <Bar
+                  data={
+                    Array [
+                      Object {
+                        "count": 6,
+                        "entity": "The Lumineers",
+                        "entityType": "artist",
+                        "id": "24",
+                        "idx": 25,
+                      },
+                      Object {
+                        "count": 6,
+                        "entity": "Train",
+                        "entityType": "artist",
+                        "id": "23",
+                        "idx": 24,
+                      },
+                      Object {
+                        "count": 8,
+                        "entity": "Backstreet Boys",
+                        "entityType": "artist",
+                        "id": "22",
+                        "idx": 23,
+                      },
+                      Object {
+                        "count": 8,
+                        "entity": "The Weeknd",
+                        "entityType": "artist",
+                        "id": "21",
+                        "idx": 22,
+                      },
+                      Object {
+                        "count": 10,
+                        "entity": "Linkin Park",
+                        "entityType": "artist",
+                        "id": "20",
+                        "idx": 21,
+                      },
+                      Object {
+                        "count": 10,
+                        "entity": "M.I.A.",
+                        "entityType": "artist",
+                        "id": "19",
+                        "idx": 20,
+                      },
+                      Object {
+                        "count": 11,
+                        "entity": "Of Monsters and Men",
+                        "entityType": "artist",
+                        "id": "18",
+                        "idx": 19,
+                      },
+                      Object {
+                        "count": 12,
+                        "entity": "Sia",
+                        "entityType": "artist",
+                        "id": "17",
+                        "idx": 18,
+                      },
+                      Object {
+                        "count": 12,
+                        "entity": "The Chainsmokers",
+                        "entityType": "artist",
+                        "id": "16",
+                        "idx": 17,
+                      },
+                      Object {
+                        "count": 12,
+                        "entity": "Tommee Profitt",
+                        "entityType": "artist",
+                        "id": "15",
+                        "idx": 16,
+                      },
+                      Object {
+                        "count": 13,
+                        "entity": "The Local train",
+                        "entityType": "artist",
+                        "id": "14",
+                        "idx": 15,
+                      },
+                      Object {
+                        "count": 15,
+                        "entity": "The Script",
+                        "entityType": "artist",
+                        "id": "13",
+                        "idx": 14,
+                      },
+                      Object {
+                        "count": 16,
+                        "entity": "Christina Perri",
+                        "entityType": "artist",
+                        "id": "12",
+                        "idx": 13,
+                      },
+                      Object {
+                        "count": 17,
+                        "entity": "George Ezra",
+                        "entityType": "artist",
+                        "id": "11",
+                        "idx": 12,
+                      },
+                      Object {
+                        "count": 19,
+                        "entity": "Ed Sheeran",
+                        "entityType": "artist",
+                        "id": "10",
+                        "idx": 11,
+                      },
+                      Object {
+                        "count": 20,
+                        "entity": "Taylor Swift",
+                        "entityType": "artist",
+                        "id": "9",
+                        "idx": 10,
+                      },
+                      Object {
+                        "count": 20,
+                        "entity": "Vance Joy",
+                        "entityType": "artist",
+                        "id": "8",
+                        "idx": 9,
+                      },
+                      Object {
+                        "count": 25,
+                        "entity": "Lenka",
+                        "entityType": "artist",
+                        "id": "7",
+                        "idx": 8,
+                      },
+                      Object {
+                        "count": 26,
+                        "entity": "Imagine Dragons",
+                        "entityType": "artist",
+                        "id": "6",
+                        "idx": 7,
+                      },
+                      Object {
+                        "count": 26,
+                        "entity": "Ritviz",
+                        "entityType": "artist",
+                        "id": "5",
+                        "idx": 6,
+                      },
+                      Object {
+                        "count": 31,
+                        "entity": "The Fray",
+                        "entityType": "artist",
+                        "id": "4",
+                        "idx": 5,
+                      },
+                      Object {
+                        "count": 36,
+                        "entity": "OneRepublic",
+                        "entityType": "artist",
+                        "id": "3",
+                        "idx": 4,
+                      },
+                      Object {
+                        "count": 38,
+                        "entity": "Maroon 5",
+                        "entityType": "artist",
+                        "id": "2",
+                        "idx": 3,
+                      },
+                      Object {
+                        "count": 54,
+                        "entity": "Ellie Goulding",
+                        "entityType": "artist",
+                        "id": "1",
+                        "idx": 2,
+                      },
+                      Object {
+                        "count": 70,
+                        "entity": "Coldplay",
+                        "entityType": "artist",
+                        "id": "0",
+                        "idx": 1,
+                      },
+                    ]
+                  }
+                  maxValue={70}
+                >
+                  <ResponsiveBar
+                    animate={false}
+                    axisLeft={
+                      Object {
+                        "renderTick": [Function],
+                        "tickPadding": 5,
+                        "tickSize": 0,
+                        "tickValues": 25,
+                      }
+                    }
+                    colors="#EB743B"
+                    data={
+                      Array [
+                        Object {
+                          "count": 6,
+                          "entity": "The Lumineers",
+                          "entityType": "artist",
+                          "id": "24",
+                          "idx": 25,
+                        },
+                        Object {
+                          "count": 6,
+                          "entity": "Train",
+                          "entityType": "artist",
+                          "id": "23",
+                          "idx": 24,
+                        },
+                        Object {
+                          "count": 8,
+                          "entity": "Backstreet Boys",
+                          "entityType": "artist",
+                          "id": "22",
+                          "idx": 23,
+                        },
+                        Object {
+                          "count": 8,
+                          "entity": "The Weeknd",
+                          "entityType": "artist",
+                          "id": "21",
+                          "idx": 22,
+                        },
+                        Object {
+                          "count": 10,
+                          "entity": "Linkin Park",
+                          "entityType": "artist",
+                          "id": "20",
+                          "idx": 21,
+                        },
+                        Object {
+                          "count": 10,
+                          "entity": "M.I.A.",
+                          "entityType": "artist",
+                          "id": "19",
+                          "idx": 20,
+                        },
+                        Object {
+                          "count": 11,
+                          "entity": "Of Monsters and Men",
+                          "entityType": "artist",
+                          "id": "18",
+                          "idx": 19,
+                        },
+                        Object {
+                          "count": 12,
+                          "entity": "Sia",
+                          "entityType": "artist",
+                          "id": "17",
+                          "idx": 18,
+                        },
+                        Object {
+                          "count": 12,
+                          "entity": "The Chainsmokers",
+                          "entityType": "artist",
+                          "id": "16",
+                          "idx": 17,
+                        },
+                        Object {
+                          "count": 12,
+                          "entity": "Tommee Profitt",
+                          "entityType": "artist",
+                          "id": "15",
+                          "idx": 16,
+                        },
+                        Object {
+                          "count": 13,
+                          "entity": "The Local train",
+                          "entityType": "artist",
+                          "id": "14",
+                          "idx": 15,
+                        },
+                        Object {
+                          "count": 15,
+                          "entity": "The Script",
+                          "entityType": "artist",
+                          "id": "13",
+                          "idx": 14,
+                        },
+                        Object {
+                          "count": 16,
+                          "entity": "Christina Perri",
+                          "entityType": "artist",
+                          "id": "12",
+                          "idx": 13,
+                        },
+                        Object {
+                          "count": 17,
+                          "entity": "George Ezra",
+                          "entityType": "artist",
+                          "id": "11",
+                          "idx": 12,
+                        },
+                        Object {
+                          "count": 19,
+                          "entity": "Ed Sheeran",
+                          "entityType": "artist",
+                          "id": "10",
+                          "idx": 11,
+                        },
+                        Object {
+                          "count": 20,
+                          "entity": "Taylor Swift",
+                          "entityType": "artist",
+                          "id": "9",
+                          "idx": 10,
+                        },
+                        Object {
+                          "count": 20,
+                          "entity": "Vance Joy",
+                          "entityType": "artist",
+                          "id": "8",
+                          "idx": 9,
+                        },
+                        Object {
+                          "count": 25,
+                          "entity": "Lenka",
+                          "entityType": "artist",
+                          "id": "7",
+                          "idx": 8,
+                        },
+                        Object {
+                          "count": 26,
+                          "entity": "Imagine Dragons",
+                          "entityType": "artist",
+                          "id": "6",
+                          "idx": 7,
+                        },
+                        Object {
+                          "count": 26,
+                          "entity": "Ritviz",
+                          "entityType": "artist",
+                          "id": "5",
+                          "idx": 6,
+                        },
+                        Object {
+                          "count": 31,
+                          "entity": "The Fray",
+                          "entityType": "artist",
+                          "id": "4",
+                          "idx": 5,
+                        },
+                        Object {
+                          "count": 36,
+                          "entity": "OneRepublic",
+                          "entityType": "artist",
+                          "id": "3",
+                          "idx": 4,
+                        },
+                        Object {
+                          "count": 38,
+                          "entity": "Maroon 5",
+                          "entityType": "artist",
+                          "id": "2",
+                          "idx": 3,
+                        },
+                        Object {
+                          "count": 54,
+                          "entity": "Ellie Goulding",
+                          "entityType": "artist",
+                          "id": "1",
+                          "idx": 2,
+                        },
+                        Object {
+                          "count": 70,
+                          "entity": "Coldplay",
+                          "entityType": "artist",
+                          "id": "0",
+                          "idx": 1,
+                        },
+                      ]
+                    }
+                    enableGridY={false}
+                    indexBy="id"
+                    keys={
+                      Array [
+                        "count",
+                      ]
+                    }
+                    labelFormat={[Function]}
+                    labelSkipWidth={0}
+                    layout="horizontal"
+                    margin={
+                      Object {
+                        "left": 35,
+                        "top": -12,
+                      }
+                    }
+                    maxValue={70}
+                    padding={0.1}
+                    theme={
+                      Object {
+                        "labels": Object {
+                          "text": Object {
+                            "fontSize": "14px",
+                          },
+                        },
+                      }
+                    }
+                    tooltip={[Function]}
+                  >
+                    <ResponsiveWrapper>
+                      <Measure
+                        bounds={true}
+                        onResize={[Function]}
+                      >
+                        <Component
+                          bounds={true}
+                          contentRect={
+                            Object {
+                              "bounds": Object {},
+                              "client": Object {},
+                              "entry": Object {},
+                              "margin": Object {},
+                              "offset": Object {},
+                              "scroll": Object {},
+                            }
+                          }
+                          measure={[Function]}
+                          measureRef={[Function]}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
+                          />
+                        </Component>
+                      </Measure>
+                    </ResponsiveWrapper>
+                  </ResponsiveBar>
+                </Bar>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <ul
+                  className="pager"
+                >
+                  <li
+                    className="previous disabled"
+                  >
+                    <a
+                      href=""
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      ← Previous
+                    </a>
+                  </li>
+                  <li
+                    className="next disabled"
+                  >
+                    <a
+                      href="?page=2&range=&entity="
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Next →
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </Loader>
+        </div>
+      </div>
+      <div
+        className="col-md-4"
+        style={
+          Object {
+            "position": "sticky",
+            "top": 20,
+          }
+        }
+      >
+        <BrainzPlayer
+          listenBrainzAPIBaseURI="http://localhost/1"
+          listens={
+            Array [
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Coldplay",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Ellie Goulding",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Maroon 5",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "OneRepublic",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Fray",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Ritviz",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Imagine Dragons",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Lenka",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Vance Joy",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Taylor Swift",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Ed Sheeran",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "George Ezra",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Christina Perri",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Script",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Local train",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Tommee Profitt",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Chainsmokers",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Sia",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Of Monsters and Men",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "M.I.A.",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Linkin Park",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Weeknd",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Backstreet Boys",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Train",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": undefined,
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Lumineers",
+                  "release_name": "",
+                  "track_name": "",
+                },
+              },
+            ]
+          }
+          newAlert={[MockFunction]}
+          refreshSpotifyToken={[Function]}
+          refreshYoutubeToken={[Function]}
+        >
+          <div>
+            <PlaybackControls
+              artistName=""
+              durationMs={0}
+              playNextTrack={[Function]}
+              playPreviousTrack={[Function]}
+              playerPaused={true}
+              progressMs={0}
+              seekToPositionMs={[Function]}
+              togglePlay={[Function]}
+              trackName=""
+            >
+              <div
+                aria-label="Playback control"
+                id="brainz-player"
+              >
+                <div
+                  className="content"
+                >
+                  <div
+                    className="connect-services-message"
+                  >
+                    You need to
+                     
+                    <a
+                      href="/profile/music-services/details/"
+                      target="_blank"
+                    >
+                      connect to a music service
+                    </a>
+                     
+                    and refresh this page in order to search for and play songs on ListenBrainz.
+                  </div>
+                  <SpotifyPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshSpotifyToken={[Function]}
+                    show={false}
+                    spotifyUser={Object {}}
+                  />
+                  <YoutubePlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshYoutubeToken={[Function]}
+                    show={false}
+                    youtubeUser={Object {}}
+                  >
+                    <div
+                      className="youtube hidden"
+                    >
+                      <YouTube
+                        className={null}
+                        containerClassName=""
+                        id={null}
+                        onEnd={[Function]}
+                        onError={[Function]}
+                        onPause={[Function]}
+                        onPlay={[Function]}
+                        onPlaybackQualityChange={[Function]}
+                        onPlaybackRateChange={[Function]}
+                        onReady={[Function]}
+                        onStateChange={[Function]}
+                        opts={
+                          Object {
+                            "height": "100%",
+                            "playerVars": Object {
+                              "autoplay": 1,
+                              "controls": 0,
+                              "fs": 0,
+                              "iv_load_policy": 3,
+                              "modestbranding": 1,
+                              "origin": "http://localhost",
+                              "rel": 0,
+                              "showinfo": 0,
+                            },
+                            "width": "100%",
+                          }
+                        }
+                        videoId={null}
+                      >
+                        <div
+                          className=""
+                        >
+                          <div
+                            className={null}
+                            id={null}
+                          />
+                        </div>
+                      </YouTube>
+                    </div>
+                  </YoutubePlayer>
+                  <SoundcloudPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    show={false}
+                  >
+                    <div
+                      className="soundcloud hidden"
+                    >
+                      <iframe
+                        allow="autoplay"
+                        frameBorder="no"
+                        height="420px"
+                        id="soundcloud-iframe"
+                        scrolling="no"
+                        src="https://w.soundcloud.com/player/?auto_play=false"
+                        title="Soundcloud player"
+                        width="100%"
+                      />
+                    </div>
+                  </SoundcloudPlayer>
+                  <div
+                    className="no-album-art"
+                  />
+                </div>
+                <div
+                  className="info showControls"
+                >
+                  <div
+                    className="currently-playing"
+                  >
+                    <div
+                      aria-label="Audio Progress Control"
+                      aria-valuemax={100}
+                      aria-valuemin={0}
+                      aria-valuenow={NaN}
+                      className="progress"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="progressbar"
+                      tabIndex={0}
+                    >
+                      <div
+                        className="progress-bar"
+                        style={
+                          Object {
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="controls"
+                  >
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="left btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            640,
+                            512,
+                            Array [],
+                            "f070",
+                            "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                          ],
+                          "iconName": "eye-slash",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Always show controls"
+                    >
+                      <div
+                        className="left btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Always show controls"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                640,
+                                512,
+                                Array [],
+                                "f070",
+                                "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                              ],
+                              "iconName": "eye-slash",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-eye-slash fa-w-20 "
+                            data-icon="eye-slash"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 640 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="previous btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f049",
+                            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                          ],
+                          "iconName": "fast-backward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Previous"
+                    >
+                      <div
+                        className="previous btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Previous"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f049",
+                                "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                              ],
+                              "iconName": "fast-backward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-backward fa-w-16 "
+                            data-icon="fast-backward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="play btn"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f144",
+                            "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                          ],
+                          "iconName": "play-circle",
+                          "prefix": "fas",
+                        }
+                      }
+                      size="2x"
+                      title="Play"
+                    >
+                      <div
+                        className="play btn"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Play"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f144",
+                                "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                              ],
+                              "iconName": "play-circle",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size="2x"
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                            data-icon="play-circle"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="next btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f050",
+                            "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                          ],
+                          "iconName": "fast-forward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Next"
+                    >
+                      <div
+                        className="next btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Next"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f050",
+                                "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                              ],
+                              "iconName": "fast-forward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-forward fa-w-16 "
+                            data-icon="fast-forward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                  </div>
+                </div>
+              </div>
+            </PlaybackControls>
+          </div>
+        </BrainzPlayer>
+      </div>
+    </div>
+  </div>
+</UserEntityChart>
+`;
+
+exports[`Sitewide Stats UserEntityChart Page renders correctly for recording 1`] = `
+<UserEntityChart
+  apiUrl="apiUrl"
+  newAlert={[MockFunction]}
+>
+  <div
+    role="main"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-8"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": "1em",
+              "minHeight": 500,
+            }
+          }
+        >
+          <Loader
+            isLoading={false}
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Artists
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Releases
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Recordings
+                  </button>
+                </Pill>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <h3>
+                  Top
+                   
+                  <span
+                    style={
+                      Object {
+                        "textTransform": "capitalize",
+                      }
+                    }
+                  />
+                   
+                  of 
+                  the
+                  <span
+                    className="dropdown"
+                    style={
+                      Object {
+                        "fontSize": 22,
+                      }
+                    }
+                  >
+                    <button
+                      className="dropdown-toggle btn-transparent capitalize-bold"
+                      data-toggle="dropdown"
+                      type="button"
+                    >
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li>
+                        <a
+                          href="?page=1&range=this_week&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_month&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_year&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=week&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=month&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=year&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=all_time&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          All time
+                        </a>
+                      </li>
+                    </ul>
+                  </span>
+                  (January 01, 1970 - January 01, 1970)
+                </h3>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <h4
+                  style={
+                    Object {
+                      "textTransform": "capitalize",
+                    }
+                  }
+                >
+                   count - 
+                  <b>
+                    0
+                  </b>
+                </h4>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-6"
+              >
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="2"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "0fe11cd3-0be4-467b-84fa-0bd524d45d74",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Ellie Goulding",
+                        "release_name": "Delirium (Deluxe)",
+                        "track_name": "Love Me Like You Do - From \\"Fifty Shades of Grey\\"",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Love Me Like You Do - From \\"Fifty Shades of Grey\\""
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/0fe11cd3-0be4-467b-84fa-0bd524d45d74"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Love Me Like You Do - From "Fifty Shades of Grey"
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ellie Goulding, Delirium (Deluxe)"
+                      >
+                        <React.Fragment>
+                          Ellie Goulding
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Delirium (Deluxe)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Love Me Like You Do - From \\"Fifty Shades of Grey\\""
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/0fe11cd3-0be4-467b-84fa-0bd524d45d74"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Love Me Like You Do - From "Fifty Shades of Grey"
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ellie Goulding, Delirium (Deluxe)"
+                          >
+                            Ellie Goulding
+                            <span>
+                               - 
+                              Delirium (Deluxe)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "0fe11cd3-0be4-467b-84fa-0bd524d45d74",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Ellie Goulding",
+                                    "release_name": "Delirium (Deluxe)",
+                                    "track_name": "Love Me Like You Do - From \\"Fifty Shades of Grey\\"",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="3"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "0008ab49-a6ad-40b5-aa90-9d2779265c22",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "The Fray",
+                        "release_name": "How to Save a Life",
+                        "track_name": "How to Save a Life",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="How to Save a Life"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/0008ab49-a6ad-40b5-aa90-9d2779265c22"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          How to Save a Life
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="The Fray, How to Save a Life"
+                      >
+                        <React.Fragment>
+                          The Fray
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            How to Save a Life
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="How to Save a Life"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/0008ab49-a6ad-40b5-aa90-9d2779265c22"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              How to Save a Life
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="The Fray, How to Save a Life"
+                          >
+                            The Fray
+                            <span>
+                               - 
+                              How to Save a Life
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "0008ab49-a6ad-40b5-aa90-9d2779265c22",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "The Fray",
+                                    "release_name": "How to Save a Life",
+                                    "track_name": "How to Save a Life",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="4"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Ritviz",
+                        "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+                        "track_name": "Udd Gaye - Bacardi House Party Sessions",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Udd Gaye - Bacardi House Party Sessions"
+                      >
+                        <React.Fragment>
+                          Udd Gaye - Bacardi House Party Sessions
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ritviz, Udd Gaye (Bacardi House Party Sessions)"
+                      >
+                        <React.Fragment>
+                          Ritviz
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Udd Gaye (Bacardi House Party Sessions)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Udd Gaye - Bacardi House Party Sessions"
+                          >
+                            Udd Gaye - Bacardi House Party Sessions
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ritviz, Udd Gaye (Bacardi House Party Sessions)"
+                          >
+                            Ritviz
+                            <span>
+                               - 
+                              Udd Gaye (Bacardi House Party Sessions)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Ritviz",
+                                    "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+                                    "track_name": "Udd Gaye - Bacardi House Party Sessions",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="5"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "00d32e28-0df2-486c-9829-750301962fb2",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "OneRepublic",
+                        "release_name": "Native",
+                        "track_name": "Counting Stars",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Counting Stars"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/00d32e28-0df2-486c-9829-750301962fb2"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Counting Stars
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="OneRepublic, Native"
+                      >
+                        <React.Fragment>
+                          OneRepublic
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Native
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Counting Stars"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/00d32e28-0df2-486c-9829-750301962fb2"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Counting Stars
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="OneRepublic, Native"
+                          >
+                            OneRepublic
+                            <span>
+                               - 
+                              Native
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "00d32e28-0df2-486c-9829-750301962fb2",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "OneRepublic",
+                                    "release_name": "Native",
+                                    "track_name": "Counting Stars",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="6"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "017cd117-e343-408f-95fe-ee4c1018e312",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Ellie Goulding",
+                        "release_name": "Halcyon Days",
+                        "track_name": "Burn",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Burn"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/017cd117-e343-408f-95fe-ee4c1018e312"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Burn
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ellie Goulding, Halcyon Days"
+                      >
+                        <React.Fragment>
+                          Ellie Goulding
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Halcyon Days
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Burn"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/017cd117-e343-408f-95fe-ee4c1018e312"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Burn
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ellie Goulding, Halcyon Days"
+                          >
+                            Ellie Goulding
+                            <span>
+                               - 
+                              Halcyon Days
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "017cd117-e343-408f-95fe-ee4c1018e312",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Ellie Goulding",
+                                    "release_name": "Halcyon Days",
+                                    "track_name": "Burn",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="7"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "01236d26-9f46-435f-adc5-6c92e6e76f53",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Taylor Swift",
+                        "release_name": "1989",
+                        "track_name": "Blank Space",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Blank Space"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/01236d26-9f46-435f-adc5-6c92e6e76f53"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Blank Space
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Taylor Swift, 1989"
+                      >
+                        <React.Fragment>
+                          Taylor Swift
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            1989
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Blank Space"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/01236d26-9f46-435f-adc5-6c92e6e76f53"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Blank Space
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Taylor Swift, 1989"
+                          >
+                            Taylor Swift
+                            <span>
+                               - 
+                              1989
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "01236d26-9f46-435f-adc5-6c92e6e76f53",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Taylor Swift",
+                                    "release_name": "1989",
+                                    "track_name": "Blank Space",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="8"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "03a0cdfb-f964-434f-bfb7-379203dc139d",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Christina Perri",
+                        "release_name": "A Thousand Years",
+                        "track_name": "A Thousand Years",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="A Thousand Years"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/03a0cdfb-f964-434f-bfb7-379203dc139d"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          A Thousand Years
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Christina Perri, A Thousand Years"
+                      >
+                        <React.Fragment>
+                          Christina Perri
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            A Thousand Years
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="A Thousand Years"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/03a0cdfb-f964-434f-bfb7-379203dc139d"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              A Thousand Years
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Christina Perri, A Thousand Years"
+                          >
+                            Christina Perri
+                            <span>
+                               - 
+                              A Thousand Years
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "03a0cdfb-f964-434f-bfb7-379203dc139d",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Christina Perri",
+                                    "release_name": "A Thousand Years",
+                                    "track_name": "A Thousand Years",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="9"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "003196a1-f6ab-4fe8-9683-b970d163cfa4",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Vance Joy",
+                        "release_name": "Dream Your Life Away (Special Edition)",
+                        "track_name": "Riptide",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Riptide"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/003196a1-f6ab-4fe8-9683-b970d163cfa4"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Riptide
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Vance Joy, Dream Your Life Away (Special Edition)"
+                      >
+                        <React.Fragment>
+                          Vance Joy
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Dream Your Life Away (Special Edition)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Riptide"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/003196a1-f6ab-4fe8-9683-b970d163cfa4"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Riptide
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Vance Joy, Dream Your Life Away (Special Edition)"
+                          >
+                            Vance Joy
+                            <span>
+                               - 
+                              Dream Your Life Away (Special Edition)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "003196a1-f6ab-4fe8-9683-b970d163cfa4",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Vance Joy",
+                                    "release_name": "Dream Your Life Away (Special Edition)",
+                                    "track_name": "Riptide",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="10"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "02ba28bc-6d79-44fb-b770-c49395661117",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Ed Sheeran",
+                        "release_name": "÷ (Deluxe)",
+                        "track_name": "Castle on the Hill",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Castle on the Hill"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/02ba28bc-6d79-44fb-b770-c49395661117"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Castle on the Hill
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ed Sheeran, ÷ (Deluxe)"
+                      >
+                        <React.Fragment>
+                          Ed Sheeran
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            ÷ (Deluxe)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Castle on the Hill"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/02ba28bc-6d79-44fb-b770-c49395661117"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Castle on the Hill
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ed Sheeran, ÷ (Deluxe)"
+                          >
+                            Ed Sheeran
+                            <span>
+                               - 
+                              ÷ (Deluxe)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "02ba28bc-6d79-44fb-b770-c49395661117",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Ed Sheeran",
+                                    "release_name": "÷ (Deluxe)",
+                                    "track_name": "Castle on the Hill",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="11"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": "",
+                        },
+                        "artist_name": "OneRepublic",
+                        "release_name": "13 Reasons Why (Season 2)",
+                        "track_name": "Start Again (feat. Logic)",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Start Again (feat. Logic)"
+                      >
+                        <React.Fragment>
+                          Start Again (feat. Logic)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="OneRepublic, 13 Reasons Why (Season 2)"
+                      >
+                        <React.Fragment>
+                          OneRepublic
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            13 Reasons Why (Season 2)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Start Again (feat. Logic)"
+                          >
+                            Start Again (feat. Logic)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="OneRepublic, 13 Reasons Why (Season 2)"
+                          >
+                            OneRepublic
+                            <span>
+                               - 
+                              13 Reasons Why (Season 2)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "OneRepublic",
+                                    "release_name": "13 Reasons Why (Season 2)",
+                                    "track_name": "Start Again (feat. Logic)",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="12"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "George Ezra",
+                        "release_name": "Staying at Tamara's",
+                        "track_name": "Shotgun",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Shotgun"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Shotgun
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="George Ezra, Staying at Tamara's"
+                      >
+                        <React.Fragment>
+                          George Ezra
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Staying at Tamara's
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Shotgun"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Shotgun
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="George Ezra, Staying at Tamara's"
+                          >
+                            George Ezra
+                            <span>
+                               - 
+                              Staying at Tamara's
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "George Ezra",
+                                    "release_name": "Staying at Tamara's",
+                                    "track_name": "Shotgun",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="13"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Tommee Profitt",
+                        "release_name": "In The End",
+                        "track_name": "In The End - Mellen Gi Remix",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="In The End - Mellen Gi Remix"
+                      >
+                        <React.Fragment>
+                          In The End - Mellen Gi Remix
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Tommee Profitt, In The End"
+                      >
+                        <React.Fragment>
+                          Tommee Profitt
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            In The End
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="In The End - Mellen Gi Remix"
+                          >
+                            In The End - Mellen Gi Remix
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Tommee Profitt, In The End"
+                          >
+                            Tommee Profitt
+                            <span>
+                               - 
+                              In The End
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Tommee Profitt",
+                                    "release_name": "In The End",
+                                    "track_name": "In The End - Mellen Gi Remix",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="14"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "045cdbf9-796e-4949-91f6-e05d9ce3ed21",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "The Script",
+                        "release_name": "#3",
+                        "track_name": "Hall of Fame",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Hall of Fame"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/045cdbf9-796e-4949-91f6-e05d9ce3ed21"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Hall of Fame
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="The Script, #3"
+                      >
+                        <React.Fragment>
+                          The Script
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            #3
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Hall of Fame"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/045cdbf9-796e-4949-91f6-e05d9ce3ed21"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Hall of Fame
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="The Script, #3"
+                          >
+                            The Script
+                            <span>
+                               - 
+                              #3
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "045cdbf9-796e-4949-91f6-e05d9ce3ed21",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "The Script",
+                                    "release_name": "#3",
+                                    "track_name": "Hall of Fame",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="15"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Maroon 5",
+                        "release_name": "Singles",
+                        "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Moves Like Jagger - Studio Recording From The Voice Performance"
+                      >
+                        <React.Fragment>
+                          Moves Like Jagger - Studio Recording From The Voice Performance
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Maroon 5, Singles"
+                      >
+                        <React.Fragment>
+                          Maroon 5
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Singles
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Moves Like Jagger - Studio Recording From The Voice Performance"
+                          >
+                            Moves Like Jagger - Studio Recording From The Voice Performance
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Maroon 5, Singles"
+                          >
+                            Maroon 5
+                            <span>
+                               - 
+                              Singles
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Maroon 5",
+                                    "release_name": "Singles",
+                                    "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="16"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "0031fba1-dde0-3755-bcb2-63b2544159f8",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Of Monsters and Men",
+                        "release_name": "My Head Is an Animal",
+                        "track_name": "Little Talks",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Little Talks"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/0031fba1-dde0-3755-bcb2-63b2544159f8"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Little Talks
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Of Monsters and Men, My Head Is an Animal"
+                      >
+                        <React.Fragment>
+                          Of Monsters and Men
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            My Head Is an Animal
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Little Talks"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/0031fba1-dde0-3755-bcb2-63b2544159f8"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Little Talks
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Of Monsters and Men, My Head Is an Animal"
+                          >
+                            Of Monsters and Men
+                            <span>
+                               - 
+                              My Head Is an Animal
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "0031fba1-dde0-3755-bcb2-63b2544159f8",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Of Monsters and Men",
+                                    "release_name": "My Head Is an Animal",
+                                    "track_name": "Little Talks",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="17"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Sia",
+                        "release_name": "Cheap Thrills (feat. Sean Paul)",
+                        "track_name": "Cheap Thrills (feat. Sean Paul)",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Cheap Thrills (feat. Sean Paul)"
+                      >
+                        <React.Fragment>
+                          Cheap Thrills (feat. Sean Paul)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Sia, Cheap Thrills (feat. Sean Paul)"
+                      >
+                        <React.Fragment>
+                          Sia
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Cheap Thrills (feat. Sean Paul)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Cheap Thrills (feat. Sean Paul)"
+                          >
+                            Cheap Thrills (feat. Sean Paul)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Sia, Cheap Thrills (feat. Sean Paul)"
+                          >
+                            Sia
+                            <span>
+                               - 
+                              Cheap Thrills (feat. Sean Paul)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Sia",
+                                    "release_name": "Cheap Thrills (feat. Sean Paul)",
+                                    "track_name": "Cheap Thrills (feat. Sean Paul)",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="18"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "0126d206-3894-4d97-b5c2-f6cf037a323a",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Maroon 5",
+                        "release_name": "Overexposed",
+                        "track_name": "Payphone",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Payphone"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/0126d206-3894-4d97-b5c2-f6cf037a323a"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Payphone
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Maroon 5, Overexposed"
+                      >
+                        <React.Fragment>
+                          Maroon 5
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Overexposed
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Payphone"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/0126d206-3894-4d97-b5c2-f6cf037a323a"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Payphone
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Maroon 5, Overexposed"
+                          >
+                            Maroon 5
+                            <span>
+                               - 
+                              Overexposed
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "0126d206-3894-4d97-b5c2-f6cf037a323a",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Maroon 5",
+                                    "release_name": "Overexposed",
+                                    "track_name": "Payphone",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="19"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "234ae263-ffad-472a-8077-dab64bcedf99",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "M.I.A.",
+                        "release_name": "Kala",
+                        "track_name": "Paper Planes",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Paper Planes"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/234ae263-ffad-472a-8077-dab64bcedf99"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Paper Planes
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="M.I.A., Kala"
+                      >
+                        <React.Fragment>
+                          M.I.A.
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Kala
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Paper Planes"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/234ae263-ffad-472a-8077-dab64bcedf99"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Paper Planes
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="M.I.A., Kala"
+                          >
+                            M.I.A.
+                            <span>
+                               - 
+                              Kala
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "234ae263-ffad-472a-8077-dab64bcedf99",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "M.I.A.",
+                                    "release_name": "Kala",
+                                    "track_name": "Paper Planes",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="20"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "14c913e9-db47-40fa-ae1a-81099a67e4bf",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Linkin Park",
+                        "release_name": "One More Light",
+                        "track_name": "Battle Symphony",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Battle Symphony"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/14c913e9-db47-40fa-ae1a-81099a67e4bf"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Battle Symphony
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Linkin Park, One More Light"
+                      >
+                        <React.Fragment>
+                          Linkin Park
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            One More Light
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Battle Symphony"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/14c913e9-db47-40fa-ae1a-81099a67e4bf"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Battle Symphony
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Linkin Park, One More Light"
+                          >
+                            Linkin Park
+                            <span>
+                               - 
+                              One More Light
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "14c913e9-db47-40fa-ae1a-81099a67e4bf",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Linkin Park",
+                                    "release_name": "One More Light",
+                                    "track_name": "Battle Symphony",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="21"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "0040980c-4f9a-43df-8be0-142dce4374f4",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Backstreet Boys",
+                        "release_name": "The Hits--Chapter One",
+                        "track_name": "I Want It That Way",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="I Want It That Way"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/0040980c-4f9a-43df-8be0-142dce4374f4"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          I Want It That Way
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Backstreet Boys, The Hits--Chapter One"
+                      >
+                        <React.Fragment>
+                          Backstreet Boys
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            The Hits--Chapter One
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="I Want It That Way"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/0040980c-4f9a-43df-8be0-142dce4374f4"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              I Want It That Way
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Backstreet Boys, The Hits--Chapter One"
+                          >
+                            Backstreet Boys
+                            <span>
+                               - 
+                              The Hits--Chapter One
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "0040980c-4f9a-43df-8be0-142dce4374f4",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Backstreet Boys",
+                                    "release_name": "The Hits--Chapter One",
+                                    "track_name": "I Want It That Way",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="22"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "036e67df-baae-4626-a2ab-951dd162e332",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Lenka",
+                        "release_name": "Two (Expanded Edition)",
+                        "track_name": "Everything at Once",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Everything at Once"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/036e67df-baae-4626-a2ab-951dd162e332"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Everything at Once
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Lenka, Two (Expanded Edition)"
+                      >
+                        <React.Fragment>
+                          Lenka
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Two (Expanded Edition)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Everything at Once"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/036e67df-baae-4626-a2ab-951dd162e332"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Everything at Once
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Lenka, Two (Expanded Edition)"
+                          >
+                            Lenka
+                            <span>
+                               - 
+                              Two (Expanded Edition)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "036e67df-baae-4626-a2ab-951dd162e332",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Lenka",
+                                    "release_name": "Two (Expanded Edition)",
+                                    "track_name": "Everything at Once",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="23"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": "",
+                        },
+                        "artist_name": "The Local train",
+                        "release_name": "Aalas Ka Pedh",
+                        "track_name": "Choo Lo",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Choo Lo"
+                      >
+                        <React.Fragment>
+                          Choo Lo
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="The Local train, Aalas Ka Pedh"
+                      >
+                        <React.Fragment>
+                          The Local train
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Aalas Ka Pedh
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Choo Lo"
+                          >
+                            Choo Lo
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="The Local train, Aalas Ka Pedh"
+                          >
+                            The Local train
+                            <span>
+                               - 
+                              Aalas Ka Pedh
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "The Local train",
+                                    "release_name": "Aalas Ka Pedh",
+                                    "track_name": "Choo Lo",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="24"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Coldplay",
+                        "release_name": "A Head Full Of Dreams",
+                        "track_name": "Up&Up",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Up&Up"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/02b47acf-3bc5-47dc-a516-e8c2c95bc07b"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Up&Up
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Coldplay, A Head Full Of Dreams"
+                      >
+                        <React.Fragment>
+                          Coldplay
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            A Head Full Of Dreams
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Up&Up"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/02b47acf-3bc5-47dc-a516-e8c2c95bc07b"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Up&Up
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Coldplay, A Head Full Of Dreams"
+                          >
+                            Coldplay
+                            <span>
+                               - 
+                              A Head Full Of Dreams
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Coldplay",
+                                    "release_name": "A Head Full Of Dreams",
+                                    "track_name": "Up&Up",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="25"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": "0132a6b9-a04f-48ea-81e7-5f3a5d608f75",
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Imagine Dragons",
+                        "release_name": "Night Visions (Deluxe)",
+                        "track_name": "On Top of the World",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="On Top of the World"
+                      >
+                        <a
+                          href="https://musicbrainz.org/recording/0132a6b9-a04f-48ea-81e7-5f3a5d608f75"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          On Top of the World
+                        </a>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Imagine Dragons, Night Visions (Deluxe)"
+                      >
+                        <React.Fragment>
+                          Imagine Dragons
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Night Visions (Deluxe)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="On Top of the World"
+                          >
+                            <a
+                              href="https://musicbrainz.org/recording/0132a6b9-a04f-48ea-81e7-5f3a5d608f75"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              On Top of the World
+                            </a>
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Imagine Dragons, Night Visions (Deluxe)"
+                          >
+                            Imagine Dragons
+                            <span>
+                               - 
+                              Night Visions (Deluxe)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": "0132a6b9-a04f-48ea-81e7-5f3a5d608f75",
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Imagine Dragons",
+                                    "release_name": "Night Visions (Deluxe)",
+                                    "track_name": "On Top of the World",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="26"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": "",
+                        },
+                        "artist_name": "Ellie Goulding",
+                        "release_name": "Close To Me (feat. Swae Lee)",
+                        "track_name": "Close to Me (with Diplo) (feat. Swae Lee)",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Close to Me (with Diplo) (feat. Swae Lee)"
+                      >
+                        <React.Fragment>
+                          Close to Me (with Diplo) (feat. Swae Lee)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ellie Goulding, Close To Me (feat. Swae Lee)"
+                      >
+                        <React.Fragment>
+                          Ellie Goulding
+                        </React.Fragment>
+                        <span>
+                           - 
+                          <React.Fragment>
+                            Close To Me (feat. Swae Lee)
+                          </React.Fragment>
+                        </span>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Close to Me (with Diplo) (feat. Swae Lee)"
+                          >
+                            Close to Me (with Diplo) (feat. Swae Lee)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ellie Goulding, Close To Me (feat. Swae Lee)"
+                          >
+                            Ellie Goulding
+                            <span>
+                               - 
+                              Close To Me (feat. Swae Lee)
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": "",
+                                    },
+                                    "artist_name": "Ellie Goulding",
+                                    "release_name": "Close To Me (feat. Swae Lee)",
+                                    "track_name": "Close to Me (with Diplo) (feat. Swae Lee)",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+              </div>
+              <div
+                className="col-xs-6"
+                style={
+                  Object {
+                    "height": "1375px",
+                    "paddingLeft": 0,
+                  }
+                }
+              >
+                <Bar
+                  data={
+                    Array [
+                      Object {
+                        "artist": "Ellie Goulding",
+                        "artistMBID": Array [],
+                        "count": 6,
+                        "entity": "Close to Me (with Diplo) (feat. Swae Lee)",
+                        "entityMBID": "",
+                        "entityType": "recording",
+                        "id": "24",
+                        "idx": 25,
+                        "release": "Close To Me (feat. Swae Lee)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Imagine Dragons",
+                        "artistMBID": Array [],
+                        "count": 6,
+                        "entity": "On Top of the World",
+                        "entityMBID": "0132a6b9-a04f-48ea-81e7-5f3a5d608f75",
+                        "entityType": "recording",
+                        "id": "23",
+                        "idx": 24,
+                        "release": "Night Visions (Deluxe)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Coldplay",
+                        "artistMBID": Array [],
+                        "count": 6,
+                        "entity": "Up&Up",
+                        "entityMBID": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
+                        "entityType": "recording",
+                        "id": "22",
+                        "idx": 23,
+                        "release": "A Head Full Of Dreams",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "The Local train",
+                        "artistMBID": Array [],
+                        "count": 8,
+                        "entity": "Choo Lo",
+                        "entityMBID": "",
+                        "entityType": "recording",
+                        "id": "21",
+                        "idx": 22,
+                        "release": "Aalas Ka Pedh",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Lenka",
+                        "artistMBID": Array [],
+                        "count": 8,
+                        "entity": "Everything at Once",
+                        "entityMBID": "036e67df-baae-4626-a2ab-951dd162e332",
+                        "entityType": "recording",
+                        "id": "20",
+                        "idx": 21,
+                        "release": "Two (Expanded Edition)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Backstreet Boys",
+                        "artistMBID": Array [],
+                        "count": 8,
+                        "entity": "I Want It That Way",
+                        "entityMBID": "0040980c-4f9a-43df-8be0-142dce4374f4",
+                        "entityType": "recording",
+                        "id": "19",
+                        "idx": 20,
+                        "release": "The Hits--Chapter One",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Linkin Park",
+                        "artistMBID": Array [],
+                        "count": 10,
+                        "entity": "Battle Symphony",
+                        "entityMBID": "14c913e9-db47-40fa-ae1a-81099a67e4bf",
+                        "entityType": "recording",
+                        "id": "18",
+                        "idx": 19,
+                        "release": "One More Light",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "M.I.A.",
+                        "artistMBID": Array [],
+                        "count": 10,
+                        "entity": "Paper Planes",
+                        "entityMBID": "234ae263-ffad-472a-8077-dab64bcedf99",
+                        "entityType": "recording",
+                        "id": "17",
+                        "idx": 18,
+                        "release": "Kala",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Maroon 5",
+                        "artistMBID": Array [],
+                        "count": 10,
+                        "entity": "Payphone",
+                        "entityMBID": "0126d206-3894-4d97-b5c2-f6cf037a323a",
+                        "entityType": "recording",
+                        "id": "16",
+                        "idx": 17,
+                        "release": "Overexposed",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Sia",
+                        "artistMBID": Array [],
+                        "count": 11,
+                        "entity": "Cheap Thrills (feat. Sean Paul)",
+                        "entityMBID": "",
+                        "entityType": "recording",
+                        "id": "15",
+                        "idx": 16,
+                        "release": "Cheap Thrills (feat. Sean Paul)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Of Monsters and Men",
+                        "artistMBID": Array [],
+                        "count": 11,
+                        "entity": "Little Talks",
+                        "entityMBID": "0031fba1-dde0-3755-bcb2-63b2544159f8",
+                        "entityType": "recording",
+                        "id": "14",
+                        "idx": 15,
+                        "release": "My Head Is an Animal",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Maroon 5",
+                        "artistMBID": Array [],
+                        "count": 11,
+                        "entity": "Moves Like Jagger - Studio Recording From The Voice Performance",
+                        "entityMBID": "",
+                        "entityType": "recording",
+                        "id": "13",
+                        "idx": 14,
+                        "release": "Singles",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "The Script",
+                        "artistMBID": Array [],
+                        "count": 12,
+                        "entity": "Hall of Fame",
+                        "entityMBID": "045cdbf9-796e-4949-91f6-e05d9ce3ed21",
+                        "entityType": "recording",
+                        "id": "12",
+                        "idx": 13,
+                        "release": "#3",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Tommee Profitt",
+                        "artistMBID": Array [],
+                        "count": 12,
+                        "entity": "In The End - Mellen Gi Remix",
+                        "entityMBID": "",
+                        "entityType": "recording",
+                        "id": "11",
+                        "idx": 12,
+                        "release": "In The End",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "George Ezra",
+                        "artistMBID": Array [],
+                        "count": 12,
+                        "entity": "Shotgun",
+                        "entityMBID": "0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994",
+                        "entityType": "recording",
+                        "id": "10",
+                        "idx": 11,
+                        "release": "Staying at Tamara's",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "OneRepublic",
+                        "artistMBID": Array [],
+                        "count": 13,
+                        "entity": "Start Again (feat. Logic)",
+                        "entityMBID": "",
+                        "entityType": "recording",
+                        "id": "9",
+                        "idx": 10,
+                        "release": "13 Reasons Why (Season 2)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Ed Sheeran",
+                        "artistMBID": Array [],
+                        "count": 14,
+                        "entity": "Castle on the Hill",
+                        "entityMBID": "02ba28bc-6d79-44fb-b770-c49395661117",
+                        "entityType": "recording",
+                        "id": "8",
+                        "idx": 9,
+                        "release": "÷ (Deluxe)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Vance Joy",
+                        "artistMBID": Array [],
+                        "count": 15,
+                        "entity": "Riptide",
+                        "entityMBID": "003196a1-f6ab-4fe8-9683-b970d163cfa4",
+                        "entityType": "recording",
+                        "id": "7",
+                        "idx": 8,
+                        "release": "Dream Your Life Away (Special Edition)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Christina Perri",
+                        "artistMBID": Array [],
+                        "count": 16,
+                        "entity": "A Thousand Years",
+                        "entityMBID": "03a0cdfb-f964-434f-bfb7-379203dc139d",
+                        "entityType": "recording",
+                        "id": "6",
+                        "idx": 7,
+                        "release": "A Thousand Years",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Taylor Swift",
+                        "artistMBID": Array [],
+                        "count": 16,
+                        "entity": "Blank Space",
+                        "entityMBID": "01236d26-9f46-435f-adc5-6c92e6e76f53",
+                        "entityType": "recording",
+                        "id": "5",
+                        "idx": 6,
+                        "release": "1989",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Ellie Goulding",
+                        "artistMBID": Array [],
+                        "count": 16,
+                        "entity": "Burn",
+                        "entityMBID": "017cd117-e343-408f-95fe-ee4c1018e312",
+                        "entityType": "recording",
+                        "id": "4",
+                        "idx": 5,
+                        "release": "Halcyon Days",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "OneRepublic",
+                        "artistMBID": Array [],
+                        "count": 18,
+                        "entity": "Counting Stars",
+                        "entityMBID": "00d32e28-0df2-486c-9829-750301962fb2",
+                        "entityType": "recording",
+                        "id": "3",
+                        "idx": 4,
+                        "release": "Native",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Ritviz",
+                        "artistMBID": Array [],
+                        "count": 20,
+                        "entity": "Udd Gaye - Bacardi House Party Sessions",
+                        "entityMBID": "",
+                        "entityType": "recording",
+                        "id": "2",
+                        "idx": 3,
+                        "release": "Udd Gaye (Bacardi House Party Sessions)",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "The Fray",
+                        "artistMBID": Array [],
+                        "count": 23,
+                        "entity": "How to Save a Life",
+                        "entityMBID": "0008ab49-a6ad-40b5-aa90-9d2779265c22",
+                        "entityType": "recording",
+                        "id": "1",
+                        "idx": 2,
+                        "release": "How to Save a Life",
+                        "releaseMBID": "",
+                      },
+                      Object {
+                        "artist": "Ellie Goulding",
+                        "artistMBID": Array [],
+                        "count": 25,
+                        "entity": "Love Me Like You Do - From \\"Fifty Shades of Grey\\"",
+                        "entityMBID": "0fe11cd3-0be4-467b-84fa-0bd524d45d74",
+                        "entityType": "recording",
+                        "id": "0",
+                        "idx": 1,
+                        "release": "Delirium (Deluxe)",
+                        "releaseMBID": "",
+                      },
+                    ]
+                  }
+                  maxValue={26}
+                >
+                  <ResponsiveBar
+                    animate={false}
+                    axisLeft={
+                      Object {
+                        "renderTick": [Function],
+                        "tickPadding": 5,
+                        "tickSize": 0,
+                        "tickValues": 25,
+                      }
+                    }
+                    colors="#EB743B"
+                    data={
+                      Array [
+                        Object {
+                          "artist": "Ellie Goulding",
+                          "artistMBID": Array [],
+                          "count": 6,
+                          "entity": "Close to Me (with Diplo) (feat. Swae Lee)",
+                          "entityMBID": "",
+                          "entityType": "recording",
+                          "id": "24",
+                          "idx": 25,
+                          "release": "Close To Me (feat. Swae Lee)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Imagine Dragons",
+                          "artistMBID": Array [],
+                          "count": 6,
+                          "entity": "On Top of the World",
+                          "entityMBID": "0132a6b9-a04f-48ea-81e7-5f3a5d608f75",
+                          "entityType": "recording",
+                          "id": "23",
+                          "idx": 24,
+                          "release": "Night Visions (Deluxe)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Coldplay",
+                          "artistMBID": Array [],
+                          "count": 6,
+                          "entity": "Up&Up",
+                          "entityMBID": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
+                          "entityType": "recording",
+                          "id": "22",
+                          "idx": 23,
+                          "release": "A Head Full Of Dreams",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "The Local train",
+                          "artistMBID": Array [],
+                          "count": 8,
+                          "entity": "Choo Lo",
+                          "entityMBID": "",
+                          "entityType": "recording",
+                          "id": "21",
+                          "idx": 22,
+                          "release": "Aalas Ka Pedh",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Lenka",
+                          "artistMBID": Array [],
+                          "count": 8,
+                          "entity": "Everything at Once",
+                          "entityMBID": "036e67df-baae-4626-a2ab-951dd162e332",
+                          "entityType": "recording",
+                          "id": "20",
+                          "idx": 21,
+                          "release": "Two (Expanded Edition)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Backstreet Boys",
+                          "artistMBID": Array [],
+                          "count": 8,
+                          "entity": "I Want It That Way",
+                          "entityMBID": "0040980c-4f9a-43df-8be0-142dce4374f4",
+                          "entityType": "recording",
+                          "id": "19",
+                          "idx": 20,
+                          "release": "The Hits--Chapter One",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Linkin Park",
+                          "artistMBID": Array [],
+                          "count": 10,
+                          "entity": "Battle Symphony",
+                          "entityMBID": "14c913e9-db47-40fa-ae1a-81099a67e4bf",
+                          "entityType": "recording",
+                          "id": "18",
+                          "idx": 19,
+                          "release": "One More Light",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "M.I.A.",
+                          "artistMBID": Array [],
+                          "count": 10,
+                          "entity": "Paper Planes",
+                          "entityMBID": "234ae263-ffad-472a-8077-dab64bcedf99",
+                          "entityType": "recording",
+                          "id": "17",
+                          "idx": 18,
+                          "release": "Kala",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Maroon 5",
+                          "artistMBID": Array [],
+                          "count": 10,
+                          "entity": "Payphone",
+                          "entityMBID": "0126d206-3894-4d97-b5c2-f6cf037a323a",
+                          "entityType": "recording",
+                          "id": "16",
+                          "idx": 17,
+                          "release": "Overexposed",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Sia",
+                          "artistMBID": Array [],
+                          "count": 11,
+                          "entity": "Cheap Thrills (feat. Sean Paul)",
+                          "entityMBID": "",
+                          "entityType": "recording",
+                          "id": "15",
+                          "idx": 16,
+                          "release": "Cheap Thrills (feat. Sean Paul)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Of Monsters and Men",
+                          "artistMBID": Array [],
+                          "count": 11,
+                          "entity": "Little Talks",
+                          "entityMBID": "0031fba1-dde0-3755-bcb2-63b2544159f8",
+                          "entityType": "recording",
+                          "id": "14",
+                          "idx": 15,
+                          "release": "My Head Is an Animal",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Maroon 5",
+                          "artistMBID": Array [],
+                          "count": 11,
+                          "entity": "Moves Like Jagger - Studio Recording From The Voice Performance",
+                          "entityMBID": "",
+                          "entityType": "recording",
+                          "id": "13",
+                          "idx": 14,
+                          "release": "Singles",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "The Script",
+                          "artistMBID": Array [],
+                          "count": 12,
+                          "entity": "Hall of Fame",
+                          "entityMBID": "045cdbf9-796e-4949-91f6-e05d9ce3ed21",
+                          "entityType": "recording",
+                          "id": "12",
+                          "idx": 13,
+                          "release": "#3",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Tommee Profitt",
+                          "artistMBID": Array [],
+                          "count": 12,
+                          "entity": "In The End - Mellen Gi Remix",
+                          "entityMBID": "",
+                          "entityType": "recording",
+                          "id": "11",
+                          "idx": 12,
+                          "release": "In The End",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "George Ezra",
+                          "artistMBID": Array [],
+                          "count": 12,
+                          "entity": "Shotgun",
+                          "entityMBID": "0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994",
+                          "entityType": "recording",
+                          "id": "10",
+                          "idx": 11,
+                          "release": "Staying at Tamara's",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "OneRepublic",
+                          "artistMBID": Array [],
+                          "count": 13,
+                          "entity": "Start Again (feat. Logic)",
+                          "entityMBID": "",
+                          "entityType": "recording",
+                          "id": "9",
+                          "idx": 10,
+                          "release": "13 Reasons Why (Season 2)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Ed Sheeran",
+                          "artistMBID": Array [],
+                          "count": 14,
+                          "entity": "Castle on the Hill",
+                          "entityMBID": "02ba28bc-6d79-44fb-b770-c49395661117",
+                          "entityType": "recording",
+                          "id": "8",
+                          "idx": 9,
+                          "release": "÷ (Deluxe)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Vance Joy",
+                          "artistMBID": Array [],
+                          "count": 15,
+                          "entity": "Riptide",
+                          "entityMBID": "003196a1-f6ab-4fe8-9683-b970d163cfa4",
+                          "entityType": "recording",
+                          "id": "7",
+                          "idx": 8,
+                          "release": "Dream Your Life Away (Special Edition)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Christina Perri",
+                          "artistMBID": Array [],
+                          "count": 16,
+                          "entity": "A Thousand Years",
+                          "entityMBID": "03a0cdfb-f964-434f-bfb7-379203dc139d",
+                          "entityType": "recording",
+                          "id": "6",
+                          "idx": 7,
+                          "release": "A Thousand Years",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Taylor Swift",
+                          "artistMBID": Array [],
+                          "count": 16,
+                          "entity": "Blank Space",
+                          "entityMBID": "01236d26-9f46-435f-adc5-6c92e6e76f53",
+                          "entityType": "recording",
+                          "id": "5",
+                          "idx": 6,
+                          "release": "1989",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Ellie Goulding",
+                          "artistMBID": Array [],
+                          "count": 16,
+                          "entity": "Burn",
+                          "entityMBID": "017cd117-e343-408f-95fe-ee4c1018e312",
+                          "entityType": "recording",
+                          "id": "4",
+                          "idx": 5,
+                          "release": "Halcyon Days",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "OneRepublic",
+                          "artistMBID": Array [],
+                          "count": 18,
+                          "entity": "Counting Stars",
+                          "entityMBID": "00d32e28-0df2-486c-9829-750301962fb2",
+                          "entityType": "recording",
+                          "id": "3",
+                          "idx": 4,
+                          "release": "Native",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Ritviz",
+                          "artistMBID": Array [],
+                          "count": 20,
+                          "entity": "Udd Gaye - Bacardi House Party Sessions",
+                          "entityMBID": "",
+                          "entityType": "recording",
+                          "id": "2",
+                          "idx": 3,
+                          "release": "Udd Gaye (Bacardi House Party Sessions)",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "The Fray",
+                          "artistMBID": Array [],
+                          "count": 23,
+                          "entity": "How to Save a Life",
+                          "entityMBID": "0008ab49-a6ad-40b5-aa90-9d2779265c22",
+                          "entityType": "recording",
+                          "id": "1",
+                          "idx": 2,
+                          "release": "How to Save a Life",
+                          "releaseMBID": "",
+                        },
+                        Object {
+                          "artist": "Ellie Goulding",
+                          "artistMBID": Array [],
+                          "count": 25,
+                          "entity": "Love Me Like You Do - From \\"Fifty Shades of Grey\\"",
+                          "entityMBID": "0fe11cd3-0be4-467b-84fa-0bd524d45d74",
+                          "entityType": "recording",
+                          "id": "0",
+                          "idx": 1,
+                          "release": "Delirium (Deluxe)",
+                          "releaseMBID": "",
+                        },
+                      ]
+                    }
+                    enableGridY={false}
+                    indexBy="id"
+                    keys={
+                      Array [
+                        "count",
+                      ]
+                    }
+                    labelFormat={[Function]}
+                    labelSkipWidth={0}
+                    layout="horizontal"
+                    margin={
+                      Object {
+                        "left": 35,
+                        "top": -12,
+                      }
+                    }
+                    maxValue={26}
+                    padding={0.1}
+                    theme={
+                      Object {
+                        "labels": Object {
+                          "text": Object {
+                            "fontSize": "14px",
+                          },
+                        },
+                      }
+                    }
+                    tooltip={[Function]}
+                  >
+                    <ResponsiveWrapper>
+                      <Measure
+                        bounds={true}
+                        onResize={[Function]}
+                      >
+                        <Component
+                          bounds={true}
+                          contentRect={
+                            Object {
+                              "bounds": Object {},
+                              "client": Object {},
+                              "entry": Object {},
+                              "margin": Object {},
+                              "offset": Object {},
+                              "scroll": Object {},
+                            }
+                          }
+                          measure={[Function]}
+                          measureRef={[Function]}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
+                          />
+                        </Component>
+                      </Measure>
+                    </ResponsiveWrapper>
+                  </ResponsiveBar>
+                </Bar>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <ul
+                  className="pager"
+                >
+                  <li
+                    className="previous disabled"
+                  >
+                    <a
+                      href=""
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      ← Previous
+                    </a>
+                  </li>
+                  <li
+                    className="next disabled"
+                  >
+                    <a
+                      href="?page=2&range=&entity="
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Next →
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </Loader>
+        </div>
+      </div>
+      <div
+        className="col-md-4"
+        style={
+          Object {
+            "position": "sticky",
+            "top": 20,
+          }
+        }
+      >
+        <BrainzPlayer
+          listenBrainzAPIBaseURI="http://localhost/1"
+          listens={
+            Array [
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "0fe11cd3-0be4-467b-84fa-0bd524d45d74",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Ellie Goulding",
+                  "release_name": "Delirium (Deluxe)",
+                  "track_name": "Love Me Like You Do - From \\"Fifty Shades of Grey\\"",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "0008ab49-a6ad-40b5-aa90-9d2779265c22",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "The Fray",
+                  "release_name": "How to Save a Life",
+                  "track_name": "How to Save a Life",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Ritviz",
+                  "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+                  "track_name": "Udd Gaye - Bacardi House Party Sessions",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "00d32e28-0df2-486c-9829-750301962fb2",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "OneRepublic",
+                  "release_name": "Native",
+                  "track_name": "Counting Stars",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "017cd117-e343-408f-95fe-ee4c1018e312",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Ellie Goulding",
+                  "release_name": "Halcyon Days",
+                  "track_name": "Burn",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "01236d26-9f46-435f-adc5-6c92e6e76f53",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Taylor Swift",
+                  "release_name": "1989",
+                  "track_name": "Blank Space",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "03a0cdfb-f964-434f-bfb7-379203dc139d",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Christina Perri",
+                  "release_name": "A Thousand Years",
+                  "track_name": "A Thousand Years",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "003196a1-f6ab-4fe8-9683-b970d163cfa4",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Vance Joy",
+                  "release_name": "Dream Your Life Away (Special Edition)",
+                  "track_name": "Riptide",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "02ba28bc-6d79-44fb-b770-c49395661117",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Ed Sheeran",
+                  "release_name": "÷ (Deluxe)",
+                  "track_name": "Castle on the Hill",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": "",
+                  },
+                  "artist_name": "OneRepublic",
+                  "release_name": "13 Reasons Why (Season 2)",
+                  "track_name": "Start Again (feat. Logic)",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "George Ezra",
+                  "release_name": "Staying at Tamara's",
+                  "track_name": "Shotgun",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Tommee Profitt",
+                  "release_name": "In The End",
+                  "track_name": "In The End - Mellen Gi Remix",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "045cdbf9-796e-4949-91f6-e05d9ce3ed21",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "The Script",
+                  "release_name": "#3",
+                  "track_name": "Hall of Fame",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Maroon 5",
+                  "release_name": "Singles",
+                  "track_name": "Moves Like Jagger - Studio Recording From The Voice Performance",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "0031fba1-dde0-3755-bcb2-63b2544159f8",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Of Monsters and Men",
+                  "release_name": "My Head Is an Animal",
+                  "track_name": "Little Talks",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Sia",
+                  "release_name": "Cheap Thrills (feat. Sean Paul)",
+                  "track_name": "Cheap Thrills (feat. Sean Paul)",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "0126d206-3894-4d97-b5c2-f6cf037a323a",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Maroon 5",
+                  "release_name": "Overexposed",
+                  "track_name": "Payphone",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "234ae263-ffad-472a-8077-dab64bcedf99",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "M.I.A.",
+                  "release_name": "Kala",
+                  "track_name": "Paper Planes",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "14c913e9-db47-40fa-ae1a-81099a67e4bf",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Linkin Park",
+                  "release_name": "One More Light",
+                  "track_name": "Battle Symphony",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "0040980c-4f9a-43df-8be0-142dce4374f4",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Backstreet Boys",
+                  "release_name": "The Hits--Chapter One",
+                  "track_name": "I Want It That Way",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "036e67df-baae-4626-a2ab-951dd162e332",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Lenka",
+                  "release_name": "Two (Expanded Edition)",
+                  "track_name": "Everything at Once",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": "",
+                  },
+                  "artist_name": "The Local train",
+                  "release_name": "Aalas Ka Pedh",
+                  "track_name": "Choo Lo",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "02b47acf-3bc5-47dc-a516-e8c2c95bc07b",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Coldplay",
+                  "release_name": "A Head Full Of Dreams",
+                  "track_name": "Up&Up",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": "0132a6b9-a04f-48ea-81e7-5f3a5d608f75",
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Imagine Dragons",
+                  "release_name": "Night Visions (Deluxe)",
+                  "track_name": "On Top of the World",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": "",
+                  },
+                  "artist_name": "Ellie Goulding",
+                  "release_name": "Close To Me (feat. Swae Lee)",
+                  "track_name": "Close to Me (with Diplo) (feat. Swae Lee)",
+                },
+              },
+            ]
+          }
+          newAlert={[MockFunction]}
+          refreshSpotifyToken={[Function]}
+          refreshYoutubeToken={[Function]}
+        >
+          <div>
+            <PlaybackControls
+              artistName=""
+              durationMs={0}
+              playNextTrack={[Function]}
+              playPreviousTrack={[Function]}
+              playerPaused={true}
+              progressMs={0}
+              seekToPositionMs={[Function]}
+              togglePlay={[Function]}
+              trackName=""
+            >
+              <div
+                aria-label="Playback control"
+                id="brainz-player"
+              >
+                <div
+                  className="content"
+                >
+                  <div
+                    className="connect-services-message"
+                  >
+                    You need to
+                     
+                    <a
+                      href="/profile/music-services/details/"
+                      target="_blank"
+                    >
+                      connect to a music service
+                    </a>
+                     
+                    and refresh this page in order to search for and play songs on ListenBrainz.
+                  </div>
+                  <SpotifyPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshSpotifyToken={[Function]}
+                    show={false}
+                    spotifyUser={Object {}}
+                  />
+                  <YoutubePlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshYoutubeToken={[Function]}
+                    show={false}
+                    youtubeUser={Object {}}
+                  >
+                    <div
+                      className="youtube hidden"
+                    >
+                      <YouTube
+                        className={null}
+                        containerClassName=""
+                        id={null}
+                        onEnd={[Function]}
+                        onError={[Function]}
+                        onPause={[Function]}
+                        onPlay={[Function]}
+                        onPlaybackQualityChange={[Function]}
+                        onPlaybackRateChange={[Function]}
+                        onReady={[Function]}
+                        onStateChange={[Function]}
+                        opts={
+                          Object {
+                            "height": "100%",
+                            "playerVars": Object {
+                              "autoplay": 1,
+                              "controls": 0,
+                              "fs": 0,
+                              "iv_load_policy": 3,
+                              "modestbranding": 1,
+                              "origin": "http://localhost",
+                              "rel": 0,
+                              "showinfo": 0,
+                            },
+                            "width": "100%",
+                          }
+                        }
+                        videoId={null}
+                      >
+                        <div
+                          className=""
+                        >
+                          <div
+                            className={null}
+                            id={null}
+                          />
+                        </div>
+                      </YouTube>
+                    </div>
+                  </YoutubePlayer>
+                  <SoundcloudPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    show={false}
+                  >
+                    <div
+                      className="soundcloud hidden"
+                    >
+                      <iframe
+                        allow="autoplay"
+                        frameBorder="no"
+                        height="420px"
+                        id="soundcloud-iframe"
+                        scrolling="no"
+                        src="https://w.soundcloud.com/player/?auto_play=false"
+                        title="Soundcloud player"
+                        width="100%"
+                      />
+                    </div>
+                  </SoundcloudPlayer>
+                  <div
+                    className="no-album-art"
+                  />
+                </div>
+                <div
+                  className="info showControls"
+                >
+                  <div
+                    className="currently-playing"
+                  >
+                    <div
+                      aria-label="Audio Progress Control"
+                      aria-valuemax={100}
+                      aria-valuemin={0}
+                      aria-valuenow={NaN}
+                      className="progress"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="progressbar"
+                      tabIndex={0}
+                    >
+                      <div
+                        className="progress-bar"
+                        style={
+                          Object {
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="controls"
+                  >
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="left btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            640,
+                            512,
+                            Array [],
+                            "f070",
+                            "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                          ],
+                          "iconName": "eye-slash",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Always show controls"
+                    >
+                      <div
+                        className="left btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Always show controls"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                640,
+                                512,
+                                Array [],
+                                "f070",
+                                "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                              ],
+                              "iconName": "eye-slash",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-eye-slash fa-w-20 "
+                            data-icon="eye-slash"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 640 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="previous btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f049",
+                            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                          ],
+                          "iconName": "fast-backward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Previous"
+                    >
+                      <div
+                        className="previous btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Previous"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f049",
+                                "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                              ],
+                              "iconName": "fast-backward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-backward fa-w-16 "
+                            data-icon="fast-backward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="play btn"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f144",
+                            "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                          ],
+                          "iconName": "play-circle",
+                          "prefix": "fas",
+                        }
+                      }
+                      size="2x"
+                      title="Play"
+                    >
+                      <div
+                        className="play btn"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Play"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f144",
+                                "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                              ],
+                              "iconName": "play-circle",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size="2x"
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                            data-icon="play-circle"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="next btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f050",
+                            "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                          ],
+                          "iconName": "fast-forward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Next"
+                    >
+                      <div
+                        className="next btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Next"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f050",
+                                "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                              ],
+                              "iconName": "fast-forward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-forward fa-w-16 "
+                            data-icon="fast-forward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                  </div>
+                </div>
+              </div>
+            </PlaybackControls>
+          </div>
+        </BrainzPlayer>
+      </div>
+    </div>
+  </div>
+</UserEntityChart>
+`;
+
+exports[`Sitewide Stats UserEntityChart Page renders correctly for releases 1`] = `
+<UserEntityChart
+  apiUrl="apiUrl"
+  newAlert={[MockFunction]}
+>
+  <div
+    role="main"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-8"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": "1em",
+              "minHeight": 500,
+            }
+          }
+        >
+          <Loader
+            isLoading={false}
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Artists
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Releases
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Recordings
+                  </button>
+                </Pill>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <h3>
+                  Top
+                   
+                  <span
+                    style={
+                      Object {
+                        "textTransform": "capitalize",
+                      }
+                    }
+                  />
+                   
+                  of 
+                  the
+                  <span
+                    className="dropdown"
+                    style={
+                      Object {
+                        "fontSize": 22,
+                      }
+                    }
+                  >
+                    <button
+                      className="dropdown-toggle btn-transparent capitalize-bold"
+                      data-toggle="dropdown"
+                      type="button"
+                    >
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li>
+                        <a
+                          href="?page=1&range=this_week&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_month&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_year&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=week&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=month&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=year&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=all_time&entity="
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          All time
+                        </a>
+                      </li>
+                    </ul>
+                  </span>
+                  (January 01, 1970 - January 01, 1970)
+                </h3>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <h4
+                  style={
+                    Object {
+                      "textTransform": "capitalize",
+                    }
+                  }
+                >
+                   count - 
+                  <b>
+                    0
+                  </b>
+                </h4>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-6"
+              >
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="2"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Coldplay",
+                        "release_name": "Live in Buenos Aires",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Live in Buenos Aires"
+                      >
+                        <React.Fragment>
+                          Live in Buenos Aires
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Coldplay, "
+                      >
+                        <React.Fragment>
+                          Coldplay
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Live in Buenos Aires"
+                          >
+                            Live in Buenos Aires
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Coldplay, "
+                          >
+                            Coldplay
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Coldplay",
+                                    "release_name": "Live in Buenos Aires",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="3"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Fray",
+                        "release_name": "How to Save a Life",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="How to Save a Life"
+                      >
+                        <React.Fragment>
+                          How to Save a Life
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="The Fray, "
+                      >
+                        <React.Fragment>
+                          The Fray
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="How to Save a Life"
+                          >
+                            How to Save a Life
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="The Fray, "
+                          >
+                            The Fray
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Fray",
+                                    "release_name": "How to Save a Life",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="4"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Ellie Goulding",
+                        "release_name": "Delirium (Deluxe)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Delirium (Deluxe)"
+                      >
+                        <React.Fragment>
+                          Delirium (Deluxe)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ellie Goulding, "
+                      >
+                        <React.Fragment>
+                          Ellie Goulding
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Delirium (Deluxe)"
+                          >
+                            Delirium (Deluxe)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ellie Goulding, "
+                          >
+                            Ellie Goulding
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Ellie Goulding",
+                                    "release_name": "Delirium (Deluxe)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="5"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Ritviz",
+                        "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Udd Gaye (Bacardi House Party Sessions)"
+                      >
+                        <React.Fragment>
+                          Udd Gaye (Bacardi House Party Sessions)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ritviz, "
+                      >
+                        <React.Fragment>
+                          Ritviz
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Udd Gaye (Bacardi House Party Sessions)"
+                          >
+                            Udd Gaye (Bacardi House Party Sessions)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ritviz, "
+                          >
+                            Ritviz
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Ritviz",
+                                    "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="6"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "OneRepublic",
+                        "release_name": "Native",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Native"
+                      >
+                        <React.Fragment>
+                          Native
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="OneRepublic, "
+                      >
+                        <React.Fragment>
+                          OneRepublic
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Native"
+                          >
+                            Native
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="OneRepublic, "
+                          >
+                            OneRepublic
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "OneRepublic",
+                                    "release_name": "Native",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="7"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Vance Joy",
+                        "release_name": "Dream Your Life Away (Special Edition)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Dream Your Life Away (Special Edition)"
+                      >
+                        <React.Fragment>
+                          Dream Your Life Away (Special Edition)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Vance Joy, "
+                      >
+                        <React.Fragment>
+                          Vance Joy
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Dream Your Life Away (Special Edition)"
+                          >
+                            Dream Your Life Away (Special Edition)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Vance Joy, "
+                          >
+                            Vance Joy
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Vance Joy",
+                                    "release_name": "Dream Your Life Away (Special Edition)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="8"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Ed Sheeran",
+                        "release_name": "÷ (Deluxe)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="÷ (Deluxe)"
+                      >
+                        <React.Fragment>
+                          ÷ (Deluxe)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ed Sheeran, "
+                      >
+                        <React.Fragment>
+                          Ed Sheeran
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="÷ (Deluxe)"
+                          >
+                            ÷ (Deluxe)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ed Sheeran, "
+                          >
+                            Ed Sheeran
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Ed Sheeran",
+                                    "release_name": "÷ (Deluxe)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="9"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Imagine Dragons",
+                        "release_name": "Night Visions (Deluxe)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Night Visions (Deluxe)"
+                      >
+                        <React.Fragment>
+                          Night Visions (Deluxe)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Imagine Dragons, "
+                      >
+                        <React.Fragment>
+                          Imagine Dragons
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Night Visions (Deluxe)"
+                          >
+                            Night Visions (Deluxe)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Imagine Dragons, "
+                          >
+                            Imagine Dragons
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Imagine Dragons",
+                                    "release_name": "Night Visions (Deluxe)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="10"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Taylor Swift",
+                        "release_name": "1989",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="1989"
+                      >
+                        <React.Fragment>
+                          1989
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Taylor Swift, "
+                      >
+                        <React.Fragment>
+                          Taylor Swift
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="1989"
+                          >
+                            1989
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Taylor Swift, "
+                          >
+                            Taylor Swift
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Taylor Swift",
+                                    "release_name": "1989",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="11"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Ellie Goulding",
+                        "release_name": "Halcyon Days",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Halcyon Days"
+                      >
+                        <React.Fragment>
+                          Halcyon Days
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Ellie Goulding, "
+                      >
+                        <React.Fragment>
+                          Ellie Goulding
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Halcyon Days"
+                          >
+                            Halcyon Days
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Ellie Goulding, "
+                          >
+                            Ellie Goulding
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Ellie Goulding",
+                                    "release_name": "Halcyon Days",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="12"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Christina Perri",
+                        "release_name": "A Thousand Years",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="A Thousand Years"
+                      >
+                        <React.Fragment>
+                          A Thousand Years
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Christina Perri, "
+                      >
+                        <React.Fragment>
+                          Christina Perri
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="A Thousand Years"
+                          >
+                            A Thousand Years
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Christina Perri, "
+                          >
+                            Christina Perri
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Christina Perri",
+                                    "release_name": "A Thousand Years",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="13"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Coldplay",
+                        "release_name": "A Head Full Of Dreams",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="A Head Full Of Dreams"
+                      >
+                        <React.Fragment>
+                          A Head Full Of Dreams
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Coldplay, "
+                      >
+                        <React.Fragment>
+                          Coldplay
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="A Head Full Of Dreams"
+                          >
+                            A Head Full Of Dreams
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Coldplay, "
+                          >
+                            Coldplay
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Coldplay",
+                                    "release_name": "A Head Full Of Dreams",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="14"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "George Ezra",
+                        "release_name": "Staying at Tamara's",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Staying at Tamara's"
+                      >
+                        <React.Fragment>
+                          Staying at Tamara's
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="George Ezra, "
+                      >
+                        <React.Fragment>
+                          George Ezra
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Staying at Tamara's"
+                          >
+                            Staying at Tamara's
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="George Ezra, "
+                          >
+                            George Ezra
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "George Ezra",
+                                    "release_name": "Staying at Tamara's",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="15"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Lenka",
+                        "release_name": "Two (Expanded Edition)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Two (Expanded Edition)"
+                      >
+                        <React.Fragment>
+                          Two (Expanded Edition)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Lenka, "
+                      >
+                        <React.Fragment>
+                          Lenka
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Two (Expanded Edition)"
+                          >
+                            Two (Expanded Edition)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Lenka, "
+                          >
+                            Lenka
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Lenka",
+                                    "release_name": "Two (Expanded Edition)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="16"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "OneRepublic",
+                        "release_name": "13 Reasons Why (Season 2)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="13 Reasons Why (Season 2)"
+                      >
+                        <React.Fragment>
+                          13 Reasons Why (Season 2)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="OneRepublic, "
+                      >
+                        <React.Fragment>
+                          OneRepublic
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="13 Reasons Why (Season 2)"
+                          >
+                            13 Reasons Why (Season 2)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="OneRepublic, "
+                          >
+                            OneRepublic
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "OneRepublic",
+                                    "release_name": "13 Reasons Why (Season 2)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="17"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Tommee Profitt",
+                        "release_name": "In The End",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="In The End"
+                      >
+                        <React.Fragment>
+                          In The End
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Tommee Profitt, "
+                      >
+                        <React.Fragment>
+                          Tommee Profitt
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="In The End"
+                          >
+                            In The End
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Tommee Profitt, "
+                          >
+                            Tommee Profitt
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Tommee Profitt",
+                                    "release_name": "In The End",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="18"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Script",
+                        "release_name": "#3",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="#3"
+                      >
+                        <React.Fragment>
+                          #3
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="The Script, "
+                      >
+                        <React.Fragment>
+                          The Script
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="#3"
+                          >
+                            #3
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="The Script, "
+                          >
+                            The Script
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Script",
+                                    "release_name": "#3",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="19"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Maroon 5",
+                        "release_name": "Singles",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Singles"
+                      >
+                        <React.Fragment>
+                          Singles
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Maroon 5, "
+                      >
+                        <React.Fragment>
+                          Maroon 5
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Singles"
+                          >
+                            Singles
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Maroon 5, "
+                          >
+                            Maroon 5
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Maroon 5",
+                                    "release_name": "Singles",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="20"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Maroon 5",
+                        "release_name": "Overexposed",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Overexposed"
+                      >
+                        <React.Fragment>
+                          Overexposed
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Maroon 5, "
+                      >
+                        <React.Fragment>
+                          Maroon 5
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Overexposed"
+                          >
+                            Overexposed
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Maroon 5, "
+                          >
+                            Maroon 5
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Maroon 5",
+                                    "release_name": "Overexposed",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="21"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Of Monsters and Men",
+                        "release_name": "My Head Is an Animal",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="My Head Is an Animal"
+                      >
+                        <React.Fragment>
+                          My Head Is an Animal
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Of Monsters and Men, "
+                      >
+                        <React.Fragment>
+                          Of Monsters and Men
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="My Head Is an Animal"
+                          >
+                            My Head Is an Animal
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Of Monsters and Men, "
+                          >
+                            Of Monsters and Men
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Of Monsters and Men",
+                                    "release_name": "My Head Is an Animal",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="22"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Sia",
+                        "release_name": "Cheap Thrills (feat. Sean Paul)",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Cheap Thrills (feat. Sean Paul)"
+                      >
+                        <React.Fragment>
+                          Cheap Thrills (feat. Sean Paul)
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Sia, "
+                      >
+                        <React.Fragment>
+                          Sia
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Cheap Thrills (feat. Sean Paul)"
+                          >
+                            Cheap Thrills (feat. Sean Paul)
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Sia, "
+                          >
+                            Sia
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Sia",
+                                    "release_name": "Cheap Thrills (feat. Sean Paul)",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="23"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Linkin Park",
+                        "release_name": "One More Light",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="One More Light"
+                      >
+                        <React.Fragment>
+                          One More Light
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Linkin Park, "
+                      >
+                        <React.Fragment>
+                          Linkin Park
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="One More Light"
+                          >
+                            One More Light
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Linkin Park, "
+                          >
+                            Linkin Park
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Linkin Park",
+                                    "release_name": "One More Light",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="24"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "M.I.A.",
+                        "release_name": "Kala",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Kala"
+                      >
+                        <React.Fragment>
+                          Kala
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="M.I.A., "
+                      >
+                        <React.Fragment>
+                          M.I.A.
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Kala"
+                          >
+                            Kala
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="M.I.A., "
+                          >
+                            M.I.A.
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "M.I.A.",
+                                    "release_name": "Kala",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="25"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "The Local train",
+                        "release_name": "Aalas Ka Pedh",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="Aalas Ka Pedh"
+                      >
+                        <React.Fragment>
+                          Aalas Ka Pedh
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="The Local train, "
+                      >
+                        <React.Fragment>
+                          The Local train
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="Aalas Ka Pedh"
+                          >
+                            Aalas Ka Pedh
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="The Local train, "
+                          >
+                            The Local train
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "The Local train",
+                                    "release_name": "Aalas Ka Pedh",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+                <ListenCard
+                  compact={true}
+                  currentFeedback={0}
+                  key="26"
+                  listen={
+                    Object {
+                      "listened_at": -1,
+                      "track_metadata": Object {
+                        "additional_info": Object {
+                          "artist_mbids": Array [],
+                          "recording_mbid": undefined,
+                          "release_mbid": undefined,
+                        },
+                        "artist_name": "Backstreet Boys",
+                        "release_name": "The Hits--Chapter One",
+                        "track_name": "",
+                      },
+                    }
+                  }
+                  listenDetails={
+                    <React.Fragment>
+                      <div
+                        className="ellipsis"
+                        title="The Hits--Chapter One"
+                      >
+                        <React.Fragment>
+                          The Hits--Chapter One
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="small text-muted ellipsis"
+                        title="Backstreet Boys, "
+                      >
+                        <React.Fragment>
+                          Backstreet Boys
+                        </React.Fragment>
+                      </div>
+                    </React.Fragment>
+                  }
+                  newAlert={[MockFunction]}
+                  showTimestamp={false}
+                  showUsername={false}
+                >
+                  <ForwardRef
+                    className="listen-card row  compact  "
+                    onDoubleClick={[Function]}
+                  >
+                    <div
+                      className="card listen-card row  compact  "
+                      onDoubleClick={[Function]}
+                    >
+                      <div
+                        className="main-content"
+                      >
+                        <div
+                          className="listen-thumbnail"
+                        >
+                          <a
+                            href="https://musicbrainz.org/doc/How_to_Add_Cover_Art"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title="How can I add missing cover art?"
+                          >
+                            <img
+                              alt="How can I add missing cover art?"
+                              src="/static/img/cover-art-placeholder.jpg"
+                            />
+                          </a>
+                        </div>
+                        <div
+                          className="listen-details"
+                        >
+                          <div
+                            className="ellipsis"
+                            title="The Hits--Chapter One"
+                          >
+                            The Hits--Chapter One
+                          </div>
+                          <div
+                            className="small text-muted ellipsis"
+                            title="Backstreet Boys, "
+                          >
+                            Backstreet Boys
+                          </div>
+                        </div>
+                        <div
+                          className="right-section"
+                        >
+                          <div
+                            className="listen-controls"
+                          >
+                            <ListenFeedbackComponent
+                              currentFeedback={0}
+                              listen={
+                                Object {
+                                  "listened_at": -1,
+                                  "track_metadata": Object {
+                                    "additional_info": Object {
+                                      "artist_mbids": Array [],
+                                      "recording_mbid": undefined,
+                                      "release_mbid": undefined,
+                                    },
+                                    "artist_name": "Backstreet Boys",
+                                    "release_name": "The Hits--Chapter One",
+                                    "track_name": "",
+                                  },
+                                }
+                              }
+                              newAlert={[MockFunction]}
+                            />
+                            <button
+                              className="btn-transparent play-button"
+                              onClick={[Function]}
+                              title="Play"
+                              type="button"
+                            >
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={false}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      512,
+                                      512,
+                                      Array [],
+                                      "f144",
+                                      "M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z",
+                                    ],
+                                    "iconName": "play-circle",
+                                    "prefix": "far",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size="2x"
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                                  data-icon="play-circle"
+                                  data-prefix="far"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 512 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+                                    fill="currentColor"
+                                    style={Object {}}
+                                  />
+                                </svg>
+                              </FontAwesomeIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </ForwardRef>
+                </ListenCard>
+              </div>
+              <div
+                className="col-xs-6"
+                style={
+                  Object {
+                    "height": "1375px",
+                    "paddingLeft": 0,
+                  }
+                }
+              >
+                <Bar
+                  data={
+                    Array [
+                      Object {
+                        "artist": "Backstreet Boys",
+                        "artistMBID": Array [],
+                        "count": 8,
+                        "entity": "The Hits--Chapter One",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "24",
+                        "idx": 25,
+                      },
+                      Object {
+                        "artist": "The Local train",
+                        "artistMBID": Array [],
+                        "count": 9,
+                        "entity": "Aalas Ka Pedh",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "23",
+                        "idx": 24,
+                      },
+                      Object {
+                        "artist": "M.I.A.",
+                        "artistMBID": Array [],
+                        "count": 10,
+                        "entity": "Kala",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "22",
+                        "idx": 23,
+                      },
+                      Object {
+                        "artist": "Linkin Park",
+                        "artistMBID": Array [],
+                        "count": 10,
+                        "entity": "One More Light",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "21",
+                        "idx": 22,
+                      },
+                      Object {
+                        "artist": "Sia",
+                        "artistMBID": Array [],
+                        "count": 11,
+                        "entity": "Cheap Thrills (feat. Sean Paul)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "20",
+                        "idx": 21,
+                      },
+                      Object {
+                        "artist": "Of Monsters and Men",
+                        "artistMBID": Array [],
+                        "count": 11,
+                        "entity": "My Head Is an Animal",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "19",
+                        "idx": 20,
+                      },
+                      Object {
+                        "artist": "Maroon 5",
+                        "artistMBID": Array [],
+                        "count": 11,
+                        "entity": "Overexposed",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "18",
+                        "idx": 19,
+                      },
+                      Object {
+                        "artist": "Maroon 5",
+                        "artistMBID": Array [],
+                        "count": 11,
+                        "entity": "Singles",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "17",
+                        "idx": 18,
+                      },
+                      Object {
+                        "artist": "The Script",
+                        "artistMBID": Array [],
+                        "count": 12,
+                        "entity": "#3",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "16",
+                        "idx": 17,
+                      },
+                      Object {
+                        "artist": "Tommee Profitt",
+                        "artistMBID": Array [],
+                        "count": 12,
+                        "entity": "In The End",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "15",
+                        "idx": 16,
+                      },
+                      Object {
+                        "artist": "OneRepublic",
+                        "artistMBID": Array [],
+                        "count": 13,
+                        "entity": "13 Reasons Why (Season 2)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "14",
+                        "idx": 15,
+                      },
+                      Object {
+                        "artist": "Lenka",
+                        "artistMBID": Array [],
+                        "count": 13,
+                        "entity": "Two (Expanded Edition)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "13",
+                        "idx": 14,
+                      },
+                      Object {
+                        "artist": "George Ezra",
+                        "artistMBID": Array [],
+                        "count": 15,
+                        "entity": "Staying at Tamara's",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "12",
+                        "idx": 13,
+                      },
+                      Object {
+                        "artist": "Coldplay",
+                        "artistMBID": Array [],
+                        "count": 16,
+                        "entity": "A Head Full Of Dreams",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "11",
+                        "idx": 12,
+                      },
+                      Object {
+                        "artist": "Christina Perri",
+                        "artistMBID": Array [],
+                        "count": 16,
+                        "entity": "A Thousand Years",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "10",
+                        "idx": 11,
+                      },
+                      Object {
+                        "artist": "Ellie Goulding",
+                        "artistMBID": Array [],
+                        "count": 16,
+                        "entity": "Halcyon Days",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "9",
+                        "idx": 10,
+                      },
+                      Object {
+                        "artist": "Taylor Swift",
+                        "artistMBID": Array [],
+                        "count": 17,
+                        "entity": "1989",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "8",
+                        "idx": 9,
+                      },
+                      Object {
+                        "artist": "Imagine Dragons",
+                        "artistMBID": Array [],
+                        "count": 17,
+                        "entity": "Night Visions (Deluxe)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "7",
+                        "idx": 8,
+                      },
+                      Object {
+                        "artist": "Ed Sheeran",
+                        "artistMBID": Array [],
+                        "count": 17,
+                        "entity": "÷ (Deluxe)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "6",
+                        "idx": 7,
+                      },
+                      Object {
+                        "artist": "Vance Joy",
+                        "artistMBID": Array [],
+                        "count": 18,
+                        "entity": "Dream Your Life Away (Special Edition)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "5",
+                        "idx": 6,
+                      },
+                      Object {
+                        "artist": "OneRepublic",
+                        "artistMBID": Array [],
+                        "count": 18,
+                        "entity": "Native",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "4",
+                        "idx": 5,
+                      },
+                      Object {
+                        "artist": "Ritviz",
+                        "artistMBID": Array [],
+                        "count": 20,
+                        "entity": "Udd Gaye (Bacardi House Party Sessions)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "3",
+                        "idx": 4,
+                      },
+                      Object {
+                        "artist": "Ellie Goulding",
+                        "artistMBID": Array [],
+                        "count": 25,
+                        "entity": "Delirium (Deluxe)",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "2",
+                        "idx": 3,
+                      },
+                      Object {
+                        "artist": "The Fray",
+                        "artistMBID": Array [],
+                        "count": 25,
+                        "entity": "How to Save a Life",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "1",
+                        "idx": 2,
+                      },
+                      Object {
+                        "artist": "Coldplay",
+                        "artistMBID": Array [],
+                        "count": 26,
+                        "entity": "Live in Buenos Aires",
+                        "entityMBID": "",
+                        "entityType": "release",
+                        "id": "0",
+                        "idx": 1,
+                      },
+                    ]
+                  }
+                  maxValue={26}
+                >
+                  <ResponsiveBar
+                    animate={false}
+                    axisLeft={
+                      Object {
+                        "renderTick": [Function],
+                        "tickPadding": 5,
+                        "tickSize": 0,
+                        "tickValues": 25,
+                      }
+                    }
+                    colors="#EB743B"
+                    data={
+                      Array [
+                        Object {
+                          "artist": "Backstreet Boys",
+                          "artistMBID": Array [],
+                          "count": 8,
+                          "entity": "The Hits--Chapter One",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "24",
+                          "idx": 25,
+                        },
+                        Object {
+                          "artist": "The Local train",
+                          "artistMBID": Array [],
+                          "count": 9,
+                          "entity": "Aalas Ka Pedh",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "23",
+                          "idx": 24,
+                        },
+                        Object {
+                          "artist": "M.I.A.",
+                          "artistMBID": Array [],
+                          "count": 10,
+                          "entity": "Kala",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "22",
+                          "idx": 23,
+                        },
+                        Object {
+                          "artist": "Linkin Park",
+                          "artistMBID": Array [],
+                          "count": 10,
+                          "entity": "One More Light",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "21",
+                          "idx": 22,
+                        },
+                        Object {
+                          "artist": "Sia",
+                          "artistMBID": Array [],
+                          "count": 11,
+                          "entity": "Cheap Thrills (feat. Sean Paul)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "20",
+                          "idx": 21,
+                        },
+                        Object {
+                          "artist": "Of Monsters and Men",
+                          "artistMBID": Array [],
+                          "count": 11,
+                          "entity": "My Head Is an Animal",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "19",
+                          "idx": 20,
+                        },
+                        Object {
+                          "artist": "Maroon 5",
+                          "artistMBID": Array [],
+                          "count": 11,
+                          "entity": "Overexposed",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "18",
+                          "idx": 19,
+                        },
+                        Object {
+                          "artist": "Maroon 5",
+                          "artistMBID": Array [],
+                          "count": 11,
+                          "entity": "Singles",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "17",
+                          "idx": 18,
+                        },
+                        Object {
+                          "artist": "The Script",
+                          "artistMBID": Array [],
+                          "count": 12,
+                          "entity": "#3",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "16",
+                          "idx": 17,
+                        },
+                        Object {
+                          "artist": "Tommee Profitt",
+                          "artistMBID": Array [],
+                          "count": 12,
+                          "entity": "In The End",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "15",
+                          "idx": 16,
+                        },
+                        Object {
+                          "artist": "OneRepublic",
+                          "artistMBID": Array [],
+                          "count": 13,
+                          "entity": "13 Reasons Why (Season 2)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "14",
+                          "idx": 15,
+                        },
+                        Object {
+                          "artist": "Lenka",
+                          "artistMBID": Array [],
+                          "count": 13,
+                          "entity": "Two (Expanded Edition)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "13",
+                          "idx": 14,
+                        },
+                        Object {
+                          "artist": "George Ezra",
+                          "artistMBID": Array [],
+                          "count": 15,
+                          "entity": "Staying at Tamara's",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "12",
+                          "idx": 13,
+                        },
+                        Object {
+                          "artist": "Coldplay",
+                          "artistMBID": Array [],
+                          "count": 16,
+                          "entity": "A Head Full Of Dreams",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "11",
+                          "idx": 12,
+                        },
+                        Object {
+                          "artist": "Christina Perri",
+                          "artistMBID": Array [],
+                          "count": 16,
+                          "entity": "A Thousand Years",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "10",
+                          "idx": 11,
+                        },
+                        Object {
+                          "artist": "Ellie Goulding",
+                          "artistMBID": Array [],
+                          "count": 16,
+                          "entity": "Halcyon Days",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "9",
+                          "idx": 10,
+                        },
+                        Object {
+                          "artist": "Taylor Swift",
+                          "artistMBID": Array [],
+                          "count": 17,
+                          "entity": "1989",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "8",
+                          "idx": 9,
+                        },
+                        Object {
+                          "artist": "Imagine Dragons",
+                          "artistMBID": Array [],
+                          "count": 17,
+                          "entity": "Night Visions (Deluxe)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "7",
+                          "idx": 8,
+                        },
+                        Object {
+                          "artist": "Ed Sheeran",
+                          "artistMBID": Array [],
+                          "count": 17,
+                          "entity": "÷ (Deluxe)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "6",
+                          "idx": 7,
+                        },
+                        Object {
+                          "artist": "Vance Joy",
+                          "artistMBID": Array [],
+                          "count": 18,
+                          "entity": "Dream Your Life Away (Special Edition)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "5",
+                          "idx": 6,
+                        },
+                        Object {
+                          "artist": "OneRepublic",
+                          "artistMBID": Array [],
+                          "count": 18,
+                          "entity": "Native",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "4",
+                          "idx": 5,
+                        },
+                        Object {
+                          "artist": "Ritviz",
+                          "artistMBID": Array [],
+                          "count": 20,
+                          "entity": "Udd Gaye (Bacardi House Party Sessions)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "3",
+                          "idx": 4,
+                        },
+                        Object {
+                          "artist": "Ellie Goulding",
+                          "artistMBID": Array [],
+                          "count": 25,
+                          "entity": "Delirium (Deluxe)",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "2",
+                          "idx": 3,
+                        },
+                        Object {
+                          "artist": "The Fray",
+                          "artistMBID": Array [],
+                          "count": 25,
+                          "entity": "How to Save a Life",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "1",
+                          "idx": 2,
+                        },
+                        Object {
+                          "artist": "Coldplay",
+                          "artistMBID": Array [],
+                          "count": 26,
+                          "entity": "Live in Buenos Aires",
+                          "entityMBID": "",
+                          "entityType": "release",
+                          "id": "0",
+                          "idx": 1,
+                        },
+                      ]
+                    }
+                    enableGridY={false}
+                    indexBy="id"
+                    keys={
+                      Array [
+                        "count",
+                      ]
+                    }
+                    labelFormat={[Function]}
+                    labelSkipWidth={0}
+                    layout="horizontal"
+                    margin={
+                      Object {
+                        "left": 35,
+                        "top": -12,
+                      }
+                    }
+                    maxValue={26}
+                    padding={0.1}
+                    theme={
+                      Object {
+                        "labels": Object {
+                          "text": Object {
+                            "fontSize": "14px",
+                          },
+                        },
+                      }
+                    }
+                    tooltip={[Function]}
+                  >
+                    <ResponsiveWrapper>
+                      <Measure
+                        bounds={true}
+                        onResize={[Function]}
+                      >
+                        <Component
+                          bounds={true}
+                          contentRect={
+                            Object {
+                              "bounds": Object {},
+                              "client": Object {},
+                              "entry": Object {},
+                              "margin": Object {},
+                              "offset": Object {},
+                              "scroll": Object {},
+                            }
+                          }
+                          measure={[Function]}
+                          measureRef={[Function]}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
+                          />
+                        </Component>
+                      </Measure>
+                    </ResponsiveWrapper>
+                  </ResponsiveBar>
+                </Bar>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <ul
+                  className="pager"
+                >
+                  <li
+                    className="previous disabled"
+                  >
+                    <a
+                      href=""
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      ← Previous
+                    </a>
+                  </li>
+                  <li
+                    className="next disabled"
+                  >
+                    <a
+                      href="?page=2&range=&entity="
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Next →
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </Loader>
+        </div>
+      </div>
+      <div
+        className="col-md-4"
+        style={
+          Object {
+            "position": "sticky",
+            "top": 20,
+          }
+        }
+      >
+        <BrainzPlayer
+          listenBrainzAPIBaseURI="http://localhost/1"
+          listens={
+            Array [
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Coldplay",
+                  "release_name": "Live in Buenos Aires",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Fray",
+                  "release_name": "How to Save a Life",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Ellie Goulding",
+                  "release_name": "Delirium (Deluxe)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Ritviz",
+                  "release_name": "Udd Gaye (Bacardi House Party Sessions)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "OneRepublic",
+                  "release_name": "Native",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Vance Joy",
+                  "release_name": "Dream Your Life Away (Special Edition)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Ed Sheeran",
+                  "release_name": "÷ (Deluxe)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Imagine Dragons",
+                  "release_name": "Night Visions (Deluxe)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Taylor Swift",
+                  "release_name": "1989",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Ellie Goulding",
+                  "release_name": "Halcyon Days",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Christina Perri",
+                  "release_name": "A Thousand Years",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Coldplay",
+                  "release_name": "A Head Full Of Dreams",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "George Ezra",
+                  "release_name": "Staying at Tamara's",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Lenka",
+                  "release_name": "Two (Expanded Edition)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "OneRepublic",
+                  "release_name": "13 Reasons Why (Season 2)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Tommee Profitt",
+                  "release_name": "In The End",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Script",
+                  "release_name": "#3",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Maroon 5",
+                  "release_name": "Singles",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Maroon 5",
+                  "release_name": "Overexposed",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Of Monsters and Men",
+                  "release_name": "My Head Is an Animal",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Sia",
+                  "release_name": "Cheap Thrills (feat. Sean Paul)",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Linkin Park",
+                  "release_name": "One More Light",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "M.I.A.",
+                  "release_name": "Kala",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "The Local train",
+                  "release_name": "Aalas Ka Pedh",
+                  "track_name": "",
+                },
+              },
+              Object {
+                "listened_at": -1,
+                "track_metadata": Object {
+                  "additional_info": Object {
+                    "artist_mbids": Array [],
+                    "recording_mbid": undefined,
+                    "release_mbid": undefined,
+                  },
+                  "artist_name": "Backstreet Boys",
+                  "release_name": "The Hits--Chapter One",
+                  "track_name": "",
+                },
+              },
+            ]
+          }
+          newAlert={[MockFunction]}
+          refreshSpotifyToken={[Function]}
+          refreshYoutubeToken={[Function]}
+        >
+          <div>
+            <PlaybackControls
+              artistName=""
+              durationMs={0}
+              playNextTrack={[Function]}
+              playPreviousTrack={[Function]}
+              playerPaused={true}
+              progressMs={0}
+              seekToPositionMs={[Function]}
+              togglePlay={[Function]}
+              trackName=""
+            >
+              <div
+                aria-label="Playback control"
+                id="brainz-player"
+              >
+                <div
+                  className="content"
+                >
+                  <div
+                    className="connect-services-message"
+                  >
+                    You need to
+                     
+                    <a
+                      href="/profile/music-services/details/"
+                      target="_blank"
+                    >
+                      connect to a music service
+                    </a>
+                     
+                    and refresh this page in order to search for and play songs on ListenBrainz.
+                  </div>
+                  <SpotifyPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshSpotifyToken={[Function]}
+                    show={false}
+                    spotifyUser={Object {}}
+                  />
+                  <YoutubePlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshYoutubeToken={[Function]}
+                    show={false}
+                    youtubeUser={Object {}}
+                  >
+                    <div
+                      className="youtube hidden"
+                    >
+                      <YouTube
+                        className={null}
+                        containerClassName=""
+                        id={null}
+                        onEnd={[Function]}
+                        onError={[Function]}
+                        onPause={[Function]}
+                        onPlay={[Function]}
+                        onPlaybackQualityChange={[Function]}
+                        onPlaybackRateChange={[Function]}
+                        onReady={[Function]}
+                        onStateChange={[Function]}
+                        opts={
+                          Object {
+                            "height": "100%",
+                            "playerVars": Object {
+                              "autoplay": 1,
+                              "controls": 0,
+                              "fs": 0,
+                              "iv_load_policy": 3,
+                              "modestbranding": 1,
+                              "origin": "http://localhost",
+                              "rel": 0,
+                              "showinfo": 0,
+                            },
+                            "width": "100%",
+                          }
+                        }
+                        videoId={null}
+                      >
+                        <div
+                          className=""
+                        >
+                          <div
+                            className={null}
+                            id={null}
+                          />
+                        </div>
+                      </YouTube>
+                    </div>
+                  </YoutubePlayer>
+                  <SoundcloudPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    show={false}
+                  >
+                    <div
+                      className="soundcloud hidden"
+                    >
+                      <iframe
+                        allow="autoplay"
+                        frameBorder="no"
+                        height="420px"
+                        id="soundcloud-iframe"
+                        scrolling="no"
+                        src="https://w.soundcloud.com/player/?auto_play=false"
+                        title="Soundcloud player"
+                        width="100%"
+                      />
+                    </div>
+                  </SoundcloudPlayer>
+                  <div
+                    className="no-album-art"
+                  />
+                </div>
+                <div
+                  className="info showControls"
+                >
+                  <div
+                    className="currently-playing"
+                  >
+                    <div
+                      aria-label="Audio Progress Control"
+                      aria-valuemax={100}
+                      aria-valuemin={0}
+                      aria-valuenow={NaN}
+                      className="progress"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="progressbar"
+                      tabIndex={0}
+                    >
+                      <div
+                        className="progress-bar"
+                        style={
+                          Object {
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="controls"
+                  >
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="left btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            640,
+                            512,
+                            Array [],
+                            "f070",
+                            "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                          ],
+                          "iconName": "eye-slash",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Always show controls"
+                    >
+                      <div
+                        className="left btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Always show controls"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                640,
+                                512,
+                                Array [],
+                                "f070",
+                                "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                              ],
+                              "iconName": "eye-slash",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-eye-slash fa-w-20 "
+                            data-icon="eye-slash"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 640 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="previous btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f049",
+                            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                          ],
+                          "iconName": "fast-backward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Previous"
+                    >
+                      <div
+                        className="previous btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Previous"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f049",
+                                "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                              ],
+                              "iconName": "fast-backward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-backward fa-w-16 "
+                            data-icon="fast-backward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="play btn"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f144",
+                            "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                          ],
+                          "iconName": "play-circle",
+                          "prefix": "fas",
+                        }
+                      }
+                      size="2x"
+                      title="Play"
+                    >
+                      <div
+                        className="play btn"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Play"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f144",
+                                "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                              ],
+                              "iconName": "play-circle",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size="2x"
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                            data-icon="play-circle"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="next btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f050",
+                            "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                          ],
+                          "iconName": "fast-forward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Next"
+                    >
+                      <div
+                        className="next btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Next"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f050",
+                                "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                              ],
+                              "iconName": "fast-forward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-forward fa-w-16 "
+                            data-icon="fast-forward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                  </div>
+                </div>
+              </div>
+            </PlaybackControls>
+          </div>
+        </BrainzPlayer>
+      </div>
+    </div>
+  </div>
+</UserEntityChart>
+`;
+
+exports[`Sitewide Stats UserEntityChart Page renders correctly if stats are not calculated 1`] = `
+<UserEntityChart
+  apiUrl="apiUrl"
+  newAlert={[MockFunction]}
+>
+  <div
+    role="main"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-8"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": "1em",
+              "minHeight": 500,
+            }
+          }
+        >
+          <Loader
+            isLoading={false}
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Pill
+                  active={true}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "#353070",
+                        "border": "2px solid #353070",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "white",
+                        "fontWeight": 700,
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Artists
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Releases
+                  </button>
+                </Pill>
+                <Pill
+                  active={false}
+                  onClick={[Function]}
+                  type="secondary"
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "transparent",
+                        "border": "2px solid #BBBBBB",
+                        "borderRadius": "24px",
+                        "boxSizing": "border-box",
+                        "color": "#BBBBBB",
+                        "margin": "2px 6px 12px 6px",
+                        "outline": "none",
+                        "padding": "3px 12px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Recordings
+                  </button>
+                </Pill>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-xs-12"
+              >
+                <h3>
+                  Top
+                   
+                  <span
+                    style={
+                      Object {
+                        "textTransform": "capitalize",
+                      }
+                    }
+                  >
+                    artists
+                  </span>
+                   
+                  of 
+                  <span
+                    className="dropdown"
+                    style={
+                      Object {
+                        "fontSize": 22,
+                      }
+                    }
+                  >
+                    <button
+                      className="dropdown-toggle btn-transparent capitalize-bold"
+                      data-toggle="dropdown"
+                      type="button"
+                    >
+                      All time
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li>
+                        <a
+                          href="?page=1&range=this_week&entity=artist"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_month&entity=artist"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=this_year&entity=artist"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          This Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=week&entity=artist"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Week
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=month&entity=artist"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Month
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=year&entity=artist"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          Last Year
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="?page=1&range=all_time&entity=artist"
+                          onClick={[Function]}
+                          role="button"
+                        >
+                          All time
+                        </a>
+                      </li>
+                    </ul>
+                  </span>
+                </h3>
+              </div>
+            </div>
+            <div
+              className="row mt-15 mb-15"
+            >
+              <div
+                className="col-xs-12 text-center"
+              >
+                <span
+                  style={
+                    Object {
+                      "fontSize": 24,
+                    }
+                  }
+                >
+                  <FontAwesomeIcon
+                    border={false}
+                    className=""
+                    fixedWidth={false}
+                    flip={null}
+                    icon={
+                      Object {
+                        "icon": Array [
+                          512,
+                          512,
+                          Array [],
+                          "f06a",
+                          "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z",
+                        ],
+                        "iconName": "exclamation-circle",
+                        "prefix": "fas",
+                      }
+                    }
+                    inverse={false}
+                    listItem={false}
+                    mask={null}
+                    pull={null}
+                    pulse={false}
+                    rotation={null}
+                    size={null}
+                    spin={false}
+                    swapOpacity={false}
+                    symbol={false}
+                    title=""
+                    transform={null}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-exclamation-circle fa-w-16 "
+                      data-icon="exclamation-circle"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                  </FontAwesomeIcon>
+                   
+                  Statistics for the user have not been calculated
+                </span>
+              </div>
+            </div>
+          </Loader>
+        </div>
+      </div>
+      <div
+        className="col-md-4"
+        style={
+          Object {
+            "position": "sticky",
+            "top": 20,
+          }
+        }
+      >
+        <BrainzPlayer
+          listenBrainzAPIBaseURI="http://localhost/1"
+          listens={Array []}
+          newAlert={[MockFunction]}
+          refreshSpotifyToken={[Function]}
+          refreshYoutubeToken={[Function]}
+        >
+          <div>
+            <PlaybackControls
+              artistName=""
+              durationMs={0}
+              playNextTrack={[Function]}
+              playPreviousTrack={[Function]}
+              playerPaused={true}
+              progressMs={0}
+              seekToPositionMs={[Function]}
+              togglePlay={[Function]}
+              trackName=""
+            >
+              <div
+                aria-label="Playback control"
+                id="brainz-player"
+              >
+                <div
+                  className="content"
+                >
+                  <div
+                    className="connect-services-message"
+                  >
+                    You need to
+                     
+                    <a
+                      href="/profile/music-services/details/"
+                      target="_blank"
+                    >
+                      connect to a music service
+                    </a>
+                     
+                    and refresh this page in order to search for and play songs on ListenBrainz.
+                  </div>
+                  <SpotifyPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshSpotifyToken={[Function]}
+                    show={false}
+                    spotifyUser={Object {}}
+                  />
+                  <YoutubePlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    refreshYoutubeToken={[Function]}
+                    show={false}
+                    youtubeUser={Object {}}
+                  >
+                    <div
+                      className="youtube hidden"
+                    >
+                      <YouTube
+                        className={null}
+                        containerClassName=""
+                        id={null}
+                        onEnd={[Function]}
+                        onError={[Function]}
+                        onPause={[Function]}
+                        onPlay={[Function]}
+                        onPlaybackQualityChange={[Function]}
+                        onPlaybackRateChange={[Function]}
+                        onReady={[Function]}
+                        onStateChange={[Function]}
+                        opts={
+                          Object {
+                            "height": "100%",
+                            "playerVars": Object {
+                              "autoplay": 1,
+                              "controls": 0,
+                              "fs": 0,
+                              "iv_load_policy": 3,
+                              "modestbranding": 1,
+                              "origin": "http://localhost",
+                              "rel": 0,
+                              "showinfo": 0,
+                            },
+                            "width": "100%",
+                          }
+                        }
+                        videoId={null}
+                      >
+                        <div
+                          className=""
+                        >
+                          <div
+                            className={null}
+                            id={null}
+                          />
+                        </div>
+                      </YouTube>
+                    </div>
+                  </YoutubePlayer>
+                  <SoundcloudPlayer
+                    handleError={[Function]}
+                    handleSuccess={[Function]}
+                    handleWarning={[Function]}
+                    onDurationChange={[Function]}
+                    onInvalidateDataSource={[Function]}
+                    onPlayerPausedChange={[Function]}
+                    onProgressChange={[Function]}
+                    onTrackEnd={[Function]}
+                    onTrackInfoChange={[Function]}
+                    onTrackNotFound={[Function]}
+                    playerPaused={true}
+                    show={false}
+                  >
+                    <div
+                      className="soundcloud hidden"
+                    >
+                      <iframe
+                        allow="autoplay"
+                        frameBorder="no"
+                        height="420px"
+                        id="soundcloud-iframe"
+                        scrolling="no"
+                        src="https://w.soundcloud.com/player/?auto_play=false"
+                        title="Soundcloud player"
+                        width="100%"
+                      />
+                    </div>
+                  </SoundcloudPlayer>
+                  <div
+                    className="no-album-art"
+                  />
+                </div>
+                <div
+                  className="info showControls"
+                >
+                  <div
+                    className="currently-playing"
+                  >
+                    <div
+                      aria-label="Audio Progress Control"
+                      aria-valuemax={100}
+                      aria-valuemin={0}
+                      aria-valuenow={NaN}
+                      className="progress"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="progressbar"
+                      tabIndex={0}
+                    >
+                      <div
+                        className="progress-bar"
+                        style={
+                          Object {
+                            "width": "NaN%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="controls"
+                  >
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="left btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            640,
+                            512,
+                            Array [],
+                            "f070",
+                            "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                          ],
+                          "iconName": "eye-slash",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Always show controls"
+                    >
+                      <div
+                        className="left btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Always show controls"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                640,
+                                512,
+                                Array [],
+                                "f070",
+                                "M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z",
+                              ],
+                              "iconName": "eye-slash",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-eye-slash fa-w-20 "
+                            data-icon="eye-slash"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 640 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="previous btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f049",
+                            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                          ],
+                          "iconName": "fast-backward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Previous"
+                    >
+                      <div
+                        className="previous btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Previous"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f049",
+                                "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+                              ],
+                              "iconName": "fast-backward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-backward fa-w-16 "
+                            data-icon="fast-backward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="play btn"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f144",
+                            "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                          ],
+                          "iconName": "play-circle",
+                          "prefix": "fas",
+                        }
+                      }
+                      size="2x"
+                      title="Play"
+                    >
+                      <div
+                        className="play btn"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Play"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f144",
+                                "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z",
+                              ],
+                              "iconName": "play-circle",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size="2x"
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-play-circle fa-w-16 fa-2x "
+                            data-icon="play-circle"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                    <PlaybackControlButton
+                      action={[Function]}
+                      className="next btn btn-xs"
+                      icon={
+                        Object {
+                          "icon": Array [
+                            512,
+                            512,
+                            Array [],
+                            "f050",
+                            "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                          ],
+                          "iconName": "fast-forward",
+                          "prefix": "fas",
+                        }
+                      }
+                      title="Next"
+                    >
+                      <div
+                        className="next btn btn-xs"
+                        onClick={[Function]}
+                        onKeyPress={[Function]}
+                        role="button"
+                        tabIndex={0}
+                        title="Next"
+                      >
+                        <FontAwesomeIcon
+                          border={false}
+                          className=""
+                          fixedWidth={false}
+                          flip={null}
+                          icon={
+                            Object {
+                              "icon": Array [
+                                512,
+                                512,
+                                Array [],
+                                "f050",
+                                "M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z",
+                              ],
+                              "iconName": "fast-forward",
+                              "prefix": "fas",
+                            }
+                          }
+                          inverse={false}
+                          listItem={false}
+                          mask={null}
+                          pull={null}
+                          pulse={false}
+                          rotation={null}
+                          size={null}
+                          spin={false}
+                          swapOpacity={false}
+                          symbol={false}
+                          title=""
+                          transform={null}
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="svg-inline--fa fa-fast-forward fa-w-16 "
+                            data-icon="fast-forward"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            style={Object {}}
+                            viewBox="0 0 512 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M512 76v360c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12V284.1L276.5 440.6c-20.6 17.2-52.5 2.8-52.5-24.6V284.1L52.5 440.6C31.9 457.8 0 443.4 0 416V96c0-27.4 31.9-41.7 52.5-24.6L224 226.8V96c0-27.4 31.9-41.7 52.5-24.6L448 226.8V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12z"
+                              fill="currentColor"
+                              style={Object {}}
+                            />
+                          </svg>
+                        </FontAwesomeIcon>
+                      </div>
+                    </PlaybackControlButton>
+                  </div>
+                </div>
+              </div>
+            </PlaybackControls>
+          </div>
+        </BrainzPlayer>
+      </div>
+    </div>
+  </div>
+</UserEntityChart>
+`;
+
+exports[`User Stats UserEntityChart Page renders correctly for artists 1`] = `
 <UserEntityChart
   apiUrl="apiUrl"
   newAlert={[MockFunction]}
@@ -5716,7 +24771,7 @@ exports[`UserEntityChart Page renders correctly for artists 1`] = `
 </UserEntityChart>
 `;
 
-exports[`UserEntityChart Page renders correctly for recording 1`] = `
+exports[`User Stats UserEntityChart Page renders correctly for recording 1`] = `
 <UserEntityChart
   apiUrl="apiUrl"
   newAlert={[MockFunction]}
@@ -12262,7 +31317,7 @@ exports[`UserEntityChart Page renders correctly for recording 1`] = `
 </UserEntityChart>
 `;
 
-exports[`UserEntityChart Page renders correctly for releases 1`] = `
+exports[`User Stats UserEntityChart Page renders correctly for releases 1`] = `
 <UserEntityChart
   apiUrl="apiUrl"
   newAlert={[MockFunction]}
@@ -18278,7 +37333,7 @@ exports[`UserEntityChart Page renders correctly for releases 1`] = `
 </UserEntityChart>
 `;
 
-exports[`UserEntityChart Page renders correctly if stats are not calculated 1`] = `
+exports[`User Stats UserEntityChart Page renders correctly if stats are not calculated 1`] = `
 <UserEntityChart
   apiUrl="apiUrl"
   newAlert={[MockFunction]}

--- a/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserListeningActivity.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserListeningActivity.test.tsx.snap
@@ -1,6 +1,2071 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserListeningActivity renders corectly when range is invalid 1`] = `
+exports[`Sitewide Stats UserListeningActivity renders corectly when range is invalid 1`] = `
+<UserListeningActivity
+  apiUrl="barfoo"
+  range="invalid_range"
+>
+  <ForwardRef
+    style={
+      Object {
+        "marginTop": 20,
+        "minHeight": 400,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "marginTop": 20,
+          "minHeight": 400,
+        }
+      }
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-10"
+        >
+          <h3
+            className="capitalize-bold"
+            style={
+              Object {
+                "marginLeft": 20,
+              }
+            }
+          >
+            Listening Activity
+          </h3>
+        </div>
+        <div
+          className="col-xs-2 text-right"
+        >
+          <h4
+            style={
+              Object {
+                "marginTop": 20,
+              }
+            }
+          >
+            <a
+              href="#listening-activity"
+            >
+              <FontAwesomeIcon
+                border={false}
+                className=""
+                color="#000000"
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      512,
+                      512,
+                      Array [],
+                      "f0c1",
+                      "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                    ],
+                    "iconName": "link",
+                    "prefix": "fas",
+                  }
+                }
+                inverse={false}
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                style={
+                  Object {
+                    "marginRight": 20,
+                  }
+                }
+                swapOpacity={false}
+                symbol={false}
+                title=""
+                transform={null}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-link fa-w-16 fa-sm "
+                  color="#000000"
+                  data-icon="link"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={
+                    Object {
+                      "marginRight": 20,
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </FontAwesomeIcon>
+            </a>
+          </h4>
+        </div>
+      </div>
+      <Loader
+        isLoading={false}
+      >
+        <div
+          className="flex-center"
+          style={
+            Object {
+              "minHeight": "inherit",
+            }
+          }
+        >
+          <span
+            className="text-center"
+            style={
+              Object {
+                "fontSize": 24,
+              }
+            }
+          >
+            <FontAwesomeIcon
+              border={false}
+              className=""
+              fixedWidth={false}
+              flip={null}
+              icon={
+                Object {
+                  "icon": Array [
+                    512,
+                    512,
+                    Array [],
+                    "f06a",
+                    "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z",
+                  ],
+                  "iconName": "exclamation-circle",
+                  "prefix": "fas",
+                }
+              }
+              inverse={false}
+              listItem={false}
+              mask={null}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size="2x"
+              spin={false}
+              swapOpacity={false}
+              symbol={false}
+              title=""
+              transform={null}
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-exclamation-circle fa-w-16 fa-2x "
+                data-icon="exclamation-circle"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </FontAwesomeIcon>
+             
+            Invalid range: invalid_range
+          </span>
+        </div>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserListeningActivity>
+`;
+
+exports[`Sitewide Stats UserListeningActivity renders correctly for all_time 1`] = `
+<UserListeningActivity
+  apiUrl="barfoo"
+  range="all_time"
+>
+  <ForwardRef
+    style={
+      Object {
+        "marginTop": 20,
+        "minHeight": 400,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "marginTop": 20,
+          "minHeight": 400,
+        }
+      }
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-10"
+        >
+          <h3
+            className="capitalize-bold"
+            style={
+              Object {
+                "marginLeft": 20,
+              }
+            }
+          >
+            Listening Activity
+          </h3>
+        </div>
+        <div
+          className="col-xs-2 text-right"
+        >
+          <h4
+            style={
+              Object {
+                "marginTop": 20,
+              }
+            }
+          >
+            <a
+              href="#listening-activity"
+            >
+              <FontAwesomeIcon
+                border={false}
+                className=""
+                color="#000000"
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      512,
+                      512,
+                      Array [],
+                      "f0c1",
+                      "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                    ],
+                    "iconName": "link",
+                    "prefix": "fas",
+                  }
+                }
+                inverse={false}
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                style={
+                  Object {
+                    "marginRight": 20,
+                  }
+                }
+                swapOpacity={false}
+                symbol={false}
+                title=""
+                transform={null}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-link fa-w-16 fa-sm "
+                  color="#000000"
+                  data-icon="link"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={
+                    Object {
+                      "marginRight": 20,
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </FontAwesomeIcon>
+            </a>
+          </h4>
+        </div>
+      </div>
+      <Loader
+        isLoading={false}
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-xs-12"
+            style={
+              Object {
+                "height": 350,
+              }
+            }
+          >
+            <BarDualTone
+              data={
+                Array [
+                  Object {
+                    "id": "2002",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1009843200,
+                  },
+                  Object {
+                    "id": "2003",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1041379200,
+                  },
+                  Object {
+                    "id": "2004",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1072915200,
+                  },
+                  Object {
+                    "id": "2005",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1104537600,
+                  },
+                  Object {
+                    "id": "2006",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1136073600,
+                  },
+                  Object {
+                    "id": "2007",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1167609600,
+                  },
+                  Object {
+                    "id": "2008",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1199145600,
+                  },
+                  Object {
+                    "id": "2009",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1230768000,
+                  },
+                  Object {
+                    "id": "2010",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1262304000,
+                  },
+                  Object {
+                    "id": "2011",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1293840000,
+                  },
+                  Object {
+                    "id": "2012",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1325376000,
+                  },
+                  Object {
+                    "id": "2013",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1356998400,
+                  },
+                  Object {
+                    "id": "2014",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1388534400,
+                  },
+                  Object {
+                    "id": "2015",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1420070400,
+                  },
+                  Object {
+                    "id": "2016",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1451606400,
+                  },
+                  Object {
+                    "id": "2017",
+                    "thisRangeCount": 96,
+                    "thisRangeTs": 1483228800,
+                  },
+                  Object {
+                    "id": "2018",
+                    "thisRangeCount": 169,
+                    "thisRangeTs": 1514764800,
+                  },
+                  Object {
+                    "id": "2019",
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1546300800,
+                  },
+                  Object {
+                    "id": "2020",
+                    "thisRangeCount": 3580,
+                    "thisRangeTs": 1577836800,
+                  },
+                ]
+              }
+              lastRangePeriod={Object {}}
+              range="all_time"
+              showLegend={false}
+              thisRangePeriod={Object {}}
+            >
+              <ResponsiveBar
+                axisBottom={
+                  Object {
+                    "format": undefined,
+                  }
+                }
+                axisLeft={
+                  Object {
+                    "format": ".2~s",
+                  }
+                }
+                colors={[Function]}
+                data={
+                  Array [
+                    Object {
+                      "id": "2002",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1009843200,
+                    },
+                    Object {
+                      "id": "2003",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1041379200,
+                    },
+                    Object {
+                      "id": "2004",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1072915200,
+                    },
+                    Object {
+                      "id": "2005",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1104537600,
+                    },
+                    Object {
+                      "id": "2006",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1136073600,
+                    },
+                    Object {
+                      "id": "2007",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1167609600,
+                    },
+                    Object {
+                      "id": "2008",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1199145600,
+                    },
+                    Object {
+                      "id": "2009",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1230768000,
+                    },
+                    Object {
+                      "id": "2010",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1262304000,
+                    },
+                    Object {
+                      "id": "2011",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1293840000,
+                    },
+                    Object {
+                      "id": "2012",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1325376000,
+                    },
+                    Object {
+                      "id": "2013",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1356998400,
+                    },
+                    Object {
+                      "id": "2014",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1388534400,
+                    },
+                    Object {
+                      "id": "2015",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1420070400,
+                    },
+                    Object {
+                      "id": "2016",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1451606400,
+                    },
+                    Object {
+                      "id": "2017",
+                      "thisRangeCount": 96,
+                      "thisRangeTs": 1483228800,
+                    },
+                    Object {
+                      "id": "2018",
+                      "thisRangeCount": 169,
+                      "thisRangeTs": 1514764800,
+                    },
+                    Object {
+                      "id": "2019",
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1546300800,
+                    },
+                    Object {
+                      "id": "2020",
+                      "thisRangeCount": 3580,
+                      "thisRangeTs": 1577836800,
+                    },
+                  ]
+                }
+                enableGridY={false}
+                enableLabel={false}
+                groupMode="grouped"
+                indexBy="id"
+                innerPadding={2}
+                keys={
+                  Array [
+                    "thisRangeCount",
+                  ]
+                }
+                layers={
+                  Array [
+                    "grid",
+                    "axes",
+                    "bars",
+                    "markers",
+                    "annotations",
+                    [Function],
+                  ]
+                }
+                legends={Array []}
+                margin={
+                  Object {
+                    "bottom": 40,
+                    "left": 45,
+                    "top": 20,
+                  }
+                }
+                minValue={0}
+                padding={0.3}
+                tooltip={[Function]}
+              >
+                <ResponsiveWrapper>
+                  <Measure
+                    bounds={true}
+                    onResize={[Function]}
+                  >
+                    <Component
+                      bounds={true}
+                      contentRect={
+                        Object {
+                          "bounds": Object {},
+                          "client": Object {},
+                          "entry": Object {},
+                          "margin": Object {},
+                          "offset": Object {},
+                          "scroll": Object {},
+                        }
+                      }
+                      measure={[Function]}
+                      measureRef={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      />
+                    </Component>
+                  </Measure>
+                </ResponsiveWrapper>
+              </ResponsiveBar>
+            </BarDualTone>
+          </div>
+        </div>
+        <div
+          className="row mt-5 mb-15"
+        >
+          <MediaQuery
+            minWidth={768}
+          />
+          <MediaQuery
+            maxWidth={767}
+          />
+        </div>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserListeningActivity>
+`;
+
+exports[`Sitewide Stats UserListeningActivity renders correctly for month 1`] = `
+<UserListeningActivity
+  apiUrl="barfoo"
+  range="month"
+>
+  <ForwardRef
+    style={
+      Object {
+        "marginTop": 20,
+        "minHeight": 400,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "marginTop": 20,
+          "minHeight": 400,
+        }
+      }
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-10"
+        >
+          <h3
+            className="capitalize-bold"
+            style={
+              Object {
+                "marginLeft": 20,
+              }
+            }
+          >
+            Listening Activity
+          </h3>
+        </div>
+        <div
+          className="col-xs-2 text-right"
+        >
+          <h4
+            style={
+              Object {
+                "marginTop": 20,
+              }
+            }
+          >
+            <a
+              href="#listening-activity"
+            >
+              <FontAwesomeIcon
+                border={false}
+                className=""
+                color="#000000"
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      512,
+                      512,
+                      Array [],
+                      "f0c1",
+                      "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                    ],
+                    "iconName": "link",
+                    "prefix": "fas",
+                  }
+                }
+                inverse={false}
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                style={
+                  Object {
+                    "marginRight": 20,
+                  }
+                }
+                swapOpacity={false}
+                symbol={false}
+                title=""
+                transform={null}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-link fa-w-16 fa-sm "
+                  color="#000000"
+                  data-icon="link"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={
+                    Object {
+                      "marginRight": 20,
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </FontAwesomeIcon>
+            </a>
+          </h4>
+        </div>
+      </div>
+      <Loader
+        isLoading={false}
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-xs-12"
+            style={
+              Object {
+                "height": 350,
+              }
+            }
+          >
+            <BarDualTone
+              data={
+                Array [
+                  Object {
+                    "id": "01",
+                    "lastRangeCount": 26,
+                    "lastRangeTs": 1588291200,
+                    "thisRangeCount": 22,
+                    "thisRangeTs": 1590969600,
+                  },
+                  Object {
+                    "id": "02",
+                    "lastRangeCount": 17,
+                    "lastRangeTs": 1588377600,
+                    "thisRangeCount": 10,
+                    "thisRangeTs": 1591056000,
+                  },
+                  Object {
+                    "id": "03",
+                    "lastRangeCount": 26,
+                    "lastRangeTs": 1588464000,
+                    "thisRangeCount": 18,
+                    "thisRangeTs": 1591142400,
+                  },
+                  Object {
+                    "id": "04",
+                    "lastRangeCount": 32,
+                    "lastRangeTs": 1588550400,
+                    "thisRangeCount": 35,
+                    "thisRangeTs": 1591228800,
+                  },
+                  Object {
+                    "id": "05",
+                    "lastRangeCount": 26,
+                    "lastRangeTs": 1588636800,
+                    "thisRangeCount": 30,
+                    "thisRangeTs": 1591315200,
+                  },
+                  Object {
+                    "id": "06",
+                    "lastRangeCount": 28,
+                    "lastRangeTs": 1588723200,
+                    "thisRangeCount": 3,
+                    "thisRangeTs": 1591401600,
+                  },
+                  Object {
+                    "id": "07",
+                    "lastRangeCount": 21,
+                    "lastRangeTs": 1588809600,
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1591488000,
+                  },
+                  Object {
+                    "id": "08",
+                    "lastRangeCount": 26,
+                    "lastRangeTs": 1588896000,
+                    "thisRangeCount": 36,
+                    "thisRangeTs": 1591574400,
+                  },
+                  Object {
+                    "id": "09",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1588982400,
+                    "thisRangeCount": 13,
+                    "thisRangeTs": 1591660800,
+                  },
+                  Object {
+                    "id": "10",
+                    "lastRangeCount": 4,
+                    "lastRangeTs": 1589068800,
+                    "thisRangeCount": 8,
+                    "thisRangeTs": 1591747200,
+                  },
+                  Object {
+                    "id": "11",
+                    "lastRangeCount": 28,
+                    "lastRangeTs": 1589155200,
+                    "thisRangeCount": 37,
+                    "thisRangeTs": 1591833600,
+                  },
+                  Object {
+                    "id": "12",
+                    "lastRangeCount": 21,
+                    "lastRangeTs": 1589241600,
+                    "thisRangeCount": 17,
+                    "thisRangeTs": 1591920000,
+                  },
+                  Object {
+                    "id": "13",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1589328000,
+                    "thisRangeCount": 22,
+                    "thisRangeTs": 1592006400,
+                  },
+                  Object {
+                    "id": "14",
+                    "lastRangeCount": 15,
+                    "lastRangeTs": 1589414400,
+                    "thisRangeCount": 8,
+                    "thisRangeTs": 1592092800,
+                  },
+                  Object {
+                    "id": "15",
+                    "lastRangeCount": 31,
+                    "lastRangeTs": 1589500800,
+                    "thisRangeCount": 66,
+                    "thisRangeTs": 1592179200,
+                  },
+                  Object {
+                    "id": "16",
+                    "lastRangeCount": 8,
+                    "lastRangeTs": 1589587200,
+                    "thisRangeCount": 34,
+                    "thisRangeTs": 1592265600,
+                  },
+                  Object {
+                    "id": "17",
+                    "lastRangeCount": 5,
+                    "lastRangeTs": 1589673600,
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1592352000,
+                  },
+                  Object {
+                    "id": "18",
+                    "lastRangeCount": 37,
+                    "lastRangeTs": 1589760000,
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1592438400,
+                  },
+                  Object {
+                    "id": "19",
+                    "lastRangeCount": 50,
+                    "lastRangeTs": 1589846400,
+                  },
+                  Object {
+                    "id": "20",
+                    "lastRangeCount": 26,
+                    "lastRangeTs": 1589932800,
+                  },
+                  Object {
+                    "id": "21",
+                    "lastRangeCount": 34,
+                    "lastRangeTs": 1590019200,
+                  },
+                  Object {
+                    "id": "22",
+                    "lastRangeCount": 36,
+                    "lastRangeTs": 1590105600,
+                  },
+                  Object {
+                    "id": "23",
+                    "lastRangeCount": 14,
+                    "lastRangeTs": 1590192000,
+                  },
+                  Object {
+                    "id": "24",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1590278400,
+                  },
+                  Object {
+                    "id": "25",
+                    "lastRangeCount": 5,
+                    "lastRangeTs": 1590364800,
+                  },
+                  Object {
+                    "id": "26",
+                    "lastRangeCount": 25,
+                    "lastRangeTs": 1590451200,
+                  },
+                  Object {
+                    "id": "27",
+                    "lastRangeCount": 53,
+                    "lastRangeTs": 1590537600,
+                  },
+                  Object {
+                    "id": "28",
+                    "lastRangeCount": 21,
+                    "lastRangeTs": 1590624000,
+                  },
+                  Object {
+                    "id": "29",
+                    "lastRangeCount": 8,
+                    "lastRangeTs": 1590710400,
+                  },
+                  Object {
+                    "id": "30",
+                    "lastRangeCount": 11,
+                    "lastRangeTs": 1590796800,
+                  },
+                  Object {
+                    "id": "31",
+                    "lastRangeCount": 11,
+                    "lastRangeTs": 1590883200,
+                  },
+                ]
+              }
+              lastRangePeriod={
+                Object {
+                  "start": 1588291200,
+                }
+              }
+              range="month"
+              showLegend={true}
+              thisRangePeriod={
+                Object {
+                  "start": 1590969600,
+                }
+              }
+            >
+              <ResponsiveBar
+                axisBottom={
+                  Object {
+                    "format": undefined,
+                  }
+                }
+                axisLeft={
+                  Object {
+                    "format": ".2~s",
+                  }
+                }
+                colors={[Function]}
+                data={
+                  Array [
+                    Object {
+                      "id": "01",
+                      "lastRangeCount": 26,
+                      "lastRangeTs": 1588291200,
+                      "thisRangeCount": 22,
+                      "thisRangeTs": 1590969600,
+                    },
+                    Object {
+                      "id": "02",
+                      "lastRangeCount": 17,
+                      "lastRangeTs": 1588377600,
+                      "thisRangeCount": 10,
+                      "thisRangeTs": 1591056000,
+                    },
+                    Object {
+                      "id": "03",
+                      "lastRangeCount": 26,
+                      "lastRangeTs": 1588464000,
+                      "thisRangeCount": 18,
+                      "thisRangeTs": 1591142400,
+                    },
+                    Object {
+                      "id": "04",
+                      "lastRangeCount": 32,
+                      "lastRangeTs": 1588550400,
+                      "thisRangeCount": 35,
+                      "thisRangeTs": 1591228800,
+                    },
+                    Object {
+                      "id": "05",
+                      "lastRangeCount": 26,
+                      "lastRangeTs": 1588636800,
+                      "thisRangeCount": 30,
+                      "thisRangeTs": 1591315200,
+                    },
+                    Object {
+                      "id": "06",
+                      "lastRangeCount": 28,
+                      "lastRangeTs": 1588723200,
+                      "thisRangeCount": 3,
+                      "thisRangeTs": 1591401600,
+                    },
+                    Object {
+                      "id": "07",
+                      "lastRangeCount": 21,
+                      "lastRangeTs": 1588809600,
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1591488000,
+                    },
+                    Object {
+                      "id": "08",
+                      "lastRangeCount": 26,
+                      "lastRangeTs": 1588896000,
+                      "thisRangeCount": 36,
+                      "thisRangeTs": 1591574400,
+                    },
+                    Object {
+                      "id": "09",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1588982400,
+                      "thisRangeCount": 13,
+                      "thisRangeTs": 1591660800,
+                    },
+                    Object {
+                      "id": "10",
+                      "lastRangeCount": 4,
+                      "lastRangeTs": 1589068800,
+                      "thisRangeCount": 8,
+                      "thisRangeTs": 1591747200,
+                    },
+                    Object {
+                      "id": "11",
+                      "lastRangeCount": 28,
+                      "lastRangeTs": 1589155200,
+                      "thisRangeCount": 37,
+                      "thisRangeTs": 1591833600,
+                    },
+                    Object {
+                      "id": "12",
+                      "lastRangeCount": 21,
+                      "lastRangeTs": 1589241600,
+                      "thisRangeCount": 17,
+                      "thisRangeTs": 1591920000,
+                    },
+                    Object {
+                      "id": "13",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1589328000,
+                      "thisRangeCount": 22,
+                      "thisRangeTs": 1592006400,
+                    },
+                    Object {
+                      "id": "14",
+                      "lastRangeCount": 15,
+                      "lastRangeTs": 1589414400,
+                      "thisRangeCount": 8,
+                      "thisRangeTs": 1592092800,
+                    },
+                    Object {
+                      "id": "15",
+                      "lastRangeCount": 31,
+                      "lastRangeTs": 1589500800,
+                      "thisRangeCount": 66,
+                      "thisRangeTs": 1592179200,
+                    },
+                    Object {
+                      "id": "16",
+                      "lastRangeCount": 8,
+                      "lastRangeTs": 1589587200,
+                      "thisRangeCount": 34,
+                      "thisRangeTs": 1592265600,
+                    },
+                    Object {
+                      "id": "17",
+                      "lastRangeCount": 5,
+                      "lastRangeTs": 1589673600,
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1592352000,
+                    },
+                    Object {
+                      "id": "18",
+                      "lastRangeCount": 37,
+                      "lastRangeTs": 1589760000,
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1592438400,
+                    },
+                    Object {
+                      "id": "19",
+                      "lastRangeCount": 50,
+                      "lastRangeTs": 1589846400,
+                    },
+                    Object {
+                      "id": "20",
+                      "lastRangeCount": 26,
+                      "lastRangeTs": 1589932800,
+                    },
+                    Object {
+                      "id": "21",
+                      "lastRangeCount": 34,
+                      "lastRangeTs": 1590019200,
+                    },
+                    Object {
+                      "id": "22",
+                      "lastRangeCount": 36,
+                      "lastRangeTs": 1590105600,
+                    },
+                    Object {
+                      "id": "23",
+                      "lastRangeCount": 14,
+                      "lastRangeTs": 1590192000,
+                    },
+                    Object {
+                      "id": "24",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1590278400,
+                    },
+                    Object {
+                      "id": "25",
+                      "lastRangeCount": 5,
+                      "lastRangeTs": 1590364800,
+                    },
+                    Object {
+                      "id": "26",
+                      "lastRangeCount": 25,
+                      "lastRangeTs": 1590451200,
+                    },
+                    Object {
+                      "id": "27",
+                      "lastRangeCount": 53,
+                      "lastRangeTs": 1590537600,
+                    },
+                    Object {
+                      "id": "28",
+                      "lastRangeCount": 21,
+                      "lastRangeTs": 1590624000,
+                    },
+                    Object {
+                      "id": "29",
+                      "lastRangeCount": 8,
+                      "lastRangeTs": 1590710400,
+                    },
+                    Object {
+                      "id": "30",
+                      "lastRangeCount": 11,
+                      "lastRangeTs": 1590796800,
+                    },
+                    Object {
+                      "id": "31",
+                      "lastRangeCount": 11,
+                      "lastRangeTs": 1590883200,
+                    },
+                  ]
+                }
+                enableGridY={false}
+                enableLabel={false}
+                groupMode="grouped"
+                indexBy="id"
+                innerPadding={2}
+                keys={
+                  Array [
+                    "lastRangeCount",
+                    "thisRangeCount",
+                  ]
+                }
+                layers={
+                  Array [
+                    "grid",
+                    "axes",
+                    "bars",
+                    "markers",
+                    "annotations",
+                    [Function],
+                  ]
+                }
+                legends={
+                  Array [
+                    Object {
+                      "anchor": "top-right",
+                      "data": Array [
+                        Object {
+                          "color": "#353070",
+                          "id": "lastRangeName",
+                          "label": "May 2020",
+                        },
+                        Object {
+                          "color": "#EB743B",
+                          "id": "thisRangeName",
+                          "label": "June 2020",
+                        },
+                      ],
+                      "dataFrom": "keys",
+                      "direction": "row",
+                      "itemHeight": 20,
+                      "itemWidth": 100,
+                      "symbolSize": 10,
+                      "translateY": -20,
+                    },
+                  ]
+                }
+                margin={
+                  Object {
+                    "bottom": 40,
+                    "left": 45,
+                    "top": 30,
+                  }
+                }
+                minValue={0}
+                padding={0.3}
+                tooltip={[Function]}
+              >
+                <ResponsiveWrapper>
+                  <Measure
+                    bounds={true}
+                    onResize={[Function]}
+                  >
+                    <Component
+                      bounds={true}
+                      contentRect={
+                        Object {
+                          "bounds": Object {},
+                          "client": Object {},
+                          "entry": Object {},
+                          "margin": Object {},
+                          "offset": Object {},
+                          "scroll": Object {},
+                        }
+                      }
+                      measure={[Function]}
+                      measureRef={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      />
+                    </Component>
+                  </Measure>
+                </ResponsiveWrapper>
+              </ResponsiveBar>
+            </BarDualTone>
+          </div>
+        </div>
+        <div
+          className="row mt-5 mb-15"
+        >
+          <MediaQuery
+            minWidth={768}
+          />
+          <MediaQuery
+            maxWidth={767}
+          />
+        </div>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserListeningActivity>
+`;
+
+exports[`Sitewide Stats UserListeningActivity renders correctly for week 1`] = `
+<UserListeningActivity
+  apiUrl="barfoo"
+  range="week"
+>
+  <ForwardRef
+    style={
+      Object {
+        "marginTop": 20,
+        "minHeight": 400,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "marginTop": 20,
+          "minHeight": 400,
+        }
+      }
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-10"
+        >
+          <h3
+            className="capitalize-bold"
+            style={
+              Object {
+                "marginLeft": 20,
+              }
+            }
+          >
+            Listening Activity
+          </h3>
+        </div>
+        <div
+          className="col-xs-2 text-right"
+        >
+          <h4
+            style={
+              Object {
+                "marginTop": 20,
+              }
+            }
+          >
+            <a
+              href="#listening-activity"
+            >
+              <FontAwesomeIcon
+                border={false}
+                className=""
+                color="#000000"
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      512,
+                      512,
+                      Array [],
+                      "f0c1",
+                      "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                    ],
+                    "iconName": "link",
+                    "prefix": "fas",
+                  }
+                }
+                inverse={false}
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                style={
+                  Object {
+                    "marginRight": 20,
+                  }
+                }
+                swapOpacity={false}
+                symbol={false}
+                title=""
+                transform={null}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-link fa-w-16 fa-sm "
+                  color="#000000"
+                  data-icon="link"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={
+                    Object {
+                      "marginRight": 20,
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </FontAwesomeIcon>
+            </a>
+          </h4>
+        </div>
+      </div>
+      <Loader
+        isLoading={false}
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-xs-12"
+            style={
+              Object {
+                "height": 350,
+              }
+            }
+          >
+            <BarDualTone
+              data={
+                Array [
+                  Object {
+                    "id": "Mon",
+                    "lastRangeCount": 22,
+                    "lastRangeTs": 1590969600,
+                    "thisRangeCount": 36,
+                    "thisRangeTs": 1591574400,
+                  },
+                  Object {
+                    "id": "Tue",
+                    "lastRangeCount": 10,
+                    "lastRangeTs": 1591056000,
+                    "thisRangeCount": 13,
+                    "thisRangeTs": 1591660800,
+                  },
+                  Object {
+                    "id": "Wed",
+                    "lastRangeCount": 18,
+                    "lastRangeTs": 1591142400,
+                    "thisRangeCount": 8,
+                    "thisRangeTs": 1591747200,
+                  },
+                  Object {
+                    "id": "Thu",
+                    "lastRangeCount": 35,
+                    "lastRangeTs": 1591228800,
+                    "thisRangeCount": 37,
+                    "thisRangeTs": 1591833600,
+                  },
+                  Object {
+                    "id": "Fri",
+                    "lastRangeCount": 30,
+                    "lastRangeTs": 1591315200,
+                    "thisRangeCount": 17,
+                    "thisRangeTs": 1591920000,
+                  },
+                  Object {
+                    "id": "Sat",
+                    "lastRangeCount": 3,
+                    "lastRangeTs": 1591401600,
+                    "thisRangeCount": 22,
+                    "thisRangeTs": 1592006400,
+                  },
+                  Object {
+                    "id": "Sun",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1591488000,
+                    "thisRangeCount": 8,
+                    "thisRangeTs": 1592092800,
+                  },
+                ]
+              }
+              lastRangePeriod={
+                Object {
+                  "end": 1591488000,
+                  "start": 1590969600,
+                }
+              }
+              range="week"
+              showLegend={true}
+              thisRangePeriod={
+                Object {
+                  "end": 1592092800,
+                  "start": 1591574400,
+                }
+              }
+            >
+              <ResponsiveBar
+                axisBottom={
+                  Object {
+                    "format": undefined,
+                  }
+                }
+                axisLeft={
+                  Object {
+                    "format": ".2~s",
+                  }
+                }
+                colors={[Function]}
+                data={
+                  Array [
+                    Object {
+                      "id": "Mon",
+                      "lastRangeCount": 22,
+                      "lastRangeTs": 1590969600,
+                      "thisRangeCount": 36,
+                      "thisRangeTs": 1591574400,
+                    },
+                    Object {
+                      "id": "Tue",
+                      "lastRangeCount": 10,
+                      "lastRangeTs": 1591056000,
+                      "thisRangeCount": 13,
+                      "thisRangeTs": 1591660800,
+                    },
+                    Object {
+                      "id": "Wed",
+                      "lastRangeCount": 18,
+                      "lastRangeTs": 1591142400,
+                      "thisRangeCount": 8,
+                      "thisRangeTs": 1591747200,
+                    },
+                    Object {
+                      "id": "Thu",
+                      "lastRangeCount": 35,
+                      "lastRangeTs": 1591228800,
+                      "thisRangeCount": 37,
+                      "thisRangeTs": 1591833600,
+                    },
+                    Object {
+                      "id": "Fri",
+                      "lastRangeCount": 30,
+                      "lastRangeTs": 1591315200,
+                      "thisRangeCount": 17,
+                      "thisRangeTs": 1591920000,
+                    },
+                    Object {
+                      "id": "Sat",
+                      "lastRangeCount": 3,
+                      "lastRangeTs": 1591401600,
+                      "thisRangeCount": 22,
+                      "thisRangeTs": 1592006400,
+                    },
+                    Object {
+                      "id": "Sun",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1591488000,
+                      "thisRangeCount": 8,
+                      "thisRangeTs": 1592092800,
+                    },
+                  ]
+                }
+                enableGridY={false}
+                enableLabel={false}
+                groupMode="grouped"
+                indexBy="id"
+                innerPadding={2}
+                keys={
+                  Array [
+                    "lastRangeCount",
+                    "thisRangeCount",
+                  ]
+                }
+                layers={
+                  Array [
+                    "grid",
+                    "axes",
+                    "bars",
+                    "markers",
+                    "annotations",
+                    [Function],
+                  ]
+                }
+                legends={
+                  Array [
+                    Object {
+                      "anchor": "top-right",
+                      "data": Array [
+                        Object {
+                          "color": "#353070",
+                          "id": "lastRangeName",
+                          "label": "Jun 01 - Jun 07",
+                        },
+                        Object {
+                          "color": "#EB743B",
+                          "id": "thisRangeName",
+                          "label": "Jun 08 - Jun 14",
+                        },
+                      ],
+                      "dataFrom": "keys",
+                      "direction": "row",
+                      "itemHeight": 20,
+                      "itemWidth": 120,
+                      "symbolSize": 10,
+                      "translateY": -20,
+                    },
+                  ]
+                }
+                margin={
+                  Object {
+                    "bottom": 40,
+                    "left": 45,
+                    "top": 30,
+                  }
+                }
+                minValue={0}
+                padding={0.3}
+                tooltip={[Function]}
+              >
+                <ResponsiveWrapper>
+                  <Measure
+                    bounds={true}
+                    onResize={[Function]}
+                  >
+                    <Component
+                      bounds={true}
+                      contentRect={
+                        Object {
+                          "bounds": Object {},
+                          "client": Object {},
+                          "entry": Object {},
+                          "margin": Object {},
+                          "offset": Object {},
+                          "scroll": Object {},
+                        }
+                      }
+                      measure={[Function]}
+                      measureRef={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      />
+                    </Component>
+                  </Measure>
+                </ResponsiveWrapper>
+              </ResponsiveBar>
+            </BarDualTone>
+          </div>
+        </div>
+        <div
+          className="row mt-5 mb-15"
+        >
+          <MediaQuery
+            minWidth={768}
+          />
+          <MediaQuery
+            maxWidth={767}
+          />
+        </div>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserListeningActivity>
+`;
+
+exports[`Sitewide Stats UserListeningActivity renders correctly for year 1`] = `
+<UserListeningActivity
+  apiUrl="barfoo"
+  range="year"
+>
+  <ForwardRef
+    style={
+      Object {
+        "marginTop": 20,
+        "minHeight": 400,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "marginTop": 20,
+          "minHeight": 400,
+        }
+      }
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-10"
+        >
+          <h3
+            className="capitalize-bold"
+            style={
+              Object {
+                "marginLeft": 20,
+              }
+            }
+          >
+            Listening Activity
+          </h3>
+        </div>
+        <div
+          className="col-xs-2 text-right"
+        >
+          <h4
+            style={
+              Object {
+                "marginTop": 20,
+              }
+            }
+          >
+            <a
+              href="#listening-activity"
+            >
+              <FontAwesomeIcon
+                border={false}
+                className=""
+                color="#000000"
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      512,
+                      512,
+                      Array [],
+                      "f0c1",
+                      "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                    ],
+                    "iconName": "link",
+                    "prefix": "fas",
+                  }
+                }
+                inverse={false}
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                style={
+                  Object {
+                    "marginRight": 20,
+                  }
+                }
+                swapOpacity={false}
+                symbol={false}
+                title=""
+                transform={null}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-link fa-w-16 fa-sm "
+                  color="#000000"
+                  data-icon="link"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={
+                    Object {
+                      "marginRight": 20,
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </FontAwesomeIcon>
+            </a>
+          </h4>
+        </div>
+      </div>
+      <Loader
+        isLoading={false}
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-xs-12"
+            style={
+              Object {
+                "height": 350,
+              }
+            }
+          >
+            <BarDualTone
+              data={
+                Array [
+                  Object {
+                    "id": "Jan",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1546300800,
+                    "thisRangeCount": 0,
+                    "thisRangeTs": 1577836800,
+                  },
+                  Object {
+                    "id": "Feb",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1548979200,
+                    "thisRangeCount": 425,
+                    "thisRangeTs": 1580515200,
+                  },
+                  Object {
+                    "id": "Mar",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1551398400,
+                    "thisRangeCount": 1429,
+                    "thisRangeTs": 1583020800,
+                  },
+                  Object {
+                    "id": "Apr",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1554076800,
+                    "thisRangeCount": 722,
+                    "thisRangeTs": 1585699200,
+                  },
+                  Object {
+                    "id": "May",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1556668800,
+                    "thisRangeCount": 645,
+                    "thisRangeTs": 1588291200,
+                  },
+                  Object {
+                    "id": "Jun",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1559347200,
+                    "thisRangeCount": 359,
+                    "thisRangeTs": 1590969600,
+                  },
+                  Object {
+                    "id": "Jul",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1561939200,
+                  },
+                  Object {
+                    "id": "Aug",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1564617600,
+                  },
+                  Object {
+                    "id": "Sep",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1567296000,
+                  },
+                  Object {
+                    "id": "Oct",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1569888000,
+                  },
+                  Object {
+                    "id": "Nov",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1572566400,
+                  },
+                  Object {
+                    "id": "Dec",
+                    "lastRangeCount": 0,
+                    "lastRangeTs": 1575158400,
+                  },
+                ]
+              }
+              lastRangePeriod={
+                Object {
+                  "start": 1546300800,
+                }
+              }
+              range="year"
+              showLegend={true}
+              thisRangePeriod={
+                Object {
+                  "start": 1577836800,
+                }
+              }
+            >
+              <ResponsiveBar
+                axisBottom={
+                  Object {
+                    "format": undefined,
+                  }
+                }
+                axisLeft={
+                  Object {
+                    "format": ".2~s",
+                  }
+                }
+                colors={[Function]}
+                data={
+                  Array [
+                    Object {
+                      "id": "Jan",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1546300800,
+                      "thisRangeCount": 0,
+                      "thisRangeTs": 1577836800,
+                    },
+                    Object {
+                      "id": "Feb",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1548979200,
+                      "thisRangeCount": 425,
+                      "thisRangeTs": 1580515200,
+                    },
+                    Object {
+                      "id": "Mar",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1551398400,
+                      "thisRangeCount": 1429,
+                      "thisRangeTs": 1583020800,
+                    },
+                    Object {
+                      "id": "Apr",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1554076800,
+                      "thisRangeCount": 722,
+                      "thisRangeTs": 1585699200,
+                    },
+                    Object {
+                      "id": "May",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1556668800,
+                      "thisRangeCount": 645,
+                      "thisRangeTs": 1588291200,
+                    },
+                    Object {
+                      "id": "Jun",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1559347200,
+                      "thisRangeCount": 359,
+                      "thisRangeTs": 1590969600,
+                    },
+                    Object {
+                      "id": "Jul",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1561939200,
+                    },
+                    Object {
+                      "id": "Aug",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1564617600,
+                    },
+                    Object {
+                      "id": "Sep",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1567296000,
+                    },
+                    Object {
+                      "id": "Oct",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1569888000,
+                    },
+                    Object {
+                      "id": "Nov",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1572566400,
+                    },
+                    Object {
+                      "id": "Dec",
+                      "lastRangeCount": 0,
+                      "lastRangeTs": 1575158400,
+                    },
+                  ]
+                }
+                enableGridY={false}
+                enableLabel={false}
+                groupMode="grouped"
+                indexBy="id"
+                innerPadding={2}
+                keys={
+                  Array [
+                    "lastRangeCount",
+                    "thisRangeCount",
+                  ]
+                }
+                layers={
+                  Array [
+                    "grid",
+                    "axes",
+                    "bars",
+                    "markers",
+                    "annotations",
+                    [Function],
+                  ]
+                }
+                legends={
+                  Array [
+                    Object {
+                      "anchor": "top-right",
+                      "data": Array [
+                        Object {
+                          "color": "#353070",
+                          "id": "lastRangeName",
+                          "label": "2019",
+                        },
+                        Object {
+                          "color": "#EB743B",
+                          "id": "thisRangeName",
+                          "label": "2020",
+                        },
+                      ],
+                      "dataFrom": "keys",
+                      "direction": "row",
+                      "itemHeight": 20,
+                      "itemWidth": 70,
+                      "symbolSize": 10,
+                      "translateY": -20,
+                    },
+                  ]
+                }
+                margin={
+                  Object {
+                    "bottom": 40,
+                    "left": 45,
+                    "top": 30,
+                  }
+                }
+                minValue={0}
+                padding={0.3}
+                tooltip={[Function]}
+              >
+                <ResponsiveWrapper>
+                  <Measure
+                    bounds={true}
+                    onResize={[Function]}
+                  >
+                    <Component
+                      bounds={true}
+                      contentRect={
+                        Object {
+                          "bounds": Object {},
+                          "client": Object {},
+                          "entry": Object {},
+                          "margin": Object {},
+                          "offset": Object {},
+                          "scroll": Object {},
+                        }
+                      }
+                      measure={[Function]}
+                      measureRef={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      />
+                    </Component>
+                  </Measure>
+                </ResponsiveWrapper>
+              </ResponsiveBar>
+            </BarDualTone>
+          </div>
+        </div>
+        <div
+          className="row mt-5 mb-15"
+        >
+          <MediaQuery
+            minWidth={768}
+          />
+          <MediaQuery
+            maxWidth={767}
+          />
+        </div>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserListeningActivity>
+`;
+
+exports[`User Stats UserListeningActivity renders corectly when range is invalid 1`] = `
 <UserListeningActivity
   apiUrl="barfoo"
   range="invalid_range"
@@ -199,7 +2264,7 @@ exports[`UserListeningActivity renders corectly when range is invalid 1`] = `
 </UserListeningActivity>
 `;
 
-exports[`UserListeningActivity renders correctly for all_time 1`] = `
+exports[`User Stats UserListeningActivity renders correctly for all_time 1`] = `
 <UserListeningActivity
   apiUrl="barfoo"
   range="all_time"
@@ -633,7 +2698,7 @@ exports[`UserListeningActivity renders correctly for all_time 1`] = `
 </UserListeningActivity>
 `;
 
-exports[`UserListeningActivity renders correctly for month 1`] = `
+exports[`User Stats UserListeningActivity renders correctly for month 1`] = `
 <UserListeningActivity
   apiUrl="barfoo"
   range="month"
@@ -1292,7 +3357,7 @@ exports[`UserListeningActivity renders correctly for month 1`] = `
 </UserListeningActivity>
 `;
 
-exports[`UserListeningActivity renders correctly for week 1`] = `
+exports[`User Stats UserListeningActivity renders correctly for week 1`] = `
 <UserListeningActivity
   apiUrl="barfoo"
   range="week"
@@ -1669,7 +3734,7 @@ exports[`UserListeningActivity renders correctly for week 1`] = `
 </UserListeningActivity>
 `;
 
-exports[`UserListeningActivity renders correctly for year 1`] = `
+exports[`User Stats UserListeningActivity renders correctly for year 1`] = `
 <UserListeningActivity
   apiUrl="barfoo"
   range="year"

--- a/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserReports.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserReports.test.tsx.snap
@@ -1,6 +1,129 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserReports renders without crashing 1`] = `
+exports[`Sitewide Stats UserReports renders without crashing 1`] = `
+<div>
+  <div
+    className="row mt-15"
+  >
+    <div
+      className="col-xs-12"
+    >
+      <Pill
+        active={false}
+        onClick={[Function]}
+        type="secondary"
+      >
+        This Week
+      </Pill>
+      <Pill
+        active={false}
+        onClick={[Function]}
+        type="secondary"
+      >
+        This Month
+      </Pill>
+      <Pill
+        active={false}
+        onClick={[Function]}
+        type="secondary"
+      >
+        This Year
+      </Pill>
+      <Pill
+        active={true}
+        onClick={[Function]}
+        type="secondary"
+      >
+        Last Week
+      </Pill>
+      <Pill
+        active={false}
+        onClick={[Function]}
+        type="secondary"
+      >
+        Last Month
+      </Pill>
+      <Pill
+        active={false}
+        onClick={[Function]}
+        type="secondary"
+      >
+        Last Year
+      </Pill>
+      <Pill
+        active={false}
+        onClick={[Function]}
+        type="secondary"
+      >
+        All time
+      </Pill>
+    </div>
+  </div>
+  <section
+    id="listening-activity"
+  >
+    <ErrorBoundary>
+      <UserListeningActivity
+        apiUrl="foobar"
+        range="week"
+      />
+    </ErrorBoundary>
+  </section>
+  <section
+    id="top-entity"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-4"
+      >
+        <ErrorBoundary>
+          <UserTopEntity
+            apiUrl="foobar"
+            entity="artist"
+            range="week"
+          />
+        </ErrorBoundary>
+      </div>
+      <div
+        className="col-md-4"
+      >
+        <ErrorBoundary>
+          <UserTopEntity
+            apiUrl="foobar"
+            entity="release"
+            range="week"
+          />
+        </ErrorBoundary>
+      </div>
+      <div
+        className="col-md-4"
+      >
+        <ErrorBoundary>
+          <UserTopEntity
+            apiUrl="foobar"
+            entity="recording"
+            range="week"
+          />
+        </ErrorBoundary>
+      </div>
+    </div>
+  </section>
+  <section
+    id="artist-origin"
+  >
+    <ErrorBoundary>
+      <UserArtistMap
+        apiUrl="foobar"
+        range="week"
+      />
+    </ErrorBoundary>
+  </section>
+</div>
+`;
+
+exports[`User Stats UserReports renders without crashing 1`] = `
 <div>
   <div
     className="row mt-15"

--- a/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserTopEntity.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserTopEntity.test.tsx.snap
@@ -1,6 +1,4745 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserTopEntity renders corectly when range is invalid 1`] = `
+exports[`Sitewide Stats UserTopEntity renders corectly when range is invalid 1`] = `
+<UserTopEntity
+  apiUrl="foobar"
+  entity="artist"
+  range="invalid_range"
+>
+  <ForwardRef
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexDirection": "column",
+        "marginTop": 20,
+        "minHeight": 550,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "column",
+          "marginTop": 20,
+          "minHeight": 550,
+        }
+      }
+    >
+      <h3
+        className="capitalize-bold"
+        style={
+          Object {
+            "display": "inline",
+          }
+        }
+      >
+        Top 
+        artists
+      </h3>
+      <h4
+        style={
+          Object {
+            "display": "inline",
+            "marginTop": 20,
+            "position": "absolute",
+            "right": 20,
+          }
+        }
+      >
+        <a
+          href="#top-entity"
+        >
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            color="#46443A"
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  512,
+                  512,
+                  Array [],
+                  "f0c1",
+                  "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                ],
+                "iconName": "link",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size="sm"
+            spin={false}
+            style={
+              Object {
+                "marginRight": 20,
+              }
+            }
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-link fa-w-16 fa-sm "
+              color="#46443A"
+              data-icon="link"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": 20,
+                }
+              }
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </FontAwesomeIcon>
+        </a>
+      </h4>
+      <Loader
+        isLoading={false}
+      >
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
+            }
+          }
+        >
+          <tbody>
+            <tr
+              style={
+                Object {
+                  "height": 440,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "fontSize": 24,
+                    "textAlign": "center",
+                    "whiteSpace": "initial",
+                  }
+                }
+              >
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={false}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        512,
+                        512,
+                        Array [],
+                        "f06a",
+                        "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z",
+                      ],
+                      "iconName": "exclamation-circle",
+                      "prefix": "fas",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="svg-inline--fa fa-exclamation-circle fa-w-16 "
+                    data-icon="exclamation-circle"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                      fill="currentColor"
+                      style={Object {}}
+                    />
+                  </svg>
+                </FontAwesomeIcon>
+                 
+                Invalid range: invalid_range
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserTopEntity>
+`;
+
+exports[`Sitewide Stats UserTopEntity renders correctly for artist 1`] = `
+<UserTopEntity
+  apiUrl="foobar"
+  entity="artist"
+  range="week"
+>
+  <ForwardRef
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexDirection": "column",
+        "marginTop": 20,
+        "minHeight": 550,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "column",
+          "marginTop": 20,
+          "minHeight": 550,
+        }
+      }
+    >
+      <h3
+        className="capitalize-bold"
+        style={
+          Object {
+            "display": "inline",
+          }
+        }
+      >
+        Top 
+        artists
+      </h3>
+      <h4
+        style={
+          Object {
+            "display": "inline",
+            "marginTop": 20,
+            "position": "absolute",
+            "right": 20,
+          }
+        }
+      >
+        <a
+          href="#top-entity"
+        >
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            color="#46443A"
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  512,
+                  512,
+                  Array [],
+                  "f0c1",
+                  "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                ],
+                "iconName": "link",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size="sm"
+            spin={false}
+            style={
+              Object {
+                "marginRight": 20,
+              }
+            }
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-link fa-w-16 fa-sm "
+              color="#46443A"
+              data-icon="link"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": 20,
+                }
+              }
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </FontAwesomeIcon>
+        </a>
+      </h4>
+      <Loader
+        isLoading={false}
+      >
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
+            }
+          }
+        >
+          <tbody>
+            <tr
+              key="0"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                1
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Coldplay
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                70
+              </td>
+            </tr>
+            <tr
+              key="1"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                2
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ellie Goulding
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                54
+              </td>
+            </tr>
+            <tr
+              key="2"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                3
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Maroon 5
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                38
+              </td>
+            </tr>
+            <tr
+              key="3"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                4
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                OneRepublic
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                36
+              </td>
+            </tr>
+            <tr
+              key="4"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                5
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Fray
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                31
+              </td>
+            </tr>
+            <tr
+              key="5"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ritviz
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                26
+              </td>
+            </tr>
+            <tr
+              key="6"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                7
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Imagine Dragons
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                26
+              </td>
+            </tr>
+            <tr
+              key="7"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Lenka
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                25
+              </td>
+            </tr>
+            <tr
+              key="8"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                9
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Vance Joy
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                20
+              </td>
+            </tr>
+            <tr
+              key="9"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Taylor Swift
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                20
+              </td>
+            </tr>
+            <tr
+              key="10"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ed Sheeran
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                19
+              </td>
+            </tr>
+            <tr
+              key="11"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                George Ezra
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                17
+              </td>
+            </tr>
+            <tr
+              key="12"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                13
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Christina Perri
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+              </td>
+            </tr>
+            <tr
+              key="13"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                14
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Script
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                15
+              </td>
+            </tr>
+            <tr
+              key="14"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                15
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Local train
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                13
+              </td>
+            </tr>
+            <tr
+              key="15"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Tommee Profitt
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              key="16"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                17
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Chainsmokers
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              key="17"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                18
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Sia
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              key="18"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                19
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Of Monsters and Men
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              key="19"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                20
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                M.I.A.
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+              </td>
+            </tr>
+            <tr
+              key="20"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                21
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Linkin Park
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+              </td>
+            </tr>
+            <tr
+              key="21"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                22
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Weeknd
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+              </td>
+            </tr>
+            <tr
+              key="22"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                23
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Backstreet Boys
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+              </td>
+            </tr>
+            <tr
+              key="23"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                24
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Train
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+              </td>
+            </tr>
+            <tr
+              key="24"
+              style={
+                Object {
+                  "height": 44,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                25
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Lumineers
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <a
+          className="mt-15"
+          href="http://localhost/statistics/charts?range=week&entity=artist"
+        >
+          View More
+        </a>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserTopEntity>
+`;
+
+exports[`Sitewide Stats UserTopEntity renders correctly for recording 1`] = `
+<UserTopEntity
+  apiUrl="foobar"
+  entity="recording"
+  range="week"
+>
+  <ForwardRef
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexDirection": "column",
+        "marginTop": 20,
+        "minHeight": 550,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "column",
+          "marginTop": 20,
+          "minHeight": 550,
+        }
+      }
+    >
+      <h3
+        className="capitalize-bold"
+        style={
+          Object {
+            "display": "inline",
+          }
+        }
+      >
+        Top 
+        recordings
+      </h3>
+      <h4
+        style={
+          Object {
+            "display": "inline",
+            "marginTop": 20,
+            "position": "absolute",
+            "right": 20,
+          }
+        }
+      >
+        <a
+          href="#top-entity"
+        >
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            color="#46443A"
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  512,
+                  512,
+                  Array [],
+                  "f0c1",
+                  "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                ],
+                "iconName": "link",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size="sm"
+            spin={false}
+            style={
+              Object {
+                "marginRight": 20,
+              }
+            }
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-link fa-w-16 fa-sm "
+              color="#46443A"
+              data-icon="link"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": 20,
+                }
+              }
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </FontAwesomeIcon>
+        </a>
+      </h4>
+      <Loader
+        isLoading={false}
+      >
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
+            }
+          }
+        >
+          <tbody>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                1
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/0fe11cd3-0be4-467b-84fa-0bd524d45d74"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Love Me Like You Do - From "Fifty Shades of Grey"
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                25
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ellie Goulding
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                2
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/0008ab49-a6ad-40b5-aa90-9d2779265c22"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  How to Save a Life
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                23
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Fray
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                3
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Udd Gaye - Bacardi House Party Sessions
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                20
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ritviz
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                4
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/00d32e28-0df2-486c-9829-750301962fb2"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Counting Stars
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                18
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                OneRepublic
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                5
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/017cd117-e343-408f-95fe-ee4c1018e312"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Burn
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ellie Goulding
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/01236d26-9f46-435f-adc5-6c92e6e76f53"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Blank Space
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Taylor Swift
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                7
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/03a0cdfb-f964-434f-bfb7-379203dc139d"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  A Thousand Years
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Christina Perri
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/003196a1-f6ab-4fe8-9683-b970d163cfa4"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Riptide
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                15
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Vance Joy
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                9
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/02ba28bc-6d79-44fb-b770-c49395661117"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Castle on the Hill
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                14
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ed Sheeran
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Start Again (feat. Logic)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                13
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                OneRepublic
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/0a4c5dfd-02c7-43dc-ba7f-1b4ce7a02994"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Shotgun
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                George Ezra
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                In The End - Mellen Gi Remix
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Tommee Profitt
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                13
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/045cdbf9-796e-4949-91f6-e05d9ce3ed21"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Hall of Fame
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Script
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                14
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Moves Like Jagger - Studio Recording From The Voice Performance
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Maroon 5
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                15
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/0031fba1-dde0-3755-bcb2-63b2544159f8"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Little Talks
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Of Monsters and Men
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Cheap Thrills (feat. Sean Paul)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Sia
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                17
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/0126d206-3894-4d97-b5c2-f6cf037a323a"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Payphone
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Maroon 5
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                18
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/234ae263-ffad-472a-8077-dab64bcedf99"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Paper Planes
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                M.I.A.
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                19
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/14c913e9-db47-40fa-ae1a-81099a67e4bf"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Battle Symphony
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Linkin Park
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                20
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/0040980c-4f9a-43df-8be0-142dce4374f4"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  I Want It That Way
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Backstreet Boys
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                21
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/036e67df-baae-4626-a2ab-951dd162e332"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Everything at Once
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Lenka
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                22
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Choo Lo
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Local train
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                23
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/02b47acf-3bc5-47dc-a516-e8c2c95bc07b"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Up&Up
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Coldplay
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                24
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                <a
+                  href="https://musicbrainz.org/recording/0132a6b9-a04f-48ea-81e7-5f3a5d608f75"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  On Top of the World
+                </a>
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Imagine Dragons
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                25
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Close to Me (with Diplo) (feat. Swae Lee)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ellie Goulding
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <a
+          className="mt-15"
+          href="http://localhost/statistics/charts?range=week&entity=recording"
+        >
+          View More
+        </a>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserTopEntity>
+`;
+
+exports[`Sitewide Stats UserTopEntity renders correctly for release 1`] = `
+<UserTopEntity
+  apiUrl="foobar"
+  entity="release"
+  range="week"
+>
+  <ForwardRef
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexDirection": "column",
+        "marginTop": 20,
+        "minHeight": 550,
+      }
+    }
+  >
+    <div
+      className="card "
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "column",
+          "marginTop": 20,
+          "minHeight": 550,
+        }
+      }
+    >
+      <h3
+        className="capitalize-bold"
+        style={
+          Object {
+            "display": "inline",
+          }
+        }
+      >
+        Top 
+        releases
+      </h3>
+      <h4
+        style={
+          Object {
+            "display": "inline",
+            "marginTop": 20,
+            "position": "absolute",
+            "right": 20,
+          }
+        }
+      >
+        <a
+          href="#top-entity"
+        >
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            color="#46443A"
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  512,
+                  512,
+                  Array [],
+                  "f0c1",
+                  "M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z",
+                ],
+                "iconName": "link",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size="sm"
+            spin={false}
+            style={
+              Object {
+                "marginRight": 20,
+              }
+            }
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-link fa-w-16 fa-sm "
+              color="#46443A"
+              data-icon="link"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": 20,
+                }
+              }
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </FontAwesomeIcon>
+        </a>
+      </h4>
+      <Loader
+        isLoading={false}
+      >
+        <table
+          style={
+            Object {
+              "tableLayout": "fixed",
+              "whiteSpace": "nowrap",
+              "width": "90%",
+            }
+          }
+        >
+          <tbody>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                1
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Live in Buenos Aires
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                26
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Coldplay
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                2
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                How to Save a Life
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                25
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Fray
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                3
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Delirium (Deluxe)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                25
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ellie Goulding
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                4
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Udd Gaye (Bacardi House Party Sessions)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                20
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ritviz
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                5
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Native
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                18
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                OneRepublic
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                6
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Dream Your Life Away (Special Edition)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                18
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Vance Joy
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                7
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                ÷ (Deluxe)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                17
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ed Sheeran
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Night Visions (Deluxe)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                17
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Imagine Dragons
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                9
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                1989
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                17
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Taylor Swift
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Halcyon Days
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Ellie Goulding
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                A Thousand Years
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Christina Perri
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                A Head Full Of Dreams
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Coldplay
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                13
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Staying at Tamara's
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                15
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                George Ezra
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                14
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Two (Expanded Edition)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                13
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Lenka
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                15
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                13 Reasons Why (Season 2)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                13
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                OneRepublic
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                16
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                In The End
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Tommee Profitt
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                17
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                #3
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                12
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Script
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                18
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Singles
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Maroon 5
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                19
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Overexposed
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Maroon 5
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                20
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                My Head Is an Animal
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Of Monsters and Men
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                21
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Cheap Thrills (feat. Sean Paul)
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                11
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Sia
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                22
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                One More Light
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Linkin Park
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                23
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Kala
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                10
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                M.I.A.
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                24
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Aalas Ka Pedh
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                9
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Local train
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td
+                style={
+                  Object {
+                    "textAlign": "end",
+                    "width": "10%",
+                  }
+                }
+              >
+                25
+                . 
+              </td>
+              <td
+                style={
+                  Object {
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                The Hits--Chapter One
+              </td>
+              <td
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              >
+                8
+              </td>
+            </tr>
+            <tr
+              style={
+                Object {
+                  "height": 22,
+                }
+              }
+            >
+              <td />
+              <td
+                style={
+                  Object {
+                    "fontSize": 12,
+                    "overflow": "hidden",
+                    "paddingRight": 10,
+                    "textOverflow": "ellipsis",
+                  }
+                }
+              >
+                Backstreet Boys
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <a
+          className="mt-15"
+          href="http://localhost/statistics/charts?range=week&entity=release"
+        >
+          View More
+        </a>
+      </Loader>
+    </div>
+  </ForwardRef>
+</UserTopEntity>
+`;
+
+exports[`User Stats UserTopEntity renders corectly when range is invalid 1`] = `
 <UserTopEntity
   apiUrl="foobar"
   entity="artist"
@@ -210,7 +4949,7 @@ exports[`UserTopEntity renders corectly when range is invalid 1`] = `
 </UserTopEntity>
 `;
 
-exports[`UserTopEntity renders correctly for artist 1`] = `
+exports[`User Stats UserTopEntity renders correctly for artist 1`] = `
 <UserTopEntity
   apiUrl="foobar"
   entity="artist"
@@ -1357,7 +6096,7 @@ exports[`UserTopEntity renders correctly for artist 1`] = `
 </UserTopEntity>
 `;
 
-exports[`UserTopEntity renders correctly for recording 1`] = `
+exports[`User Stats UserTopEntity renders correctly for recording 1`] = `
 <UserTopEntity
   apiUrl="foobar"
   entity="recording"
@@ -3112,7 +7851,7 @@ exports[`UserTopEntity renders correctly for recording 1`] = `
 </UserTopEntity>
 `;
 
-exports[`UserTopEntity renders correctly for release 1`] = `
+exports[`User Stats UserTopEntity renders correctly for release 1`] = `
 <UserTopEntity
   apiUrl="foobar"
   entity="release"

--- a/listenbrainz/webserver/static/js/tests/utils/APIService.test.ts
+++ b/listenbrainz/webserver/static/js/tests/utils/APIService.test.ts
@@ -319,6 +319,13 @@ describe("getUserEntity", () => {
     );
   });
 
+  it("calls fetch correctly when username is not passed", async () => {
+    await apiService.getUserEntity(undefined, "release", "all_time", 10, 5);
+    expect(window.fetch).toHaveBeenCalledWith(
+      "foobar/1/stats/sitewide/releases?offset=10&range=all_time&count=5"
+    );
+  });
+
   it("calls fetch correctly when optional parameters are not passed", async () => {
     await apiService.getUserEntity("foobar", "artist");
     expect(window.fetch).toHaveBeenCalledWith(
@@ -364,6 +371,13 @@ describe("getUserListeningActivity", () => {
     await apiService.getUserListeningActivity("foobar", "week");
     expect(window.fetch).toHaveBeenCalledWith(
       "foobar/1/stats/user/foobar/listening-activity?range=week"
+    );
+  });
+
+  it("calls fetch correctly when username is not passed", async () => {
+    await apiService.getUserListeningActivity(undefined);
+    expect(window.fetch).toHaveBeenCalledWith(
+      "foobar/1/stats/sitewide/listening-activity?range=all_time"
     );
   });
 
@@ -467,6 +481,13 @@ describe("getUserArtistMap", () => {
     await apiService.getUserArtistMap("foobar");
     expect(window.fetch).toHaveBeenCalledWith(
       "foobar/1/stats/user/foobar/artist-map?range=all_time&force_recalculate=false"
+    );
+  });
+
+  it("calls fetch correctly when username is not passed", async () => {
+    await apiService.getUserArtistMap(undefined);
+    expect(window.fetch).toHaveBeenCalledWith(
+      "foobar/1/stats/sitewide/artist-map?range=all_time&force_recalculate=false"
     );
   });
 

--- a/listenbrainz/webserver/templates/index/charts.html
+++ b/listenbrainz/webserver/templates/index/charts.html
@@ -1,5 +1,7 @@
 {% extends 'base-react.html' %}
 
+{% block title %}Sitewide Statistics - ListenBrainz{% endblock %}
+
 {% block profile_content %}
     <div id="react-container" ></div>
 {% endblock %}

--- a/listenbrainz/webserver/templates/index/charts.html
+++ b/listenbrainz/webserver/templates/index/charts.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+
+{% block profile_content %}
+    <div id="react-container" ></div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ get_static_path('userEntityChart.js') }}" type="text/javascript"></script>
+{% endblock %}

--- a/listenbrainz/webserver/templates/index/charts.html
+++ b/listenbrainz/webserver/templates/index/charts.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'base-react.html' %}
 
 {% block profile_content %}
     <div id="react-container" ></div>

--- a/listenbrainz/webserver/templates/index/reports.html
+++ b/listenbrainz/webserver/templates/index/reports.html
@@ -1,5 +1,7 @@
 {% extends 'base-react.html' %}
 
+{% block title %}Sitewide Statistics - ListenBrainz{% endblock %}
+
 {% block profile_content %}
     <div id="react-container" ></div>
 {% endblock %}

--- a/listenbrainz/webserver/templates/index/reports.html
+++ b/listenbrainz/webserver/templates/index/reports.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'base-react.html' %}
 
 {% block profile_content %}
     <div id="react-container" ></div>

--- a/listenbrainz/webserver/templates/index/reports.html
+++ b/listenbrainz/webserver/templates/index/reports.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+
+{% block profile_content %}
+    <div id="react-container" ></div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ get_static_path('userReports.js') }}" type="text/javascript"></script>
+{% endblock %}

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -288,3 +288,15 @@ def huesound():
         "index/huesound.html",
         props=ujson.dumps({})
     )
+
+
+@index_bp.route("/sitewide/charts/")
+def charts():
+    """ Show the top sitewide entities. """
+    return render_template("index/charts.html")
+
+
+@index_bp.route("/sitewide/reports/")
+def reports():
+    """ Show sitewide reports """
+    return render_template("index/reports.html")

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -290,13 +290,13 @@ def huesound():
     )
 
 
-@index_bp.route("/sitewide/charts/")
+@index_bp.route("/statistics/charts/")
 def charts():
     """ Show the top sitewide entities. """
     return render_template("index/charts.html")
 
 
-@index_bp.route("/sitewide/reports/")
+@index_bp.route("/statistics/")
 def reports():
     """ Show sitewide reports """
     return render_template("index/reports.html")

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -388,7 +388,8 @@ def get_daily_activity(user_name: str):
         raise APINoContent('')
 
     daily_activity_unprocessed = [x.dict() for x in stats.data.__root__]
-    daily_activity = {calendar.day_name[day]: [{"hour": hour, "listen_count": 0} for hour in range(0, 24)] for day in range(0, 7)}
+    daily_activity = {calendar.day_name[day]: [{"hour": hour, "listen_count": 0} for hour in range(0, 24)] for day in
+                      range(0, 7)}
 
     for day, day_data in daily_activity.items():
         for hour_data in day_data:
@@ -465,62 +466,7 @@ def get_artist_map(user_name: str):
 
     """
     user, stats_range = _validate_stats_user_params(user_name)
-
-    recalculate_param = request.args.get('force_recalculate', default='false')
-    if recalculate_param.lower() not in ['true', 'false']:
-        raise APIBadRequest("Invalid value of force_recalculate: {}".format(recalculate_param))
-    force_recalculate = recalculate_param.lower() == 'true'
-
-    # Check if stats are present in DB, if not calculate them
-    calculated = not force_recalculate
-    stats = db_stats.get_user_artist_map(user['id'], stats_range)
-    if stats is None:
-        calculated = False
-
-    # Check if the stats present in DB have been calculated in the past week, if not recalculate them
-    stale = False
-    if calculated:
-        if (datetime.now(timezone.utc) - stats.last_updated).days >= STATS_CALCULATION_INTERVAL:
-            stale = True
-
-    if stale or not calculated:
-        artist_stats = db_stats.get_user_stats(user['id'], stats_range, 'artists')
-
-        # If top artists are missing, return the stale stats if present, otherwise return 204
-        if artist_stats is None:
-            if stale:
-                result = stats
-            else:
-                raise APINoContent('')
-        else:
-            # Calculate the data
-            artist_mbid_counts = defaultdict(int)
-            for artist in artist_stats.data.__root__:
-                for artist_mbid in artist.artist_mbids:
-                    artist_mbid_counts[artist_mbid] += artist.listen_count
-
-            country_code_data = _get_country_wise_counts(artist_mbid_counts)
-            result = StatApi[UserArtistMapRecord](**{
-                "data": country_code_data,
-                "from_ts": artist_stats.from_ts,
-                "to_ts": artist_stats.to_ts,
-                "stats_range": stats_range,
-                # this isn't stored in the database, but adding it here to avoid a subsequent db call to
-                # just fetch last updated. could just store this value instead in db but that complicates
-                # the implementation a bit
-                "last_updated": datetime.now(),
-                "user_id": user['id']
-            })
-
-            # Store in DB for future use
-            try:
-                db_stats.insert_user_jsonb_data(user['id'], 'artist_map', result)
-            except Exception as err:
-                current_app.logger.error("Error while inserting artist map stats for {user}. Error: {err}. Data: {data}".format(
-                    user=user_name, err=err, data=result), exc_info=True)
-    else:
-        result = stats
-
+    result = _get_artist_map_stats(user["id"], stats_range)
     return jsonify({
         "payload": {
             "user_id": user_name,
@@ -810,7 +756,7 @@ def get_sitewide_listening_activity():
     if not _is_valid_range(stats_range):
         raise APIBadRequest(f"Invalid range: {stats_range}")
 
-    stats = db_stats.get_sitewide_stats(stats_range, "listening_activity")
+    stats = db_stats.get_sitewide_listening_activity(stats_range)
     if stats is None:
         raise APINoContent('')
 
@@ -822,6 +768,135 @@ def get_sitewide_listening_activity():
         "range": stats_range,
         "last_updated": int(stats.last_updated.timestamp())
     }})
+
+
+@stats_api_bp.route("/sitewide/artist-map")
+@crossdomain()
+@ratelimit()
+def get_sitewide_artist_map():
+    """
+    Get the sitewide artist map. The artist map shows the number of artists listened to by users
+    from different countries of the world.
+
+    A sample response from the endpoint may look like:
+
+    .. code-block:: json
+
+        {
+            "payload": {
+                "from_ts": 1587945600,
+                "last_updated": 1592807084,
+                "artist_map": [
+                    {
+                        "country": "USA",
+                        "artist_count": 34
+                    },
+                    {
+                        "country": "GBR",
+                        "artist_count": 69
+                    },
+                    {
+                        "country": "IND",
+                        "artist_count": 32
+                    }
+                ],
+                "stats_range": "all_time"
+                "to_ts": 1589155200,
+            }
+        }
+
+    .. note::
+        - This endpoint is currently in beta
+        - We cache the results for this query for a week to improve page load times, if you want to request fresh data
+         you can use the ``force_recalculate`` flag.
+
+    :param range: Optional, time interval for which statistics should be returned, possible values are
+        :data:`~data.model.common_stat.ALLOWED_STATISTICS_RANGE`, defaults to ``all_time``
+    :type range: ``str``
+    :param force_recalculate: Optional, recalculate the data instead of returning the cached result.
+    :type force_recalculate: ``bool``
+    :statuscode 200: Successful query, you have data!
+    :statuscode 204: Statistics for the user haven't been calculated, empty response will be returned
+    :statuscode 400: Bad request, check ``response['error']`` for more details
+    :statuscode 404: User not found
+    :resheader Content-Type: *application/json*
+
+    """
+    stats_range = request.args.get("range", default="all_time")
+    if not _is_valid_range(stats_range):
+        raise APIBadRequest(f"Invalid range: {stats_range}")
+
+    result = _get_artist_map_stats(db_stats.SITEWIDE_STATS_USER_ID, stats_range)
+
+    return jsonify({
+        "payload": {
+            "range": stats_range,
+            "from_ts": result.from_ts,
+            "to_ts": result.to_ts,
+            "last_updated": int(result.last_updated.timestamp()),
+            "artist_map": [x.dict() for x in result.data.__root__]
+        }
+    })
+
+
+def _get_artist_map_stats(user_id, stats_range):
+    recalculate_param = request.args.get('force_recalculate', default='false')
+    if recalculate_param.lower() not in ['true', 'false']:
+        raise APIBadRequest("Invalid value of force_recalculate: {}".format(recalculate_param))
+    force_recalculate = recalculate_param.lower() == 'true'
+
+    # Check if stats are present in DB, if not calculate them
+    calculated = not force_recalculate
+    stats = db_stats.get_user_artist_map(user_id, stats_range)
+    if stats is None:
+        calculated = False
+
+    # Check if the stats present in DB have been calculated in the past week, if not recalculate them
+    stale = False
+    if calculated:
+        if (datetime.now(timezone.utc) - stats.last_updated).days >= STATS_CALCULATION_INTERVAL:
+            stale = True
+
+    if stale or not calculated:
+        artist_stats = db_stats.get_user_stats(user_id, stats_range, 'artists')
+
+        # If top artists are missing, return the stale stats if present, otherwise return 204
+        if artist_stats is None:
+            if stale:
+                result = stats
+            else:
+                raise APINoContent('')
+        else:
+            # Calculate the data
+            artist_mbid_counts = defaultdict(int)
+            for artist in artist_stats.data.__root__:
+                for artist_mbid in artist.artist_mbids:
+                    artist_mbid_counts[artist_mbid] += artist.listen_count
+
+            country_code_data = _get_country_wise_counts(artist_mbid_counts)
+            result = StatApi[UserArtistMapRecord](**{
+                "data": country_code_data,
+                "from_ts": artist_stats.from_ts,
+                "to_ts": artist_stats.to_ts,
+                "stats_range": stats_range,
+                # this isn't stored in the database, but adding it here to avoid a subsequent db call to
+                # just fetch last updated. could just store this value instead in db but that complicates
+                # the implementation a bit
+                "last_updated": datetime.now(),
+                "user_id": user_id
+            })
+
+            # Store in DB for future use
+            try:
+                db_stats.insert_user_jsonb_data(user_id, 'artist_map', result)
+            except Exception as err:
+                current_app.logger.error(
+                    "Error while inserting artist map stats for {user}. Error: {err}. Data: {data}".format(
+                        user=user_id, err=err, data=result), exc_info=True)
+    else:
+        result = stats
+
+    return result
 
 
 @stats_api_bp.route("/user/<user_name>/year-in-music/")


### PR DESCRIPTION
Add dedicated pages to view sitewide stats. For the frontend side of changes, I have made the user prop optional in stat components. If present, that particular user's stats are loaded otherwise the sitewide stats are loaded.

WIP. Test Pending.