### PR TITLE
Fix CBReview modal MBIDs

### DIFF
--- a/listenbrainz/webserver/static/js/src/cb-review/CBReviewModal.tsx
+++ b/listenbrainz/webserver/static/js/src/cb-review/CBReviewModal.tsx
@@ -521,7 +521,7 @@ export default class CBReviewModal extends React.Component<
               data-toggle="dropdown"
               type="button"
             >
-              {`${entityToReview.name}
+              {`${entityToReview.name} 
               (${entityToReview.type.replace("_", " ")})`}
               <span className="caret" />
             </button>


### PR DESCRIPTION
Currently, CBReviewmodal is broken.
Clicking on "write a review" for a listen that definitely has recording and artist MBIDs somewhere in its metadata (i.e from mbid_mapping), this is what appears:
![image](https://user-images.githubusercontent.com/6179856/156420765-24cdf54d-4f12-49d4-81c9-143574f81437.png)

The is some duplicated code to get MBIDs from listens that doesn't target the correct properties.
![image](https://user-images.githubusercontent.com/6179856/156421181-9706cfe7-4096-41f2-99a3-e29f93fdc12f.png)


Instead, we should use existing utilities that were created for that purpose
