### PR TITLE
Harmonize ListenCard play icon width

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -480,7 +480,11 @@
 		
 		.play-button {
 			color: #8d8d8d;
-			margin-left: .4em;
+			width: 2em;
+			min-width: 2em;
+			margin-left: 0;
+			margin-right: 0.5em;
+			padding: 0;
 		}
 		// If the user has an input method compatible with hovering (f.e. a mouse)
 		// hide the play button by default and show it on card hover


### PR DESCRIPTION
I've finally had enough of looking at this annoying spacing/margin issue with play icons on listencards:
![image](https://user-images.githubusercontent.com/6179856/157223003-481d2303-3e34-42ef-a554-8fdfae4cccd6.png)
We use different icons between the play button shown on currently playing item and on hover over listencards, which is  creating a difference of width and insetting the rest of the control.
Ugly. Need fix. Here fix.

![image](https://user-images.githubusercontent.com/6179856/157223216-39a57108-1c23-4a21-af96-c989bfea9e69.png)
