### PR TITLE
LB-759, LB-962, LB-1047, LB-1074, LB-1075: Relinking Spotify throws `duplicate key` error

### DIFF
--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -21,10 +21,18 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
     token_expires = utils.unix_timestamp_to_datetime(token_expires_ts)
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            INSERT INTO external_service_oauth 
+            INSERT INTO external_service_oauth
             (user_id, service, access_token, refresh_token, token_expires, scopes)
-            VALUES 
+            VALUES
             (:user_id, :service, :access_token, :refresh_token, :token_expires, :scopes)
+            ON CONFLICT (user_id, service)
+            DO UPDATE SET
+                user_id = EXCLUDED.user_id,
+                service = EXCLUDED.service,
+                access_token = EXCLUDED.access_token,
+                refresh_token = EXCLUDED.refresh_token,
+                token_expires = EXCLUDED.token_expires,
+                scopes = EXCLUDED.scopes
             RETURNING id
             """), {
                 "user_id": user_id,
@@ -42,6 +50,10 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
                 (external_service_oauth_id, user_id, service)
                 VALUES
                 (:external_service_oauth_id, :user_id, :service)
+                ON CONFLICT (user_id, service) DO UPDATE SET
+                    external_service_oauth_id = EXCLUDED.external_service_oauth_id,
+                    user_id = EXCLUDED.user_id,
+                    service = EXCLUDED.service
                 """), {
                 "external_service_oauth_id": external_service_oauth_id,
                 "user_id": user_id,

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -53,7 +53,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             scopes=['user-read-recently-played']
         )
         user = db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY)
-        self.assertEqual('token', user['new_token'])
+        self.assertEqual(user['access_token'], 'new_token')
 
     def test_update_token(self):
         db_oauth.update_token(

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -38,6 +38,23 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         user = db_oauth.get_token(2, ExternalServiceType.SPOTIFY)
         self.assertEqual('token', user['access_token'])
 
+    def test_create_oauth_multiple(self):
+        """ Test saving the token again for a given service and user_id
+         overwrites existing one without crash. """
+        # one time already saved in db by setup method
+        # second time here
+        db_oauth.save_token(
+            user_id=self.user['id'],
+            service=ExternalServiceType.SPOTIFY,
+            access_token='new_token',
+            refresh_token='refresh_token',
+            token_expires_ts=int(time.time()),
+            record_listens=True,
+            scopes=['user-read-recently-played']
+        )
+        user = db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY)
+        self.assertEqual('token', user['new_token'])
+
     def test_update_token(self):
         db_oauth.update_token(
             user_id=self.user['id'],


### PR DESCRIPTION
For a long time we were unable to reproduce this error, @alastair  reproduced this reliably by double clicking the button causing spotify to send multiple payload to the callback and trying multiple inserts. There may be other possible reasons as well which we may not know of. ON CONFLICT DO UPDATE seems like a good thing to do in these cases.