### PR TITLE
Update default rank for CF recommendations

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -241,7 +241,7 @@ def parse_list(ctx, args):
 
 
 @cli.command(name='request_model')
-@click.option("--rank", callback=parse_list, default=[5, 10], type=int, multiple=True, help="Number of hidden features")
+@click.option("--rank", callback=parse_list, default=[100, 120], type=int, multiple=True, help="Number of hidden features")
 @click.option("--itr", callback=parse_list, default=[5, 10], type=int, multiple=True, help="Number of iterations to run.")
 @click.option("--lmbda", callback=parse_list, default=[0.1, 10.0], type=float, multiple=True, help="Controls over fitting.")
 @click.option("--alpha", default=3.0, type=float, help="Baseline level of confidence weighting applied.")


### PR DESCRIPTION
Experiments show that RMSE is minimized when rank is around 100 - 120 so updating the ranks we use in CF recommendations.