### PR TITLE
Simplify @crossdomain decorator

### DIFF
--- a/listenbrainz/webserver/decorators.py
+++ b/listenbrainz/webserver/decorators.py
@@ -1,54 +1,29 @@
 from functools import update_wrapper, wraps
-from datetime import timedelta
-from typing import List
 
 from flask import request, current_app, make_response, redirect, url_for
-from six import string_types
 
 from listenbrainz.webserver import timescale_connection
 
 
-def crossdomain(origin='*', methods=None, headers: List[str] = None,
-                max_age=21600, attach_to_all=True,
-                automatic_options=True):
-    # Based on snippet by Armin Ronacher located at http://flask.pocoo.org/snippets/56/.
-    if methods is not None:
-        methods = ', '.join(sorted(x.upper() for x in methods))
-    all_headers = {"AUTHORIZATION", "CONTENT-TYPE"}
-    if headers is not None:
-        all_headers.update(headers)
-    all_headers = ', '.join(x.upper() for x in all_headers)
-    if not isinstance(origin, string_types):
-        origin = ', '.join(origin)
-    if isinstance(max_age, timedelta):
-        max_age = max_age.total_seconds()
-
-    def get_methods():
-        if methods is not None:
-            return methods
-
+def crossdomain(f):
+    """ Decorator to add CORS headers to flask endpoints """
+    @wraps(f)
+    def decorator(*args, **kwargs):
         options_resp = current_app.make_default_options_response()
-        return options_resp.headers['allow']
 
-    def decorator(f):
-        def wrapped_function(*args, **kwargs):
-            if automatic_options and request.method == 'OPTIONS':
-                resp = current_app.make_default_options_response()
-            else:
-                resp = make_response(f(*args, **kwargs))
-            if not attach_to_all and request.method != 'OPTIONS':
-                return resp
+        if request.method == 'OPTIONS':
+            resp = options_resp
+        else:
+            resp = make_response(f(*args, **kwargs))
 
-            h = resp.headers
+        h = resp.headers
+        h["Access-Control-Allow-Origin"] = "*"
+        h["Access-Control-Allow-Methods"] = options_resp.headers['allow']
+        h["Access-Control-Max-Age"] = "21600"
+        h["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
+        return resp
 
-            h['Access-Control-Allow-Origin'] = origin
-            h['Access-Control-Allow-Methods'] = get_methods()
-            h['Access-Control-Max-Age'] = str(max_age)
-            h['Access-Control-Allow-Headers'] = all_headers
-            return resp
-
-        f.provide_automatic_options = False
-        return update_wrapper(wrapped_function, f)
+    f.provide_automatic_options = False
     return decorator
 
 

--- a/listenbrainz/webserver/decorators.py
+++ b/listenbrainz/webserver/decorators.py
@@ -18,7 +18,7 @@ def crossdomain(f):
 
         h = resp.headers
         h["Access-Control-Allow-Origin"] = "*"
-        h["Access-Control-Allow-Methods"] = options_resp.headers['allow']
+        h["Access-Control-Allow-Methods"] = options_resp.headers["allow"]
         h["Access-Control-Max-Age"] = "21600"
         h["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
         return resp

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -199,7 +199,7 @@ def init_error_handlers(app):
         return handle_error(error, 504)
 
     @app.errorhandler(APIError)
-    @crossdomain()
+    @crossdomain
     def api_error(error):
         return jsonify(error.to_dict()), error.status_code
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -32,7 +32,7 @@ DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL = 25
 
 
 @api_bp.route("/submit-listens", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def submit_listen():
     """
@@ -105,7 +105,7 @@ def submit_listen():
 
 
 @api_bp.route("/user/<user_name>/listens", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def get_listens(user_name):
@@ -150,7 +150,7 @@ def get_listens(user_name):
 
 
 @api_bp.route("/user/<user_name>/listen-count", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def get_listen_count(user_name):
@@ -181,7 +181,7 @@ def get_listen_count(user_name):
 
 
 @api_bp.route("/user/<user_name>/playing-now", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_playing_now(user_name):
     """
@@ -219,7 +219,7 @@ def get_playing_now(user_name):
 
 
 @api_bp.route("/user/<user_name>/similar-users", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_similar_users(user_name):
     """
@@ -254,7 +254,7 @@ def get_similar_users(user_name):
 
 
 @api_bp.route("/user/<user_name>/similar-to/<other_user_name>", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_similar_to_user(user_name, other_user_name):
     """
@@ -286,7 +286,7 @@ def get_similar_to_user(user_name, other_user_name):
 
 
 @api_bp.route('/latest-import', methods=['GET', 'POST', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def latest_import():
     """
@@ -358,7 +358,7 @@ def latest_import():
 
 
 @api_bp.route('/validate-token', methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def validate_token():
     """
@@ -425,7 +425,7 @@ def validate_token():
 
 
 @api_bp.route('/delete-listen', methods=['POST', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def delete_listen():
@@ -504,7 +504,7 @@ def serialize_playlists(playlists, playlist_count, count, offset):
 
 
 @api_bp.route("/user/<playlist_user_name>/playlists", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_playlists_for_user(playlist_user_name):
     """
@@ -539,7 +539,7 @@ def get_playlists_for_user(playlist_user_name):
 
 
 @api_bp.route("/user/<playlist_user_name>/playlists/createdfor", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_playlists_created_for_user(playlist_user_name):
     """
@@ -570,7 +570,7 @@ def get_playlists_created_for_user(playlist_user_name):
 
 
 @api_bp.route("/user/<playlist_user_name>/playlists/collaborator", methods=['GET', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_playlists_collaborated_on_for_user(playlist_user_name):
     """

--- a/listenbrainz/webserver/views/color_api.py
+++ b/listenbrainz/webserver/views/color_api.py
@@ -16,7 +16,7 @@ color_api_bp = Blueprint('color_api_v1', __name__)
 
 
 @color_api_bp.route("/<color>", methods=["GET", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def huesound(color):
     """

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -20,7 +20,7 @@ FEEDBACK_DEFAULT_SCORE = 0
 
 
 @feedback_api_bp.route("/recording-feedback", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def recording_feedback():
     """
@@ -69,7 +69,7 @@ def recording_feedback():
 
 
 @feedback_api_bp.route("/user/<user_name>/get-feedback", methods=["GET"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_feedback_for_user(user_name):
     """
@@ -121,7 +121,7 @@ def get_feedback_for_user(user_name):
     })
 
 @feedback_api_bp.route("/recording/<recording_mbid>/get-feedback-mbid", methods=["GET"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_feedback_for_recording_mbid(recording_mbid):
     """
@@ -145,7 +145,7 @@ def get_feedback_for_recording_mbid(recording_mbid):
 
 
 @feedback_api_bp.route("/recording/<recording_msid>/get-feedback", methods=["GET"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_feedback_for_recording_msid(recording_msid):
     """
@@ -194,7 +194,7 @@ def _get_feedback_for_recording(recording_type, recording):
 
 
 @feedback_api_bp.route("/user/<user_name>/get-feedback-for-recordings", methods=["GET"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_feedback_for_recordings_for_user(user_name):
     """

--- a/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
+++ b/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
@@ -33,7 +33,7 @@ missing_musicbrainz_data_api_bp = Blueprint('missing_musicbrainz_data_v1', __nam
 
 
 @missing_musicbrainz_data_api_bp.route("/user/<user_name>/")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_missing_musicbrainz_data(user_name):
     """ Get musicbrainz data sorted on "listened_at" that the user has submitted to ListenBrainz but has not

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -21,7 +21,7 @@ pinned_recording_api_bp = Blueprint("pinned_rec_api_bp_v1", __name__)
 
 
 @pinned_recording_api_bp.route("/pin", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def pin_recording_for_user():
     """
@@ -73,7 +73,7 @@ def pin_recording_for_user():
 
 
 @pinned_recording_api_bp.route("/pin/unpin", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def unpin_recording_for_user():
     """
@@ -101,7 +101,7 @@ def unpin_recording_for_user():
 
 
 @pinned_recording_api_bp.route("/pin/delete/<row_id>", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def delete_pin_for_user(row_id):
     """
@@ -131,7 +131,7 @@ def delete_pin_for_user(row_id):
 
 
 @pinned_recording_api_bp.route("/<user_name>/pins", methods=["GET", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_pins_for_user(user_name):
     """
@@ -207,7 +207,7 @@ def get_pins_for_user(user_name):
 
 
 @pinned_recording_api_bp.route("/<user_name>/pins/following", methods=["GET", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_pins_for_user_following(user_name):
     """

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -224,7 +224,7 @@ def fetch_playlist_recording_metadata(playlist: Playlist):
 
 
 @playlist_api_bp.route("/create", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def create_playlist():
@@ -329,7 +329,7 @@ def create_playlist():
 
 
 @playlist_api_bp.route("/edit/<playlist_mbid>", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def edit_playlist(playlist_mbid):
@@ -409,7 +409,7 @@ def edit_playlist(playlist_mbid):
 
 
 @playlist_api_bp.route("/<playlist_mbid>", methods=["GET", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def get_playlist(playlist_mbid):
@@ -450,7 +450,7 @@ def get_playlist(playlist_mbid):
 
 @playlist_api_bp.route("/<playlist_mbid>/item/add/<int:offset>", methods=["POST", "OPTIONS"])
 @playlist_api_bp.route("/<playlist_mbid>/item/add", methods=["POST", "OPTIONS"], defaults={'offset': None})
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def add_playlist_item(playlist_mbid, offset):
@@ -512,7 +512,7 @@ def add_playlist_item(playlist_mbid, offset):
 
 
 @playlist_api_bp.route("/<playlist_mbid>/item/move", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def move_playlist_item(playlist_mbid):
@@ -564,7 +564,7 @@ def move_playlist_item(playlist_mbid):
 
 
 @playlist_api_bp.route("/<playlist_mbid>/item/delete", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def delete_playlist_item(playlist_mbid):
@@ -614,7 +614,7 @@ def delete_playlist_item(playlist_mbid):
 
 
 @playlist_api_bp.route("/<playlist_mbid>/delete", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def delete_playlist(playlist_mbid):
@@ -652,7 +652,7 @@ def delete_playlist(playlist_mbid):
 
 
 @playlist_api_bp.route("/<playlist_mbid>/copy", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def copy_playlist(playlist_mbid):

--- a/listenbrainz/webserver/views/recommendations_cf_recording_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_api.py
@@ -21,7 +21,7 @@ class RecommendationArtistType(Enum):
 
 
 @recommendations_cf_recording_api_bp.route("/user/<user_name>/recording")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_recommendations(user_name):
     """ Get recommendations sorted on rating and ratings for user ``user_name``.

--- a/listenbrainz/webserver/views/recommendations_cf_recording_feedback_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_feedback_api.py
@@ -26,7 +26,7 @@ recommendation_feedback_api_bp = Blueprint('recommendation_feedback_api_v1', __n
 
 
 @recommendation_feedback_api_bp.route("submit", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def submit_recommendation_feedback():
     """
@@ -75,7 +75,7 @@ def submit_recommendation_feedback():
 
 
 @recommendation_feedback_api_bp.route("delete", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def delete_recommendation_feedback():
     """
@@ -120,7 +120,7 @@ def delete_recommendation_feedback():
 
 
 @recommendation_feedback_api_bp.route("/user/<user_name>", methods=["GET"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_feedback_for_user(user_name):
     """
@@ -192,7 +192,7 @@ def get_feedback_for_user(user_name):
 
 
 @recommendation_feedback_api_bp.route("/user/<user_name>/recordings", methods=["GET"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_feedback_for_recordings_for_user(user_name):
     """

--- a/listenbrainz/webserver/views/social_api.py
+++ b/listenbrainz/webserver/views/social_api.py
@@ -12,7 +12,7 @@ social_api_bp = Blueprint('social_api_v1', __name__)
 
 
 @social_api_bp.route("/user/<user_name>/followers", methods=["GET", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_followers(user_name: str):
     """
@@ -44,7 +44,7 @@ def get_followers(user_name: str):
 
 
 @social_api_bp.route("/user/<user_name>/following", methods=["GET", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_following(user_name: str):
     """
@@ -76,7 +76,7 @@ def get_following(user_name: str):
 
 
 @social_api_bp.route("/user/<user_name>/follow", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def follow_user(user_name: str):
     """
@@ -114,7 +114,7 @@ def follow_user(user_name: str):
 
 
 @social_api_bp.route("/user/<user_name>/unfollow", methods=["POST", "OPTIONS"])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def unfollow_user(user_name: str):
     """

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -29,7 +29,7 @@ stats_api_bp = Blueprint('stats_api_v1', __name__)
 
 
 @stats_api_bp.route("/user/<user_name>/artists")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_user_artist(user_name):
     """
@@ -92,7 +92,7 @@ def get_user_artist(user_name):
 
 
 @stats_api_bp.route("/user/<user_name>/releases")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_release(user_name):
     """
@@ -161,7 +161,7 @@ def get_release(user_name):
 
 
 @stats_api_bp.route("/user/<user_name>/recordings")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_recording(user_name):
     """
@@ -253,7 +253,7 @@ def _get_entity_stats(user_name: str, entity: str, count_key: str):
 
 
 @stats_api_bp.route("/user/<user_name>/listening-activity")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_listening_activity(user_name: str):
     """
@@ -328,7 +328,7 @@ def get_listening_activity(user_name: str):
 
 
 @stats_api_bp.route("/user/<user_name>/daily-activity")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_daily_activity(user_name: str):
     """
@@ -413,7 +413,7 @@ def get_daily_activity(user_name: str):
 
 
 @stats_api_bp.route("/user/<user_name>/artist-map")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_artist_map(user_name: str):
     """
@@ -480,7 +480,7 @@ def get_artist_map(user_name: str):
 
 
 @stats_api_bp.route("/sitewide/artists")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_sitewide_artist():
     """
@@ -538,7 +538,7 @@ def get_sitewide_artist():
 
 
 @stats_api_bp.route("/sitewide/releases")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_sitewide_release():
     """
@@ -606,7 +606,7 @@ def get_sitewide_release():
 
 
 @stats_api_bp.route("/sitewide/recordings")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_sitewide_recording():
     """
@@ -698,7 +698,7 @@ def _get_sitewide_stats(entity: str):
 
 
 @stats_api_bp.route("/sitewide/listening-activity")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_sitewide_listening_activity():
     """
@@ -771,7 +771,7 @@ def get_sitewide_listening_activity():
 
 
 @stats_api_bp.route("/sitewide/artist-map")
-@crossdomain()
+@crossdomain
 @ratelimit()
 def get_sitewide_artist_map():
     """

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -50,7 +50,7 @@ user_timeline_event_api_bp = Blueprint('user_timeline_event_api_bp', __name__)
 
 
 @user_timeline_event_api_bp.route('/user/<user_name>/timeline-event/create/recording', methods=['POST', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def create_user_recording_recommendation_event(user_name):
     """ Make the user recommend a recording to their followers.
@@ -104,7 +104,7 @@ def create_user_recording_recommendation_event(user_name):
 
 
 @user_timeline_event_api_bp.route('/user/<user_name>/timeline-event/create/notification', methods=['POST', 'OPTIONS'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def create_user_notification_event(user_name):
     """ Post a message with a link on a user's timeline. Only approved users are allowed to perform this action.
@@ -156,7 +156,7 @@ def create_user_notification_event(user_name):
 
 
 @user_timeline_event_api_bp.route('/user/<user_name>/feed/events', methods=['OPTIONS', 'GET'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 @api_listenstore_needed
 def user_feed(user_name: str):
@@ -237,7 +237,7 @@ def user_feed(user_name: str):
 
 
 @user_timeline_event_api_bp.route("/user/<user_name>/feed/events/delete", methods=['OPTIONS', 'POST'])
-@crossdomain()
+@crossdomain
 @ratelimit()
 def delete_feed_events(user_name):
     '''


### PR DESCRIPTION
The @crossdomain decorators takes many parameters as input which we never use. We had copied it from the popular CORS snippet at some point. Since then some flask internal behaviour with regards to automatic options has changed as well. In any case, we do not see a use to maintain this complexity so removing all args and always use fixed set of constants. For methods, determine it from flask.