### PR TITLE
Allow multiple alpha values for request_model job

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -244,7 +244,7 @@ def parse_list(ctx, args):
 @click.option("--rank", callback=parse_list, default=[100, 120], type=int, multiple=True, help="Number of hidden features")
 @click.option("--itr", callback=parse_list, default=[5, 10], type=int, multiple=True, help="Number of iterations to run.")
 @click.option("--lmbda", callback=parse_list, default=[0.1, 10.0], type=float, multiple=True, help="Controls over fitting.")
-@click.option("--alpha", default=3.0, type=float, help="Baseline level of confidence weighting applied.")
+@click.option("--alpha", callback=parse_list, default=[3.0], type=float, help="Baseline level of confidence weighting applied.")
 def request_model(rank, itr, lmbda, alpha):
     """ Send the cluster a request to train the model.
 

--- a/listenbrainz/spark/test_request_manage.py
+++ b/listenbrainz/spark/test_request_manage.py
@@ -144,7 +144,7 @@ class RequestManageTestCase(unittest.TestCase):
                 'ranks': [1, 2],
                 'lambdas': [2.0, 3.0],
                 'iterations': [2, 3],
-                'alpha': 3.0,
+                'alpha': [3.0],
             }
         }
         expected_message = ujson.dumps(message)

--- a/listenbrainz_spark/recommendations/recording/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_models.py
@@ -133,7 +133,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
         ranks = [3]
         lambdas = [4.8]
         iterations = [2]
-        alpha = 3.0
+        alpha = [3.0]
         mock_rmse.return_value = 6.999
         best_model, model_metadata = train_models.get_best_model(mock_rdd_training, mock_rdd_validation, num_validation,
                                                                  ranks, lambdas, iterations, alpha)

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -177,7 +177,7 @@ def train(training_data, rank, iteration, lmbda, alpha, model_id):
         raise
 
 
-def get_best_model(training_data, validation_data, num_validation, ranks, lambdas, iterations, alpha):
+def get_best_model(training_data, validation_data, num_validation, ranks, lambdas, iterations, alphas):
     """ Train models and get the best model.
 
         Args:
@@ -187,7 +187,7 @@ def get_best_model(training_data, validation_data, num_validation, ranks, lambda
             ranks (list): Number of factors in ALS model.
             lambdas (list): Controls regularization.
             iterations (list): Number of iterations to run.
-            alpha (float): Baseline level of confidence weighting applied.
+            alphas (list): Baseline level of confidence weighting applied.
 
         Returns:
             best_model: Model with least RMSE value.
@@ -197,7 +197,7 @@ def get_best_model(training_data, validation_data, num_validation, ranks, lambda
     best_model_metadata = defaultdict(dict)
     model_metadata = list()
 
-    for rank, lmbda, iteration in itertools.product(ranks, lambdas, iterations):
+    for rank, lmbda, iteration, alpha in itertools.product(ranks, lambdas, iterations, alphas):
         model_id = generate_model_id()
 
         t0 = time.monotonic()


### PR DESCRIPTION
Allowing multiple values let us compare multiple models and know which params work better.