### PR TITLE
BrainzPlayer: Warn before closing page if BrainzPlayer is playing

### DIFF
--- a/listenbrainz/webserver/static/js/src/brainzplayer/BrainzPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/BrainzPlayer.tsx
@@ -180,7 +180,7 @@ export default class BrainzPlayer extends React.Component<
   componentDidMount = () => {
     window.addEventListener("storage", this.onLocalStorageEvent);
     window.addEventListener("message", this.receiveBrainzPlayerMessage);
-
+    window.addEventListener("beforeunload", this.alertBeforeClosingPage);
     // Remove SpotifyPlayer if the user doesn't have the relevant permissions to use it
     const { spotifyAuth } = this.context;
     if (
@@ -194,7 +194,21 @@ export default class BrainzPlayer extends React.Component<
   componentWillUnMount = () => {
     window.removeEventListener("storage", this.onLocalStorageEvent);
     window.removeEventListener("message", this.receiveBrainzPlayerMessage);
+    window.removeEventListener("beforeunload", this.alertBeforeClosingPage);
     this.stopPlayerStateTimer();
+  };
+
+  alertBeforeClosingPage = (event: BeforeUnloadEvent) => {
+    const { playerPaused } = this.state;
+    if (!playerPaused) {
+      // Some old browsers may allow to set a custom message, but this is deprecated.
+      event.preventDefault();
+      // eslint-disable-next-line no-param-reassign
+      event.returnValue = `You are currently playing music from this page.
+      Are you sure you want to close it? Playback will be stopped.`;
+      return event.returnValue;
+    }
+    return null;
   };
 
   receiveBrainzPlayerMessage = (event: MessageEvent) => {


### PR DESCRIPTION
Closing the page or navigating by mistake will stop music playback, which is pretty bad user experience.
[A user has suggested](https://community.metabrainz.org/t/introducing-the-new-listenbrainz-player/576230/3?u=mr_monkey) prompting before closing/navigating, which will also make sense when we have a SPA.