### PR TITLE
Fix ON CONFLICT clause for spotify reader

### DIFF
--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -32,7 +32,8 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
                 access_token = EXCLUDED.access_token,
                 refresh_token = EXCLUDED.refresh_token,
                 token_expires = EXCLUDED.token_expires,
-                scopes = EXCLUDED.scopes
+                scopes = EXCLUDED.scopes,
+                last_updated = NOW()
             RETURNING id
             """), {
                 "user_id": user_id,
@@ -53,7 +54,10 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
                 ON CONFLICT (user_id, service) DO UPDATE SET
                     external_service_oauth_id = EXCLUDED.external_service_oauth_id,
                     user_id = EXCLUDED.user_id,
-                    service = EXCLUDED.service
+                    service = EXCLUDED.service,
+                    last_updated = NULL,
+                    latest_listened_at = NULL,
+                    error_message = NULL
                 """), {
                 "external_service_oauth_id": external_service_oauth_id,
                 "user_id": user_id,

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -18,6 +18,13 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
         record_listens: True if user wishes to import listens, False otherwise
         scopes: the oauth scopes
     """
+    # regardless of whether a row is inserted or updated, the end result of the query
+    # should remain the same. if not so, weird things can happen as it is likely we
+    # assume the defaults exist for new users while writing code elsewhere.
+    # due to this reason, we update all columns in UPDATE section of following queries
+    # to use the new values. any column which does not have a new value to be set should
+    # be explicitly set to the default value (which would have been used if the row was
+    # inserted instead).
     token_expires = utils.unix_timestamp_to_datetime(token_expires_ts)
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime, timezone
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.db.testing import DatabaseTestCase
@@ -43,6 +44,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
          overwrites existing one without crash. """
         # one time already saved in db by setup method
         # second time here
+        time_before_update = datetime.now(timezone.utc)
         db_oauth.save_token(
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
@@ -54,6 +56,11 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         )
         user = db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual(user['access_token'], 'new_token')
+        # also check that last_updated column is updated, if it is the last_updated in db
+        # will be >= than the one we saved just before the 2nd update. if its lesser, then
+        # the last updated in the db is still of 1st update and the 2nd update didn't update
+        # last_updated column
+        self.assertGreater(user['last_updated'], time_before_update)
 
     def test_update_token(self):
         db_oauth.update_token(


### PR DESCRIPTION
We added the ON CONFLICT clause in #1897. However, forgot to reset some columns in case of UPDATE. If inserting, these columns are set to their defaults but in case of UPDATE the old values are kept. This is wrong because it will not clear the error_message due to which such users may not be reselected for updating listens.

It is essential that INSERT and UPDATE behave the same way otherwise the spotify_reader code may not work correctly and we'll have to add further cases. To fix this issue, set all remaining columns to their defaults in the update clause.
