### PR TITLE
Reports world map: Show tooltip on click instead of hover

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/Choropleth.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/Choropleth.tsx
@@ -1,12 +1,22 @@
 import { Theme } from "@nivo/core";
-import { Choropleth } from "@nivo/geo";
+import {
+  Choropleth,
+  ChoroplethBoundFeature,
+  ChoroplethEventHandler,
+} from "@nivo/geo";
 import { BoxLegendSvg, LegendProps } from "@nivo/legends";
 import { Chip } from "@nivo/tooltip";
 import { scaleThreshold } from "d3-scale";
 import { schemeOranges } from "d3-scale-chromatic";
 import { format } from "d3-format";
 import { maxBy } from "lodash";
-import * as React from "react";
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useEffect,
+  useRef,
+} from "react";
 import { useMediaQuery } from "react-responsive";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
@@ -20,6 +30,12 @@ export type ChoroplethProps = {
 };
 
 export default function CustomChoropleth(props: ChoroplethProps) {
+  const [tooltipPosition, setTooltipPosition] = useState([0, 0]);
+  const [selectedCountry, setSelectedCountry] = useState<
+    ChoroplethBoundFeature
+  >();
+  const refContainer = useRef<HTMLDivElement>(null);
+
   const isMobile = useMediaQuery({ maxWidth: 767 });
 
   const commonLegendProps = {
@@ -27,6 +43,7 @@ export default function CustomChoropleth(props: ChoroplethProps) {
     direction: "column",
     itemDirection: "left-to-right",
     itemOpacity: 0.85,
+    itemWidth: 90,
     effects: [
       {
         on: "hover",
@@ -40,7 +57,6 @@ export default function CustomChoropleth(props: ChoroplethProps) {
 
   const legends = {
     desktop: {
-      itemWidth: 90,
       itemHeight: 18,
       symbolSize: 18,
       translateX: 50,
@@ -48,7 +64,6 @@ export default function CustomChoropleth(props: ChoroplethProps) {
       ...commonLegendProps,
     } as LegendProps,
     mobile: {
-      itemWidth: 90,
       itemHeight: 10,
       symbolSize: 10,
       translateX: 20,
@@ -78,9 +93,9 @@ export default function CustomChoropleth(props: ChoroplethProps) {
   };
 
   const { data } = props;
-  let { width } = props;
-  width = width || 1200; // Set default width to 1200
-  const height = width / 2;
+  const { width } = props;
+  const containerWidth = width || 1200; // Set default width to 1200
+  const containerHeight = containerWidth / 2;
 
   // Calculate logarithmic domain
   const domain = (() => {
@@ -103,8 +118,8 @@ export default function CustomChoropleth(props: ChoroplethProps) {
   // Create a custom legend component because the default doesn't work with scaleThreshold
   const CustomLegend = () => (
     <BoxLegendSvg
-      containerHeight={height}
-      containerWidth={width!}
+      containerHeight={containerHeight}
+      containerWidth={containerWidth}
       data={colorScale.range().map((color, index) => {
         // eslint-disable-next-line prefer-const
         let [start, end] = colorScale.invertExtent(color);
@@ -125,18 +140,19 @@ export default function CustomChoropleth(props: ChoroplethProps) {
       {...(isMobile ? legends.mobile : legends.desktop)}
     />
   );
+  const tooltipWidth = 250;
 
-  const CustomTooltip = ({ feature }: { feature: any }) => {
-    if (feature.data === undefined) {
+  const customTooltip = useMemo(() => {
+    if (!selectedCountry?.data) {
       return null;
     }
 
     const { selectedMetric } = props;
     let suffix = `${selectedMetric[0].toUpperCase()}${selectedMetric.slice(1)}`;
-    if (feature.formattedValue !== "1") {
+    if (Number(selectedCountry.formattedValue) !== 1) {
       suffix = `${suffix}s`;
     }
-    const { artists } = feature.data;
+    const { artists } = selectedCountry.data;
 
     return (
       <div
@@ -147,20 +163,20 @@ export default function CustomChoropleth(props: ChoroplethProps) {
           borderRadius: "2px",
           boxShadow: "0 1px 2px rgba(0, 0, 0, 0.25)",
           padding: "5px 9px",
+          maxWidth: `${tooltipWidth}px`,
         }}
       >
         <div
           style={{
-            whiteSpace: "pre",
             display: "flex",
             alignItems: "center",
           }}
         >
-          <Chip color={feature.color!} style={{ marginRight: 7 }} />
+          <Chip color={selectedCountry.color!} style={{ marginRight: 7 }} />
           <span>
-            {feature.label}:{" "}
+            {selectedCountry.label}:{" "}
             <strong>
-              {feature.formattedValue} {suffix}
+              {selectedCountry.formattedValue} {suffix}
             </strong>
           </span>
         </div>
@@ -174,7 +190,11 @@ export default function CustomChoropleth(props: ChoroplethProps) {
               />
               {artist.listen_count}
             </span>
-            <a href={`https://musicbrainz.org/artist/${artist.artist_mbid}`}>
+            <a
+              href={`https://musicbrainz.org/artist/${artist.artist_mbid}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {artist.artist_name}
             </a>
             <br />
@@ -182,31 +202,85 @@ export default function CustomChoropleth(props: ChoroplethProps) {
         ))}
       </div>
     );
-  };
+  }, [selectedCountry]);
+
+  // Hide our custom tooltip when user clicks somewhere that isn't a country
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      setSelectedCountry(undefined);
+    },
+    [setSelectedCountry]
+  );
+
+  useEffect(() => {
+    document.addEventListener("click", handleClickOutside, true);
+    return () => {
+      document.removeEventListener("click", handleClickOutside, true);
+    };
+  });
+
+  const showTooltipFromEvent: ChoroplethEventHandler = useCallback(
+    (feature, event: React.MouseEvent<HTMLElement>) => {
+      // Cancel other events, such as our handleClickOutside defined above
+      event.preventDefault();
+      // relative mouse position
+      let x = event.clientX;
+      let y = event.clientY;
+      if (refContainer.current) {
+        // Make position relative to parent container
+        const bounds = refContainer.current.getBoundingClientRect();
+        x -= bounds.left;
+        y -= bounds.top;
+        // Show tooltip on the left if there isn't enough space
+        if (x > bounds.width - tooltipWidth) x -= tooltipWidth / 2;
+      }
+      setTooltipPosition([x, y]);
+      setSelectedCountry(feature);
+    },
+    [setSelectedCountry, setTooltipPosition]
+  );
 
   return (
-    <Choropleth
-      data={data}
-      width={width}
-      height={height}
-      features={worldCountries.features}
-      margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-      colors={colorScale}
-      domain={domain}
-      theme={isMobile ? themes.mobile : themes.desktop}
-      valueFormat=".2~s"
-      tooltip={CustomTooltip}
-      unknownColor="#efefef"
-      label="properties.name"
-      projectionScale={width / 5.5}
-      projectionType="naturalEarth1"
-      projectionTranslation={[0.5, 0.53]}
-      borderWidth={0.5}
-      borderColor="#152538"
-      // The typescript definition file for Choropleth is incomplete, so disable typescript
-      // until it is fixed.
-      // @ts-ignore
-      layers={["features", CustomLegend]}
-    />
+    <div ref={refContainer} style={{ position: "relative" }}>
+      <Choropleth
+        data={data}
+        width={containerWidth}
+        height={containerHeight}
+        features={worldCountries.features}
+        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+        colors={colorScale}
+        domain={domain}
+        theme={isMobile ? themes.mobile : themes.desktop}
+        valueFormat=".2~s"
+        // We can't set isInteractive to false (need onClick event)
+        // But we don't want to show a tooltip, so this function returns an empty element
+        tooltip={() => <></>}
+        onClick={showTooltipFromEvent}
+        unknownColor="#efefef"
+        label="properties.name"
+        projectionScale={containerWidth / 5.5}
+        projectionType="naturalEarth1"
+        projectionTranslation={[0.5, 0.53]}
+        borderWidth={0.5}
+        borderColor="#152538"
+        // The typescript definition file for Choropleth is incomplete, so disable typescript
+        // until it is fixed.
+        // @ts-ignore
+        layers={["features", CustomLegend]}
+      />
+      {selectedCountry && (
+        <div
+          style={{
+            transform: `translate(${tooltipPosition[0]}px, ${tooltipPosition[1]}px)`,
+            position: "absolute",
+            zIndex: 10,
+            top: "0px",
+            left: "0px",
+          }}
+        >
+          {customTooltip}
+        </div>
+      )}
+    </div>
   );
 }

--- a/listenbrainz/webserver/static/js/src/stats/Choropleth.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/Choropleth.tsx
@@ -10,18 +10,14 @@ import { scaleThreshold } from "d3-scale";
 import { schemeOranges } from "d3-scale-chromatic";
 import { format } from "d3-format";
 import { maxBy } from "lodash";
-import React, {
-  useState,
-  useCallback,
-  useMemo,
-  useEffect,
-  useRef,
-} from "react";
+import * as React from "react";
 import { useMediaQuery } from "react-responsive";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { faHeadphones } from "@fortawesome/free-solid-svg-icons";
 import * as worldCountries from "../../tests/__mocks__/world_countries.json";
+
+const { useState, useCallback, useMemo, useEffect, useRef } = React;
 
 export type ChoroplethProps = {
   data: UserArtistMapData;

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -179,6 +179,7 @@ export default class UserArtistMap extends React.Component<
             className="col-md-2 col-xs-4 text-right"
             style={{ marginTop: 20 }}
           >
+            <span>Rank by</span>
             <span className="dropdown">
               <button
                 className="dropdown-toggle btn-transparent capitalize-bold"
@@ -189,7 +190,9 @@ export default class UserArtistMap extends React.Component<
                 <span className="caret" />
               </button>
               <ul className="dropdown-menu" role="menu">
-                <li>
+                <li
+                  className={selectedMetric === "listen" ? "active" : undefined}
+                >
                   <a
                     href=""
                     role="button"
@@ -197,10 +200,12 @@ export default class UserArtistMap extends React.Component<
                       this.changeSelectedMetric("listen", event)
                     }
                   >
-                    number of listens
+                    Listens
                   </a>
                 </li>
-                <li>
+                <li
+                  className={selectedMetric === "artist" ? "active" : undefined}
+                >
                   <a
                     href=""
                     role="button"
@@ -208,7 +213,7 @@ export default class UserArtistMap extends React.Component<
                       this.changeSelectedMetric("artist", event)
                     }
                   >
-                    number of artists
+                    Artists
                   </a>
                 </li>
               </ul>

--- a/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
+++ b/listenbrainz/webserver/static/js/src/stats/UserArtistMap.tsx
@@ -170,8 +170,9 @@ export default class UserArtistMap extends React.Component<
       >
         <div className="row">
           <div className="col-md-9 col-xs-6">
-            <h3 className="capitalize-bold" style={{ marginLeft: 20 }}>
-              Artist Origins
+            <h3 style={{ marginLeft: 20 }}>
+              <span className="capitalize-bold">Artist Origins</span>
+              <small>&nbsp;Click on a country to see more details</small>
             </h3>
           </div>
           <div
@@ -196,7 +197,7 @@ export default class UserArtistMap extends React.Component<
                       this.changeSelectedMetric("listen", event)
                     }
                   >
-                    Listens
+                    number of listens
                   </a>
                 </li>
                 <li>
@@ -207,7 +208,7 @@ export default class UserArtistMap extends React.Component<
                       this.changeSelectedMetric("artist", event)
                     }
                   >
-                    Artists
+                    number of artists
                   </a>
                 </li>
               </ul>

--- a/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserArtistMap.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserArtistMap.test.tsx.snap
@@ -53,6 +53,9 @@ exports[`Sitewide Stats UserArtistMap renders corectly when range is invalid 1`]
             }
           }
         >
+          <span>
+            Rank by
+          </span>
           <span
             className="dropdown"
           >
@@ -77,16 +80,18 @@ exports[`Sitewide Stats UserArtistMap renders corectly when range is invalid 1`]
                   onClick={[Function]}
                   role="button"
                 >
-                  number of listens
+                  Listens
                 </a>
               </li>
-              <li>
+              <li
+                className="active"
+              >
                 <a
                   href=""
                   onClick={[Function]}
                   role="button"
                 >
-                  number of artists
+                  Artists
                 </a>
               </li>
             </ul>
@@ -287,6 +292,9 @@ exports[`Sitewide Stats UserArtistMap renders correctly 1`] = `
         }
       }
     >
+      <span>
+        Rank by
+      </span>
       <span
         className="dropdown"
       >
@@ -311,16 +319,18 @@ exports[`Sitewide Stats UserArtistMap renders correctly 1`] = `
               onClick={[Function]}
               role="button"
             >
-              number of listens
+              Listens
             </a>
           </li>
-          <li>
+          <li
+            className="active"
+          >
             <a
               href=""
               onClick={[Function]}
               role="button"
             >
-              number of artists
+              Artists
             </a>
           </li>
         </ul>
@@ -569,6 +579,9 @@ exports[`User Stats UserArtistMap renders corectly when range is invalid 1`] = `
             }
           }
         >
+          <span>
+            Rank by
+          </span>
           <span
             className="dropdown"
           >
@@ -593,16 +606,18 @@ exports[`User Stats UserArtistMap renders corectly when range is invalid 1`] = `
                   onClick={[Function]}
                   role="button"
                 >
-                  number of listens
+                  Listens
                 </a>
               </li>
-              <li>
+              <li
+                className="active"
+              >
                 <a
                   href=""
                   onClick={[Function]}
                   role="button"
                 >
-                  number of artists
+                  Artists
                 </a>
               </li>
             </ul>
@@ -803,6 +818,9 @@ exports[`User Stats UserArtistMap renders correctly 1`] = `
         }
       }
     >
+      <span>
+        Rank by
+      </span>
       <span
         className="dropdown"
       >
@@ -827,16 +845,18 @@ exports[`User Stats UserArtistMap renders correctly 1`] = `
               onClick={[Function]}
               role="button"
             >
-              number of listens
+              Listens
             </a>
           </li>
-          <li>
+          <li
+            className="active"
+          >
             <a
               href=""
               onClick={[Function]}
               role="button"
             >
-              number of artists
+              Artists
             </a>
           </li>
         </ul>

--- a/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserArtistMap.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/stats/__snapshots__/UserArtistMap.test.tsx.snap
@@ -29,14 +29,20 @@ exports[`Sitewide Stats UserArtistMap renders corectly when range is invalid 1`]
           className="col-md-9 col-xs-6"
         >
           <h3
-            className="capitalize-bold"
             style={
               Object {
                 "marginLeft": 20,
               }
             }
           >
-            Artist Origins
+            <span
+              className="capitalize-bold"
+            >
+              Artist Origins
+            </span>
+            <small>
+               Click on a country to see more details
+            </small>
           </h3>
         </div>
         <div
@@ -71,7 +77,7 @@ exports[`Sitewide Stats UserArtistMap renders corectly when range is invalid 1`]
                   onClick={[Function]}
                   role="button"
                 >
-                  Listens
+                  number of listens
                 </a>
               </li>
               <li>
@@ -80,7 +86,7 @@ exports[`Sitewide Stats UserArtistMap renders corectly when range is invalid 1`]
                   onClick={[Function]}
                   role="button"
                 >
-                  Artists
+                  number of artists
                 </a>
               </li>
             </ul>
@@ -257,14 +263,20 @@ exports[`Sitewide Stats UserArtistMap renders correctly 1`] = `
       className="col-md-9 col-xs-6"
     >
       <h3
-        className="capitalize-bold"
         style={
           Object {
             "marginLeft": 20,
           }
         }
       >
-        Artist Origins
+        <span
+          className="capitalize-bold"
+        >
+          Artist Origins
+        </span>
+        <small>
+           Click on a country to see more details
+        </small>
       </h3>
     </div>
     <div
@@ -299,7 +311,7 @@ exports[`Sitewide Stats UserArtistMap renders correctly 1`] = `
               onClick={[Function]}
               role="button"
             >
-              Listens
+              number of listens
             </a>
           </li>
           <li>
@@ -308,7 +320,7 @@ exports[`Sitewide Stats UserArtistMap renders correctly 1`] = `
               onClick={[Function]}
               role="button"
             >
-              Artists
+              number of artists
             </a>
           </li>
         </ul>
@@ -533,14 +545,20 @@ exports[`User Stats UserArtistMap renders corectly when range is invalid 1`] = `
           className="col-md-9 col-xs-6"
         >
           <h3
-            className="capitalize-bold"
             style={
               Object {
                 "marginLeft": 20,
               }
             }
           >
-            Artist Origins
+            <span
+              className="capitalize-bold"
+            >
+              Artist Origins
+            </span>
+            <small>
+               Click on a country to see more details
+            </small>
           </h3>
         </div>
         <div
@@ -575,7 +593,7 @@ exports[`User Stats UserArtistMap renders corectly when range is invalid 1`] = `
                   onClick={[Function]}
                   role="button"
                 >
-                  Listens
+                  number of listens
                 </a>
               </li>
               <li>
@@ -584,7 +602,7 @@ exports[`User Stats UserArtistMap renders corectly when range is invalid 1`] = `
                   onClick={[Function]}
                   role="button"
                 >
-                  Artists
+                  number of artists
                 </a>
               </li>
             </ul>
@@ -761,14 +779,20 @@ exports[`User Stats UserArtistMap renders correctly 1`] = `
       className="col-md-9 col-xs-6"
     >
       <h3
-        className="capitalize-bold"
         style={
           Object {
             "marginLeft": 20,
           }
         }
       >
-        Artist Origins
+        <span
+          className="capitalize-bold"
+        >
+          Artist Origins
+        </span>
+        <small>
+           Click on a country to see more details
+        </small>
       </h3>
     </div>
     <div
@@ -803,7 +827,7 @@ exports[`User Stats UserArtistMap renders correctly 1`] = `
               onClick={[Function]}
               role="button"
             >
-              Listens
+              number of listens
             </a>
           </li>
           <li>
@@ -812,7 +836,7 @@ exports[`User Stats UserArtistMap renders correctly 1`] = `
               onClick={[Function]}
               role="button"
             >
-              Artists
+              number of artists
             </a>
           </li>
         </ul>


### PR DESCRIPTION
The standard tooltips used in nivo components, including Choropleth (the world map we have on user reports page, only work on hovering over a country.
This prevents users from clicking the links to artists as the tooltip disappears when the mouse moves.

I also threw in some very minor refactoring (no change in functionality) while I was in there.


Instead of using the tooltip property to pass a custom tooltip component, we'll render and place said custom component ourselves !
This allows us to bind this to an onClick event (as opposed to onMouseEnter etc.) and listen to clicks on the outside to hide it.

This will look the same as currently deployed, but trust me, links are clickable now !
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/6179856/158877590-105b551a-b377-4364-a947-fe061de813c7.png">

