### PR TITLE
Fix "does nothing if datasource already submits listens" test

### DIFF
--- a/listenbrainz/webserver/static/js/tests/brainzplayer/BrainzPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/brainzplayer/BrainzPlayer.test.tsx
@@ -645,12 +645,8 @@ describe("BrainzPlayer", () => {
       expect(ds).toBeInstanceOf(SpotifyPlayer);
       // GlobalContextMock.spotifyAuth includes permissions suggesting LB records Spotify listens already
       expect(ds.datasourceRecordsListens()).toBeTruthy();
-      const submitListensAPISpy = jest.spyOn(
-        instance.context.APIService,
-        "submitListens"
-      );
       await instance.submitListenToListenBrainz("single", listen);
-      expect(submitListensAPISpy).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it("submits a playing_now with the expected metadata", async () => {


### PR DESCRIPTION
While investigating LFM importer issues, I was looking into usage of APIService.submitListens. I saw BP is no longer using it but one of it tests incorrectly spies on it. Fix the test by checking fetchMock instead.