### PR TITLE
Cancel in progress jobs if new commit is pushed

### DIFF
--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -15,6 +15,10 @@ on:
       - '**.md'
       - 'docs/**'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   prod:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -16,6 +16,10 @@ on:
       - 'docker/docker-compose.test.yml'
       - 'test.sh'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   test:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,10 @@ on:
       - '**.less'
       - '**.md'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   test:

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -13,6 +13,10 @@ on:
       - 'docker/docker-compose.spark*.yml'
       - 'test.sh'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   test:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,6 +19,10 @@ on:
       - '**.less'
       - '**.md'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   test:


### PR DESCRIPTION
In almost all cases, we don't need the existing to complete if a new commit is pushed so cancel those.

As documented here: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow