### PR TITLE
Simplify dump exception handling

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -669,54 +669,18 @@ def import_postgres_dump(private_dump_archive_path=None,
     """
 
     if private_dump_archive_path:
-        current_app.logger.info(
-            'Importing private dump %s...', private_dump_archive_path)
-        try:
-            _import_dump(private_dump_archive_path,
-                         db.engine, PRIVATE_TABLES, db.SCHEMA_VERSION_CORE, threads)
-            current_app.logger.info(
-                'Import of private dump %s done!', private_dump_archive_path)
-        except IOError as e:
-            current_app.logger.critical(
-                'IOError while importing private dump: %s', str(e), exc_info=True)
-            raise
-        except SchemaMismatchException as e:
-            current_app.logger.critical(
-                'SchemaMismatchException: %s', str(e), exc_info=True)
-            raise
-        except Exception as e:
-            current_app.logger.critical(
-                'Error while importing private dump: %s', str(e), exc_info=True)
-            raise
-        current_app.logger.info(
-            'Private dump %s imported!', private_dump_archive_path)
+        current_app.logger.info('Importing private dump %s...', private_dump_archive_path)
+        _import_dump(private_dump_archive_path, db.engine, PRIVATE_TABLES, db.SCHEMA_VERSION_CORE, threads)
+        current_app.logger.info('Import of private dump %s done!', private_dump_archive_path)
 
     if private_timescale_dump_archive_path:
-        current_app.logger.info(
-            'Importing private timescale dump %s...', private_timescale_dump_archive_path)
-        try:
-            _import_dump(private_timescale_dump_archive_path,
-                         timescale.engine, PRIVATE_TABLES_TIMESCALE, timescale.SCHEMA_VERSION_TIMESCALE, threads)
-            current_app.logger.info(
-                'Import of private timescale dump %s done!', private_timescale_dump_archive_path)
-        except IOError as e:
-            current_app.logger.critical(
-                'IOError while importing private timescale dump: %s', str(e), exc_info=True)
-            raise
-        except SchemaMismatchException as e:
-            current_app.logger.critical(
-                'SchemaMismatchException: %s', str(e), exc_info=True)
-            raise
-        except Exception as e:
-            current_app.logger.critical(
-                'Error while importing private timescale dump: %s', str(e), exc_info=True)
-            raise
-        current_app.logger.info(
-            'Private timescale dump %s imported!', private_timescale_dump_archive_path)
+        current_app.logger.info('Importing private timescale dump %s...', private_timescale_dump_archive_path)
+        _import_dump(private_timescale_dump_archive_path, timescale.engine, PRIVATE_TABLES_TIMESCALE,
+                     timescale.SCHEMA_VERSION_TIMESCALE, threads)
+        current_app.logger.info('Import of private timescale dump %s done!', private_timescale_dump_archive_path)
 
     if public_dump_archive_path:
-        current_app.logger.info(
-            'Importing public dump %s...', public_dump_archive_path)
+        current_app.logger.info('Importing public dump %s...', public_dump_archive_path)
 
         tables_to_import = PUBLIC_TABLES_IMPORT.copy()
         if private_dump_archive_path:
@@ -725,49 +689,14 @@ def import_postgres_dump(private_dump_archive_path=None,
             # so remove it from tables_to_import
             del tables_to_import['"user"']
 
-        try:
-            _import_dump(public_dump_archive_path, db.engine,
-                         tables_to_import, db.SCHEMA_VERSION_CORE, threads)
-            current_app.logger.info(
-                'Import of Public dump %s done!', public_dump_archive_path)
-        except IOError as e:
-            current_app.logger.critical(
-                'IOError while importing public dump: %s', str(e), exc_info=True)
-            raise
-        except SchemaMismatchException as e:
-            current_app.logger.critical(
-                'SchemaMismatchException: %s', str(e), exc_info=True)
-            raise
-        except Exception as e:
-            current_app.logger.critical(
-                'Error while importing public dump: %s', str(e), exc_info=True)
-            raise
-        current_app.logger.info(
-            'Public dump %s imported!', public_dump_archive_path)
+        _import_dump(public_dump_archive_path, db.engine, tables_to_import, db.SCHEMA_VERSION_CORE, threads)
+        current_app.logger.info('Import of Public dump %s done!', public_dump_archive_path)
 
     if public_timescale_dump_archive_path:
-        current_app.logger.info(
-            'Importing public timescale dump %s...', public_timescale_dump_archive_path)
-
-        try:
-            _import_dump(public_timescale_dump_archive_path, timescale.engine,
-                         PUBLIC_TABLES_TIMESCALE_DUMP, timescale.SCHEMA_VERSION_TIMESCALE, threads)
-            current_app.logger.info(
-                'Import of Public timescale dump %s done!', public_timescale_dump_archive_path)
-        except IOError as e:
-            current_app.logger.critical(
-                'IOError while importing public timescale dump: %s', str(e), exc_info=True)
-            raise
-        except SchemaMismatchException as e:
-            current_app.logger.critical(
-                'SchemaMismatchException: %s', str(e), exc_info=True)
-            raise
-        except Exception as e:
-            current_app.logger.critical(
-                'Error while importing public timescale dump: %s', str(e), exc_info=True)
-            raise
-        current_app.logger.info(
-            'Public timescale dump %s imported!', public_timescale_dump_archive_path)
+        current_app.logger.info('Importing public timescale dump %s...', public_timescale_dump_archive_path)
+        _import_dump(public_timescale_dump_archive_path, timescale.engine, PUBLIC_TABLES_TIMESCALE_DUMP,
+                     timescale.SCHEMA_VERSION_TIMESCALE, threads)
+        current_app.logger.info('Import of Public timescale dump %s done!', public_timescale_dump_archive_path)
 
     try:
         current_app.logger.info("Creating sequences")


### PR DESCRIPTION
No need to catch different exceptions in separate catch blocks for the same action. Actually, no need for a catch block at all since we do only log and re-raise the error. Not doing this would let the error propagate and be logged anyway. While unlikely this code will ever be used in production, I also tested sentry integration. Uncaught errors are logged to sentry.
