### PR TITLE
Separate timescale db dumps from postgres db dumps

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -31,6 +31,7 @@ import tempfile
 import traceback
 from datetime import datetime, timedelta
 from ftplib import FTP
+from typing import Tuple, Optional
 
 import sqlalchemy
 import ujson
@@ -230,7 +231,6 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
         Returns:
             a tuple: (path to private dump, path to public dump)
     """
-
     current_app.logger.info('Beginning dump of PostgreSQL database...')
     current_app.logger.info('dump path: %s', location)
 
@@ -252,6 +252,41 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
     current_app.logger.info(
         'Dump of private data created at %s!', private_dump)
 
+    current_app.logger.info('Creating dump of public data...')
+    try:
+        public_dump = create_public_dump(location, dump_time, threads)
+    except IOError as e:
+        current_app.logger.critical(
+            'IOError while creating public dump: %s', str(e), exc_info=True)
+        current_app.logger.info('Removing created files and giving up...')
+        shutil.rmtree(location)
+        return
+    except Exception as e:
+        current_app.logger.critical(
+            'Unable to create public dump due to error %s', str(e), exc_info=True)
+        current_app.logger.info('Removing created files and giving up...')
+        shutil.rmtree(location)
+        return
+
+    current_app.logger.info(
+        'ListenBrainz PostgreSQL data dump created at %s!', location)
+    return private_dump, public_dump
+
+
+def dump_timescale_db(location: str, dump_time: datetime = datetime.today(),
+                      threads: int = DUMP_DEFAULT_THREAD_COUNT) -> Optional[Tuple[str, str]]:
+    """ Create timescale database (excluding listens) dump in the specified location
+
+        Arguments:
+            location: Directory where the final dump will be stored
+            dump_time: datetime object representing when the dump was started
+            threads: Maximal number of threads to run during compression
+
+        Returns:
+            a tuple: (path to private dump, path to public dump)
+    """
+    current_app.logger.info('Beginning dump of Timescale database...')
+
     current_app.logger.info('Creating dump of timescale private data...')
     try:
         private_timescale_dump = create_private_timescale_dump(location, dump_time, threads)
@@ -269,22 +304,6 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
         return
     current_app.logger.info(
         'Dump of private timescale data created at %s!', private_timescale_dump)
-
-    current_app.logger.info('Creating dump of public data...')
-    try:
-        public_dump = create_public_dump(location, dump_time, threads)
-    except IOError as e:
-        current_app.logger.critical(
-            'IOError while creating public dump: %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
-    except Exception as e:
-        current_app.logger.critical(
-            'Unable to create public dump due to error %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
 
     current_app.logger.info('Creating dump of timescale public data...')
     try:
@@ -304,9 +323,7 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=None):
 
     current_app.logger.info('Dump of public timescale data created at %s!', public_timescale_dump)
 
-    current_app.logger.info(
-        'ListenBrainz PostgreSQL data dump created at %s!', location)
-    return private_dump, private_timescale_dump, public_dump, public_timescale_dump
+    return private_timescale_dump, public_timescale_dump
 
 
 def dump_feedback_for_spark(location, dump_time=datetime.today(), threads=None):

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -71,9 +71,10 @@ def send_dump_creation_notification(dump_name, dump_type):
               help="the ID of the ListenBrainz data dump")
 @click.option('--listen/--no-listen', 'do_listen_dump', default=True)
 @click.option('--spark/--no-spark', 'do_spark_dump', type=bool, default=True)
-@click.option('--db/--no-db', 'do_db_dump', type=bool, default=True,
-              help="flag indicating whether to create a full dump from the last entry in the dump table")
-def create_full(location, threads, dump_id, do_listen_dump: bool, do_spark_dump: bool, do_db_dump: bool):
+@click.option('--db/--no-db', 'do_db_dump', type=bool, default=True)
+@click.option('--timescale/--no-timescale', 'do_timescale_dump', type=bool, default=True)
+def create_full(location, threads, dump_id, do_listen_dump: bool, do_spark_dump: bool,
+                do_db_dump: bool, do_timescale_dump: bool):
     """ Create a ListenBrainz data dump which includes a private dump, a statistics dump
         and a dump of the actual listens from the listenstore.
 
@@ -83,7 +84,8 @@ def create_full(location, threads, dump_id, do_listen_dump: bool, do_spark_dump:
             dump_id (int): the ID of the ListenBrainz data dump
             do_listen_dump: If True, make a listens dump
             do_spark_dump: If True, make a spark listens dump
-            do_db_dump: If True, make a public/private postgres/timescale dump
+            do_db_dump: If True, make a public/private postgres dump
+            do_timescale_dump: If True, make a public/private timescale dump
     """
     app = create_app()
     with app.app_context():
@@ -107,7 +109,10 @@ def create_full(location, threads, dump_id, do_listen_dump: bool, do_spark_dump:
         expected_num_dumps = 0
         if do_db_dump:
             db_dump.dump_postgres_db(dump_path, end_time, threads)
-            expected_num_dumps += 4
+            expected_num_dumps += 2
+        if do_timescale_dump:
+            db_dump.dump_timescale_db(dump_path, end_time, threads)
+            expected_num_dumps += 2
         if do_listen_dump:
             ls.dump_listens(dump_path, dump_id=dump_id, end_time=end_time, threads=threads)
             expected_num_dumps += 1

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -34,6 +34,7 @@ from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.webserver import create_app
 from listenbrainz.db.model.feedback import Feedback
 
+
 class DumpTestCase(DatabaseTestCase):
 
     def setUp(self):
@@ -84,7 +85,7 @@ class DumpTestCase(DatabaseTestCase):
             self.assertEqual(user_count, 1)
 
             # do a db dump and reset the db
-            private_dump, private_ts_dump, public_dump, public_ts_dump = db_dump.dump_postgres_db(self.tempdir)
+            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir)
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)
@@ -122,7 +123,7 @@ class DumpTestCase(DatabaseTestCase):
             db_feedback.insert(feedback)
 
             # do a db dump and reset the db
-            private_dump, private_ts_dump, public_dump, public_ts_dump = db_dump.dump_postgres_db(self.tempdir)
+            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir)
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)


### PR DESCRIPTION
Often during maintenance and migrations, we only want to do backup dumps for timescale. So having an option to do only timescale dumps is useful.