### PR TITLE
Disable spotify error emails temporarily

### DIFF
--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -333,18 +333,18 @@ def process_one_user(user: dict, service: SpotifyService) -> int:
     except ExternalServiceInvalidGrantError:
         error_message = "It seems like you've revoked permission for us to read your spotify account"
         service.update_user_import_status(user_id=user['user_id'], error=error_message)
-        if not current_app.config['TESTING']:
-            notify_error(user['musicbrainz_id'], error_message)
+        # if not current_app.config['TESTING']:
+        #    notify_error(user['musicbrainz_id'], error_message)
         # user has revoked authorization through spotify ui or deleted their spotify account etc.
         # in any of these cases, we should delete the user's token from.
-        service.revoke_user(user['user_id'])
+        # service.revoke_user(user['user_id'])
         raise ExternalServiceError("User has revoked spotify authorization")
 
     except ExternalServiceAPIError as e:
         # if it is an error from the Spotify API, show the error message to the user
         service.update_user_import_status(user_id=user['user_id'], error=str(e))
-        if not current_app.config['TESTING']:
-            notify_error(user['musicbrainz_id'], str(e))
+        # if not current_app.config['TESTING']:
+        #    notify_error(user['musicbrainz_id'], str(e))
         raise ExternalServiceError("Could not refresh user token from spotify")
 
 


### PR DESCRIPTION
For when we run the recovery script, in case something goes wrong we do not want to spam users and also commenting the revoke method to not delete user tokens. The errors are still recorded in the database and sentry.

No need to merge, I'll deploy a version from the branch once approved.