### PR TITLE
Add Terms of Service page with Youtube and Google ToS links

### DIFF
--- a/listenbrainz/webserver/templates/index/terms-of-service.html
+++ b/listenbrainz/webserver/templates/index/terms-of-service.html
@@ -4,14 +4,14 @@
 <h2 class="page-title">Terms of Service</h2>
 
 <p>As one of the projects of the <a href="https://metabrainz.org/projects">MetaBrainz Foundation</a>,
-	ListenBrainz follows the terms of service and privacy policies of the Foundation.
+	ListenBrainz' terms of service are defined by the social contract and privacy policies of the Foundation.
 	You will find these detailed on the MetaBrainz website:
 </p>
 <ul>
+	<li><a href="https://metabrainz.org/social-contract">Social Contract</a></li>
 	<li><a href="https://metabrainz.org/privacy">Privacy Policy</a></li>
 	<li><a href="https://metabrainz.org/gdpr">GDPR Compliance</a></li>
 	<li><a href="https://metabrainz.org/code-of-conduct">Code of Conduct</a></li>
-	<li><a href="https://metabrainz.org/social-contract">Social Contract</a></li>
 	<li><a href="https://metabrainz.org/conflict-policy">Conflict Resolution Policy</a></li>
 </ul>
 

--- a/listenbrainz/webserver/templates/index/terms-of-service.html
+++ b/listenbrainz/webserver/templates/index/terms-of-service.html
@@ -1,0 +1,37 @@
+{%- extends 'base.html' -%}
+{%- block title -%}Terms of Service - ListenBrainz{%- endblock -%}
+{%- block content -%}
+<h2 class="page-title">Terms of Service</h2>
+
+<p>As one of the projects of the MetaBrainz Foundation,
+	ListenBrainz follows the terms of service and privacy policies of the Foundation.
+	You will find these detailed on the MetaBrainz website:
+</p>
+<ul>
+	<li><a href="https://metabrainz.org/privacy">Privacy Policy</a></li>
+	<li><a href="https://metabrainz.org/gdpr">GDPR Compliance</a></li>
+	<li><a href="https://metabrainz.org/code-of-conduct">Code of Conduct</a></li>
+	<li><a href="https://metabrainz.org/social-contract">Social Contract</a></li>
+	<li><a href="https://metabrainz.org/conflict-policy">Conflict Resolution Policy</a></li>
+</ul>
+
+<h3>Third party resources</h3>
+<p>
+	Additionally, we use the following third party resources to enable you to play music on ListenBrainz:
+</p>
+<ul>
+	<li><b><a href="https://developer.spotify.com/documentation/web-playback-sdk/">Spotify web player SDK</a></b>: Only loaded if you <a href="{{ url_for('profile.music_services_details') }}">linked you Spotify pro account</a></li>
+	<li><b><a href="https://developers.google.com/youtube/iframe_api_reference">Youtube embedded player</a></b>: This is always loaded and serves as our backup player.
+		The search is not as precise as other music services but it enables playback for everyone by default</li>
+	<li><b><a href="https://developers.soundcloud.com/docs/api/html5-widget">Soundcloud player widget</a></b>: Always loaded, only used to play Soundcloud URLs</li>
+</ul>
+<p>
+	We use the YouTube API Services to search for and play music directly on ListenBrainz.
+	See their ToS and privacy policy below:
+</p>
+<ul>
+	<li><a href="https://www.youtube.com/t/terms">Youtube Terms of Service</a></li>
+	<li><a href="https://policies.google.com/privacy">Google Privacy Policy</a></li>
+</ul>
+
+{%- endblock -%}

--- a/listenbrainz/webserver/templates/index/terms-of-service.html
+++ b/listenbrainz/webserver/templates/index/terms-of-service.html
@@ -3,7 +3,7 @@
 {%- block content -%}
 <h2 class="page-title">Terms of Service</h2>
 
-<p>As one of the projects of the MetaBrainz Foundation,
+<p>As one of the projects of the <a href="https://metabrainz.org/projects">MetaBrainz Foundation</a>,
 	ListenBrainz follows the terms of service and privacy policies of the Foundation.
 	You will find these detailed on the MetaBrainz website:
 </p>

--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -53,8 +53,7 @@
             <li><a href="{{ url_for('index.messybrainz') }}">MessyBrainz</a></li>
             <li><a href="https://listenbrainz.readthedocs.io">API Docs</a></li>
             <li><a href="{{ url_for('index.current_status') }}">Current site status</a></li>
-            <li><a href="https://metabrainz.org/gdpr">GDPR compliance</a></li>
-            <li><a href="https://metabrainz.org/privacy">Privacy policy</a></li>
+            <li><a href="{{ url_for('index.terms_of_service') }}">Terms of service</a></li>
             <li><a href="https://metabrainz.org">About MetaBrainz</a></li>
           </ul>
         </li>

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -89,6 +89,7 @@ def proxy():
 def about():
     return render_template("index/about.html")
 
+
 @index_bp.route("/terms-of-service/")
 def terms_of_service():
     return render_template("index/terms-of-service.html")

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -89,6 +89,10 @@ def proxy():
 def about():
     return render_template("index/about.html")
 
+@index_bp.route("/terms-of-service/")
+def terms_of_service():
+    return render_template("index/terms-of-service.html")
+
 
 @index_bp.route("/current-status/")
 @web_listenstore_needed

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -35,7 +35,7 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
     def test_about(self):
         resp = self.client.get(url_for('index.about'))
         self.assert200(resp)
-        
+
     def test_terms_of_service(self):
         resp = self.client.get(url_for('index.terms_of_service'))
         self.assert200(resp)

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -35,6 +35,10 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
     def test_about(self):
         resp = self.client.get(url_for('index.about'))
         self.assert200(resp)
+        
+    def test_terms_of_service(self):
+        resp = self.client.get(url_for('index.terms_of_service'))
+        self.assert200(resp)
 
     def test_add_data_info(self):
         resp = self.client.get(url_for('index.add_data_info'))


### PR DESCRIPTION
Youtube requires us to show a link to their Terms of service on our ToS page, which is a problem because we don't have a ToS page on ListenBrainz.
Instead we link to various MetaBrainz pages.


This PR creates a new ToS page with links to our various policies as well as some information related to third party content players, and in particular the Youtube stuff they require.

Help and review of the wording is very welcome !

<img width="217" alt="image" src="https://user-images.githubusercontent.com/6179856/159541475-8b6f44f5-2a00-4054-b063-35ae1e30f9bb.png">

![image](https://user-images.githubusercontent.com/6179856/159541807-f19b8c49-eb05-41b5-a33c-1e65bee08491.png)
