### PR TITLE
[LB-1078] update API endpoint to /user/ 

### DIFF
--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -130,7 +130,7 @@ def delete_pin_for_user(row_id):
     return jsonify({"status": "ok"})
 
 
-@pinned_recording_api_bp.route("/<user_name>/pins", methods=["GET", "OPTIONS"])
+@pinned_recording_api_bp.route("/user/<user_name>/pins", methods=["GET", "OPTIONS"])
 @crossdomain
 @ratelimit()
 def get_pins_for_user(user_name):
@@ -206,7 +206,7 @@ def get_pins_for_user(user_name):
     )
 
 
-@pinned_recording_api_bp.route("/<user_name>/pins/following", methods=["GET", "OPTIONS"])
+@pinned_recording_api_bp.route("/user/<user_name>/pins/following", methods=["GET", "OPTIONS"])
 @crossdomain
 @ratelimit()
 def get_pins_for_user_following(user_name):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -362,7 +362,7 @@ def collaborations(user_name: str):
     )
 
 
-@user_bp.route("/<user_name>/pins/")
+@user_bp.route("/user/<user_name>/pins/")
 def pins(user_name: str):
     """ Show user pin history """
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
[API endpoint for user pins should be under /user/](https://tickets.metabrainz.org/projects/LB/issues/LB-1078?filter=allopenissues)
Currently, the API endpoint to get a user's pins is {}{{/1/$user_name/pins.
{}}}For consistency with other endpoints relating to a user's data, the endpoint should be {{/1/user/$user_name/pins }} with an extra /user/ in there.

Same goes for /pins/following

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Alter the endpoints on function handling the pings from `/<user_name>/pin` to `/user/<user_name>/pin` in files. 
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


