### PR TITLE
Add Profile link to user navigation menu

### DIFF
--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -71,6 +71,7 @@
               {{ current_user.musicbrainz_id }} <span class="caret"></span>
             </a>
             <ul class="dropdown-menu" role="menu">
+              <li><a href="{{ url_for('user.profile', user_name=current_user.musicbrainz_id) }}">Profile</a></li>
               <li><a href="{{ url_for('profile.info') }}">Settings</a></li>
               <li><a href="{{ url_for('user.playlists', user_name=current_user.musicbrainz_id) }}">Playlists</a></li>
               <li><a href="{{ url_for('recommendations_cf_recording.info', user_name=current_user.musicbrainz_id) }}">Tracks you might like</a></li>


### PR DESCRIPTION
# Problem
There’s no obvious way to navigate to my own profile page after I’ve logged in to the service. The quickest method requires three clicks and three page loads from the front page: 1) click on the username menu: 2) click playlists: 3) click listens.

# Solution
Add a link to the profile page as the top item in the username menu. This is a design pattern used on lots of other websites with username-based drop down menus like this one.

# Action
This is completely untested. The code is my best guess at the correct implementation based on how other menu links are created and how profile links where created on the _similar users_ page.
