### PR TITLE
Use zip_longest in BulkInsertTable

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/bulk_table.py
+++ b/listenbrainz/mbid_mapping/mapping/bulk_table.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from itertools import zip_longest
 
 import psycopg2
 from psycopg2.errors import OperationalError
@@ -344,7 +345,7 @@ class BulkInsertTable:
             queries = self.get_insert_queries()
             values = self.get_insert_queries_test_values()
 
-            for i, db_query_vals in enumerate(zip(queries, values)):
+            for i, db_query_vals in enumerate(zip_longest(queries, values)):
                 db = db_query_vals[0][0]
                 query = db_query_vals[0][1]
                 vals = db_query_vals[1]


### PR DESCRIPTION
When using the BulkInsertTable class to build mapping tables, test values can be specified optionally to build a limited test table instead. If we don't want a test table, we return an empty list in get_insert_queries_test_values. This is zipped with get_insert_queries. This is problematic because zip stops at the end of the smallest list. So zipping with empty list will return an empty list and no queries will be executed.

Instead, use zip_longest which goes till the end of the longest list and substitutes None (configurable to something else) once no more elements are left in the shorter lists.