### PR TITLE
Pin markupsafe and itsdangerous in spark requirements

### DIFF
--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -1,6 +1,8 @@
 click==7.1.2
 hdfs == 2.5.8
 Jinja2 == 2.11.3
+MarkupSafe==2.0.1
+itsdangerous==2.0.1
 pika==1.2.0
 python-dateutil==2.8.0
 numpy==1.21.0


### PR DESCRIPTION
Doing this to ensure compatible versions are installed.