### PR TITLE
Automatically shut down the listenstore based on consul config value

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -53,21 +53,27 @@ MB_DATABASE_URI = 'postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrain
 MB_DATABASE_URI = "SERVICEDOESNOTEXIST_pgbouncer-slave_pgbouncer-master"
 {{end}}
 
-SQLALCHEMY_TIMESCALE_URI = ""
-TIMESCALE_ADMIN_URI=""
-TIMESCALE_ADMIN_LB_URI=""
 
+# Use a key 'listenstore_up' in consul (python boolean True or False) to decide if we connect to timescale.
+# If we set SQLALCHEMY_TIMESCALE_URI to an empty string, then the @api_listenstore_needed and @web_listenstore_needed
+# decorators will prevent the webserver from accessing the timescale database
+if {{template "KEY" "listenstore_up"}}:
 {{if service "timescale-listenbrainz"}}
 {{with index (service "timescale-listenbrainz") 0}}
-SQLALCHEMY_TIMESCALE_URI = """postgresql://listenbrainz_ts:{{template "KEY" "timescale_lb_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
-TIMESCALE_ADMIN_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/postgres"""
-TIMESCALE_ADMIN_LB_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
+    SQLALCHEMY_TIMESCALE_URI = """postgresql://listenbrainz_ts:{{template "KEY" "timescale_lb_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
+    TIMESCALE_ADMIN_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/postgres"""
+    TIMESCALE_ADMIN_LB_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
 {{end}}
 {{else}}
-SQLALCHEMY_TIMESCALE_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
-TIMESCALE_ADMIN_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
-TIMESCALE_ADMIN_LB_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
+    SQLALCHEMY_TIMESCALE_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
+    TIMESCALE_ADMIN_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
+    TIMESCALE_ADMIN_LB_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
 {{end}}
+
+else:
+    SQLALCHEMY_TIMESCALE_URI = ""
+    TIMESCALE_ADMIN_URI=""
+    TIMESCALE_ADMIN_LB_URI=""
 
 {{if service "pgbouncer-aretha"}}
 {{with index (service "pgbouncer-aretha") 0}}

--- a/listenbrainz/webserver/templates/index/listens_offline.html
+++ b/listenbrainz/webserver/templates/index/listens_offline.html
@@ -18,9 +18,5 @@
      checking our <a href="https://twitter.com/ListenBrainz">Twitter
      feed</a>.
   </p>
-  <div id="twitter-block">
-    <a class="twitter-timeline" data-dnt="true" data-lang="en" href="https://twitter.com/ListenBrainz" data-widget-id="640261552604643328" data-height="450px">Tweets by @ListenBrainz</a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-  </div>
 
 {%- endblock -%}

--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request, redirect, render_template, url_for, session, current_app, Markup
 from flask_login import login_user, logout_user, login_required
 from brainzutils.musicbrainz_db import engine as mb_engine
+from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.login import login_forbidden, provider, User
 from listenbrainz.webserver import flash
 import listenbrainz.db.user as db_user
@@ -12,12 +13,14 @@ login_bp = Blueprint('login', __name__)
 
 
 @login_bp.route('/')
+@web_listenstore_needed
 @login_forbidden
 def index():
     return render_template('login/login.html')
 
 
 @login_bp.route('/musicbrainz/')
+@web_listenstore_needed
 @login_forbidden
 def musicbrainz():
     session['next'] = request.args.get('next')
@@ -25,6 +28,7 @@ def musicbrainz():
 
 
 @login_bp.route('/musicbrainz/post/')
+@web_listenstore_needed
 @login_forbidden
 def musicbrainz_post():
     """Callback endpoint."""


### PR DESCRIPTION
# Problem
Sometimes we need to shut down the timescale database, and we should stop the webserver and other tools from accessing it. Before now we have typically done this by rebuilding an image with the DB connection strings set to "" and then re-deploying. This takes extra work each time we need to do this process.


# Solution
Add a new consul config option to disable the datastore. If this is set to True, automatically set the connection string to "", even if the service is available and running

# Action

This just takes care of the webserver. At the moment the timescale writer is shut down manually, though we should be able to use this same process to make that shut down automatically too.

Mapping tools write to a schema in the timescale database, see if we can shut these down too.