### PR TITLE
LB-119: Add track duration as optional field to listens

### DIFF
--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -96,6 +96,7 @@ A complete submit listen JSON document may look like:
               ],
               "recording_mbid": "98255a8c-017a-4bc7-8dd6-1fa36124572b",
               "tags": [ "you", "just", "got", "rick rolled!"]
+              "duration_ms": 222000
             },
             "artist_name": "Rick Astley",
             "track_name": "Never Gonna Give You Up",
@@ -211,7 +212,10 @@ the data for any of the following fields, omit the key entirely:
      - If the song being listened to comes from an online service and you don't know the canonical domain, a name that represents the service.
    * - ``origin_url``
      - If the song of this listen comes from an online source, the URL to the place where it is available. This could be a spotify url (see ``spotify_id``), a YouTube video URL, a Soundcloud recording page URL, or the full URL to a public MP3 file. If there is a webpage for this song (e.g. Youtube page, Soundcloud page) **do not** try and resolve the URL to an actual audio resource.
-
+   * - ``duration_ms``
+     - The duration of the track in milliseconds(integer type).
+   * - ``duration``
+     - The duration of the track in seconds(integer type). Ignored if duration_ms has been given.
 .. note::
 
   **Music service names**

--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -212,10 +212,8 @@ the data for any of the following fields, omit the key entirely:
      - If the song being listened to comes from an online service and you don't know the canonical domain, a name that represents the service.
    * - ``origin_url``
      - If the song of this listen comes from an online source, the URL to the place where it is available. This could be a spotify url (see ``spotify_id``), a YouTube video URL, a Soundcloud recording page URL, or the full URL to a public MP3 file. If there is a webpage for this song (e.g. Youtube page, Soundcloud page) **do not** try and resolve the URL to an actual audio resource.
-   * - ``duration_ms``
-     - The duration of the track in milliseconds. You can include either ``duration_ms`` or ``duration``, but please don't include both.
-   * - ``duration``
-     - The duration of the track in seconds. 
+   * - ``duration_ms`` and ``duration``
+     - The duration of the track in milliseconds and seconds respectively. You should only include one of ``duration_ms`` or ``duration``.
 .. note::
 
   **Music service names**

--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -213,9 +213,9 @@ the data for any of the following fields, omit the key entirely:
    * - ``origin_url``
      - If the song of this listen comes from an online source, the URL to the place where it is available. This could be a spotify url (see ``spotify_id``), a YouTube video URL, a Soundcloud recording page URL, or the full URL to a public MP3 file. If there is a webpage for this song (e.g. Youtube page, Soundcloud page) **do not** try and resolve the URL to an actual audio resource.
    * - ``duration_ms``
-     - The duration of the track in milliseconds(integer type).
+     - The duration of the track in milliseconds. You can include either ``duration_ms`` or ``duration``, but please don't include both.
    * - ``duration``
-     - The duration of the track in seconds(integer type). Ignored if duration_ms has been given.
+     - The duration of the track in seconds. 
 .. note::
 
   **Music service names**

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -59,6 +59,8 @@ class Listen(object):
         'artist_msid',
         'release_msid',
         'recording_msid',
+        'duration_ms',
+        'duration',
     )
 
     TOP_LEVEL_KEYS = (

--- a/listenbrainz/testdata/invalid_duration.json
+++ b/listenbrainz/testdata/invalid_duration.json
@@ -1,0 +1,16 @@
+{
+    "payload": [
+        {
+            "listened_at": 1486709515,
+            "track_metadata": {
+                "track_name": "Every Step Every Way",
+                "artist_name": "Majid Jordan",
+                "additional_info": {
+                    "duration": null
+                },
+                "release_name": "Majid Jordan"
+            }
+        }
+    ],
+    "listen_type": "import"
+}

--- a/listenbrainz/testdata/invalid_duration.json
+++ b/listenbrainz/testdata/invalid_duration.json
@@ -1,0 +1,16 @@
+{
+    "payload": [
+        {
+            "listened_at": 1486709515,
+            "track_metadata": {
+                "track_name": "Every Step Every Way",
+                "artist_name": "Majid Jordan",
+                "additional_info": {
+                    "duration": 20.1
+                },
+                "release_name": "Majid Jordan"
+            }
+        }
+    ],
+    "listen_type": "import"
+}

--- a/listenbrainz/testdata/multi_duration.json
+++ b/listenbrainz/testdata/multi_duration.json
@@ -1,0 +1,17 @@
+{
+    "payload": [
+        {
+            "listened_at": 1486709515,
+            "track_metadata": {
+                "track_name": "Every Step Every Way",
+                "artist_name": "Majid Jordan",
+                "additional_info": {
+                    "duration": 222,
+                    "duration_ms": 200000
+                },
+                "release_name": "Majid Jordan"
+            }
+        }
+    ],
+    "listen_type": "import"
+}

--- a/listenbrainz/testdata/valid_duration.json
+++ b/listenbrainz/testdata/valid_duration.json
@@ -6,7 +6,7 @@
                 "track_name": "Every Step Every Way",
                 "artist_name": "Majid Jordan",
                 "additional_info": {
-                    "duration": 20.1
+                    "duration_ms": 1222.6
                 },
                 "release_name": "Majid Jordan"
             }

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -476,7 +476,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json['code'], 400)
     
     def test_multi_duration(self):
-        """ Test for duration and duration_both given """
+        """ Test for duration and duration_ms both given """
         with open(self.path_to_data_file('multi_duration.json'), 'r') as f:
             payload = json.load(f)
         response = self.send_data(payload)

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -236,6 +236,13 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert401(response)
         self.assertEqual(response.json['code'], 401)
 
+    def test_valid_single(self):
+        """ Test for valid submissioon of listen_type listen """
+        with open(self.path_to_data_file('valid_single.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
 
     def test_single_more_than_one_listen(self):
         """ Test for an invalid submission which has listen_type 'single' but
@@ -480,19 +487,19 @@ class APITestCase(ListenAPIIntegrationTestCase):
         with open(self.path_to_data_file('multi_duration.json'), 'r') as f:
             payload = json.load(f)
         response = self.send_data(payload)
-        self.assert200(response)
-        self.assertEqual(response.json['status'], 'ok')
-    
-
-    def test_invalid_duration(self):
-        """ Test for invalid submission in which a listen contains an invalid duration_ms field
-            in additional_info
-        """
-        with open(self.path_to_data_file('invalid_duration.json'), 'r') as f:
-            payload = json.load(f)
-        response = self.send_data(payload)
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
+    
+
+    def test_valid_duration(self):
+        """ Test for valid submission in which a listen contains a valid duration_ms field
+            in additional_info
+        """
+        with open(self.path_to_data_file('valid_duration.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
 
 
     def test_unicode_null_error(self):

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -236,14 +236,6 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert401(response)
         self.assertEqual(response.json['code'], 401)
 
-    def test_valid_single(self):
-        """ Test for valid submissioon of listen_type listen
-        """
-        with open(self.path_to_data_file('valid_single.json'), 'r') as f:
-            payload = json.load(f)
-        response = self.send_data(payload)
-        self.assert200(response)
-        self.assertEqual(response.json['status'], 'ok')
 
     def test_single_more_than_one_listen(self):
         """ Test for an invalid submission which has listen_type 'single' but
@@ -482,6 +474,26 @@ class APITestCase(ListenAPIIntegrationTestCase):
         response = self.send_data(payload)
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
+    
+    def test_multi_duration(self):
+        """ Test for duration and duration_both given """
+        with open(self.path_to_data_file('multi_duration.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
+    
+
+    def test_invalid_duration(self):
+        """ Test for invalid submission in which a listen contains an invalid duration_ms field
+            in additional_info
+        """
+        with open(self.path_to_data_file('invalid_duration.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+
 
     def test_unicode_null_error(self):
         with open(self.path_to_data_file('listen_having_unicode_null.json'), 'r') as f:

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -2,7 +2,7 @@ import json
 import time
 
 import pytest
-from flask import url_for, current_app
+from flask import url_for
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
@@ -489,9 +489,18 @@ class APITestCase(ListenAPIIntegrationTestCase):
         response = self.send_data(payload)
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
-        self.assertEqual('Both duration and duraion_ms are given, please choose one',
+        self.assertEqual('JSON document should not contain both duration and duration_ms.',
                          response.json['error'])
-    
+
+    def test_invalid_duration(self):
+        """ Test for error on invalid duration """
+        with open(self.path_to_data_file('invalid_duration.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+        self.assertEqual('Value for duration is invalid, should be a positive integer.',
+                         response.json['error'])
 
     def test_valid_duration(self):
         """ Test for valid submission in which a listen contains a valid duration_ms field
@@ -502,7 +511,6 @@ class APITestCase(ListenAPIIntegrationTestCase):
         response = self.send_data(payload)
         self.assert200(response)
         self.assertEqual(response.json['status'], 'ok')
-
 
     def test_unicode_null_error(self):
         with open(self.path_to_data_file('listen_having_unicode_null.json'), 'r') as f:

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -489,6 +489,8 @@ class APITestCase(ListenAPIIntegrationTestCase):
         response = self.send_data(payload)
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
+        self.assertEqual('Both duration and duraion_ms are given, please choose one',
+                         response.json['error'])
     
 
     def test_valid_duration(self):

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -46,7 +46,6 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         )
         self.log = logging.getLogger(__name__)
         self.ls = timescale_connection._ts
-        self.maxDiff = None
 
     def test_complete_workflow_json(self):
         """ Integration test for complete workflow to submit a listen using Last.fm compat api """

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -46,6 +46,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         )
         self.log = logging.getLogger(__name__)
         self.ls = timescale_connection._ts
+        self.maxDiff = None
 
     def test_complete_workflow_json(self):
         """ Integration test for complete workflow to submit a listen using Last.fm compat api """

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -221,7 +221,7 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         duration_key = ["duration", "duration_ms"]
         for key in duration_key:
             validate_duration_field(listen, key)
-        # if both duration and duration_ms are given and valid, only duration_ms will be accepted without raising an error.
+        # if both duration and duration_ms are given and valid, only duration_ms will be accepted but no error raised.
         if 'duration' in listen['track_metadata']['additional_info'] and 'duration_ms' in listen['track_metadata']['additional_info']:
             del listen['track_metadata']['additional_info']['duration']
 

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -217,13 +217,13 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
                                                 "longer than %d characters." % MAX_TAG_SIZE, listen)
         
         
-        # duration
-        duration_key = ["duration", "duration_ms"]
-        for key in duration_key:
-            validate_duration_field(listen, key)
         # if both duration and duration_ms are given and valid, an error will be raised.
         if 'duration' in listen['track_metadata']['additional_info'] and 'duration_ms' in listen['track_metadata']['additional_info']:
             raise ListenValidationError("Both duration and duraion_ms are given, please choose one")
+        # check duration validity
+        duration_key = ["duration", "duration_ms"]
+        for key in duration_key:
+            validate_duration_field(listen, key)
 
 
         # MBIDs, both of the mbid validation methods mutate the listen payload if needed.

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -221,9 +221,9 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         duration_key = ["duration", "duration_ms"]
         for key in duration_key:
             validate_duration_field(listen, key)
-        # if both duration and duration_ms are given and valid, only duration_ms will be accepted but no error raised.
+        # if both duration and duration_ms are given and valid, an error will be raised.
         if 'duration' in listen['track_metadata']['additional_info'] and 'duration_ms' in listen['track_metadata']['additional_info']:
-            del listen['track_metadata']['additional_info']['duration']
+            raise ListenValidationError("Both duration and duraion_ms are given, please choose one")
 
 
         # MBIDs, both of the mbid validation methods mutate the listen payload if needed.
@@ -280,9 +280,13 @@ def validate_duration_field(listen, key):
         if not duration:
             del listen['track_metadata']['additional_info'][key]
             return
-        if not isinstance(duration, int):
-            raise ListenValidationError("%s type invalid. Int is accepted" % (key,), listen)
-
+        try:
+            value = int(duration)
+            if value <= 0:
+                raise ListenValidationError("%s type invalid. Positive int is accepted" % (key,), listen)
+        except ValueError:
+            raise ListenValidationError("%s type invalid. Positive int is accepted" % (key,), listen)
+        
 
 def validate_single_mbid_field(listen, key):
     """ Verify that mbid if present in the listen with given key is valid.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

fix problem mentioned in https://tickets.metabrainz.org/browse/LB-119



# Solution

1.update doc to specify the type of duration
2.add validation of duration field submitted by clients
* `duration` and `duration_ms` will only accept integer type. 
* If both fields are given, `duration` will be ignored without raising an error.


# Action

failures not fixed:
https://gist.github.com/YouzhiL/cb0810c811fec50c5f6dbb38640c0e92


