### PR TITLE
[LB-1086] ListenCountCard: Fix card message when visiting another user's page

### DIFF
--- a/listenbrainz/webserver/static/js/src/listens/ListenCountCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCountCard.tsx
@@ -3,7 +3,6 @@ import Card from "../components/Card";
 import GlobalAppContext from "../utils/GlobalAppContext";
 
 export type ListenCountCardProps = {
-  isCurrentUser: Boolean;
   listenCount?: number;
   user: ListenBrainzUser;
 };

--- a/listenbrainz/webserver/static/js/src/listens/ListenCountCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCountCard.tsx
@@ -1,25 +1,38 @@
 import * as React from "react";
 import Card from "../components/Card";
+import GlobalAppContext from "../utils/GlobalAppContext";
 
 export type ListenCountCardProps = {
+  isCurrentUser: Boolean;
   listenCount?: number;
+  user: ListenBrainzUser;
 };
 
 const ListenCountCard = (props: ListenCountCardProps) => {
-  const { listenCount } = props;
+  const { currentUser } = React.useContext(GlobalAppContext);
+  const { listenCount, user } = props;
+  const isCurrentUser = currentUser?.name === user?.name;
 
   return (
     <Card id="listen-count-card">
       {listenCount && (
         <div>
-          You have listened to
+          {isCurrentUser
+            ? "You have listened to"
+            : `${user.name} has listened to`}
           <hr />
           {listenCount.toLocaleString()}
           <br />
           <small className="text-muted">songs so far</small>
         </div>
       )}
-      {!listenCount && <p>You have not listened to any songs so far</p>}
+      {!listenCount && (
+        <p>
+          {isCurrentUser
+            ? "You have not listened to any songs so far"
+            : `${user.name} has not listened to any songs so far`}
+        </p>
+      )}
     </Card>
   );
 };

--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -650,7 +650,7 @@ export default class Listens extends React.Component<
                 newAlert={newAlert}
               />
             )}
-            <ListenCountCard listenCount={listenCount} />
+            <ListenCountCard user={user} listenCount={listenCount} />
             {user && (
               <div
                 className="card hidden-xs hidden-sm"

--- a/listenbrainz/webserver/static/js/tests/listens/ListenCountCard.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/listens/ListenCountCard.test.tsx
@@ -1,15 +1,50 @@
 import * as React from "react";
 import { mount } from "enzyme";
 
+import GlobalAppContext, {
+  GlobalAppContextT,
+} from "../../src/utils/GlobalAppContext";
 import ListenCountCard from "../../src/listens/ListenCountCard";
+import APIService from "../../src/utils/APIService";
+
+const user = {
+  id: 1,
+  name: "track_listener",
+};
+
+const loggedInUser = {
+  id: 2,
+  name: "iliekcomputers",
+};
+
+const globalContext: GlobalAppContextT = {
+  APIService: new APIService("foo"),
+  currentUser: loggedInUser,
+};
 
 describe("ListenCountCard", () => {
   it("renders correctly when listen count is not zero", () => {
-    const wrapper = mount(<ListenCountCard listenCount={100} />);
+    const wrapper = mount(<ListenCountCard user={user} listenCount={100} />);
     expect(wrapper).toMatchSnapshot();
   });
   it("renders correctly when listen count is zero or undefined", () => {
-    const wrapper = mount(<ListenCountCard />);
+    const wrapper = mount(<ListenCountCard user={user} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it("renders user's name instead of 'You' when visiting another user's page", () => {
+    const wrapper = mount(
+      <GlobalAppContext.Provider value={globalContext}>
+        <ListenCountCard user={user} listenCount={100} />
+      </GlobalAppContext.Provider>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+  it("renders 'You' when on current user's page", () => {
+    const wrapper = mount(
+      <GlobalAppContext.Provider value={globalContext}>
+        <ListenCountCard user={loggedInUser} listenCount={100} />
+      </GlobalAppContext.Provider>
+    );
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/listenbrainz/webserver/static/js/tests/listens/ListenCountCard.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/listens/ListenCountCard.test.tsx
@@ -37,7 +37,11 @@ describe("ListenCountCard", () => {
         <ListenCountCard user={user} listenCount={100} />
       </GlobalAppContext.Provider>
     );
-    expect(wrapper).toMatchSnapshot();
+    const countCard = wrapper.find("#listen-count-card").first().children();
+    const cardDiv = countCard.children().first();
+    expect(cardDiv.html()).toEqual(
+      '<div>track_listener has listened to<hr>100<br><small class="text-muted">songs so far</small></div>'
+    );
   });
   it("renders 'You' when on current user's page", () => {
     const wrapper = mount(
@@ -45,6 +49,10 @@ describe("ListenCountCard", () => {
         <ListenCountCard user={loggedInUser} listenCount={100} />
       </GlobalAppContext.Provider>
     );
-    expect(wrapper).toMatchSnapshot();
+    const countCard = wrapper.find("#listen-count-card").first().children();
+    const cardDiv = countCard.children().first();
+    expect(cardDiv.html()).toEqual(
+      '<div>You have listened to<hr>100<br><small class="text-muted">songs so far</small></div>'
+    );
   });
 });

--- a/listenbrainz/webserver/static/js/tests/listens/__snapshots__/ListenCountCard.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/listens/__snapshots__/ListenCountCard.test.tsx.snap
@@ -1,8 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ListenCountCard renders correctly when listen count is not zero 1`] = `
+exports[`ListenCountCard renders 'You' when on current user's page 1`] = `
 <ListenCountCard
   listenCount={100}
+  user={
+    Object {
+      "id": 2,
+      "name": "iliekcomputers",
+    }
+  }
 >
   <ForwardRef
     id="listen-count-card"
@@ -27,8 +33,48 @@ exports[`ListenCountCard renders correctly when listen count is not zero 1`] = `
 </ListenCountCard>
 `;
 
+exports[`ListenCountCard renders correctly when listen count is not zero 1`] = `
+<ListenCountCard
+  listenCount={100}
+  user={
+    Object {
+      "id": 1,
+      "name": "track_listener",
+    }
+  }
+>
+  <ForwardRef
+    id="listen-count-card"
+  >
+    <div
+      className="card "
+      id="listen-count-card"
+    >
+      <div>
+        track_listener has listened to
+        <hr />
+        100
+        <br />
+        <small
+          className="text-muted"
+        >
+          songs so far
+        </small>
+      </div>
+    </div>
+  </ForwardRef>
+</ListenCountCard>
+`;
+
 exports[`ListenCountCard renders correctly when listen count is zero or undefined 1`] = `
-<ListenCountCard>
+<ListenCountCard
+  user={
+    Object {
+      "id": 1,
+      "name": "track_listener",
+    }
+  }
+>
   <ForwardRef
     id="listen-count-card"
   >
@@ -37,8 +83,41 @@ exports[`ListenCountCard renders correctly when listen count is zero or undefine
       id="listen-count-card"
     >
       <p>
-        You have not listened to any songs so far
+        track_listener has not listened to any songs so far
       </p>
+    </div>
+  </ForwardRef>
+</ListenCountCard>
+`;
+
+exports[`ListenCountCard renders user's name instead of 'You' when visiting another user's page 1`] = `
+<ListenCountCard
+  listenCount={100}
+  user={
+    Object {
+      "id": 1,
+      "name": "track_listener",
+    }
+  }
+>
+  <ForwardRef
+    id="listen-count-card"
+  >
+    <div
+      className="card "
+      id="listen-count-card"
+    >
+      <div>
+        track_listener has listened to
+        <hr />
+        100
+        <br />
+        <small
+          className="text-muted"
+        >
+          songs so far
+        </small>
+      </div>
     </div>
   </ForwardRef>
 </ListenCountCard>

--- a/listenbrainz/webserver/static/js/tests/listens/__snapshots__/ListenCountCard.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/listens/__snapshots__/ListenCountCard.test.tsx.snap
@@ -1,38 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ListenCountCard renders 'You' when on current user's page 1`] = `
-<ListenCountCard
-  listenCount={100}
-  user={
-    Object {
-      "id": 2,
-      "name": "iliekcomputers",
-    }
-  }
->
-  <ForwardRef
-    id="listen-count-card"
-  >
-    <div
-      className="card "
-      id="listen-count-card"
-    >
-      <div>
-        You have listened to
-        <hr />
-        100
-        <br />
-        <small
-          className="text-muted"
-        >
-          songs so far
-        </small>
-      </div>
-    </div>
-  </ForwardRef>
-</ListenCountCard>
-`;
-
 exports[`ListenCountCard renders correctly when listen count is not zero 1`] = `
 <ListenCountCard
   listenCount={100}
@@ -85,39 +52,6 @@ exports[`ListenCountCard renders correctly when listen count is zero or undefine
       <p>
         track_listener has not listened to any songs so far
       </p>
-    </div>
-  </ForwardRef>
-</ListenCountCard>
-`;
-
-exports[`ListenCountCard renders user's name instead of 'You' when visiting another user's page 1`] = `
-<ListenCountCard
-  listenCount={100}
-  user={
-    Object {
-      "id": 1,
-      "name": "track_listener",
-    }
-  }
->
-  <ForwardRef
-    id="listen-count-card"
-  >
-    <div
-      className="card "
-      id="listen-count-card"
-    >
-      <div>
-        track_listener has listened to
-        <hr />
-        100
-        <br />
-        <small
-          className="text-muted"
-        >
-          songs so far
-        </small>
-      </div>
     </div>
   </ForwardRef>
 </ListenCountCard>


### PR DESCRIPTION
# Problem

Listen count says "You have…" instead of "'username' has" when visiting another user's page.
Ticket link - https://tickets.metabrainz.org/browse/LB-1086


# Solution

A `user` prop is passed to `ListenCountCard` component from `Listens` component.
ListenCountCard uses `GlobalAppContext` to get the current user and compares
the current user name to the user name from props to determine the
`isCurrentUser` boolean.

isCurrentUser is then used to conditionally render the message on the
ListenCountCard component.

## Screenshots

<details><summary>Screenshots</summary>

**1. When users see their own page**
![When user sees their own page](https://user-images.githubusercontent.com/6230769/163731011-c179435e-8545-4306-a069-b1aee2de7c27.png)

**2. When no user is logged in**
![When no user is logged in](https://user-images.githubusercontent.com/6230769/163730999-b06be0c2-7fbb-455d-888f-d9ae7eb37393.png)

**3. When a user visits another user's page**
![When a user visits another user's page](https://user-images.githubusercontent.com/6230769/163731012-284986e4-b425-4fd2-bf02-8c37e80d4fbb.png)
</details>