### PR TITLE
Do not harcode alpha in html report

### DIFF
--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -213,7 +213,7 @@ def get_best_model(training_data, validation_data, num_validation, ranks, lambda
         logger.info("Validation RMSE calculated!")
         vt = '{:.2f}'.format((time.monotonic() - t0) / 60)
 
-        model_metadata.append((model_id, mt, rank, '{:.1f}'.format(lmbda), iteration, round(validation_rmse, 2), vt))
+        model_metadata.append((model_id, mt, rank, '{:.1f}'.format(lmbda), iteration, alpha, round(validation_rmse, 2), vt))
 
         if best_model is None or validation_rmse < best_model.validation_rmse:
             best_model = Model(

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -43,7 +43,7 @@ from pyspark.sql import Row
 from pyspark.mllib.recommendation import ALS, Rating
 
 logger = logging.getLogger(__name__)
-Model = namedtuple('Model', 'model validation_rmse rank lmbda iteration model_id training_time rmse_time, alpha')
+Model = namedtuple('Model', 'model validation_rmse rank lmbda iteration alpha model_id training_time rmse_time')
 
 # training HTML is generated if set to true
 SAVE_TRAINING_HTML = True
@@ -222,10 +222,10 @@ def get_best_model(training_data, validation_data, num_validation, ranks, lambda
                 rank=rank,
                 lmbda=lmbda,
                 iteration=iteration,
+                alpha=alpha,
                 model_id=model_id,
                 training_time=mt,
                 rmse_time=vt,
-                alpha=alpha,
             )
 
     return best_model, model_metadata

--- a/listenbrainz_spark/recommendations/templates/model.html
+++ b/listenbrainz_spark/recommendations/templates/model.html
@@ -35,6 +35,7 @@
 			<th>Best model rank</th>
 			<th>Best model lmbda</th>
 			<th>Best model iteration</th>
+            <td>Best model alpha</td>
 			<th>Best model RMSE</th>
 			<th>Best model RMSE computation time(min)</th>
 		</tr>
@@ -44,6 +45,7 @@
 			<td>{{ best_model.rank }}</td>
 			<td>{{ best_model.lmbda }}</td>
 			<td>{{ best_model.iteration }}</td>
+            <td>{{ best_model.alpha }}</td>
 			<td>{{ best_model.validation_rmse }}</td>
 			<td>{{ best_model.rmse_time }}</td>
 		</tr>
@@ -59,6 +61,7 @@
 			<th>rank</th>
 			<th>lmbda</th>
 			<th>iterations</th>
+            <th>alpha</th>
 			<th>RMSE</th>
 			<th>RMSE computation time(min)</th>
 		</tr>
@@ -77,7 +80,6 @@
 		<li><b>iterations</b></li><p>This refers to the number of iterations to run(around 10 is often a good default).</p>
 		<li><b>alpha</b></li><p>The alpha parameter controls the baseline level of confidence weighting applied.A higher level of alpha tends to make the model more confident about the fact that missing data equates to no preference for the relevant user-item pair.</p>
 	</ul>
-	<p>Value of alpha used is <b>3.0</b></p>
 	<p>The Mean Squared Error (MSE) is a direct measure of the reconstruction error of the user-item rating matrix. It is defined as the sum of the squared errors divided by the number of observations. The squared error, in turn, is the square of the difference between the predicted rating for a given user-item pair and the actual rating.</p>
 	<p>Ratings are predicted for all the (user_id, recording_id) pairs in validation data, the predicted ratings are then subtracted with actual ratings and RMSE is calculated.</p>
 	<p><i><b>Note: </b>Number of rows in a dataframe or number of elements in an RDD (count information) is not included because it leades to unnecessary computation time.</i></p>

--- a/listenbrainz_spark/recommendations/templates/model.html
+++ b/listenbrainz_spark/recommendations/templates/model.html
@@ -35,7 +35,7 @@
 			<th>Best model rank</th>
 			<th>Best model lmbda</th>
 			<th>Best model iteration</th>
-            <td>Best model alpha</td>
+            <th>Best model alpha</th>
 			<th>Best model RMSE</th>
 			<th>Best model RMSE computation time(min)</th>
 		</tr>


### PR DESCRIPTION
We now support multiple alphas for a run so display the alpha used for each model in the report.