### PR TITLE
Use entire training data to generate candidate sets

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -261,7 +261,7 @@ def request_model(rank, itr, lmbda, alpha):
 
 
 @cli.command(name='request_candidate_sets')
-@click.option("--days", type=int, default=7, help="Request recommendations to be generated on history of given number of days")
+@click.option("--days", type=int, required=False, help="Request recommendations to be generated on history of given number of days")
 @click.option("--top", type=int, default=20, help="Calculate given number of top artist.")
 @click.option("--similar", type=int, default=20, help="Calculate given number of similar artist.")
 @click.option("--html", is_flag=True, default=False, help='Enable/disable HTML file generation')
@@ -271,12 +271,13 @@ def request_candidate_sets(days, top, similar, users, html):
     """ Send the cluster a request to generate candidate sets.
     """
     params = {
-        'recommendation_generation_window': days,
         "top_artist_limit": top,
         "similar_artist_limit": similar,
         "users": users,
         "html_flag": html
     }
+    if days:
+        params['recommendation_generation_window'] = days
     send_request_to_spark_cluster('cf.recommendations.recording.candidate_sets', **params)
 
 

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -271,13 +271,12 @@ def request_candidate_sets(days, top, similar, users, html):
     """ Send the cluster a request to generate candidate sets.
     """
     params = {
+        "recommendation_generation_window": days,
         "top_artist_limit": top,
         "similar_artist_limit": similar,
         "users": users,
         "html_flag": html
     }
-    if days:
-        params['recommendation_generation_window'] = days
     send_request_to_spark_cluster('cf.recommendations.recording.candidate_sets', **params)
 
 

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -82,6 +82,7 @@
     "name": "cf.recommendations.recording.candidate_sets",
     "description": "Create candidate sets to generate recommendations",
     "params": [
+      "recommendation_generation_window",
       "top_artist_limit",
       "similar_artist_limit",
       "users",

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -82,7 +82,6 @@
     "name": "cf.recommendations.recording.candidate_sets",
     "description": "Create candidate sets to generate recommendations",
     "params": [
-      "recommendation_generation_window",
       "top_artist_limit",
       "similar_artist_limit",
       "users",

--- a/listenbrainz_spark/recommendations/recording/candidate_sets.py
+++ b/listenbrainz_spark/recommendations/recording/candidate_sets.py
@@ -510,17 +510,20 @@ def main(recommendation_generation_window=None, top_artist_limit=None, similar_a
         logger.error(str(err), exc_info=True)
         raise
 
-    from_date, to_date = get_dates_to_generate_candidate_sets(mapped_listens_df, recommendation_generation_window)
-
     logger.info('Fetching listens to get top artists...')
-    mapped_listens_subset = get_listens_to_fetch_top_artists(mapped_listens_df, from_date, to_date)
+    if recommendation_generation_window is not None:
+        logger.info('Recommendation generation window is specified, calculating subset of listens')
+        from_date, to_date = get_dates_to_generate_candidate_sets(mapped_listens_df, recommendation_generation_window)
+        mapped_listens_df = get_listens_to_fetch_top_artists(mapped_listens_df, from_date, to_date)
+    else:
+        from_date, to_date = None, None
 
     logger.info('Fetching top artists...')
-    top_artist_df = get_top_artists(mapped_listens_subset, top_artist_limit, users)
+    top_artist_df = get_top_artists(mapped_listens_df, top_artist_limit, users)
 
     logger.info('Preparing top artists candidate set...')
     top_artist_candidate_set_df, top_artist_candidate_set_df_html = get_top_artist_candidate_set(top_artist_df, recordings_df,
-                                                                                                 users_df, mapped_listens_subset)
+                                                                                                 users_df, mapped_listens_df)
 
     logger.info('Fetching similar artists...')
     similar_artist_df, similar_artist_df_html = get_similar_artists(top_artist_df, artist_relation_df, similar_artist_limit)
@@ -530,7 +533,7 @@ def main(recommendation_generation_window=None, top_artist_limit=None, similar_a
                                                                                 similar_artist_df,
                                                                                 recordings_df,
                                                                                 users_df,
-                                                                                mapped_listens_subset)
+                                                                                mapped_listens_df)
 
     logger.info('Saving candidate sets...')
     save_candidate_sets(top_artist_candidate_set_df, similar_artist_candidate_set_df)

--- a/listenbrainz_spark/recommendations/templates/candidate.html
+++ b/listenbrainz_spark/recommendations/templates/candidate.html
@@ -12,7 +12,11 @@
 		<h1>Data Preprocessing to generate recommendations</h1>
 	</center>
 	<p>To get personalized recommendations for users, candidate sets are generated for each user consisting of recording ids and the user id.</p>
-    <p>The candidate sets have been generated using listens from <b>{{ from_date }}</b> to <b>{{ to_date }}</b></p>
+    {% if from_date and to_date %}
+        <p>The candidate sets have been generated using listens from <b>{{ from_date }}</b> to <b>{{ to_date }}</b></p>
+    {% else %}
+        <p>The candidate sets have been generated using listens from entire listen data used for training.</p>
+    {% endif %}
     <p>Total time taken to generate candidates set for all users: <b>{{ total_time }}m</b></p>
 	{% for user_name, data in user_data.items() -%}
 	<p><center><h4>{{ user_name }}</h4></center></p>


### PR DESCRIPTION
By default, candidate sets used to use a subset of listens to calculate top artists and similar artists. In experiments, this has led to worse results. Therefore, now changing the default to use entire training data instead of a subset.