### PR TITLE
Include CF model id and url with the recommendations

### DIFF
--- a/data/model/user_cf_recommendations_recording_message.py
+++ b/data/model/user_cf_recommendations_recording_message.py
@@ -38,6 +38,8 @@ class UserRecommendationsJson(BaseModel):
     """
     top_artist: Optional[List[UserRecommendationsRecord]]
     similar_artist: Optional[List[UserRecommendationsRecord]]
+    model_id: Optional[str]
+    model_url: Optional[str]
 
 
 class UserRecommendationsData(BaseModel):

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -226,10 +226,7 @@ def handle_recommendations(data):
     try:
         db_recommendations_cf_recording.insert_user_recommendation(
             user_id,
-            UserRecommendationsJson(**{
-                'top_artist': recommendations['top_artist'],
-                'similar_artist': recommendations['similar_artist']
-            })
+            UserRecommendationsJson(**recommendations)
         )
     except ValidationError:
         current_app.logger.error(f"""ValidationError while inserting recommendations for user with musicbrainz_id:

--- a/listenbrainz/webserver/views/recommendations_cf_recording_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_api.py
@@ -98,6 +98,8 @@ def get_recommendations(user_name):
 
     payload = {
         'payload': {
+            'model_id': recommendations['model_id'],
+            'model_url': recommendations['model_url'],
             'mbids': mbid_list,
             'entity': "recording",
             'type': artist_type,

--- a/listenbrainz/webserver/views/recommendations_cf_recording_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_api.py
@@ -98,8 +98,8 @@ def get_recommendations(user_name):
 
     payload = {
         'payload': {
-            'model_id': recommendations.model_id,
-            'model_url': recommendations.model_url,
+            'model_id': recommendations.recording_mbid.model_id,
+            'model_url': recommendations.recording_mbid.model_url,
             'mbids': mbid_list,
             'entity': "recording",
             'type': artist_type,

--- a/listenbrainz/webserver/views/recommendations_cf_recording_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_api.py
@@ -98,8 +98,8 @@ def get_recommendations(user_name):
 
     payload = {
         'payload': {
-            'model_id': recommendations['model_id'],
-            'model_url': recommendations['model_url'],
+            'model_id': recommendations.model_id,
+            'model_url': recommendations.model_url,
             'mbids': mbid_list,
             'entity': "recording",
             'type': artist_type,

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -51,7 +51,7 @@ RECOMMENDATION_RECORDING_SIMILAR_ARTIST_CANDIDATE_SET = os.path.join(RECOMMENDAT
                                                                      'similar_artist.parquet')
 # Absolute path to model metadata.
 RECOMMENDATION_RECORDING_MODEL_METADATA = RECOMMENDATION_RECORDING_MODEL_DIR + \
-    '/' + 'model_metadata.parquet'
+    '/' + 'model_metadata_new.parquet'
 # Absolute path to mapped listens.
 RECOMMENDATION_RECORDING_MAPPED_LISTENS = RECOMMENDATION_RECORDING_DATAFRAME_DIR + \
     '/' + 'mapped_listens_df.parquet'

--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -333,7 +333,7 @@ def create_messages(params, top_artist_rec_mbid_df, similar_artist_rec_mbid_df, 
                 'top_artist': data.get('top_artist', []),
                 'similar_artist': data.get('similar_artist', []),
                 'model_id': params.model_id,
-                'model_url': f"https://michael.metabrainz.org/{params.model_html_file}"
+                'model_url': f"http://michael.metabrainz.org/{params.model_html_file}"
             }
         }
         yield messages

--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -39,9 +39,11 @@ logger = logging.getLogger(__name__)
 
 class RecommendationParams:
 
-    def __init__(self, recordings_df, model, top_artist_candidate_set_df, similar_artist_candidate_set_df,
-                 recommendation_top_artist_limit, recommendation_similar_artist_limit):
+    def __init__(self, recordings_df, model_id, model_html_file, model, top_artist_candidate_set_df,
+                 similar_artist_candidate_set_df, recommendation_top_artist_limit, recommendation_similar_artist_limit):
         self.recordings_df = recordings_df
+        self.model_id = model_id
+        self.model_html_file = model_html_file
         self.model = model
         self.top_artist_candidate_set_df = top_artist_candidate_set_df
         self.similar_artist_candidate_set_df = similar_artist_candidate_set_df
@@ -49,32 +51,25 @@ class RecommendationParams:
         self.recommendation_similar_artist_limit = recommendation_similar_artist_limit
 
 
-def get_most_recent_model_id():
+def get_most_recent_model_meta():
     """ Get model id of recently created model.
 
         Returns:
             model_id (str): Model identification string.
     """
-    try:
-        model_metadata = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_MODEL_METADATA)
-    except PathNotFoundException as err:
-        logger.error(str(err), exc_info=True)
-        raise
-    except FileNotFetchedException as err:
-        logger.error(str(err), exc_info=True)
-        raise
-
-    latest_ts = model_metadata.select(func.max('model_created').alias('model_created')).take(1)[0].model_created
-    model_id = model_metadata.select('model_id') \
-                             .where(col('model_created') == latest_ts).take(1)[0].model_id
-
-    return model_id
+    utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_MODEL_METADATA).createOrReplaceTempView("model_metadata")
+    meta = listenbrainz_spark.sql_context.sql("""
+        SELECT model_id, model_html_file
+          FROM model_metadata
+      ORDER BY model_created DESC
+         LIMIT 1 
+    """).collect()[0]
+    return meta.model_id, meta.model_html_file
 
 
-def load_model():
+def load_model(model_id):
     """ Load model from given path in HDFS.
     """
-    model_id = get_most_recent_model_id()
     dest_path = get_model_path(model_id)
     try:
         model = MatrixFactorizationModel.load(listenbrainz_spark.context, dest_path)
@@ -269,8 +264,8 @@ def check_for_ratings_beyond_range(top_artist_rec_df, similar_artist_rec_df):
     return max_rating > 1.0, min_rating < -1.0
 
 
-def create_messages(top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_user_count, total_time,
-                    top_artist_rec_user_count, similar_artist_rec_user_count):
+def create_messages(params, top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_user_count,
+                    total_time, top_artist_rec_user_count, similar_artist_rec_user_count):
     """ Create messages to send the data to the webserver via RabbitMQ.
 
         Args:
@@ -336,7 +331,9 @@ def create_messages(top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_u
             'type': 'cf_recommendations_recording_recommendations',
             'recommendations': {
                 'top_artist': data.get('top_artist', []),
-                'similar_artist': data.get('similar_artist', [])
+                'similar_artist': data.get('similar_artist', []),
+                'model_id': params.model_id,
+                'model_url': f"https://michael.metabrainz.org/{params.model_html_file}"
             }
         }
         yield messages
@@ -417,16 +414,16 @@ def main(recommendation_top_artist_limit=None, recommendation_similar_artist_lim
         raise
 
     logger.info('Loading model...')
-    model = load_model()
+    model_id, model_html_file = get_most_recent_model_meta()
+    model = load_model(model_id)
 
     # an action must be called to persist data in memory
     recordings_df.count()
     recordings_df.persist()
 
-    params = RecommendationParams(recordings_df, model, top_artist_candidate_set_df,
-                                  similar_artist_candidate_set_df,
-                                  recommendation_top_artist_limit,
-                                  recommendation_similar_artist_limit)
+    params = RecommendationParams(recordings_df, model_id, model_html_file, model,
+                                  top_artist_candidate_set_df, similar_artist_candidate_set_df,
+                                  recommendation_top_artist_limit, recommendation_similar_artist_limit)
 
     try:
         # timestamp when the script was invoked
@@ -471,8 +468,8 @@ def main(recommendation_top_artist_limit=None, recommendation_similar_artist_lim
     total_time = time.monotonic() - ts_initial
     logger.info('Total time: {:.2f}sec'.format(total_time))
 
-    result = create_messages(top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_user_count, total_time,
-                             top_artist_rec_user_count, similar_artist_rec_user_count)
+    result = create_messages(params, top_artist_rec_mbid_df, similar_artist_rec_mbid_df, active_user_count,
+                             total_time, top_artist_rec_user_count, similar_artist_rec_user_count)
 
     users_df.unpersist()
 

--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -62,7 +62,7 @@ def get_most_recent_model_meta():
         SELECT model_id, model_html_file
           FROM model_metadata
       ORDER BY model_created DESC
-         LIMIT 1 
+         LIMIT 1
     """).collect()[0]
     return meta.model_id, meta.model_html_file
 
@@ -269,10 +269,11 @@ def create_messages(params, top_artist_rec_mbid_df, similar_artist_rec_mbid_df, 
     """ Create messages to send the data to the webserver via RabbitMQ.
 
         Args:
+            params: recommendation params to get model id and model url from
             top_artist_rec_mbid_df (dataframe): Top artist recommendations.
             similar_artist_rec_mbid_df (dataframe): Similar artist recommendations.
             active_user_count (int): Number of users active in the last week.
-            total_time (str): Time taken in exceuting the whole script.
+            total_time (float): Time taken in exceuting the whole script.
             top_artist_rec_user_count (int): Number of users for whom top artist recommendations were generated.
             similar_artist_rec_user_count (int): Number of users for whom similar artist recommendations were generated.
 

--- a/listenbrainz_spark/recommendations/recording/tests/__init__.py
+++ b/listenbrainz_spark/recommendations/recording/tests/__init__.py
@@ -58,6 +58,7 @@ class RecommendationsTestCase(SparkNewTestCase):
         return {
             'dataframe_id': 'xxxxx',
             'model_id': model_id,
+            'model_html_file': f"{model_id}.html",
             'alpha': 3.0,
             'lmbda': 2.0,
             'iteration': 2,

--- a/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
@@ -274,7 +274,7 @@ class RecommendTestClass(RecommendationsTestCase):
         model_metadata = df_1.union(df_2)
         utils.save_parquet(model_metadata, path.RECOMMENDATION_RECORDING_MODEL_METADATA)
 
-        expected_model_id = recommend.get_most_recent_model_id()
+        expected_model_id = recommend.get_most_recent_model_meta()
         self.assertEqual(expected_model_id, model_id_2)
 
     @patch('listenbrainz_spark.recommendations.recording.recommend.get_candidate_set_rdd_for_user')

--- a/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
@@ -279,8 +279,9 @@ class RecommendTestClass(RecommendationsTestCase):
         model_metadata = df_1.union(df_2)
         utils.save_parquet(model_metadata, path.RECOMMENDATION_RECORDING_MODEL_METADATA)
 
-        expected_model_id = recommend.get_most_recent_model_meta()
-        self.assertEqual(expected_model_id, model_id_2)
+        expected_model_meta = recommend.get_most_recent_model_meta()
+        self.assertEqual(expected_model_meta[0], model_id_2)
+        self.assertEqual(expected_model_meta[1], f"{model_id_2}.html")
 
     @patch('listenbrainz_spark.recommendations.recording.recommend.get_candidate_set_rdd_for_user')
     @patch('listenbrainz_spark.recommendations.recording.recommend.generate_recommendations')
@@ -407,7 +408,7 @@ class RecommendTestClass(RecommendationsTestCase):
                 ],
                 'similar_artist': [],
                 'model_id': 'foobar',
-                'model_html_file': 'foobar.html'
+                'model_url': 'http://michael.metabrainz.org/foobar.html'
             }
         })
 
@@ -428,7 +429,7 @@ class RecommendTestClass(RecommendationsTestCase):
                     }
                 ],
                 'model_id': 'foobar',
-                'model_html_file': 'foobar.html'
+                'model_url': 'http://michael.metabrainz.org/foobar.html'
             }
         })
 
@@ -448,7 +449,7 @@ class RecommendTestClass(RecommendationsTestCase):
                     }
                 ],
                 'model_id': 'foobar',
-                'model_html_file': 'foobar.html'
+                'model_url': 'http://michael.metabrainz.org/foobar.html'
             }
         })
 

--- a/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_recommend.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from unittest.mock import patch, call, MagicMock
 
 import listenbrainz_spark
@@ -22,17 +23,22 @@ class RecommendTestClass(RecommendationsTestCase):
     def test_recommendation_params_init(self):
         recordings_df = utils.create_dataframe(Row(col1=3, col2=9), schema=None)
         model = MagicMock()
+        model_id = "foobar"
+        model_html_file = "foobar.html"
         top_artist_candidate_set_df = utils.create_dataframe(Row(col1=4, col2=5, col3=5), schema=None)
         similar_artist_candidate_set_df = utils.create_dataframe(Row(col1=1), schema=None)
         recommendation_top_artist_limit = 20
         recommendation_similar_artist_limit = 40
 
-        params = recommend.RecommendationParams(recordings_df, model, top_artist_candidate_set_df,
+        params = recommend.RecommendationParams(recordings_df, model_id, model_html_file, model,
+                                                top_artist_candidate_set_df,
                                                 similar_artist_candidate_set_df,
                                                 recommendation_top_artist_limit,
                                                 recommendation_similar_artist_limit)
 
         self.assertEqual(sorted(params.recordings_df.columns), sorted(recordings_df.columns))
+        self.assertEqual(params.model_id, model_id)
+        self.assertEqual(params.model_html_file, model_html_file)
         self.assertEqual(params.model, model)
         self.assertEqual(sorted(params.top_artist_candidate_set_df.columns), sorted(top_artist_candidate_set_df.columns))
         self.assertEqual(sorted(params.similar_artist_candidate_set_df.columns), sorted(similar_artist_candidate_set_df.columns))
@@ -253,11 +259,10 @@ class RecommendTestClass(RecommendationsTestCase):
     @patch('listenbrainz_spark.recommendations.recording.recommend.MatrixFactorizationModel')
     @patch('listenbrainz_spark.recommendations.recording.recommend.listenbrainz_spark')
     @patch('listenbrainz_spark.recommendations.recording.recommend.get_model_path')
-    @patch('listenbrainz_spark.recommendations.recording.recommend.get_most_recent_model_id')
-    def test_load_model(self, mock_id, mock_model_path, mock_lb, mock_matrix_model):
-        model = recommend.load_model()
-        mock_id.assert_called_once()
-        mock_model_path.assert_called_once_with(mock_id.return_value)
+    def test_load_model(self, mock_model_path, mock_lb, mock_matrix_model):
+        model_id = uuid.uuid4()
+        recommend.load_model(model_id)
+        mock_model_path.assert_called_once_with(model_id)
         mock_matrix_model.load.assert_called_once_with(mock_lb.context, mock_model_path.return_value)
 
     def test_get_most_recent_model_id(self):
@@ -375,6 +380,7 @@ class RecommendTestClass(RecommendationsTestCase):
         self.assertEqual(max_test, True)
 
     def test_create_messages(self):
+        params = self.get_recommendation_params()
         top_artist_rec_df = self.get_top_artist_rec_df()
         similar_artist_rec_df = self.get_similar_artist_rec_df()
         active_user_count = 10
@@ -382,8 +388,8 @@ class RecommendTestClass(RecommendationsTestCase):
         similar_artist_rec_user_count = 4
         total_time = 3600
 
-        data = recommend.create_messages(top_artist_rec_df, similar_artist_rec_df, active_user_count, total_time,
-                               top_artist_rec_user_count, similar_artist_rec_user_count)
+        data = recommend.create_messages(params, top_artist_rec_df, similar_artist_rec_df, active_user_count,
+                                         total_time, top_artist_rec_user_count, similar_artist_rec_user_count)
 
         self.assertEqual(next(data), {
             'user_id': 3,
@@ -399,7 +405,9 @@ class RecommendTestClass(RecommendationsTestCase):
                         'score': -0.8
                     }
                 ],
-                'similar_artist': []
+                'similar_artist': [],
+                'model_id': 'foobar',
+                'model_html_file': 'foobar.html'
             }
         })
 
@@ -418,7 +426,9 @@ class RecommendTestClass(RecommendationsTestCase):
                         'recording_mbid': "7acb406f-c716-45f8-a8bd-96ca3939c2e5",
                         'score': 0.19
                     }
-                ]
+                ],
+                'model_id': 'foobar',
+                'model_html_file': 'foobar.html'
             }
         })
 
@@ -436,7 +446,9 @@ class RecommendTestClass(RecommendationsTestCase):
                         'recording_mbid': "8acb406f-c716-45f8-a8bd-96ca3939c2e5",
                         'score': -2.8
                     }
-                ]
+                ],
+                'model_id': 'foobar',
+                'model_html_file': 'foobar.html'
             }
         })
 
@@ -459,12 +471,15 @@ class RecommendTestClass(RecommendationsTestCase):
     def get_recommendation_params(self):
         recordings_df = self.get_recordings_df()
         model = MagicMock()
+        model_id = "foobar"
+        model_html_file = "foobar.html"
         top_artist_candidate_set_df = self.get_candidate_set()
         similar_artist_candidate_set_df = self.get_candidate_set()
         recommendation_top_artist_limit = 2
         recommendation_similar_artist_limit = 1
 
-        params = recommend.RecommendationParams(recordings_df, model, top_artist_candidate_set_df,
+        params = recommend.RecommendationParams(recordings_df, model_id, model_html_file, model,
+                                                top_artist_candidate_set_df,
                                                 similar_artist_candidate_set_df,
                                                 recommendation_top_artist_limit,
                                                 recommendation_similar_artist_limit)

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -151,6 +151,7 @@ def get_best_model_metadata(best_model):
         'rmse_time': best_model.rmse_time,
         'training_time': best_model.training_time,
         'validation_rmse': best_model.validation_rmse,
+        'model_html_file': f"Model-{datetime.utcnow().strftime('%Y-%m-%d-%H:%M')}-{uuid.uuid4()}.html"
     }
 
 
@@ -299,8 +300,6 @@ def save_training_html(time_, num_training, num_validation, num_test, model_meta
             ti (str): Value of the monotonic clock when the script was run.
             models_training_data (str): Time taken to train all the models.
     """
-    date = datetime.utcnow().strftime('%Y-%m-%d-%H:%M')
-    model_html = 'Model-{}-{}.html'.format(date, uuid.uuid4())
     context = {
         'time' : time_,
         'num_training' : '{:,}'.format(num_training),
@@ -311,7 +310,7 @@ def save_training_html(time_, num_training, num_validation, num_test, model_meta
         'models_training_time' : models_training_time,
         'total_time' : '{:.2f}'.format((time.monotonic() - ti) / 3600)
     }
-    save_html(model_html, context, 'model.html')
+    save_html(best_model_metadata['model_html_file'], context, 'model.html')
 
 
 def main(ranks=None, lambdas=None, iterations=None, alphas=None):

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -30,8 +30,8 @@ model_param_schema = StructType(sorted(model_param_schema, key=lambda field: fie
 model_metadata_schema = [
     StructField('dataframe_id', StringType(), nullable=False),  # dataframe id or identification string of dataframe.
     StructField('model_created', TimestampType(), nullable=False),  # Timestamp when the model is saved in HDFS.
-    StructField('model_id', StringType(), nullable=False),  # Model id or identification string of best model.
     StructField('model_html_file', StringType(), nullable=False),  # Model html file name
+    StructField('model_id', StringType(), nullable=False),  # Model id or identification string of best model.
     StructField('model_param', model_param_schema, nullable=False),  # Parameters used to train the model.
     StructField('test_data_count', IntegerType(), nullable=False),  # Number of listens used to test the model.
     StructField('test_rmse', FloatType(), nullable=False),  # Root mean squared error for test data.
@@ -93,6 +93,7 @@ def convert_model_metadata_to_row(meta):
     return Row(
         dataframe_id=meta.get('dataframe_id'),
         model_created=datetime.utcnow(),
+        model_html_file=meta.get('model_html_file'),
         model_id=meta.get('model_id'),
         model_param=Row(
             alpha=meta.get('alpha'),
@@ -100,7 +101,6 @@ def convert_model_metadata_to_row(meta):
             lmbda=meta.get('lmbda'),
             rank=meta.get('rank'),
         ),
-        model_html_file=meta.get('model_html_file'),
         test_data_count=meta.get('test_data_count'),
         test_rmse=meta.get('test_rmse'),
         training_data_count=meta.get('training_data_count'),

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -30,9 +30,9 @@ model_param_schema = StructType(sorted(model_param_schema, key=lambda field: fie
 model_metadata_schema = [
     StructField('dataframe_id', StringType(), nullable=False),  # dataframe id or identification string of dataframe.
     StructField('model_created', TimestampType(), nullable=False),  # Timestamp when the model is saved in HDFS.
-    StructField('model_param', model_param_schema, nullable=False),  # Parameters used to train the model.
     StructField('model_id', StringType(), nullable=False),  # Model id or identification string of best model.
-    StructField('model_html_file', StringType(), nullable=False),  # Model id or identification string of best model.
+    StructField('model_html_file', StringType(), nullable=False),  # Model html file name
+    StructField('model_param', model_param_schema, nullable=False),  # Parameters used to train the model.
     StructField('test_data_count', IntegerType(), nullable=False),  # Number of listens used to test the model.
     StructField('test_rmse', FloatType(), nullable=False),  # Root mean squared error for test data.
     StructField('training_data_count', IntegerType(), nullable=False),  # Number of listens used to train the model.

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -32,6 +32,7 @@ model_metadata_schema = [
     StructField('model_created', TimestampType(), nullable=False),  # Timestamp when the model is saved in HDFS.
     StructField('model_param', model_param_schema, nullable=False),  # Parameters used to train the model.
     StructField('model_id', StringType(), nullable=False),  # Model id or identification string of best model.
+    StructField('model_html_file', StringType(), nullable=False),  # Model id or identification string of best model.
     StructField('test_data_count', IntegerType(), nullable=False),  # Number of listens used to test the model.
     StructField('test_rmse', FloatType(), nullable=False),  # Root mean squared error for test data.
     StructField('training_data_count', IntegerType(), nullable=False),  # Number of listens used to train the model.
@@ -99,6 +100,7 @@ def convert_model_metadata_to_row(meta):
             lmbda=meta.get('lmbda'),
             rank=meta.get('rank'),
         ),
+        model_html_file=meta.get('model_html_file'),
         test_data_count=meta.get('test_data_count'),
         test_rmse=meta.get('test_rmse'),
         training_data_count=meta.get('training_data_count'),


### PR DESCRIPTION
In order to compare recommendations from various runs, we intend to create playlists of the recommendations linking back to the original model details that generated it. For this, metabrainz/troi-recommendation-playground#52 added a patch. Adding model id and model url to the api for the same.