### PR TITLE
Trust input from approved bots

### DIFF
--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -283,7 +283,7 @@ def create_playlist():
 
     # filter description
     description = data["playlist"].get("annotation", None)
-    if description is not None:
+    if description is not None and user["musicbrainz_id"] not in current_app.config["APPROVED_PLAYLIST_BOTS"]:
         description = _filter_description_html(description)
 
     # Check to see if the submitted playlist has algorithm_metadata defined and the current user an approved

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -144,7 +144,9 @@ def create_user_notification_event(user_name):
     if "message" not in data:
         raise APIBadRequest("Invalid metadata: message is missing")
 
-    message = _filter_description_html(data["message"])
+    # Not filtering html in the message because only approved users can use this endpoint.
+    # if this changes in the future, add back html cleanup here.
+    message = data["message"]
     metadata = NotificationMetadata(creator=creator['musicbrainz_id'], message=message)
 
     try:


### PR DESCRIPTION
troi-bot needs to add urls to the playlist descriptions which aren't in the allowlist. Its easier to disable all input verification for troi-bot instead of disabling checks incrementally when needed.
