### PR TITLE
Add support for running troi after recommendations are run. 

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -20,6 +20,7 @@ from data.model.user_listening_activity import ListeningActivityRecord
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
 from listenbrainz.db.similar_users import import_user_similarities
+from listenbrainz.spark.troi_bot import run_post_recommendation_troi_bot
 
 
 TIME_TO_CONSIDER_STATS_AS_OLD = 20  # minutes
@@ -233,6 +234,9 @@ def handle_recommendations(data):
                                  {user["musicbrainz_id"]}. \nData: {json.dumps(data, indent=3)}""")
 
     current_app.logger.debug("recommendation for {} inserted".format(user["musicbrainz_id"]))
+
+    current_app.logger.debug("Running post recommendation steps for user {}".format(user["musicbrainz_id"]))
+    run_post_recommendation_troi_bot(user["musicbrainz_id"])
 
 
 def notify_mapping_import(data):

--- a/listenbrainz/spark/troi_bot.py
+++ b/listenbrainz/spark/troi_bot.py
@@ -1,0 +1,22 @@
+""" This function contains code to run the various troi-bot functions after
+    recommendations have been generated.
+"""
+from troi.core import generate_playlist
+import config
+
+USER_TO_PROCESS = ["mr_monkey", "rob", "akshaaatt", "Damselfish", "lucifer", "alastairp", "CatCat", "atj"]
+
+def run_post_recommendation_troi_bot(user):
+    """
+        Top level function called after spark CF recommendations have been completed.
+    """
+
+    if user in USERS_TO_PROCESS:
+        make_playlist_from_recommendations(user)
+        # Add others here
+
+def make_playlist_from_recommendations(user):
+
+    token = config.WHITELISTED_AUTH_TOKENS[0]
+    for type in ["top", "similar"]:
+        generate_playlist("recs-to-playlist", args=[user, type], upload=True, token=token, created_for=user)

--- a/listenbrainz/spark/troi_bot.py
+++ b/listenbrainz/spark/troi_bot.py
@@ -4,7 +4,8 @@
 from flask import current_app
 from troi.core import generate_playlist
 
-USER_TO_PROCESS = ["mr_monkey", "rob", "akshaaatt", "Damselfish", "lucifer", "alastairp", "CatCat", "atj"]
+USERS_TO_PROCESS = ["mr_monkey", "rob", "akshaaatt", "Damselfish", "lucifer", "alastairp", "CatCat", "atj"]
+
 
 def run_post_recommendation_troi_bot(user):
     """
@@ -15,8 +16,8 @@ def run_post_recommendation_troi_bot(user):
         make_playlist_from_recommendations(user)
         # Add others here
 
-def make_playlist_from_recommendations(user):
 
-    token = current.app.config["WHITELISTED_AUTH_TOKENS"][0]
+def make_playlist_from_recommendations(user):
+    token = current_app.config["WHITELISTED_AUTH_TOKENS"][0]
     for type in ["top", "similar"]:
         generate_playlist("recs-to-playlist", args=[user, type], upload=True, token=token, created_for=user)

--- a/listenbrainz/spark/troi_bot.py
+++ b/listenbrainz/spark/troi_bot.py
@@ -1,8 +1,8 @@
 """ This function contains code to run the various troi-bot functions after
     recommendations have been generated.
 """
+from flask import current_app
 from troi.core import generate_playlist
-import config
 
 USER_TO_PROCESS = ["mr_monkey", "rob", "akshaaatt", "Damselfish", "lucifer", "alastairp", "CatCat", "atj"]
 
@@ -17,6 +17,6 @@ def run_post_recommendation_troi_bot(user):
 
 def make_playlist_from_recommendations(user):
 
-    token = config.WHITELISTED_AUTH_TOKENS[0]
+    token = current.app.config["WHITELISTED_AUTH_TOKENS"][0]
     for type in ["top", "similar"]:
         generate_playlist("recs-to-playlist", args=[user, type], upload=True, token=token, created_for=user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pika == 1.2.0
 git+https://github.com/metabrainz/brainzutils-python.git@v2.3.1
 spotipy == 2.17.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster
-git+https://github.com/metabrainz/troi-recommendation-playground.git@f3fb908#egg=troi
+git+https://github.com/metabrainz/troi-recommendation-playground.git#egg=troi
 pyyaml == 5.4.1
 eventlet == 0.31.0
 uWSGI == 2.0.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pika == 1.2.0
 git+https://github.com/metabrainz/brainzutils-python.git@v2.3.1
 spotipy == 2.17.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster
-git+https://github.com/metabrainz/troi-recommendation-playground.git#egg=troi
+git+https://github.com/metabrainz/troi-recommendation-playground.git@b855df3c#egg=troi
 pyyaml == 5.4.1
 eventlet == 0.31.0
 uWSGI == 2.0.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pika == 1.2.0
 git+https://github.com/metabrainz/brainzutils-python.git@v2.3.1
 spotipy == 2.17.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster
-git+https://github.com/metabrainz/troi-recommendation-playground.git@2feb09c#egg=troi
+git+https://github.com/metabrainz/troi-recommendation-playground.git@21f9e99#egg=troi
 pyyaml == 5.4.1
 eventlet == 0.31.0
 uWSGI == 2.0.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pika == 1.2.0
 git+https://github.com/metabrainz/brainzutils-python.git@v2.3.1
 spotipy == 2.17.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster
-git+https://github.com/metabrainz/troi-recommendation-playground.git@21f9e99#egg=troi
+git+https://github.com/metabrainz/troi-recommendation-playground.git@f3fb908#egg=troi
 pyyaml == 5.4.1
 eventlet == 0.31.0
 uWSGI == 2.0.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pika == 1.2.0
 git+https://github.com/metabrainz/brainzutils-python.git@v2.3.1
 spotipy == 2.17.1
 git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0#egg=datasethoster
+git+https://github.com/metabrainz/troi-recommendation-playground.git@2feb09c#egg=troi
 pyyaml == 5.4.1
 eventlet == 0.31.0
 uWSGI == 2.0.19.1
@@ -52,3 +53,5 @@ more-itertools==8.8.0
 librabbitmq-fork==2.0.2.dev1
 kombu==5.1.0
 itsdangerous==2.0.1
+pylistenbrainz==0.5.1
+countryinfo==0.1.2


### PR DESCRIPTION
This PR add the ability to run scripts as troi-bot once recommendations are complete. The only patch running right now is the one that sends a playlist to LB with a link to the model metadata.

The inner core of this code (which invokes troi) has been tested, but the rest... no idea how to do that.
