### PR TITLE
Navbar: Fix logo width

### DIFF
--- a/listenbrainz/webserver/static/css/main.less
+++ b/listenbrainz/webserver/static/css/main.less
@@ -54,7 +54,7 @@ body {
     .pull-right;
     color: @red;
   }
-  @logo-width: 166px + 15px;
+  @logo-width: 165px + 15px;
   .navbar-variant(#353070, @logo-width);
   .import-link {
     > a {

--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -10,7 +10,7 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand logo" href="{{ url_for('index.index') }}">
-          <img src="{{ url_for('static', filename='img/navbar_logo.svg') }}" alt="ListenBrainz" />
+          <img src="{{ url_for('static', filename='img/navbar_logo.svg') }}" alt="ListenBrainz" width="180" />
       </a>
     </div>
 


### PR DESCRIPTION
Recent changes in logos 'broke' the navbar (making it wrap):

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/6179856/165078062-ec87cab3-e925-4e05-ba06-1c916c56f8e2.png">


This PR makes sure the logo (with padding) is set to a specific width of 180px (not sure why we were at 181px before, decided to round it up). Adjusted the CSS to remove that 1 pixel.
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/6179856/165078162-f8e70c95-d3bb-4bef-981a-b0f3fec0904c.png">


