### PR TITLE
Replace TrainValidationSplit with CrossValidation

### DIFF
--- a/listenbrainz_spark/recommendations/recording/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_models.py
@@ -1,6 +1,5 @@
-import re
 from unittest import mock
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, MagicMock
 
 from listenbrainz_spark.recommendations.recording.tests import RecommendationsTestCase
 from listenbrainz_spark.recommendations.recording.train_models import Model
@@ -51,7 +50,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
         expected_dataframe_id = train_models.get_latest_dataframe_id()
         self.assertEqual(expected_dataframe_id, df_id_2)
 
-    @patch('listenbrainz_spark.recommendations.recording.train_models.TrainValidationSplit')
+    @patch('listenbrainz_spark.recommendations.recording.train_models.CrossValidator')
     @patch('listenbrainz_spark.recommendations.recording.train_models.ParamGridBuilder')
     @patch('listenbrainz_spark.recommendations.recording.train_models.ALS')
     def test_get_best_model(self, mock_als_cls, mock_params, mock_tvs):
@@ -73,7 +72,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
             estimator=mock_als_cls.return_value,
             estimatorParamMaps=mock.ANY,
             evaluator=mock_evaluator,
-            trainRatio=0.80,
+            numFolds=5,
             collectSubModels=True
         )
         mock_tvs.return_value.fit.assert_called_once_with(mock_training)

--- a/listenbrainz_spark/recommendations/recording/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_models.py
@@ -2,7 +2,7 @@ from unittest import mock
 from unittest.mock import patch, MagicMock
 
 from listenbrainz_spark.recommendations.recording.tests import RecommendationsTestCase
-from listenbrainz_spark.recommendations.recording.train_models import Model
+from listenbrainz_spark.recommendations.recording.train_models import Model, NUM_FOLDS
 from listenbrainz_spark.tests import TEST_PLAYCOUNTS_PATH, PLAYCOUNTS_COUNT
 from listenbrainz_spark import utils, config, path, schema
 from listenbrainz_spark.recommendations.recording import train_models
@@ -72,7 +72,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
             estimator=mock_als_cls.return_value,
             estimatorParamMaps=mock.ANY,
             evaluator=mock_evaluator,
-            numFolds=5,
+            numFolds=NUM_FOLDS,
             collectSubModels=True,
             parallelism=3
         )

--- a/listenbrainz_spark/recommendations/recording/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_models.py
@@ -73,7 +73,8 @@ class TrainModelsTestCase(RecommendationsTestCase):
             estimatorParamMaps=mock.ANY,
             evaluator=mock_evaluator,
             numFolds=5,
-            collectSubModels=True
+            collectSubModels=True,
+            parallelism=3
         )
         mock_tvs.return_value.fit.assert_called_once_with(mock_training)
 

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -39,6 +39,9 @@ logger = logging.getLogger(__name__)
 Model = namedtuple('Model', 'model validation_rmse rank lmbda iteration alpha model_id')
 
 
+NUM_FOLDS = 5  # number of folds to use for k-folds cross validation
+
+
 def get_model_path(model_id: str):
     """ Get path to save or load model
 
@@ -159,11 +162,11 @@ def train_models(training_data, evaluator, ranks, lambdas, iterations, alphas, c
         estimator=als,
         estimatorParamMaps=params,
         evaluator=evaluator,
-        numFolds=5,
+        numFolds=NUM_FOLDS,
         collectSubModels=True,
         parallelism=3
     )
-    context["num_folds"] = 5
+    context["num_folds"] = NUM_FOLDS
     cv_model: CrossValidatorModel = cv.fit(training_data)
     logger.info("Model trained!")
 

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -160,7 +160,8 @@ def train_models(training_data, evaluator, ranks, lambdas, iterations, alphas, c
         estimatorParamMaps=params,
         evaluator=evaluator,
         numFolds=5,
-        collectSubModels=True
+        collectSubModels=True,
+        parallelism=3
     )
     context["num_folds"] = 5
     cv_model: CrossValidatorModel = cv.fit(training_data)

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -100,7 +100,7 @@ def get_models(als: ALS, params: List[dict], cv_model: CrossValidatorModel) -> T
     best_model_metadata = None
 
     metadatas = []
-    for param, model, metric in zip(params, cv_model.subModels, cv_model.avgMetrics):
+    for param, model, metric in zip(params, cv_model.subModels[0], cv_model.avgMetrics):
         model_metadata = Model(
             model=model,
             rank=param[als.rank],

--- a/listenbrainz_spark/recommendations/templates/model.html
+++ b/listenbrainz_spark/recommendations/templates/model.html
@@ -34,9 +34,9 @@
 
     <p>
         Preprocessing of playcounts dataframe takes <b>{{ time_preprocessing }}</b>. The preprocessed data divided the
-        data into training and test data, in {{ train_test_ratio }}. Further, {{ train_validation_ratio * 100 | round(2)}}
-        % of the training dataset was used for training the model. The remaining listens in the training dataset were
-        used for validating phase of the model. From the models trained, the best one is selected to generate recommendations.
+        data into training and test data, in {{ train_test_ratio }}. The model was then trained on the training data
+        using K-Folds Cross Validation with {{ num_folds }} folds. From the models trained, the one with least RMSE
+        is selected to generate recommendations.
     </p>
     <p>
         Of all the trained models, the model with the least RMSE value is chosen to generate recommendations. The model


### PR DESCRIPTION
CrossValidation splits the training data multiple times as opposed to TrainValidationSplit which only does it once. Therefore, CrossValidation takes more time to train but can also help in less randomness in models.