### PR TITLE
Check if the canonical_release_redirect table exists before running

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/bulk_table.py
+++ b/listenbrainz/mbid_mapping/mapping/bulk_table.py
@@ -133,6 +133,20 @@ class BulkInsertTable:
             any flushing/cleanup needed can be completed.
         """
 
+    def table_exists(self):
+        conn = self.lb_conn if self.lb_conn is not None else self.mb_conn
+        try:
+            with conn.cursor() as curs:
+                query = f"""SELECT count(*)
+                            FROM {self.table_name}"""
+                curs.execute(query)
+                if curs.fetchone()[0] > 0:
+                    return True
+                else:
+                    return False
+        except psycopg2.errors.UndefinedTable as err:
+            return False
+
     def _create_tables(self):
         """
             This function creates the temp table, given the provided specification.

--- a/listenbrainz/mbid_mapping/mapping/bulk_table.py
+++ b/listenbrainz/mbid_mapping/mapping/bulk_table.py
@@ -156,6 +156,9 @@ class BulkInsertTable:
         conn = self.lb_conn if self.lb_conn is not None else self.mb_conn
         try:
             with conn.cursor() as curs:
+                if "." in self.table_name:
+                    schema = self.table_name.split(".")[0]
+                    curs.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
 
                 columns = []
                 for name, types in self.get_create_table_columns():

--- a/listenbrainz/mbid_mapping/mapping/bulk_table.py
+++ b/listenbrainz/mbid_mapping/mapping/bulk_table.py
@@ -134,6 +134,12 @@ class BulkInsertTable:
         """
 
     def table_exists(self):
+        """Check if the table for this bulk inserter exists.
+
+        Returns:
+            True if it exists and has data in it
+            False if it doesn't exist or is empty
+        """
         conn = self.lb_conn if self.lb_conn is not None else self.mb_conn
         try:
             with conn.cursor() as curs:

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -9,6 +9,7 @@ import ujson
 from mapping.utils import create_schema, insert_rows, log
 from mapping.formats import create_formats_table
 from mapping.bulk_table import BulkInsertTable
+from mapping.canonical_release_redirect import CanonicalReleaseRedirect
 import config
 
 
@@ -419,6 +420,11 @@ def create_mb_metadata_cache():
         lb_conn = None
         if config.SQLALCHEMY_TIMESCALE_URI:
             lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
+
+        can_rel = CanonicalReleaseRedirect(mb_conn)
+        if not can_rel.table_exists():
+            log("mb metadata cache: canonical_release_redirect table doesn't exist, run `canonical-data` manage command first")
+            return
 
         cache = MusicBrainzMetadataCache(mb_conn, lb_conn)
         cache.run()


### PR DESCRIPTION
# Problem

The `canonical_release_redirect` and `canonical_musicbrainz_data` tables are needed to generate the metadata cache, so check that one of them exists before running.

I initially thought to also run the necessary loaders in the case that the tables don't exist, but I noticed that the [setup code](https://github.com/metabrainz/listenbrainz-server/blob/16a61d1a0d142e453942cf110dfffc67deb7ce99/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py#L151) requires a careful order in the execution of the tables, along with manual swapping so that `get_post_process_queries` can use some existing `_tmp` tables.
I didn't want to copy this entire code block again just for a special case in the metadata loader, so I decided to just push a simple check for now. In the future we could update the helper methods to deduplicate code if needed.


