### PR TITLE
Use consul-template if-statement to check if the listenstore is up

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -54,26 +54,30 @@ MB_DATABASE_URI = "SERVICEDOESNOTEXIST_pgbouncer-slave_pgbouncer-master"
 {{end}}
 
 
-# Use a key 'listenstore_up' in consul (python boolean True or False) to decide if we connect to timescale.
+# Use a key 'listenstore_up' in consul (json boolean true or false) to decide if we connect to timescale.
 # If we set SQLALCHEMY_TIMESCALE_URI to an empty string, then the @api_listenstore_needed and @web_listenstore_needed
 # decorators will prevent the webserver from accessing the timescale database
-if {{template "KEY" "listenstore_up"}}:
-{{if service "timescale-listenbrainz"}}
-{{with index (service "timescale-listenbrainz") 0}}
-    SQLALCHEMY_TIMESCALE_URI = """postgresql://listenbrainz_ts:{{template "KEY" "timescale_lb_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
-    TIMESCALE_ADMIN_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/postgres"""
-    TIMESCALE_ADMIN_LB_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
-{{end}}
+{{- /* This needs to use key/printf again here instead of our pre-defined template at the top of the file as you cannot
+     call a template in an if statement or variable declaration */}}
+{{- $listenstore_up := (key (printf "docker-server-configs/LB/config.%s.json/listenstore_up" (env "DEPLOY_ENV"))) }}
+{{- if $listenstore_up | parseBool}}
+    {{- if service "timescale-listenbrainz"}}
+    {{with index (service "timescale-listenbrainz") 0}}
+SQLALCHEMY_TIMESCALE_URI = """postgresql://listenbrainz_ts:{{template "KEY" "timescale_lb_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
+TIMESCALE_ADMIN_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/postgres"""
+TIMESCALE_ADMIN_LB_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
+    {{end}}
+    {{else}}
+SQLALCHEMY_TIMESCALE_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
+TIMESCALE_ADMIN_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
+TIMESCALE_ADMIN_LB_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
+    {{end}}
 {{else}}
-    SQLALCHEMY_TIMESCALE_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
-    TIMESCALE_ADMIN_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
-    TIMESCALE_ADMIN_LB_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
+SQLALCHEMY_TIMESCALE_URI = ""
+TIMESCALE_ADMIN_URI=""
+TIMESCALE_ADMIN_LB_URI=""
 {{end}}
 
-else:
-    SQLALCHEMY_TIMESCALE_URI = ""
-    TIMESCALE_ADMIN_URI=""
-    TIMESCALE_ADMIN_LB_URI=""
 
 {{if service "pgbouncer-aretha"}}
 {{with index (service "pgbouncer-aretha") 0}}


### PR DESCRIPTION
We want a consul setting that we can use to shut down the listenstore
when we need to do maintenance.
We initially used a python if statement here, expecting to be able to
render the config file as

```py
if False:
    SQLALCHEMY_TIMESCALE_URI = """postgresql:// ..."""
else:
    SQLALCHEMY_TIMESCALE_URI = ""
```

However this doesn't work when the service disappears from consul (for
example if we shut down the server). The config file ends up as

```py
if False:
    SQLALCHEMY_TIMESCALE_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"
else:
    SQLALCHEMY_TIMESCALE_URI = ""
```

and our startup script (run-lb-command) fails because it finds the sentinel
SERVICEDOESNOTEXIST in the config and refuses to continue.

Instead, use a consul-template {{if}} to render this config depending on
the listenstore_up config item.

This usage duplicates the (printf / env ()) syntax used in our KEY
template as it's not possible to call a template inside an if statement
or a variable declaration

This requires an update to the consul settings for LB to switch to using a json boolean (true/false) instead of a string with a python True/False at the same time that we deploy this.
