### PR TITLE
LB-1099: Do not show feedback cards without track name 

### DIFF
--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -102,6 +102,9 @@ def fetch_track_metadata_for_items(items: List[ModelT]) -> List[ModelT]:
     msid_metadatas = load_recordings_from_msids(remaining_item_map.keys())
     for metadata in msid_metadatas:
         msid = metadata["ids"]["recording_msid"]
+        if msid not in remaining_item_map:
+            continue
+
         for item in remaining_item_map[msid]:
             item.track_metadata = {
                 "track_name": metadata["payload"]["title"],

--- a/listenbrainz/messybrainz/data.py
+++ b/listenbrainz/messybrainz/data.py
@@ -184,10 +184,12 @@ def submit_recording(connection, data):
 
 def load_recordings_from_msids(connection, messybrainz_ids):
     """ Returns data for a recordings corresponding to a given list of MessyBrainz IDs.
+    msids not found in the database are omitted from the returned dict (usually indicates the msid
+    is wrong because data is not deleted from MsB).
 
     Args:
         connection: sqlalchemy connection to execute db queries with
-        messybrainz_id (list [uuid]): the MessyBrainz IDs of the recordings to fetch data for
+        messybrainz_ids (list [uuid]): the MessyBrainz IDs of the recordings to fetch data for
 
     Returns:
         list [dict]: a list of the recording data for the recordings in the order of the given MSIDs.
@@ -210,7 +212,7 @@ def load_recordings_from_msids(connection, messybrainz_ids):
 
     rows = result.fetchall()
     if not rows:
-        raise exceptions.NoDataFoundException
+        return []
 
     msid_recording_map = {str(x["gid"]): x for x in rows}
 
@@ -218,7 +220,7 @@ def load_recordings_from_msids(connection, messybrainz_ids):
     results = []
     for msid in messybrainz_ids:
         if msid not in msid_recording_map:
-            raise exceptions.NoDataFoundException
+            continue
         row = msid_recording_map[msid]
         results.append({
             "payload": row["data"],

--- a/listenbrainz/messybrainz/exceptions.py
+++ b/listenbrainz/messybrainz/exceptions.py
@@ -2,13 +2,11 @@ class MessyBrainzException(Exception):
     """Base exception for this package."""
     pass
 
-class NoDataFoundException(MessyBrainzException):
-    """Should be used when no data has been found."""
-    pass
 
 class BadDataException(MessyBrainzException):
     """Should be used when incorrect data is being submitted."""
     pass
+
 
 class ErrorAddingException(MessyBrainzException):
     """Should be used when incorrect data is being submitted."""

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -128,8 +128,6 @@ class TimescaleWriterSubscriber:
         except (messybrainz.exceptions.BadDataException, messybrainz.exceptions.ErrorAddingException):
             current_app.logger.error("MessyBrainz lookup for listens failed: ", exc_info=True)
             return []
-        except messybrainz.exceptions.NoDataFoundException:
-            return []
 
         augmented_listens = []
         for listen, messybrainz_resp in zip(listens, msb_responses['payload']):

--- a/listenbrainz/webserver/static/js/tests/user/UserFeedback.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/user/UserFeedback.test.tsx
@@ -6,7 +6,9 @@ import UserFeedback, {
   UserFeedbackProps,
   UserFeedbackState,
 } from "../../src/user/UserFeedback";
-import GlobalAppContext, { GlobalAppContextT } from "../../src/utils/GlobalAppContext";
+import GlobalAppContext, {
+  GlobalAppContextT,
+} from "../../src/utils/GlobalAppContext";
 import APIService from "../../src/utils/APIService";
 import * as userFeedbackProps from "../__mocks__/userFeedbackProps.json";
 import * as userFeedbackAPIResponse from "../__mocks__/userFeedbackAPIResponse.json";
@@ -173,6 +175,44 @@ describe("UserFeedback", () => {
     );
     const listens = wrapper.find(ListenCard);
     expect(listens).toHaveLength(15);
+  });
+
+  it("does not render ListenCard items for feedback item without track name", async () => {
+    const withoutTrackNameProps = {
+      ...props,
+      feedback: [
+        {
+          created: 1631778335,
+          recording_msid: "8aa379ad-852e-4794-9c01-64959f5d0b17",
+          score: 1,
+          track_metadata: {
+            additional_info: {
+              artist_msid: "49cd7874-b996-4caf-bece-cad2997b0fe3",
+              recording_mbid: "9812475d-c800-4f29-8a9a-4ac4af4b4dfd",
+              release_mbid: "17276c50-dd38-4c62-990e-186ef0ff36f4",
+            },
+            artist_name: "Hobocombo",
+            release_name: "",
+            track_name: "Bird's lament",
+          },
+          user_id: "mr_monkey",
+        },
+        {
+          created: 1631553259,
+          recording_msid: "edfa0bb9-a58c-406c-9f7c-f16741443f9c",
+          score: 1,
+          track_metadata: null,
+          user_id: "mr_monkey",
+        },
+      ],
+    };
+    const wrapper = mount<UserFeedback>(
+      <GlobalAppContext.Provider value={mountOptions.context}>
+        <UserFeedback {...(withoutTrackNameProps as UserFeedbackProps)} />
+      </GlobalAppContext.Provider>
+    );
+    const listens = wrapper.find(ListenCard);
+    expect(listens).toHaveLength(1);
   });
 
   it("shows feedback on the ListenCards according to recordingFeedbackMap", async () => {


### PR DESCRIPTION
LB-1099, discovered when a user's feedback page errored with ISE. When feedback is added, we only check that the mbid and msid are valid uuids but not whether the those actually exist in the database and refer to some track. Therefore, loosen the check on retrieval and ignore such MSIDs. Also, do not show feedback cards without track name.