### PR TITLE
LB-1095: Ignore all dumps in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ env
 # tmp folder
 tmp/
 
-# Listenbrainz listens dump
-listenbrainz-listens*
+# Listenbrainz dumps
+listenbrainz-*dump*.tar.*
 
 # ListenBrainz application data
 docker/data

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ env
 tmp/
 
 # Listenbrainz dumps
-listenbrainz-*dump*.tar.*
+listenbrainz-*dump*.tar*
 
 # ListenBrainz application data
 docker/data


### PR DESCRIPTION
Current `gitignore` only ignores `listens` dumps, leaving out other dumps.
This change will ignore all kinds of dumps.

# Problem

https://tickets.metabrainz.org/browse/LB-1095

# Solution
Modify the pattern to ignore all dumps
```gitignore
listenbrainz-*dump*.tar.*
```

