### PR TITLE
Removing extra Z from missing MB data API and view

### DIFF
--- a/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
+++ b/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
@@ -47,10 +47,6 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
         self.assert200(response)
         data = json.loads(response.data)['payload']
 
-        for index in range(len(data["data"])):
-            # To remove the Z at the end
-            data["data"][index]["listened_at"] = data["data"][index]["listened_at"][:-1]
-
         received_user_name = data['user_name']
         self.assertEqual(received_user_name, self.user['musicbrainz_id'])
 
@@ -77,10 +73,6 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
                                    query_string={'count': 10})
         self.assert200(response)
         data = json.loads(response.data)['payload']
-
-        for index in range(len(data["data"])):
-            # To remove the Z at the end
-            data["data"][index]["listened_at"] = data["data"][index]["listened_at"][:-1]
 
         received_user_name = data['user_name']
         self.assertEqual(received_user_name, self.user['musicbrainz_id'])
@@ -110,10 +102,6 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
         self.assert200(response)
         data = json.loads(response.data)['payload']
 
-        for index in range(len(data["data"])):
-            # To remove the Z at the end
-            data["data"][index]["listened_at"] = data["data"][index]["listened_at"][:-1]
-
         received_user_name = data['user_name']
         self.assertEqual(received_user_name, self.user['musicbrainz_id'])
 
@@ -142,10 +130,6 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
 
         self.assert200(response)
         data = json.loads(response.data)['payload']
-
-        for index in range(len(data["data"])):
-            # To remove the Z at the end
-            data["data"][index]["listened_at"] = data["data"][index]["listened_at"][:-1]
 
         received_user_name = data['user_name']
         self.assertEqual(received_user_name, self.user['musicbrainz_id'])

--- a/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
+++ b/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
@@ -110,9 +110,6 @@ def get_missing_musicbrainz_data(user_name):
 
     missing_musicbrainz_data_list_filtered = missing_musicbrainz_data_list[offset:count]
 
-    for index in range(len(missing_musicbrainz_data_list_filtered)):
-            missing_musicbrainz_data_list_filtered[index]["listened_at"] += "Z"
-
     payload = {
         'payload': {
             'user_name': user_name,

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -542,8 +542,6 @@ def missing_mb_data(user_name: str):
         missing_data_list = []
     else:
         missing_data_list = missing_data.data.dict()["missing_musicbrainz_data"]
-        for item in missing_data_list:
-            item["listened_at"] += "Z"
 
     props = {
         "missingData": missing_data_list,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
Earlier we had manually add `Z` at the end of timestamps to denote UTC timezone. Now spark adds the Z and hence this causes double Z
![image](https://user-images.githubusercontent.com/11733600/167888140-18c42d4a-d21f-467b-9502-549c70d89309.png)
![image](https://user-images.githubusercontent.com/11733600/167888196-01d0a75f-079a-4066-a8c0-79b01568738c.png)

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Removed the Z from API, view and tests
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



