### PR TITLE
Metadata viewer: Show better message if no listen to show

### DIFF
--- a/listenbrainz/webserver/static/css/metadata-viewer.less
+++ b/listenbrainz/webserver/static/css/metadata-viewer.less
@@ -26,6 +26,7 @@
 		z-index: 2;
 	}
 	.no-listen {
+		max-width: 50em;
 		min-width: 340px;
 		height: 300px;
 		// frosted glass effect
@@ -34,7 +35,7 @@
 		backdrop-filter: blur(10px);
 		box-shadow: 0 0 2rem 0 fade(black,20%);
 		// contents
-		font-size: 1.2em;
+		font-size: 1.3em;
 		padding: 2em;
 		display: flex;
 		justify-content: center;

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { faHeart, faHeartBroken } from "@fortawesome/free-solid-svg-icons";
+import { faPauseCircle } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as tinycolor from "tinycolor2";
 import { first, get, isEmpty, isNumber, isPlainObject, pick } from "lodash";
@@ -204,14 +205,30 @@ export default function MetadataViewer(props: MetadataViewerProps) {
         <div className="no-listen-container">
           <div className="no-listen">
             <p>
-              We don&apos;t have a <i>Playing Now</i> listen for you at the
-              moment.
+              <hr />
+              <div style={{ marginTop: "-2.1em" }}>
+                <FontAwesomeIcon icon={faPauseCircle} size="2x" />
+              </div>
+              Sorry, we do not know what music you are currently listening to,
+              since we have not received any recent <i>Playing Now</i> events
+              for your account.
               <br />
-              Are you&nbsp;<a href="/add-data/">sending listens</a> to
-              ListenBrainz?
+              As soon as a <i>Playing Now</i> listen comes through, this page
+              will be updated automatically.
               <br />
-              Sometimes it takes a while for us to receive listens from
-              third-party services, please be patient
+              <br />
+              <small>
+                In order to receive these events, you will need to{" "}
+                <a href="/add-data/">send listens</a> to ListenBrainz.
+                <br />
+                We work hard to make this data available to you as soon as we
+                receive it, but until your music service sends us a{" "}
+                <a href="https://listenbrainz.readthedocs.io/en/production/dev/json/?highlight=playing%20now#submission-json">
+                  <i>Playing Now</i> event
+                </a>
+                , we cannot display anything here.
+              </small>
+              <hr />
             </p>
           </div>
         </div>


### PR DESCRIPTION
Currently, the metadata viewer (https://listenbrainz.org/playing-now) only show a bit of text if there is no playing-now to show.
It's ugly and not user friendly at all.

Instead, let's show a more helpful message with a link to how to send data to LB as well as some basic expectation management text (and a nice frosted glass transparency effect).
Feedback on the wording is very welcome ! 
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/6179856/167905172-ff4e3be7-ca5a-4a25-b6a8-5ac853ce4663.png">
