### PR TITLE
Return empty results if MusicBrainz database connection isn't available

### DIFF
--- a/listenbrainz/labs_api/labs/api/artist_country_from_artist_mbid.py
+++ b/listenbrainz/labs_api/labs/api/artist_country_from_artist_mbid.py
@@ -28,7 +28,7 @@ class ArtistCountryFromArtistMBIDQuery(Query):
         if not current_app.config["MB_DATABASE_URI"]:
             return []
 
-        with psycopg2.connect(config.MB_DATABASE_URI) as conn:
+        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
 
                 acs = tuple([r['artist_mbid'] for r in params])

--- a/listenbrainz/labs_api/labs/api/artist_credit_from_artist_mbid.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_from_artist_mbid.py
@@ -26,7 +26,7 @@ class ArtistCreditIdFromArtistMBIDQuery(Query):
         if not current_app.config["MB_DATABASE_URI"]:
             return []
 
-        with psycopg2.connect(config.MB_DATABASE_URI) as conn:
+        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
 
                 acs = tuple([p['artist_mbid'] for p in params])

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -31,7 +31,7 @@ class RecordingFromRecordingMBIDQuery(Query):
             return []
 
         mbids = [p['[recording_mbid]'] for p in params]
-        with psycopg2.connect(config.MB_DATABASE_URI) as conn:
+        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
 
                 # First lookup and MBIDs that may have been redirected


### PR DESCRIPTION
# Problem

related: https://github.com/metabrainz/listenbrainz-server/pull/1990
When the MusicBrainz database connection isn't available we don't want an exception to be raised when accessing labs-api endpoints that require the MB database


# Solution
Identify if the db is unavailable, and if so return an empty result instead of trying to connect to it.


# Action

In the future we could update dataset-hoster to return http 503 service unavailable in this case instead of a valid response that could be interpreted as "no data available for this query".


