### PR TITLE
Add information about cron stop script to maintainers docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Contents
    :maxdepth: 2
    :caption: Maintainer Documentation
 
+   maintainers/deploy
    maintainers/docker-image
    maintainers/dumps
    maintainers/spotify-reader

--- a/docs/maintainers/deploy.rst
+++ b/docs/maintainers/deploy.rst
@@ -1,0 +1,18 @@
+Production Deployment
+=====================
+
+.. note::
+
+    This documentation is for ListenBrainz maintainers for when they deploy the website
+
+Cron
+^^^^
+
+You can cleanly shut down cron from ``docker-server-configs`` by running
+
+.. code-block:: bash
+
+    ./scripts/terminate_lb_cron.sh
+
+If no cron jobs are running, this will stop and delete the cron container. If a job is running
+it will notify you and not stop the container.


### PR DESCRIPTION
# Problem

I keep forgetting about the tools that we have available to help us deploy cron and other containers to prod


# Solution

Add some docs about the cron check script. This document could be further updated with instructions about how to deploy other containers (and especially an explicit indication if they can be restarted at any time).


