### PR TITLE
Add initial mapping documentation for developers and maintainers

### DIFF
--- a/docs/developers/mapping.rst
+++ b/docs/developers/mapping.rst
@@ -1,0 +1,76 @@
+:orphan:
+
+.. _developers-mapping:
+
+MBID Mapping
+============
+
+The MBID mapping scripts allow us to take metadata from the messybrainz database and look up recording MBIDs
+from the MusicBrainz database.
+
+.. note::
+    The MBID Mapping source code lives in ``listenbrainz/mbid_mapping`` but is run independently
+    from the main listenbrainz web docker image. You can use your own virtual environment or use
+    ``listenbrainz/mbid_mapping/build.sh`` to build a standalone docker image.
+
+Database tables
+^^^^^^^^^^^^^^^
+
+The MBID Mapping supplemental tables hold preprocessed data from the MusicBrainz database.
+
+* ``mapping.canonical_musicbrainz_data``: The MBID and Name of Recordings, Artists (and credits), and Releases for all recordings in MusicBrainz
+* ``mapping.canonical_recording_redirect``: A mapping to find the "canonical" recording given an artist credit + recording name
+* ``mapping.canonical_release_redirect``: A mapping to find the "canonical" release given an artist credit + release name
+
+These tables can be populated by running 
+
+.. code:: bash
+
+    python mapper/manage.py canonical-data
+
+The update process build the new data in a temporary table and then
+replaces them in a single transaction. This means that lookups can continue to run on the 
+existing tables while the new ones are being built.
+
+Fuzzy lookups
+^^^^^^^^^^^^^
+
+We use typesense as a way of performing quick, fuzzy lookups based on artist name and recording name
+
+Build the typesese index with
+
+.. code:: bash
+
+    python mapper/manage.py build-index
+
+As with the data tables, a new typesense collection is created and then swapped into place in a
+single operation.
+
+Build the mapping tables and then the typesense index directly afterwards with 
+
+.. code:: bash
+
+    python mapper/manage.py create-all
+
+MBID Mapper
+^^^^^^^^^^^
+
+The mapper looks for new MSIDs submitted to messybrainz and finds a matching MBID in MusicBrainz
+
+    ``python3 -u -m listenbrainz.mbid_mapping_writer.mbid_mapping_writer``
+
+A background thread pushes items to be processed onto a queue - recent submissions first, and then if nothing
+is to be done, old items.
+The processing thread pops items off the queue and then looks them up, adding them to the ``mbid_mapping`` table.
+
+There is also a background thread that fires off daily, which looks for listens that have been written to the 
+listens table, but for some reason do not have a matching mapping entry. (This could happen due to 
+restarts or problems with the mapper itself). These are called legacy listens.
+
+The background thread will walk the entire listens table once a day to find these legacy listens and attempt to
+map them. In the same thread we also look for mapping items with timestamp of the unix epoch (1970-01-01 00:00:00),
+which indicates that they ought to be re-checked. Currently we have no automated mechanism in place for setting any mapping 
+entries to the epoch.
+
+TODO: Detuning algorithm
+TODO: match quality types

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Contents
    developers/spark-devel-env
    developers/architecture
    developers/spark-architecture
+   developers/mapping
    developers/commands
 
 .. toctree::
@@ -43,6 +44,7 @@ Contents
 
    maintainers/docker-image
    maintainers/dumps
+   maintainers/mapping
    maintainers/spotify-reader
    maintainers/updating-prod-db-schema
    maintainers/pull-requests

--- a/docs/maintainers/mapping.rst
+++ b/docs/maintainers/mapping.rst
@@ -1,0 +1,51 @@
+MBID Mapping
+============
+
+For a background on how the mapping works, see :ref:`developers-mapping`
+
+
+Containers
+^^^^^^^^^^
+
+The mapping tools run in two containers:
+
+ * ``mbid-mapping-writer-prod``: Populates the ``mbid_mapping`` table for new listens. Built from the 
+    main ListenBrainz dockerfile.
+
+ * ``mbid-mapping``: Periodically generates the MBID Mapping supplemental tables, typesense index,
+    and huesound index. Built from ``listenbrainz/mbid_mapping/Dockerfile``
+
+
+Data sources
+^^^^^^^^^^^^
+
+In the production environment, the ``mbid-mapping`` container reads from the MB replica on aretha.
+
+
+Debugging lookups
+^^^^^^^^^^^^^^^^^
+
+If a listen isn't showing up as mapped on ListenBrainz, one of the following might be true:
+
+* The item wasn't in musicbrainz at the time that the lookup was made
+* There is a bug in the mapping algorithm
+
+If the recording doesn't exist in MusicBrainz during mapping, a row will be added to the ``mbid_mapping`` table
+with the MSID and a ``match_type`` of ``no_match``. Currently no_match values aren't looked up again automatically.
+
+You can test the results of a lookup by using `https://labs.api.listenbrainz.org/explain-mbid-mapping <https://labs.api.listenbrainz.org/explain-mbid-mapping>`
+This uses the same lookup process that the mapper uses. If this returns a result, but there is no mapping present
+it could be due to data being recently added to MusicBrainz or improvements to the mapping algorithm.
+
+If no data is returned or an incorrect match is being returned, this should be reported to us, by adding a comment
+to `LB-1036 <https://tickets.metabrainz.org/browse/LB-1036>`.
+
+In this case you can retrigger a lookup by seting the ``mbid_mapping.last_updated`` field to '1970-01-01 00:00:00' (the unix epoch). 
+The mapper will pick up these items and put them on the queue again.
+
+.. code:: sql
+
+    UPDATE mbid_mapping SET last_updated = 'epoch' WHERE recording_msid = '00000737-3a59-4499-b30a-31fe2464555d';
+    UPDATE mbid_mapping SET last_updated = 'epoch' WHERE match_type = 'no_match' AND last_updated = now() - interval '1 day';
+
+In the LB production environment these items will be picked up and re-processed once a day.

--- a/listenbrainz/mbid_mapping/docker/crontab
+++ b/listenbrainz/mbid_mapping/docker/crontab
@@ -1,4 +1,4 @@
-# Create the typesense index periodically
+# Create the mapping indexes (typesense, canonical data tables) each day at 4am
 0 4 * * * listenbrainz /usr/local/bin/python /code/mapper/manage.py create-all >> /code/mapper/lb-cron.log 2>&1
 
 # Run the huesound color sync hourly


### PR DESCRIPTION
# Problem

This is an initial attempt at documenting the MBID mapper for the following purposes:
* Information for potential developers, showing them how to build the metadata tables and configure the mapper
* Information for people who want to use the metadata dumps and 
* Information for maintainers who want to debug why the mapping isn't working for some submissions.

# Solution

Write some docs! I split it into two parts, one general description for developers, and another page with debugging information for maintainers.


# Action

I expect that much of this document may be incorrect, the idea was to get some text in place so that someone can tell me that I'm wrong and point me in the correct direction to fix it.
I added a few TODOs that I'd like to fill in before merging this. Any other recommendations for todos would be good too.
I added a few names of management commands or python commands to run the tools, but I'm not sure if we should directly link to lines of code too - these links would go out of date quickly if they link to a specific line number in master branch, so maybe we could just list the important functions instead?

There is still no docker-compose setup for local development to run all of these services (however there are some run commands in the mbid_mapping README). We can decide if we want to make a new docker-compose file for this process in this PR, or if we add it at a later stage. 


