### PR TITLE
Add `listenbrainz-mpd` submission client

### DIFF
--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -8,7 +8,7 @@
     These are programs that submit listens to ListenBrainz:
   </p>
   <ul>
-    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, a flexible, powerful, server-side application for playing music: <a href="https://github.com/kori/wylt"><code>wylt</code></a></li>
+    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, a flexible, powerful, server-side application for playing music: <a href="https://codeberg.org/elomatreb/listenbrainz-mpd"><code>listenbrainz-mpd</code></a>, <a href="https://github.com/kori/wylt"><code>wylt</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
     <li><em><a href="https://github.com/InputUsername/rescrobbled">Rescrobbled</a></em>, a universal Linux scrobbler for MPRIS enabled players</li>

--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -8,7 +8,7 @@
     These are programs that submit listens to ListenBrainz:
   </p>
   <ul>
-    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, a flexible, powerful, server-side application for playing music: <a href="https://github.com/kori/libra"><code>libra</code></a></li>
+    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, a flexible, powerful, server-side application for playing music: <a href="https://github.com/kori/wylt"><code>wylt</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
     <li><em><a href="https://github.com/InputUsername/rescrobbled">Rescrobbled</a></em>, a universal Linux scrobbler for MPRIS enabled players</li>


### PR DESCRIPTION
This pull request adds a link to the [`listenbrainz-mpd`](https://codeberg.org/elomatreb/listenbrainz-mpd) submission client. It also updates the name and URL of the existing client for MPD (renamed from "libra" to "wylt").

I took the liberty of listing my client first because it is capable of submitting MusicBrainz Identifiers (among other things), which "wylt" does not support.