### PR TITLE
Add release_tags

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -130,12 +130,21 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 tag["genre_mbid"] = genre_mbid
             artist_tags.append(tag)
 
+        release_tags = []
+        for tag, count, release_mbid, genre_mbid in row["release_tags"] or []:
+            tag = {"tag": tag,
+                   "count": count,
+                   "release_mbid": release_mbid}
+            if genre_mbid is not None:
+                tag["genre_mbid"] = genre_mbid
+            release_tags.append(tag)
+
         return (row["recording_mbid"],
                 list(set(artist_mbids)),
                 row["release_mbid"],
                 ujson.dumps({"rels": recording_rels}),
                 ujson.dumps(artists),
-                ujson.dumps({"recording": recording_tags, "artist": artist_tags}),
+                ujson.dumps({"recording": recording_tags, "artist": artist_tags, "release": release_tags}),
                 ujson.dumps(release))
 
     def get_metadata_cache_query(self, with_values=False):
@@ -264,7 +273,24 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 ON t.name = g.name
                               {values_join}
                              WHERE count > 0
-                             GROUP BY r.gid
+                          GROUP BY r.gid
+                   ), release_tags AS (
+                            SELECT r.gid AS recording_mbid
+                                 , array_agg(jsonb_build_array(t.name, count, rel.gid, g.gid)) AS release_tags
+                              FROM recording r
+                         LEFT JOIN mapping.canonical_release_redirect crr
+                                ON r.gid = crr.recording_mbid
+                         LEFT JOIN release rel
+                                ON crr.release_mbid = rel.gid
+                              JOIN release_tag rt
+                                ON rt.release = rel.id
+                              JOIN tag t
+                                ON rt.tag = t.id
+                         LEFT JOIN genre g
+                                ON t.name = g.name
+                              {values_join}
+                             WHERE count > 0
+                          GROUP BY r.gid
                    ), release_data AS (
                             SELECT * FROM (
                                     SELECT r.gid AS recording_mbid
@@ -289,6 +315,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , artist_data
                                  , artist_tags
                                  , recording_tags
+                                 , release_tags
                                  , r.length
                                  , r.gid::TEXT AS recording_mbid
                                  , rd.release_mbid::TEXT
@@ -313,6 +340,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 ON rt.recording_mbid = r.gid
                          LEFT JOIN artist_tags ats
                                 ON ats.recording_mbid = r.gid
+                         LEFT JOIN release_tags rts
+                                ON rts.recording_mbid = r.gid
                          LEFT JOIN release_data rd
                                 ON rd.recording_mbid = r.gid
                          LEFT JOIN mapping.canonical_musicbrainz_data cmb
@@ -322,6 +351,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , r.length
                                  , recording_links
                                  , recording_tags
+                                 , release_tags
                                  , artist_data
                                  , artist_tags
                                  , rd.release_mbid


### PR DESCRIPTION
When I first created the mb metadata cache I skipped the release_tags. Finally adding them now.

This PR uses the MBID mapping supplemental tables to find the canonical release and then pluck the release_tags from it to be included in the index. Nothing really new here.