### PR TITLE
Fix check for discovery timestamp

### DIFF
--- a/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
+++ b/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
@@ -253,7 +253,7 @@ export default class Recommendations extends React.Component<
                   // Backwards compatible support for various timestamp property names
                   let discoveryTimestamp: string | number | undefined | null =
                     recommendation.latest_listened_at;
-                  if (discoveryTimestamp) {
+                  if (!discoveryTimestamp) {
                     discoveryTimestamp = recommendation.listened_at_iso;
                   }
                   if (


### PR DESCRIPTION
The check intends to look for listened_at_iso field if nothing was found in the latest_listened_at field but currently it doesn't do that. Discovered when experimenting on the recommendations page on LB.