### PR TITLE
Send recording mbid in feedback if available

### DIFF
--- a/listenbrainz/webserver/static/js/src/listens/ListenFeedbackComponent.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenFeedbackComponent.tsx
@@ -3,6 +3,7 @@ import { faHeart, faHeartBroken } from "@fortawesome/free-solid-svg-icons";
 import { get } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import GlobalAppContext from "../utils/GlobalAppContext";
+import {getRecordingMBID} from "../utils/utils";
 
 export type ListenFeedbackComponentProps = {
   newAlert: (
@@ -33,11 +34,14 @@ export default class ListenFeedbackComponent extends React.Component<
         "track_metadata.additional_info.recording_msid"
       );
 
+      const recordingMBID = getRecordingMBID(listen);
+
       try {
         const status = await APIService.submitFeedback(
           currentUser.auth_token,
           score,
-          recordingMSID
+          recordingMSID,
+          recordingMBID
         );
         if (status === 200) {
           //   this.setState({ feedback: score });

--- a/listenbrainz/webserver/static/js/src/listens/ListenFeedbackComponent.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenFeedbackComponent.tsx
@@ -3,7 +3,7 @@ import { faHeart, faHeartBroken } from "@fortawesome/free-solid-svg-icons";
 import { get } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import GlobalAppContext from "../utils/GlobalAppContext";
-import {getRecordingMBID} from "../utils/utils";
+import { getRecordingMBID } from "../utils/utils";
 
 export type ListenFeedbackComponentProps = {
   newAlert: (

--- a/listenbrainz/webserver/static/js/tests/listens/ListenFeedbackComponent.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/listens/ListenFeedbackComponent.test.tsx
@@ -63,7 +63,7 @@ describe("ListenFeedbackComponent", () => {
       await instance.submitFeedback(-1);
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith("baz", -1, "bar");
+      expect(spy).toHaveBeenCalledWith("baz", -1, "bar", "yyyy");
 
       expect(instance.props.updateFeedbackCallback).toHaveBeenCalledTimes(1);
       expect(instance.props.updateFeedbackCallback).toHaveBeenCalledWith(
@@ -111,7 +111,7 @@ describe("ListenFeedbackComponent", () => {
       instance.submitFeedback(-1);
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith("baz", -1, "bar");
+      expect(spy).toHaveBeenCalledWith("baz", -1, "bar", "yyyy");
 
       expect(props.updateFeedbackCallback).toHaveBeenCalledTimes(0);
     });

--- a/listenbrainz/webserver/static/js/tests/user/UserFeedback.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/user/UserFeedback.test.tsx
@@ -325,7 +325,8 @@ describe("UserFeedback", () => {
     expect(APIsubmitFeedbackSpy).toHaveBeenCalledWith(
       "lalala",
       1,
-      "8aa379ad-852e-4794-9c01-64959f5d0b17"
+      "8aa379ad-852e-4794-9c01-64959f5d0b17",
+      "9812475d-c800-4f29-8a9a-4ac4af4b4dfd"
     );
     expect(updateFeedbackSpy).toHaveBeenCalledWith(
       "8aa379ad-852e-4794-9c01-64959f5d0b17",


### PR DESCRIPTION
The feedback submission endpoint accepts both msids and mbids. Thus, it makes sense to submit mbids as well when available. Also, makes more data available to 3rd party apps as those usually don't have msids at hand.