### PR TITLE
Allow a maximim number of listens per import

### DIFF
--- a/docs/users/api/core.rst
+++ b/docs/users/api/core.rst
@@ -59,6 +59,7 @@ Constants
 Constants that are relevant to using the API:
 
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTEN_SIZE
+.. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTENS_PER_REQUEST
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_ITEMS_PER_GET
 .. autodata:: listenbrainz.webserver.views.api_tools.DEFAULT_ITEMS_PER_GET
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_TAGS_PER_LISTEN

--- a/docs/users/api/core.rst
+++ b/docs/users/api/core.rst
@@ -58,6 +58,7 @@ Constants
 
 Constants that are relevant to using the API:
 
+.. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTEN_PAYLOAD_SIZE
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTEN_SIZE
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTENS_PER_REQUEST
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_ITEMS_PER_GET

--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -37,10 +37,13 @@ the ``submit-listens`` endpoint. Submit one of three types JSON documents:
 
    - ``payload`` should contain information about *at least one* track
 
-   - submitting multiple listens in one go is allowed up to a maximum of
-     :data:`~webserver.views.api.MAX_LISTENS_PER_REQUEST` listens. The complete JSON
-     document may not exceed :data:`~webserver.views.api.MAX_LISTEN_SIZE` bytes
-     in size
+   - submitting multiple listens in one request is permitted. There are some
+     limitations on the size of a submission. A request must be less than
+     :data:`~listenbrainz.webserver.views.api_tools.MAX_LISTEN_PAYLOAD_SIZE`
+     bytes, and you can only submit up to
+     :data:`~listenbrainz.webserver.views.api_tools.MAX_LISTENS_PER_REQUEST` listens per
+     request. Each listen may not exceed
+     :data:`~listenbrainz.webserver.views.api_tools.MAX_LISTEN_SIZE` bytes in size
 
 The ``listen_type`` element defines different types of submissions. The element
 is placed at the top-most level of the JSON document. The only other required
@@ -154,7 +157,7 @@ A minimal payload must include
 
 The payload should also include the ``listened_at`` element, which must be an integer
 representing the Unix time when the track was listened to. The minimum accepted
-value for this field is :data:`~webserver.views.api.LISTEN_MINIMUM_TS`.
+value for this field is :data:`~listenbrainz.webserver.views.api_tools.LISTEN_MINIMUM_TS`.
 playing_now requests should not have a ``listened_at`` field
 
 Add additional metadata you may have for a track to the ``additional_info``
@@ -198,7 +201,7 @@ the data for any of the following fields, omit the key entirely:
    * - ``spotify_id``
      - The Spotify track URL associated with this recording.  e.g.: http://open.spotify.com/track/1rrgWMXGCGHru5bIRxGFV0
    * - ``tags``
-     - A list of user-defined folksonomy tags to be associated with this recording. For example, you have apply tags such as ``punk``, ``see-live``, ``smelly``. You may submit up to :data:`~webserver.views.api.MAX_TAGS_PER_LISTEN` tags and each tag may be up to :data:`~webserver.views.api.MAX_TAG_SIZE` characters large.
+     - A list of user-defined folksonomy tags to be associated with this recording. For example, you have apply tags such as ``punk``, ``see-live``, ``smelly``. You may submit up to :data:`~listenbrainz.webserver.views.api_tools.MAX_TAGS_PER_LISTEN` tags and each tag may be up to :data:`~listenbrainz.webserver.views.api_tools.MAX_TAG_SIZE` characters large.
    * - ``media_player``
      - The name of the program being used to listen to music. Don't include a version number here.
    * - ``media_player_version``

--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -37,7 +37,8 @@ the ``submit-listens`` endpoint. Submit one of three types JSON documents:
 
    - ``payload`` should contain information about *at least one* track
 
-   - submitting multiple listens in one go is allowed, but the complete JSON
+   - submitting multiple listens in one go is allowed up to a maximum of
+     :data:`~webserver.views.api.MAX_LISTENS_PER_REQUEST` listens. The complete JSON
      document may not exceed :data:`~webserver.views.api.MAX_LISTEN_SIZE` bytes
      in size
 

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -351,14 +351,29 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
 
-    def test_empty_track_name(self):
-        """ Test for invalid submission in which a listen contains an empty track name
+    def test_too_many_listens(self):
+        """ Test for invalid submission in which more than 1000 listens are in a single request
         """
-        with open(self.path_to_data_file('empty_track_name.json'), 'r') as f:
+        with open(self.path_to_data_file('too_large_listen.json'), 'r') as f:
             payload = json.load(f)
         response = self.send_data(payload)
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
+
+    def test_empty_track_name(self):
+        """ Test for invalid submission in which a listen contains an empty track name
+        """
+        with open(self.path_to_data_file('valid_import.json'), 'r') as f:
+            payload = json.load(f)
+
+        # 2 messages in this file, * 500 to make more up to 1000
+        payload['payload'] = payload['payload'] * 500 + payload['payload']
+        self.assertEqual(len(payload['payload']), 1002)
+
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+        self.assertTrue("Too many listens" in response.json['error'])
 
         del payload["payload"][0]["track_metadata"]["track_name"]
         response = self.send_data(payload)

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -350,18 +350,17 @@ class APITestCase(ListenAPIIntegrationTestCase):
         response = self.send_data(payload)
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
+        self.assertTrue("JSON document is too large." in response.json['error'])
 
-    def test_too_many_listens(self):
-        """ Test for invalid submission in which more than 1000 listens are in a single request
-        """
-        with open(self.path_to_data_file('too_large_listen.json'), 'r') as f:
-            payload = json.load(f)
+        # This document is 45kb, increase it to over 10k kb
+        payload['payload'] = payload['payload'] * 300
         response = self.send_data(payload)
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
+        self.assertTrue("Payload too large." in response.json['error'])
 
-    def test_empty_track_name(self):
-        """ Test for invalid submission in which a listen contains an empty track name
+    def test_too_many_listens(self):
+        """ Test for invalid submission in which more than 1000 listens are in a single request
         """
         with open(self.path_to_data_file('valid_import.json'), 'r') as f:
             payload = json.load(f)
@@ -374,6 +373,12 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
         self.assertTrue("Too many listens" in response.json['error'])
+
+    def test_empty_track_name(self):
+        """ Test for invalid submission in which a listen contains an empty track name
+        """
+        with open(self.path_to_data_file('empty_track_name.json'), 'r') as f:
+            payload = json.load(f)
 
         del payload["payload"][0]["track_metadata"]["track_name"]
         response = self.send_data(payload)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -21,9 +21,10 @@ from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError,
     APIUnauthorized, ListenValidationError
 from listenbrainz.webserver.models import SubmitListenUserMetadata
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
-from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400, validate_listen, parse_param_list, \
-    is_valid_uuid, MAX_LISTEN_SIZE, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, _validate_get_endpoint_params, \
-    _parse_int_arg, LISTEN_TYPE_PLAYING_NOW, validate_auth_header, get_non_negative_param, MAX_LISTENS_PER_REQUEST
+from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400, validate_listen, \
+    is_valid_uuid, MAX_LISTEN_PAYLOAD_SIZE, MAX_LISTENS_PER_REQUEST, MAX_LISTEN_SIZE, LISTEN_TYPE_SINGLE, \
+    LISTEN_TYPE_IMPORT, _validate_get_endpoint_params, LISTEN_TYPE_PLAYING_NOW, validate_auth_header, \
+    get_non_negative_param
 from listenbrainz.webserver.views.playlist_api import serialize_jspf
 
 api_bp = Blueprint('api_v1', __name__)
@@ -59,9 +60,9 @@ def submit_listen():
 
     raw_data = request.get_data()
 
-    if len(raw_data) > MAX_LISTENS_PER_REQUEST * MAX_LISTEN_SIZE:
+    if len(raw_data) > MAX_LISTEN_PAYLOAD_SIZE:
         log_raise_400(
-            "Payload too large. Payload cannot exceed %s bytes" % MAX_LISTENS_PER_REQUEST * MAX_LISTEN_SIZE
+            "Payload too large. Payload cannot exceed %s bytes" % MAX_LISTEN_PAYLOAD_SIZE
         )
 
     try:

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -23,7 +23,7 @@ from listenbrainz.webserver.models import SubmitListenUserMetadata
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
 from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400, validate_listen, parse_param_list, \
     is_valid_uuid, MAX_LISTEN_SIZE, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, _validate_get_endpoint_params, \
-    _parse_int_arg, LISTEN_TYPE_PLAYING_NOW, validate_auth_header, get_non_negative_param
+    _parse_int_arg, LISTEN_TYPE_PLAYING_NOW, validate_auth_header, get_non_negative_param, MAX_LISTENS_PER_REQUEST
 from listenbrainz.webserver.views.playlist_api import serialize_jspf
 
 api_bp = Blueprint('api_v1', __name__)
@@ -76,6 +76,11 @@ def submit_listen():
         if len(payload) == 0:
             log_raise_400(
                 "JSON document does not contain any listens", payload)
+
+        if len(payload) > MAX_LISTENS_PER_REQUEST:
+            log_raise_400(
+                "Too many listens. You may not submit more than %s listens at once." % MAX_LISTENS_PER_REQUEST
+            )
 
         if len(raw_data) > len(payload) * MAX_LISTEN_SIZE:
             log_raise_400("JSON document is too large. In aggregate, listens may not "

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -58,6 +58,12 @@ def submit_listen():
         raise APIUnauthorized(REJECT_LISTENS_WITHOUT_EMAIL_ERROR)
 
     raw_data = request.get_data()
+
+    if len(raw_data) > MAX_LISTENS_PER_REQUEST * MAX_LISTEN_SIZE:
+        log_raise_400(
+            "Payload too large. Payload cannot exceed %s bytes" % MAX_LISTENS_PER_REQUEST * MAX_LISTEN_SIZE
+        )
+
     try:
         data = ujson.loads(raw_data.decode("utf-8"))
     except ValueError as e:
@@ -83,8 +89,8 @@ def submit_listen():
             )
 
         if len(raw_data) > len(payload) * MAX_LISTEN_SIZE:
-            log_raise_400("JSON document is too large. In aggregate, listens may not "
-                          "be larger than %d characters." % MAX_LISTEN_SIZE, payload)
+            log_raise_400("JSON document is too large. Each listens may not "
+                          "be larger than %d bytes." % MAX_LISTEN_SIZE, payload)
 
         if data['listen_type'] not in ('playing_now', 'single', 'import'):
             log_raise_400(

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -32,6 +32,9 @@ MAX_TAGS_PER_LISTEN = 50
 #: The maximum number of listens in a request.
 MAX_LISTENS_PER_REQUEST = 1000
 
+#: The maximum size of a payload in bytes. The same as MAX_LISTEN_SIZE * MAX_LISTENS_PER_REQUEST.
+MAX_LISTEN_PAYLOAD_SIZE = MAX_LISTEN_SIZE * MAX_LISTENS_PER_REQUEST
+
 #: The maximum length of a tag
 MAX_TAG_SIZE = 64
 

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -29,6 +29,9 @@ MAX_LISTEN_SIZE = 10240
 #: The maximum number of tags per listen.
 MAX_TAGS_PER_LISTEN = 50
 
+#: The maximum number of listens in a request.
+MAX_LISTENS_PER_REQUEST = 1000
+
 #: The maximum length of a tag
 MAX_TAG_SIZE = 64
 

--- a/listenbrainz/webserver/views/color_api.py
+++ b/listenbrainz/webserver/views/color_api.py
@@ -3,7 +3,7 @@ from flask import Blueprint, jsonify
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest
 from brainzutils.ratelimit import ratelimit
-from listenbrainz.webserver.views.api import _parse_int_arg
+from listenbrainz.webserver.views.api_tools import _parse_int_arg
 from listenbrainz.db.color import get_releases_for_color
 from brainzutils import cache
 

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -8,8 +8,7 @@ from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APINotFound
 from listenbrainz.webserver.utils import parse_boolean_arg
-from listenbrainz.webserver.views.api import _parse_int_arg
-from listenbrainz.webserver.views.api_tools import log_raise_400, is_valid_uuid, \
+from listenbrainz.webserver.views.api_tools import _parse_int_arg, log_raise_400, is_valid_uuid, \
     DEFAULT_ITEMS_PER_GET, MAX_ITEMS_PER_GET, get_non_negative_param, parse_param_list, \
     validate_auth_header
 


### PR DESCRIPTION
# Problem

Processing too many items in a single import (rabbitmq message) can cause delays and issues with the timescale writer.


# Solution

Limit the max number of messages to 1k per import.


# Action

The documentation is incorrect - it says

> The complete JSON document may not exceed :data:`~webserver.views.api.MAX_LISTEN_SIZE` bytes in size

but we actually check that num listens * max_listen_size is not higher than the submitted payload. We should decide which is true, and update the docs or the check.

Also need to check what is the max number of items that the lastfm import uses at once and check it's under this limit.



