### PR TITLE
Add more examples to feedback json doc

### DIFF
--- a/docs/users/feedback-json.rst
+++ b/docs/users/feedback-json.rst
@@ -16,6 +16,23 @@ A sample feedback may look like:
 .. code-block:: json
 
     {
+        "recording_mbid": "9f24c0f7-a644-4074-8fbd-a1dba03de129",
+        "score": 1
+    }
+
+
+.. code-block:: json
+
+    {
+        "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+        "score": 1
+    }
+
+
+.. code-block:: json
+
+    {
+        "recording_mbid": "9f24c0f7-a644-4074-8fbd-a1dba03de129",
         "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
         "score": 1
     }
@@ -48,6 +65,7 @@ The JSON documents returned from our API for recording feedback look like the fo
             {
                 "user_id": "-- the MusicBrainz ID of the user --",
                 "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                "recording_msid": "9f24c0f7-a644-4074-8fbd-a1dba03de129",
                 "score": 1
             },
             "-- more feedback data here ---"
@@ -60,4 +78,4 @@ The number of feedback items in the document are returned by the top-level ``cou
 feedback items for the user/recording are returned by the top-level ``total_count``. ``offset`` specifies the
 number of feedback to skip from the beginning, for pagination.  The other element is the ``feedback`` element.
 This is a list which contains the feedback JSON elements having a ``user_id`` the MusicBrainz ID of the user,
-a ``recording_msid`` and a ``score`` key.
+a ``recording_msid``, a ``recording_mbid`` and a ``score`` key.


### PR DESCRIPTION
Add examples of json documents containing recording mbids to reflect the current API responses.