### PR TITLE
Fix logging error in listen deletion cron job

### DIFF
--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -201,7 +201,7 @@ def delete_listens():
             return
 
         max_id = row["max_id"]
-        logger.info("Found max id in listen_delete_metadata table: %d", max_id)
+        logger.info("Found max id in listen_delete_metadata table: %s", max_id)
 
         logger.info("Deleting Listens and updating affected listens counts")
         connection.execute(text(delete_listens_and_update_listen_counts), max_id=max_id)


### PR DESCRIPTION
If there is no listen to be deleted, then max_id will be None which cannot be converted to a number so use %s formatter.