### PR TITLE
Fix extraneous 0 in listen count card

### DIFF
--- a/listenbrainz/webserver/static/js/src/listens/ListenCountCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCountCard.tsx
@@ -12,28 +12,31 @@ const ListenCountCard = (props: ListenCountCardProps) => {
   const { listenCount, user } = props;
   const isCurrentUser = currentUser?.name === user?.name;
 
-  return (
-    <Card id="listen-count-card">
-      {listenCount && (
-        <div>
-          {isCurrentUser
-            ? "You have listened to"
-            : `${user.name} has listened to`}
-          <hr />
-          {listenCount.toLocaleString()}
-          <br />
-          <small className="text-muted">songs so far</small>
-        </div>
-      )}
-      {!listenCount && (
-        <p>
-          {isCurrentUser
-            ? "You have not listened to any songs so far"
-            : `${user.name} has not listened to any songs so far`}
-        </p>
-      )}
-    </Card>
-  );
+  let content;
+
+  if (listenCount) {
+    content = (
+      <div>
+        {isCurrentUser
+          ? "You have listened to"
+          : `${user.name} has listened to`}
+        <hr />
+        {listenCount.toLocaleString()}
+        <br />
+        <small className="text-muted">songs so far</small>
+      </div>
+    );
+  } else {
+    content = (
+      <p>
+        {isCurrentUser
+          ? "You have not listened to any songs so far"
+          : `${user.name} has not listened to any songs so far`}
+      </p>
+    );
+  }
+
+  return <Card id="listen-count-card">{content}</Card>;
 };
 
 export default ListenCountCard;


### PR DESCRIPTION
Don't use {listen_count && components} because of the way React and JS treat falsy values like 0. JS will evaluate 0 && as false so the part after && is not rendered. However, React will still render the listen count as 0. To use { && form, you'll need to do !!listen_count, but it is easier to just use an explicit if.

Before:
![Screenshot from 2022-05-26 21-51-10](https://user-images.githubusercontent.com/27751938/170543183-755a2058-6576-4f88-b816-dea4f6b23b5f.png)

After:
![Screenshot from 2022-05-26 22-59-49](https://user-images.githubusercontent.com/27751938/170543193-cafac92e-58d6-421b-8d78-0890768f6269.png)

