### PR TITLE
Add basic .readthedocs.yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+   configuration: docs/conf.py
+
+formats: all
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,6 @@ sys.path.insert(0, os.path.abspath('..'))
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
-from listenbrainz import webserver
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.


### PR DESCRIPTION
RTD build logs shows that builds for docs are failing for quite some time now. It appears that pandas 1.4.1 requires at least python 3.8 whereas RTD is trying to build with python 3.7. Therefore, installing deps and the fixing the python version used. RTD recommends adding a .readthedocs.yaml file so adding it as well.

Remove an unneeded import from docs/conf.py which was breaking builds.