### PR TITLE
Fix env variable issues with cron_lock script

### DIFF
--- a/admin/test_cron_job.sh
+++ b/admin/test_cron_job.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "$(date): Start"
+sleep 60
+
+echo "$(date): Sourced"
+source /code/listenbrainz/admin/config.sh
+
+echo "$(date): Locking Cron"
+/usr/local/bin/python /code/listenbrainz/admin/cron_lock.py lock-cron test-locks "Testing cron_lock script"
+
+echo "$(date): Sleeping"
+sleep 300
+
+echo "$(date): Unlocking Cron"
+/usr/local/bin/python /code/listenbrainz/admin/cron_lock.py unlock-cron test-locks
+echo "$(date): Exit"

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -32,3 +32,6 @@ MAILTO=""
 
 # Request missing MB data each month after a new dump has been imported to spark cluster
 30 7 * * 1 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_missing_mb_data >> /logs/stats.log 2>&1
+
+# cron job to test cron_lock script
+@reboot root /code/listenbrainz/admin/test_cron_job.sh >> /logs/test_cron_job.log 2>&1


### PR DESCRIPTION
cronjob doesn't observe environment variables set by docker. Therefore, the deploy_env check always fails in production and the cron lock is never created. This forfeits the purpose of the script. Fixing the issue by reading the admin/config.sh file instead. If that file doesn't exist, exit with error.