### PR TITLE
Improve validation in MsidMbidModel

### DIFF
--- a/data/model/validators.py
+++ b/data/model/validators.py
@@ -3,26 +3,21 @@ from datetime import datetime
 
 
 def check_valid_uuid(param: str):
-    """Validates that a UUID is valid. Otherwise, raises a ValueError.
-
-    * Validating constr(min_length=1) accepts valid UUID's only, while
-      validating Optional[str] accepts valid UUID's, None, and ''.
+    """Validates that a UUID is valid or None. Otherwise, raises a ValueError.
 
     Args:
-        id: the UUID to validate.
+        param: the UUID to validate.
 
     Returns:
         The validated recording UUID as a string.
     """
     if param is None:
         return None
-    if param == '':
-        return ''
     try:
         param = uuid.UUID(param)
         return str(param)
     except (AttributeError, ValueError):
-        raise ValueError("'{}' must be a valid UUID.".format(param))
+        raise ValueError(f"'{param}' must be a valid UUID.")
 
 
 def check_datetime_has_tzinfo(date_time: datetime):

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -3,7 +3,7 @@ from typing import Iterable, Dict, List, TypeVar
 from typing import Optional, Tuple
 
 from flask import current_app
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, root_validator
 from sqlalchemy import text
 
 from data.model.validators import check_valid_uuid
@@ -27,6 +27,13 @@ class MsidMbidModel(BaseModel):
         "recording_mbid",
         allow_reuse=True
     )(check_valid_uuid)
+
+    @root_validator
+    def check_at_least_mbid_or_msid(cls, values):
+        recording_msid, recording_mbid = values.get('recording_msid'), values.get('recording_mbid')
+        if recording_msid is None and recording_mbid is None:
+            raise ValueError("at least one of recording_msid or recording_mbid should be specified")
+        return values
 
 
 def load_recordings_from_mapping(mbids: Iterable[str], msids: Iterable[str]) -> Tuple[Dict, Dict]:

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -17,7 +17,7 @@ class MappingTestCase(TimescaleTestCase):
         with self.assertRaisesRegex(ValueError, "(?s)recording_msid.*must be a valid UUID"):
             model = MsidMbidModel(recording_msid='', recording_mbid=str(uuid.uuid4()))
 
-        with self.assertRaises(ValueError, "(?s)recording_mbid.*must be a valid UUID"):
+        with self.assertRaisesRegex(ValueError, "(?s)recording_mbid.*must be a valid UUID"):
             model = MsidMbidModel(recording_msid=str(uuid.uuid4()), recording_mbid='')
 
         # test that 2 valid uuids doesn't raise error

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -14,10 +14,10 @@ class MappingTestCase(TimescaleTestCase):
         with self.assertRaisesRegex(ValueError, 'at least one of recording_msid or recording_mbid should be specified'):
             model = MsidMbidModel(recording_mbid=None, recording_msid=None)
 
-        with self.assertRaisesRegex(ValueError, "'recording_msid' must be a valid UUID."):
+        with self.assertRaisesRegex(ValueError, "(?s)recording_msid.*must be a valid UUID"):
             model = MsidMbidModel(recording_msid='', recording_mbid=str(uuid.uuid4()))
 
-        with self.assertRaises(ValueError, "'recording_mbid' must be a valid UUID."):
+        with self.assertRaises(ValueError, "(?s)recording_mbid.*must be a valid UUID"):
             model = MsidMbidModel(recording_msid=str(uuid.uuid4()), recording_mbid='')
 
         # test that 2 valid uuids doesn't raise error

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy import text
 
 from listenbrainz import messybrainz
@@ -7,6 +9,19 @@ from listenbrainz.db import timescale as ts
 
 
 class MappingTestCase(TimescaleTestCase):
+
+    def test_msid_mbid_model(self):
+        with self.assertRaisesRegex(ValueError, 'at least one of recording_msid or recording_mbid should be specified'):
+            model = MsidMbidModel(recording_mbid=None, recording_msid=None)
+
+        with self.assertRaisesRegex(ValueError, "'recording_msid' must be a valid UUID."):
+            model = MsidMbidModel(recording_msid='', recording_mbid=str(uuid.uuid4()))
+
+        with self.assertRaises(ValueError, "'recording_mbid' must be a valid UUID."):
+            model = MsidMbidModel(recording_msid=str(uuid.uuid4()), recording_mbid='')
+
+        # test that 2 valid uuids doesn't raise error
+        model = MsidMbidModel(recording_msid=str(uuid.uuid4()), recording_mbid=str(uuid.uuid4()))
 
     def insert_recording_in_mapping(self, recording, match_type):
         with ts.engine.connect() as connection:


### PR DESCRIPTION
1. Error if the mbid or msid specified is empty string.
2. Error if both msid and mbid are None. (at least 1 is required)