### PR TITLE
create new table, modify UI and endpoint for timezone

### DIFF
--- a/admin/sql/create_foreign_keys.sql
+++ b/admin/sql/create_foreign_keys.sql
@@ -133,4 +133,10 @@ ALTER TABLE pinned_recording
     REFERENCES "user" (id)
     ON DELETE CASCADE;
 
+ALTER TABLE user_setting
+    ADD CONSTRAINT user_setting_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
+    
 COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -57,6 +57,6 @@ CREATE INDEX user_id_ndx_pinned_recording ON pinned_recording (user_id);
 CREATE INDEX release_mbid_ndx_release_color ON release_color (release_mbid);
 CREATE UNIQUE INDEX caa_id_ndx_release_color ON release_color (caa_id);
 
-CREATE INDEX user_id_ndx_user_setting ON user_setting (user_id);
+CREATE UNIQUE INDEX user_id_ndx_user_setting ON user_setting (user_id);
 
 COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -57,4 +57,6 @@ CREATE INDEX user_id_ndx_pinned_recording ON pinned_recording (user_id);
 CREATE INDEX release_mbid_ndx_release_color ON release_color (release_mbid);
 CREATE UNIQUE INDEX caa_id_ndx_release_color ON release_color (caa_id);
 
+CREATE INDEX user_id_ndx_user_setting ON user_setting (user_id);
+
 COMMIT;

--- a/admin/sql/create_primary_keys.sql
+++ b/admin/sql/create_primary_keys.sql
@@ -30,4 +30,6 @@ ALTER TABLE pinned_recording ADD CONSTRAINT pinned_recording_pkey PRIMARY KEY (i
 
 ALTER TABLE release_color ADD CONSTRAINT release_color_pkey PRIMARY KEY (id);
 
+ALTER TABLE user_setting ADD CONSTRAINT user_setting_pkey PRIMARY KEY (id);
+
 COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -257,6 +257,12 @@ ALTER TABLE pinned_recording
     ADD CONSTRAINT pinned_rec_recording_msid_or_recording_mbid_check
     CHECK ( recording_msid IS NOT NULL OR recording_mbid IS NOT NULL );
 
+CREATE TABLE user_setting(
+    id                     SERIAL, --PK
+    user_id                INTEGER NOT NULL, --FK to "user".id
+    timezone_name          TEXT NOT NULL CHECK (now() AT TIME ZONE timezone_name IS NOT NULL)   
+);
+
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO listenbrainz;
 
 COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -262,6 +262,7 @@ CREATE TABLE user_setting(
     user_id                INTEGER NOT NULL, --FK to "user".id
     timezone_name          TEXT NOT NULL CHECK (now() AT TIME ZONE timezone_name IS NOT NULL)   
 );
+ALTER TABLE user_setting ADD CONSTRAINT setting_user_id_unique UNIQUE (user_id);
 
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO listenbrainz;
 

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -260,9 +260,12 @@ ALTER TABLE pinned_recording
 CREATE TABLE user_setting(
     id                     SERIAL, --PK
     user_id                INTEGER NOT NULL, --FK to "user".id
-    timezone_name          TEXT NOT NULL CHECK (now() AT TIME ZONE timezone_name IS NOT NULL)   
+    timezone_name          TEXT   
 );
-ALTER TABLE user_setting ADD CONSTRAINT setting_user_id_unique UNIQUE (user_id);
+
+ALTER TABLE user_setting
+    ADD CONSTRAINT user_setting_timezone_name_check
+    CHECK ( timezone_name IS NULL OR now() AT TIME ZONE timezone_name IS NOT NULL );
 
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO listenbrainz;
 

--- a/admin/sql/drop_tables.sql
+++ b/admin/sql/drop_tables.sql
@@ -13,5 +13,6 @@ DROP TABLE IF EXISTS user_timeline_event            CASCADE;
 DROP TABLE IF EXISTS reported_users                 CASCADE;
 DROP TABLE IF EXISTS pinned_recording               CASCADE;
 DROP TABLE IF EXISTS release_color                  CASCADE;
+DROP TABLE IF EXISTS user_setting                   CASCADE;
 
 COMMIT;

--- a/admin/sql/updates/2022-27-06-user-setting.sql
+++ b/admin/sql/updates/2022-27-06-user-setting.sql
@@ -1,12 +1,14 @@
 BEGIN;
 
-CREATE TABLE CREATE TABLE user_setting(
+CREATE TABLE user_setting(
     id                     SERIAL, --PK
     user_id                INTEGER NOT NULL, --FK to "user".id
-    timezone_name          TEXT NOT NULL CHECK (now() AT TIME ZONE timezone_name IS NOT NULL)   
+    timezone_name          TEXT   
 );
 
-ALTER TABLE user_setting ADD CONSTRAINT setting_user_id_unique UNIQUE (user_id);
+ALTER TABLE user_setting
+    ADD CONSTRAINT user_setting_timezone_name_check
+    CHECK ( timezone_name IS NULL OR now() AT TIME ZONE timezone_name IS NOT NULL );
 
 ALTER TABLE user_setting
     ADD CONSTRAINT user_setting_user_id_foreign_key

--- a/admin/sql/updates/2022-27-06-user-setting.sql
+++ b/admin/sql/updates/2022-27-06-user-setting.sql
@@ -18,4 +18,6 @@ ALTER TABLE user_setting
 
 ALTER TABLE user_setting ADD CONSTRAINT user_setting_pkey PRIMARY KEY (id);
 
+CREATE UNIQUE INDEX user_id_ndx_user_setting ON user_setting (user_id);
+
 COMMIT;

--- a/admin/sql/updates/2022-27-06-user-setting.sql
+++ b/admin/sql/updates/2022-27-06-user-setting.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+CREATE TABLE CREATE TABLE user_setting(
+    id                     SERIAL, --PK
+    user_id                INTEGER NOT NULL, --FK to "user".id
+    timezone_name          TEXT NOT NULL CHECK (now() AT TIME ZONE timezone_name IS NOT NULL)   
+);
+
+ALTER TABLE user_setting ADD CONSTRAINT setting_user_id_unique UNIQUE (user_id);
+
+ALTER TABLE user_setting
+    ADD CONSTRAINT user_setting_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
+
+ALTER TABLE user_setting ADD CONSTRAINT user_setting_pkey PRIMARY KEY (id);
+
+COMMIT;

--- a/listenbrainz/db/tests/test_user_setting.py
+++ b/listenbrainz/db/tests/test_user_setting.py
@@ -1,0 +1,24 @@
+import listenbrainz.db.user_setting as db_setting
+import listenbrainz.db.external_service_oauth as db_oauth
+
+import listenbrainz.db.user as db_user
+
+from listenbrainz.db.testing import DatabaseTestCase
+
+class UserSettingTestCase(DatabaseTestCase):
+    def setUp(self):
+        DatabaseTestCase.setUp(self)
+        self.user = db_user.get_or_create(1, "user_setting_user")
+
+    def test_set_timezone(self):
+        # test if timezone is not null
+        test_zonename = 'America/New_York'
+        db_setting.set_timezone(self.user['id'], test_zonename)
+        result = db_setting.get(self.user['id'])
+        self.assertEqual(result['timezone_name'], test_zonename)
+
+        # test if timezone is null
+        test_zonename = None
+        db_setting.set_timezone(self.user['id'], test_zonename)
+        result = db_setting.get(self.user['id'])
+        self.assertEqual(result['timezone_name'], 'UTC')

--- a/listenbrainz/db/tests/test_user_setting.py
+++ b/listenbrainz/db/tests/test_user_setting.py
@@ -1,9 +1,8 @@
 import listenbrainz.db.user_setting as db_setting
-import listenbrainz.db.external_service_oauth as db_oauth
-
 import listenbrainz.db.user as db_user
 
 from listenbrainz.db.testing import DatabaseTestCase
+
 
 class UserSettingTestCase(DatabaseTestCase):
     def setUp(self):

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -1,0 +1,118 @@
+import sqlalchemy
+from datetime import datetime, timedelta
+from listenbrainz import db
+from listenbrainz.db.exceptions import DatabaseException
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def get_pg_timezone():
+    """ Get list of time zones PostgreSQL supports.
+
+    Returns:
+        list of tuple('zone_name', 'utc_offset')
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT * FROM pg_timezone_names
+            ORDER BY name
+        """))
+        timezones = [(row["name"], row["utc_offset"]) for row in result.fetchall()]
+        timezones = standardize_timezone(timezones)
+        return timezones
+
+
+def get(user_id: int):
+    """Get user setting with the row ID of the user in the DB, or create if there's setting history.
+    Args:
+        user_id (int): the row ID of the user in the DB
+    Returns:
+        zone_name (str): the user selected timezone name. If not selected by user, return 'UTC'
+    """
+    with db.engine.connect() as connection:
+        try:
+            result = connection.execute(sqlalchemy.text("""
+                SELECT timezone_name
+                FROM user_setting
+                WHERE user_id = :user_id
+            """), {
+                "user_id": user_id,
+            })
+            if result.rowcount:
+                return dict(result.fetchone())
+            return None
+            # print("get from db...user_timezone: ", row)
+        except sqlalchemy.exc.ProgrammingError as err:
+            logger.error(err)
+            raise DatabaseException(
+                "Couldn't get user's timezone: %s" % str(err))
+
+def create(user_id: int, timezone_name: str = "UTC"):
+    """Create setting for user
+
+    Args:
+        user_id (int): the row ID of the user in the DB
+        timezone_name(str): with default as "UTC
+
+    Returns:
+        ID of newly created user setting.
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            INSERT INTO user_setting (user_id, timezone_name)
+                 VALUES (:user_id, :timezone_name)
+              RETURNING id
+        """), {
+            "user_id": user_id,
+            "timezone_name": timezone_name,
+        })
+        return result.fetchone()["id"]
+
+   
+def get_or_create(user_id: int):
+    """Get user setting with the row ID of the user in the DB, or create if there's setting history.
+    Args:
+        user_id (int): the row ID of the user in the DB
+    Returns:
+        dict: user settings
+    """
+    user_settings = get(user_id)
+    if not user_settings:
+        create(user_id)
+        user_settings = get(user_id)
+    return user_settings
+
+def update_timezone(user_id: int, timezone_name:str):
+    """update user's timezone
+    Args:
+        user_id (int): the row ID of the user in the DB
+        zone_name (str): the user selected timezone name
+
+    """
+    with db.engine.connect() as connection:
+        try:
+            connection.execute(sqlalchemy.text("""
+                UPDATE "user_setting"
+                SET timezone_name = :timezone_name
+                WHERE user_id = :user_id
+                """), {
+                "user_id": user_id,
+                "timezone_name": timezone_name,
+            })
+            # print('db: ',get_user_timezone(user_id) )
+        except sqlalchemy.exc.ProgrammingError as err:
+            logger.error(err)
+            raise DatabaseException(
+                "Couldn't update user's timezone: %s" % str(err))
+
+def standardize_timezone(timezones):
+    result = []
+    for (name, offset) in timezones:
+        if offset.days > -1:
+            result.append((name, "+" + str(offset) + " GMT"))
+        else:
+            # result.append((name, str(int(str(offset)[8:10]) - 24) + ":00:00"))
+            result.append((name, str(offset.seconds//3600 - 24) + ":00:00 GMT"))
+    return result

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -8,6 +8,9 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+DEFAULT_TIMEZONE  = "UTC"
+
+
 def get_pg_timezone():
     """ Get list of time zones PostgreSQL supports.
 
@@ -25,11 +28,12 @@ def get_pg_timezone():
 
 
 def get(user_id: int):
-    """Get user setting with the row ID of the user in the DB, or create if there's setting history.
+    """ Get user settings with the row ID of the user in the DB.
     Args:
         user_id (int): the row ID of the user in the DB
     Returns:
-        zone_name (str): the user selected timezone name. If not selected by user, return 'UTC'
+        user settings (dict) where
+        timezone_name: user selected local timezone, with default value "UTC".
     """
     with db.engine.connect() as connection:
         try:
@@ -40,77 +44,50 @@ def get(user_id: int):
             """), {
                 "user_id": user_id,
             })
+            
             if result.rowcount:
-                return dict(result.fetchone())
-            return None
-            # print("get from db...user_timezone: ", row)
+                user_setting = dict(result.fetchone())
+                if not user_setting["timezone_name"]:
+                    user_setting["timezone_name"] = DEFAULT_TIMEZONE
+                return user_setting
+            return {"timezone_name": DEFAULT_TIMEZONE}
         except sqlalchemy.exc.ProgrammingError as err:
             logger.error(err)
             raise DatabaseException(
-                "Couldn't get user's timezone: %s" % str(err))
+                "Couldn't get user's setting: %s" % str(err))
 
-def create(user_id: int, timezone_name: str = "UTC"):
-    """Create setting for user
 
+def set_timezone(user_id: int, timezone_name: str):
+    """ Set user's timezone. Update user timezone if the row exists. Otherwise insert a new row.
     Args:
         user_id (int): the row ID of the user in the DB
-        timezone_name(str): with default as "UTC
-
-    Returns:
-        ID of newly created user setting.
-    """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            INSERT INTO user_setting (user_id, timezone_name)
-                 VALUES (:user_id, :timezone_name)
-              RETURNING id
-        """), {
-            "user_id": user_id,
-            "timezone_name": timezone_name,
-        })
-        return result.fetchone()["id"]
-
-   
-def get_or_create(user_id: int):
-    """Get user setting with the row ID of the user in the DB, or create if there's setting history.
-    Args:
-        user_id (int): the row ID of the user in the DB
-    Returns:
-        dict: user settings
-    """
-    user_settings = get(user_id)
-    if not user_settings:
-        create(user_id)
-        user_settings = get(user_id)
-    return user_settings
-
-def update_timezone(user_id: int, timezone_name:str):
-    """update user's timezone
-    Args:
-        user_id (int): the row ID of the user in the DB
-        zone_name (str): the user selected timezone name
+        timezone_name (str): the user selected timezone name
 
     """
     with db.engine.connect() as connection:
         try:
             connection.execute(sqlalchemy.text("""
-                UPDATE "user_setting"
-                SET timezone_name = :timezone_name
-                WHERE user_id = :user_id
+                INSERT INTO user_setting (user_id, timezone_name)
+                VALUES (:user_id, :timezone_name)
+                ON CONFLICT (user_id)
+                DO 
+                    UPDATE SET timezone_name = :timezone_name
                 """), {
                 "user_id": user_id,
                 "timezone_name": timezone_name,
             })
-            # print('db: ',get_user_timezone(user_id) )
         except sqlalchemy.exc.ProgrammingError as err:
             logger.error(err)
             raise DatabaseException(
                 "Couldn't update user's timezone: %s" % str(err))
 
+
 def standardize_timezone(timezones):
-    """standardize timezone format
+    """ Standardize timezone format retrieved by pg for better display 
+        E.x., Convert "Africa/Adnodjan (3:00:00)" to "Africa/addis_Ababa (+3:00:00 GMT)"
+        Convert "America/Adak (-1day, 15:00:00)" to "America/Adak (-9:00:00 GMT)"
     Args:
-        timezone (list): timezone retrived by pg
+        timezones (list): timezones retrieved by pg
     return:
         list of tuples: [(Africa/Abidjan, +0:00:00 GMT), (Africa/addis_Ababa, +3:00:00 GMT),...]
 
@@ -120,6 +97,5 @@ def standardize_timezone(timezones):
         if offset.days > -1:
             result.append((name, "+" + str(offset) + " GMT"))
         else:
-            # result.append((name, str(int(str(offset)[8:10]) - 24) + ":00:00"))
             result.append((name, str(offset.seconds//3600 - 24) + ":00:00 GMT"))
     return result

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -108,6 +108,13 @@ def update_timezone(user_id: int, timezone_name:str):
                 "Couldn't update user's timezone: %s" % str(err))
 
 def standardize_timezone(timezones):
+    """standardize timezone format
+    Args:
+        timezone (list): timezone retrived by pg
+    return:
+        list of tuples: [(Africa/Abidjan, +0:00:00 GMT), (Africa/addis_Ababa, +3:00:00 GMT),...]
+
+    """
     result = []
     for (name, offset) in timezones:
         if offset.days > -1:

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -8,7 +8,7 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-DEFAULT_TIMEZONE  = "UTC"
+DEFAULT_TIMEZONE = "UTC"
 
 
 def get_pg_timezone():
@@ -44,7 +44,7 @@ def get(user_id: int):
             """), {
                 "user_id": user_id,
             })
-            
+
             if result.rowcount:
                 user_setting = dict(result.fetchone())
                 if not user_setting["timezone_name"]:

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -3,10 +3,6 @@ from datetime import datetime, timedelta
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
 
-import logging
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 DEFAULT_TIMEZONE = "UTC"
 
@@ -52,7 +48,6 @@ def get(user_id: int):
                 return user_setting
             return {"timezone_name": DEFAULT_TIMEZONE}
         except sqlalchemy.exc.ProgrammingError as err:
-            logger.error(err)
             raise DatabaseException(
                 "Couldn't get user's setting: %s" % str(err))
 
@@ -77,7 +72,6 @@ def set_timezone(user_id: int, timezone_name: str):
                 "timezone_name": timezone_name,
             })
         except sqlalchemy.exc.ProgrammingError as err:
-            logger.error(err)
             raise DatabaseException(
                 "Couldn't update user's timezone: %s" % str(err))
 

--- a/listenbrainz/webserver/forms.py
+++ b/listenbrainz/webserver/forms.py
@@ -1,0 +1,15 @@
+from flask_wtf import FlaskForm
+from wtforms import SelectField
+from wtforms.validators import DataRequired
+
+class TimezoneForm(FlaskForm):
+    timezone = SelectField(
+        'timezone',
+        [DataRequired()],
+        # choices=[
+        #         ('Africa/Abidjan', 'Africa/Abidjan'),
+        #         ('Africa/Accra', 'Africa/Accra'),
+        #         ('Africa/Addis_Ababa', 'Africa/Addis_Ababa'),
+        #     ],
+        choices = [],
+        )

--- a/listenbrainz/webserver/forms.py
+++ b/listenbrainz/webserver/forms.py
@@ -2,14 +2,10 @@ from flask_wtf import FlaskForm
 from wtforms import SelectField
 from wtforms.validators import DataRequired
 
+
 class TimezoneForm(FlaskForm):
     timezone = SelectField(
         'timezone',
         [DataRequired()],
-        # choices=[
-        #         ('Africa/Abidjan', 'Africa/Abidjan'),
-        #         ('Africa/Accra', 'Africa/Accra'),
-        #         ('Africa/Addis_Ababa', 'Africa/Addis_Ababa'),
-        #     ],
-        choices = [],
+        choices=[],
         )

--- a/listenbrainz/webserver/templates/profile/info.html
+++ b/listenbrainz/webserver/templates/profile/info.html
@@ -24,6 +24,15 @@
       <span class="btn btn-info btn-lg" style="width: 200px"><a href="{{ url_for("profile.reset_token") }}" style="color: white;">Reset token</a></span>
     </p>
 
+    <h3>Reset Timezone</h3>
+    <p>
+      If you would like to reset your timezone, click below to choose your local timezone. Your daily recommendation will be updated based on your local timezone.
+    </p>
+
+    <p>
+      <span class="btn btn-info btn-lg" style="width: 300px"><a href="{{ url_for("profile.reset_time_zone") }}" style="color: white;">Reset Timezone</a></span>
+    </p>
+
     <h3> Reset Last.FM Import timestamp </h3>
     <p>
       If you think that a partial import has somehow missed some listens, you may reset your previous

--- a/listenbrainz/webserver/templates/profile/info.html
+++ b/listenbrainz/webserver/templates/profile/info.html
@@ -24,13 +24,14 @@
       <span class="btn btn-info btn-lg" style="width: 200px"><a href="{{ url_for("profile.reset_token") }}" style="color: white;">Reset token</a></span>
     </p>
 
-    <h3>Reset Timezone</h3>
+    <h3>Select Timezone</h3>
     <p>
-      If you would like to reset your timezone, click below to choose your local timezone. Your daily recommendation will be updated based on your local timezone.
+      Your current timezone is <b>{{ user_setting.timezone_name }}</b>.
+      <br>Please select an appropriate timezone so that we may associated a timezone with your listens and know when to generate recommendations for you.
     </p>
 
     <p>
-      <span class="btn btn-info btn-lg" style="width: 300px"><a href="{{ url_for("profile.reset_time_zone") }}" style="color: white;">Reset Timezone</a></span>
+      <span class="btn btn-info btn-lg" style="width: 300px"><a href="{{ url_for("profile.select_timezone") }}" style="color: white;">Select Timezone</a></span>
     </p>
 
     <h3> Reset Last.FM Import timestamp </h3>

--- a/listenbrainz/webserver/templates/profile/info.html
+++ b/listenbrainz/webserver/templates/profile/info.html
@@ -27,7 +27,7 @@
     <h3>Select Timezone</h3>
     <p>
       Your current timezone is <b>{{ user_setting.timezone_name }}</b>.
-      <br>Please select an appropriate timezone so that we may associated a timezone with your listens and know when to generate recommendations for you.
+      <br>Please select an appropriate timezone so that we may associate a timezone with your listens and know when to generate recommendations for you.
     </p>
 
     <p>

--- a/listenbrainz/webserver/templates/profile/resettimezone.html
+++ b/listenbrainz/webserver/templates/profile/resettimezone.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+
+{% block title %}Reset Timezone- ListenBrainz{% endblock %}
+
+{% block content %}
+  <h3 class="page-title">Reset Timezone</h3>
+  <p>
+    Your current timezone setting is: {{ user_timezone }}. By choosing your local time zone, 
+    you will have a local timestamp for your submitted listens.
+    You can also get new recommendations in the morning. 
+  </p>
+
+  <form method="post">
+      {{ form.hidden_tag() }}
+      <p>
+        <form action="">
+            <label for="timezone">Choose you local timezone:</label>
+            
+            <select name="timezone" id="timezone" class="span5">
+              {% for timezone in pg_timezones %}
+                <option value="{{ timezone[0] }}">{{ timezone[0] }} ({{ timezone[1] }})</option>
+                <!-- <option value="Africa/Accra">(GMT 00:00) Africa/Accra</option>
+                <option value="Africa/Addis_Ababa">(EAT 03:00) Africa/Addis_Ababa</option> -->
+                {% endfor %}
+            </select>
+            
+            <br><br>
+            <p>
+                <button type="submit" class="btn btn-info btn-lg" style="width: 240px">Save Timezone</button>
+            <p>
+        </form>
+      <p>
+  </form>
+
+{% endblock %}
+

--- a/listenbrainz/webserver/templates/profile/resettimezone.html
+++ b/listenbrainz/webserver/templates/profile/resettimezone.html
@@ -1,13 +1,14 @@
 {% extends 'base.html' %}
 
-{% block title %}Reset Timezone- ListenBrainz{% endblock %}
+{% block title %}Select Timezone- ListenBrainz{% endblock %}
 
 {% block content %}
-  <h3 class="page-title">Reset Timezone</h3>
+  <h3 class="page-title">Select Timezone</h3>
   <p>
-    Your current timezone setting is: {{ user_timezone }}. By choosing your local time zone, 
-    you will have a local timestamp for your submitted listens.
-    You can also get new recommendations in the morning. 
+    Your current timezone setting is <b>{{ user_timezone }}</b>. 
+    <br>By choosing your local time zone, 
+    you will have a local timestamps part of your submitted listens. 
+    This also informs as when to generate daily playlists and other recommendations for you.
   </p>
 
   <form method="post">

--- a/listenbrainz/webserver/templates/profile/selecttimezone.html
+++ b/listenbrainz/webserver/templates/profile/selecttimezone.html
@@ -20,8 +20,6 @@
             <select name="timezone" id="timezone" class="span5">
               {% for timezone in pg_timezones %}
                 <option value="{{ timezone[0] }}">{{ timezone[0] }} ({{ timezone[1] }})</option>
-                <!-- <option value="Africa/Accra">(GMT 00:00) Africa/Accra</option>
-                <option value="Africa/Addis_Ababa">(EAT 03:00) Africa/Addis_Ababa</option> -->
                 {% endfor %}
             </select>
             

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -66,13 +66,13 @@ def select_timezone():
         try:
             update_timezone = str(form.timezone.data)
             db_usersetting.set_timezone(current_user.id, update_timezone)
-            flash.info("timezone reset")
+            flash.info("Your timezone has been saved.")
         except DatabaseException:
             flash.error("Something went wrong! Unable to update timezone right now.")
         return redirect(url_for("profile.info"))
 
     if form.csrf_token.errors:
-        flash.error('Cannot update timezone due to error during authentication, please try again later.')
+        flash.error('Unable to update timezone.')
         return redirect(url_for('profile.info'))
 
     return render_template(

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -54,18 +54,18 @@ def reset_token():
     )
 
 
-@profile_bp.route("/reset_time_zone/", methods=["GET", "POST"])
+@profile_bp.route("/select_timezone/", methods=["GET", "POST"])
 @login_required
-def reset_time_zone():
+def select_timezone():
     pg_timezones = db_usersetting.get_pg_timezone()
     form = TimezoneForm()
-    form.timezone.choices = [(zone_name, zone_name) for (zone_name,offset) in pg_timezones]
-    user_settings = db_usersetting.get_or_create(current_user.id)
+    form.timezone.choices = [(zone_name, zone_name) for (zone_name, offset) in pg_timezones]
+    user_settings = db_usersetting.get(current_user.id)
     user_timezone = user_settings['timezone_name']
     if form.validate_on_submit():
         try:
             update_timezone = str(form.timezone.data)
-            db_usersetting.update_timezone(current_user.id, update_timezone)
+            db_usersetting.set_timezone(current_user.id, update_timezone)
             flash.info("timezone reset")
         except DatabaseException:
             flash.error("Something went wrong! Unable to update timezone right now.")
@@ -77,12 +77,12 @@ def reset_time_zone():
 
     return render_template(
         "profile/resettimezone.html",
-        user_timezone = user_timezone,
-        pg_timezones = pg_timezones,
-        form=form
+        user_timezone=user_timezone,
+        pg_timezones=pg_timezones,
+        form=form,
     )
 
-    
+
 @profile_bp.route("/resetlatestimportts/", methods=["GET", "POST"])
 @login_required
 def reset_latest_import_timestamp():
@@ -109,9 +109,11 @@ def reset_latest_import_timestamp():
 @login_required
 def info():
 
+    user_setting = db_usersetting.get(current_user.id)
     return render_template(
         "profile/info.html",
-        user=current_user
+        user=current_user,
+        user_setting = user_setting,
     )
 
 

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import NotFound, BadRequest
 
 import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.user as db_user
+import listenbrainz.db.user_setting as db_usersetting
 from data.model.external_service import ExternalServiceType
 from listenbrainz.db import listens_importer
 from listenbrainz.db.exceptions import DatabaseException
@@ -22,7 +23,9 @@ from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.errors import APIServiceUnavailable, APINotFound
 from listenbrainz.webserver.login import api_login_required
+from listenbrainz.webserver.forms import TimezoneForm
 from listenbrainz.webserver.views.user import delete_user, delete_listens_history
+
 
 profile_bp = Blueprint("profile", __name__)
 
@@ -51,6 +54,35 @@ def reset_token():
     )
 
 
+@profile_bp.route("/reset_time_zone/", methods=["GET", "POST"])
+@login_required
+def reset_time_zone():
+    pg_timezones = db_usersetting.get_pg_timezone()
+    form = TimezoneForm()
+    form.timezone.choices = [(zone_name, zone_name) for (zone_name,offset) in pg_timezones]
+    user_settings = db_usersetting.get_or_create(current_user.id)
+    user_timezone = user_settings['timezone_name']
+    if form.validate_on_submit():
+        try:
+            update_timezone = str(form.timezone.data)
+            db_usersetting.update_timezone(current_user.id, update_timezone)
+            flash.info("timezone reset")
+        except DatabaseException:
+            flash.error("Something went wrong! Unable to update timezone right now.")
+        return redirect(url_for("profile.info"))
+
+    if form.csrf_token.errors:
+        flash.error('Cannot update timezone due to error during authentication, please try again later.')
+        return redirect(url_for('profile.info'))
+
+    return render_template(
+        "profile/resettimezone.html",
+        user_timezone = user_timezone,
+        pg_timezones = pg_timezones,
+        form=form
+    )
+
+    
 @profile_bp.route("/resetlatestimportts/", methods=["GET", "POST"])
 @login_required
 def reset_latest_import_timestamp():

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -76,7 +76,7 @@ def select_timezone():
         return redirect(url_for('profile.info'))
 
     return render_template(
-        "profile/resettimezone.html",
+        "profile/selecttimezone.html",
         user_timezone=user_timezone,
         pg_timezones=pg_timezones,
         form=form,

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -113,7 +113,7 @@ def info():
     return render_template(
         "profile/info.html",
         user=current_user,
-        user_setting = user_setting,
+        user_setting=user_setting,
     )
 
 

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -71,7 +71,7 @@ def select_timezone():
             flash.error("Something went wrong! Unable to update timezone right now.")
         return redirect(url_for("profile.info"))
 
-    if form.csrf_token.errors:
+    if form.errors:
         flash.error('Unable to update timezone.')
         return redirect(url_for('profile.info'))
 

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -138,8 +138,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assert200(response)
 
         response = self.client.post(select_timezone_url, data={'csrf_token': 'invalid-auth-token'})
-        self.assertMessageFlashed('Unable to update timezone.',
-                                  'error')
+        self.assertMessageFlashed('Unable to update timezone.', 'error')
         self.assertRedirects(response, url_for('profile.info'))
         
     def test_music_services_details(self):

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -140,7 +140,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         response = self.client.post(select_timezone_url, data={'csrf_token': 'invalid-auth-token'})
         self.assertMessageFlashed('Unable to update timezone.', 'error')
         self.assertRedirects(response, url_for('profile.info'))
-        
+  
     def test_music_services_details(self):
         self.temporary_login(self.user['login_id'])
         r = self.client.get(url_for('profile.music_services_details'))

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -130,7 +130,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertStatus(response, 302)
         self.assertRedirects(response, url_for('login.index', next=select_timezone_url))
 
-    def test_delete_listens_invalid_csrf_token(self):
+    def test_select_timezone_invalid_csrf_token(self):
         """Tests select timezone end point with invalid auth token """
         self.temporary_login(self.user['login_id'])
         select_timezone_url = url_for('profile.select_timezone')

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -108,6 +108,40 @@ class ProfileViewsTestCase(IntegrationTestCase):
                                   'error')
         self.assertRedirects(response, url_for('profile.info'))
 
+    def test_select_timezone(self):
+        """Tests select timezone end point"""
+        self.temporary_login(self.user['login_id'])
+        select_timezone_url = url_for('profile.select_timezone')
+        response = self.client.get(select_timezone_url)
+        self.assert200(response)
+
+        response = self.client.post(select_timezone_url, data={'csrf_token': g.csrf_token, 'timezone': 'America/New_York'})
+        self.assertMessageFlashed('Your timezone has been saved.', 'info')
+        self.assertRedirects(response, url_for('profile.info'))
+
+    def test_select_timezone_logged_out(self):
+        """Tests select timezone view when not logged in"""
+        select_timezone_url = url_for('profile.select_timezone')
+        response = self.client.get(select_timezone_url)
+        self.assertStatus(response, 302)
+        self.assertRedirects(response, url_for('login.index', next=select_timezone_url))
+
+        response = self.client.post(select_timezone_url)
+        self.assertStatus(response, 302)
+        self.assertRedirects(response, url_for('login.index', next=select_timezone_url))
+
+    def test_delete_listens_invalid_csrf_token(self):
+        """Tests select timezone end point with invalid auth token """
+        self.temporary_login(self.user['login_id'])
+        select_timezone_url = url_for('profile.select_timezone')
+        response = self.client.get(select_timezone_url)
+        self.assert200(response)
+
+        response = self.client.post(select_timezone_url, data={'csrf_token': 'invalid-auth-token'})
+        self.assertMessageFlashed('Unable to update timezone.',
+                                  'error')
+        self.assertRedirects(response, url_for('profile.info'))
+        
     def test_music_services_details(self):
         self.temporary_login(self.user['login_id'])
         r = self.client.get(url_for('profile.music_services_details'))

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -140,7 +140,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
         response = self.client.post(select_timezone_url, data={'csrf_token': 'invalid-auth-token'})
         self.assertMessageFlashed('Unable to update timezone.', 'error')
         self.assertRedirects(response, url_for('profile.info'))
-  
+
     def test_music_services_details(self):
         self.temporary_login(self.user['login_id'])
         r = self.client.get(url_for('profile.music_services_details'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
Listens on ListenBrainz are collected in the UTC instead of their local timestamp currently, without taking DST in to consideration. Adding timezone preference for users will contribute to the analysis and thus provide better user experience.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
## database: 
1. Create a new table `user_setting`. The user_timezone information and other user preferences can be stored here.
2. Create a function to get all timezone recognized by PostgreSQL.
3. Create functions to create, get, and modify user settings.
4. Create a function to convert timezones retrieved by PostgreSQL to standardized format for display.
## UI: 
1. Add a `Reset timezone`  UI module in the general setting page.
2. Create a new webpage for user to select timezone.
## endpoint
Create an endpoint for getting and resetting user timezone preference by creating a `TimezoneForm` extended from `FlaskForm`.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->





