### PR TITLE
Dockerfile: Always install `postgresql-client` from current apt repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
 # PostgreSQL client
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ENV PG_MAJOR 12
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
PostgreSQL doesn't currently support xenial.

1. This approach (`$(lsb_release -cs)`) will eliminate the need to change repository source names every time the base image is updated to a newer version.
2. This approach is mentioned on [PostgreSQL docs](https://www.postgresql.org/download/linux/ubuntu/).

Output of `cat /etc/apt/sources.list.d/pgdg.list`:
<pre>
deb http://apt.postgresql.org/pub/repos/apt/ <b>focal</b>-pgdg main 12
</pre>
...which is correct for current base image.