### PR TITLE
Lookup MBIDs for now playing listens

### DIFF
--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -396,7 +396,7 @@ export default class Listens extends React.Component<
   getFeedback = async () => {
     const { newAlert } = this.props;
     const { APIService, currentUser } = this.context;
-    const { listens } = this.state;
+    const { listens, playingNowListen } = this.state;
     let recording_msids = "";
     let recording_mbids = "";
 
@@ -411,6 +411,12 @@ export default class Listens extends React.Component<
           recording_mbids += `${recordingMBID},`;
         }
       });
+
+      if (playingNowListen) {
+        const playingNowMbid = getRecordingMBID(playingNowListen);
+        recording_mbids += `${playingNowMbid}`;
+      }
+
       try {
         const data = await APIService.getFeedbackForUserForRecordings(
           currentUser.name,

--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -243,9 +243,17 @@ export default class Listens extends React.Component<
     }
   };
 
-  receiveNewPlayingNow = (newPlayingNow: string): void => {
+  receiveNewPlayingNow = async (newPlayingNow: string): Promise<void> => {
     const playingNow = JSON.parse(newPlayingNow) as Listen;
     playingNow.playing_now = true;
+
+    const { APIService } = this.context;
+    const metadata = await APIService.lookupRecordingMetadata(
+      playingNow.track_metadata.track_name,
+      playingNow.track_metadata.artist_name,
+      false
+    );
+    playingNow.track_metadata.mbid_mapping = metadata as MbidMapping;
 
     this.setState({
       playingNowListen: playingNow,
@@ -612,6 +620,77 @@ export default class Listens extends React.Component<
     window.history.pushState(null, "", `?min_ts=${minTimestampInSeconds}`);
   };
 
+  getListenCard = (listen: Listen): JSX.Element => {
+    const { deletedListen } = this.state;
+    const { newAlert } = this.props;
+    const { currentUser } = this.context;
+    const isCurrentUser =
+      Boolean(listen.user_name) && listen.user_name === currentUser?.name;
+    const listenedAt = get(listen, "listened_at");
+    const recordingMSID = getRecordingMSID(listen);
+    const recordingMBID = getRecordingMBID(listen);
+    const artistMBIDs = getArtistMBIDs(listen);
+    const trackMBID = get(listen, "track_metadata.additional_info.track_mbid");
+    const releaseGroupMBID = getReleaseGroupMBID(listen);
+    const canDelete =
+      isCurrentUser && Boolean(listenedAt) && Boolean(recordingMSID);
+
+    const isListenReviewable =
+      Boolean(recordingMBID) ||
+      artistMBIDs?.length ||
+      Boolean(trackMBID) ||
+      Boolean(releaseGroupMBID);
+    // All listens in this array should have either an MSID or MBID or both,
+    // so we can assume we can pin them. Playing_now listens are displayed separately.
+    /* eslint-disable react/jsx-no-bind */
+    const additionalMenuItems = (
+      <>
+        <ListenControl
+          text="Pin this recording"
+          icon={faThumbtack}
+          action={this.updateRecordingToPin.bind(this, listen)}
+          dataToggle="modal"
+          dataTarget="#PinRecordingModal"
+        />
+        {isListenReviewable && (
+          <ListenControl
+            text="Write a review"
+            icon={faPencilAlt}
+            action={this.updateRecordingToReview.bind(this, listen)}
+            dataToggle="modal"
+            dataTarget="#CBReviewModal"
+          />
+        )}
+        {canDelete && (
+          <ListenControl
+            text="Delete Listen"
+            icon={faTrashAlt}
+            action={this.deleteListen.bind(this, listen)}
+          />
+        )}
+      </>
+    );
+    const shouldBeDeleted = isEqual(deletedListen, listen);
+    /* eslint-enable react/jsx-no-bind */
+    return (
+      <ListenCard
+        key={`${listen.listened_at}-${getTrackName(listen)}-${
+          listen.track_metadata?.additional_info?.recording_msid
+        }-${listen.user_name}`}
+        showTimestamp
+        showUsername={false}
+        listen={listen}
+        currentFeedback={this.getFeedbackForListen(listen)}
+        updateFeedbackCallback={this.updateFeedback}
+        newAlert={newAlert}
+        className={`${listen.playing_now ? "playing-now " : ""}${
+          shouldBeDeleted ? "deleted " : ""
+        }`}
+        additionalMenuItems={additionalMenuItems}
+      />
+    );
+  };
+
   afterListensFetch() {
     this.setState({ loading: false });
     // Scroll to the top of the listens list
@@ -636,7 +715,6 @@ export default class Listens extends React.Component<
       dateTimePickerValue,
       recordingToPin,
       recordingToReview,
-      deletedListen,
       userPinnedRecording,
       playingNowListen,
     } = this.state;
@@ -663,18 +741,7 @@ export default class Listens extends React.Component<
         <h3>Recent listens</h3>
         <div className="row">
           <div className="col-md-4 col-md-push-8">
-            {playingNowListen && (
-              <ListenCard
-                key={`playing-now-${getTrackName(
-                  playingNowListen
-                )}-${getArtistName(playingNowListen)}`}
-                showTimestamp
-                showUsername={false}
-                listen={playingNowListen}
-                newAlert={newAlert}
-                className="playing-now"
-              />
-            )}
+            {playingNowListen && this.getListenCard(playingNowListen)}
             {userPinnedRecording && (
               <PinnedRecordingCard
                 userName={user.name}
@@ -719,82 +786,7 @@ export default class Listens extends React.Component<
                   ref={this.listensTable}
                   style={{ opacity: loading ? "0.4" : "1" }}
                 >
-                  {listens.map((listen) => {
-                    const isCurrentUser =
-                      Boolean(listen.user_name) &&
-                      listen.user_name === currentUser?.name;
-                    const listenedAt = get(listen, "listened_at");
-                    const recordingMSID = getRecordingMSID(listen);
-                    const recordingMBID = getRecordingMBID(listen);
-                    const artistMBIDs = getArtistMBIDs(listen);
-                    const trackMBID = get(
-                      listen,
-                      "track_metadata.additional_info.track_mbid"
-                    );
-                    const releaseGroupMBID = getReleaseGroupMBID(listen);
-                    const canDelete =
-                      isCurrentUser &&
-                      Boolean(listenedAt) &&
-                      Boolean(recordingMSID);
-
-                    const isListenReviewable =
-                      Boolean(recordingMBID) ||
-                      artistMBIDs?.length ||
-                      Boolean(trackMBID) ||
-                      Boolean(releaseGroupMBID);
-                    // All listens in this array should have either an MSID or MBID or both,
-                    // so we can assume we can pin them. Playing_now listens are displayed separately.
-                    /* eslint-disable react/jsx-no-bind */
-                    const additionalMenuItems = (
-                      <>
-                        <ListenControl
-                          text="Pin this recording"
-                          icon={faThumbtack}
-                          action={this.updateRecordingToPin.bind(this, listen)}
-                          dataToggle="modal"
-                          dataTarget="#PinRecordingModal"
-                        />
-                        {isListenReviewable && (
-                          <ListenControl
-                            text="Write a review"
-                            icon={faPencilAlt}
-                            action={this.updateRecordingToReview.bind(
-                              this,
-                              listen
-                            )}
-                            dataToggle="modal"
-                            dataTarget="#CBReviewModal"
-                          />
-                        )}
-                        {canDelete && (
-                          <ListenControl
-                            text="Delete Listen"
-                            icon={faTrashAlt}
-                            action={this.deleteListen.bind(this, listen)}
-                          />
-                        )}
-                      </>
-                    );
-                    const shouldBeDeleted = isEqual(deletedListen, listen);
-                    /* eslint-enable react/jsx-no-bind */
-                    return (
-                      <ListenCard
-                        key={`${listen.listened_at}-${getTrackName(listen)}-${
-                          listen.track_metadata?.additional_info?.recording_msid
-                        }-${listen.user_name}`}
-                        showTimestamp
-                        showUsername={false}
-                        listen={listen}
-                        currentFeedback={this.getFeedbackForListen(listen)}
-                        updateFeedbackCallback={this.updateFeedback}
-                        newAlert={newAlert}
-                        className={`${
-                          listen.playing_now ? "playing-now " : ""
-                        }${shouldBeDeleted ? "deleted " : ""}`}
-                        additionalMenuItems={additionalMenuItems}
-                      />
-                    );
-                  })}
+                  {listens.map((listen) => this.getListenCard(listen))}
                 </div>
                 {listens.length < this.expectedListensPerPage && (
                   <h5 className="text-center">No more listens to show</h5>

--- a/listenbrainz/webserver/static/js/src/utils/APIService.ts
+++ b/listenbrainz/webserver/static/js/src/utils/APIService.ts
@@ -1093,24 +1093,29 @@ export default class APIService {
 
   lookupRecordingMetadata = async (
     trackName: string,
-    artistName: string
+    artistName: string,
+    metadata: boolean = true
   ): Promise<MetadataLookup | null> => {
     if (!trackName) {
       return null;
     }
     const queryParams: any = {
       recording_name: trackName,
-      metadata: true,
     };
     if (artistName) {
       queryParams.artist_name = artistName;
+    }
+    if (metadata) {
+      queryParams.metadata = true;
     }
     const url = new URL(`${this.APIBaseURI}/metadata/lookup/`);
     // Iterate and add each queryParams
     Object.keys(queryParams).map((key) =>
       url.searchParams.append(key, queryParams[key])
     );
-    url.searchParams.append("inc", "artist tag release");
+    if (metadata) {
+      url.searchParams.append("inc", "artist tag release");
+    }
 
     const response = await fetch(url.toString());
     await this.checkStatus(response);

--- a/listenbrainz/webserver/static/js/tests/user/Listens.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/user/Listens.test.tsx
@@ -225,7 +225,7 @@ describe("addWebsocketsHandlers", () => {
     instance.addWebsocketsHandlers();
 
     expect(instance.receiveNewPlayingNow).toHaveBeenCalledWith(
-      JSON.stringify(recentListensPropsPlayingNow.listens[0])
+      recentListensPropsPlayingNow.listens[0]
     );
     spy.mockReset();
   });
@@ -331,7 +331,7 @@ describe("receiveNewPlayingNow", () => {
     expect(wrapper.state("listens")).toEqual(result);
     expect(wrapper.state("playingNowListen")).toEqual(firstPlayingNow);
 
-    instance.receiveNewPlayingNow(JSON.stringify(mockListenOne));
+    instance.receiveNewPlayingNow(mockListenOne);
     wrapper.update();
     expect(wrapper.state("listens")).toEqual(result);
     expect(wrapper.state("playingNowListen")).toEqual({

--- a/listenbrainz/webserver/static/js/tests/user/Listens.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/user/Listens.test.tsx
@@ -301,22 +301,28 @@ describe("receiveNewPlayingNow", () => {
       artist_name: "Coldplay",
       track_name: "Viva La Vida",
     },
+    playing_now: true,
     user_name: "ishaanshah",
     listened_at: 1586580524,
     listened_at_iso: "2020-04-10T10:12:04Z",
   };
 
-  it("sets state correctly for other modes", () => {
+  it("sets state correctly for other modes", async () => {
+    const spy = jest
+      .spyOn(mountOptions.context.APIService, "lookupRecordingMetadata")
+      .mockImplementation(() => Promise.resolve(null));
     /* JSON.parse(JSON.stringify(object) is a fast way to deep copy an object,
      * so that it doesn't get passed as a reference.
      */
     const wrapper = mount<Listens>(
-      <Listens
-        {...(JSON.parse(
-          JSON.stringify(recentListensPropsPlayingNow)
-        ) as ListensProps)}
-        newAlert={jest.fn()}
-      />
+      <GlobalAppContext.Provider value={mountOptions.context}>
+        <Listens
+          {...(JSON.parse(
+            JSON.stringify(recentListensPropsPlayingNow)
+          ) as ListensProps)}
+          newAlert={jest.fn()}
+        />
+      </GlobalAppContext.Provider>
     );
     const instance = wrapper.instance();
 
@@ -331,13 +337,11 @@ describe("receiveNewPlayingNow", () => {
     expect(wrapper.state("listens")).toEqual(result);
     expect(wrapper.state("playingNowListen")).toEqual(firstPlayingNow);
 
-    instance.receiveNewPlayingNow(mockListenOne);
+    await instance.receiveNewPlayingNow(mockListenOne);
     wrapper.update();
     expect(wrapper.state("listens")).toEqual(result);
-    expect(wrapper.state("playingNowListen")).toEqual({
-      ...mockListenOne,
-      playing_now: true,
-    });
+    expect(wrapper.state("playingNowListen")).toEqual(mockListenOne);
+    spy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Now Playing listens are received on frontend using Websockets and through the listens in props on initial page load. Now playing listens don't have msids or mbid mapping data when first received. To add mbid mapping data to now playing listens, we lookup the metadata using the track and artist name and according update the listen.