### PR TITLE
Fix listen dedup in database

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -3,7 +3,7 @@ BEGIN;
 CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id);
 CREATE INDEX created_ndx_listen ON listen (created);
 
-CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id);
+CREATE UNIQUE INDEX listened_at_user_id_track_name_ndx_listen ON listen (listened_at DESC, user_id, LOWER(track_name));
 
 CREATE INDEX recording_msid_ndx_listen on listen ((data->'track_metadata'->'additional_info'->>'recording_msid'));
 

--- a/admin/timescale/updates/2022-06-18-fix-listen-dedup-index.sql
+++ b/admin/timescale/updates/2022-06-18-fix-listen-dedup-index.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX listened_at_user_id_track_name_ndx_listen ON listen (listened_at DESC, user_id, LOWER(track_name));
+
+DROP INDEX listened_at_track_name_user_id_ndx_listen;

--- a/listenbrainz/listenstore/tests/test_dumplistenstore.py
+++ b/listenbrainz/listenstore/tests/test_dumplistenstore.py
@@ -50,7 +50,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
 
         query = """INSERT INTO listen (listened_at, track_name, user_name, user_id, data, created)
                         VALUES %s
-                   ON CONFLICT (listened_at, track_name, user_id)
+                   ON CONFLICT (listened_at, user_id, LOWER(track_name))
                     DO NOTHING
                 """
 

--- a/listenbrainz/listenstore/timescale_dedup_listens.py
+++ b/listenbrainz/listenstore/timescale_dedup_listens.py
@@ -1,0 +1,118 @@
+"""
+Utility tool for de-duplicating listens for which were submitted multiple times with
+different casing for track names. It can be run multiple times.
+
+1. take the min(listened_at)
+2. work in chunks of 432000 seconds (5 days, this is the size of a timescale hypertable)
+3. fetch tracks for deletion and then batch delete those using execute_values
+"""
+import math
+import time
+from datetime import datetime, timedelta
+
+import psycopg2.extras
+from sqlalchemy import text
+
+from listenbrainz.db import timescale
+from listenbrainz.listenstore import LISTEN_MINIMUM_TS
+
+CHUNK_SECONDS = 432000
+
+
+def process_chunk(chunk_start):
+    chunk_start_dt = datetime.fromtimestamp(chunk_start)
+    chunk_start_dt = chunk_start_dt.replace(microsecond=0)
+    chunk_end_dt = datetime.fromtimestamp(chunk_start + CHUNK_SECONDS)
+    chunk_end_dt = chunk_end_dt.replace(microsecond=0)
+    print(f"Processing chunk: {chunk_start_dt.isoformat()} - {chunk_end_dt.isoformat()}")
+
+    with timescale.engine.connect() as connection:
+        result = connection.execute(text("""
+            WITH all_tracks AS (
+                SELECT listened_at
+                     , user_id
+                     , track_name
+                     , row_number() over (PARTITION BY listened_at, user_id, lower(track_name)) AS rnum
+                  FROM listen
+                 WHERE listened_at >= :start AND listened_at < :end
+            ) SELECT listened_at, user_id, track_name
+                FROM all_tracks
+               WHERE rnum > 1
+        """), start=chunk_start, end=chunk_start + CHUNK_SECONDS)
+        if result.rowcount == 0:
+            print(" - No more items in this chunk")
+            return
+        else:
+            rows_to_delete = [(row['listened_at'], row['user_id'], row['track_name']) for row in result]
+            print(f" - got {len(rows_to_delete)} rows to delete")
+
+    s = time.monotonic()
+    dbapi_conn = timescale.engine.raw_connection()
+    try:
+        cursor = dbapi_conn.cursor()
+        query = """
+            DELETE FROM listen l
+                  USING (VALUES %%s) d (listened_at, user_id, track_name)
+                  WHERE l.listened_at = d.listened_at
+                    AND l.user_id = d.user_id
+                    AND l.track_name = d.track_name
+        """
+        # Push in chunk boundaries
+        query = cursor.mogrify(query, (chunk_start, chunk_start + CHUNK_SECONDS))
+        psycopg2.extras.execute_values(cursor, query, rows_to_delete)
+        dbapi_conn.commit()
+    finally:
+        dbapi_conn.close()
+    e = time.monotonic()
+    print(f" - processed chunk in {round(e-s, 2)}s")
+
+    return True
+
+
+def dedup_listens():
+    with timescale.engine.connect() as connection:
+        result = connection.execute(
+            text("""
+               SELECT min(listened_at) as min_listened_at
+                    , max(listened_at) as max_listened_at
+                 FROM listen
+                WHERE listened_at >= :least_accepted_ts"""),
+            least_accepted_ts=LISTEN_MINIMUM_TS)
+        row = result.fetchone()
+        min_listened_at = row['min_listened_at']
+        max_listened_at = row['max_listened_at']
+
+    if min_listened_at is None:
+        print("No chunks found for processing.")
+        return
+
+    number_chunks = math.ceil((max_listened_at - min_listened_at) / CHUNK_SECONDS)
+    chunk_count = 0
+    start_time = time.monotonic()
+    chunk_start = min_listened_at
+    while chunk_start < max_listened_at:
+        result = process_chunk(chunk_start)
+        if result is not True:
+            # If we quit early, then remove this chunk from the count
+            # so that completion time is more accurate
+            number_chunks -= 1
+        else:
+            chunk_count += 1
+        print_status_update(chunk_count, number_chunks, start_time)
+        chunk_start += CHUNK_SECONDS
+
+    print("Finished.")
+
+
+def print_status_update(chunk_count, number_chunks, start_time):
+    """Print a basic status update based on how many chunks have been computed"""
+    if number_chunks > 0:
+        chunk_time = time.monotonic()
+        chunk_percentage = chunk_count / number_chunks
+        duration = round(chunk_time - start_time)
+        durdelta = timedelta(seconds=duration)
+        remaining = round((duration / (chunk_percentage or 0.01)) - duration)
+        remdelta = timedelta(seconds=remaining)
+        print(f" - Done {chunk_count}/{number_chunks} in {str(durdelta)}; {str(remdelta)} remaining")
+    else:
+        print(f" No chunks processed")

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -182,7 +182,7 @@ class TimescaleListenStore:
 
         query = """INSERT INTO listen (listened_at, track_name, user_name, user_id, data)
                         VALUES %s
-                   ON CONFLICT (listened_at, track_name, user_id)
+                   ON CONFLICT (listened_at, user_id, LOWER(track_name))
                     DO NOTHING
                      RETURNING listened_at, track_name, user_name, user_id"""
 

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -8,6 +8,7 @@ from listenbrainz import db
 from listenbrainz import webserver
 from listenbrainz.db import timescale as ts
 from listenbrainz.listenstore import timescale_fill_userid
+from listenbrainz.listenstore import timescale_dedup_listens
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data as ts_recalculate_all_user_data, \
     update_user_listen_data as ts_update_user_listen_data, \
     add_missing_to_listen_users_metadata as ts_add_missing_to_listen_users_metadata,\
@@ -335,3 +336,13 @@ def listen_add_userid():
     app = create_app()
     with app.app_context():
         timescale_fill_userid.fill_userid()
+
+
+@cli.command()
+def listen_deduplicate():
+    """
+        Deduplicate listens using case insensitivity for track name.
+    """
+    app = create_app()
+    with app.app_context():
+        timescale_dedup_listens.dedup_listens()


### PR DESCRIPTION
The Unique Index used for deduplication in the listen table is case-sensitive which is undesirable. msids already ignores casing while calculating the hash. Update the index to be case-insensitive. Found while investigating LB-1109.

Hypertables do not support concurrent or per chunk indexing so we cannot use either of those optimizations for listen table. My intent for the upgrade is to stop TS writer, add the new index and start TS writer with new changes. The old index will be kept around for a while so that it can be used in case we need to downgrade a service later.