### PR TITLE
LB-1103: Prefer front cover art for releases

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -472,20 +472,23 @@ const getAlbumArtFromListenMetadata = async (
       );
       if (CAAResponse.ok) {
         const body: CoverArtArchiveResponse = await CAAResponse.json();
-        const frontImage =
-          body.images.find((image) => image.front && image.thumbnails) ??
-          body.images[0];
-        if (!frontImage.thumbnails) {
+        if (!body.images?.length) {
           return undefined;
         }
-        const { thumbnails } = frontImage;
-        return (
-          thumbnails[250] ??
-          thumbnails.small ??
-          // If neither of the above exists, return the first one we find
-          // @ts-ignore
-          thumbnails[Object.keys(thumbnails)?.[0]]
-        );
+
+        const frontImage =
+          body.images.find((image) => image.front) ?? body.images[0];
+        if (frontImage.thumbnails) {
+          const { thumbnails } = frontImage;
+          return (
+            thumbnails[250] ??
+            thumbnails.small ??
+            // If neither of the above exists, return the first one we find
+            // @ts-ignore
+            thumbnails[Object.keys(thumbnails)?.[0]]
+          );
+        }
+        return frontImage.image;
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -472,10 +472,13 @@ const getAlbumArtFromListenMetadata = async (
       );
       if (CAAResponse.ok) {
         const body: CoverArtArchiveResponse = await CAAResponse.json();
-        if (!body.images?.[0]?.thumbnails) {
+        const frontImage =
+          body.images.find((image) => image.front && image.thumbnails) ??
+          body.images[0];
+        if (!frontImage.thumbnails) {
           return undefined;
         }
-        const { thumbnails } = body.images[0];
+        const { thumbnails } = frontImage;
         return (
           thumbnails[250] ??
           thumbnails.small ??


### PR DESCRIPTION
LB-1103

MB shows front cover art for releases if possible. We should also try to show the front cover art for releases if one is available. In the longer run, it would be better to fetch the cover art on the release group level but this in itself should be a nice improvement.
