### PR TITLE
Daily jams fine tuning

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -28,7 +28,11 @@ MAILTO=""
 00 6 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feedback >> /logs/dumps.log 2>&1
 
 # Request recommendations after dump and mapping has been imported into the spark cluster
-30 6 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_recommendations >> /logs/stats.log 2>&1
+30 6 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_recommendations_without_model >> /logs/stats.log 2>&1
 
 # Request missing MB data each month after a new dump has been imported to spark cluster
 30 7 * * 1 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_missing_mb_data >> /logs/stats.log 2>&1
+
+# Request model training once a week on sundays, so the new model gets used on monday
+30 7 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_model >> /logs/stats.log 2>&1
+

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -13,26 +13,20 @@ MAILTO=""
 # After the daily dumping is done, make sure everything turned out ok, otherwise mail the observability list.
 0 2 * * * root flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py dump check_dump_ages >> /logs/dumps.log 2>&1
 
+# Dump user feedback before we generate recommendations
+15 2 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feedback >> /logs/dumps.log 2>&1
+
+# batch up all the spark requests, spaced by 1 minute in order to ensure the correct order
 # Request all statistics
-00 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_all_stats >> /logs/stats.log 2>&1
+0 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_all_stats >> /logs/stats.log 2>&1
+# Request recommendations after dump and mapping has been imported into the spark cluster
+1 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_recommendations >> /logs/stats.log 2>&1
+# Request missing MB data each month after a new dump has been imported to spark cluster
+2 2 * * 1 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_missing_mb_data >> /logs/stats.log 2>&1
+# Calculate user similarity
+3 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_similar_users >> /logs/stats.log 2>&1
 
 ## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
 0 4 1,15 * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/dumps.log 2>&1
 ## Around 24 hours later, trigger a full import into the spark cluster, and this time wait for the lock, in case the dump hasn't finished.
 0 4 2,16 * * root flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full >> /logs/dumps.log 2>&1
-
-# Calculate user similarity
-30 5 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_similar_users >> /logs/stats.log 2>&1
-
-# Dump user feedback before we generate recommendations
-00 6 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feedback >> /logs/dumps.log 2>&1
-
-# Request recommendations after dump and mapping has been imported into the spark cluster
-30 6 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_recommendations_without_model >> /logs/stats.log 2>&1
-
-# Request missing MB data each month after a new dump has been imported to spark cluster
-30 7 * * 1 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_missing_mb_data >> /logs/stats.log 2>&1
-
-# Request model training once a week on sundays, so the new model gets used on monday
-30 7 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_model >> /logs/stats.log 2>&1
-

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -137,7 +137,7 @@ DEBUG_TB_INTERCEPT_REDIRECTS = False
 # Users who are allowed to view the LB admin interface
 ADMINS = []
 # Users who are allowed to submit playlists made for someone else.
-APPROVED_PLAYLIST_BOTS = ['troi-bot, 'troi-bot-debug']
+APPROVED_PLAYLIST_BOTS = ['troi-bot', 'troi-bot-debug']
 
 # Auth tokens that are not subject to rate limits:
 WHITELISTED_AUTH_TOKENS = []

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -137,7 +137,7 @@ DEBUG_TB_INTERCEPT_REDIRECTS = False
 # Users who are allowed to view the LB admin interface
 ADMINS = []
 # Users who are allowed to submit playlists made for someone else.
-APPROVED_PLAYLIST_BOTS = ['troi-bot']
+APPROVED_PLAYLIST_BOTS = ['troi-bot, 'troi-bot-debug']
 
 # Auth tokens that are not subject to rate limits:
 WHITELISTED_AUTH_TOKENS = []

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -14,6 +14,7 @@ from flask import current_app
 
 
 TROI_BOT_USER_ID = 12939
+TROI_BOT_DEBUG_USER_ID = 19055
 
 
 def get_by_mbid(playlist_id: str, load_recordings: bool = True) -> Optional[model_playlist.Playlist]:

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -393,3 +393,11 @@ def cron_request_recommendations(ctx):
     ctx.invoke(request_candidate_sets)
     ctx.invoke(request_recording_discovery)
     ctx.invoke(request_recommendations)
+
+@cli.command(name='cron_request_recommendations_without_model')
+@click.pass_context
+def cron_request_recommendations_without_model(ctx):
+    ctx.invoke(request_dataframes)
+    ctx.invoke(request_candidate_sets)
+    ctx.invoke(request_recording_discovery)
+    ctx.invoke(request_recommendations)

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -393,11 +393,3 @@ def cron_request_recommendations(ctx):
     ctx.invoke(request_candidate_sets)
     ctx.invoke(request_recording_discovery)
     ctx.invoke(request_recommendations)
-
-@cli.command(name='cron_request_recommendations_without_model')
-@click.pass_context
-def cron_request_recommendations_without_model(ctx):
-    ctx.invoke(request_dataframes)
-    ctx.invoke(request_candidate_sets)
-    ctx.invoke(request_recording_discovery)
-    ctx.invoke(request_recommendations)

--- a/listenbrainz/spark/troi_bot.py
+++ b/listenbrainz/spark/troi_bot.py
@@ -32,7 +32,7 @@ def make_playlist_from_recommendations(user):
     """
         Save the top 100 tracks from the current tracks you might like into a playlist.
     """
-    token = current_app.config["WHITELISTED_AUTH_TOKENS"][0]
+    token = current_app.config["WHITELISTED_AUTH_TOKENS"][1]
     for type in ["top", "similar"]:
         generate_playlist("recs-to-playlist", args=[user, type], upload=True, token=token, created_for=user)
 

--- a/listenbrainz/spark/troi_bot.py
+++ b/listenbrainz/spark/troi_bot.py
@@ -4,14 +4,10 @@
 from flask import current_app
 from troi.core import generate_playlist
 
-from listenbrainz.db.playlist import TROI_BOT_USER_ID
+from listenbrainz.db.playlist import TROI_BOT_USER_ID, TROI_BOT_DEBUG_USER_ID
 from listenbrainz.db.user import get_by_mb_id
 from listenbrainz.db.user_relationship import get_followers_of_user
 from listenbrainz.db.user_timeline_event import create_user_timeline_event, UserTimelineEventType, NotificationMetadata
-
-
-def get_users_to_process():
-    return ["mr_monkey", "rob", "akshaaatt", "Damselfish", "lucifer", "alastairp", "CatCat", "atj"]
 
 
 def run_post_recommendation_troi_bot():
@@ -19,13 +15,14 @@ def run_post_recommendation_troi_bot():
         Top level function called after spark CF recommendations have been completed.
     """
     # Save playlists for just a handful of people
-    for user in get_users_to_process():
+    users = get_followers_of_user(TROI_BOT_DEBUG_USER_ID)
+    users = [user["musicbrainz_id"] for user in users]
+    for user in users:
         make_playlist_from_recommendations(user)
 
     # Now generate daily jams (and other in the future) for users who follow troi bot
     users = get_followers_of_user(TROI_BOT_USER_ID)
     users = [user["musicbrainz_id"] for user in users]
-
     for user in users:
         run_daily_jams(user)
         # Add others here

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.6.1
 spotipy == 2.19.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-06-03
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-06-30
 PyYAML==6.0
 eventlet == 0.33.1
 uWSGI == 2.0.20


### PR DESCRIPTION
This PR improves the daily jams feature by:

1. Not generating models each day (only sundays as the last thing, ready for monday's recs)
2. Use the latest troi release
3. Put debugging playlists under troi-bot-debug user, freeing up troi-bot for non dev purposes.

@amCap1712 : Please sanity check the modified cron calls -- I forget if we need to create dataframes (I think so) even if we're not generating a model each time.