### PR TITLE
Display error message on Last.fm import page if user has no email 

### DIFF
--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -4,53 +4,54 @@
 
 {% block content %}
     <h2 class="page-title">Import to user {{ user.musicbrainz_id }}</h2>
-    {% if user_has_email %}
-        {% if current_user.is_authenticated and current_user == user %}
-
-            <p>
-                Most users will want to import from Last.fm directly.
-                <br>
-                Fun Fact: The term <strong>scrobble</strong> is a trademarked term
-                by Last.fm, and we cannot use it. Instead, we use the term <strong>listen</strong> for our data.
-            </p>
-
-            <h3>Direct import from Last.fm and Libre.fm</h3>
-            <p>
-                The importer manually steps through your listen history and imports the listens
-                one page at a time. Should it fail for whatever reason, it is safe to restart the import
-                process. Running the import process multiple times <strong>does not</strong> create duplicates in your
-                ListenBrainz listen history.
-            </p>
-            <p>In order for this to work, you must disable the &#34;Hide recent listening information&#34;
-                setting in your Last.fm <a href="https://www.last.fm/settings/privacy">Privacy Settings</a>.
-            </p>
-            <p>
-                Clicking the "Import now!" button will import your profile now without the need to open lastfm.<br/>
-                You need to keep this page open for the tool to work, it might take a while to complete. Though, you can
-                continue doing your work. :)
-            </p>
-            <p>
-                <em>NOTE</em>: Please note that your listen counts may not be accurate for up to 24 hours after
-                you import your data!
-                Also, running the Last.fm importer twice will not cause duplicates in your listen history.
-            </p>
-            <div class="row">
-                <div class="well col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
-                    <div id="react-container">
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-    {% else %}
+    {% if not user_has_email %}
         <p>
             You have not provided an email address. Please provide an <a href="https://musicbrainz.org/account/edit">
             email address</a> to submit listens. Read this <a href="https://blog.metabrainz.org/?p=8915">blog post</a>
             to understand why we need your email.
         </p>
     {% endif %}
+    {% if current_user.is_authenticated and current_user == user %}
+
+        <p>
+            Most users will want to import from Last.fm directly.
+            <br>
+            Fun Fact: The term <strong>scrobble</strong> is a trademarked term
+            by Last.fm, and we cannot use it. Instead, we use the term <strong>listen</strong> for our data.
+        </p>
+
+        <h3>Direct import from Last.fm and Libre.fm</h3>
+        <p>
+            The importer manually steps through your listen history and imports the listens
+            one page at a time. Should it fail for whatever reason, it is safe to restart the import
+            process. Running the import process multiple times <strong>does not</strong> create duplicates in your
+            ListenBrainz listen history.
+        </p>
+        <p>In order for this to work, you must disable the &#34;Hide recent listening information&#34;
+            setting in your Last.fm <a href="https://www.last.fm/settings/privacy">Privacy Settings</a>.
+        </p>
+        <p>
+            Clicking the "Import now!" button will import your profile now without the need to open lastfm.<br/>
+            You need to keep this page open for the tool to work, it might take a while to complete. Though, you can
+            continue doing your work. :)
+        </p>
+        <p>
+            <em>NOTE</em>: Please note that your listen counts may not be accurate for up to 24 hours after
+            you import your data!
+            Also, running the Last.fm importer twice will not cause duplicates in your listen history.
+        </p>
+        <div class="row">
+            <div class="well col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
+                <div id="react-container">
+                </div>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block scripts %}
     {{ super() }}
-    <script src="{{ get_static_path('import.js') }}" type="text/javascript"></script>
+    {% if user_has_email %}
+        <script src="{{ get_static_path('import.js') }}" type="text/javascript"></script>
+    {% endif %}
 {% endblock %}

--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -40,12 +40,14 @@
             you import your data!
             Also, running the Last.fm importer twice will not cause duplicates in your listen history.
         </p>
-        <div class="row">
-            <div class="well col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
-                <div id="react-container">
+        {% if user_has_email %}
+            <div class="row">
+                <div class="well col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
+                    <div id="react-container">
+                    </div>
                 </div>
             </div>
-        </div>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -3,45 +3,54 @@
 {% block title %}Import for "{{ user.musicbrainz_id }}" - ListenBrainz{% endblock %}
 
 {% block content %}
-  <h2 class="page-title">Import to user {{ user.musicbrainz_id }}</h2>
-  {% if current_user.is_authenticated and current_user == user %}
+    <h2 class="page-title">Import to user {{ user.musicbrainz_id }}</h2>
+    {% if user_has_email %}
+        {% if current_user.is_authenticated and current_user == user %}
 
-    <p>
-        Most users will want to import from Last.fm directly.
-      <br>
-      Fun Fact: The term <strong>scrobble</strong> is a trademarked term
-      by Last.fm, and we cannot use it. Instead, we use the term <strong>listen</strong> for our data.
-    </p>
+            <p>
+                Most users will want to import from Last.fm directly.
+                <br>
+                Fun Fact: The term <strong>scrobble</strong> is a trademarked term
+                by Last.fm, and we cannot use it. Instead, we use the term <strong>listen</strong> for our data.
+            </p>
 
-    <h3>Direct import from Last.fm and Libre.fm</h3>
-      <p>
-        The importer manually steps through your listen history and imports the listens
-        one page at a time. Should it fail for whatever reason, it is safe to restart the import
-        process. Running the import process multiple times <strong>does not</strong> create duplicates in your
-        ListenBrainz listen history.
-      </p>
-      <p>In order for this to work, you must disable the &#34;Hide recent listening information&#34;
-        setting in your Last.fm <a href="https://www.last.fm/settings/privacy">Privacy Settings</a>.
-      </p>
-      <p>
-        Clicking the "Import now!" button will import your profile now without the need to open lastfm.<br/>
-        You need to keep this page open for the tool to work, it might take a while to complete. Though, you can continue doing your work. :)
-      </p>
-      <p>
-        <em>NOTE</em>: Please note that your listen counts may not be accurate for up to 24 hours after
-        you import your data!
-        Also, running the Last.fm importer twice will not cause duplicates in your listen history.
-      </p>
-      <div class="row">
-      <div class="well col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
-        <div id="react-container">
-        </div>
-      </div>
-      </div>
-  {% endif %}
+            <h3>Direct import from Last.fm and Libre.fm</h3>
+            <p>
+                The importer manually steps through your listen history and imports the listens
+                one page at a time. Should it fail for whatever reason, it is safe to restart the import
+                process. Running the import process multiple times <strong>does not</strong> create duplicates in your
+                ListenBrainz listen history.
+            </p>
+            <p>In order for this to work, you must disable the &#34;Hide recent listening information&#34;
+                setting in your Last.fm <a href="https://www.last.fm/settings/privacy">Privacy Settings</a>.
+            </p>
+            <p>
+                Clicking the "Import now!" button will import your profile now without the need to open lastfm.<br/>
+                You need to keep this page open for the tool to work, it might take a while to complete. Though, you can
+                continue doing your work. :)
+            </p>
+            <p>
+                <em>NOTE</em>: Please note that your listen counts may not be accurate for up to 24 hours after
+                you import your data!
+                Also, running the Last.fm importer twice will not cause duplicates in your listen history.
+            </p>
+            <div class="row">
+                <div class="well col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
+                    <div id="react-container">
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    {% else %}
+        <p>
+            You have not provided an email address. Please provide an <a href="https://musicbrainz.org/account/edit">
+            email address</a> to submit listens. Read this <a href="https://blog.metabrainz.org/?p=8915">blog post</a>
+            to understand why we need your email.
+        </p>
+    {% endif %}
 {% endblock %}
 
 {% block scripts %}
-  {{ super() }}
-  <script src="{{ get_static_path('import.js') }}" type="text/javascript"></script>
+    {{ super() }}
+    <script src="{{ get_static_path('import.js') }}" type="text/javascript"></script>
 {% endblock %}

--- a/listenbrainz/webserver/templates/user/import.html
+++ b/listenbrainz/webserver/templates/user/import.html
@@ -5,11 +5,11 @@
 {% block content %}
     <h2 class="page-title">Import to user {{ user.musicbrainz_id }}</h2>
     {% if not user_has_email %}
-        <p>
+        <div class="alert alert-danger">
             You have not provided an email address. Please provide an <a href="https://musicbrainz.org/account/edit">
             email address</a> to submit listens. Read this <a href="https://blog.metabrainz.org/?p=8915">blog post</a>
             to understand why we need your email.
-        </p>
+        </div>
     {% endif %}
     {% if current_user.is_authenticated and current_user == user %}
 

--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -45,8 +45,7 @@ def musicbrainz_post():
             user = provider.get_user()
             if current_app.config["REJECT_NEW_USERS_WITHOUT_EMAIL"] and not user["email"]:
                 # existing user without email, show a warning
-                flash.warning(no_email_warning + 'before 1 November 2021, or you will be unable to submit '
-                                                 'listens. ' + blog_link)
+                flash.warning(no_email_warning + 'to submit listens. ' + blog_link)
 
             db_user.update_last_login(user["musicbrainz_id"])
             login_user(User.from_dbrow(user),

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -87,6 +87,8 @@ def info():
 @login_required
 def import_data():
     """ Displays the import page to user, giving various options """
+    user = db_user.get(current_user.id, fetch_email=True)
+    user_has_email = user["email"] is None
 
     # Return error if LASTFM_API_KEY is not given in config.py
     if 'LASTFM_API_KEY' not in current_app.config or current_app.config['LASTFM_API_KEY'] == "":
@@ -96,6 +98,7 @@ def import_data():
         "id": current_user.id,
         "name": current_user.musicbrainz_id,
         "auth_token": current_user.auth_token,
+        "user_has_email": user_has_email
     }
 
     props = {

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -88,7 +88,7 @@ def info():
 def import_data():
     """ Displays the import page to user, giving various options """
     user = db_user.get(current_user.id, fetch_email=True)
-    user_has_email = user["email"] is None
+    user_has_email = user["email"] is not None
 
     # Return error if LASTFM_API_KEY is not given in config.py
     if 'LASTFM_API_KEY' not in current_app.config or current_app.config['LASTFM_API_KEY'] == "":

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -98,7 +98,6 @@ def import_data():
         "id": current_user.id,
         "name": current_user.musicbrainz_id,
         "auth_token": current_user.auth_token,
-        "user_has_email": user_has_email
     }
 
     props = {
@@ -113,6 +112,7 @@ def import_data():
     return render_template(
         "user/import.html",
         user=current_user,
+        user_has_email=user_has_email,
         props=ujson.dumps(props),
     )
 


### PR DESCRIPTION
Multiple users have reported issues using the Last.fm importer. A few times the reason behind the issues was that the user hadn't added an email to their account. To improve the UX somewhat, do not show the importer at all if the user doesn't have an email associated.

This is what the error looks like for users without email opening the importer page.

![Screenshot from 2022-07-05 00-30-21](https://user-images.githubusercontent.com/27751938/177536236-7f95b993-5fe2-4d27-b6da-ccd8c631f73c.png)
