### PR TITLE
Upgrade ujson

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -180,7 +180,7 @@ class Listen(object):
         return {
             'user_id': self.user_id,
             'user_name': self.user_name,
-            'timestamp': self.timestamp,
+            'timestamp': int(self.timestamp.timestamp()) if self.timestamp else None,
             'track_metadata': self.data,
             'recording_msid': self.recording_msid
         }

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -171,7 +171,7 @@ class Listen(object):
             'listened_at': self.ts_since_epoch,
             'recording_msid': self.recording_msid,
             'user_name': self.user_name,
-            'inserted_at' : self.inserted_timestamp or 0
+            'inserted_at': int(self.inserted_timestamp.timestamp()) if self.inserted_timestamp else 0
         }
 
         return data

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -193,7 +193,7 @@ class TimescaleWriterSubscriber:
         for listen in data:
             k = '%d-%s-%s' % (listen.ts_since_epoch, listen.data['track_name'], listen.user_name)
             if k in inserted_index:
-                unique.append(listen)
+                unique.append(listen.to_json())
 
         if not unique:
             return len(data)

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -193,25 +193,25 @@ class TimescaleWriterSubscriber:
         for listen in data:
             k = '%d-%s-%s' % (listen.ts_since_epoch, listen.data['track_name'], listen.user_name)
             if k in inserted_index:
-                unique.append(listen.to_json())
+                unique.append(listen)
 
         if not unique:
             return len(data)
+
+        self.redis_listenstore.update_recent_listens(unique)
+        self.unique_listens += len(unique)
 
         while True:
             try:
                 self.unique_ch.basic_publish(
                     exchange=current_app.config['UNIQUE_EXCHANGE'],
                     routing_key='',
-                    body=ujson.dumps(unique),
+                    body=ujson.dumps([listen.to_json() for listen in unique]),
                     properties=pika.BasicProperties(delivery_mode=2,),
                 )
                 break
             except pika.exceptions.ConnectionClosed:
                 self.connect_to_rabbitmq()
-
-        self.redis_listenstore.update_recent_listens(unique)
-        self.unique_listens += len(unique)
 
         if monotonic() > self.metric_submission_time:
             self.metric_submission_time += METRIC_UPDATE_INTERVAL

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -123,7 +123,9 @@ def profile(user_name):
 
     pin = get_current_pin_for_user(user_id=user.id)
     if pin:
-        pin = dict(fetch_track_metadata_for_items([pin])[0])
+        pin = fetch_track_metadata_for_items([pin])[0].dict()
+        pin["created"] = int(pin["created"].timestamp())
+        pin["pinned_until"] = int(pin["pinned_until"].timestamp())
 
     props = {
         "user": {

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -525,7 +525,6 @@ def get_listen_events(
     for listen in listens:
         try:
             listen_dict = listen.to_api()
-            listen_dict['inserted_at'] = listen_dict['inserted_at'].timestamp()
             api_listen = APIListen(**listen_dict)
             events.append(APITimelineEvent(
                 event_type=UserTimelineEventType.LISTEN,

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.6.1
 spotipy == 2.19.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@upgrade-ujson
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-07-11
 PyYAML==6.0
 eventlet == 0.33.1
 uWSGI == 2.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.6.1
 spotipy == 2.19.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-06-30
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@upgrade-ujson
 PyYAML==6.0
 eventlet == 0.33.1
 uWSGI == 2.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ setproctitle == 1.2.2
 markupsafe == 2.1.1
 psycopg2-binary == 2.9.3
 python-dateutil == 2.8.2
-ujson == 1.35
+ujson == 5.4.0
 redis == 4.3.3
 yattag == 1.14.0
 xmltodict == 0.13.0


### PR DESCRIPTION
Newer versions of ujson don't support serializing arbitrary python types so convert timestamps to int and listens to dict before calling ujson.dumps on it. This lets us upgrade ujson in the project. Also, need to release a new version of Troi.