### PR TITLE
Limit top stats in Spark SQL query itself

### DIFF
--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -100,7 +100,6 @@ class RequestConsumer:
             avg_size_of_message = 0
             logger.warning("No messages calculated", exc_info=True)
 
-        logger.info("Done!")
         logger.info("Number of messages sent: {}".format(num_of_messages))
         logger.info("Average size of message: {} bytes".format(avg_size_of_message))
 

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -57,7 +57,11 @@ def get_entity_stats(entity: str, stats_range: str, message_type="user_entity")\
 def calculate_entity_stats(from_date: datetime, to_date: datetime, table: str,
                            entity: str, stats_range: str, message_type: str):
     handler = entity_handler_map[entity]
-    data = handler(table)
+    if message_type == "year_in_music_top_stats":
+        number_of_results = NUMBER_OF_YIM_ENTITIES
+    else:
+        number_of_results = NUMBER_OF_TOP_ENTITIES
+    data = handler(table, number_of_results)
     return create_messages(data=data, entity=entity, stats_range=stats_range,
                            from_date=from_date, to_date=to_date, message_type=message_type)
 
@@ -67,13 +71,8 @@ def parse_one_user_stats(entry, entity: str, stats_range: str, message_type: str
     _dict = entry.asDict(recursive=True)
     total_entity_count = len(_dict[entity])
 
-    if message_type == "year_in_music_top_stats":
-        retain = NUMBER_OF_YIM_ENTITIES
-    else:
-        retain = NUMBER_OF_TOP_ENTITIES
-
     entity_list = []
-    for item in _dict[entity][:retain]:
+    for item in _dict[entity]:
         try:
             entity_list.append(entity_model_map[entity](**item))
         except ValidationError:

--- a/listenbrainz_spark/stats/user/recording.py
+++ b/listenbrainz_spark/stats/user/recording.py
@@ -1,13 +1,14 @@
 from listenbrainz_spark.stats import run_query
 
 
-def get_recordings(table):
+def get_recordings(table: str, number_of_results: int):
     """
     Get recording information (recording_name, recording_mbid etc) for every user
     ordered by listen count (number of times a user has listened to the track/recording).
 
     Args:
         table: name of the temporary table
+        number_of_results: number of top results to keep per user.
 
     Returns:
         iterator (iter): an iterator over result:
@@ -44,6 +45,17 @@ def get_recordings(table):
                  , artist_credit_mbids
                  , lower(release_name)
                  , release_mbid
+        ), ranked_stats as (
+            SELECT user_id
+                 , any_recording_name AS recording_name
+                 , recording_mbid
+                 , any_release_name AS release_name
+                 , release_mbid
+                 , any_artist_name AS artist_name
+                 , artist_credit_mbids
+                 , listen_count
+                 , row_number() OVER (PARTITION BY user_id ORDER BY listen_count DESC) AS rank
+              FROM intermediate_table
         )
         SELECT user_id
              , sort_array(
@@ -60,7 +72,8 @@ def get_recordings(table):
                     )
                    , false
                 ) as recordings
-          FROM intermediate_table
+          FROM ranked_stats
+         WHERE rank < {number_of_results}
       GROUP BY user_id
         """)
 

--- a/listenbrainz_spark/stats/user/recording.py
+++ b/listenbrainz_spark/stats/user/recording.py
@@ -47,7 +47,7 @@ def get_recordings(table: str, number_of_results: int):
                  , release_mbid
         ), ranked_stats as (
             SELECT user_id
-                 , any_recording_name AS recording_name
+                 , any_recording_name AS track_name
                  , recording_mbid
                  , any_release_name AS release_name
                  , release_mbid
@@ -62,11 +62,11 @@ def get_recordings(table: str, number_of_results: int):
                     collect_list(
                         struct(
                             listen_count
-                          , any_recording_name AS track_name
+                          , track_name
                           , recording_mbid
-                          , any_artist_name AS artist_name
+                          , artist_name
                           , coalesce(artist_credit_mbids, array()) AS artist_mbids
-                          , any_release_name AS release_name
+                          , release_name
                           , release_mbid
                         )
                     )

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -59,39 +59,6 @@ class UserEntityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='all_time',
                                                 from_date=from_date, to_date=to_date, message_type="user_entity")
 
-    def test_create_messages_recordings(self):
-        """ Test to check if the number of recordings are clipped to top 1000 """
-        recordings = []
-        for i in range(0, 2000):
-            recordings.append({
-                'artist_name': 'artist_{}'.format(i),
-                'artist_mbids': [str(uuid.uuid4())],
-                'release_name': 'release_{}'.format(i),
-                'release_mbid': str(uuid.uuid4()),
-                'track_name': 'recording_{}'.format(i),
-                'recording_mbid': str(uuid.uuid4()),
-                'listen_count': i
-            })
-
-        mock_result = MagicMock()
-        mock_result.asDict.return_value = {
-            'user_id': 1,
-            'recordings': recordings
-        }
-
-        messages = entity.create_messages([mock_result], 'recordings', 'all_time',
-                                          datetime.now(), datetime.now(), "user_entity")
-
-        message = next(messages)
-        user_data = message["data"][0]
-        received_list = user_data["data"]
-        expected_list = recordings[:1000]
-        self.assertCountEqual(received_list, expected_list)
-
-        received_count = user_data['count']
-        expected_count = 2000
-        self.assertEqual(received_count, expected_count)
-
     def test_skip_incorrect_artists_stats(self):
         """ Test to check if entries with incorrect data is skipped for top user artists """
         with open(self.path_to_data_file('user_top_artists_incorrect.json')) as f:


### PR DESCRIPTION
Instead of collecting all stats and then removing extra stats in post-processing, modify the SQL query to only collect the desired number of stats at max.