### PR TITLE
Fix websockets after upgrading ujson

### DIFF
--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -38,8 +38,6 @@ class ListensDispatcher(ConsumerMixin):
             if event_name == "playing_now":
                 listen = NowPlayingListen(user_id=data["user_id"], user_name=data["user_name"], data=data["track_metadata"])
             else:
-                data["track_metadata"] = data["data"]
-                del data["data"]
                 listen = Listen.from_json(data)
             self.socketio.emit(event_name, json.dumps(listen.to_api()), to=listen.user_name)
         message.ack()


### PR DESCRIPTION
When upgrading ujson, the format of listens sent to websockets changed. This is because at some places we were not explicitly dumping python objects and their fields became the json keys. To fix, update websockets to use new format.