### PR TITLE
Fix mbid mapping writer after ujson upgrade :sweat:

### DIFF
--- a/listenbrainz/mbid_mapping_writer/matcher.py
+++ b/listenbrainz/mbid_mapping_writer/matcher.py
@@ -198,8 +198,8 @@ def lookup_listens(app, listens, stats, exact, debug):
 
     params = []
     for listen in listens:
-        params.append({'[artist_credit_name]': listen["data"]["artist_name"],
-                       '[recording_name]': listen["data"]["track_name"]})
+        params.append({'[artist_credit_name]': listen["track_metadata"]["artist_name"],
+                       '[recording_name]': listen["track_metadata"]["track_name"]})
 
     rows = []
     hits = q.fetch(params)


### PR DESCRIPTION
When upgrading ujson, the format of listens sent to mbid mapper changed. This is because at some places we were not explicitly dumping python objects and their fields became the json keys. To fix, update mapper to use new format.