### PR TITLE
Fix mbid mapper legacy listens checker

### DIFF
--- a/listenbrainz/mbid_mapping_writer/job_queue.py
+++ b/listenbrainz/mbid_mapping_writer/job_queue.py
@@ -137,10 +137,16 @@ class MappingJobQueue(threading.Thread):
                 if not result:
                     break
 
-                self.queue.put(JobItem(priority, [{"data": {"artist_name": result[2],
-                                                            "track_name": result[1]},
-                                                   "recording_msid": result[0],
-                                                   "priority": priority}]))
+                self.queue.put(JobItem(priority, [
+                    {
+                        "track_metadata": {
+                            "artist_name": result[2],
+                            "track_name": result[1]
+                        },
+                        "recording_msid": result[0],
+                        "priority": priority
+                    }
+                ]))
                 count += 1
 
         return count


### PR DESCRIPTION
When doing #2062, forgot to update the code adding legacy listens. Doing it now.