### PR TITLE
Fix parse_list callback in click script

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -242,8 +242,8 @@ def request_missing_mb_data(days):
     send_request_to_spark_cluster('cf.missing_mb_data', days=days)
 
 
-def parse_list(ctx, args):
-    return list(args)
+def parse_list(ctx, param, value):
+    return list(value)
 
 
 @cli.command(name='request_model')


### PR DESCRIPTION
Invoking request_recommendations from CLI failed because of parse_list throwing a number of args mismatch error. Looking into docs, callback receives 3 args so updating the callback accordingly.