### PR TITLE
Improve Listening Now page

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -264,7 +264,7 @@ def _register_blueprints(app):
     _register_blueprint_with_context(app, player_bp, url_prefix='/player')
 
     from listenbrainz.webserver.views.metadata_viewer import metadata_viewer_bp
-    _register_blueprint_with_context(app, metadata_viewer_bp, url_prefix='/playing-now')
+    _register_blueprint_with_context(app, metadata_viewer_bp, url_prefix='/listening-now')
 
     from listenbrainz.webserver.views.playlist import playlist_bp
     _register_blueprint_with_context(app, playlist_bp, url_prefix='/playlist')

--- a/listenbrainz/webserver/static/css/metadata-viewer.less
+++ b/listenbrainz/webserver/static/css/metadata-viewer.less
@@ -15,32 +15,22 @@
     max-width: 100%;
   }
 
-  .no-listen-container {
-    position: fixed;
-    padding: 5em;
-    width: 100%;
-    height: 80%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 2;
-  }
   .no-listen {
-    max-width: 50em;
-    min-width: 340px;
-    height: 300px;
-    // frosted glass effect
-    background: fade(#ccc, 35%);
-    border-radius: 20px;
-    backdrop-filter: blur(10px);
-    box-shadow: 0 0 2rem 0 fade(black, 20%);
-    // contents
-    font-size: 1.3em;
+    height: 100%;
+    font-size: 1.2em;
     padding: 2em;
     display: flex;
     justify-content: center;
     align-items: center;
     text-align: center;
+    .pause-icon {
+      margin-top: -2.1em;
+      background-color: white;
+      display: block;
+      width: max-content;
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 
   @media (min-width: @screen-xs) {

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -257,7 +257,10 @@ export default class ListenCard extends React.Component<
       <>
         {listen.playing_now ? (
           <span className="listen-time">
-            <FontAwesomeIcon icon={faMusic as IconProp} /> Playing now &#8212;
+            <a href="/listening-now/" target="_blank" rel="noopener noreferrer">
+              <FontAwesomeIcon icon={faMusic as IconProp} /> Listening now
+              &#8212;
+            </a>
           </span>
         ) : (
           <span

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -513,6 +513,7 @@ export default function MetadataViewer(props: MetadataViewerProps) {
               aria-labelledby="headingTwo"
             >
               <div className="panel-body">
+                <TagsComponent tags={metadata?.tag?.release_group} />
                 <OpenInMusicBrainzButton
                   entityType="release"
                   entityMBID={recordingData?.release_mbid}

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -199,192 +199,42 @@ export default function MetadataViewer(props: MetadataViewerProps) {
   const supportLinks = pick(artist?.rels, ...supportLinkTypes);
   const lyricsLink = pick(artist?.rels, "lyrics");
 
-  return (
-    <div id="metadata-viewer">
-      {!playingNow && (
-        <div className="no-listen-container">
-          <div className="no-listen">
-            <p>
-              <hr />
-              <div style={{ marginTop: "-2.1em" }}>
-                <FontAwesomeIcon icon={faPauseCircle} size="2x" />
-              </div>
-              Sorry, we do not know what music you are currently listening to,
-              since we have not received any recent <i>Playing Now</i> events
-              for your account.
-              <br />
-              As soon as a <i>Playing Now</i> listen comes through, this page
-              will be updated automatically.
-              <br />
-              <br />
-              <small>
-                In order to receive these events, you will need to{" "}
-                <a href="/add-data/">send listens</a> to ListenBrainz.
-                <br />
-                We work hard to make this data available to you as soon as we
-                receive it, but until your music service sends us a{" "}
-                <a href="https://listenbrainz.readthedocs.io/en/production/dev/json/?highlight=playing%20now#submission-json">
-                  <i>Playing Now</i> event
-                </a>
-                , we cannot display anything here.
-              </small>
-              <hr />
-            </p>
-          </div>
-        </div>
-      )}
-      <div
-        className="left-side"
-        style={{
-          backgroundColor: adjustedAlbumColor.toRgbString(),
-          color: textColor.toString(),
-        }}
-      >
-        <div className="track-info">
-          <div className="track-details">
-            <div
-              title={trackName}
-              className="track-name strong ellipsis-2-lines"
-            >
-              <a
-                href={
-                  recordingData?.recording_mbid
-                    ? `${musicBrainzURLRoot}recording/${recordingData?.recording_mbid}`
-                    : undefined
-                }
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {trackName}
-              </a>
-            </div>
-            <span className="artist-name small ellipsis" title={artistName}>
-              <a
-                href={
-                  artistMBID
-                    ? `${musicBrainzURLRoot}artist/${artistMBID}`
-                    : undefined
-                }
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {artistName}
-              </a>
+  let rightSideContent;
+  if (!playingNow) {
+    rightSideContent = (
+      <div className="right-side">
+        <div className="no-listen">
+          <p>
+            <hr />
+            <span className="pause-icon">
+              <FontAwesomeIcon icon={faPauseCircle} size="2x" />
             </span>
-          </div>
-          <div className="love-hate">
-            <button
-              className="btn-transparent"
-              onClick={() =>
-                submitFeedback(currentListenFeedback === 1 ? 0 : 1)
-              }
-              type="button"
-            >
-              <FontAwesomeIcon
-                icon={faHeart}
-                title="Love"
-                size="2x"
-                className={`${currentListenFeedback === 1 ? " loved" : ""}`}
-              />
-            </button>
-            <button
-              className="btn-transparent"
-              onClick={() =>
-                submitFeedback(currentListenFeedback === -1 ? 0 : -1)
-              }
-              type="button"
-            >
-              <FontAwesomeIcon
-                icon={faHeartBroken}
-                title="Hate"
-                size="2x"
-                className={`${currentListenFeedback === -1 ? " hated" : ""}`}
-              />
-            </button>
-          </div>
-        </div>
-
-        <div className="album-art">
-          <img
-            src={coverArtSrc}
-            ref={albumArtRef}
-            crossOrigin="anonymous"
-            alt="Album art"
-          />
-        </div>
-        <div className="bottom">
-          <a href="https://listenbrainz.org/my/listens">
+            <h3>What are you listening to?</h3>
+            We have not received any recent <i>playing-now</i> events for your
+            account.
+            <br />
+            As soon as a <i>playing-now</i> listen comes through, this page will
+            be updated automatically.
+            <br />
+            <br />
             <small>
-              Powered by&nbsp;
-              <img
-                className="logo"
-                src="/static/img/navbar_logo.svg"
-                alt="ListenBrainz"
-              />
+              In order to receive these events, you will need to{" "}
+              <a href="/add-data/">send listens</a> to ListenBrainz.
+              <br />
+              We work hard to make this data available to you as soon as we
+              receive it, but until your music service sends us a{" "}
+              <a href="https://listenbrainz.readthedocs.io/en/production/dev/json/?highlight=playing%20now#submission-json">
+                <i>playing-now</i> event
+              </a>
+              , we cannot display anything here.
             </small>
-          </a>
-          <div className="support-artist-btn dropup">
-            <button
-              className={`dropdown-toggle btn btn-primary${
-                isPlainObject(artist?.rels) &&
-                !Object.keys(artist?.rels as object).length
-                  ? " disabled"
-                  : ""
-              }`}
-              data-toggle="dropdown"
-              type="button"
-            >
-              <b>Support the artist</b>
-              <span className="caret" />
-            </button>
-            <ul className="dropdown-menu dropdown-menu-right" role="menu">
-              {!isEmpty(supportLinks) ? (
-                Object.entries(supportLinks).map(([key, value]) => {
-                  return (
-                    <li key={key}>
-                      <a href={value} target="_blank" rel="noopener noreferrer">
-                        {key}
-                      </a>
-                    </li>
-                  );
-                })
-              ) : (
-                <>
-                  <li
-                    className="dropdown-header"
-                    style={{ textAlign: "center" }}
-                  >
-                    We couldn&apos;t find any links
-                  </li>
-                  <li>
-                    <a
-                      href={
-                        artistMBID
-                          ? `${musicBrainzURLRoot}artist/${artistMBID}`
-                          : `${musicBrainzURLRoot}artist/create`
-                      }
-                      aria-label="Edit in MusicBrainz"
-                      title="Edit in MusicBrainz"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <img
-                        src="/static/img/meb-icons/MusicBrainz.svg"
-                        width="18"
-                        height="18"
-                        alt="MusicBrainz"
-                        style={{ verticalAlign: "bottom" }}
-                      />{" "}
-                      {artistMBID ? "Add links" : "Create"} in MusicBrainz
-                    </a>
-                  </li>
-                </>
-              )}
-            </ul>
-          </div>
+            <hr />
+          </p>
         </div>
       </div>
-
+    );
+  } else {
+    rightSideContent = (
       <div
         className="right-side panel-group"
         id="accordion"
@@ -572,6 +422,164 @@ export default function MetadataViewer(props: MetadataViewerProps) {
           </div>
         </div>
       </div>
+    );
+  }
+
+  return (
+    <div id="metadata-viewer">
+      <div
+        className="left-side"
+        style={{
+          backgroundColor: adjustedAlbumColor.toRgbString(),
+          color: textColor.toString(),
+        }}
+      >
+        <div className="track-info">
+          <div className="track-details">
+            <div
+              title={trackName}
+              className="track-name strong ellipsis-2-lines"
+            >
+              <a
+                href={
+                  recordingData?.recording_mbid
+                    ? `${musicBrainzURLRoot}recording/${recordingData?.recording_mbid}`
+                    : undefined
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {trackName}
+              </a>
+            </div>
+            <span className="artist-name small ellipsis" title={artistName}>
+              <a
+                href={
+                  artistMBID
+                    ? `${musicBrainzURLRoot}artist/${artistMBID}`
+                    : undefined
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {artistName}
+              </a>
+            </span>
+          </div>
+          <div className="love-hate">
+            <button
+              className="btn-transparent"
+              onClick={() =>
+                submitFeedback(currentListenFeedback === 1 ? 0 : 1)
+              }
+              type="button"
+            >
+              <FontAwesomeIcon
+                icon={faHeart}
+                title="Love"
+                size="2x"
+                className={`${currentListenFeedback === 1 ? " loved" : ""}`}
+              />
+            </button>
+            <button
+              className="btn-transparent"
+              onClick={() =>
+                submitFeedback(currentListenFeedback === -1 ? 0 : -1)
+              }
+              type="button"
+            >
+              <FontAwesomeIcon
+                icon={faHeartBroken}
+                title="Hate"
+                size="2x"
+                className={`${currentListenFeedback === -1 ? " hated" : ""}`}
+              />
+            </button>
+          </div>
+        </div>
+
+        <div className="album-art">
+          <img
+            src={coverArtSrc}
+            ref={albumArtRef}
+            crossOrigin="anonymous"
+            alt="Album art"
+          />
+        </div>
+        <div className="bottom">
+          <a href="https://listenbrainz.org/my/listens">
+            <small>
+              Powered by&nbsp;
+              <img
+                className="logo"
+                src="/static/img/navbar_logo.svg"
+                alt="ListenBrainz"
+              />
+            </small>
+          </a>
+          <div className="support-artist-btn dropup">
+            <button
+              className={`dropdown-toggle btn btn-primary${
+                isPlainObject(artist?.rels) &&
+                !Object.keys(artist?.rels as object).length
+                  ? " disabled"
+                  : ""
+              }`}
+              data-toggle="dropdown"
+              type="button"
+            >
+              <b>Support the artist</b>
+              <span className="caret" />
+            </button>
+            <ul className="dropdown-menu dropdown-menu-right" role="menu">
+              {!isEmpty(supportLinks) ? (
+                Object.entries(supportLinks).map(([key, value]) => {
+                  return (
+                    <li key={key}>
+                      <a href={value} target="_blank" rel="noopener noreferrer">
+                        {key}
+                      </a>
+                    </li>
+                  );
+                })
+              ) : (
+                <>
+                  <li
+                    className="dropdown-header"
+                    style={{ textAlign: "center" }}
+                  >
+                    We couldn&apos;t find any links
+                  </li>
+                  <li>
+                    <a
+                      href={
+                        artistMBID
+                          ? `${musicBrainzURLRoot}artist/${artistMBID}`
+                          : `${musicBrainzURLRoot}artist/create`
+                      }
+                      aria-label="Edit in MusicBrainz"
+                      title="Edit in MusicBrainz"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <img
+                        src="/static/img/meb-icons/MusicBrainz.svg"
+                        width="18"
+                        height="18"
+                        alt="MusicBrainz"
+                        style={{ verticalAlign: "bottom" }}
+                      />{" "}
+                      {artistMBID ? "Add links" : "Create"} in MusicBrainz
+                    </a>
+                  </li>
+                </>
+              )}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {rightSideContent}
     </div>
   );
 }

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -91,12 +91,12 @@ export default function MetadataViewer(props: MetadataViewerProps) {
         return;
       }
       try {
-        const feedbackArray = await APIService.getFeedbackForUserForMBIDs(
+        const feedbackObject = await APIService.getFeedbackForUserForMBIDs(
           currentUser.name,
           recordingMBID
         );
-        if (feedbackArray.length) {
-          const feedback: any = first(feedbackArray);
+        if (feedbackObject?.feedback?.length) {
+          const feedback: any = first(feedbackObject.feedback);
           setCurrentListenFeedback(feedback.score);
         } else {
           setCurrentListenFeedback(0);

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewerPageWrapper.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewerPageWrapper.tsx
@@ -84,16 +84,15 @@ export default function PlayingNowPage(props: PlayingNowPageProps) {
   /** On page load, hit the API to get the user's most recent playing-now (if any) */
   React.useEffect(() => {
     // Only run this if no playing-now was present in the props on load
-    if (!currentListen) {
+    if (!currentListen || !recordingData) {
       const fetchPlayingNow = async () => {
         if (!recordingData && currentUser) {
           try {
-            // lookup playing_now from API
-            const newPlayingNow = await APIService.getPlayingNowForUser(
-              currentUser.name
-            );
-            if (newPlayingNow) {
-              await onNewPlayingNow(newPlayingNow);
+            const propOrFetchedPlayingNow =
+              currentListen ??
+              (await APIService.getPlayingNowForUser(currentUser.name));
+            if (propOrFetchedPlayingNow) {
+              await onNewPlayingNow(propOrFetchedPlayingNow);
             }
           } catch (error) {
             props.newAlert(

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewerPageWrapper.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewerPageWrapper.tsx
@@ -18,16 +18,13 @@ import MetadataViewer from "./MetadataViewer";
 
 export type PlayingNowPageProps = {
   playingNow?: Listen;
-  initialRecordingData?: MetadataLookup;
 } & WithAlertNotificationsInjectedProps;
 
 export default function PlayingNowPage(props: PlayingNowPageProps) {
-  const { initialRecordingData, playingNow, newAlert } = props;
+  const { playingNow, newAlert } = props;
   const { APIService, currentUser } = React.useContext(GlobalAppContext);
   const [currentListen, setCurrentListen] = React.useState(playingNow);
-  const [recordingData, setRecordingData] = React.useState(
-    initialRecordingData
-  );
+  const [recordingData, setRecordingData] = React.useState<MetadataLookup>();
 
   if (!currentUser) {
     return (
@@ -127,7 +124,7 @@ document.addEventListener("DOMContentLoaded", () => {
     youtube,
     sentry_traces_sample_rate,
   } = globalReactProps;
-  const { playing_now, metadata } = reactProps;
+  const { playing_now } = reactProps;
 
   if (sentry_dsn) {
     Sentry.init({
@@ -158,7 +155,6 @@ document.addEventListener("DOMContentLoaded", () => {
         <PlayingNowPageWithAlertNotifications
           initialAlerts={optionalAlerts}
           playingNow={playing_now}
-          // initialRecordingData={fakeData2}
         />
       </GlobalAppContext.Provider>
     </ErrorBoundary>,

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/TagsComponent.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/TagsComponent.tsx
@@ -26,11 +26,11 @@ export default function TagsComponent(props: {
           <span>Be the first to add a tag</span>
         )}
       </div>
-      <div className="add-tag">
+      {/* <div className="add-tag">
         <button className="btn btn-xs btn-outline" type="button">
           + Add tag
         </button>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
@@ -27,6 +27,10 @@ declare type RecordingTag = {
   tag: string;
 };
 
+declare type ReleaseGroupTag = RecordingTag & {
+  release_group_mbid: string;
+};
+
 declare type ListenMetadata = {
   artist?: Array<MusicBrainzArtist>;
   recording?: {
@@ -41,6 +45,7 @@ declare type ListenMetadata = {
   tag?: {
     artist?: Array<ArtistTag>;
     recording?: Array<RecordingTag>;
+    release_group?: Array<ReleaseGroupTag>;
   };
 };
 

--- a/listenbrainz/webserver/templates/player/metadata-viewer.html
+++ b/listenbrainz/webserver/templates/player/metadata-viewer.html
@@ -3,7 +3,7 @@
 <head>
   {%- block head -%}
   <meta charset="utf-8" />
-  <title>{% block title %}ListenBrainz Now playing{% endblock %}</title>
+  <title>{% block title %}Listening Now{% endblock %}</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 


### PR DESCRIPTION
A few improvements rolled up into this PR:

1. As [previously discussed on IRC](https://chatlogs.metabrainz.org/libera/metabrainz/2022-05-19/?msg=5008384&page=2) we adopted the name "Listening Now" instead of "Playing Now". The route has also changed accordingly to `/listening-now`
2. Add release group tags to the album section
3. Fetch metadata for the listen on startup (previously metadata was not fetched and we had to wait to receive another listen)
4. Tweak and move the "no listen"  message:
![image](https://user-images.githubusercontent.com/6179856/179267249-08f67794-5aaf-45a4-9025-5670a1488155.png)
5. Disable "add tag" button that is not implemented. Future PR coming with tag improvements and allowing users to tag directly from in here
6. In the ListenCard component, for playing-now listens make the "listening now" text link to the /listening-now page to increase discovery. We should think about how this page will be accessible; in which menu does it fit?