### PR TITLE
Improve mapping rg type sort

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -5,7 +5,7 @@ from psycopg2.errors import OperationalError
 from unidecode import unidecode
 
 from mapping.utils import create_schema, insert_rows, log
-from mapping.formats import create_formats_table
+from mapping.custom_sorts import create_custom_sort_tables
 from mapping.bulk_table import BulkInsertTable
 from mapping.canonical_recording_redirect import CanonicalRecordingRedirect
 from mapping.canonical_release_redirect import CanonicalReleaseRedirect
@@ -167,7 +167,7 @@ def create_canonical_musicbrainz_data():
         mapping.add_additional_bulk_table(can)
 
         # Carry out the bulk of the work
-        create_formats_table(mb_conn)
+        create_custom_sort_tables(mb_conn)
         releases.run(no_swap=True)
         mapping.run(no_swap=True)
         can_rel.run(no_swap=True)

--- a/listenbrainz/mbid_mapping/mapping/custom_sorts.py
+++ b/listenbrainz/mbid_mapping/mapping/custom_sorts.py
@@ -6,9 +6,11 @@ RELEASE_GROUP_SECONDARY_TYPES = [
     (2, "Soundtrack"),
     (6, "Live"),
     (7, "Remix"),
+    (10, "Demo"),
     (8, "DJ-mix"),
     (9, "Mixtape/Street"),
     (5, "Audiobook"),
+    (11, "Audio drama"),
     (3, "Spokenword"),
     (4, "Interview")
 ]
@@ -104,16 +106,18 @@ ANALOG_FORMATS = [
 ]
 
 
-def insert_rows(id, curs, formats):
+def insert_rows(sort_index, curs, formats):
     '''
         Helper function for inserting format rows.
     '''
 
     for format_id, _ in formats:
-        curs.execute("INSERT INTO mapping.format_sort values (%s, %s);",  tuple((id, format_id)))
-        id += 1
+        curs.execute("""INSERT INTO mapping.format_sort
+                                    (format, sort)
+                             VALUES (%s, %s);""",  tuple((format_id, sort_index)))
+        sort_index += 1
 
-    return id
+    return sort_index
 
 
 def create_custom_sort_tables(conn):
@@ -125,9 +129,9 @@ def create_custom_sort_tables(conn):
         with conn.cursor() as curs:
             curs.execute("DROP TABLE IF EXISTS mapping.format_sort")
             curs.execute("CREATE TABLE mapping.format_sort ( format integer, sort integer )")
-            id = insert_rows(1, curs, DIGITAL_FORMATS)
-            id = insert_rows(id, curs, VIDEO_FORMATS)
-            id = insert_rows(id, curs, ANALOG_FORMATS)
+            sort_index = insert_rows(1, curs, DIGITAL_FORMATS)
+            sort_index = insert_rows(sort_index, curs, VIDEO_FORMATS)
+            sort_index = insert_rows(sort_index, curs, ANALOG_FORMATS)
             curs.execute("CREATE INDEX format_sort_format_ndx ON mapping.format_sort(format)")
             curs.execute("CREATE INDEX format_sort_sort_ndx ON mapping.format_sort(sort)")
         conn.commit()
@@ -139,12 +143,16 @@ def create_custom_sort_tables(conn):
     try:
         with conn.cursor() as curs:
             curs.execute("DROP TABLE IF EXISTS mapping.release_group_secondary_type_sort")
-            curs.execute("CREATE TABLE mapping.release_group_secondary_type_sort ( secondary_type integer, sort integer )")
+            curs.execute("""CREATE TABLE mapping.release_group_secondary_type_sort (
+                                         sort INTEGER
+                                       , secondary_type INTEGER)""")
 
-            id = 1
-            for type_id, _ in RELEASE_GROUP_SECONDARY_TYPES:
-                curs.execute("INSERT INTO mapping.release_group_secondary_type_sort values (%s, %s);",  tuple((id, type_id)))
-                id += 1
+            sort_index = 1
+            for secondary_type_id, _ in RELEASE_GROUP_SECONDARY_TYPES:
+                curs.execute("""INSERT INTO mapping.release_group_secondary_type_sort
+                                            (sort, secondary_type)
+                                     VALUES (%s, %s);""", tuple((sort_index, secondary_type_id)))
+                sort_index += 1
 
             curs.execute("""CREATE INDEX release_group_secondary_type_sort_ndx_secondary_type
                                       ON mapping.release_group_secondary_type_sort(secondary_type)""")

--- a/listenbrainz/mbid_mapping/mapping/mapping_test/mapping_test_cases.csv
+++ b/listenbrainz/mbid_mapping/mapping/mapping_test/mapping_test_cases.csv
@@ -21,4 +21,8 @@ god bless the girl,david bowie,6241d76e-45d9-4f7e-b9fc-24ad33e4955a
 2013,arctic monkeys,a432408f-335e-4d64-b33a-c1fb809af58f
 verdict for worst dictator,void,5941ccda-d6b5-4d5e-8a1a-5ca755321482
 die walkure: feuerzauber,richard wagner,1756c795-9c60-4052-8aae-a4847c5a243c
-rising from the ashes,erosion 89,68ac39dc-617f-4723-88a2-d762a6ba1fce
+rising from the ashes,erosion 89,6979fc1a-f6bc-45a6-9240-a0ca06d213b3
+1Stp klosr,linkin park,f662175c-070f-4d93-b85b-0068aeaacdfc
+Ppr:kut,linkin park,f662175c-070f-4d93-b85b-0068aeaacdfc
+new york,jonah matranga,9a9a1473-d4a6-41c8-bee8-ded086677d18
+the professional,halou,ab5301c5-4ab9-4c71-81fc-96cc3faf9de4

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -7,7 +7,6 @@ import psycopg2.extras
 import ujson
 
 from mapping.utils import create_schema, insert_rows, log
-from mapping.formats import create_formats_table
 from mapping.bulk_table import BulkInsertTable
 from mapping.canonical_release_redirect import CanonicalReleaseRedirect
 import config


### PR DESCRIPTION
The release group primary and secondary types were not really being sorted (or I just previously got kinda lucky). The primary type accidentally works well to sort on id, but the secondary type, that was not the case.

This PR add a new custom sort order for secondary release types and sort the canonical releases using this new sort and then adds some new tests that where highlighted by Pratamesh's work.