### PR TITLE
Update link to an active, existing rust library

### DIFF
--- a/docs/users/clients.rst
+++ b/docs/users/clients.rst
@@ -13,7 +13,7 @@ Go
 
 Rust
 ^^^^
-* `listenbrainz-rust <https://github.com/treeshateorcs/listenbrainz-rust>`_
+* `listenbrainz <https://crates.io/crates/listenbrainz>`_
 
 .NET
 ^^^^


### PR DESCRIPTION
The repository for listenbrainz-rust is gone from Github, and the crates.io entry hasn't been updated in 3 years: https://crates.io/crates/listenbrainz-rust

Instead, this points to https://crates.io/crates/listenbrainz which was last updated 2 months ago and still has a live repository on Github.