### PR TITLE
 Update sphinx and related deps to fix rtd build 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-Sphinx==3.4.1
-sphinxcontrib-httpdomain==1.7.0
+Sphinx==5.0.2
+sphinxcontrib-httpdomain==1.8.0
 sphinx_rtd_theme==0.5.1
-docutils==0.12.0
-sphinx-click==3.0.0
+docutils==0.17.1
+sphinx-click==4.3.0
 -r ../requirements.txt

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -26,6 +26,7 @@ def get_fresh_releases():
     This endpoint fetches upcoming and recently released (fresh) releases and returns a list of:
 
     .. code-block:: json
+
         {
             "artist_credit_name": "R\u00f6yksopp",
             "artist_mbids": [


### PR DESCRIPTION
Docs were failing due to Sphinx being incompatible with new Jinja2 versions. https://readthedocs.org/projects/listenbrainz/builds/17500865/ 

Accordingly update sphinx and related dependencies. Builds now pass: https://readthedocs.org/projects/listenbrainz/builds/17502930/

Also fix a docs warning while at it.