### PR TITLE
Set metrics when the various spark jobs complete

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -24,6 +24,7 @@ from listenbrainz.spark.troi_bot import run_post_recommendation_troi_bot
 TIME_TO_CONSIDER_STATS_AS_OLD = 20  # minutes
 TIME_TO_CONSIDER_RECOMMENDATIONS_AS_OLD = 7  # days
 
+
 def is_new_user_stats_batch():
     """ Returns True if this batch of user stats is new, False otherwise
 

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -4,6 +4,7 @@
 import json
 from datetime import datetime, timezone, timedelta
 
+from brainzutils import metrics
 from brainzutils.mail import send_mail
 from flask import current_app, render_template
 from pydantic import ValidationError
@@ -24,6 +25,7 @@ from listenbrainz.spark.troi_bot import run_post_recommendation_troi_bot
 TIME_TO_CONSIDER_STATS_AS_OLD = 20  # minutes
 TIME_TO_CONSIDER_RECOMMENDATIONS_AS_OLD = 7  # days
 
+metrics.init("listenbrainz")
 
 def is_new_user_stats_batch():
     """ Returns True if this batch of user stats is new, False otherwise
@@ -48,6 +50,7 @@ def notify_user_stats_update(stat_type):
             from_name='ListenBrainz',
             from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN']
         )
+        metrics.set("listenbrainz-spark-user-stats", 1)
 
 
 def handle_user_entity(data):
@@ -76,11 +79,15 @@ def _handle_user_activity_stats(stats_type, data):
 def handle_user_listening_activity(data):
     """ Take listening activity stats for user and save it in database. """
     _handle_user_activity_stats("listening_activity", data)
+    if not current_app.config['TESTING']:
+        metrics.set("listenbrainz-spark-user-listening-activity", 1)
 
 
 def handle_user_daily_activity(data):
     """ Take daily activity stats for user and save it in database. """
     _handle_user_activity_stats("daily_activity", data)
+    if not current_app.config['TESTING']:
+        metrics.set("listenbrainz-spark-user-daily-activity", 1)
 
 
 def handle_sitewide_entity(data):
@@ -94,6 +101,8 @@ def handle_sitewide_entity(data):
 
     try:
         db_stats.insert_sitewide_jsonb_data(entity, StatRange[EntityRecord](**data))
+        if not current_app.config['TESTING']:
+            metrics.set("listenbrainz-spark-sitewide-entity-stats", 1)
     except ValidationError:
         current_app.logger.error(f"""ValidationError while inserting {stats_range} sitewide top {entity}.
         Data: {json.dumps(data, indent=3)}""", exc_info=True)
@@ -101,6 +110,8 @@ def handle_sitewide_entity(data):
 
 def handle_sitewide_listening_activity(data):
     db_stats.insert_sitewide_jsonb_data("listening_activity", StatRange[ListeningActivityRecord](**data))
+    if not current_app.config['TESTING']:
+        metrics.set("listenbrainz-spark-sitewide-listening-activity", 1)
 
 
 def handle_dump_imported(data):
@@ -122,6 +133,7 @@ def handle_dump_imported(data):
             from_name='ListenBrainz',
             from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
         )
+    metrics.set("listenbrainz-spark-dump-imported", 1)
 
 
 def handle_dataframes(data):
@@ -142,6 +154,7 @@ def handle_dataframes(data):
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
     )
+    metrics.set("listenbrainz-spark-handle-dataframes", 1)
 
 
 def handle_missing_musicbrainz_data(data):
@@ -164,6 +177,8 @@ def handle_missing_musicbrainz_data(data):
             UserMissingMusicBrainzDataJson(missing_musicbrainz_data=missing_musicbrainz_data),
             source
         )
+        if not current_app.config['TESTING']:
+            metrics.set("listenbrainz-spark-missing-mb-data", 1)
     except ValidationError:
         current_app.logger.error(f"""
         ValidationError while inserting missing MusicBrainz data from source "{source}" for user with musicbrainz_id:
@@ -188,6 +203,7 @@ def handle_model(data):
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
     )
+    metrics.set("listenbrainz-spark-model-created", 1)
 
 
 def handle_candidate_sets(data):
@@ -208,6 +224,7 @@ def handle_candidate_sets(data):
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
     )
+    metrics.set("listenbrainz-spark-candidate-sets-created", 1)
 
 
 def handle_recommendations(data):
@@ -227,6 +244,8 @@ def handle_recommendations(data):
             user_id,
             UserRecommendationsJson(**recommendations)
         )
+        if not current_app.config['TESTING']:
+            metrics.set("listenbrainz-spark-recommendations", 1)
     except ValidationError:
         current_app.logger.error(f"""ValidationError while inserting recommendations for user with musicbrainz_id:
                                  {user["musicbrainz_id"]}. \nData: {json.dumps(data, indent=3)}""")
@@ -256,6 +275,7 @@ def notify_mapping_import(data):
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
     )
+    metrics.set("listenbrainz-spark-mapping-imported", 1)
 
 
 def notify_artist_relation_import(data):
@@ -277,6 +297,7 @@ def notify_artist_relation_import(data):
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
     )
+    metrics.set("listenbrainz-spark-relation-imported", 1)
 
 
 def cf_recording_recommendations_complete(data):
@@ -303,6 +324,7 @@ def cf_recording_recommendations_complete(data):
         from_name='ListenBrainz',
         from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
     )
+    metrics.set("listenbrainz-spark-recommendations-complete", 1)
 
 
 def handle_similar_users(message):
@@ -329,6 +351,7 @@ def handle_similar_users(message):
             from_name='ListenBrainz',
             from_addr='noreply@'+current_app.config['MAIL_FROM_DOMAIN'],
         )
+        metrics.set("listenbrainz-spark-similar-users", 1)
 
 
 def handle_similar_users_year_end(message):

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -59,8 +59,6 @@ response_handler_map = {
 
 RABBITMQ_HEARTBEAT_TIME = 60 * 60  # 1 hour, in seconds
 
-metrics.init("listenbrainz")
-
 
 class SparkReader:
     def __init__(self):


### PR DESCRIPTION
Currently we have no way of knowing when a spark job fails until one of us notices the data is out of date. This PR adds a metric submission to each of the spark jobs so that we can set grafana alerts for each of them. Since I have no meaningful way to test this PR, this PR IS UNTESTED. 

@amCap1712 I am not sure if I got the stats all correct -- some things are not clear and straightforward there. Please have a look and suggest improvements.

Once this PR is merged, we will need to setup the alerts in grafana to complete this task.