### PR TITLE
Move artist map stats to redis cache

### DIFF
--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test.json
@@ -1,5 +1,5 @@
 {
-    "data": [
+    "artist_map": [
         {
             "artist_count": 8,
             "artists": [
@@ -134,6 +134,5 @@
     "from_ts": 1009843200,
     "last_updated": 1599918137,
     "to_ts": 1589496658,
-    "user_id": "ishaanshah",
-    "stats_range": "all_time"
+    "range": "all_time"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_month.json
@@ -1,5 +1,5 @@
 {
-  "data": [
+  "artist_map": [
         {
             "artist_count": 10,
             "artists": [
@@ -397,6 +397,5 @@
   "from_ts": 1588373458,
   "last_updated": 1599918137,
   "to_ts": 1589496658,
-  "user_id": "ishaanshah",
-  "stats_range": "month"
+  "range": "month"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_week.json
@@ -1,5 +1,5 @@
 {
-    "data": [
+    "artist_map": [
         {
             "artist_count": 10,
             "artists": [
@@ -397,6 +397,5 @@
     "from_ts": 1592265583,
     "last_updated": 1599918137,
     "to_ts": 1592870383,
-    "user_id": "ishaanshah",
-    "stats_range": "week"
+    "range": "week"
 }

--- a/listenbrainz/testdata/user_artist_map_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/user_artist_map_db_data_for_api_test_year.json
@@ -1,5 +1,5 @@
 {
-    "data": [
+    "artist_map": [
         {
             "artist_count": 8,
             "artists": [
@@ -134,6 +134,5 @@
     "from_ts": 1577919058,
     "to_ts": 1589496658,
     "last_updated": 1599918137,
-    "user_id": "ishaanshah",
-    "stats_range": "year"
+    "range": "year"
 }

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -864,7 +864,7 @@ def _get_artist_map_stats(user_id, stats_range):
         "from_ts": artist_stats.from_ts,
         "to_ts": artist_stats.to_ts,
         "last_updated": int(datetime.now().timestamp()),
-        "artist_map": country_code_data
+        "artist_map": [x.dict() for x in country_code_data]
     }
 
     try:

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -843,7 +843,7 @@ def _get_artist_map_stats(user_id, stats_range):
     key = f"{ARTIST_MAP_CACHE_PREFIX}:{stats_range}:{user_id}"
 
     if not force_recalculate:
-        stats = cache.get(key, decode=False)
+        stats = cache.get(key)
         if stats is not None:
             return ujson.loads(stats)
 
@@ -868,7 +868,7 @@ def _get_artist_map_stats(user_id, stats_range):
     }
 
     try:
-        cache.set(key, ujson.dumps(stats), ARTIST_MAP_CACHE_DURATION, encode=False)
+        cache.set(key, ujson.dumps(stats).encode('utf-8'), ARTIST_MAP_CACHE_DURATION)
     except Exception as err:
         current_app.logger.error(f"Error while inserting artist map stats for {user_id}. "
                                  f"Error: {err}. Data: {stats}", exc_info=True)

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -868,7 +868,7 @@ def _get_artist_map_stats(user_id, stats_range):
     }
 
     try:
-        cache.set(key, ujson.dumps(stats).encode('utf-8'), ARTIST_MAP_CACHE_DURATION)
+        cache.set(key, ujson.dumps(stats), ARTIST_MAP_CACHE_DURATION)
     except Exception as err:
         current_app.logger.error(f"Error while inserting artist map stats for {user_id}. "
                                  f"Error: {err}. Data: {stats}", exc_info=True)


### PR DESCRIPTION
We generate artist map stats on demand and cache them in PG. Soon, we'll be using CouchDB for stats which is not a natural fit for caching. So instead use Redis for caching.