### PR TITLE
fixed path to docker-compose.labs.api.yml in start-labs-api.sh

### DIFF
--- a/docker/start-labs-api.sh
+++ b/docker/start-labs-api.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose -f docker/docker-compose-labs-api.yml -p listenbrainz "$@"
+docker-compose -f docker/docker-compose.labs.api.yml -p listenbrainz "$@"

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -284,9 +284,9 @@ class MBIDMapper:
                         <td>{hit['document']["recording_name"]}</td>
                         <td>{hit['document']["release_name"]}</td>
                         <td>{hit['document']["artist_credit_name"]}</td>
-                        <td>{hit['document']["recording_mbid"]}</td>
-                        <td>{hit['document']["release_mbid"]}</td>
-                        <td>{hit['document']["artist_credit_id"]}</td>
+                        <td><a href="https://musicbrainz.org/recording/{hit['document']['recording_mbid']}">{hit['document']["recording_mbid"]}</a></td>
+                        <td><a href="https://musicbrainz.org/release/{hit['document']['release_mbid']}">{hit['document']["release_mbid"]}</a></td>
+                        <td><{hit['document']["artist_credit_id"]}</td>
                     </tr>
                 </table>
             """))

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -286,7 +286,7 @@ class MBIDMapper:
                         <td>{hit['document']["artist_credit_name"]}</td>
                         <td><a href="https://musicbrainz.org/recording/{hit['document']['recording_mbid']}">{hit['document']["recording_mbid"]}</a></td>
                         <td><a href="https://musicbrainz.org/release/{hit['document']['release_mbid']}">{hit['document']["release_mbid"]}</a></td>
-                        <td><{hit['document']["artist_credit_id"]}</td>
+                        <td>{hit['document']["artist_credit_id"]}</td>
                     </tr>
                 </table>
             """))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
start-labs-api.sh was calling docker-compose-labs.api.yml instead of docker-compose.labs.api.yml
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
replaced the "docker-compose-labs.api.yml" with "docker-compose.labs.api.yml" in start-labs-api.sh
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
N/A
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


