### PR TITLE
Add global react props to huesound template

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -285,7 +285,7 @@ def _register_blueprints(app):
     app.register_blueprint(api_bp_compat)
 
     from listenbrainz.webserver.views.explore import explore_bp
-    app.register_blueprint(explore_bp, url_prefix='/explore')
+    _register_blueprint_with_context(app, explore_bp, url_prefix='/explore')
 
     from listenbrainz.webserver.views.api import api_bp
     app.register_blueprint(api_bp, url_prefix=API_PREFIX)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

Reported at https://community.metabrainz.org/t/huesound-error/594804, huesound API queries are hitting https://listenbrainz.org/1/whatever instead of https://api.listenbrainz.org
This appears to be due only to a missing global prop containing the api_key


# Solution

Add global props to the flask template



