### PR TITLE
LB-1122: Show delete listen control if listened_at = 0

### DIFF
--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -682,7 +682,9 @@ export default class Listens extends React.Component<
     const trackMBID = get(listen, "track_metadata.additional_info.track_mbid");
     const releaseGroupMBID = getReleaseGroupMBID(listen);
     const canDelete =
-      isCurrentUser && Boolean(listenedAt) && Boolean(recordingMSID);
+      isCurrentUser &&
+      (Boolean(listenedAt) || listenedAt === 0) &&
+      Boolean(recordingMSID);
 
     const isListenReviewable =
       Boolean(recordingMBID) ||


### PR DESCRIPTION
For some invalid listens, listened_at is epoch. We may remove those en masse in future but in the meantime we should let the users delete those manually if they want to.