### PR TITLE
Fix typo in ReleaseGroupSecondaryType

### DIFF
--- a/listenbrainz/db/model/fresh_releases.py
+++ b/listenbrainz/db/model/fresh_releases.py
@@ -25,7 +25,7 @@ class ReleaseGroupSecondaryType(Enum):
     DJMIX = "DJ-mix"
     MIXTAPESTREET = "Mixtape/Street"
     DEMO = "Demo"
-    AUDIO = "drama Audio drama"
+    AUDIO = "Audio drama"
 
 
 class FreshRelease(BaseModel):


### PR DESCRIPTION
Fresh Releases API is currently erroring because the Audio Drama is named incorrectly due to which validation fails.