### PR TITLE
metadata lookup: convert artist mbids to str

### DIFF
--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
@@ -50,7 +50,7 @@ class ArtistCreditRecordingLookupQuery(Query):
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
                 curs.execute("""SELECT artist_credit_name,
                                        artist_credit_id,
-                                       artist_mbids,
+                                       artist_mbids::TEXT[],
                                        release_name,
                                        release_mbid,
                                        recording_name,

--- a/listenbrainz/mbid_mapping_writer/matcher.py
+++ b/listenbrainz/mbid_mapping_writer/matcher.py
@@ -213,7 +213,7 @@ def lookup_listens(app, listens, stats, exact, debug):
                      hit["recording_mbid"],
                      hit["release_mbid"],
                      hit["release_name"],
-                     [str(x) for x in hit["artist_mbids"]],
+                     hit["artist_mbids"],
                      hit["artist_credit_id"],
                      hit["artist_credit_name"],
                      hit["recording_name"],

--- a/listenbrainz/mbid_mapping_writer/matcher.py
+++ b/listenbrainz/mbid_mapping_writer/matcher.py
@@ -213,7 +213,7 @@ def lookup_listens(app, listens, stats, exact, debug):
                      hit["recording_mbid"],
                      hit["release_mbid"],
                      hit["release_name"],
-                     str(hit["artist_mbids"]),
+                     [str(x) for x in hit["artist_mbids"]],
                      hit["artist_credit_id"],
                      hit["artist_credit_name"],
                      hit["recording_name"],

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -93,7 +93,7 @@ def process_results(match, metadata, incs):
     result = {
         "recording_mbid": recording_mbid,
         "release_mbid": match["release_mbid"],
-        "artist_mbids": [str(x) for x in match["artist_mbids"]],
+        "artist_mbids": match["artist_mbids"],
         "recording_name": match["recording_name"],
         "release_name": match["release_name"],
         "artist_credit_name": match["artist_credit_name"]


### PR DESCRIPTION
Earlier tried to fix this in #2084 but that only fixed the issue for metadata API and left the mapper still broken. So convert at time of looking up from db so that fixed for all uses.