### PR TITLE
Fix huesound endpoint url

### DIFF
--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -63,7 +63,7 @@ def get_fresh_releases():
     return jsonify([r.to_dict() for r in listenbrainz.db.fresh_releases.get_sitewide_fresh_releases(release_date, days)])
 
 
-@explore_api_bp.route("/<color>", methods=["GET", "OPTIONS"])
+@explore_api_bp.route("/color/<color>", methods=["GET", "OPTIONS"])
 @crossdomain
 @ratelimit()
 def huesound(color):


### PR DESCRIPTION
#2085 added global props to the page but huesound still doesn't work because the endpoint url was invalid. Fix the url. Tested on beta works now.