### PR TITLE
Export env vars to fix cron lock script

### DIFF
--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -34,5 +34,6 @@ RSYNC_INCREMENTAL_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-du
 RSYNC_SPARK_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-spark'
 
 # Check to make sure that this container is the prod cron container, otherwise never rsync anything!
-PROD="{{ (env "DEPLOY_ENV") }}"
-CONTAINER_NAME="{{ (env "CONTAINER_NAME") }}"
+# these variables may also be read by the dump command in python so export to ensure availability
+export PROD="{{ (env "DEPLOY_ENV") }}"
+export CONTAINER_NAME="{{ (env "CONTAINER_NAME") }}"


### PR DESCRIPTION
Currently, the script to create a lock file to prevent the termination script from stopping the container if a dumps cron job is running is broken. This is because the environment variables to signal that the container is prod cron container are not visible to the python command.

Initially, I thought this was due to environment variables being not visible to cron jobs (which is true but not the sole culprit here).
So we decided on sourcing admin/config.sh before running the lock command. It turns out we already do it and the env vars are still not visible in the python command because those are not exported.

export the appropriate env vars to fix.