### PR TITLE
Spotify metadata cache (WIP)

### DIFF
--- a/listenbrainz/db/couchdb.py
+++ b/listenbrainz/db/couchdb.py
@@ -162,8 +162,6 @@ def create_index(database: str, index_data: dict):
     with start_span(op="http", description="create couchdb index"):
         couchdb_url = f"{get_base_url()}/{database}/_index"
         response = requests.post(couchdb_url, data=data, headers={"Content-Type": "application/json"})
-        if response.status_code != 200:
-            print(response.text)
         response.raise_for_status()
 
 def insert_data(database: str, data: list[dict]):
@@ -174,8 +172,6 @@ def insert_data(database: str, data: list[dict]):
     with start_span(op="http", description="insert docs in couchdb using api"):
         couchdb_url = f"{get_base_url()}/{database}/_bulk_docs"
         response = requests.post(couchdb_url, data=docs, headers={"Content-Type": "application/json"})
-        if response.status_code != 200:
-            print(response.text)
         response.raise_for_status()
 
 

--- a/listenbrainz/db/couchdb.py
+++ b/listenbrainz/db/couchdb.py
@@ -132,6 +132,39 @@ def fetch_data(prefix: str, user_id: int):
 
     return None
 
+def get(database: str, document_id: str):
+    base_url = get_base_url()
+    document_url = f"{base_url}/{database}/{document_id}"
+    response = requests.get(document_url)
+    if response.status_code == 404:
+        return None
+
+    response.raise_for_status()
+
+    return response.json()
+
+
+def find_data(database: str, query: dict):
+    base_url = get_base_url()
+    document_url = f"{base_url}/{database}/_find"
+    response = requests.post(document_url, json=query)
+    if response.status_code == 404:
+        return None
+
+    response.raise_for_status()
+
+    return response.json()["docs"]
+
+def create_index(database: str, index_data: dict):
+    with start_span(op="serializing", description="serialize data to json"):
+        data = ujson.dumps(index_data)
+
+    with start_span(op="http", description="create couchdb index"):
+        couchdb_url = f"{get_base_url()}/{database}/_index"
+        response = requests.post(couchdb_url, data=data, headers={"Content-Type": "application/json"})
+        if response.status_code != 200:
+            print(response.text)
+        response.raise_for_status()
 
 def insert_data(database: str, data: list[dict]):
     """ Insert the given data into the specified database. """

--- a/listenbrainz/db/couchdb.py
+++ b/listenbrainz/db/couchdb.py
@@ -174,6 +174,8 @@ def insert_data(database: str, data: list[dict]):
     with start_span(op="http", description="insert docs in couchdb using api"):
         couchdb_url = f"{get_base_url()}/{database}/_bulk_docs"
         response = requests.post(couchdb_url, data=docs, headers={"Content-Type": "application/json"})
+        if response.status_code != 200:
+            print(response.text)
         response.raise_for_status()
 
 

--- a/listenbrainz/mbid_mapping/README.md
+++ b/listenbrainz/mbid_mapping/README.md
@@ -63,3 +63,12 @@ To test searching the index:
 To run the mapping tests:
 
 ```manage.py test-mapping```
+
+Running the Spotify Metadata Cache
+----------------------------------
+
+If you plan to work with the metadata cache, start a couchdb instance like this:
+
+```
+docker run -p 127.0.0.1:5984:5984 -d -v listenbrainz-spotify-couchdb:/opt/couchdb/data --name=listenbrainz-spotify-couchdb couchdb:3.2.2
+```

--- a/listenbrainz/mbid_mapping/config.py.sample
+++ b/listenbrainz/mbid_mapping/config.py.sample
@@ -20,6 +20,9 @@ REDIS_HOST = "redis"
 REDIS_PORT = 6379
 REDIS_NAMESPACE = "listenbrainz"
 
+# Spotify Metadata cache keys
+SPOTIFY_APP_CLIENT_ID = ""
+SPOTIFY_APP_CLIENT_SECRET = ""
 
 # For debugging, only fetches a tiny portion of the data if True
 USE_MINIMAL_DATASET = True 

--- a/listenbrainz/mbid_mapping/config.py.sample
+++ b/listenbrainz/mbid_mapping/config.py.sample
@@ -24,5 +24,11 @@ REDIS_NAMESPACE = "listenbrainz"
 SPOTIFY_APP_CLIENT_ID = ""
 SPOTIFY_APP_CLIENT_SECRET = ""
 
+# CouchDB config
+COUCHDB_HOST = "localhost"
+COUCHDB_PORT = 5984
+COUCHDB_USER = "listenbrainz"
+COUCHDB_PASSWORD = "listenbrainz"
+
 # For debugging, only fetches a tiny portion of the data if True
 USE_MINIMAL_DATASET = True 

--- a/listenbrainz/mbid_mapping/couchdb.ini
+++ b/listenbrainz/mbid_mapping/couchdb.ini
@@ -1,0 +1,2 @@
+[couchdb]
+single_node = true

--- a/listenbrainz/mbid_mapping/couchdb.ini
+++ b/listenbrainz/mbid_mapping/couchdb.ini
@@ -1,2 +1,4 @@
 [couchdb]
 single_node = true
+max_document_size = 4294967296 ; 4 GB
+file_compression = snappy

--- a/listenbrainz/mbid_mapping/docker-compose.yml
+++ b/listenbrainz/mbid_mapping/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.4"
+
+# IMPORTANT NOTE: Volume paths mounted on containers are relative to the
+# directory that this file is in (`docker/`) and so probably need to start with
+# `../` to refer to a directory in the main code checkout
+
+volumes:
+  couchdb:
+
+services:
+
+  couchdb:
+    image: couchdb:3.2.2
+    environment:
+      COUCHDB_USER: listenbrainz
+      COUCHDB_PASSWORD: listenbrainz
+    ports:
+      - "127.0.0.1:5984:5984" 
+    volumes:
+      - ./couchdb.ini:/opt/couchdb/etc/local.ini
+      - couchdb:/opt/couchdb/data

--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -15,8 +15,8 @@ from reports.tracks_of_the_year import calculate_tracks_of_the_year
 from reports.top_discoveries import calculate_top_discoveries
 from mapping.mb_metadata_cache import create_mb_metadata_cache
 from mapping.spotify_cache import run_spotify_metadata_cache as action_run_spotify_metadata_cache, \
-                                  queue_spotify_ids as action_queue_spotify_ids, \
-                                  load_spotify_ids_from_file as action_load_spotify_ids_from_file
+    queue_spotify_ids as action_queue_spotify_ids, \
+    load_spotify_ids_from_file as action_load_spotify_ids_from_file
 import config
 
 
@@ -131,6 +131,7 @@ def queue_spotify_ids(spotify_ids):
     """
     action_queue_spotify_ids(spotify_ids)
 
+
 @cli.command()
 @click.argument('filename')
 def load_spotify_ids(filename):
@@ -138,6 +139,7 @@ def load_spotify_ids(filename):
         Load spotify ids from a file, one per line.
     """
     action_load_spotify_ids_from_file(filename)
+
 
 def usage(command):
     with click.Context(command) as ctx:

--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -14,6 +14,7 @@ from mapping.release_colors import sync_release_color_table, incremental_update_
 from reports.tracks_of_the_year import calculate_tracks_of_the_year
 from reports.top_discoveries import calculate_top_discoveries
 from mapping.mb_metadata_cache import create_mb_metadata_cache
+from mapping.spotify_cache import run_spotify_metadata_cache as action_run_spotify_metadata_cache
 import config
 
 
@@ -110,6 +111,14 @@ def build_mb_metadata_cache():
         Build the MB metadata cache that LB uses
     """
     create_mb_metadata_cache()
+
+
+@cli.command()
+def run_spotify_metadata_cache():
+    """
+        Run the spotify mapping cache process
+    """
+    action_run_spotify_metadata_cache()
 
 
 def usage(command):

--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -15,7 +15,8 @@ from reports.tracks_of_the_year import calculate_tracks_of_the_year
 from reports.top_discoveries import calculate_top_discoveries
 from mapping.mb_metadata_cache import create_mb_metadata_cache
 from mapping.spotify_cache import run_spotify_metadata_cache as action_run_spotify_metadata_cache, \
-                                  queue_spotify_ids as action_queue_spotify_ids
+                                  queue_spotify_ids as action_queue_spotify_ids, \
+                                  load_spotify_ids_from_file as action_load_spotify_ids_from_file
 import config
 
 
@@ -130,6 +131,13 @@ def queue_spotify_ids(spotify_ids):
     """
     action_queue_spotify_ids(spotify_ids)
 
+@cli.command()
+@click.argument('filename')
+def load_spotify_ids(filename):
+    """
+        Load spotify ids from a file, one per line.
+    """
+    action_load_spotify_ids_from_file(filename)
 
 def usage(command):
     with click.Context(command) as ctx:

--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -14,7 +14,8 @@ from mapping.release_colors import sync_release_color_table, incremental_update_
 from reports.tracks_of_the_year import calculate_tracks_of_the_year
 from reports.top_discoveries import calculate_top_discoveries
 from mapping.mb_metadata_cache import create_mb_metadata_cache
-from mapping.spotify_cache import run_spotify_metadata_cache as action_run_spotify_metadata_cache
+from mapping.spotify_cache import run_spotify_metadata_cache as action_run_spotify_metadata_cache, \
+                                  queue_spotify_ids as action_queue_spotify_ids
 import config
 
 
@@ -119,6 +120,15 @@ def run_spotify_metadata_cache():
         Run the spotify mapping cache process
     """
     action_run_spotify_metadata_cache()
+
+
+@cli.command()
+@click.argument('spotify_ids', nargs=-1)
+def queue_spotify_ids(spotify_ids):
+    """
+       Queue an spotify ids for inclusion in spotify metadata cache. Ids must start with artist: or track:
+    """
+    action_queue_spotify_ids(spotify_ids)
 
 
 def usage(command):

--- a/listenbrainz/mbid_mapping/mapping/spotify_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/spotify_cache.py
@@ -227,3 +227,19 @@ def queue_spotify_ids(spotify_ids):
     smc = SpotifyMetadataCache()
     smc.add_pending_spotify_ids(spotify_ids)
     smc.flush_pending_ids()
+
+def load_spotify_ids_from_file(filename):
+    smc = SpotifyMetadataCache()
+    count = 0
+    with open(filename, "r") as f:
+        while True:
+            spotify_id = f.readline()
+            if not spotify_id:
+                break
+
+            spotify_id = spotify_id.strip()
+            smc.add_pending_spotify_ids([spotify_id])
+            count += 1
+
+    smc.flush_pending_ids()
+    print("%d ids inserted" % count)

--- a/listenbrainz/mbid_mapping/mapping/spotify_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/spotify_cache.py
@@ -54,26 +54,29 @@ class SpotifyMetadataCache():
         dbs = couchdb.list_databases("")
         if self.COUCHDB_NAME not in dbs:
             couchdb.create_database(self.COUCHDB_NAME)
-        couchdb.create_index(self.COUCHDB_NAME, {
-            "index": {
-                "fields": ["status", "queued"]
-            },
-            "name": "status-index",
-            "type": "json"
-        })
+            couchdb.create_index(self.COUCHDB_NAME, {
+                "index": {
+                    "fields": ["status", "queued"]
+                },
+                "name": "status-index",
+                "type": "json"
+            })
 
     def queue_id(self, spotify_id):
         self.id_queue.put(spotify_id)
 
     def fetch_artist(self, artist_id, add_discovered_artists=False):
+        print("Fetch artist")
         artist = self.sp.artist(artist_id)
 
+        print("Fetch albums")
         results = self.sp.artist_albums(artist_id, album_type='album,single,compilation')
         albums = results['items']
         while results['next']:
             results = self.sp.next(results)
             albums.extend(results['items'])
 
+        print("Fetch tracks")
         for album in albums:
             results = self.sp.album_tracks(album["id"], limit=50)
             tracks = results["items"]
@@ -90,6 +93,7 @@ class SpotifyMetadataCache():
             album["tracks"] = tracks
 
         artist["albums"] = albums
+        print("Fetch artist complete")
 
         return artist
 
@@ -119,7 +123,7 @@ class SpotifyMetadataCache():
     def add_pending_spotify_ids(self, spotify_ids):
         try:
             iter(spotify_ids)
-        except TypeException:
+        except TypeError:
             raise ValueError("Must pass an iterable.")
 
         to_add = []

--- a/listenbrainz/mbid_mapping/mapping/spotify_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/spotify_cache.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from datetime import datetime
+import json
+from queue import Queue
+
+import spotipy
+from spotipy.oauth2 import SpotifyClientCredentials
+
+import config
+
+class UniqueQueue(object):
+    def __init__(self):
+        self.queue = Queue()
+        self.set = set()
+
+    def put(self, d):
+        if not d in self.set:
+            self.queue.put(d) 
+            self.set.add(d)
+            return True
+        return False
+
+    def get(self):
+        d = self.queue.get()
+        self.set.remove(d)
+        return d
+
+    def size(self):
+        return self.queue.qsize()
+
+
+class SpotifyMetadataCache():
+
+    def __init__(self):
+        self.id_queue = UniqueQueue()
+        self.seen_ids = {}
+        self.sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials(client_id=config.SPOTIFY_APP_CLIENT_ID,
+                                                                        client_secret=config.SPOTIFY_APP_CLIENT_SECRET))
+
+    def queue_id(self, spotify_id):
+        self.id_queue.put(spotify_id)
+
+    def fetch_artist(self, artist_id):
+        artist = self.sp.artist(artist_id)
+
+        results = self.sp.artist_albums(artist_id, album_type='album,single,compilation')
+        albums = results['items']
+        while results['next']:
+            results = self.sp.next(results)
+            albums.extend(results['items'])
+
+        for album in albums:
+            results = self.sp.album_tracks(album["id"], limit=50)
+            tracks = results["items"]
+            while results["next"]:
+                results = self.sp.next(results)
+                tracks.extend(results["items"])
+
+            for track in tracks:
+                for artist in track["artists"]:
+                    if artist["id"] != artist_id and artist["id"] not in self.seen_ids:
+                        self.id_queue.put("artist:%s" % artist["id"])
+
+            album["tracks"] = tracks
+
+        artist["albums"] = albums
+
+        return artist
+
+    def fetch_artist_ids_from_track_id(self, track_id):
+        return [ a["id"] for a in self.sp.track(track_id)["artists"] ]
+
+    def insert_artist(self, artist):
+        print("Insert artist '%s' %s" % (artist["name"], artist["id"]))
+        artist["_id"] = artist["id"]
+
+    def start(self):
+        """ Main loop of the application """
+
+        while True:
+            spotify_id = self.id_queue.get()
+
+            # Check to see if we've recently queried this id, if so move to the next id
+            if spotify_id in self.seen_ids:
+                continue
+
+            if spotify_id.startswith("track:"):
+                artist_ids = self.fetch_artist_ids_from_track_id(spotify_id[6:])
+            elif spotify_id.startswith("artist:"):
+                artist_ids = [ spotify_id[7:] ]
+            else:
+                raise ValueError("Unknown ID type", spotify_id)
+
+            for artist_id in artist_ids:
+                if artist_id in self.seen_ids:
+                    continue
+
+                artist_data = self.fetch_artist(artist_id)
+                self.insert_artist(artist_data)
+                self.seen_ids[artist_id] = datetime.now()
+
+            print("%d items in queue." % self.id_queue.size())
+
+
+
+smc = SpotifyMetadataCache()
+smc.queue_id("artist:6liAMWkVf5LH7YR9yfFy1Y")
+smc.queue_id("track:6ALWsAWq3bZmKBNnVKcMJG")
+#smc.queue_id("track:1eGS5RmdaGchUUoXSU5YyI")
+#smc.queue_id("track:0WIbzDVEpmOyBnqqdtqIL9")
+#smc.queue_id("track:0h2UMi51QXuJkwbPmXCRwK")
+#smc.queue_id("track:0DBIL8arX0Zo6eAuxNIpik")
+#smc.queue_id("track:4kiauw5SBqEsu5GuGD09aM")
+#smc.queue_id("track:6zEoAdcJHyx58lOGMeFcjw")
+#smc.queue_id("track:0NP7R5r4WMTWu5V3DcKHuf")
+#smc.queue_id("track:2uZtETOMzzREDMkvkHnaVn")
+#smc.queue_id("track:75AKiSgU8tTI2z8J1Qf1IT")
+#smc.queue_id("track:5wdub8zu2WLds6uRN0jUsV")
+#smc.queue_id("track:4AICh68Ef6M0Y50vf5RSeK")
+#smc.queue_id("track:4oxPEiseuJYdZ6yx0vKPiQ")
+#smc.queue_id("track:2Mor7Tp1w61mPKozLewqey")
+smc.start()

--- a/listenbrainz/mbid_mapping/mapping/spotify_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/spotify_cache.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 from datetime import datetime, timedelta
+from time import sleep
 import json
 from queue import Queue
+import uuid
 
-import couchdb
 import spotipy
 import dateutil.parser
 from spotipy.oauth2 import SpotifyClientCredentials
 
+from listenbrainz.db import couchdb
 import config
+from icecream import ic
+
 
 class UniqueQueue(object):
     def __init__(self):
@@ -17,7 +21,7 @@ class UniqueQueue(object):
 
     def put(self, d):
         if not d in self.set:
-            self.queue.put(d) 
+            self.queue.put(d)
             self.set.add(d)
             return True
         return False
@@ -30,6 +34,9 @@ class UniqueQueue(object):
     def size(self):
         return self.queue.qsize()
 
+    def empty(self):
+        return self.queue.empty()
+
 
 class SpotifyMetadataCache():
 
@@ -38,23 +45,24 @@ class SpotifyMetadataCache():
 
     def __init__(self):
         self.id_queue = UniqueQueue()
-        self.seen_ids = {}
         self.sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials(client_id=config.SPOTIFY_APP_CLIENT_ID,
                                                                         client_secret=config.SPOTIFY_APP_CLIENT_SECRET))
-        self.couch = couchdb.Server('http://listenbrainz:listenbrainz@localhost:5984/')
-        try:
-            self.db = self.couch[self.COUCHDB_NAME]
-        except couchdb.http.ResourceNotFound:
-            self.create_db()
-            self.db = self.couch[self.COUCHDB_NAME]
-
-    def create_db(self):
-        self.couch.create(self.COUCHDB_NAME)
+        self.couch = couchdb.init(config.COUCHDB_USER, config.COUCHDB_PASSWORD, config.COUCHDB_HOST, config.COUCHDB_PORT)
+        dbs = couchdb.list_databases("")
+        if self.COUCHDB_NAME not in dbs:
+            couchdb.create_database(self.COUCHDB_NAME)
+        couchdb.create_index(self.COUCHDB_NAME, {
+            "index": {
+                "fields": ["status", "queued"]
+            },
+            "name": "status-index",
+            "type": "json"
+        })
 
     def queue_id(self, spotify_id):
         self.id_queue.put(spotify_id)
 
-    def fetch_artist(self, artist_id):
+    def fetch_artist(self, artist_id, add_discovered_artists=False):
         artist = self.sp.artist(artist_id)
 
         results = self.sp.artist_albums(artist_id, album_type='album,single,compilation')
@@ -70,10 +78,11 @@ class SpotifyMetadataCache():
                 results = self.sp.next(results)
                 tracks.extend(results["items"])
 
-            for track in tracks:
-                for track_artist in track["artists"]:
-                    if track_artist["id"] != artist_id and track_artist["id"] not in self.seen_ids:
-                        self.id_queue.put("artist:%s" % track_artist["id"])
+            if add_discovered_artists:
+                for track in tracks:
+                    for track_artist in track["artists"]:
+                        if track_artist["id"] != artist_id and track_artist["id"]:
+                            self.id_queue.put("artist:%s" % track_artist["id"])
 
             album["tracks"] = tracks
 
@@ -82,55 +91,77 @@ class SpotifyMetadataCache():
         return artist
 
     def fetch_artist_ids_from_track_id(self, track_id):
-        return [ a["id"] for a in self.sp.track(track_id)["artists"] ]
+        return [a["id"] for a in self.sp.track(track_id)["artists"]]
 
-    def insert_artist(self, artist, exists=False):
+    def insert_artist(self, artist):
         artist["_id"] = artist["id"]
         artist["fetched"] = datetime.utcnow().isoformat()
         artist["expires"] = (datetime.utcnow() + timedelta(days=self.CACHE_TIME)).isoformat()
-        if exists:
-            self.db.update([artist])
-        else:
-            self.db.save(artist)
-        print("Inserted artist '%s' %s" % (artist["name"], artist["id"]))
+        artist["status"] = "fetched"
+        couchdb.insert_data(self.COUCHDB_NAME, [artist])
+
+    def add_pending_spotify_ids(self, spotify_ids):
+        for spotify_id in spotify_ids:
+            if not spotify_id.startswith("artist:") and not spotify_id.startswith("track:"):
+                print("Invalid ID submitted -- all IDs must start with artist: or track:")
+                return
+
+        data = {"status": "pending",
+                          "_id": str(uuid.uuid4()),
+                          "spotify_ids": spotify_ids,
+                          "queued": datetime.utcnow().isoformat()}
+        couchdb.insert_data(self.COUCHDB_NAME, [data])
+
+    def load_ids_to_process(self):
+        mango = {"selector": {"status": "pending"},
+                 "fields": ["queued", "spotify_ids"],
+                 "sort": [{"queued": "asc"}]}
+        ret = False
+        for row in couchdb.find_data(self.COUCHDB_NAME, mango):
+            for spotify_id in row["spotify_ids"]:
+                print("Add spotify id %s to queue" % spotify_id)
+                self.id_queue.put(spotify_id)
+                ret = True
+
+        return ret
 
     def process_artist(self, artist_id):
 
-        # Check our internal cache if we've seen it recently
-        if artist_id in self.seen_ids:
-            return
-
-        # Mark this ID as recently seen
-        self.seen_ids[artist_id] = datetime.now()
+        print(f"Process {artist_id}")
 
         # Fetch an existing doc and if found, see if it has expired
-        existing_doc = self.db.get(artist_id)
+        existing_doc = couchdb.get(self.COUCHDB_NAME, artist_id)
         if existing_doc is not None:
             expires = dateutil.parser.isoparse(existing_doc["expires"])
             if dateutil.parser.isoparse(existing_doc["expires"]) > datetime.utcnow():
-                print("Artist '%s' in db, not stale. Skipping." % artist_id)
+                print("Find existing doc!")
                 return
-            else:
-                print("Artist '%s' in db, stale. Fetch new." % artist_id)
+            rev = int(existing_doc["_rev"]) + 1
+        else:
+            rev = 1
 
         artist_data = self.fetch_artist(artist_id)
+        artist_data["_rev"] = str(rev)
 
-        self.insert_artist(artist_data, existing_doc is not None)
+        self.insert_artist(artist_data)
 
     def start(self):
         """ Main loop of the application """
 
         while True:
-            spotify_id = self.id_queue.get()
+            # If we have no more artists in the queue, fetch from the DB. If there are none, sleep, try again.
+            if self.id_queue.empty():
+                if not self.load_ids_to_process():
+                    sleep(60)
+                    continue
 
-            # Check to see if we've recently queried this id, if so move to the next id
-            if spotify_id in self.seen_ids:
-                continue
+            spotify_id = self.id_queue.get()
+            print(f"got {spotify_id}")
 
             if spotify_id.startswith("track:"):
                 artist_ids = self.fetch_artist_ids_from_track_id(spotify_id[6:])
             elif spotify_id.startswith("artist:"):
-                artist_ids = [ spotify_id[7:] ]
+                artist_ids = [spotify_id[7:]]
             else:
                 raise ValueError("Unknown ID type", spotify_id)
 
@@ -142,6 +173,9 @@ class SpotifyMetadataCache():
 
 def run_spotify_metadata_cache():
     smc = SpotifyMetadataCache()
-    smc.queue_id("artist:6liAMWkVf5LH7YR9yfFy1Y")
-    smc.queue_id("track:5wdub8zu2WLds6uRN0jUsV")
     smc.start()
+
+
+def queue_spotify_ids(spotify_ids):
+    smc = SpotifyMetadataCache()
+    smc.add_pending_spotify_ids(spotify_ids)

--- a/listenbrainz/mbid_mapping/mapping/spotify_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/spotify_cache.py
@@ -129,7 +129,7 @@ class SpotifyMetadataCache():
 
             if self.add_recent_id(spotify_id):
                 to_add.append(spotify_id)
-                
+
         self.pending_ids.extend(to_add)
         if len(self.pending_ids) > self.MAX_CACHED_PENDING_IDS:
             self.flush_pending_ids()
@@ -156,7 +156,6 @@ class SpotifyMetadataCache():
                 ret = True
             couchdb.delete_data(self.COUCHDB_NAME, row["_id"])
             break
-
 
         return ret
 
@@ -217,7 +216,6 @@ class SpotifyMetadataCache():
                 self.process_artist(artist_id)
 
 
-
 def run_spotify_metadata_cache():
     smc = SpotifyMetadataCache()
     smc.start()
@@ -227,6 +225,7 @@ def queue_spotify_ids(spotify_ids):
     smc = SpotifyMetadataCache()
     smc.add_pending_spotify_ids(spotify_ids)
     smc.flush_pending_ids()
+
 
 def load_spotify_ids_from_file(filename):
     smc = SpotifyMetadataCache()

--- a/listenbrainz/mbid_mapping/requirements.txt
+++ b/listenbrainz/mbid_mapping/requirements.txt
@@ -6,4 +6,5 @@ ujson==5.4.0
 typesense
 unidecode
 spotipy==2.20.0
+python-dateutil==2.8.2
 git+https://github.com/metabrainz/brainzutils-python.git@v2.1.0

--- a/listenbrainz/mbid_mapping/requirements.txt
+++ b/listenbrainz/mbid_mapping/requirements.txt
@@ -1,8 +1,9 @@
 click==7.1.2
 pytest==5.4.3
 pytest-cov==2.10.0
-psycopg2-binary==2.8.5
+psycopg2-binary==2.9.3
 ujson==5.4.0
 typesense
 unidecode
+spotipy==2.20.0
 git+https://github.com/metabrainz/brainzutils-python.git@v2.1.0


### PR DESCRIPTION
This PR is very much a work in progress, but I could use some head-checks to see if anyone sees anything badly wrong with my approach for building a spotify metadata cache.

The idea is that to warm up this giant cache, we're going to seed all the known spotify artist ids as a set of "pending ids" to be fetched. As these artists are fetched and stored in couchdb, we discover new artist ids and then add them to the list of pending ids. Once we've collected 1000 pending ids, these ids are written to a special document in couchdb. 

This program, which will run indefinitely, has a queue of what artists to look up next. If that runs dry, the next pending ids document is fetched from couchdb, inserted into the internal queue and then deleted from the db. The main loop of the program will continually fetch artists (by fetching all fo their albums and their tracks) and then write the results to couchdb. 

In order to keep the pending_ids from exploding, there is a recent_ids dict that tracks ids that have either been recently added or recently added to the pending list, so that we can forget about it for the time being. RIght now the recently added dict has no pruning in place, so this is something to keep an eye on.

Actually using this data is beyond the scope of this PR. We have several months before we've collected enough data.

TODO: Clean up couchdb additions, docstrings, add more gutt to README.
