### PR TITLE
Only allow pinning if playing now listen has msid or mbid

### DIFF
--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -691,17 +691,20 @@ export default class Listens extends React.Component<
       artistMBIDs?.length ||
       Boolean(trackMBID) ||
       Boolean(releaseGroupMBID);
+    const canPin = Boolean(recordingMBID) || Boolean(recordingMSID);
 
     /* eslint-disable react/jsx-no-bind */
     const additionalMenuItems = (
       <>
-        <ListenControl
-          text="Pin this recording"
-          icon={faThumbtack}
-          action={this.updateRecordingToPin.bind(this, listen)}
-          dataToggle="modal"
-          dataTarget="#PinRecordingModal"
-        />
+        {canPin && (
+          <ListenControl
+            text="Pin this recording"
+            icon={faThumbtack}
+            action={this.updateRecordingToPin.bind(this, listen)}
+            dataToggle="modal"
+            dataTarget="#PinRecordingModal"
+          />
+        )}
         {isListenReviewable && (
           <ListenControl
             text="Write a review"


### PR DESCRIPTION
Add a guard to only show the pin recording control if the listen has a msid or mbid. Normal listens always have msid but playing now listens never do. And metadata lookup may not always be able to find a match for the playing now listen so need the check.