### PR TITLE
Hide actions menu if empty

### DIFF
--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -245,7 +245,7 @@ export default class ListenCard extends React.Component<
 
     // Hide the actions menu if in compact mode or no buttons to be shown
     const hasActionOptions =
-      (additionalMenuItems && additionalMenuItems.length) ||
+      additionalMenuItems?.length ||
       enableRecommendButton ||
       recordingMBID ||
       spotifyURL ||

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -68,7 +68,7 @@ export type ListenCardProps = {
   // The default Listen fedback (love/hate) can be replaced
   feedbackComponent?: JSX.Element;
   // These go in the dropdown menu
-  additionalMenuItems?: JSX.Element;
+  additionalMenuItems?: JSX.Element[];
   // This optional JSX element is for a custom icon
   additionalActions?: JSX.Element;
 };
@@ -245,7 +245,7 @@ export default class ListenCard extends React.Component<
 
     // Hide the actions menu if in compact mode or no buttons to be shown
     const hasActionOptions =
-      additionalMenuItems ||
+      (additionalMenuItems && additionalMenuItems.length) ||
       enableRecommendButton ||
       recordingMBID ||
       spotifyURL ||

--- a/listenbrainz/webserver/static/js/src/pins/PinnedRecordingCard.tsx
+++ b/listenbrainz/webserver/static/js/src/pins/PinnedRecordingCard.tsx
@@ -160,22 +160,24 @@ export default class PinnedRecordingCard extends React.Component<
       </div>
     ) : undefined;
 
-    const additionalMenuItems = (
-      <>
-        {currentlyPinned && (
-          <ListenControl
-            title="Unpin"
-            text="Unpin"
-            action={() => this.unpinRecording()}
-          />
-        )}
+    const additionalMenuItems = [];
+    if (currentlyPinned) {
+      additionalMenuItems.push(
         <ListenControl
-          title="Delete Pin"
-          text="Delete Pin"
-          action={() => this.deletePin(pinnedRecording)}
+          title="Unpin"
+          text="Unpin"
+          action={() => this.unpinRecording()}
         />
-      </>
+      );
+    }
+    additionalMenuItems.push(
+      <ListenControl
+        title="Delete Pin"
+        text="Delete Pin"
+        action={() => this.deletePin(pinnedRecording)}
+      />
     );
+
     const cssClasses = ["pinned-recording-card"];
     if (currentlyPinned) {
       cssClasses.push("currently-pinned");

--- a/listenbrainz/webserver/static/js/src/playlists/PlaylistItemCard.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/PlaylistItemCard.tsx
@@ -61,18 +61,17 @@ export default class PlaylistItemCard extends React.Component<
         />
       </div>
     ) : undefined;
-    const additionalMenuItems = (
-      <>
-        {canEdit && (
-          <ListenControl
-            title="Remove from playlist"
-            text="Remove from playlist"
-            icon={faMinusCircle}
-            action={this.removeTrack}
-          />
-        )}
-      </>
-    );
+    let additionalMenuItems;
+    if (canEdit) {
+      additionalMenuItems = [
+        <ListenControl
+          title="Remove from playlist"
+          text="Remove from playlist"
+          icon={faMinusCircle}
+          action={this.removeTrack}
+        />,
+      ];
+    }
     const listen = JSPFTrackToListen(track);
     return (
       <ListenCard

--- a/listenbrainz/webserver/static/js/src/recent/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/recent/RecentListens.tsx
@@ -205,29 +205,26 @@ export default class RecentListens extends React.Component<
                   // On the Recent page listens should have either an MSID or MBID or both,
                   // so we can assume we can pin them
                   /* eslint-disable react/jsx-no-bind */
-                  const additionalMenuItems = (
-                    <>
+                  const additionalMenuItems = [
+                    <ListenControl
+                      text="Pin this recording"
+                      icon={faThumbtack}
+                      action={this.updateRecordingToPin.bind(this, listen)}
+                      dataToggle="modal"
+                      dataTarget="#PinRecordingModal"
+                    />,
+                  ];
+                  if (isListenReviewable) {
+                    additionalMenuItems.push(
                       <ListenControl
-                        text="Pin this recording"
-                        icon={faThumbtack}
-                        action={this.updateRecordingToPin.bind(this, listen)}
+                        text="Write a review"
+                        icon={faPencilAlt}
+                        action={this.updateRecordingToReview.bind(this, listen)}
                         dataToggle="modal"
-                        dataTarget="#PinRecordingModal"
+                        dataTarget="#CBReviewModal"
                       />
-                      {isListenReviewable && (
-                        <ListenControl
-                          text="Write a review"
-                          icon={faPencilAlt}
-                          action={this.updateRecordingToReview.bind(
-                            this,
-                            listen
-                          )}
-                          dataToggle="modal"
-                          dataTarget="#CBReviewModal"
-                        />
-                      )}
-                    </>
-                  );
+                    );
+                  }
                   /* eslint-enable react/jsx-no-bind */
                   return (
                     <ListenCard

--- a/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
+++ b/listenbrainz/webserver/static/js/src/user-feed/UserFeed.tsx
@@ -615,6 +615,22 @@ export default class UserFeedPage extends React.Component<
         listen = metadata as Listen;
         additionalContent = getAdditionalContent(metadata);
       }
+      let additionalMenuItems;
+      if (
+        (event.event_type === EventType.RECORDING_RECOMMENDATION ||
+          event.event_type === EventType.RECORDING_PIN) &&
+        event.user_name === currentUser.name
+      ) {
+        additionalMenuItems = [
+          <ListenControl
+            icon={faTrash}
+            title="Delete Event"
+            text="Delete Event"
+            // eslint-disable-next-line react/jsx-no-bind
+            action={this.deleteFeedEvent.bind(this, event)}
+          />,
+        ];
+      }
       return (
         <div className="event-content">
           <ListenCard
@@ -625,19 +641,7 @@ export default class UserFeedPage extends React.Component<
             listen={listen}
             additionalContent={additionalContent}
             newAlert={newAlert}
-            additionalMenuItems={
-              (event.event_type === EventType.RECORDING_RECOMMENDATION ||
-                event.event_type === EventType.RECORDING_PIN) &&
-              event.user_name === currentUser.name ? (
-                <ListenControl
-                  icon={faTrash}
-                  title="Delete Event"
-                  text="Delete Event"
-                  // eslint-disable-next-line react/jsx-no-bind
-                  action={this.deleteFeedEvent.bind(this, event)}
-                />
-              ) : undefined
-            }
+            additionalMenuItems={additionalMenuItems}
           />
         </div>
       );

--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -694,35 +694,38 @@ export default class Listens extends React.Component<
     const canPin = Boolean(recordingMBID) || Boolean(recordingMSID);
 
     /* eslint-disable react/jsx-no-bind */
-    const additionalMenuItems = (
-      <>
-        {canPin && (
-          <ListenControl
-            text="Pin this recording"
-            icon={faThumbtack}
-            action={this.updateRecordingToPin.bind(this, listen)}
-            dataToggle="modal"
-            dataTarget="#PinRecordingModal"
-          />
-        )}
-        {isListenReviewable && (
-          <ListenControl
-            text="Write a review"
-            icon={faPencilAlt}
-            action={this.updateRecordingToReview.bind(this, listen)}
-            dataToggle="modal"
-            dataTarget="#CBReviewModal"
-          />
-        )}
-        {canDelete && (
-          <ListenControl
-            text="Delete Listen"
-            icon={faTrashAlt}
-            action={this.deleteListen.bind(this, listen)}
-          />
-        )}
-      </>
-    );
+    const additionalMenuItems = [];
+    if (canPin) {
+      additionalMenuItems.push(
+        <ListenControl
+          text="Pin this recording"
+          icon={faThumbtack}
+          action={this.updateRecordingToPin.bind(this, listen)}
+          dataToggle="modal"
+          dataTarget="#PinRecordingModal"
+        />
+      );
+    }
+    if (isListenReviewable) {
+      additionalMenuItems.push(
+        <ListenControl
+          text="Write a review"
+          icon={faPencilAlt}
+          action={this.updateRecordingToReview.bind(this, listen)}
+          dataToggle="modal"
+          dataTarget="#CBReviewModal"
+        />
+      );
+    }
+    if (canDelete) {
+      additionalMenuItems.push(
+        <ListenControl
+          text="Delete Listen"
+          icon={faTrashAlt}
+          action={this.deleteListen.bind(this, listen)}
+        />
+      );
+    }
     const shouldBeDeleted = isEqual(deletedListen, listen);
     /* eslint-enable react/jsx-no-bind */
     return (

--- a/listenbrainz/webserver/static/js/src/user/UserFeedback.tsx
+++ b/listenbrainz/webserver/static/js/src/user/UserFeedback.tsx
@@ -511,19 +511,17 @@ export default class UserFeedback extends React.Component<
                   style={{ opacity: loading ? "0.4" : "1" }}
                 >
                   {listensFromFeedback.map((listen) => {
-                    const additionalMenuItems = (
-                      <>
-                        <ListenControl
-                          title="Pin this recording"
-                          text="Pin this recording"
-                          icon={faThumbtack}
-                          // eslint-disable-next-line react/jsx-no-bind
-                          action={this.updateRecordingToPin.bind(this, listen)}
-                          dataToggle="modal"
-                          dataTarget="#PinRecordingModal"
-                        />
-                      </>
-                    );
+                    const additionalMenuItems = [
+                      <ListenControl
+                        title="Pin this recording"
+                        text="Pin this recording"
+                        icon={faThumbtack}
+                        // eslint-disable-next-line react/jsx-no-bind
+                        action={this.updateRecordingToPin.bind(this, listen)}
+                        dataToggle="modal"
+                        dataTarget="#PinRecordingModal"
+                      />,
+                    ];
                     return (
                       <ListenCard
                         showUsername={false}

--- a/listenbrainz/webserver/static/js/tests/pins/__snapshots__/PinnedRecordingCard.test.tsx.snap
+++ b/listenbrainz/webserver/static/js/tests/pins/__snapshots__/PinnedRecordingCard.test.tsx.snap
@@ -33,18 +33,18 @@ exports[`PinnedRecordingCard renders correctly 1`] = `
       </div>
     }
     additionalMenuItems={
-      <React.Fragment>
+      Array [
         <ListenControl
           action={[Function]}
           text="Unpin"
           title="Unpin"
-        />
+        />,
         <ListenControl
           action={[Function]}
           text="Delete Pin"
           title="Delete Pin"
-        />
-      </React.Fragment>
+        />,
+      ]
     }
     className="pinned-recording-card currently-pinned"
     listen={


### PR DESCRIPTION
Empty Fragment <></> also evaluates to true, so we end up showing an empty menu if an empty fragment is passed as additionalMenuItems. Instead, accept an array of action item elements and only render if array is not empty.