### PR TITLE
Add option to create canonical data tables in MB

### DIFF
--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -14,7 +14,6 @@ from mapping.release_colors import sync_release_color_table, incremental_update_
 from reports.tracks_of_the_year import calculate_tracks_of_the_year
 from reports.top_discoveries import calculate_top_discoveries
 from mapping.mb_metadata_cache import create_mb_metadata_cache
-import config
 
 
 @click.group()
@@ -27,16 +26,17 @@ def create_all():
     """
         Create all canonical data in one go. First mb canonical data, then its typesense index.
     """
-    create_canonical_musicbrainz_data()
+    create_canonical_musicbrainz_data(True)
     action_build_index()
 
 
 @cli.command()
-def canonical_data():
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
+def canonical_data(use_lb_conn):
     """
         Create the MBID Mapping tables. (mbid_mapping, mbid_mapping_release, canonical_recording, recording_canonical_release)
     """
-    create_canonical_musicbrainz_data()
+    create_canonical_musicbrainz_data(use_lb_conn)
 
 
 @cli.command()
@@ -109,7 +109,7 @@ def build_mb_metadata_cache():
     """
         Build the MB metadata cache that LB uses
     """
-    create_mb_metadata_cache()
+    create_mb_metadata_cache(False)
 
 
 def usage(command):

--- a/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -148,15 +148,18 @@ class CanonicalMusicBrainzData(BulkInsertTable):
             return None
 
 
-def create_canonical_musicbrainz_data():
+def create_canonical_musicbrainz_data(use_lb_conn: bool):
     """
         Main function for creating the MBID mapping and its related tables.
+
+        Arguments:
+            use_lb_conn: whether to use LB conn or not
     """
 
     with psycopg2.connect(config.MBID_MAPPING_DATABASE_URI) as mb_conn:
 
         lb_conn = None
-        if config.SQLALCHEMY_TIMESCALE_URI:
+        if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
             lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
 
         # Setup all the needed objects

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -463,20 +463,23 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         log("mb metadata update: Done!")
 
 
-def create_mb_metadata_cache():
+def create_mb_metadata_cache(use_lb_conn: bool):
     """
         Main function for creating the MB metadata cache and its related tables.
+
+        Arguments:
+            use_lb_conn: whether to use LB conn or not
     """
 
     psycopg2.extras.register_uuid()
     with psycopg2.connect(config.MBID_MAPPING_DATABASE_URI) as mb_conn:
         lb_conn = None
-        if config.SQLALCHEMY_TIMESCALE_URI:
+        if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
             lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
 
         can_rel = CanonicalReleaseRedirect(mb_conn)
         if not can_rel.table_exists():
-            log("mb metadata cache: canonical_release_redirect table doesn't exist, run `canonical-data` manage command first")
+            log("mb metadata cache: canonical_release_redirect table doesn't exist, run `canonical-data` manage command first with --use-mb-conn option")
             return
 
         cache = MusicBrainzMetadataCache(mb_conn, lb_conn)


### PR DESCRIPTION
The query to build mb_metadata_cache table contains some joins to canonical_release_redirect and canonical_musicbrainz_data tables. However, currently these tables are always created in LB db whereas the mb_metadata_cache query runs in MB db. The simplest solution is probably to add an option for which db the canonical tables should be created in and running it once to store tables in LB and next time to store in MB.