### PR TITLE
Add new fields to mapping.mb_metadata_cache

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -139,10 +139,16 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 tag["genre_mbid"] = genre_mbid
             release_group_tags.append(tag)
 
+        recording_data = {
+            "rels": recording_rels
+        }
+        if row["length"]:
+            recording_data["length"] = row["length"]
+
         return (row["recording_mbid"],
                 list(set(artist_mbids)),
                 row["release_mbid"],
-                ujson.dumps({"rels": recording_rels}),
+                ujson.dumps(recording_data),
                 ujson.dumps(artists),
                 ujson.dumps({"recording": recording_tags, "artist": artist_tags, "release_group": release_group_tags}),
                 ujson.dumps(release))

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -107,7 +107,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
             artists_rels.append(data)
             artist_mbids.append(uuid.UUID(mbid))
 
-        artist["rels"] = artists_rels
+        artist["artists"] = artists_rels
 
         recording_rels = []
         for rel_type, artist_name, artist_mbid, instrument in row["recording_links"] or []:

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -194,7 +194,7 @@ export default function MetadataViewer(props: MetadataViewerProps) {
     metadata?.recording?.duration ??
     playingNow?.track_metadata?.additional_info?.duration_ms;
 
-  const artist = metadata?.artist?.[0];
+  const artist = metadata?.artist?.artists?.[0];
 
   const supportLinks = pick(artist?.rels, ...supportLinkTypes);
   const lyricsLink = pick(artist?.rels, "lyrics");

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
@@ -32,7 +32,10 @@ declare type ReleaseGroupTag = RecordingTag & {
 };
 
 declare type ListenMetadata = {
-  artist?: Array<MusicBrainzArtist>;
+  artist?: {
+    name?: string;
+    artists?: Array<MusicBrainzArtist>;
+  };
   recording?: {
     rels?: Array<MusicBrainzRecordingRel>;
     duration?: number;


### PR DESCRIPTION
1. We already had length but forgot to use it in process_row, need it for session based mbid similarity.
2. Need recording_name, artist_credit_name, release_name to replace usages of mbid_mapping_metadata in future.