### PR TITLE
Upgrade timescaledb image in dev/test to 2.6.0-pg12

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -7,7 +7,7 @@ version: "3.4"
 services:
 
   lb_db:
-    image: timescale/timescaledb:2.2.0-pg11
+    image: timescale/timescaledb:2.6.0-pg12
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -7,7 +7,7 @@ version: "3.4"
 services:
 
   lb_db:
-    image: timescale/timescaledb:2.2.0-pg11
+    image: timescale/timescaledb:2.6.0-pg12
     command: postgres -F
     environment:
       POSTGRES_PASSWORD: 'postgres'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - redis:/data:z
 
   lb_db:
-    image: timescale/timescaledb:2.2.0-pg11
+    image: timescale/timescaledb:2.6.0-pg12
     volumes:
       - timescaledb:/var/lib/postgresql/data:z
     ports:

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -243,4 +243,4 @@ class UserTestCase(DatabaseTestCase):
             )
 
         results = db_user.search("cif", 10, searcher_id)
-        self.assertEqual(results, [("Cécile", 0.1, None), ("Cecile", 0.1, 0.42), ("lucifer", 0.0909091, 0.61)])
+        self.assertEqual(results, [("Cécile", 0.1, None), ("Cecile", 0.1, 0.42), ("lucifer", 0.09090909, 0.61)])


### PR DESCRIPTION
In production timescale cluster, we use 2.6.0-pg13 image but the main db cluster shared with other projects is still on PG 12. In dev/tests, we have only 1 container for both databases so upgrading it to 2.6.0-pg12 only. This should prevent accidental usage of PG 13 features like gen_random_uuid() etc which would otherwise pass in tests but fail in production if used in queries executing on the main cluster.

Note: All devs will need to upgrade local databases once this is merged. Alternatively, they'll need to recreate the local db. **Notify currently active devs on merge**.