### PR TITLE
this needs to be 80, otherwise development server will run on wrong port

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - ..:/code/listenbrainz:z
       - ../listenbrainz/webserver/static:/static
     ports:
-      - "8100:80"
+      - "80:80"
     depends_on:
       - redis
       - lb_db


### PR DESCRIPTION
sorry if i've done something wrong. this is my first (well, second, first one was unsuccessful) pull request in this repo. i'm just starting out with the codebase. if you have any tips, please tell me

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
server starts in docker on the wrong port, so when you point your browser to http://localhost it shows that it can't connect to server
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
change port from 8100 to 80 
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

