### PR TITLE
Update labs api consul/uwsgi to match other flask apps

### DIFF
--- a/docker/services/labs_api/consul-template-labs-api.conf
+++ b/docker/services/labs_api/consul-template-labs-api.conf
@@ -4,9 +4,9 @@ template {
 }
 
 exec {
-    command = "run-lb-command uwsgi /etc/uwsgi/uwsgi-labs-api.ini"
+    command = "run-lb-command uwsgi --die-on-term /etc/uwsgi/uwsgi-labs-api.ini"
     splay = "5s"
     reload_signal = "SIGHUP"
-    kill_signal = "SIGINT"
+    kill_signal = "SIGTERM"
     kill_timeout = "30s"
 }


### PR DESCRIPTION
Every some days, labs api container is plagued with this error:

probably another instance of uWSGI is running on the same address (0.0.0.0:3031)
    bind(): Address already in use

When looking at the consul config, labs api's config is different from that of web and api compat. My hunch is when consul template restarts the process say due to the restart of a service dependency, the old uwsgi process is not shut down properly. Updating the labs api config to match other flask apps to hopefully fix the issue.