### PR TITLE
Remove librabbitmq-fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,6 @@ google-auth==1.30.0
 pandas==1.4.2
 pyarrow==8.0.0
 more-itertools==8.13.0
-librabbitmq-fork==2.0.2.dev1
 kombu==5.1.0
 itsdangerous==2.1.2
 countryinfo==0.1.2


### PR DESCRIPTION
Currently, we use kombu and consequently librabbitmq-fork in websockets listen dispatcher only. However, we patch eventlet in it, and it turns out patching eventlet disables use of librabbitmq and kombu instead fallbacks to py-amqp.

So, actually we have been using py-amqp all along and trying to use librabbitmq (i.e not calling eventlet.monkey_patch which disables it) actually segfaults so removing librabbitmq.