### PR TITLE
Add missing index and fix use_lb_conn

### DIFF
--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -105,11 +105,12 @@ def top_tracks(year):
 
 
 @cli.command()
-def build_mb_metadata_cache():
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
+def build_mb_metadata_cache(use_lb_conn):
     """
         Build the MB metadata cache that LB uses
     """
-    create_mb_metadata_cache(False)
+    create_mb_metadata_cache(use_lb_conn)
 
 
 def usage(command):

--- a/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -102,8 +102,11 @@ class CanonicalMusicBrainzData(BulkInsertTable):
         """]
 
     def get_index_names(self):
-        return [("canonical_musicbrainz_data_idx_combined_lookup",              "combined_lookup", False),
-                ("canonical_musicbrainz_data_idx_artist_credit_recording_name", "artist_credit_name, recording_name", False)]
+        return [
+            ("canonical_musicbrainz_data_idx_combined_lookup",              "combined_lookup", False),
+            ("canonical_musicbrainz_data_idx_artist_credit_recording_name", "artist_credit_name, recording_name", False),
+            ("canonical_musicbrainz_data_idx_recording_mbid", "recording_mbid", True)
+        ]
 
     def process_row(self, row):
 


### PR DESCRIPTION
1. Add index on `mapping.canonical_musicbrainz_data (recording_mbid)`. In the query to generate mb_metadata_cache, we have:
    ```sql
    LEFT JOIN mapping..canonical_musicbrainz_data cmb
        ON cmb.recording_mbid = r.gid
    ```
    In the absence of the index, we have a SeqScan which is slow.

2. Fix use_lb_conn for mb_metadata_cache
    
    When creating mb_metadata_cache table, we want to create the resultant table by default in TS db. The current default to create in MB db is wrong.