### PR TITLE
Convert recording_mbid to str in ArtistCreditRecordingLookup

### DIFF
--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
@@ -54,7 +54,7 @@ class ArtistCreditRecordingLookupQuery(Query):
                                        release_name,
                                        release_mbid,
                                        recording_name,
-                                       recording_mbid,
+                                       recording_mbid::TEXT,
                                        year,
                                        combined_lookup
                                   FROM mapping.canonical_musicbrainz_data


### PR DESCRIPTION
The metadata lookup API doesn't work correctly currently because the recording_mbid returned here is a UUID.

For instance, it fails here because the former is a UUID instance while the latter is a string: 
https://github.com/metabrainz/listenbrainz-server/blob/7a0efb731ddb30f2e42db795f2110dff6eb3b490/listenbrainz/webserver/views/metadata_api.py#L102
https://github.com/metabrainz/listenbrainz-server/blob/7a0efb731ddb30f2e42db795f2110dff6eb3b490/listenbrainz/webserver/views/metadata_api.py#L43

Also, we have 2 types of lookups here and the other one returns a string type so aligning the types to string is possibly the simplest fix.