### PR TITLE
Remove reliance on implicit autocommit 

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -34,6 +34,7 @@ services:
       - ..:/code/listenbrainz:z
     environment:
       PYTHONDONTWRITEBYTECODE: 1
+      SQLALCHEMY_WARN_20: 1
     depends_on:
       - redis
       - lb_db

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -35,6 +35,7 @@ services:
       - ..:/code/listenbrainz:z
     environment:
       PYTHONDONTWRITEBYTECODE: 1
+      SQLALCHEMY_WARN_20: 1
     depends_on:
       - redis
       - lb_db

--- a/listenbrainz/db/__init__.py
+++ b/listenbrainz/db/__init__.py
@@ -42,7 +42,7 @@ def init_db_connection(connect_str):
 
 def run_sql_script(sql_file_path):
     with open(sql_file_path) as sql:
-        with engine.connect() as connection, connection.begin():
+        with engine.begin() as connection:
             connection.execute(sql.read())
 
 

--- a/listenbrainz/db/__init__.py
+++ b/listenbrainz/db/__init__.py
@@ -1,3 +1,4 @@
+from typing import Optional
 
 import sqlalchemy
 from sqlalchemy import create_engine
@@ -13,7 +14,7 @@ import psycopg2.extras
 # public dump
 SCHEMA_VERSION_CORE = 8
 
-engine = None
+engine: Optional[sqlalchemy.engine.Engine] = None
 
 DUMP_DEFAULT_THREAD_COUNT = 4
 
@@ -41,7 +42,7 @@ def init_db_connection(connect_str):
 
 def run_sql_script(sql_file_path):
     with open(sql_file_path) as sql:
-        with engine.connect() as connection:
+        with engine.connect() as connection, connection.begin():
             connection.execute(sql.read())
 
 

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -685,7 +685,7 @@ def add_dump_entry(timestamp):
             id (int): the id of the new entry added
     """
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         result = connection.execute(sqlalchemy.text("""
                 INSERT INTO data_dump (created)
                      VALUES (TO_TIMESTAMP(:ts))

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -685,7 +685,7 @@ def add_dump_entry(timestamp):
             id (int): the id of the new entry added
     """
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         result = connection.execute(sqlalchemy.text("""
                 INSERT INTO data_dump (created)
                      VALUES (TO_TIMESTAMP(:ts))

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -26,7 +26,7 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
     # be explicitly set to the default value (which would have been used if the row was
     # inserted instead).
     token_expires = utils.unix_timestamp_to_datetime(token_expires_ts)
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         result = connection.execute(sqlalchemy.text("""
             INSERT INTO external_service_oauth
             (user_id, service, access_token, refresh_token, token_expires, scopes)
@@ -80,7 +80,7 @@ def delete_token(user_id: int, service: ExternalServiceType, remove_import_log: 
         service: the service for which the token should be deleted
         remove_import_log: whether the (user, service) combination should be removed from the listens_importer table also
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             DELETE FROM external_service_oauth
                   WHERE user_id = :user_id AND service = :service
@@ -110,7 +110,7 @@ def update_token(user_id: int, service: ExternalServiceType, access_token: str,
         expires_at: the unix timestamp at which the access token expires
     """
     token_expires = utils.unix_timestamp_to_datetime(expires_at)
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             UPDATE external_service_oauth
                SET access_token = :access_token

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -26,7 +26,7 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
     # be explicitly set to the default value (which would have been used if the row was
     # inserted instead).
     token_expires = utils.unix_timestamp_to_datetime(token_expires_ts)
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         result = connection.execute(sqlalchemy.text("""
             INSERT INTO external_service_oauth
             (user_id, service, access_token, refresh_token, token_expires, scopes)
@@ -80,7 +80,7 @@ def delete_token(user_id: int, service: ExternalServiceType, remove_import_log: 
         service: the service for which the token should be deleted
         remove_import_log: whether the (user, service) combination should be removed from the listens_importer table also
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             DELETE FROM external_service_oauth
                   WHERE user_id = :user_id AND service = :service
@@ -110,7 +110,7 @@ def update_token(user_id: int, service: ExternalServiceType, access_token: str,
         expires_at: the unix timestamp at which the access token expires
     """
     token_expires = utils.unix_timestamp_to_datetime(expires_at)
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             UPDATE external_service_oauth
                SET access_token = :access_token

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -64,7 +64,7 @@ def insert(feedback: Feedback):
         delete_query = DELETE_QUERIES["msid"]
         insert_query = INSERT_QUERIES["msid"]
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         # delete the existing feedback and then insert new feedback. we cannot use ON CONFLICT DO UPDATE
         # because it is possible for a user to submit the feedback using recording_msid only and then using
         # both recording_msid and recording_mbid at once in which case the ON CONFLICT doesn't work well.
@@ -92,7 +92,7 @@ def delete(feedback: Feedback):
         params['recording_msid'] = feedback.recording_msid
         query = DELETE_QUERIES["msid"]
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(text(query), params)
 
 

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -92,7 +92,7 @@ def delete(feedback: Feedback):
         params['recording_msid'] = feedback.recording_msid
         query = DELETE_QUERIES["msid"]
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(text(query), params)
 
 

--- a/listenbrainz/db/lastfm_session.py
+++ b/listenbrainz/db/lastfm_session.py
@@ -48,7 +48,7 @@ class Session(object):
 
     @staticmethod
     def generate(user_id, sid, api_key):
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             result = connection.execute(text("""
                 INSERT INTO api_compat.session (user_id, sid, api_key)
                      VALUES (:user_id, :sid, :api_key)

--- a/listenbrainz/db/lastfm_session.py
+++ b/listenbrainz/db/lastfm_session.py
@@ -48,7 +48,7 @@ class Session(object):
 
     @staticmethod
     def generate(user_id, sid, api_key):
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             result = connection.execute(text("""
                 INSERT INTO api_compat.session (user_id, sid, api_key)
                      VALUES (:user_id, :sid, :api_key)

--- a/listenbrainz/db/lastfm_token.py
+++ b/listenbrainz/db/lastfm_token.py
@@ -50,7 +50,7 @@ class Token(object):
                           AND api_key = :api_key"""
             params['api_key'] = api_key
 
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             result = connection.execute(text(query), params)
             row = result.fetchone()
             if row:
@@ -60,7 +60,7 @@ class Token(object):
     @staticmethod
     def generate(api_key):
         token = os.urandom(20).hex()
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             q = """ INSERT INTO api_compat.token (token, api_key) VALUES (:token, :api_key)
                     ON CONFLICT(api_key) DO UPDATE SET token = EXCLUDED.token, ts = EXCLUDED.ts
                 """
@@ -76,7 +76,7 @@ class Token(object):
     def approve(self, user):
         """ Authenticate the token. User has to be present.
         """
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             connection.execute(text("UPDATE api_compat.token SET user_id = :uid WHERE token=:token"),
                                {'uid': User.get_id(user), 'token': self.token})
         self.user = User.load_by_name(user)
@@ -84,5 +84,5 @@ class Token(object):
     def consume(self):
         """ Use token to be able to create a new session.
         """
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             connection.execute(text("DELETE FROM api_compat.token WHERE id=:id"), {'id': self.id})

--- a/listenbrainz/db/lastfm_token.py
+++ b/listenbrainz/db/lastfm_token.py
@@ -50,7 +50,7 @@ class Token(object):
                           AND api_key = :api_key"""
             params['api_key'] = api_key
 
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             result = connection.execute(text(query), params)
             row = result.fetchone()
             if row:
@@ -60,7 +60,7 @@ class Token(object):
     @staticmethod
     def generate(api_key):
         token = os.urandom(20).hex()
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             q = """ INSERT INTO api_compat.token (token, api_key) VALUES (:token, :api_key)
                     ON CONFLICT(api_key) DO UPDATE SET token = EXCLUDED.token, ts = EXCLUDED.ts
                 """
@@ -76,7 +76,7 @@ class Token(object):
     def approve(self, user):
         """ Authenticate the token. User has to be present.
         """
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             connection.execute(text("UPDATE api_compat.token SET user_id = :uid WHERE token=:token"),
                                {'uid': User.get_id(user), 'token': self.token})
         self.user = User.load_by_name(user)
@@ -84,5 +84,5 @@ class Token(object):
     def consume(self):
         """ Use token to be able to create a new session.
         """
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             connection.execute(text("DELETE FROM api_compat.token WHERE id=:id"), {'id': self.id})

--- a/listenbrainz/db/listens_importer.py
+++ b/listenbrainz/db/listens_importer.py
@@ -14,7 +14,7 @@ def update_import_status(user_id: int, service: ExternalServiceType, error_messa
         service (data.model.ExternalServiceType): service to add error for the user
         error_message (str): the user-friendly error message to be displayed
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             UPDATE listens_importer
                SET last_updated = now()
@@ -37,7 +37,7 @@ def update_latest_listened_at(user_id: int, service: ExternalServiceType, timest
         service (data.model.ExternalServiceType): service to update latest listen timestamp for
         timestamp (int): the unix timestamp of the latest listen imported for the user
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             INSERT INTO listens_importer (user_id, service, last_updated, latest_listened_at)
                  VALUES (:user_id, :service, now(), :timestamp)

--- a/listenbrainz/db/listens_importer.py
+++ b/listenbrainz/db/listens_importer.py
@@ -14,7 +14,7 @@ def update_import_status(user_id: int, service: ExternalServiceType, error_messa
         service (data.model.ExternalServiceType): service to add error for the user
         error_message (str): the user-friendly error message to be displayed
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             UPDATE listens_importer
                SET last_updated = now()
@@ -37,7 +37,7 @@ def update_latest_listened_at(user_id: int, service: ExternalServiceType, timest
         service (data.model.ExternalServiceType): service to update latest listen timestamp for
         timestamp (int): the unix timestamp of the latest listen imported for the user
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             INSERT INTO listens_importer (user_id, service, last_updated, latest_listened_at)
                  VALUES (:user_id, :service, now(), :timestamp)

--- a/listenbrainz/db/missing_musicbrainz_data.py
+++ b/listenbrainz/db/missing_musicbrainz_data.py
@@ -37,7 +37,7 @@ def insert_user_missing_musicbrainz_data(user_id: int, missing_musicbrainz_data:
                    but is not submitted to MusicBrainz.
             source : Source of generation of missing MusicBrainz data.
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             INSERT INTO missing_musicbrainz_data (user_id, data, source)
                  VALUES (:user_id, :missing_musicbrainz_data, :source)

--- a/listenbrainz/db/missing_musicbrainz_data.py
+++ b/listenbrainz/db/missing_musicbrainz_data.py
@@ -37,7 +37,7 @@ def insert_user_missing_musicbrainz_data(user_id: int, missing_musicbrainz_data:
                    but is not submitted to MusicBrainz.
             source : Source of generation of missing MusicBrainz data.
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             INSERT INTO missing_musicbrainz_data (user_id, data, source)
                  VALUES (:user_id, :missing_musicbrainz_data, :source)

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -38,7 +38,7 @@ def pin(pinned_recording: WritablePinnedRecording):
         'created': pinned_recording.created
     }
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             UPDATE pinned_recording
                SET pinned_until = NOW()
@@ -67,7 +67,7 @@ def unpin(user_id: int):
             False if no pinned recording belonging to the given user_id was currently pinned.
     """
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         result = connection.execute(sqlalchemy.text("""
             UPDATE pinned_recording
                SET pinned_until = NOW()
@@ -90,7 +90,7 @@ def delete(row_id: int, user_id: int):
             False if the pinned recording for the given row_id and user_id did not exist.
     """
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         result = connection.execute(sqlalchemy.text("""
             DELETE FROM pinned_recording
              WHERE id = :row_id

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -38,7 +38,7 @@ def pin(pinned_recording: WritablePinnedRecording):
         'created': pinned_recording.created
     }
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             UPDATE pinned_recording
                SET pinned_until = NOW()
@@ -67,7 +67,7 @@ def unpin(user_id: int):
             False if no pinned recording belonging to the given user_id was currently pinned.
     """
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         result = connection.execute(sqlalchemy.text("""
             UPDATE pinned_recording
                SET pinned_until = NOW()
@@ -90,7 +90,7 @@ def delete(row_id: int, user_id: int):
             False if the pinned recording for the given row_id and user_id did not exist.
     """
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         result = connection.execute(sqlalchemy.text("""
             DELETE FROM pinned_recording
              WHERE id = :row_id

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -499,7 +499,7 @@ def update_playlist(playlist: model_playlist.Playlist):
              , public = :public
          WHERE id = :id
     """)
-    with ts.engine.connect() as connection, connection.begin():
+    with ts.engine.begin() as connection:
         params = playlist.dict(include={'id', 'name', 'description', 'public'})
         connection.execute(query, params)
         # Unconditionally add collaborators, this allows us to delete all collaborators
@@ -563,7 +563,7 @@ def delete_playlist_by_mbid(playlist_mbid: str):
         DELETE FROM playlist.playlist
               WHERE playlist.mbid = :playlist_mbid
     """)
-    with ts.engine.connect() as connection, connection.begin():
+    with ts.engine.begin() as connection:
         result = connection.execute(query, {"playlist_mbid": playlist_mbid})
         return result.rowcount == 1
 
@@ -648,7 +648,7 @@ def delete_recordings_from_playlist(playlist: model_playlist.Playlist, remove_fr
          WHERE playlist_id = :playlist_id
            AND position >= :position
     """)
-    with ts.engine.connect() as connection, connection.begin():
+    with ts.engine.begin() as connection:
         delete_params = {"playlist_id": playlist.id,
                          "position_start": remove_from,
                          "position_end": remove_from+remove_count}
@@ -692,7 +692,7 @@ def add_recordings_to_playlist(playlist: model_playlist.Playlist,
     """)
     if position is None:
         position = len(playlist.recordings)
-    with ts.engine.connect() as connection, connection.begin():
+    with ts.engine.begin() as connection:
         if position < len(playlist.recordings):
             reorder_params = {"playlist_id": playlist.id,
                               "offset": len(recordings),

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -3,14 +3,11 @@ import datetime
 from typing import List, Optional
 
 import sqlalchemy
-from sqlalchemy.orm import Session
 import ujson
 
 from listenbrainz.db.model import playlist as model_playlist
 from listenbrainz.db import timescale as ts
 from listenbrainz.db import user as db_user
-
-from flask import current_app
 
 
 TROI_BOT_USER_ID = 12939
@@ -502,7 +499,7 @@ def update_playlist(playlist: model_playlist.Playlist):
              , public = :public
          WHERE id = :id
     """)
-    with ts.engine.connect() as connection:
+    with ts.engine.connect() as connection, connection.begin():
         params = playlist.dict(include={'id', 'name', 'description', 'public'})
         connection.execute(query, params)
         # Unconditionally add collaborators, this allows us to delete all collaborators
@@ -566,7 +563,7 @@ def delete_playlist_by_mbid(playlist_mbid: str):
         DELETE FROM playlist.playlist
               WHERE playlist.mbid = :playlist_mbid
     """)
-    with ts.engine.connect() as connection:
+    with ts.engine.connect() as connection, connection.begin():
         result = connection.execute(query, {"playlist_mbid": playlist_mbid})
         return result.rowcount == 1
 
@@ -651,7 +648,7 @@ def delete_recordings_from_playlist(playlist: model_playlist.Playlist, remove_fr
          WHERE playlist_id = :playlist_id
            AND position >= :position
     """)
-    with ts.engine.connect() as connection:
+    with ts.engine.connect() as connection, connection.begin():
         delete_params = {"playlist_id": playlist.id,
                          "position_start": remove_from,
                          "position_end": remove_from+remove_count}
@@ -695,7 +692,7 @@ def add_recordings_to_playlist(playlist: model_playlist.Playlist,
     """)
     if position is None:
         position = len(playlist.recordings)
-    with ts.engine.connect() as connection:
+    with ts.engine.connect() as connection, connection.begin():
         if position < len(playlist.recordings):
             reorder_params = {"playlist_id": playlist.id,
                               "offset": len(recordings),

--- a/listenbrainz/db/recommendations_cf_recording.py
+++ b/listenbrainz/db/recommendations_cf_recording.py
@@ -51,7 +51,7 @@ def insert_user_recommendation(user_id: int, recommendations: UserRecommendation
             user_id (int): row id of the user.
             recommendations (dict): User recommendations.
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             INSERT INTO recommendation.cf_recording (user_id, recording_mbid)
                  VALUES (:user_id, :recommendation)

--- a/listenbrainz/db/recommendations_cf_recording.py
+++ b/listenbrainz/db/recommendations_cf_recording.py
@@ -51,7 +51,7 @@ def insert_user_recommendation(user_id: int, recommendations: UserRecommendation
             user_id (int): row id of the user.
             recommendations (dict): User recommendations.
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             INSERT INTO recommendation.cf_recording (user_id, recording_mbid)
                  VALUES (:user_id, :recommendation)

--- a/listenbrainz/db/recommendations_cf_recording_feedback.py
+++ b/listenbrainz/db/recommendations_cf_recording_feedback.py
@@ -16,7 +16,7 @@ def insert(feedback_submit: RecommendationFeedbackSubmit):
             feedback_submit: An object of class RecommendationFeedbackSubmit
     """
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             INSERT INTO recommendation_feedback (user_id, recording_mbid, rating)
                  VALUES (:user_id, :recording_mbid, :rating)
@@ -38,7 +38,7 @@ def delete(feedback_delete: RecommendationFeedbackDelete):
             feedback_delete: An object of class RecommendationFeedbackDelete
     """
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             DELETE FROM recommendation_feedback
              WHERE user_id = :user_id

--- a/listenbrainz/db/recommendations_cf_recording_feedback.py
+++ b/listenbrainz/db/recommendations_cf_recording_feedback.py
@@ -16,7 +16,7 @@ def insert(feedback_submit: RecommendationFeedbackSubmit):
             feedback_submit: An object of class RecommendationFeedbackSubmit
     """
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             INSERT INTO recommendation_feedback (user_id, recording_mbid, rating)
                  VALUES (:user_id, :recording_mbid, :rating)
@@ -38,7 +38,7 @@ def delete(feedback_delete: RecommendationFeedbackDelete):
             feedback_delete: An object of class RecommendationFeedbackDelete
     """
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             DELETE FROM recommendation_feedback
              WHERE user_id = :user_id

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -37,7 +37,7 @@ class DatabaseTestCase(unittest.TestCase):
     @classmethod
     def create_user_with_id(cls, lb_id: int, musicbrainz_row_id: int, musicbrainz_id: str):
         """ Create a new user with the specified LB id. """
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text("""
                 INSERT INTO "user" (id, musicbrainz_id, musicbrainz_row_id, auth_token)
                      VALUES (:id, :mb_id, :mb_row_id, :token)

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -37,7 +37,7 @@ class DatabaseTestCase(unittest.TestCase):
     @classmethod
     def create_user_with_id(cls, lb_id: int, musicbrainz_row_id: int, musicbrainz_id: str):
         """ Create a new user with the specified LB id. """
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             connection.execute(sqlalchemy.text("""
                 INSERT INTO "user" (id, musicbrainz_id, musicbrainz_row_id, auth_token)
                      VALUES (:id, :mb_id, :mb_row_id, :token)

--- a/listenbrainz/db/tests/test_color.py
+++ b/listenbrainz/db/tests/test_color.py
@@ -11,7 +11,7 @@ from listenbrainz.db.color import get_releases_for_color
 class HuesoundTestCase(DatabaseTestCase):
 
     def insert_test_data(self):
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             connection.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
                                                        VALUES (1, 'e97f805a-ab48-4c52-855e-07049142113d', 0, 0, 255, '(0, 0, 255)')"""))
             connection.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)

--- a/listenbrainz/db/tests/test_color.py
+++ b/listenbrainz/db/tests/test_color.py
@@ -11,7 +11,7 @@ from listenbrainz.db.color import get_releases_for_color
 class HuesoundTestCase(DatabaseTestCase):
 
     def insert_test_data(self):
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
                                                        VALUES (1, 'e97f805a-ab48-4c52-855e-07049142113d', 0, 0, 255, '(0, 0, 255)')"""))
             connection.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -68,7 +68,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
     def insert_test_data_with_metadata(self, user_id):
         """ Insert test data with metadata into the database """
 
-        with msb_db.engine.connect() as connection:
+        with msb_db.engine.connect() as connection, connection.begin():
             submitted = msb_db.insert_single(connection, self.sample_recording)
             msid = str(submitted["ids"]["recording_msid"])
 
@@ -84,14 +84,14 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
                                 '{6a221fda-2200-11ec-ac7d-dfa16a57158f}'::UUID[],
                                 'Portishead', 'Strangers')"""
 
-        with ts.engine.connect() as connection:
+        with ts.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text(query))
 
         query = """INSERT INTO mbid_mapping
                                (recording_msid, recording_mbid, match_type, last_updated)
                         VALUES (:msid, :mbid, :match_type, now())"""
 
-        with ts.engine.connect() as connection:
+        with ts.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text(query),
                                {"msid": msid, "mbid": "076255b4-1575-11ec-ac84-135bf6a670e3", "match_type": "exact_match"})
 

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -68,7 +68,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
     def insert_test_data_with_metadata(self, user_id):
         """ Insert test data with metadata into the database """
 
-        with msb_db.engine.connect() as connection, connection.begin():
+        with msb_db.engine.begin() as connection:
             submitted = msb_db.insert_single(connection, self.sample_recording)
             msid = str(submitted["ids"]["recording_msid"])
 
@@ -84,14 +84,14 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainzT
                                 '{6a221fda-2200-11ec-ac7d-dfa16a57158f}'::UUID[],
                                 'Portishead', 'Strangers')"""
 
-        with ts.engine.connect() as connection, connection.begin():
+        with ts.engine.begin() as connection:
             connection.execute(sqlalchemy.text(query))
 
         query = """INSERT INTO mbid_mapping
                                (recording_msid, recording_mbid, match_type, last_updated)
                         VALUES (:msid, :mbid, :match_type, now())"""
 
-        with ts.engine.connect() as connection, connection.begin():
+        with ts.engine.begin() as connection:
             connection.execute(sqlalchemy.text(query),
                                {"msid": msid, "mbid": "076255b4-1575-11ec-ac84-135bf6a670e3", "match_type": "exact_match"})
 

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -24,7 +24,7 @@ class MappingTestCase(TimescaleTestCase):
         model = MsidMbidModel(recording_msid=str(uuid.uuid4()), recording_mbid=str(uuid.uuid4()))
 
     def insert_recording_in_mapping(self, recording, match_type):
-        with ts.engine.connect() as connection:
+        with ts.engine.connect() as connection, connection.begin():
             if match_type == "exact_match":
                 connection.execute(text("""
                     INSERT INTO mbid_mapping_metadata (artist_credit_id, recording_mbid, release_mbid, release_name,

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -24,7 +24,7 @@ class MappingTestCase(TimescaleTestCase):
         model = MsidMbidModel(recording_msid=str(uuid.uuid4()), recording_mbid=str(uuid.uuid4()))
 
     def insert_recording_in_mapping(self, recording, match_type):
-        with ts.engine.connect() as connection, connection.begin():
+        with ts.engine.begin() as connection:
             if match_type == "exact_match":
                 connection.execute(text("""
                     INSERT INTO mbid_mapping_metadata (artist_credit_id, recording_mbid, release_mbid, release_name,

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 
 import sqlalchemy
@@ -112,7 +111,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainz
         submitted_data = msb_db.insert_all_in_transaction(recordings)
         msids = [x["ids"]["recording_msid"] for x in submitted_data]
 
-        with ts.engine.connect() as connection:
+        with ts.engine.connect() as connection, connection.begin():
             query = """
                 INSERT INTO mbid_mapping_metadata
                             (recording_mbid, release_mbid, release_name, artist_credit_id,

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -111,7 +111,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainz
         submitted_data = msb_db.insert_all_in_transaction(recordings)
         msids = [x["ids"]["recording_msid"] for x in submitted_data]
 
-        with ts.engine.connect() as connection, connection.begin():
+        with ts.engine.begin() as connection:
             query = """
                 INSERT INTO mbid_mapping_metadata
                             (recording_mbid, release_mbid, release_name, artist_credit_id,

--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -17,7 +17,7 @@ class SimilarUserTestCase(DatabaseTestCase):
         similar_users_1 = {user_id_2: [0.42, 0.01]}
         similar_users_2 = {user_id_1: [0.42, 0.02]}
 
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             connection.execute(sqlalchemy.text("""
             INSERT INTO recommendation.similar_user (user_id, similar_users)
                  VALUES (:user_id_1, :similar_users_1), (:user_id_2, :similar_users_2)

--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -17,7 +17,7 @@ class SimilarUserTestCase(DatabaseTestCase):
         similar_users_1 = {user_id_2: [0.42, 0.01]}
         similar_users_2 = {user_id_1: [0.42, 0.02]}
 
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text("""
             INSERT INTO recommendation.similar_user (user_id, similar_users)
                  VALUES (:user_id_1, :similar_users_1), (:user_id_2, :similar_users_2)

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -41,7 +41,7 @@ class UserTestCase(DatabaseTestCase):
         user = db_user.get_or_create(2, 'testlastloginuser')
 
         # set the last login value of the user to 0
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
                    SET last_login = to_timestamp(0)
@@ -219,7 +219,7 @@ class UserTestCase(DatabaseTestCase):
         user_id_l = db_user.create(2, "lucifer")
         user_id_r = db_user.create(3, "rob")
 
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             connection.execute(sqlalchemy.text(
                 "INSERT INTO recommendation.similar_user (user_id, similar_users) VALUES (:user_id, :similar_users)"),
                 user_id=searcher_id,

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -41,7 +41,7 @@ class UserTestCase(DatabaseTestCase):
         user = db_user.get_or_create(2, 'testlastloginuser')
 
         # set the last login value of the user to 0
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
                    SET last_login = to_timestamp(0)
@@ -219,7 +219,7 @@ class UserTestCase(DatabaseTestCase):
         user_id_l = db_user.create(2, "lucifer")
         user_id_r = db_user.create(3, "rob")
 
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text(
                 "INSERT INTO recommendation.similar_user (user_id, similar_users) VALUES (:user_id, :similar_users)"),
                 user_id=searcher_id,

--- a/listenbrainz/db/timescale.py
+++ b/listenbrainz/db/timescale.py
@@ -44,7 +44,7 @@ def init_db_connection(connect_str):
 
 def run_sql_script(sql_file_path):
     with open(sql_file_path) as sql:
-        with engine.connect() as connection, connection.begin():
+        with engine.begin() as connection:
             connection.execute(sql.read())
 
 

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -27,7 +27,7 @@ def create(musicbrainz_row_id: int, musicbrainz_id: str, email: str = None) -> i
     Returns:
         ID of newly created user.
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         result = connection.execute(sqlalchemy.text("""
             INSERT INTO "user" (musicbrainz_id, musicbrainz_row_id, auth_token, email)
                  VALUES (:mb_id, :mb_row_id, :token, :email)
@@ -48,7 +48,7 @@ def update_token(id):
     Args:
         id (int) - the row id of the user to update
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -257,7 +257,7 @@ def update_last_login(musicbrainz_id):
         musicbrainz_id (str): MusicBrainz username of a user
     """
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -320,7 +320,7 @@ def delete(id):
     Args:
         id (int): the row ID of the listenbrainz user
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         try:
             connection.execute(sqlalchemy.text("""
                 DELETE FROM "user"
@@ -339,7 +339,7 @@ def agree_to_gdpr(musicbrainz_id):
     Args:
         musicbrainz_id (str): the MusicBrainz ID of the user
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -361,7 +361,7 @@ def update_musicbrainz_row_id(musicbrainz_id, musicbrainz_row_id):
         musicbrainz_id (str): the MusicBrainz ID (username) of the user
         musicbrainz_row_id (int): the MusicBrainz row ID of the user
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -500,7 +500,7 @@ def is_user_reported(reporter_id: int, reported_id: int):
 def report_user(reporter_id: int, reported_id: int, reason: str = None):
     """ Create a report from user with reporter_id against user with
      reported_id"""
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             INSERT INTO reported_users (reporter_user_id, reported_user_id, reason)
                  VALUES (:reporter_id, :reported_id, :reason)
@@ -521,7 +521,7 @@ def update_user_details(lb_id: int, musicbrainz_id: str, email: str):
         email: email of a user
     """
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -27,7 +27,7 @@ def create(musicbrainz_row_id: int, musicbrainz_id: str, email: str = None) -> i
     Returns:
         ID of newly created user.
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         result = connection.execute(sqlalchemy.text("""
             INSERT INTO "user" (musicbrainz_id, musicbrainz_row_id, auth_token, email)
                  VALUES (:mb_id, :mb_row_id, :token, :email)
@@ -48,7 +48,7 @@ def update_token(id):
     Args:
         id (int) - the row id of the user to update
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -257,7 +257,7 @@ def update_last_login(musicbrainz_id):
         musicbrainz_id (str): MusicBrainz username of a user
     """
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -320,7 +320,7 @@ def delete(id):
     Args:
         id (int): the row ID of the listenbrainz user
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         try:
             connection.execute(sqlalchemy.text("""
                 DELETE FROM "user"
@@ -339,7 +339,7 @@ def agree_to_gdpr(musicbrainz_id):
     Args:
         musicbrainz_id (str): the MusicBrainz ID of the user
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -361,7 +361,7 @@ def update_musicbrainz_row_id(musicbrainz_id, musicbrainz_row_id):
         musicbrainz_id (str): the MusicBrainz ID (username) of the user
         musicbrainz_row_id (int): the MusicBrainz row ID of the user
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"
@@ -500,7 +500,7 @@ def is_user_reported(reporter_id: int, reported_id: int):
 def report_user(reporter_id: int, reported_id: int, reason: str = None):
     """ Create a report from user with reporter_id against user with
      reported_id"""
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             INSERT INTO reported_users (reporter_user_id, reported_user_id, reason)
                  VALUES (:reporter_id, :reported_id, :reason)
@@ -521,7 +521,7 @@ def update_user_details(lb_id: int, musicbrainz_id: str, email: str):
         email: email of a user
     """
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         try:
             connection.execute(sqlalchemy.text("""
                 UPDATE "user"

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -33,7 +33,7 @@ def insert(user_0: int, user_1: int, relationship_type: str) -> None:
     if relationship_type not in VALID_RELATIONSHIP_TYPES:
         raise ValueError(f"Invalid relationship type: {relationship_type}")
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             INSERT INTO user_relationship (user_0, user_1, relationship_type)
                  VALUES (:user_0, :user_1, :relationship_type)
@@ -90,7 +90,7 @@ def delete(user_0: int, user_1: int, relationship_type: str) -> None:
     if relationship_type not in VALID_RELATIONSHIP_TYPES:
         raise ValueError(f"Invalid relationship type: {relationship_type}")
 
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         connection.execute(sqlalchemy.text("""
             DELETE
               FROM user_relationship

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -33,7 +33,7 @@ def insert(user_0: int, user_1: int, relationship_type: str) -> None:
     if relationship_type not in VALID_RELATIONSHIP_TYPES:
         raise ValueError(f"Invalid relationship type: {relationship_type}")
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             INSERT INTO user_relationship (user_0, user_1, relationship_type)
                  VALUES (:user_0, :user_1, :relationship_type)
@@ -90,7 +90,7 @@ def delete(user_0: int, user_1: int, relationship_type: str) -> None:
     if relationship_type not in VALID_RELATIONSHIP_TYPES:
         raise ValueError(f"Invalid relationship type: {relationship_type}")
 
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         connection.execute(sqlalchemy.text("""
             DELETE
               FROM user_relationship

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -58,7 +58,7 @@ def set_timezone(user_id: int, timezone_name: str):
         timezone_name (str): the user selected timezone name
 
     """
-    with db.engine.connect() as connection, connection.begin():
+    with db.engine.begin() as connection:
         try:
             connection.execute(sqlalchemy.text("""
                 INSERT INTO user_setting (user_id, timezone_name)

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -1,5 +1,4 @@
 import sqlalchemy
-from datetime import datetime, timedelta
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
 
@@ -59,7 +58,7 @@ def set_timezone(user_id: int, timezone_name: str):
         timezone_name (str): the user selected timezone name
 
     """
-    with db.engine.connect() as connection:
+    with db.engine.connect() as connection, connection.begin():
         try:
             connection.execute(sqlalchemy.text("""
                 INSERT INTO user_setting (user_id, timezone_name)

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -45,7 +45,7 @@ def create_user_timeline_event(
     """ Creates a user timeline event in the database and returns the event.
     """
     try:
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             result = connection.execute(sqlalchemy.text("""
                 INSERT INTO user_timeline_event (user_id, event_type, metadata)
                     VALUES (:user_id, :event_type, :metadata)
@@ -88,7 +88,7 @@ def delete_user_timeline_event(
 ) -> bool:
     ''' Deletes recommendation and notification event using id'''
     try:
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             result = connection.execute(sqlalchemy.text('''
                     DELETE FROM user_timeline_event
                     WHERE user_id = :user_id
@@ -119,7 +119,7 @@ def create_personal_recommendation_event(user_id: int, metadata:
         metadata key are the recommendee
     """
     try:
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             result = connection.execute(sqlalchemy.text("""
                 INSERT INTO user_timeline_event (user_id, event_type, metadata)
                     VALUES (
@@ -324,7 +324,7 @@ def get_user_notification_events(user_id: int, count: int = 50) -> List[UserTime
 def hide_user_timeline_event(user_id: int, event_type: UserTimelineEventType, event_id: int) -> bool:
     """ Adds events that are to be hidden """
     try:
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             result = connection.execute(sqlalchemy.text('''
                 INSERT INTO hide_user_timeline_event (user_id, event_type, event_id)
                     VALUES (:user_id, :event_type, :event_id)
@@ -364,7 +364,7 @@ def get_hidden_timeline_events(user_id: int, count: int) -> List[HiddenUserTimel
 def unhide_timeline_event(user: int, event_type: UserTimelineEventType, event_id: int) -> bool:
     ''' Deletes hidden timeline events for a user with specific row id '''
     try:
-        with db.engine.connect() as connection:
+        with db.engine.connect() as connection, connection.begin():
             result = connection.execute(sqlalchemy.text('''
                 DELETE FROM hide_user_timeline_event WHERE
                 user_id = :user_id AND

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -45,7 +45,7 @@ def create_user_timeline_event(
     """ Creates a user timeline event in the database and returns the event.
     """
     try:
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             result = connection.execute(sqlalchemy.text("""
                 INSERT INTO user_timeline_event (user_id, event_type, metadata)
                     VALUES (:user_id, :event_type, :metadata)
@@ -88,7 +88,7 @@ def delete_user_timeline_event(
 ) -> bool:
     ''' Deletes recommendation and notification event using id'''
     try:
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             result = connection.execute(sqlalchemy.text('''
                     DELETE FROM user_timeline_event
                     WHERE user_id = :user_id
@@ -119,7 +119,7 @@ def create_personal_recommendation_event(user_id: int, metadata:
         metadata key are the recommendee
     """
     try:
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             result = connection.execute(sqlalchemy.text("""
                 INSERT INTO user_timeline_event (user_id, event_type, metadata)
                     VALUES (
@@ -324,7 +324,7 @@ def get_user_notification_events(user_id: int, count: int = 50) -> List[UserTime
 def hide_user_timeline_event(user_id: int, event_type: UserTimelineEventType, event_id: int) -> bool:
     """ Adds events that are to be hidden """
     try:
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             result = connection.execute(sqlalchemy.text('''
                 INSERT INTO hide_user_timeline_event (user_id, event_type, event_id)
                     VALUES (:user_id, :event_type, :event_id)
@@ -364,7 +364,7 @@ def get_hidden_timeline_events(user_id: int, count: int) -> List[HiddenUserTimel
 def unhide_timeline_event(user: int, event_type: UserTimelineEventType, event_id: int) -> bool:
     ''' Deletes hidden timeline events for a user with specific row id '''
     try:
-        with db.engine.connect() as connection, connection.begin():
+        with db.engine.begin() as connection:
             result = connection.execute(sqlalchemy.text('''
                 DELETE FROM hide_user_timeline_event WHERE
                 user_id = :user_id AND

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -1,9 +1,7 @@
 import logging
-import os
 import random
 from time import time
 
-import psycopg2
 import sqlalchemy
 from brainzutils import cache
 from sqlalchemy import text
@@ -11,9 +9,8 @@ from sqlalchemy import text
 import listenbrainz.db.user as db_user
 from listenbrainz.db import timescale as ts, timescale
 from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
-from listenbrainz.listen import Listen
 from listenbrainz.listenstore.tests.util import create_test_data_for_timescalelistenstore
-from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT, REDIS_USER_TIMESTAMPS, \
+from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT, \
     TimescaleListenStore, REDIS_TOTAL_LISTEN_COUNT
 from listenbrainz.listenstore.timescale_utils import delete_listens_and_update_user_listen_data,\
     recalculate_all_user_data, add_missing_to_listen_users_metadata, update_user_listen_data
@@ -61,7 +58,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
                                (recording_msid, recording_mbid, match_type)
                         VALUES ('%s', '%s', 'exact_match')""" % (msid, '076255b4-1575-11ec-ac84-135bf6a670e3')
 
-        with ts.engine.connect() as connection:
+        with ts.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text(query))
             connection.execute(sqlalchemy.text(join_query))
 

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -58,7 +58,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
                                (recording_msid, recording_mbid, match_type)
                         VALUES ('%s', '%s', 'exact_match')""" % (msid, '076255b4-1575-11ec-ac84-135bf6a670e3')
 
-        with ts.engine.connect() as connection, connection.begin():
+        with ts.engine.begin() as connection:
             connection.execute(sqlalchemy.text(query))
             connection.execute(sqlalchemy.text(join_query))
 

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -52,7 +52,7 @@ class TimescaleListenStore:
         """When a user is created, set the timestamp keys and insert an entry in the listen count
          table so that we can avoid the expensive lookup for a brand new user."""
         query = """INSERT INTO listen_user_metadata VALUES (:user_id, 0, NULL, NULL, NOW())"""
-        with timescale.engine.connect() as connection, connection.begin():
+        with timescale.engine.begin() as connection:
             connection.execute(sqlalchemy.text(query), user_id=user_id)
 
     def get_listen_count_for_user(self, user_id: int):
@@ -475,7 +475,7 @@ class TimescaleListenStore:
             DELETE FROM listen WHERE user_id = :user_id;
         """
         try:
-            with timescale.engine.connect() as connection, connection.begin():
+            with timescale.engine.begin() as connection:
                 connection.execute(sqlalchemy.text(query), user_id=user_id)
         except psycopg2.OperationalError as e:
             self.log.error("Cannot delete listens for user: %s" % str(e))

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -52,7 +52,7 @@ class TimescaleListenStore:
         """When a user is created, set the timestamp keys and insert an entry in the listen count
          table so that we can avoid the expensive lookup for a brand new user."""
         query = """INSERT INTO listen_user_metadata VALUES (:user_id, 0, NULL, NULL, NOW())"""
-        with timescale.engine.connect() as connection:
+        with timescale.engine.connect() as connection, connection.begin():
             connection.execute(sqlalchemy.text(query), user_id=user_id)
 
     def get_listen_count_for_user(self, user_id: int):
@@ -475,7 +475,7 @@ class TimescaleListenStore:
             DELETE FROM listen WHERE user_id = :user_id;
         """
         try:
-            with timescale.engine.connect() as connection:
+            with timescale.engine.connect() as connection, connection.begin():
                 connection.execute(sqlalchemy.text(query), user_id=user_id)
         except psycopg2.OperationalError as e:
             self.log.error("Cannot delete listens for user: %s" % str(e))

--- a/listenbrainz/messybrainz/__init__.py
+++ b/listenbrainz/messybrainz/__init__.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional
 
 import sqlalchemy.exc
 
@@ -12,7 +13,7 @@ from listenbrainz.messybrainz import exceptions, data
 # This value must be incremented after schema changes on replicated tables!
 SCHEMA_VERSION = 1
 
-engine = None
+engine: Optional[sqlalchemy.engine.Engine] = None
 
 
 def init_db_connection(connect_str):

--- a/listenbrainz/messybrainz/tests/test_data.py
+++ b/listenbrainz/messybrainz/tests/test_data.py
@@ -47,49 +47,49 @@ recording_diff_case = {
 class DataTestCase(MessyBrainzTestCase):
 
     def test_get_id_from_meta_hash(self):
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             recording_msid = data.submit_recording(connection, recording)
             self.assertEqual(recording_msid, str(data.get_id_from_meta_hash(connection, recording)))
 
     def test_submit_recording(self):
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             recording_msid = data.submit_recording(connection, recording)
             self.assertEqual(recording_msid, str(data.get_id_from_recording(connection, recording)))
 
     def test_get_artist_credit(self):
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             recording_msid = data.submit_recording(connection, recording)
             artist_msid = data.get_artist_credit(connection, recording['artist'])
             recording_data = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertEqual(artist_msid, recording_data['ids']['artist_msid'])
 
     def test_get_release(self):
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             recording_msid = data.submit_recording(connection, recording)
             release_msid = data.get_release(connection, recording['release'])
             recording_data = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertEqual(release_msid, recording_data['ids']['release_msid'])
 
     def test_add_artist_credit(self):
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             artist_msid = data.add_artist_credit(connection, 'Kanye West')
             self.assertEqual(artist_msid, data.get_artist_credit(connection, 'Kanye West'))
 
     def test_add_release(self):
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             release_msid = data.add_release(connection, 'The College Dropout')
             self.assertEqual(release_msid, data.get_release(connection, 'The College Dropout'))
 
     def test_add_recording_different_cases(self):
         """ Tests that recordings with only case differences get the same MessyBrainz ID.
         """
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             msid1 = data.submit_recording(connection, recording)
             msid2 = str(data.get_id_from_recording(connection, recording_diff_case))
             self.assertEqual(msid1, msid2)
 
     def test_load_recordings_from_msids(self):
-        with messybrainz.engine.connect() as connection, connection.begin():
+        with messybrainz.engine.begin() as connection:
             recording_msid = data.submit_recording(connection, recording)
             result = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertDictEqual(result['payload'], recording)

--- a/listenbrainz/messybrainz/tests/test_data.py
+++ b/listenbrainz/messybrainz/tests/test_data.py
@@ -47,49 +47,49 @@ recording_diff_case = {
 class DataTestCase(MessyBrainzTestCase):
 
     def test_get_id_from_meta_hash(self):
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             recording_msid = data.submit_recording(connection, recording)
             self.assertEqual(recording_msid, str(data.get_id_from_meta_hash(connection, recording)))
 
     def test_submit_recording(self):
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             recording_msid = data.submit_recording(connection, recording)
             self.assertEqual(recording_msid, str(data.get_id_from_recording(connection, recording)))
 
     def test_get_artist_credit(self):
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             recording_msid = data.submit_recording(connection, recording)
             artist_msid = data.get_artist_credit(connection, recording['artist'])
             recording_data = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertEqual(artist_msid, recording_data['ids']['artist_msid'])
 
     def test_get_release(self):
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             recording_msid = data.submit_recording(connection, recording)
             release_msid = data.get_release(connection, recording['release'])
             recording_data = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertEqual(release_msid, recording_data['ids']['release_msid'])
 
     def test_add_artist_credit(self):
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             artist_msid = data.add_artist_credit(connection, 'Kanye West')
             self.assertEqual(artist_msid, data.get_artist_credit(connection, 'Kanye West'))
 
     def test_add_release(self):
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             release_msid = data.add_release(connection, 'The College Dropout')
             self.assertEqual(release_msid, data.get_release(connection, 'The College Dropout'))
 
     def test_add_recording_different_cases(self):
         """ Tests that recordings with only case differences get the same MessyBrainz ID.
         """
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             msid1 = data.submit_recording(connection, recording)
             msid2 = str(data.get_id_from_recording(connection, recording_diff_case))
             self.assertEqual(msid1, msid2)
 
     def test_load_recordings_from_msids(self):
-        with messybrainz.engine.connect() as connection:
+        with messybrainz.engine.connect() as connection, connection.begin():
             recording_msid = data.submit_recording(connection, recording)
             result = data.load_recordings_from_msids(connection, [recording_msid])[0]
             self.assertDictEqual(result['payload'], recording)

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -1000,4 +1000,11 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         self.assertEqual(1, len(events))
 
-        self.assertEqual(metadata, events[0].metadata.dict())
+        received = events[0].metadata.dict()
+        self.assertEqual(metadata["track_name"], received["track_name"])
+        self.assertEqual(metadata["artist_name"], received["artist_name"])
+        self.assertEqual(metadata["release_name"], received["release_name"])
+        self.assertEqual(metadata["recording_mbid"], received["recording_mbid"])
+        self.assertEqual(metadata["recording_msid"], received["recording_msid"])
+        self.assertEqual(metadata["blurb_content"], received["blurb_content"])
+        self.assertCountEqual(metadata["users"], received["users"])

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -265,7 +265,7 @@ class UserViewsTestCase(IntegrationTestCase):
         self.assert400(response, "Reason must be a string.")
 
     def test_user_pins(self):
-        with timescale.engine.connect() as connection:
+        with timescale.engine.connect() as connection, connection.begin():
             connection.execute(text("""
                 INSERT INTO mbid_mapping_metadata (artist_credit_id, recording_mbid, release_mbid, release_name,
                                                    artist_mbids, artist_credit_name, recording_name)

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -265,7 +265,7 @@ class UserViewsTestCase(IntegrationTestCase):
         self.assert400(response, "Reason must be a string.")
 
     def test_user_pins(self):
-        with timescale.engine.connect() as connection, connection.begin():
+        with timescale.engine.begin() as connection:
             connection.execute(text("""
                 INSERT INTO mbid_mapping_metadata (artist_credit_id, recording_mbid, release_mbid, release_name,
                                                    artist_mbids, artist_credit_name, recording_name)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=listenbrainz/tests/integration listenbrainz_spark relations listenbrainz/mbid_mapping
-addopts = --cov=listenbrainz --no-cov-on-fail
+addopts = -W always::DeprecationWarning --cov=listenbrainz --no-cov-on-fail

--- a/test.sh
+++ b/test.sh
@@ -230,7 +230,7 @@ if [ "$1" == "int" ]; then
     if [ -z "$*" ]; then
         TESTS_TO_RUN="listenbrainz/tests/integration"
     else
-        TESTS_TO_RUN="$*"
+        TESTS_TO_RUN="$@"
     fi
     echo "Running tests $TESTS_TO_RUN"
 
@@ -238,7 +238,7 @@ if [ "$1" == "int" ]; then
                   -wait tcp://lb_db:5432 -timeout 60s \
                   -wait tcp://redis:6379 -timeout 60s \
                   -wait tcp://rabbitmq:5672 -timeout 60s \
-                bash -c "pytest -W always::DeprecationWarning $TESTS_TO_RUN"
+                bash -c "pytest $TESTS_TO_RUN"
     RET=$?
     echo "Taking containers down"
     int_dcdown
@@ -315,13 +315,13 @@ if [ $DB_EXISTS -eq 1 -a $DB_RUNNING -eq 1 ]; then
     bring_up_unit_db
     unit_setup
     echo "Running tests"
-    docker_compose_run listenbrainz pytest "-W always::DeprecationWarning $*"
+    docker_compose_run listenbrainz pytest "$@"
     RET=$?
     unit_dcdown
     exit $RET
 else
     # Else, we have containers, just run tests
     echo "Running tests"
-    docker_compose_run listenbrainz pytest "-W always::DeprecationWarning $*"
+    docker_compose_run listenbrainz pytest "$@"
     exit $?
 fi

--- a/test.sh
+++ b/test.sh
@@ -227,10 +227,10 @@ if [ "$1" == "int" ]; then
     echo "Bringing containers up"
     bring_up_int_containers
     shift
-    if [ -z "$@" ]; then
+    if [ -z "$*" ]; then
         TESTS_TO_RUN="listenbrainz/tests/integration"
     else
-        TESTS_TO_RUN="$@"
+        TESTS_TO_RUN="$*"
     fi
     echo "Running tests $TESTS_TO_RUN"
 
@@ -238,7 +238,7 @@ if [ "$1" == "int" ]; then
                   -wait tcp://lb_db:5432 -timeout 60s \
                   -wait tcp://redis:6379 -timeout 60s \
                   -wait tcp://rabbitmq:5672 -timeout 60s \
-                bash -c "pytest $TESTS_TO_RUN"
+                bash -c "pytest -W always::DeprecationWarning $TESTS_TO_RUN"
     RET=$?
     echo "Taking containers down"
     int_dcdown
@@ -315,13 +315,13 @@ if [ $DB_EXISTS -eq 1 -a $DB_RUNNING -eq 1 ]; then
     bring_up_unit_db
     unit_setup
     echo "Running tests"
-    docker_compose_run listenbrainz pytest "$@"
+    docker_compose_run listenbrainz pytest "-W always::DeprecationWarning $*"
     RET=$?
     unit_dcdown
     exit $RET
 else
     # Else, we have containers, just run tests
     echo "Running tests"
-    docker_compose_run listenbrainz pytest "$@"
+    docker_compose_run listenbrainz pytest "-W always::DeprecationWarning $*"
     exit $?
 fi


### PR DESCRIPTION
This PR is the first in a series of PRs to prepare the codebase for upgrading to SQLAlchemy 2.0. The 2.0 version isn't out yet but we can use the future flag in version 1.4 to use the newer API. Some of these API changes are useful when migrating to transactional tests.

This PR enables the SQLAlchemy Deprecation warnings in tests and fixes one type of those warnings:

The current statement is being autocommitted using implicit autocommit, which will be removed in SQLAlchemy 2.0. Use the .begin() method of Engine or Connection in order to use an explicit transaction for DML and DDL statements.

(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

For rationale, see section: https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#library-level-but-not-driver-level-autocommit-removed-from-both-core-and-orm