### PR TITLE
Only pass text-wrapped string to connection.execute

### DIFF
--- a/listenbrainz/db/similar_users.py
+++ b/listenbrainz/db/similar_users.py
@@ -7,6 +7,7 @@ from psycopg2.errors import OperationalError
 from psycopg2.extras import execute_values
 import ujson
 from flask import current_app
+from sqlalchemy import text
 
 from listenbrainz import db
 
@@ -127,7 +128,7 @@ def get_top_similar_users(count: int = 200):
     similar_users = {}
     try:
         with db.engine.connect() as connection:
-            result = connection.execute("""
+            result = connection.execute(text("""
                 SELECT u.musicbrainz_id AS user_name
                      , ou.musicbrainz_id AS other_user_name
                      , value->1 AS similarity -- first element of array is similarity, second is global_similarity
@@ -138,7 +139,7 @@ def get_top_similar_users(count: int = 200):
                     ON j.key::int = ou.id  -- user_name of other user stored in jsonb
                   JOIN "user" u
                    ON r.user_id = u.id -- user_name of the user_id stored directly in column
-            """)
+            """))
             while True:
                 row = result.fetchone()
                 if not row:

--- a/listenbrainz/db/timescale.py
+++ b/listenbrainz/db/timescale.py
@@ -1,12 +1,10 @@
 from typing import Optional
 
 import sqlalchemy
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 import time
 import psycopg2
-
-from listenbrainz import config
 
 # The schema version of the timescale database (tables created
 # from ./admin/timescale/create-tables.sql). This includes user playlists
@@ -43,14 +41,12 @@ def init_db_connection(connect_str):
 
 
 def run_sql_script(sql_file_path):
-    with open(sql_file_path) as sql:
-        with engine.begin() as connection:
-            connection.execute(sql.read())
+    with open(sql_file_path) as sql, engine.begin() as connection:
+        connection.execute(text(sql.read()))
 
 
 def run_sql_script_without_transaction(sql_file_path):
-    with open(sql_file_path) as sql:
-        connection = engine.connect()
+    with open(sql_file_path) as sql, engine.connect() as connection:
         connection.connection.set_isolation_level(0)
         lines = sql.read().splitlines()
         retries = 0
@@ -62,7 +58,7 @@ def run_sql_script_without_transaction(sql_file_path):
                         # TODO: Not a great way of removing comments. The alternative is to catch
                         # the exception sqlalchemy.exc.ProgrammingError "can't execute an empty query"
                         if line and not line.startswith("--"):
-                            connection.execute(line)
+                            connection.execute(text(line))
                 break
             except sqlalchemy.exc.ProgrammingError as e:
                 print("Error: {}".format(e))
@@ -76,5 +72,4 @@ def run_sql_script_without_transaction(sql_file_path):
                 continue
             finally:
                 connection.connection.set_isolation_level(1)
-                connection.close()
         return True

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -193,7 +193,7 @@ def delete_listens():
     delete_user_metadata = "DELETE FROM listen_delete_metadata WHERE id <= :max_id"
 
     with timescale.engine.begin() as connection:
-        result = connection.execute(select_max_id)
+        result = connection.execute(text(select_max_id))
         row = result.fetchone()
 
         if not row:
@@ -264,7 +264,7 @@ def add_missing_to_listen_users_metadata():
     query = 'SELECT id FROM "user"'
     try:
         with db.engine.connect() as connection:
-            result = connection.execute(sqlalchemy.text(query))
+            result = connection.execute(text(query))
             for row in result:
                 user_list.append(row[0])
     except psycopg2.OperationalError as e:
@@ -299,7 +299,7 @@ def recalculate_all_user_data():
     query = 'SELECT id FROM "user"'
     try:
         with db.engine.connect() as connection:
-            result = connection.execute(sqlalchemy.text(query))
+            result = connection.execute(text(query))
             user_list = [row.id for row in result]
     except psycopg2.OperationalError:
         logger.error("Cannot query db to fetch user list", exc_info=True)

--- a/listenbrainz/messybrainz/__init__.py
+++ b/listenbrainz/messybrainz/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import sqlalchemy.exc
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 import sqlalchemy
 import psycopg2
@@ -29,15 +29,12 @@ def init_db_connection(connect_str):
 
 
 def run_sql_script(sql_file_path):
-    with open(sql_file_path) as sql:
-        connection = engine.connect()
-        connection.execute(sql.read())
-        connection.close()
+    with open(sql_file_path) as sql, engine.connect() as connection, connection.begin():
+        connection.execute(text(sql.read()))
 
 
 def run_sql_script_without_transaction(sql_file_path):
-    with open(sql_file_path) as sql:
-        connection = engine.connect()
+    with open(sql_file_path) as sql, engine.connect() as connection:
         connection.connection.set_isolation_level(0)
         lines = sql.read().splitlines()
         try:
@@ -45,13 +42,12 @@ def run_sql_script_without_transaction(sql_file_path):
                 # TODO: Not a great way of removing comments. The alternative is to catch
                 # the exception sqlalchemy.exc.ProgrammingError "can't execute an empty query"
                 if line and not line.startswith("--"):
-                    connection.execute(line)
+                    connection.execute(text(line))
         except sqlalchemy.exc.ProgrammingError as e:
             print("Error: {}".format(e))
             return False
         finally:
             connection.connection.set_isolation_level(1)
-            connection.close()
         return True
 
 


### PR DESCRIPTION
Builds on #2120

This PR fixes the warning:

Passing a string to Connection.execute() is deprecated and will be removed in version 2.0.  Use the text() construct, or the
Connection.exec_driver_sql() method to invoke a driver-level SQL string.
(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

For rationale, see section:
https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#execute-method-more-strict-execution-options-are-more-prominent
