### PR TITLE
Pass parameters to connection.execute() as a dictionary

### DIFF
--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -221,7 +221,7 @@ def get_feedback_count_for_recording(recording_type: str, recording: str) -> int
     """
     query = "SELECT count(*) AS value FROM recording_feedback WHERE " + recording_type + " = :recording"
     with db.engine.connect() as connection:
-        result = connection.execute(text(query), recording=recording)
+        result = connection.execute(text(query), {"recording": recording})
         count = int(result.fetchone().value)
     return count
 

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -68,7 +68,7 @@ def load_recordings_from_mapping(mbids: Iterable[str], msids: Iterable[str]) -> 
     """
 
     with timescale.engine.connect() as connection:
-        result = connection.execute(text(query), mbids=tuple(mbids), msids=tuple(msids))
+        result = connection.execute(text(query), {"mbids": tuple(mbids), "msids": tuple(msids)})
         rows = result.mappings().all()
 
         mbid_rows = {row["recording_mbid"]: row for row in rows if row["recording_mbid"] in mbids}

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -31,16 +31,18 @@ class MappingTestCase(TimescaleTestCase):
                                                        artist_mbids, artist_credit_name, recording_name)
                      VALUES (:artist_credit_id, :recording_mbid ::UUID, :release_mbid ::UUID, :release,
                              :artist_mbids ::UUID[], :artist, :title)
-                """), **recording)
+                """), recording)
 
             connection.execute(
                 text("""
                 INSERT INTO mbid_mapping (recording_msid, recording_mbid, match_type)
                                   VALUES (:recording_msid, :recording_mbid, :match_type)
             """),
-                recording_msid=recording["recording_msid"],
-                recording_mbid=recording["recording_mbid"],
-                match_type=match_type
+                {
+                    "recording_msid": recording["recording_msid"],
+                    "recording_mbid": recording["recording_mbid"],
+                    "match_type": match_type
+                }
             )
 
     def insert_recordings(self):

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -128,7 +128,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase, MessyBrainz
             query = """INSERT INTO mbid_mapping
                                    (recording_msid, recording_mbid, match_type, last_updated)
                             VALUES (:msid, '076255b4-1575-11ec-ac84-135bf6a670e3', 'exact_match', now())"""
-            connection.execute(sqlalchemy.text(query), msid=msids[0])
+            connection.execute(sqlalchemy.text(query), {"msid": msids[0]})
 
         pinned_recs = [
             {

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -222,12 +222,14 @@ class UserTestCase(DatabaseTestCase):
         with db.engine.begin() as connection:
             connection.execute(sqlalchemy.text(
                 "INSERT INTO recommendation.similar_user (user_id, similar_users) VALUES (:user_id, :similar_users)"),
-                user_id=searcher_id,
-                similar_users=json.dumps({
-                    str(user_id_c): [0.42, 0.20],
-                    str(user_id_l): [0.61, 0.25],
-                    str(user_id_r): [0.87, 0.43]
-                })
+                {
+                    "user_id": searcher_id,
+                    "similar_users": json.dumps({
+                        str(user_id_c): [0.42, 0.20],
+                        str(user_id_l): [0.61, 0.25],
+                        str(user_id_r): [0.87, 0.43]
+                    })
+                }
             )
 
         results = db_user.search("cif", 10, searcher_id)

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -451,7 +451,7 @@ def get_similar_users(user_id: int) -> Optional[SimilarUsers]:
               JOIN "user" u
                 ON j.key::int = u.id 
              WHERE user_id = :user_id
-        """), user_id=user_id)
+        """), {"user_id": user_id})
         users = {row.user_name: row.similarity for row in result.fetchall()}
         return SimilarUsers(user_id=user_id, similar_users=users)
 

--- a/listenbrainz/listenstore/tests/test_timescale_utils.py
+++ b/listenbrainz/listenstore/tests/test_timescale_utils.py
@@ -41,7 +41,7 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
                     SELECT count, min_listened_at, max_listened_at
                       FROM listen_user_metadata
                      WHERE user_id = :user_id
-                """), user_id=user["id"])
+                """), {"user_id": user["id"]})
             return result.fetchone()._asdict()
 
     def test_delete_listens_update_metadata(self):

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -253,7 +253,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
                     SELECT count, min_listened_at, max_listened_at
                       FROM listen_user_metadata
                      WHERE user_id = :user_id
-                """), user_id=user_id)
+                """), {"user_id": user_id})
             return result.fetchone()._asdict()
 
     def test_for_empty_timestamps(self):

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -204,16 +204,16 @@ def delete_listens():
         logger.info("Found max id in listen_delete_metadata table: %s", max_id)
 
         logger.info("Deleting Listens and updating affected listens counts")
-        connection.execute(text(delete_listens_and_update_listen_counts), max_id=max_id)
+        connection.execute(text(delete_listens_and_update_listen_counts), {"max_id": max_id})
 
         logger.info("Update minimum listen timestamp affected by deleted listens")
-        connection.execute(text(update_listen_min_ts), max_id=max_id)
+        connection.execute(text(update_listen_min_ts), {"max_id": max_id})
 
         logger.info("Update maximum listen timestamp affected by deleted listens")
-        connection.execute(text(update_listen_max_ts), max_id=max_id)
+        connection.execute(text(update_listen_max_ts), {"max_id": max_id})
 
         logger.info("Clean up listen delete metadata table")
-        connection.execute(text(delete_user_metadata), max_id=max_id)
+        connection.execute(text(delete_user_metadata), {"max_id": max_id})
 
         logger.info("Completed deleting listens and updating affected metadata")
 
@@ -247,7 +247,7 @@ def update_user_listen_data():
     # in remaining LB is beyond me then.
     with timescale.engine.begin() as connection:
         logger.info("Starting to update listen counts")
-        connection.execute(text(query), until=datetime.now())
+        connection.execute(text(query), {"until": datetime.now()})
         logger.info("Completed updating listen counts")
 
 

--- a/listenbrainz/messybrainz/data.py
+++ b/listenbrainz/messybrainz/data.py
@@ -126,7 +126,7 @@ def get_id_from_recording(connection, data):
                  LEFT JOIN recording_json sj
                         ON sj.id = s.data
                      WHERE sj.data_sha256 = :data_sha256""")
-    result = connection.execute(query, data_sha256=data_sha256)
+    result = connection.execute(query, {"data_sha256": data_sha256})
     if result.rowcount:
         return result.fetchone().gid
     else:
@@ -207,7 +207,7 @@ def load_recordings_from_msids(connection, messybrainz_ids):
                  LEFT JOIN recording AS r
                         ON rj.id = r.data
                      WHERE r.gid IN :msids""")
-    result = connection.execute(query, msids=tuple(messybrainz_ids))
+    result = connection.execute(query, {"msids": tuple(messybrainz_ids)})
 
     rows = result.fetchall()
     if not rows:

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -848,7 +848,14 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         self.assertEqual(1, len(events))
 
-        self.assertEqual(metadata, events[0].metadata.dict())
+        received = events[0].metadata.dict()
+        self.assertEqual(metadata["track_name"], received["track_name"])
+        self.assertEqual(metadata["artist_name"], received["artist_name"])
+        self.assertEqual(metadata["release_name"], received["release_name"])
+        self.assertEqual(metadata["recording_mbid"], received["recording_mbid"])
+        self.assertEqual(metadata["recording_msid"], received["recording_msid"])
+        self.assertEqual(metadata["blurb_content"], received["blurb_content"])
+        self.assertCountEqual(metadata["users"], received["users"])
 
     def test_personal_recommendation_checks_auth_token(self):
         user_one = db_user.get_or_create(2, "riksucks")


### PR DESCRIPTION
Based on #2121

The connection.execute() method in SQLAlchemy 2.0 will accept parameters as a single dictionary or a single sequence of dictionaries only. Parameters passed as keyword arguments, tuples or positionally oriented dictionaries and/or tuples will no longer be accepted.
(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

For rationale, see section:
https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#execute-method-more-strict-execution-options-are-more-prominent