### PR TITLE
Return event metadata from create_user_notification_event endpoint

### DIFF
--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -211,39 +211,40 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         # Adding notification to the db
         metadata_not = {"message": 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'}
         approved_user = db_user.get_or_create(11, "troi-bot")
-        self.client.post(
-            url_for('user_timeline_event_api_bp.create_user_notification_event',
-            user_name=self.user['musicbrainz_id']),
+        r = self.client.post(
+            url_for('user_timeline_event_api_bp.create_user_notification_event', user_name=self.user['musicbrainz_id']),
             data=json.dumps({"metadata": metadata_not}),
             headers={'Authorization': 'Token {}'.format(approved_user['auth_token'])}
         )
+        self.assert200(r)
+        notification_event_id = r.json["id"]
         # Adding recording recommendation to db
-        new_user = db_user.get_or_create(2, "riksucks")
+        new_user = db_user.get_or_create(202, "riksucks")
         metadata_rec = {
             'artist_name': 'Nujabes',
             'track_name': 'Aruarian Dance',
             'artist_msid':  str(uuid.uuid4()),
             'recording_msid': str(uuid.uuid4()),
         }
-        self.client.post(
+        r = self.client.post(
             url_for('user_timeline_event_api_bp.create_user_recording_recommendation_event',
-            user_name=new_user['musicbrainz_id']),
+                    user_name=new_user['musicbrainz_id']),
             data=json.dumps({'metadata': metadata_rec}),
             headers={'Authorization': 'Token {}'.format(new_user['auth_token'])},
         )
+        self.assert200(r)
+        rec_event_id = r.json["id"]
         # Deleting notification
         r_del_not = self.client.post(
-            url_for('user_timeline_event_api_bp.delete_feed_events',
-            user_name=self.user["musicbrainz_id"]),
-            data=json.dumps({'event_type': UserTimelineEventType.NOTIFICATION.value, 'id': 1}),
+            url_for('user_timeline_event_api_bp.delete_feed_events', user_name=self.user["musicbrainz_id"]),
+            data=json.dumps({'event_type': UserTimelineEventType.NOTIFICATION.value, 'id': notification_event_id}),
             headers={'Authorization': 'Token {}'.format(self.user['auth_token'])}
         )
         self.assert200(r_del_not)
 
         # Checking if notification still exists
         r_not = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed',
-            user_name=self.user['musicbrainz_id']),
+            url_for('user_timeline_event_api_bp.user_feed', user_name=self.user['musicbrainz_id']),
             headers={'Authorization': 'Token {}'.format(self.user['auth_token'])}
         )
         payload_not = r_not.json["payload"]
@@ -252,17 +253,15 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         # Deleting recommendation event
         r_del_rec = self.client.post(
-            url_for('user_timeline_event_api_bp.delete_feed_events',
-            user_name=new_user["musicbrainz_id"]),
-            data=json.dumps({'event_type': UserTimelineEventType.RECORDING_RECOMMENDATION.value, 'id': 2}),
+            url_for('user_timeline_event_api_bp.delete_feed_events', user_name=new_user["musicbrainz_id"]),
+            data=json.dumps({'event_type': UserTimelineEventType.RECORDING_RECOMMENDATION.value, 'id': rec_event_id}),
             headers={'Authorization': 'Token {}'.format(new_user['auth_token'])}
         )
         self.assert200(r_del_rec)
 
         # Checking if recording recommendation still exists
         r_rec = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed',
-            user_name=new_user['musicbrainz_id']),
+            url_for('user_timeline_event_api_bp.user_feed', user_name=new_user['musicbrainz_id']),
             headers={'Authorization': 'Token {}'.format(new_user['auth_token'])}
         )
         payload_rec = r_rec.json["payload"]

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -154,11 +154,14 @@ def create_user_notification_event(user_name):
     metadata = NotificationMetadata(creator=creator['musicbrainz_id'], message=message)
 
     try:
-        db_user_timeline_event.create_user_notification_event(user['id'], metadata)
+        event = db_user_timeline_event.create_user_notification_event(user['id'], metadata)
     except DatabaseException:
         raise APIInternalServerError("Something went wrong, please try again.")
 
-    return jsonify({'status': 'ok'})
+    event_data = event.dict()
+    event_data['created'] = event_data['created'].timestamp()
+    event_data['event_type'] = event_data['event_type'].value
+    return jsonify(event_data)
 
 
 @user_timeline_event_api_bp.route('/user/<user_name>/timeline-event/create/review', methods=['POST', 'OPTIONS'])


### PR DESCRIPTION
Currently, the notification event id is hardcoded in tests and it works fine because the relevant sequence is reset before each test. However, as a part of upcoming test speed improvements that will no longer be the case. So, we need to retrieve the event id from the api. We already return this metadata for other event types, so it should be fine.