### PR TITLE
Reduce time.sleep 's in tests

### DIFF
--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -23,7 +23,6 @@ import os
 import shutil
 import tempfile
 import time
-from time import sleep
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -125,11 +124,9 @@ class DumpManagerTestCase(DatabaseTestCase):
 
         listens = generate_data(1, self.user_name, 1500000000, 5)
         self.listenstore.insert(listens)
-        sleep(1)
 
         # create a full dump
-        self.runner.invoke(dump_manager.create_full, [
-                           '--location', self.tempdir])
+        self.runner.invoke(dump_manager.create_full, ['--location', self.tempdir])
         self.assertEqual(len(os.listdir(self.tempdir)), 1)
         dump_name = os.listdir(self.tempdir)[0]
 
@@ -179,7 +176,6 @@ class DumpManagerTestCase(DatabaseTestCase):
         base = int(time.time())
         dump_id = db_dump.add_dump_entry(base - 60)
         print("%d dump id" % dump_id)
-        sleep(1)
         self.listenstore.insert(generate_data(1, self.user_name, base - 30, 5))
         result = self.runner.invoke(dump_manager.create_incremental, [
                                     '--location', self.tempdir])
@@ -208,10 +204,7 @@ class DumpManagerTestCase(DatabaseTestCase):
         # create a base dump entry
         t = int(time.time())
         db_dump.add_dump_entry(t)
-        sleep(1)
-        self.listenstore.insert(generate_data(
-            1, self.user_name, 1500000000, 5))
-        sleep(1)
+        self.listenstore.insert(generate_data(1, self.user_name, 1500000000, 5))
 
         # create a new dump ID to recreate later
         dump_id = db_dump.add_dump_entry(int(time.time()))

--- a/listenbrainz/db/tests/test_user_relationship.py
+++ b/listenbrainz/db/tests/test_user_relationship.py
@@ -120,10 +120,10 @@ class UserRelationshipTestCase(DatabaseTestCase):
         db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
         db_user_relationship.insert(self.main_user['id'], self.followed_user_2['id'], 'follow')
 
-        time.sleep(3)
+        ts2 = time.time()
+
         new_user = db_user.get_or_create(4, 'new_user')
         db_user_relationship.insert(self.followed_user_1['id'], new_user['id'], 'follow')
-
 
         # max_ts is too low, won't return anything
         events = db_user_relationship.get_follow_events(
@@ -137,7 +137,7 @@ class UserRelationshipTestCase(DatabaseTestCase):
         # check that it honors min_ts as well
         events = db_user_relationship.get_follow_events(
             user_ids=(self.main_user['id'], self.followed_user_1['id']),
-            min_ts=ts + 1,
+            min_ts=ts2,
             max_ts=ts + 10,
             count=50
         )

--- a/listenbrainz/db/tests/test_user_timeline_event.py
+++ b/listenbrainz/db/tests/test_user_timeline_event.py
@@ -183,7 +183,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
             )
         )
 
-        time.sleep(3)
+        ts2 = time.time()
         new_user = db_user.get_or_create(4, 'new_user')
         db_user_timeline_event.create_user_track_recommendation_event(
             user_id=new_user['id'],
@@ -206,7 +206,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
         # check that it honors min_ts as well
         events = db_user_timeline_event.get_recording_recommendation_events_for_feed(
             user_ids=(self.user['id'], new_user['id']),
-            min_ts=ts + 1,
+            min_ts=ts2,
             max_ts=ts + 10,
             count=50,
         )

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -141,17 +141,20 @@ def get_following_for_user(user: int) -> List[dict]:
         return result.mappings().all()
 
 
-def get_follow_events(user_ids: Tuple[int], min_ts: int, max_ts: int, count: int) -> List[dict]:
+def get_follow_events(user_ids: Tuple[int], min_ts: float, max_ts: float, count: int) -> List[dict]:
     """ Gets a list of follow events for specified users.
 
-    user_ids is a tuple of user row IDs.
+    Args:
+        user_ids: is a tuple of user row IDs.
 
-    Returns a list of dicts of the following format:
-        {
-            user_name_0: str,
-            user_name_1: str,
-            created: datetime,
-        }
+    Returns:
+         a list of dicts of the following format:
+
+            {
+                user_name_0: str,
+                user_name_1: str,
+                created: datetime,
+            }
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -191,7 +191,8 @@ def get_user_track_recommendation_events(user_id: int, count: int = 50) -> List[
     )
 
 
-def get_recording_recommendation_events_for_feed(user_ids: List[int], min_ts: int, max_ts: int, count: int) -> List[UserTimelineEvent]:
+def get_recording_recommendation_events_for_feed(user_ids: List[int], min_ts: float, max_ts: float, count: int) \
+        -> List[UserTimelineEvent]:
     """ Gets a list of recording_recommendation events for specified users.
 
     user_ids is a tuple of user row IDs.

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -55,12 +55,13 @@ class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):
         count = 0
         while count < 10:
             count += 1
-            time.sleep(1)
 
             response = self.client.get(url, **kwargs)
             data = json.loads(response.data)['payload']
             if data['count'] == num_items:
                 break
+            time.sleep(0.5)
+
         return response
 
     def send_data(self, payload, user=None, recalculate=False):
@@ -78,9 +79,10 @@ class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):
             # recalculate only if asked because there are many tests for invalid
             # submissions or where we don't fetch listens. in those cases, this
             # sleep will add unnecessary slowness.
-            time.sleep(1)  # wait for listens to be picked up by timescale writer
+            time.sleep(0.5)  # wait for listens to be picked up by timescale writer
             recalculate_all_user_data()
         return response
+
 
 class APICompatIntegrationTestCase(APICompatServerTestCase, DatabaseTestCase, TimescaleTestCase):
 

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -286,8 +286,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
         time.sleep(1.1)
 
         # should have expired by now
-        r = self.client.get(url_for('api_v1.get_playing_now',
-                                    user_name=self.user['musicbrainz_id']))
+        r = self.client.get(url_for('api_v1.get_playing_now', user_name=self.user['musicbrainz_id']))
         self.assertEqual(r.json['payload']['count'], 0)
 
     def test_playing_now_with_duration_ms(self):

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -125,7 +125,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(expected, r.json)
 
         # Check if listen reached the timescale listenstore
-        time.sleep(1)
+        time.sleep(0.5)
         recalculate_all_user_data()
         listens, _, _ = self.ls.fetch_listens(self.lb_user, from_ts=data["timestamp[0]"]-1)
         self.assertEqual(len(listens), 1)
@@ -268,7 +268,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response['lfm']['scrobbles']['@accepted'], '1')
 
         # Check if listen reached the timescale listenstore
-        time.sleep(1)
+        time.sleep(0.5)
         recalculate_all_user_data()
         listens, _, _ = self.ls.fetch_listens(self.lb_user, from_ts=timestamp-1)
         self.assertEqual(len(listens), 1)
@@ -328,7 +328,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response['lfm']['scrobbles']['@accepted'], '2')
 
         # Check if listens reached the timescale listenstore
-        time.sleep(1)
+        time.sleep(0.5)
         recalculate_all_user_data()
         listens, _, _ = self.ls.fetch_listens(self.lb_user, from_ts=timestamp-1)
         self.assertEqual(len(listens), 2)

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -148,7 +148,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.assert200(r)
         self.assertEqual(r.data.decode('utf-8'), 'OK\n')
 
-        time.sleep(1)
+        time.sleep(0.5)
         recalculate_all_user_data()
         to_ts = int(time.time())
         listens, _, _ = self.ls.fetch_listens(self.user, to_ts=to_ts)

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -72,7 +72,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # This sleep allows for the timescale subscriber to take its time in getting
         # the listen submitted from redis and writing it to timescale.
-        time.sleep(2)
+        time.sleep(1)
 
         response = self.client.get(
             url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
@@ -124,7 +124,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             self.assert200(response)
             self.assertEqual(response.json['status'], 'ok')
 
-        time.sleep(5)
+        time.sleep(1)
 
         # max_ts = 2, should have sent back 2 listens
         r = self.client.get(
@@ -192,7 +192,6 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         new_user_1 = db_user.get_or_create(104, 'new_user_1')
         db_user_relationship.insert(self.following_user_1['id'], new_user_1['id'], 'follow')
 
-
         # this should show up in the events
         r = self.client.get(
             url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
@@ -232,7 +231,6 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
                 track_name="Lose yourself to dance",
                 artist_name="Daft Punk",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
 
@@ -243,10 +241,8 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
-
 
         # this should show up in the events
         r = self.client.get(
@@ -295,7 +291,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         new_user_1 = db_user.get_or_create(104, 'new_user_1')
         db_user_relationship.insert(self.following_user_1['id'], new_user_1['id'], 'follow')
 
-        time.sleep(1.5) # sleep a bit to avoid ordering conflicts, cannot mock this time as it comes from postgres
+        time.sleep(1)  # sleep a bit to avoid ordering conflicts, cannot mock this time as it comes from postgres
 
         # create a recording recommendation for a user we follow
         db_user_timeline_event.create_user_track_recommendation_event(
@@ -304,18 +300,17 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
                 track_name="Sunflower",
                 artist_name="Swae Lee & Post Malone",
                 recording_msid=str(uuid.uuid4()),
-                artist_msid=str(uuid.uuid4()),
             )
         )
 
-        time.sleep(2)
+        time.sleep(1)
 
         r = self.client.get(
             url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
         )
         self.assert200(r)
-        self.assertEqual(5, r.json['payload']['count']) # 3 events we created + 2 own follow events
+        self.assertEqual(5, r.json['payload']['count'])  # 3 events we created + 2 own follow events
         self.assertEqual('recording_recommendation', r.json['payload']['events'][0]['event_type'])
         self.assertEqual('follow', r.json['payload']['events'][1]['event_type'])
-        self.assertEqual('listen', r.json['payload']['events'][4]['event_type']) # last event should be a listen
+        self.assertEqual('listen', r.json['payload']['events'][4]['event_type'])  # last event should be a listen

--- a/listenbrainz/tests/integration/test_spotify_read_listens.py
+++ b/listenbrainz/tests/integration/test_spotify_read_listens.py
@@ -10,7 +10,9 @@ from listenbrainz.spotify_updater import spotify_read_listens
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from listenbrainz.db import external_service_oauth
 
+
 class SpotifyReaderTestCase(ListenAPIIntegrationTestCase):
+
     def setUp(self):
         super(SpotifyReaderTestCase, self).setUp()
         external_service_oauth.save_token(user_id=self.user['id'],
@@ -30,7 +32,7 @@ class SpotifyReaderTestCase(ListenAPIIntegrationTestCase):
         result = spotify_read_listens.process_all_spotify_users()
         self.assertEqual(result, (1, 0))
 
-        time.sleep(1)
+        time.sleep(0.5)
         recalculate_all_user_data()
 
         with open(self.path_to_data_file('spotify_recently_played_expected.json')) as f:


### PR DESCRIPTION
We had a few unnecessary time.sleep 's in tests, removed those to speed up tests. The remaining ones are in listen integration tests and cannot be removed entirely. Those sleeps are there to wait for timescale writer to pick up and insert the listens. Reducing the sleep duration there a bit to poll more frequently.