### PR TITLE
Create flask app once per TestCase

### DIFF
--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -16,6 +16,11 @@ TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.
 
 class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        ServerTestCase.setUpClass()
+        DatabaseTestCase.setUpClass()
+
     def setUp(self):
         ServerTestCase.setUp(self)
         DatabaseTestCase.setUp(self)
@@ -23,6 +28,11 @@ class IntegrationTestCase(ServerTestCase, DatabaseTestCase):
     def tearDown(self):
         ServerTestCase.tearDown(self)
         DatabaseTestCase.tearDown(self)
+
+    @classmethod
+    def tearDownClass(cls):
+        ServerTestCase.tearDownClass()
+        DatabaseTestCase.tearDownClass()
 
 
 class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -43,7 +43,6 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.log = logging.getLogger(__name__)
         self.ls = timescale_connection._ts
 
-
     def handshake(self, user_name, auth_token, timestamp):
         """ Makes a request to the handshake endpoint of the AudioScrobbler API and
             returns the response.
@@ -61,10 +60,8 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
         return self.client.get('/', query_string=args)
 
-
     def test_handshake(self):
         """ Tests handshake for a user that exists """
-
         timestamp = int(time.time())
         audioscrobbler_auth_token = _get_audioscrobbler_auth_token(self.user['auth_token'], timestamp)
 
@@ -78,7 +75,6 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
     def test_handshake_post(self):
         """ Tests POST requests to handshake endpoint """
-
         ts = int(time.time())
         args = {
             'hs': 'true',
@@ -98,13 +94,10 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.assertEqual(response[0], 'OK')
         self.assertEqual(len(response[1]), 32)
 
-
     def test_root_url_when_no_handshake(self):
         """ Tests the root url when there's no handshaking taking place """
-
         r = self.client.get('/')
         self.assertStatus(r, 302)
-
 
     def test_handshake_unknown_user(self):
         """ Tests handshake for user that is not in the db """
@@ -112,19 +105,16 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         r = self.handshake('', '', '')
         self.assert401(r)
 
-
     def test_handshake_invalid_auth(self):
         """ Tests handshake when invalid authorization token is sent """
 
         r = self.handshake(self.user['musicbrainz_id'], '', int(time.time()))
         self.assert401(r)
 
-
     def test_submit_listen(self):
         """ Sends a valid listen after handshaking and checks if it is present in the
             listenstore
         """
-
         timestamp = int(time.time())
         audioscrobbler_auth_token = _get_audioscrobbler_auth_token(self.user['auth_token'], timestamp)
 
@@ -154,7 +144,6 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         listens, _, _ = self.ls.fetch_listens(self.user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
-
     def test_submit_listen_invalid_sid(self):
         """ Tests endpoint for 400 Bad Request if invalid session id is sent """
 
@@ -173,10 +162,8 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.assert401(r)
         self.assertEqual(r.data.decode('utf-8'), 'BADSESSION\n')
 
-
     def test_submit_listen_invalid_data(self):
         """ Tests endpoint for 400 Bad Request if invalid data is sent """
-
         timestamp = int(time.time())
         audioscrobbler_auth_token = _get_audioscrobbler_auth_token(self.user['auth_token'], timestamp)
 
@@ -221,10 +208,8 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.assert400(r)
         self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')
 
-
     def test_playing_now(self):
         """ Tests playing now notifications """
-
         timestamp = int(time.time())
         audioscrobbler_auth_token = _get_audioscrobbler_auth_token(self.user['auth_token'], timestamp)
 
@@ -245,7 +230,6 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         self.assert200(r)
         self.assertEqual(r.data.decode('utf-8'), 'OK\n')
 
-
     def test_get_session(self):
         """ Tests _get_session method in api_compat_deprecated """
 
@@ -254,19 +238,16 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         session = _get_session(s.sid)
         self.assertEqual(s.sid, session.sid)
 
-
     def test_get_session_which_doesnt_exist(self):
         """ Make sure BadRequest is raised when we try to get a session that doesn't exists """
 
         with self.assertRaises(BadRequest):
             session = _get_session('')
 
-
     def test_404(self):
 
         r = self.client.get('/thisurldoesnotexist')
         self.assert404(r)
-
 
     def test_to_native_api_now_playing(self):
         """ Tests _to_native_api when used with data sent to the now_playing endpoint """
@@ -302,10 +283,8 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         native_data = _to_native_api(data, '')
         self.assertIsNone(native_data)
 
-
     def test_to_native_api(self):
         """ Tests _to_native_api with data that is sent to the submission endpoint """
-
         t = int(time.time())
 
         data = {

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -124,7 +124,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             self.assert200(response)
             self.assertEqual(response.json['status'], 'ok')
 
-        time.sleep(1)
+        time.sleep(2)
 
         # max_ts = 2, should have sent back 2 listens
         r = self.client.get(
@@ -155,7 +155,6 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             query_string={'min_ts': ts + 1}
         )
         self.assert200(r)
-        print(json.dumps(r.json))
         payload = self.remove_own_follow_events(r.json['payload'])
         self.assertEqual(4, payload['count'])
 

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -155,6 +155,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             query_string={'min_ts': ts + 1}
         )
         self.assert200(r)
+        print(json.dumps(r.json))
         payload = self.remove_own_follow_events(r.json['payload'])
         self.assertEqual(4, payload['count'])
 

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -35,7 +35,7 @@ class StatsAPITestCase(IntegrationTestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        couchdb.init(config.COUCHDB_USER, config.COUCHDB_ADMIN_KEY, config.COUCHDB_HOST, config.COUCHDB_PORT)
+        super(StatsAPITestCase, cls).setUpClass()
         stats = ["artists", "releases", "recordings", "daily_activity", "listening_activity", "artistmap"]
         ranges = ["week", "month", "year", "all_time"]
         for stat in stats:

--- a/listenbrainz/webserver/admin/test_admin.py
+++ b/listenbrainz/webserver/admin/test_admin.py
@@ -1,13 +1,11 @@
 import listenbrainz.db.user as db_user
+from listenbrainz.tests.integration import IntegrationTestCase
 
-from listenbrainz.webserver.testing import ServerTestCase
-from listenbrainz.db.testing import DatabaseTestCase
 
-class AdminTestCase(ServerTestCase, DatabaseTestCase):
+class AdminTestCase(IntegrationTestCase):
 
     def setUp(self):
-        ServerTestCase.setUp(self)
-        DatabaseTestCase.setUp(self)
+        IntegrationTestCase.setUp(self)
         self.authorized_user = db_user.get_or_create(1, 'iliekcomputers')
         db_user.agree_to_gdpr(self.authorized_user['musicbrainz_id'])
         self.unauthorized_user = db_user.get_or_create(2, 'blahblahblah')

--- a/listenbrainz/webserver/test/test_routes.py
+++ b/listenbrainz/webserver/test/test_routes.py
@@ -1,15 +1,10 @@
 import flask
 
-from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.webserver import API_PREFIX
 from listenbrainz.webserver.testing import ServerTestCase
 
 
-class RoutesTestCase(DatabaseTestCase, ServerTestCase):
-
-    def setUp(self):
-        ServerTestCase.setUp(self)
-        DatabaseTestCase.setUp(self)
+class RoutesTestCase(ServerTestCase):
 
     def test_routes_have_trailing_slash(self):
         """Check that all user-facing routes have a trailing /"""

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -1,9 +1,22 @@
-import flask_testing
+import unittest
+
+from flask import template_rendered, message_flashed
 
 from listenbrainz.webserver import create_api_compat_app, create_web_app
 
 
-class ServerTestCase(flask_testing.TestCase):
+class ServerTestCase(unittest.TestCase):
+    """ TestCase for Flask App tests, most of the code here has been borrowed from flask_testing.TestCase
+    (https://github.com/jarus/flask-testing/blob/5107691011fa891835c01547e73e991c484fa07f/flask_testing/utils.py#L118).
+    A key difference is that flask_testing's TestCase creates the flask app for each test method whereas
+    our ServerTestCase creates it once per class. flask_testing's test case allows also for custom Response mixins
+    and other stuff to be compatible across flask versions. Since, we don't need that the implementation can be
+    simplified.
+
+    Notably, the implementation of the setUpClass, setUp, tearDown, tearDownClass, assertMessageFlashed,
+    assertTemplateUsed has been adapted to use class level variables. The implementation of assertRedirects has been
+    modified to fix concerning absolute and relative urls in Location header.
+    """
 
     @classmethod
     def create_app(cls):
@@ -15,6 +28,87 @@ class ServerTestCase(flask_testing.TestCase):
         with self.client.session_transaction() as session:
             session['_user_id'] = user_login_id
             session['_fresh'] = True
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = cls.create_app()
+        cls.client = cls.app.test_client()
+
+        template_rendered.connect(cls._set_template)
+        message_flashed.connect(cls._add_flash_message)
+
+        cls.template = None
+        cls.flashed_messages = []
+
+    def setUp(self) -> None:
+        self._ctx = self.app.test_request_context()
+        self._ctx.push()
+
+        ServerTestCase.template = None
+        ServerTestCase.flashed_messages = []
+
+    @classmethod
+    def _add_flash_message(cls, app, message, category):
+        cls.flashed_messages.append((message, category))
+
+    @classmethod
+    def _set_template(cls, app, template, context):
+        cls.template = (template, context)
+
+    def tearDown(self):
+        self._ctx.pop()
+        del self._ctx
+        del ServerTestCase.template
+        del ServerTestCase.flashed_messages
+
+    @classmethod
+    def tearDownClass(cls):
+        template_rendered.disconnect(cls._set_template)
+        message_flashed.disconnect(cls._add_flash_message)
+        del cls.client
+        del cls.app
+
+    def assertMessageFlashed(self, message, category='message'):
+        """
+        Checks if a given message was flashed.
+        Only works if your version of Flask has message_flashed
+        signal support (0.10+) and blinker is installed.
+        :param message: expected message
+        :param category: expected message category
+        """
+        for _message, _category in ServerTestCase.flashed_messages:
+            if _message == message and _category == category:
+                return True
+
+        raise AssertionError("Message '%s' in category '%s' wasn't flashed" % (message, category))
+
+    def assertTemplateUsed(self, name):
+        """
+        Checks if a given template is used in the request.
+        Only works if your version of Flask has signals
+        support (0.6+) and blinker is installed.
+        If the template engine used is not Jinja2, provide
+        ``tmpl_name_attribute`` with a value of its `Template`
+        class attribute name which contains the provided ``name`` value.
+        :versionadded: 0.2
+        :param name: template name
+        """
+        used_template = ServerTestCase.template[0].name
+        self.assertEqual(used_template, name, f"Template {name} not used. Template used: {used_template}")
+
+    def get_context_variable(self, name):
+        context = ServerTestCase.template[1]
+        if name in context:
+            return context[name]
+        raise ValueError()
+
+    def assertContext(self, name, value, message=None):
+        try:
+            self.assertEqual(self.get_context_variable(name), value, message)
+        except ValueError:
+            self.fail(message or "Context variable does not exist: %s" % name)
+
+    assert_context = assertContext
 
     def assertRedirects(self, response, location, message=None, permanent=False):
         if permanent:
@@ -29,12 +123,34 @@ class ServerTestCase(flask_testing.TestCase):
         location_mismatch = "Expected redirect location %s but got %s" % (response.location, location)
         self.assertTrue(response.location.endswith(location), message or location_mismatch)
 
-    assert_redirects = assertRedirects
+    def assertStatus(self, response, status_code, message=None):
+        message = message or 'HTTP Status %s expected but got %s' \
+                             % (status_code, response.status_code)
+        self.assertEqual(response.status_code, status_code, message)
+
+    def assert200(self, response, message=None):
+        self.assertStatus(response, 200, message)
+
+    def assert400(self, response, message=None):
+        self.assertStatus(response, 400, message)
+
+    def assert401(self, response, message=None):
+        self.assertStatus(response, 401, message)
+
+    def assert403(self, response, message=None):
+        self.assertStatus(response, 403, message)
+
+    def assert404(self, response, message=None):
+        self.assertStatus(response, 404, message)
+
+    def assert500(self, response, message=None):
+        self.assertStatus(response, 500, message)
 
 
-class APICompatServerTestCase(flask_testing.TestCase):
+class APICompatServerTestCase(ServerTestCase):
 
-    def create_app(self):
+    @classmethod
+    def create_app(cls):
         app = create_api_compat_app()
         app.config['TESTING'] = True
         return app

--- a/listenbrainz/webserver/views/test/test_explore.py
+++ b/listenbrainz/webserver/views/test/test_explore.py
@@ -1,18 +1,12 @@
 import datetime
-from unittest import mock
 from unittest.mock import patch
 
 from flask import url_for
 
-from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.webserver.testing import ServerTestCase
+from listenbrainz.tests.integration import IntegrationTestCase
 
 
-class ExploreViewsTestCase(ServerTestCase, DatabaseTestCase):
-
-    def setUp(self):
-        ServerTestCase.setUp(self)
-        DatabaseTestCase.setUp(self)
+class ExploreViewsTestCase(IntegrationTestCase):
 
     def test_hue_sound(self):
         resp = self.client.get(url_for('explore.huesound', color="FF00FF"))

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -1,7 +1,6 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
-import ujson
 from flask import url_for
 from flask_login import login_required
 from requests.exceptions import HTTPError
@@ -9,16 +8,11 @@ from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import listenbrainz.db.user as db_user
 import listenbrainz.webserver.login
-from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.tests.integration import IntegrationTestCase
 from listenbrainz.webserver import create_web_app
-from listenbrainz.webserver.testing import ServerTestCase
 
 
-class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
-
-    def setUp(self):
-        ServerTestCase.setUp(self)
-        DatabaseTestCase.setUp(self)
+class IndexViewsTestCase(IntegrationTestCase):
 
     def test_index(self):
         resp = self.client.get(url_for('index.index'))
@@ -173,9 +167,9 @@ class IndexViewsTestCase(ServerTestCase, DatabaseTestCase):
 
         mock_user_get.return_value = user
 
-        @self.app.route('/page_that_returns_500')
+        @self.app.route('/page_that_returns_500_2')
         @login_required
-        def view500():
+        def view500_2():
             # flask-login user is loaded during @login_required, so check that the db has been queried
             mock_user_get.assert_called_with(user['login_id'])
             raise InternalServerError('error')

--- a/listenbrainz/webserver/views/test/test_player.py
+++ b/listenbrainz/webserver/views/test/test_player.py
@@ -1,14 +1,9 @@
 from flask import url_for
 
-from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.webserver.testing import ServerTestCase
+from listenbrainz.tests.integration import IntegrationTestCase
 
 
-class PlayerViewsTestCase(ServerTestCase, DatabaseTestCase):
-
-    def setUp(self):
-        ServerTestCase.setUp(self)
-        DatabaseTestCase.setUp(self)
+class PlayerViewsTestCase(IntegrationTestCase):
 
     def test_player_get_instant(self):
         resp = self.client.get(url_for('player.load_instant', recording_mbids="97e69767-5d34-4c97-b36a-f3b2b1ef9dae"))

--- a/listenbrainz/webserver/views/test/test_status.py
+++ b/listenbrainz/webserver/views/test/test_status.py
@@ -1,18 +1,10 @@
 from datetime import datetime, timedelta
-from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.webserver.testing import ServerTestCase
+from listenbrainz.tests.integration import IntegrationTestCase
 
 import listenbrainz.db.dump as db_dump
 
 
-class StatusViewsTestCase(ServerTestCase, DatabaseTestCase):
-    def setUp(self):
-        ServerTestCase.setUp(self)
-        DatabaseTestCase.setUp(self)
-
-    def tearDown(self):
-        ServerTestCase.tearDown(self)
-        DatabaseTestCase.tearDown(self)
+class StatusViewsTestCase(IntegrationTestCase):
 
     def test_dump_get_404(self):
         r = self.client.get("/1/status/get-dump-info", query_string={"id": 1})


### PR DESCRIPTION
To improve test speed, initialize the flask app only once per TestCase instead of doing it for each test case. This speeds up unit tests by 30-45s and integration tests by ~60s on wolf.