### PR TITLE
Relax ratelimit during PinnedRecordingAPI tests

### DIFF
--- a/listenbrainz/tests/integration/test_pinned_recording_api.py
+++ b/listenbrainz/tests/integration/test_pinned_recording_api.py
@@ -1,3 +1,5 @@
+from brainzutils import cache
+from brainzutils.ratelimit import set_rate_limits
 from flask import url_for
 from typing import List
 from unittest.mock import patch
@@ -19,8 +21,17 @@ def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRec
     return pins
 
 
-
 class PinnedRecAPITestCase(IntegrationTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(PinnedRecAPITestCase, cls).setUpClass()
+        set_rate_limits(5000, 50000, 10)
+
+    @classmethod
+    def tearDownClass(cls):
+        cache._r.flushdb()
+        super(PinnedRecAPITestCase, cls).tearDownClass()
 
     def setUp(self):
         super(PinnedRecAPITestCase, self).setUp()


### PR DESCRIPTION
There are a few pinned recording api tests that fails occasionally due to ratelimiting. So relax the ratelimit during PinnedRecordingAPI tests, if in future we see more tests failing due to rate limits we can probably move the rate limit relaxation logic to ServerTestCase.