### PR TITLE
Document permitted data types of metadata and validate release name

### DIFF
--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -167,56 +167,78 @@ submit them!
 
 The following optional elements may also be included in the ``track_metadata`` element:
 
-======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
-element                 description
-======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
-``release_name``        the name of the release this recording was played from.
-======================= ===========================================================================================================================================================================================================================================================================================================================================================================================================
+======================= ===========  =========================================================
+element                 data type    description
+======================= ===========  =========================================================
+``release_name``        string       the name of the release this recording was played from.
+======================= ===========  =========================================================
 
-The following optional elements may also be included in the ``additional_info`` element. If you do not have
-the data for any of the following fields, omit the key entirely:
+The following optional elements may also be included in the ``additional_info`` element.
 
-.. list-table:: Title
-   :widths: 25 50
+.. note::
+
+  If you do not have the data for any of the following fields, omit the key entirely:
+
+.. list-table:: Additional Info Fields
+   :widths: 25 10 40
    :header-rows: 1
 
    * - element
+     - data type
      - description
    * - ``artist_mbids``
+     - array of strings
      - A list of MusicBrainz Artist IDs, one or more Artist IDs may be included here. If you have a complete MusicBrainz artist credit that contains multiple Artist IDs, include them all in this list.
    * - ``release_group_mbid``
+     - string
      - A MusicBrainz Release Group ID of the release group this recording was played from.
    * - ``release_mbid``
+     - string
      - A MusicBrainz Release ID of the release this recording was played from.
    * - ``recording_mbid``
+     - string
      - A MusicBrainz Recording ID of the recording that was played.
    * - ``track_mbid``
+     - string
      - A MusicBrainz Track ID associated with the recording that was played.
    * - ``work_mbids``
+     - array of strings
      - A list of MusicBrainz Work IDs that may be associated with this recording.
    * - ``tracknumber``
+     - integer
      - The tracknumber of the recording. This first recording on a release is tracknumber 1.
    * - ``isrc``
+     - string
      - The ISRC code associated with the recording.
    * - ``spotify_id``
+     - string
      - The Spotify track URL associated with this recording.  e.g.: http://open.spotify.com/track/1rrgWMXGCGHru5bIRxGFV0
    * - ``tags``
+     - array of string
      - A list of user-defined folksonomy tags to be associated with this recording. For example, you have apply tags such as ``punk``, ``see-live``, ``smelly``. You may submit up to :data:`~listenbrainz.webserver.views.api_tools.MAX_TAGS_PER_LISTEN` tags and each tag may be up to :data:`~listenbrainz.webserver.views.api_tools.MAX_TAG_SIZE` characters large.
    * - ``media_player``
+     - string
      - The name of the program being used to listen to music. Don't include a version number here.
    * - ``media_player_version``
+     - string
      - The version of the program being used to listen to music.
    * - ``submission_client``
+     - string
      - The name of the client that is being used to submit listens to ListenBrainz. If the media player has the ability to submit listens built-in then this value may be the same as ``media_player``. Don't include a version number here.
    * - ``submission_client_version``
+     - string
      - The version of the submission client.
    * - ``music_service``
+     - string
      - If the song being listened to comes from an online service, the canonical domain of this service (see below for more details).
    * - ``music_service_name``
+     - string
      - If the song being listened to comes from an online service and you don't know the canonical domain, a name that represents the service.
    * - ``origin_url``
+     - string
      - If the song of this listen comes from an online source, the URL to the place where it is available. This could be a spotify url (see ``spotify_id``), a YouTube video URL, a Soundcloud recording page URL, or the full URL to a public MP3 file. If there is a webpage for this song (e.g. Youtube page, Soundcloud page) **do not** try and resolve the URL to an actual audio resource.
    * - ``duration_ms`` and ``duration``
+     - integer or float
      - The duration of the track in milliseconds and seconds respectively. You should only include one of ``duration_ms`` or ``duration``.
 .. note::
 

--- a/listenbrainz/testdata/invalid_release_name.json
+++ b/listenbrainz/testdata/invalid_release_name.json
@@ -1,0 +1,17 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": 1486449409,
+            "track_metadata": {
+                "artist_name": "Kanye West",
+                "track_name": "The Life of Pablo",
+                "release_name": 20,
+                "additional_info": {
+                    "listening_from": "spotify",
+                    "recording_msid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
+                }
+            }
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -385,6 +385,15 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
 
+    def test_invalid_release_name(self):
+        with open(self.path_to_data_file('invalid_release_name.json'), 'r') as f:
+            payload = json.load(f)
+
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+        self.assertEqual(response.json['error'], "track_metadata.release_name must be a single string.")
+
     def test_bad_track_name_format(self):
         """Test for invalid submission in which a listen has a track_name field but it's not a string"""
         with open(self.path_to_data_file('empty_track_name.json'), 'r') as f:

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -188,27 +188,9 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         raise ListenValidationError("JSON document may not have track_metadata with null value.", listen)
 
     # Basic metadata
-    if 'track_name' in listen['track_metadata']:
-        if not isinstance(listen['track_metadata']['track_name'], str):
-            raise ListenValidationError("track_metadata.track_name must be a single string.", listen)
-
-        listen['track_metadata']['track_name'] = listen['track_metadata']['track_name'].strip()
-        if len(listen['track_metadata']['track_name']) == 0:
-            raise ListenValidationError("required field track_metadata.track_name is empty.", listen)
-    else:
-        raise ListenValidationError("JSON document does not contain required track_metadata.track_name.", listen)
-
-
-    if 'artist_name' in listen['track_metadata']:
-        if not isinstance(listen['track_metadata']['artist_name'], str):
-            raise ListenValidationError("track_metadata.artist_name must be a single string.", listen)
-
-        listen['track_metadata']['artist_name'] = listen['track_metadata']['artist_name'].strip()
-        if len(listen['track_metadata']['artist_name']) == 0:
-            raise ListenValidationError("required field track_metadata.artist_name is empty.", listen)
-    else:
-        raise ListenValidationError("JSON document does not contain required track_metadata.artist_name.", listen)
-
+    validate_basic_metadata(listen, "track_name")
+    validate_basic_metadata(listen, "artist_name")
+    validate_basic_metadata(listen, "release_name", required=False)
 
     if 'additional_info' in listen['track_metadata']:
         # Tags
@@ -245,6 +227,18 @@ def validate_listen(listen: Dict, listen_type) -> Dict:
         check_for_unicode_null_recursively(listen)
 
     return listen
+
+
+def validate_basic_metadata(listen, key, required=True):
+    if key in listen["track_metadata"]:
+        if not isinstance(listen["track_metadata"][key], str):
+            raise ListenValidationError(f"track_metadata.{key} must be a single string.", listen)
+
+        listen['track_metadata'][key] = listen['track_metadata'][key].strip()
+        if len(listen['track_metadata'][key]) == 0:
+            raise ListenValidationError(f"field track_metadata.{key} is empty.", listen)
+    elif required:
+        raise ListenValidationError(f"JSON document does not contain required field track_metadata.{key}.", listen)
 
 
 def is_valid_uuid(u):


### PR DESCRIPTION
Document data type for various metadata fields to avoid possible confusion.

Also, The MsB lookup for release_msid when creating a new msid fails if the release name is an integer. This broke the TS Writer a few days ago. To avoid this in the future, validate release name in the API.

Preview of updated docs:
![image](https://user-images.githubusercontent.com/27751938/186746819-2db6e722-bc00-4cdc-b370-cd12c4b8c364.png)
