### PR TITLE
Fix country codes for North Korea and South Korea

### DIFF
--- a/listenbrainz/webserver/static/js/src/stats/world_countries.json
+++ b/listenbrainz/webserver/static/js/src/stats/world_countries.json
@@ -45236,7 +45236,7 @@
             "name": "Dem. Rep. Korea"
         },
         "type": "Feature",
-        "id": "KP"
+        "id": "PRK"
     },
     {
         "geometry": {
@@ -45327,7 +45327,7 @@
             "name": "Korea"
         },
         "type": "Feature",
-        "id": "KR"
+        "id": "KOR"
     }
     ]
   }


### PR DESCRIPTION
The stats endpoint returns country codes as ISO 3166 alpha-3 code via pycountry.
LB-1088 (#1958) separated the two countries on the world map, but incorrectly used two letter codes, breaking the map matching in the frontend.
This commit changes the country codes to the correct alpha-3 codes as defined by the ISO<sup>[[1]](https://www.iso.org/obp/ui/#iso:code:3166:KR), [[2]](https://www.iso.org/obp/ui/#iso:code:3166:KP)</sup>.


