### PR TITLE
Cache wordpress API locally in LB and serve to clients from the cache

### DIFF
--- a/listenbrainz/webserver/static/js/src/home/Blog.tsx
+++ b/listenbrainz/webserver/static/js/src/home/Blog.tsx
@@ -1,23 +1,23 @@
 import React, { useEffect, useState } from "react";
 
-const Blog = () => {
-  const [blogDetails, setBlogDetails] = useState([{}]);
+const Blog = ({ apiUrl }: { apiUrl: string }) => {
+  const [blogDetails, setBlogDetails] = useState<object[]>();
 
   const fetchBlogDetails = async () => {
     try {
-      let response: any = await fetch(
-        `https://public-api.wordpress.com/rest/v1.1/sites/blog.metabrainz.org/posts/`
-      );
-      response = await response.json();
-      const objectArray: any = [];
-      for (let postIndex = 0; postIndex <= 6; postIndex += 1) {
-        const object: any = {};
-        object.id = response.posts[postIndex].ID;
-        object.title = response.posts[postIndex].title;
-        object.link = response.posts[postIndex].URL;
-        objectArray.push(object);
+      let response: any = await fetch(`${window.location.origin}/blog-data/`);
+      if (response.status === 200) {
+        response = await response.json();
+        const objectArray: any = [];
+        for (let postIndex = 0; postIndex <= 6; postIndex += 1) {
+          const object: any = {};
+          object.id = response.posts[postIndex].ID;
+          object.title = response.posts[postIndex].title;
+          object.link = response.posts[postIndex].URL;
+          objectArray.push(object);
+        }
+        setBlogDetails(objectArray);
       }
-      setBlogDetails(objectArray);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e);
@@ -33,18 +33,20 @@ const Blog = () => {
         <strong>News & Updates</strong>
       </div>
       <div className="panel-body">
-        {blogDetails.map((post: any) => (
-          <li>
-            <a
-              href={post.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="card-link"
-            >
-              {post.title}
-            </a>
-          </li>
-        ))}
+        {blogDetails &&
+          blogDetails.map((post: any) => (
+            <li>
+              <a
+                href={post.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="card-link"
+              >
+                {post.title}
+              </a>
+            </li>
+          ))}
+        {!blogDetails && <li>None yet...</li>}
       </div>
       <div className="panel-footer center-p">
         <a

--- a/listenbrainz/webserver/static/js/src/home/Homepage.tsx
+++ b/listenbrainz/webserver/static/js/src/home/Homepage.tsx
@@ -29,7 +29,7 @@ import ErrorBoundary from "../utils/ErrorBoundary";
 document.addEventListener("DOMContentLoaded", () => {
   const domContainer = document.querySelector("#blogs");
   const { globalReactProps } = getPageProps();
-  const { sentry_dsn, sentry_traces_sample_rate } = globalReactProps;
+  const { api_url, sentry_dsn, sentry_traces_sample_rate } = globalReactProps;
 
   if (sentry_dsn) {
     Sentry.init({
@@ -41,7 +41,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   ReactDOM.render(
     <ErrorBoundary>
-      <Blog />
+      <Blog apiUrl={api_url} />
     </ErrorBoundary>,
     domContainer
   );

--- a/listenbrainz/webserver/templates/index/index.html
+++ b/listenbrainz/webserver/templates/index/index.html
@@ -1,4 +1,4 @@
-{%- extends 'base.html' -%}
+{%- extends 'base-react.html' -%}
 {%- block content -%}
   <div id="homepage" class="row">
       <h2 class="page-title">


### PR DESCRIPTION
# Problem
When a user visits LB, we shouldn't share their IP address to wordpress when we render the list of recent blog posts


# Solution
Add an endpoint on the LB server which downloads and caches the wordpress recent posts API endpoint. Cache this data for an hour, return an error back to the client and don't cache anything if wordpress returns us bad data.



