### PR TITLE
Fix invalid entries in canonical_recording_redirect table

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/bulk_table.py
+++ b/listenbrainz/mbid_mapping/mapping/bulk_table.py
@@ -132,6 +132,7 @@ class BulkInsertTable:
             This function will be called after the last row has been sent to process_row, so that
             any flushing/cleanup needed can be completed.
         """
+        return []
 
     def table_exists(self):
         """Check if the table for this bulk inserter exists.


### PR DESCRIPTION
## Problem

Here are two entries from the canonical_recording_redirect table which demonstrate the issue at hand:

|id     |recording_mbid                      |canonical_recording_mbid            |canonical_release_mbid              |
|-------|------------------------------------|------------------------------------|------------------------------------|
|7588031|00017a6b-8544-4f1b-a8da-2ff1f12a759b|ed9b3e75-a6c6-4584-9753-e244f604cda9|42de1934-589f-4fff-a40e-5dfb8130648f|
|5390082|bb3bd364-8468-47a8-b008-b029e935e1cc|00017a6b-8544-4f1b-a8da-2ff1f12a759b|140263a0-74da-41e9-a006-0ee1f849f085|

Note how `00017a6b-8544-4f1b-a8da-2ff1f12a759b` is present once as recording_mbid and once as canonical_recording_mbid.
Further, the canonical_musicbrainz_data table only has metadata row for `ed9b3e75-a6c6-4584-9753-e244f604cda9`. There is no metadata row for `00017a6b-8544-4f1b-a8da-2ff1f12a759b`. Looking at the recordings in MB, also we see that `bb3bd364-8468-47a8-b008-b029e935e1cc` should be redirected to `ed9b3e75-a6c6-4584-9753-e244f604cda9`.

## Debugging

To debug the issue, I started looking into the post process queries of canonical_musicbrainz_data table. I built the table till the inserts and then manually ran the query at

https://github.com/metabrainz/listenbrainz-server/blob/f4a2d0c96a190c75a9f24dee2440980aeafeadfb/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py#L84-L101

and its variants to narrow down the issue. The query seemed to return a correct set of rows for the mbids in the example above. After more looking, I found that there is another point of insert in canonical_recording_redirect table, in the process_row method. The inserts there are causing the problem.

https://github.com/metabrainz/listenbrainz-server/blob/f4a2d0c96a190c75a9f24dee2440980aeafeadfb/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py#L124-L145

Continuing with the three recording_mbids seen above, the insert query returns them in the following order:

| artist_credit_id | combined_lookup |            recording_mbid|
|------------------|-----------------|--------------------------------------|
|           221600 | lysspeechless   | ed9b3e75-a6c6-4584-9753-e244f604cda9|
|           349451 | lysspeechless   | 00017a6b-8544-4f1b-a8da-2ff1f12a759b|
|           349451 | lysspeechless   | bb3bd364-8468-47a8-b008-b029e935e1cc|

process_row receives the first row and sees that the combined_lookup is not present in self.artist_recordings so it adds it there for insertion in canonical_musicbrainz_data. after some time, process_row receives the second row. Since, the artist_credit_id changed self.artist_recordings has already been reset and does not have this combined lookup. It ends up treating the recording_mbid in the second row as a canonical one. Then the third row arrives, the artist credit id hasn't changed so the combined lookup is still present and the third row goes to else and gets treated as a redirect to the second row.

At this point, we have the following row in the canonical_recording_redirect table:

|id     |recording_mbid                      |canonical_recording_mbid            |canonical_release_mbid              |
|-------|------------------------------------|------------------------------------|------------------------------------|
|5390082|bb3bd364-8468-47a8-b008-b029e935e1cc|00017a6b-8544-4f1b-a8da-2ff1f12a759b|140263a0-74da-41e9-a006-0ee1f849f085|

and the following two rows in the canonical_musicbrainz_data table:

 |artist_credit_id | combined_lookup |            recording_mbid|
|------------------|-----------------|--------------------------------------|
|           221600 | lysspeechless   | ed9b3e75-a6c6-4584-9753-e244f604cda9|
|           349451 | lysspeechless   | 00017a6b-8544-4f1b-a8da-2ff1f12a759b|

After the insert query, post process queries run. The query linked previously finds that the first row in the table just before has a higher "score" than the second. It accordingly proceeds to delete the second row from the table and inserts its mbid in the canonical_recording_redirect table.

## Solution

The root cause of the issue is that the inserts in the process_row only consider recordings of a particular artist_credit_id at a time when inserting redirects. However, this inherently assumes that all recordings with the same combined_lookup also have the same artist_credit_id. This assumption is broken in the case of some recordings like we saw above.

To solve this, we can get rid of the if/else from process_row and always insert recordings unconditionally in the canonical_musicbrainz_data table. The post process query partitions on combined_lookup and correctly inserts the redirects. To weed out some redundant redirects where recording_mbid = canonical_recording_mbid, we also need to add a new where clause.

With this change, we get the expected rows in the canonical_recording_redirect table.

|   id    |            recording_mbid            |       canonical_recording_mbid       |        canonical_release_mbid |
|---------|--------------------------------------|--------------------------------------|-------------------------------------- |
| 2828751 | bb3bd364-8468-47a8-b008-b029e935e1cc | ed9b3e75-a6c6-4584-9753-e244f604cda9 | 42de1934-589f-4fff-a40e-5dfb8130648f |
| 2828752 | 00017a6b-8544-4f1b-a8da-2ff1f12a759b | ed9b3e75-a6c6-4584-9753-e244f604cda9 | 42de1934-589f-4fff-a40e-5dfb8130648f |
