### PR TITLE
Fix mb_metadata_cache for artists without type/gender

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -6,7 +6,7 @@ from psycopg2.errors import OperationalError
 import psycopg2.extras
 import ujson
 
-from mapping.utils import create_schema, insert_rows, log
+from mapping.utils import insert_rows, log
 from mapping.bulk_table import BulkInsertTable
 from mapping.canonical_release_redirect import CanonicalReleaseRedirect
 import config
@@ -244,7 +244,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 ON acn.artist_credit = ac.id
                               JOIN artist a
                                 ON acn.artist = a.id
-                              JOIN artist_type  at
+                         LEFT JOIN artist_type  at
                                 ON a.type = at.id
                          LEFT JOIN gender ag
                                 ON a.gender = ag.id

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -349,10 +349,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 ON acn.artist_credit = ac.id
                               JOIN artist a
                                 ON acn.artist = a.id
-                              JOIN artist_type  at
-                                ON a.type = at.id
-                              JOIN gender ag
-                                ON a.type = ag.id
                          LEFT JOIN artist_data ard
                                 ON ard.gid = r.gid
                          LEFT JOIN recording_rels rrl


### PR DESCRIPTION
The type/gender of an artist can be NULL and therefore the INNER JOINs removed in this commit is problematic. These JOINs exclude the recordings whose artists don't have a type/gender set from the mb_metadata_cache. We don't seem to use anything from type/gender table in the last select, so we can safely remove these.

To confirm this happens, let's take the example of this artist:
https://musicbrainz.org/artist/8ee49164-d82e-4bcd-9998-e66c13ede5b2

```
listenbrainz_ts=> select * from mapping.mb_metadata_cache where '8ee49164-d82e-4bcd-9998-e66c13ede5b2' = ANY(artist_mbids);
```
| dirty | recording_mbid | artist_mbids | release_mbid | recording_data | artist_data | tag_data | release_data |
|-------|----------------|--------------|--------------|----------------|-------------|----------|--------------|
(0 rows)

Also trying a random recording from the artist:
https://musicbrainz.org/recording/e015d46b-1c2a-45dc-bd3e-258026616ae6

```sql
select * from mapping.mb_metadata_cache where recording_mbid = 'e015d46b-1c2a-45dc-bd3e-258026616ae6';
```
| dirty | recording_mbid | artist_mbids | release_mbid | recording_data | artist_data | tag_data | release_data |
|-------|----------------|--------------|--------------|----------------|-------------|----------|--------------|
(0 rows)

Further, looking at the row count in mapping.mb_metadata_cache and
recording table we see that some rows are clearly missing from the cache
table.

```sql
select count(gid) from recording;
```
|  count   |
|----------|
| 27558428 |
(1 row)

```sql
select count(recording_mbid) from mapping.mb_metadata_cache;
```
|  count   |
|----------|
| 25580354 |
(1 row)

The number of recordings expected to be missing from the cache due to the problematic join is close but more than the actual missing number. I suspect some of those are recordings with multiple artists and another artist on the credit has type/gender set.

```sql
select count(r.gid) from recording r join artist_credit_name acn using (artist_credit) join artist a on acn.artist = a.id where a.type IS NULL;
```
|  count  |
|---------|
| 2330186 |
(1 row)
