### PR TITLE
Simplify mb_metadata_cache queries

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -170,10 +170,9 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 SELECT a.gid
                                      , array_agg(distinct(ARRAY[lt.name, url])) AS artist_links
                                   FROM recording r
-                                  JOIN artist_credit ac
-                                    ON r.artist_credit = ac.id
                                   JOIN artist_credit_name acn
-                                    ON acn.artist_credit = ac.id
+                                 USING (artist_credit)
+                                -- we cannot directly start as FROM artist a because the values_join JOINs on recording
                                   JOIN artist a
                                     ON acn.artist = a.id
                              LEFT JOIN l_artist_url lau
@@ -238,13 +237,11 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                                               ,ar.name
                                                               ,artist_links)) AS artist_data
                               FROM recording r
-                              JOIN artist_credit ac
-                                ON r.artist_credit = ac.id
                               JOIN artist_credit_name acn
-                                ON acn.artist_credit = ac.id
+                             USING (artist_credit)
                               JOIN artist a
                                 ON acn.artist = a.id
-                         LEFT JOIN artist_type  at
+                         LEFT JOIN artist_type at
                                 ON a.type = at.id
                          LEFT JOIN gender ag
                                 ON a.gender = ag.id
@@ -271,10 +268,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                             SELECT r.gid AS recording_mbid
                                  , array_agg(jsonb_build_array(t.name, count, a.gid, g.gid)) AS artist_tags
                               FROM recording r
-                              JOIN artist_credit ac
-                                ON r.artist_credit = ac.id
                               JOIN artist_credit_name acn
-                                ON acn.artist_credit = ac.id
+                             USING (artist_credit)
                               JOIN artist a
                                 ON acn.artist = a.id
                               JOIN artist_tag at

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -345,10 +345,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                               FROM recording r
                               JOIN artist_credit ac
                                 ON r.artist_credit = ac.id
-                              JOIN artist_credit_name acn
-                                ON acn.artist_credit = ac.id
-                              JOIN artist a
-                                ON acn.artist = a.id
                          LEFT JOIN artist_data ard
                                 ON ard.gid = r.gid
                          LEFT JOIN recording_rels rrl


### PR DESCRIPTION
1. Remove redundant joins in mb_metadata_cache query

   We join to artist and artist_credit_name in the last query in mb_metadata_cache but as far as I can see we don't use any data from those or removing the JOINs.

2. Remove JOINs to artist_credit where not needed

    At multiple places, we have JOINs of the form:

    ```sql
     FROM recording r
     JOIN artist_credit ac
       ON r.artist_credit = ac.id
     JOIN artist_credit_name acn
       ON acn.artist_credit = ac.id
     ```

     where we do not use the values of artist_credit table. In these cases we can simplify the JOINs to:

     ```sql
      FROM recording r
      JOIN artist_credit_name acn
   USING (artist_credit)
   ```