### PR TITLE
Fix check_dump_ages

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -908,7 +908,6 @@ def _fetch_latest_file_info_from_ftp_dir(directory: str, has_id: bool):
 
     def process_line(file):
         nonlocal latest_dump_id, latest_dt
-        file = file[56:].strip()
         if file:
             if has_id:
                 dump_id, dt = _parse_ftp_name_with_id(file)
@@ -922,7 +921,7 @@ def _fetch_latest_file_info_from_ftp_dir(directory: str, has_id: bool):
     ftp = FTP(MAIN_FTP_SERVER_URL)
     ftp.login()
     ftp.cwd(directory)
-    ftp.retrlines('LIST', process_line)
+    ftp.retrlines('NLST', process_line)
 
     return latest_dump_id, latest_dt
 


### PR DESCRIPTION
We recently reached id 1000 for listen dumps which means for first time since check_dump_ages was added, the alphabetical order of sorting ids is not the same as the actual numerical order. This creates a problem that LIST seemingly returns results in alphabetical order, and thus it daily returns the dump with id 999 and parses its info emailing us that dumps are old.

To fix this parse all dump lines returned by LIST. Parsing gives us the dump_id as a number and the dump creation time as datetime. Using the dump creation time find the latest dump and then do the comparison on it.