### PR TITLE
Remove fresh_releases from website

### DIFF
--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -39,7 +39,6 @@
              Explore<span class="caret"></span>
           </a>
           <ul class="dropdown-menu" role="menu">
-            <li><a href="{{ url_for('explore.fresh_releases') }}">Fresh Releases</a></li>
             <li><a href="{{ url_for('explore.huesound') }}">Hue Sound</a></li>
             <li><a href="{{ url_for('explore.similar_users') }}">Top similar users</a></li>
             <li><a href="{{ url_for('user.year_in_music', user_name=current_user.musicbrainz_id) }}">Your Year In Music</a></li>

--- a/listenbrainz/webserver/views/explore.py
+++ b/listenbrainz/webserver/views/explore.py
@@ -28,13 +28,3 @@ def similar_users():
         "explore/similar-users.html",
         similar_users=similar_users
     )
-
-
-@explore_bp.route("/fresh-releases/")
-def fresh_releases():
-    """ Explore fresh releases """
-
-    return render_template(
-        "explore/fresh-releases.html",
-        props=ujson.dumps({})
-    )

--- a/listenbrainz/webserver/views/test/test_explore.py
+++ b/listenbrainz/webserver/views/test/test_explore.py
@@ -30,10 +30,6 @@ class ExploreViewsTestCase(ServerTestCase, DatabaseTestCase):
         resp = self.client.get(url_for('index.similar_users'))
         self.assertStatus(resp, 302)
 
-    def test_fresh_releases(self):
-        resp = self.client.get(url_for('explore.fresh_releases'))
-        self.assert200(resp)
-
     @patch('listenbrainz.db.fresh_releases.get_sitewide_fresh_releases')
     def test_fresh_releases_api(self, mock_fresh):
         resp = self.client.get(url_for('explore_api_v1.get_fresh_releases'))


### PR DESCRIPTION
The feature is still pending so removing from website. The API endpoint backing it is ready so keeping it as is.