### PR TITLE
Update start-spark-request-consumer.sh

### DIFF
--- a/docker/start-spark-request-consumer.sh
+++ b/docker/start-spark-request-consumer.sh
@@ -1,3 +1,4 @@
+  GNU nano 4.8                                                                      docker/start-spark-request-consumer.sh                                                                       Modified
 #!/bin/bash
 set -e
 
@@ -21,15 +22,13 @@ zip -rq listenbrainz_spark_request_consumer.zip listenbrainz_spark/
 zip -rq models.zip data/
 
 source spark_config.sh
-spark-submit \
-        --packages org.apache.spark:spark-avro_2.12:3.1.1 \
-        --master yarn \
-        --conf "spark.yarn.dist.archives"=pyspark_venv.tar.gz#environment \
+"${SPARK_HOME}/bin/spark-submit" \
+        --master spark://leader:7077 \
+        --archives "pyspark_venv.tar.gz#environment" \
         --conf "spark.scheduler.listenerbus.eventqueue.capacity"=$LISTENERBUS_CAPACITY \
         --conf "spark.cores.max"=$MAX_CORES \
-        --conf "spark.executor.cores"=$EXECUTOR_CORES \
-        --conf "spark.executor.memory"=$EXECUTOR_MEMORY \
-        --conf "spark.driver.memory"=$DRIVER_MEMORY \
-        --conf "spark.yarn.appMasterEnv.GIT_SHA"=$GIT_COMMIT_SHA \
+        --executor-cores $EXECUTOR_CORES \
+        --executor-memory $EXECUTOR_MEMORY \
+        --driver-memory $DRIVER_MEMORY \
         --py-files listenbrainz_spark_request_consumer.zip,models.zip \
     spark_manage.py request_consumer


### PR DESCRIPTION
These changes are part of the move from yarn to spark standalone cluster . I had forgotten to check in these changes earlier and only realised it when debugging the cluster's failure to launch after today's release.