### PR TITLE
Footer typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## About
 
-ListenBrainz keeps tracks of what music you listen to and
+ListenBrainz keeps track of music you listen to and
 provides you with insights into your listening habits. We're
 completely open-source and publish our data as open data.
 

--- a/listenbrainz/webserver/templates/base.html
+++ b/listenbrainz/webserver/templates/base.html
@@ -48,7 +48,7 @@
           </h3>
           <br/>
           <p class="color-gray">
-            ListenBrainz keeps tracks of what music you listen to and provides you with insights into your listening habits.
+            ListenBrainz keeps track of music you listen to and provides you with insights into your listening habits.
             <br>
             You can use ListenBrainz to track your listening habits, discover new music with personalized recommendations, and share your musical taste with others using our visualizations.
           </p>

--- a/listenbrainz/webserver/templates/index/index.html
+++ b/listenbrainz/webserver/templates/index/index.html
@@ -5,7 +5,7 @@
         Visualize and share your music listening history
       </h2>
       <p>
-        ListenBrainz keeps tracks of what music you listen to and
+        ListenBrainz keeps track of music you listen to and
         provides you with insights into your listening habits.
         <br>
         We're completely open-source and publish our data as open data.


### PR DESCRIPTION
# Problem

Typo in the footer.

# Solution

Removed the extra ‘s’, removed an extraneous word while I was at it.
Text could be made a bit more snappy in general but just fixing the typo for now!