### PR TITLE
Fix test_get_listens_ts_unavailable

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -1,5 +1,6 @@
 import json
 import time
+from unittest.mock import patch
 
 import pytest
 from flask import url_for
@@ -8,7 +9,6 @@ import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 from listenbrainz import db
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
-from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
 
@@ -35,10 +35,9 @@ class APITestCase(ListenAPIIntegrationTestCase):
             url, query_string={'max_ts': '1400000000', 'min_ts': '1500000000'})
         self.assert400(response)
 
+    @patch("listenbrainz.webserver.timescale_connection._ts", None)
     def test_get_listens_ts_unavailable(self):
         """Check that an error message is returned if the listenstore is unavailable"""
-        timescale_connection._ts = None
-
         url = url_for('api_v1.get_listens',
                       user_name=self.user['musicbrainz_id'])
         response = self.client.get(url)


### PR DESCRIPTION
This test sets timescale_connection._ts to None in order to test the behaviour when listenstore behaviour. However, it never reverts the listenstore to its actual value. This is an issue since we do not create a flask app for every method now but only once per class. Any call to get listens endpoint in any test run after this test in the same class will fail with a 503.

Use mock.patch to auto restore the value after the test to fix the issue.