### PR TITLE
Improve handling of duration/duration_ms fields in listen submission json

### DIFF
--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -238,7 +238,7 @@ The following optional elements may also be included in the ``additional_info`` 
      - string
      - If the song of this listen comes from an online source, the URL to the place where it is available. This could be a spotify url (see ``spotify_id``), a YouTube video URL, a Soundcloud recording page URL, or the full URL to a public MP3 file. If there is a webpage for this song (e.g. Youtube page, Soundcloud page) **do not** try and resolve the URL to an actual audio resource.
    * - ``duration_ms`` and ``duration``
-     - integer or float
+     - integer
      - The duration of the track in milliseconds and seconds respectively. You should only include one of ``duration_ms`` or ``duration``.
 .. note::
 

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -539,6 +539,21 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json['status'], 'ok')
 
+    def test_string_duration_conversion(self):
+        """Test that api converts string durations to integer if possible (but users are discouraged from doing this)"""
+        with open(self.path_to_data_file('valid_duration.json'), 'r') as f:
+            payload = json.load(f)
+        payload["payload"][0]["track_metadata"]["additional_info"]["duration_ms"] = "300000"
+
+        response = self.send_data(payload, recalculate=True)
+        self.assert200(response)
+        self.assertEqual(response.json['status'], 'ok')
+
+        url = url_for('api_v1.get_listens', user_name=self.user['musicbrainz_id'])
+        response = self.wait_for_query_to_have_items(url, 1, query_string={'count': '1'})
+        self.assert200(response)
+        self.assertEqual(300000, response.json["payload"]["listens"][0]["track_metadata"]["additional_info"]["duration_ms"])
+
     def test_unicode_null_error(self):
         with open(self.path_to_data_file('listen_having_unicode_null.json'), 'r') as f:
             payload = json.load(f)

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Dict, Tuple
 from urllib.parse import urlparse
 
@@ -273,12 +272,17 @@ def log_raise_400(msg, data=""):
 
 
 def validate_duration_field(listen, key):
-    if key in listen['track_metadata']['additional_info']:
-        duration = listen['track_metadata']['additional_info'][key]
+    additional_info = listen["track_metadata"]["additional_info"]
+    if key in additional_info:
+        duration = additional_info[key]
         try:
+            # the listen submission docs say we accept only integers for duration fields, but the current validation
+            # also allows strings if those are convertible to integers. we need this to work around api_compat quirks.
+            # see commit message for details.
             value = int(duration)
             if value <= 0:
                 raise ListenValidationError(f"Value for {key} is invalid, should be a positive integer.", listen)
+            additional_info[key] = value
         except (ValueError, TypeError):
             raise ListenValidationError(f"Value for {key} is invalid, should be a positive integer.", listen)
 


### PR DESCRIPTION
While validation duration fields, we try converting duration to integer and check if its positive. However, we do not assign the int value back to the original listen. So, the value stored in the duration field can be a string while still passing validation.

Ideally, we'd reject integers sent as string in duration field but since this validation code is shared with api_compat we can't easily do so.

https://github.com/metabrainz/listenbrainz-server/blob/789cc5383a877fc2ecf2e27bb6001ad27920cb54/listenbrainz/webserver/views/api_compat.py#L85

This line returns even int values as strings, there are two int fields in api compat. listened_at and duration, we already have the same handling for listened_at field as this PR adds for duration.
