### PR TITLE
Don't fail webpack build for style issues in development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = function (env, argv) {
     }),
     new StylelintPlugin({
       configFile: ".stylelintrc.js",
+      failOnError: isProd,
       files: "**/static/css/**/*.less",
       fix: !isProd,
       threads: true,


### PR DESCRIPTION
As requested by @alastair

In development mode, configure the Stylelint webpack plugin to not fail module compilation if there is a linting error.
This does not change the production mechanism, so CI tests will still fail on linting errors.
