### PR TITLE
Fix msb indices and transfer script

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -36,7 +36,12 @@ CREATE INDEX last_updated_ndx_mbid_mapping ON mbid_mapping (last_updated);
 
 -- messybrainz
 CREATE UNIQUE INDEX messybrainz_gid_ndx ON messybrainz.submissions (gid);
--- can't have a unique index here due to historical duplicates
-CREATE INDEX messybrainz_data_ndx ON messybrainz.submissions (lower(recording), lower(artist_credit), lower(release), lower(track_number), duration);
+-- can't use a single index here because some values in these columns are too large and exceed the max
+-- index size allowed when used together.
+CREATE INDEX messybrainz_recording_ndx ON messybrainz.submissions (lower(recording));
+CREATE INDEX messybrainz_artist_credit_ndx ON messybrainz.submissions (lower(artist_credit));
+CREATE INDEX messybrainz_release_ndx ON messybrainz.submissions (lower(release));
+CREATE INDEX messybrainz_track_number_ndx ON messybrainz.submissions (lower(track_number));
+CREATE INDEX messybrainz_duration_ndx ON messybrainz.submissions (duration);
 
 COMMIT;

--- a/admin/timescale/updates/2022-09-11-migrate-msb.sql
+++ b/admin/timescale/updates/2022-09-11-migrate-msb.sql
@@ -14,8 +14,13 @@ CREATE TABLE messybrainz.submissions (
 );
 
 CREATE UNIQUE INDEX messybrainz_gid_ndx ON messybrainz.submissions (gid);
--- can't have a unique index here due to historical duplicates
-CREATE INDEX messybrainz_data_ndx ON messybrainz.submissions (lower(recording), lower(artist_credit), lower(release), lower(track_number), duration);
+-- can't use a single index here because some values in these columns are too large and exceed the max
+-- index size allowed when used together.
+CREATE INDEX messybrainz_recording_ndx ON messybrainz.submissions (lower(recording));
+CREATE INDEX messybrainz_artist_credit_ndx ON messybrainz.submissions (lower(artist_credit));
+CREATE INDEX messybrainz_release_ndx ON messybrainz.submissions (lower(release));
+CREATE INDEX messybrainz_track_number_ndx ON messybrainz.submissions (lower(track_number));
+CREATE INDEX messybrainz_duration_ndx ON messybrainz.submissions (duration);
 
 
 COMMIT;

--- a/listenbrainz/messybrainz/transfer_to_timescale.py
+++ b/listenbrainz/messybrainz/transfer_to_timescale.py
@@ -65,6 +65,7 @@ def insert_data(values):
         -- MsB so existing data in MsB will not have this field
         INSERT INTO messybrainz.submissions (gid, recording, artist_credit, release, track_number, submitted)
              VALUES %s
+             ON CONFLICT (gid) DO NOTHING
     """
     with raw_conn.cursor() as curs:
         execute_values(curs, query, values)


### PR DESCRIPTION
The original index creation statement failed with:

listenbrainz_ts=> CREATE INDEX messybrainz_data_ndx ON messybrainz.submissions (lower(recording), lower(artist_credit), lower(release), lower(track_number), duration); ERROR:  index row size 2784 exceeds btree version 4 maximum 2704 for index "messybrainz_data_ndx" DETAIL:  Index row references tuple (549197,1) in relation "submissions". HINT:  Values larger than 1/3 of a buffer page cannot be indexed. Consider a function index of an MD5 hash of the value, or use full text indexing.

For now, create separate index on each column to workaround.

Also, since we have a UNIQUE index in place on the table now, use it to avoid duplicates from the transfer script (it currently duplicates the last transferred row on the next run).
