### PR TITLE
Coerce track_number to str in messybrainz

### DIFF
--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -76,8 +76,10 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
                 'artist': listen['track_metadata']['artist_name'],
                 'title': listen['track_metadata']['track_name'],
                 'release': listen['track_metadata'].get('release_name'),
-                'track_number': listen['track_metadata']['additional_info'].get('track_number')
             }
+            track_number = listen['track_metadata']['additional_info'].get('track_number')
+            if track_number:
+                data['track_number'] = str(track_number)
 
             duration = listen['track_metadata']['additional_info'].get('duration')
             if duration:


### PR DESCRIPTION
track_number in messybrainz is string because of historical values that are string. But some listens also send track numbers as integers so changing it to str before passing it to messybrainz.

Not doing this on api level yet, because I want to have discussion about track_number field in general.