### PR TITLE
Add foobar2000 player and its plugin to compatible players list

### DIFF
--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -8,15 +8,16 @@
     These are programs that submit listens to ListenBrainz:
   </p>
   <ul>
-    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, a flexible, powerful, server-side application for playing music: <a href="https://codeberg.org/elomatreb/listenbrainz-mpd"><code>listenbrainz-mpd</code></a>, <a href="https://github.com/kori/wylt"><code>wylt</code></a></li>
+    <li><em><a href="https://www.videolan.org/vlc/">VLC</a></em>, cross-platform multimedia player: <a href="https://github.com/amCap1712/vlc-listenbrainz-plugin"><code>VLC Listenbrainz plugin</code></a></li>
+    <li><em><a href="https://www.musicpd.org/">mpd</a></em>, cross-platform server-side application for playing music: <a href="https://codeberg.org/elomatreb/listenbrainz-mpd"><code>listenbrainz-mpd</code></a>, <a href="https://github.com/kori/wylt"><code>wylt</code></a></li>
+    <li><em><a href="https://www.foobar2000.org/">Foobar2000</a></em>, full-fledged audio player for Windows: <a href="https://github.com/phw/foo_listenbrainz2"><code>foo_listenbrainz2</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
     <li><em><a href="https://github.com/InputUsername/rescrobbled">Rescrobbled</a></em>, a universal Linux scrobbler for MPRIS enabled players</li>
-    <li><em><a href="https://add0n.com/lastfm-scrobbler.html">Last.fm Scrobbler</a></em>, an extension for Firefox and Chrome</li>
     <li><em><a href="https://github.com/tgwizard/sls">Simple Last.fm Scrobbler</a></em>, for Android devices</li>
-    <li><em><a href="https://github.com/amCap1712/vlc-listenbrainz-plugin">VLC Listenbrainz plugin</a></em>, cross-platform plugin for VLC player</li>
-    <li><em><a href="https://web-scrobbler.com/">Web Scrobbler</a></em>, an extension for Firefox and Chromium-based browsers</li>
     <li><em><a href="https://play.google.com/store/apps/details?id=com.arn.scrobble">Pano Scrobbler</a></em>, a scrobbling application for Android Devices</li>
+    <li><em><a href="https://add0n.com/lastfm-scrobbler.html">Last.fm Scrobbler</a></em>, an extension for Firefox and Chrome</li>
+    <li><em><a href="https://web-scrobbler.com/">Web Scrobbler</a></em>, an extension for Firefox and Chromium-based browsers</li>
   </ul>
 
   <h3>Submitting via Spotify</h3>


### PR DESCRIPTION
Adds [foobar2000](https://www.foobar2000.org/components) player and its [plugin](https://github.com/phw/foo_listenbrainz2) to compatible players list.

Entire list has been rearranged to put cross platform players at top, then windows-only players, then unix-only ones, Android ones and finally web browsers plugins. Previously they were scattered without any specific order.

VLC entry has been reworked to link both the software and its plugin, like the other entries. Previously only the plugin was linked to