### PR TITLE
Remove redundant LEFT JOINs from mb_metadata_cache query

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -175,16 +175,16 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 -- we cannot directly start as FROM artist a because the values_join JOINs on recording
                                   JOIN artist a
                                     ON acn.artist = a.id
-                             LEFT JOIN l_artist_url lau
+                                  JOIN l_artist_url lau
                                     ON lau.entity0 = a.id
-                             LEFT JOIN url u
+                                  JOIN url u
                                     ON lau.entity1 = u.id
-                             LEFT JOIN link l
+                                  JOIN link l
                                     ON lau.link = l.id
-                             LEFT JOIN link_type lt
+                                  JOIN link_type lt
                                     ON l.link_type = lt.id
                                   {values_join}
-                                 WHERE (lt.gid IN ('99429741-f3f6-484b-84f8-23af51991770'
+                                 WHERE lt.gid IN ('99429741-f3f6-484b-84f8-23af51991770'
                                                   ,'fe33d22f-c3b0-4d68-bd53-a856badf2b15'
                                                   ,'fe33d22f-c3b0-4d68-bd53-a856badf2b15'
                                                   ,'689870a4-a1e4-4912-b17f-7b2664215698'
@@ -197,7 +197,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                                   ,'769085a1-c2f7-4c24-a532-2375a77693bd'
                                                   ,'63cc5d1f-f096-4c94-a43f-ecb32ea94161'
                                                   ,'6a540e5b-58c6-4192-b6ba-dbc71ec8fcf0')
-                                        OR lt.gid IS NULL)
                               GROUP BY a.gid
                    ), recording_rels AS (
                                 SELECT r.gid

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -202,29 +202,27 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 SELECT r.gid
                                      , array_agg(ARRAY[lt.name, a1.name, a1.gid::TEXT, lat.name]) AS recording_links
                                   FROM recording r
-                             LEFT JOIN l_artist_recording lar
+                                  JOIN l_artist_recording lar
                                     ON lar.entity1 = r.id
                                   JOIN artist a1
                                     ON lar.entity0 = a1.id
-                             LEFT JOIN link l
+                                  JOIN link l
                                     ON lar.link = l.id
-                             LEFT JOIN link_type lt
+                                  JOIN link_type lt
                                     ON l.link_type = lt.id
-                             LEFT JOIN link_attribute la
+                                  JOIN link_attribute la
                                     ON la.link = l.id
-                             LEFT JOIN link_attribute_type lat
+                                  JOIN link_attribute_type lat
                                     ON la.attribute_type = lat.id
                                   {values_join}
-                                 WHERE (lt.gid IN ('628a9658-f54c-4142-b0c0-95f031b544da'
-                                                   ,'59054b12-01ac-43ee-a618-285fd397e461'
-                                                   ,'0fdbe3c6-7700-4a31-ae54-b53f06ae1cfa'
-                                                   ,'234670ce-5f22-4fd0-921b-ef1662695c5d'
-                                                   ,'3b6616c5-88ba-4341-b4ee-81ce1e6d7ebb'
-                                                   ,'92777657-504c-4acb-bd33-51a201bd57e1'
-                                                   ,'45d0cbc5-d65b-4e77-bdfd-8a75207cb5c5'
-                                                   ,'7e41ef12-a124-4324-afdb-fdbae687a89c'
-                                                   ,'b5f3058a-666c-406f-aafb-f9249fc7b122')
-                                       OR lt.gid IS NULL)
+                                 WHERE lt.gid IN ('628a9658-f54c-4142-b0c0-95f031b544da'
+                                                  ,'0fdbe3c6-7700-4a31-ae54-b53f06ae1cfa'
+                                                  ,'234670ce-5f22-4fd0-921b-ef1662695c5d'
+                                                  ,'3b6616c5-88ba-4341-b4ee-81ce1e6d7ebb'
+                                                  ,'92777657-504c-4acb-bd33-51a201bd57e1'
+                                                  ,'45d0cbc5-d65b-4e77-bdfd-8a75207cb5c5'
+                                                  ,'7e41ef12-a124-4324-afdb-fdbae687a89c'
+                                                  ,'b5f3058a-666c-406f-aafb-f9249fc7b122')
                                GROUP BY r.gid
                    ), artist_data AS (
                             SELECT r.gid

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -283,9 +283,9 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , rg.gid AS release_group_mbid
                                  , array_agg(jsonb_build_array(t.name, count, rg.gid, g.gid)) AS release_group_tags
                               FROM recording r
-                         LEFT JOIN mapping.canonical_release_redirect crr
+                              JOIN mapping.canonical_release_redirect crr
                                 ON r.gid = crr.recording_mbid
-                         LEFT JOIN release rel
+                              JOIN release rel
                                 ON crr.release_mbid = rel.gid
                               JOIN release_group rg
                                 ON rel.release_group = rg.id

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -307,9 +307,9 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                          , caa.id AS caa_id
                                          , row_number() OVER (partition by recording_mbid ORDER BY ordering) AS rownum
                                       FROM recording r
-                                 LEFT JOIN mapping.canonical_release_redirect crr
+                                      JOIN mapping.canonical_release_redirect crr
                                         ON r.gid = crr.recording_mbid
-                                 LEFT JOIN release rel
+                                      JOIN release rel
                                         ON crr.release_mbid = rel.gid
                                  LEFT JOIN cover_art_archive.cover_art caa
                                         ON caa.release = rel.id


### PR DESCRIPTION
The logic behind removing these LEFT JOINs is that each individual CTE only needs to collect data for the recordings that have the respective data. The LEFT JOINs in the final select will ensure that all recordings all included in the final result even when some of the intermediate CTEs don't have any results for them. 

We only need LEFT JOINs in the intermediate CTEs when:
1. we are collecting more than one column of data
2. at least one of those columns can be NULL independent of the values in the other columns
3. we want that data should be collected even if not all but some columns are present.

See commit message for more details on which LEFT JOIN was removed why.