### PR TITLE
Fix order of artist credit mbids

### DIFF
--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -69,7 +69,7 @@ class RecordingFromRecordingMBIDQuery(Query):
                                   r.comment,
                                   ac.id AS artist_credit_id,
                                   ac.name AS artist_credit_name,
-                                  array_agg(a.gid)::TEXT[] AS artist_credit_mbids
+                                  array_agg(a.gid ORDER BY acn.position)::TEXT[] AS artist_credit_mbids
                              FROM recording r
                              JOIN artist_credit ac
                                ON r.artist_credit = ac.id

--- a/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -65,7 +65,7 @@ class CanonicalMusicBrainzData(BulkInsertTable):
                    ON rl.id = m.release
                  JOIN mapping.canonical_musicbrainz_data_release_tmp rpr
                    ON rl.id = rpr.release
-                 JOIN (SELECT artist_credit, array_agg(gid) AS artist_mbids
+                 JOIN (SELECT artist_credit, array_agg(gid ORDER BY position) AS artist_mbids
                          FROM artist_credit_name acn2
                          JOIN artist a2
                            ON acn2.artist = a2.id


### PR DESCRIPTION
artist_credit_mbids should be order'ed by position column in the artist_credit_name table. The website otherwise cannot link to the first artist's mbid correctly.