### PR TITLE
Allow recommendations with only mbids

### DIFF
--- a/listenbrainz/db/model/user_timeline_event.py
+++ b/listenbrainz/db/model/user_timeline_event.py
@@ -16,8 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-from pydantic import BaseModel, validator, NonNegativeInt, constr
-from data.model.validators import check_valid_uuid
+from pydantic import BaseModel, NonNegativeInt, constr
 
 from datetime import datetime
 from enum import Enum
@@ -25,6 +24,7 @@ from typing import Union, Optional, List
 
 from data.model.listen import APIListen
 from listenbrainz.db.model.review import CBReviewTimelineMetadata
+from listenbrainz.db.msid_mbid_mapping import MsidMbidModel
 
 
 class UserTimelineEventType(Enum):
@@ -37,18 +37,10 @@ class UserTimelineEventType(Enum):
     PERSONAL_RECORDING_RECOMMENDATION = 'personal_recording_recommendation'
 
 
-class RecordingRecommendationMetadata(BaseModel):
+class RecordingRecommendationMetadata(MsidMbidModel):
     artist_name: constr(min_length=1)
     track_name: constr(min_length=1)
     release_name: Optional[str]
-    recording_mbid: Optional[str]
-    recording_msid: constr(min_length=1)
-
-    _validate_uuids: classmethod = validator(
-        "recording_mbid",
-        "recording_msid",
-        allow_reuse=True
-    )(check_valid_uuid)
 
 
 class PersonalRecordingRecommendationMetadata(RecordingRecommendationMetadata):
@@ -62,7 +54,7 @@ class NotificationMetadata(BaseModel):
 
 
 UserTimelineEventMetadata = Union[CBReviewTimelineMetadata, PersonalRecordingRecommendationMetadata,
-    RecordingRecommendationMetadata, NotificationMetadata]
+                                  RecordingRecommendationMetadata, NotificationMetadata]
 
 
 class UserTimelineEvent(BaseModel):

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -32,7 +32,7 @@ from listenbrainz.db.model.user_timeline_event import (
 )
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
-from typing import List
+from typing import List, Tuple
 
 from listenbrainz.db.model.review import CBReviewTimelineMetadata
 
@@ -191,7 +191,7 @@ def get_user_track_recommendation_events(user_id: int, count: int = 50) -> List[
     )
 
 
-def get_recording_recommendation_events_for_feed(user_ids: List[int], min_ts: float, max_ts: float, count: int) \
+def get_recording_recommendation_events_for_feed(user_ids: Tuple[int], min_ts: float, max_ts: float, count: int) \
         -> List[UserTimelineEvent]:
     """ Gets a list of recording_recommendation events for specified users.
 

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -20,7 +20,7 @@ import logging
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Iterable
 
 import pydantic
 import ujson
@@ -273,7 +273,6 @@ def user_feed(user_name: str):
     )
 
     recording_recommendation_events = get_recording_recommendation_events(
-        user=user,
         users_for_events=users_for_feed_events,
         min_ts=min_ts or 0,
         max_ts=max_ts or int(time.time()),
@@ -297,7 +296,6 @@ def user_feed(user_name: str):
     notification_events = get_notification_events(user, count)
 
     recording_pin_events = get_recording_pin_events(
-        user=user,
         users_for_events=users_for_feed_events,
         min_ts=min_ts or 0,
         max_ts=max_ts or int(time.time()),
@@ -559,6 +557,7 @@ def create_personal_recommendation_event(user_name):
 
     return jsonify({"status": "ok"})
 
+
 def get_listen_events(
     users: List[Dict],
     min_ts: int,
@@ -654,14 +653,12 @@ def get_notification_events(user: dict, count: int) -> List[APITimelineEvent]:
 
 
 def get_recording_recommendation_events(
-        user: dict,
-        users_for_events: List[dict],
-        min_ts: int,
-        max_ts: int,
-        count: int
-        ) -> List[APITimelineEvent]:
-    """ Gets all recording recommendation events in the feed.
-    """
+    users_for_events: Iterable[dict],
+    min_ts: int,
+    max_ts: int,
+    count: int
+) -> List[APITimelineEvent]:
+    """ Gets all recording recommendation events in the feed. """
 
     id_username_map = {user['id']: user['musicbrainz_id'] for user in users_for_events}
     recording_recommendation_events_db = db_user_timeline_event.get_recording_recommendation_events_for_feed(
@@ -752,12 +749,11 @@ def get_cb_review_events(users_for_events: List[dict], min_ts: int, max_ts: int,
 
 
 def get_recording_pin_events(
-        user: dict,
-        users_for_events: List[dict],
-        min_ts: int,
-        max_ts: int,
-        count: int
-        ) -> List[APITimelineEvent]:
+    users_for_events: List[dict],
+    min_ts: int,
+    max_ts: int,
+    count: int
+) -> List[APITimelineEvent]:
     """ Gets all recording pin events in the feed."""
 
     id_username_map = {user['id']: user['musicbrainz_id'] for user in users_for_events}
@@ -801,11 +797,11 @@ def get_recording_pin_events(
 
 
 def get_personal_recording_recommendation_events(
-        user: dict,
-        min_ts: int,
-        max_ts: int,
-        count: int
-        ) -> List[APITimelineEvent]:
+    user: dict,
+    min_ts: int,
+    max_ts: int,
+    count: int
+) -> List[APITimelineEvent]:
     """ Gets all personal recording recommendation events in the feed.
     """
 


### PR DESCRIPTION
Currently, we require msid and optionally mbid for recommending tracks. But with mbid_mapping_metadata table, this restriction becomes arbitrary. As with feedback and pinned recordings, just one of msid or mbid is sufficient.
