### PR TITLE
Incrementally update mb_metadata_cache

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -162,5 +162,10 @@ CREATE TABLE spotify_cache.rel_track_artist (
     position        INTEGER NOT NULL
 );
 
+CREATE TABLE background_worker_state (
+    key     TEXT NOT NULL,
+    value   TEXT
+);
+COMMENT ON TABLE background_worker_state IS 'This table is used to store miscellaneous data by various background processes or the ListenBrainz webserver. Use it when storing the data is redis is not reliable enough.';
 
 COMMIT;

--- a/listenbrainz/mbid_mapping/docker/crontab
+++ b/listenbrainz/mbid_mapping/docker/crontab
@@ -6,3 +6,10 @@
 
 # Rebuild the spotify metadata index every friday at 1 A.M.
 0 1 * * 5 listenbrainz /usr/local/bin/python /code/mapper/manage.py build-spotify-metadata-index >> /code/mapper/cron-spotify-metadata-index.log 2>&1
+
+
+# Build the mb metadata cache from scratch on first thursday of every month, MB dumps run on Wed and Sat so avoid those days
+0 15 * * 4 listenbrainz [ $(date +\%d) -le 7 ] && /usr/local/bin/python /code/mapper/manage.py cron-build-mb-metadata-cache >> /code/mapper/lb-cron.log 2>&1
+
+# Update the mb metadata cache incrementally every 4 hours
+0 */4 * * * listenbrainz /usr/local/bin/python /code/mapper/manage.py update-mb-metadata-cache >> /code/mapper/lb-cron.log 2>&1

--- a/listenbrainz/mbid_mapping/docker/crontab
+++ b/listenbrainz/mbid_mapping/docker/crontab
@@ -9,7 +9,7 @@
 
 
 # Build the mb metadata cache from scratch on first thursday of every month, MB dumps run on Wed and Sat so avoid those days
-0 15 * * 4 listenbrainz [ $(date +\%d) -le 7 ] && /usr/local/bin/python /code/mapper/manage.py cron-build-mb-metadata-cache >> /code/mapper/lb-cron.log 2>&1
+0 15 * * 4 listenbrainz [ $(date +\%d) -le 7 ] && /usr/local/bin/python /code/mapper/manage.py cron-build-mb-metadata-cache >> /code/mapper/cron-mb-metadata-cache.log 2>&1
 
 # Update the mb metadata cache incrementally every 4 hours
-0 */4 * * * listenbrainz /usr/local/bin/python /code/mapper/manage.py update-mb-metadata-cache >> /code/mapper/lb-cron.log 2>&1
+0 */4 * * * listenbrainz /usr/local/bin/python /code/mapper/manage.py update-mb-metadata-cache >> /code/mapper/cron-mb-metadata-cache.log 2>&1

--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -124,6 +124,12 @@ def update_mb_metadata_cache(use_lb_conn):
 
 
 @cli.command()
+def cron_build_mb_metadata_cache():
+    create_canonical_musicbrainz_data(False)
+    create_mb_metadata_cache(True)
+
+
+@cli.command()
 @click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
 def build_spotify_metadata_index(use_lb_conn):
     """

--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -13,7 +13,7 @@ from mapping.utils import log, CRON_LOG_FILE
 from mapping.release_colors import sync_release_color_table, incremental_update_release_color_table
 from reports.tracks_of_the_year import calculate_tracks_of_the_year
 from reports.top_discoveries import calculate_top_discoveries
-from mapping.mb_metadata_cache import create_mb_metadata_cache
+from mapping.mb_metadata_cache import create_mb_metadata_cache, incremental_update_mb_metadata_cache
 from mapping.spotify_metadata_index import create_spotify_metadata_index
 
 
@@ -116,13 +116,22 @@ def build_mb_metadata_cache(use_lb_conn):
 
 @cli.command()
 @click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
+def update_mb_metadata_cache(use_lb_conn):
+    """
+        Update the MB metadata cache that LB uses incrementally.
+    """
+    incremental_update_mb_metadata_cache(use_lb_conn)
+
+
+@cli.command()
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
 def build_spotify_metadata_index(use_lb_conn):
     """
         Build the spotify metadata index that LB uses
     """
     create_spotify_metadata_index(use_lb_conn)
 
-        
+
 def usage(command):
     with click.Context(command) as ctx:
         click.echo(command.get_help(ctx))

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -583,6 +583,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
 
         try:
             with self.mb_conn.cursor() as curs:
+                self.config_postgres_join_limit(curs)
                 recording_mbids = set()
 
                 log("mb metadata cache: querying recording mbids to update")

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -599,7 +599,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                   UPDATE {self.table_name}
                      SET dirty = 't'
                     FROM dirty_mbids
-                   WHERE {self.table_name}.artist_mbids @> dirty_mbids.artist_mbid::text
+                   WHERE {self.table_name}.artist_mbids::text[] @> dirty_mbids.artist_mbid::text
                 """
                 execute_values(curs, query, [(mbid,) for mbid in artist_mbids], page_size=len(artist_mbids))
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -715,6 +715,7 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         log("mb metadata cache: starting incremental update")
 
         timestamp = select_metadata_cache_timestamp(lb_conn or mb_conn)
+        log(f"mb metadata cache: last update timestamp - {timestamp}")
         if not timestamp:
             return
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -619,7 +619,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 log("mb metadata update: Running looooong query on dirty items")
                 query = self.get_metadata_cache_query(with_values=True)
                 values = [(mbid,) for mbid in recording_mbids]
-                print(values)
                 execute_values(mb_curs, query, values, page_size=len(values))
 
                 rows = []
@@ -722,6 +721,11 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         new_timestamp = datetime.now()
         recording_mbids = cache.query_last_updated_items(timestamp)
         cache.update_dirty_cache_items(recording_mbids)
+
+        if len(recording_mbids) == 0:
+            log("mb metadata cache: no recording mbids found to update")
+            return
+
         update_metadata_cache_timestamp(lb_conn or mb_conn, new_timestamp)
 
         log("mb metadata cache: incremental update completed")

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -443,16 +443,16 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                              ,'63cc5d1f-f096-4c94-a43f-ecb32ea94161'
                              ,'6a540e5b-58c6-4192-b6ba-dbc71ec8fcf0')
                    AND (
-                        lau.last_updated > :timestamp
-                     OR   u.last_updated > :timestamp
-                     OR  lt.last_updated > :timestamp
+                        lau.last_updated > %(timestamp)s
+                     OR   u.last_updated > %(timestamp)s
+                     OR  lt.last_updated > %(timestamp)s
                    )
         UNION
             SELECT a.gid
               FROM artist a
               JOIN area ar
                 ON a.area = ar.id
-             WHERE ar.last_updated > :timestamp
+             WHERE ar.last_updated > %(timestamp)s
         UNION
             SELECT a.gid
               FROM artist a
@@ -462,12 +462,12 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 ON at.tag = t.id
          LEFT JOIN genre g
                 ON t.name = g.name
-             WHERE at.last_updated > :timestamp
-                OR  g.last_updated > :timestamp
+             WHERE at.last_updated > %(timestamp)s
+                OR  g.last_updated > %(timestamp)s
         UNION
             SELECT a.gid
               FROM artist a
-             WHERE a.last_updated > :timestamp
+             WHERE a.last_updated > %(timestamp)s
         """
 
         # 2. recording_rels, recording_tags, recording
@@ -501,9 +501,9 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  ,'7e41ef12-a124-4324-afdb-fdbae687a89c'
                                  ,'b5f3058a-666c-406f-aafb-f9249fc7b122')
                    AND (
-                         lar.last_updated > :timestamp
-                      OR  lt.last_updated > :timestamp
-                      OR lat.last_updated > :timestamp
+                         lar.last_updated > %(timestamp)s
+                      OR  lt.last_updated > %(timestamp)s
+                      OR lat.last_updated > %(timestamp)s
                    )
             UNION
                 SELECT r.gid
@@ -514,12 +514,12 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     ON rt.recording = r.id
              LEFT JOIN genre g
                     ON t.name = g.name
-                 WHERE rt.last_updated > :timestamp
-                    OR  g.last_updated > :timestamp
+                 WHERE rt.last_updated > %(timestamp)s
+                    OR  g.last_updated > %(timestamp)s
             UNION
                 SELECT r.gid
                   FROM recording r
-                 WHERE r.last_updated > :timestamp
+                 WHERE r.last_updated > %(timestamp)s
         """
 
         # 3. release_group_tags, release_data
@@ -543,8 +543,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     ON rgt.tag = t.id
              LEFT JOIN genre g
                     ON t.name = g.name
-                 WHERE rgt.last_updated > :timestamp
-                    OR   g.last_updated > :timestamp
+                 WHERE rgt.last_updated > %(timestamp)s
+                    OR   g.last_updated > %(timestamp)s
             UNION
                 SELECT rel.gid
                   FROM mapping.canonical_release_redirect crr
@@ -552,19 +552,19 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     ON crr.release_mbid = rel.gid
                   JOIN release_group rg
                     ON rel.release_group = rg.id
-                 WHERE rel.last_updated > :timestamp
-                   AND  rg.last_updated > :timestamp
+                 WHERE rel.last_updated > %(timestamp)s
+                   AND  rg.last_updated > %(timestamp)s
         """
 
         try:
             with conn.cursor() as curs:
-                curs.execute(artist_mbids_query, (timestamp,))
+                curs.execute(artist_mbids_query, {"timestamp": timestamp})
                 artist_mbids = [row[0] for row in curs.fetchall()]
 
-                curs.execute(recording_mbids_query, (timestamp,))
+                curs.execute(recording_mbids_query, {"timestamp": timestamp})
                 recording_mbids = [row[0] for row in curs.fetchall()]
 
-                curs.execute(release_mbids_query, (timestamp,))
+                curs.execute(release_mbids_query, {"timestamp": timestamp})
                 release_mbids = [row[0] for row in curs.fetchall()]
 
                 return recording_mbids, artist_mbids, release_mbids

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -599,7 +599,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                   UPDATE {self.table_name}
                      SET dirty = 't'
                     FROM dirty_mbids
-                   WHERE {self.table_name}.artist_mbids && dirty_mbids.artist_mbid
+                   WHERE {self.table_name}.artist_mbids @> dirty_mbids.artist_mbid
                 """
                 execute_values(curs, query, [([mbid],) for mbid in artist_mbids], page_size=len(artist_mbids))
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -560,8 +560,11 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     ON crr.release_mbid = rel.gid
                   JOIN release_group rg
                     ON rel.release_group = rg.id
-                 WHERE rel.last_updated > %(timestamp)s
-                   AND  rg.last_updated > %(timestamp)s
+             LEFT JOIN cover_art_archive.cover_art caa
+                    ON caa.release = rel.id
+                 WHERE  rel.last_updated > %(timestamp)s
+                    OR   rg.last_updated > %(timestamp)s
+                    OR caa.date_uploaded > %(timestamp)s
             ) SELECT r.gid
                 FROM recording r
                 JOIN track t

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -33,7 +33,7 @@ ARTIST_LINK_GIDS = (
     '63cc5d1f-f096-4c94-a43f-ecb32ea94161',
     '6a540e5b-58c6-4192-b6ba-dbc71ec8fcf0'
 )
-ARTIST_LINK_GIDS_SQL = ", ".join(ARTIST_LINK_GIDS)
+ARTIST_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in ARTIST_LINK_GIDS])
 
 RECORDING_LINK_GIDS = (
     '628a9658-f54c-4142-b0c0-95f031b544da',
@@ -46,7 +46,7 @@ RECORDING_LINK_GIDS = (
     '7e41ef12-a124-4324-afdb-fdbae687a89c',
     'b5f3058a-666c-406f-aafb-f9249fc7b122'
 )
-RECORDING_LINK_GIDS_SQL = ", ".join(RECORDING_LINK_GIDS)
+RECORDING_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in RECORDING_LINK_GIDS])
 
 
 class MusicBrainzMetadataCache(BulkInsertTable):

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -677,7 +677,7 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         log("mb metadata cache: starting incremental update")
 
         # TODO: Update logic to get last update timestamp
-        timestamp = datetime(2022, 8, 17, 16, 0, 0)
+        timestamp = datetime(2022, 10, 4, 0, 0, 0)
         recording_mbids = cache.query_last_updated_items(timestamp)
         cache.update_dirty_cache_items(recording_mbids)
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -614,7 +614,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 log("mb metadata update: Running looooong query on dirty items")
                 query = self.get_metadata_cache_query(with_values=True)
                 values = [(mbid,) for mbid in recording_mbids]
-                print(len(values))
                 execute_values(mb_curs, query, values, page_size=len(values))
 
                 rows = []

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -399,8 +399,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         curs.execute('SET join_collapse_limit = 15')
 
     def query_last_updated_items(self, timestamp):
-        conn = self.lb_conn if self.lb_conn is not None else self.mb_conn
-
         # there queries here try to mirror the structure and logic of the main cache building queries
         # note that the tags queries in any of these omit the count > 0 clause because possible removal
         # of a tag is also a change.
@@ -557,7 +555,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         """
 
         try:
-            with conn.cursor() as curs:
+            with self.mb_conn.cursor() as curs:
                 curs.execute(artist_mbids_query, {"timestamp": timestamp})
                 artist_mbids = [row[0] for row in curs.fetchall()]
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -714,7 +714,7 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         log("mb metadata cache: starting incremental update")
 
         # TODO: Update logic to get last update timestamp
-        timestamp = datetime(2022, 8, 17, 14, 0, 0)
+        timestamp = datetime(2022, 8, 17, 16, 0, 0)
         recording_mbids, artist_mbids, release_mbids = cache.query_last_updated_items(timestamp)
         cache.mark_rows_as_dirty(recording_mbids, artist_mbids, release_mbids)
         cache.update_dirty_cache_items()

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -646,6 +646,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 log("mb metadata update: Running looooong query on dirty items")
                 query = self.get_metadata_cache_query(with_values=True)
                 values = [(row[0],) for row in recording_mbids]
+                print(len(values))
                 psycopg2.extras.execute_values(mb_curs, query, values, page_size=len(values))
 
                 rows = []
@@ -713,7 +714,7 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         log("mb metadata cache: starting incremental update")
 
         # TODO: Update logic to get last update timestamp
-        timestamp = datetime(2022, 8, 17, 0, 0, 0)
+        timestamp = datetime(2022, 8, 17, 14, 0, 0)
         recording_mbids, artist_mbids, release_mbids = cache.query_last_updated_items(timestamp)
         cache.mark_rows_as_dirty(recording_mbids, artist_mbids, release_mbids)
         cache.update_dirty_cache_items()

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -562,9 +562,11 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     ON rel.release_group = rg.id
              LEFT JOIN cover_art_archive.cover_art caa
                     ON caa.release = rel.id
+             LEFT JOIN cover_art_archive.cover_art_type cat
+                    ON cat.id = caa.id
                  WHERE  rel.last_updated > %(timestamp)s
                     OR   rg.last_updated > %(timestamp)s
-                    OR caa.date_uploaded > %(timestamp)s
+                    OR (caa.date_uploaded > %(timestamp)s AND (type_id = 1 OR type_id IS NULL))
             ) SELECT r.gid
                 FROM recording r
                 JOIN track t

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -420,8 +420,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         # |   artist_tags   |  artist tags                   |  recording_tag, genre              | artist
         # |   artist        |                                |  artist                            |
         artist_mbids_query = """
-        WITH artist_mbids(mbid) AS (
-            SELECT a.gid
+        WITH artist_mbids(id) AS (
+            SELECT a.id
               FROM artist a
               JOIN l_artist_url lau
                 ON lau.entity0 = a.id
@@ -449,13 +449,13 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                      OR  lt.last_updated > %(timestamp)s
                    )
         UNION
-            SELECT a.gid
+            SELECT a.id
               FROM artist a
               JOIN area ar
                 ON a.area = ar.id
              WHERE ar.last_updated > %(timestamp)s
         UNION
-            SELECT a.gid
+            SELECT a.id
               FROM artist a
               JOIN artist_tag at
                 ON at.artist = a.id
@@ -466,17 +466,15 @@ class MusicBrainzMetadataCache(BulkInsertTable):
              WHERE at.last_updated > %(timestamp)s
                 OR  g.last_updated > %(timestamp)s
         UNION
-            SELECT a.gid
+            SELECT a.id
               FROM artist a
              WHERE a.last_updated > %(timestamp)s
         ) SELECT r.gid
             FROM recording r
             JOIN artist_credit_name acn
            USING (artist_credit)
-            JOIN artist a
-              ON acn.artist = a.id
             JOIN artist_mbids am
-              ON a.gid = am.mbid           
+              ON acn.artist = am.id          
         """
 
         # 2. recording_rels, recording_tags, recording
@@ -540,8 +538,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         # |   release_data       |  release name, cover art   |                             | release, release_group
         # |   release            |                            |  release, release_group     |
         release_mbids_query = """
-            WITH release_mbids(mbid) AS (
-                SELECT rel.gid AS release_mbid
+            WITH release_mbids(id) AS (
+                SELECT rel.id
                   FROM mapping.canonical_release_redirect crr
                   JOIN release rel
                     ON crr.release_mbid = rel.gid
@@ -556,7 +554,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                  WHERE rgt.last_updated > %(timestamp)s
                     OR   g.last_updated > %(timestamp)s
             UNION
-                SELECT rel.gid
+                SELECT rel.id
                   FROM mapping.canonical_release_redirect crr
                   JOIN release rel
                     ON crr.release_mbid = rel.gid
@@ -570,10 +568,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                   ON t.recording = r.id
                 JOIN medium m
                   ON m.id = t.medium
-                JOIN release rel
-                  ON rel.id = m.release
-                JOIN release_mbids rm 
-                  ON rm.mbid = rel.gid
+                JOIN release_mbids rm
+                  ON rm.id = m.release
         """
 
         try:

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -404,13 +404,13 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         curs.execute('SET join_collapse_limit = 15')
 
     def query_last_updated_items(self, timestamp):
-        # there queries here try to mirror the structure and logic of the main cache building queries
+        # there queries mirror the structure and logic of the main cache building queries
         # note that the tags queries in any of these omit the count > 0 clause because possible removal
         # of a tag is also a change.
         # the last_updated considered and last_updated ignored columns below together list all the last_updated
         # columns a given CTE touches. any other tables touched by a given CTE do not have a last_updated column.
 
-        # further note that these queries only take updates and deletions into consideration, not deletes
+        # these queries only take updates and deletions into consideration, not deletes
 
         # 1. artist_rels, artist_data, artist_tags, artist
         # these CTEs and tables concern artist data and we fetch artist mbids from these. all of the CTEs touch

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -46,7 +46,7 @@ RECORDING_LINK_GIDS = (
     '7e41ef12-a124-4324-afdb-fdbae687a89c',
     'b5f3058a-666c-406f-aafb-f9249fc7b122'
 )
-RECORDING_LINK_GIDS_SQL = ", ".format(RECORDING_LINK_GIDS)
+RECORDING_LINK_GIDS_SQL = ", ".join(RECORDING_LINK_GIDS)
 
 
 class MusicBrainzMetadataCache(BulkInsertTable):

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -595,11 +595,11 @@ class MusicBrainzMetadataCache(BulkInsertTable):
 
                 log("mb metadata cache: marking dirty artist mbids")
                 query = f"""
-                    WITH dirty_mbids(artist_mbids) AS (VALUES %s)  
+                    WITH dirty_mbids(artist_mbid) AS (VALUES %s)  
                   UPDATE {self.table_name}
                      SET dirty = 't'
                     FROM dirty_mbids
-                   WHERE {self.table_name}.artist_mbids && dirty_mbids.artist_mbids
+                   WHERE ANY({self.table_name}.artist_mbids) = dirty_mbids.artist_mbid
                 """
                 execute_values(curs, query, [(mbid,) for mbid in artist_mbids], page_size=len(artist_mbids))
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -619,6 +619,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 log("mb metadata update: Running looooong query on dirty items")
                 query = self.get_metadata_cache_query(with_values=True)
                 values = [(mbid,) for mbid in recording_mbids]
+                print(values)
                 execute_values(mb_curs, query, values, page_size=len(values))
 
                 rows = []

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -599,9 +599,9 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                   UPDATE {self.table_name}
                      SET dirty = 't'
                     FROM dirty_mbids
-                   WHERE {self.table_name}.artist_mbids::text[] @> dirty_mbids.artist_mbid::text
+                   WHERE {self.table_name}.artist_mbids && dirty_mbids.artist_mbid
                 """
-                execute_values(curs, query, [(mbid,) for mbid in artist_mbids], page_size=len(artist_mbids))
+                execute_values(curs, query, [([mbid],) for mbid in artist_mbids], page_size=len(artist_mbids))
 
                 log("mb metadata cache: marking dirty release mbids")
                 query = f"""

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -7,6 +7,7 @@ import psycopg2
 from psycopg2.errors import OperationalError
 import psycopg2.extras
 import ujson
+from psycopg2.extras import execute_values
 
 from mapping.utils import insert_rows, log
 from mapping.bulk_table import BulkInsertTable
@@ -590,7 +591,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     FROM dirty_mbids
                    WHERE {self.table_name}.recording_mbid = dirty_mbids.recording_mbid
                 """
-                curs.execute(query, (tuple(recording_mbids),))
+                execute_values(curs, query, [(mbid,) for mbid in recording_mbids], page_size=len(recording_mbids))
 
                 log("mb metadata cache: marking dirty artist mbids")
                 query = f"""
@@ -600,7 +601,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     FROM dirty_mbids
                    WHERE {self.table_name}.artist_mbids && dirty_mbids.artist_mbids
                 """
-                curs.execute(query, (artist_mbids,))
+                execute_values(curs, query, [(mbid,) for mbid in artist_mbids], page_size=len(artist_mbids))
 
                 log("mb metadata cache: marking dirty release mbids")
                 query = f"""
@@ -610,7 +611,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     FROM dirty_mbids
                    WHERE {self.table_name}.release_mbid = dirty_mbids.release_mbid
                 """
-                curs.execute(query, (tuple(release_mbids),))
+                execute_values(curs, query, [(mbid,) for mbid in release_mbids], page_size=len(release_mbids))
 
                 conn.commit()
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -599,7 +599,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                   UPDATE {self.table_name}
                      SET dirty = 't'
                     FROM dirty_mbids
-                   WHERE ANY({self.table_name}.artist_mbids) = dirty_mbids.artist_mbid
+                   WHERE {self.table_name}.artist_mbids @> dirty_mbids.artist_mbid
                 """
                 execute_values(curs, query, [(mbid,) for mbid in artist_mbids], page_size=len(artist_mbids))
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
-from typing import List, Iterable
+from typing import List, Set
 import uuid
 
 import psycopg2
@@ -600,7 +600,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
             log("mb metadata cache: cannot query rows for update", err)
             return None
 
-    def update_dirty_cache_items(self, recording_mbids: set[uuid.UUID]):
+    def update_dirty_cache_items(self, recording_mbids: Set[uuid.UUID]):
         """Refresh any dirty items in the mb_metadata_cache table.
 
         This process first looks for all recording MIBDs which are dirty, gets updated metadata for them, and then
@@ -615,7 +615,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 query = self.get_metadata_cache_query(with_values=True)
                 values = [(mbid,) for mbid in recording_mbids]
                 print(len(values))
-                psycopg2.extras.execute_values(mb_curs, query, values, page_size=len(values))
+                execute_values(mb_curs, query, values, page_size=len(values))
 
                 rows = []
                 count = 0

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -685,7 +685,7 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         log("mb metadata cache: starting incremental update")
 
         # TODO: Update logic to get last update timestamp
-        timestamp = datetime.now() + timedelta(hours=-4)
+        timestamp = datetime(2022, 8, 17, 0, 0, 0)
         recording_mbids, artist_mbids, release_mbids = cache.query_last_updated_items(timestamp)
         cache.mark_rows_as_dirty(recording_mbids, artist_mbids, release_mbids)
         cache.update_dirty_cache_items()

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -33,7 +33,7 @@ ARTIST_LINK_GIDS = (
     '63cc5d1f-f096-4c94-a43f-ecb32ea94161',
     '6a540e5b-58c6-4192-b6ba-dbc71ec8fcf0'
 )
-ARTIST_LINK_GIDS_SQL = Literal(", ".join(ARTIST_LINK_GIDS))
+ARTIST_LINK_GIDS_SQL = ", ".join(ARTIST_LINK_GIDS)
 
 RECORDING_LINK_GIDS = (
     '628a9658-f54c-4142-b0c0-95f031b544da',
@@ -46,7 +46,7 @@ RECORDING_LINK_GIDS = (
     '7e41ef12-a124-4324-afdb-fdbae687a89c',
     'b5f3058a-666c-406f-aafb-f9249fc7b122'
 )
-RECORDING_LINK_GIDS_SQL = Literal(", ".format(RECORDING_LINK_GIDS))
+RECORDING_LINK_GIDS_SQL = ", ".format(RECORDING_LINK_GIDS)
 
 
 class MusicBrainzMetadataCache(BulkInsertTable):

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -682,7 +682,7 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         log("mb metadata cache: starting incremental update")
 
         # TODO: Update logic to get last update timestamp
-        timestamp = datetime(2022, 10, 4, 0, 0, 0)
+        timestamp = datetime(2022, 10, 11, 0, 0, 0)
         recording_mbids = cache.query_last_updated_items(timestamp)
         cache.update_dirty_cache_items(recording_mbids)
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -599,7 +599,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                   UPDATE {self.table_name}
                      SET dirty = 't'
                     FROM dirty_mbids
-                   WHERE {self.table_name}.artist_mbids @> dirty_mbids.artist_mbid
+                   WHERE {self.table_name}.artist_mbids @> dirty_mbids.artist_mbid::text
                 """
                 execute_values(curs, query, [(mbid,) for mbid in artist_mbids], page_size=len(artist_mbids))
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -573,7 +573,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 JOIN release rel
                   ON rel.id = m.release
                 JOIN release_mbids rm 
-                  ON rm.gid = rel.gid
+                  ON rm.mbid = rel.gid
         """
 
         try:

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -669,7 +669,7 @@ def update_metadata_cache_timestamp(conn, ts: datetime):
     query = SQL("UPDATE background_worker_state SET value = %s WHERE key = {key}") \
         .format(key=Literal(MB_METADATA_CACHE_TIMESTAMP_KEY))
     with conn.cursor() as curs:
-        curs.execute(query, (ts.isoformat()))
+        curs.execute(query, (ts.isoformat(),))
     conn.commit()
 
 


### PR DESCRIPTION
The comment in the methods covers most of the details of the queries.

Need to figure out how to store/handle the value of timestamp - the mark above which changed values are retrieved, store last time incremental ran in redis or maybe add a last_updated column to mb_metadata_cache ?

Can also try to add a test for checking that incremental updates is not missing cases but crafting a comprehensive test dataset is hard.