### PR TITLE
LB-1126: show track duration properly on ListenCard

### DIFF
--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -26,7 +26,7 @@ import {
   getReleaseMBID,
   getArtistName,
   getTrackName,
-  getTrackDuration,
+  getTrackDurationInMs,
   getRecordingMSID,
 } from "../utils/utils";
 import GlobalAppContext from "../utils/GlobalAppContext";
@@ -238,7 +238,7 @@ export default class ListenCard extends React.Component<
 
     const trackName = getTrackName(listen);
     const artistName = getArtistName(listen);
-    const trackDuration = getTrackDuration(listen);
+    const trackDurationMs = getTrackDurationInMs(listen);
 
     const hasRecordingMSID = Boolean(recordingMSID);
     const enableRecommendButton = artistName && trackName && hasRecordingMSID;
@@ -335,10 +335,10 @@ export default class ListenCard extends React.Component<
                 <div title={trackName} className="ellipsis-2-lines">
                   {getTrackLink(listen)}
                 </div>
-                {trackDuration && (
+                {trackDurationMs && (
                   <div className="small text-muted" title="Duration">
-                    {isNumber(trackDuration) &&
-                      millisecondsToStr(trackDuration)}
+                    {isNumber(trackDurationMs) &&
+                      millisecondsToStr(trackDurationMs)}
                   </div>
                 )}
               </div>

--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -145,9 +145,9 @@ const getReleaseGroupMBID = (listen: Listen): string | undefined =>
 const getTrackName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
   _.get(listen, "track_metadata.track_name", "") || _.get(listen, "title", "");
 
-const getTrackDuration = (listen?: Listen | JSPFTrack): number =>
+const getTrackDurationInMs = (listen?: Listen | JSPFTrack): number =>
   _.get(listen, "track_metadata.additional_info.duration_ms", "") ||
-  _.get(listen, "track_metadata.additional_info.duration", "") ||
+  _.get(listen, "track_metadata.additional_info.duration", "") * 1000 ||
   _.get(listen, "duration", "");
 
 const getArtistName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
@@ -652,7 +652,7 @@ export {
   getArtistMBIDs,
   getArtistName,
   getTrackName,
-  getTrackDuration,
+  getTrackDurationInMs,
   pinnedRecordingToListen,
   getAlbumArtFromListenMetadata,
   getAverageRGBOfImage,

--- a/listenbrainz/webserver/static/js/tests/listens/ListenCard.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/listens/ListenCard.test.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { mount, shallow } from "enzyme";
+import { mount } from "enzyme";
 
+import { omit, set } from "lodash";
 import ListenCard, { ListenCardProps } from "../../src/listens/ListenCard";
 import * as utils from "../../src/utils/utils";
 import APIServiceClass from "../../src/utils/APIService";
 import GlobalAppContext from "../../src/utils/GlobalAppContext";
-import RecommendationControl from "../../src/recommendations/RecommendationControl";
+
 // Font Awesome generates a random hash ID for each icon everytime.
 // Mocking Math.random() fixes this
 // https://github.com/FortAwesome/react-fontawesome/issues/194#issuecomment-627235075
@@ -125,6 +126,27 @@ describe("ListenCard", () => {
     instance.playListen();
 
     expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("should render the formatted duration_ms if present in the listen metadata", () => {
+    const wrapper = mount<ListenCard>(<ListenCard {...props} />);
+    const durationElement = wrapper.find('[title="Duration"]');
+    expect(durationElement).toBeDefined();
+    expect(durationElement.text()).toEqual("2:03");
+  });
+  it("should render the formatted duration if present in the listen metadata", () => {
+    // We remove the duration_ms field and replace it with a duration field
+    const listenWithDuration = omit(
+      listen,
+      "track_metadata.additional_info.duration_ms"
+    );
+    set(listenWithDuration, "track_metadata.additional_info.duration", 142);
+    const wrapper = mount<ListenCard>(
+      <ListenCard {...{ ...props, listen: listenWithDuration }} />
+    );
+    const durationElement = wrapper.find('[title="Duration"]');
+    expect(durationElement).toBeDefined();
+    expect(durationElement.text()).toEqual("2:22");
   });
 
   describe("handleError", () => {


### PR DESCRIPTION
Currently, a lot of listens are showing "0:00" as track duration on the ListenCard, because they are not converted to milliseconds.
When using the duration field (i.e. the duration_ms filed is not present), transform to milliseconds before formatting in human readable format.
Added two tests to check the formatted duration as well.