### PR TITLE
Add dumps for musicbrainz metadata tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
                        redis-tools \
                        rsync \
                        uuid \
+                       zstd \
     && rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client

--- a/docs/developers/mapping.rst
+++ b/docs/developers/mapping.rst
@@ -1,0 +1,76 @@
+:orphan:
+
+.. _developers-mapping:
+
+MBID Mapping
+============
+
+The MBID mapping scripts allow us to take metadata from the messybrainz database and look up recording MBIDs
+from the MusicBrainz database.
+
+.. note::
+    The MBID Mapping source code lives in ``listenbrainz/mbid_mapping`` but is run independently
+    from the main listenbrainz web docker image. You can use your own virtual environment or use
+    ``listenbrainz/mbid_mapping/build.sh`` to build a standalone docker image.
+
+Database tables
+^^^^^^^^^^^^^^^
+
+The MBID Mapping supplemental tables hold preprocessed data from the MusicBrainz database.
+
+* ``mapping.canonical_musicbrainz_data``: The MBID and Name of Recordings, Artists (and credits), and Releases for all recordings in MusicBrainz
+* ``mapping.canonical_recording_redirect``: A mapping to find the "canonical" recording given an artist credit + recording name
+* ``mapping.canonical_release_redirect``: A mapping to find the "canonical" release given an artist credit + release name
+
+These tables can be populated by running 
+
+.. code:: bash
+
+    python mapper/manage.py canonical-data
+
+The update process build the new data in a temporary table and then
+replaces them in a single transaction. This means that lookups can continue to run on the 
+existing tables while the new ones are being built.
+
+Fuzzy lookups
+^^^^^^^^^^^^^
+
+We use typesense as a way of performing quick, fuzzy lookups based on artist name and recording name
+
+Build the typesese index with
+
+.. code:: bash
+
+    python mapper/manage.py build-index
+
+As with the data tables, a new typesense collection is created and then swapped into place in a
+single operation.
+
+Build the mapping tables and then the typesense index directly afterwards with 
+
+.. code:: bash
+
+    python mapper/manage.py create-all
+
+MBID Mapper
+^^^^^^^^^^^
+
+The mapper looks for new MSIDs submitted to messybrainz and finds a matching MBID in MusicBrainz
+
+    ``python3 -u -m listenbrainz.mbid_mapping_writer.mbid_mapping_writer``
+
+A background thread pushes items to be processed onto a queue - recent submissions first, and then if nothing
+is to be done, old items.
+The processing thread pops items off the queue and then looks them up, adding them to the ``mbid_mapping`` table.
+
+There is also a background thread that fires off daily, which looks for listens that have been written to the 
+listens table, but for some reason do not have a matching mapping entry. (This could happen due to 
+restarts or problems with the mapper itself). These are called legacy listens.
+
+The background thread will walk the entire listens table once a day to find these legacy listens and attempt to
+map them. In the same thread we also look for mapping items with timestamp of the unix epoch (1970-01-01 00:00:00),
+which indicates that they ought to be re-checked. Currently we have no automated mechanism in place for setting any mapping 
+entries to the epoch.
+
+TODO: Detuning algorithm
+TODO: match quality types

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Contents
    developers/spark-devel-env
    developers/architecture
    developers/spark-architecture
+   developers/mapping
    developers/commands
 
 .. toctree::
@@ -44,6 +45,7 @@ Contents
    maintainers/deploy
    maintainers/docker-image
    maintainers/dumps
+   maintainers/mapping
    maintainers/spotify-reader
    maintainers/updating-prod-db-schema
    maintainers/pull-requests

--- a/docs/maintainers/mapping.rst
+++ b/docs/maintainers/mapping.rst
@@ -1,0 +1,51 @@
+MBID Mapping
+============
+
+For a background on how the mapping works, see :ref:`developers-mapping`
+
+
+Containers
+^^^^^^^^^^
+
+The mapping tools run in two containers:
+
+ * ``mbid-mapping-writer-prod``: Populates the ``mbid_mapping`` table for new listens. Built from the 
+    main ListenBrainz dockerfile.
+
+ * ``mbid-mapping``: Periodically generates the MBID Mapping supplemental tables, typesense index,
+    and huesound index. Built from ``listenbrainz/mbid_mapping/Dockerfile``
+
+
+Data sources
+^^^^^^^^^^^^
+
+In the production environment, the ``mbid-mapping`` container reads from the MB replica on aretha.
+
+
+Debugging lookups
+^^^^^^^^^^^^^^^^^
+
+If a listen isn't showing up as mapped on ListenBrainz, one of the following might be true:
+
+* The item wasn't in musicbrainz at the time that the lookup was made
+* There is a bug in the mapping algorithm
+
+If the recording doesn't exist in MusicBrainz during mapping, a row will be added to the ``mbid_mapping`` table
+with the MSID and a ``match_type`` of ``no_match``. Currently no_match values aren't looked up again automatically.
+
+You can test the results of a lookup by using `https://labs.api.listenbrainz.org/explain-mbid-mapping <https://labs.api.listenbrainz.org/explain-mbid-mapping>`
+This uses the same lookup process that the mapper uses. If this returns a result, but there is no mapping present
+it could be due to data being recently added to MusicBrainz or improvements to the mapping algorithm.
+
+If no data is returned or an incorrect match is being returned, this should be reported to us, by adding a comment
+to `LB-1036 <https://tickets.metabrainz.org/browse/LB-1036>`.
+
+In this case you can retrigger a lookup by seting the ``mbid_mapping.last_updated`` field to '1970-01-01 00:00:00' (the unix epoch). 
+The mapper will pick up these items and put them on the queue again.
+
+.. code:: sql
+
+    UPDATE mbid_mapping SET last_updated = 'epoch' WHERE recording_msid = '00000737-3a59-4499-b30a-31fe2464555d';
+    UPDATE mbid_mapping SET last_updated = 'epoch' WHERE match_type = 'no_match' AND last_updated = now() - interval '1 day';
+
+In the LB production environment these items will be picked up and re-processed once a day.

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -32,7 +32,7 @@ from flask import current_app, render_template
 
 from brainzutils.mail import send_mail
 import listenbrainz.db.dump as db_dump
-import listenbrainz.mbid_mapping.mapping.dump as mapping_dump
+from listenbrainz.db import mapping_dump
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
 from listenbrainz.db.year_in_music import insert_playlists
 from listenbrainz.listenstore.dump_listenstore import DumpListenStore
@@ -75,7 +75,7 @@ def create_mapping(location):
         dump_path = os.path.join(location, dump_name)
         create_path(dump_path)
 
-        mapping_dump.create_public_mapping_dump(dump_path, end_time)
+        mapping_dump.create_mapping_dump(dump_path, end_time)
         expected_num_dumps = 1
 
         try:

--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -65,6 +65,14 @@ PUBLIC_TABLES_MAPPING = {
             'canonical_recording_mbid',
             'canonical_release_mbid'
         )
+    },
+    'mapping.canonical_release_redirect': {
+        'filename': 'canonical_release_redirect.csv',
+        'columns': (
+            'release_mbid',
+            'canonical_release_mbid',
+            'release_group_mbid'
+        )
     }
 }
 

--- a/mbid_mapping/docker/crontab
+++ b/mbid_mapping/docker/crontab
@@ -1,4 +1,4 @@
-# Create the typesense index periodically
+# Create the mapping indexes (typesense, canonical data tables) each day at 4am
 0 4 * * * listenbrainz /usr/local/bin/python /code/mapper/manage.py create-all >> /code/mapper/lb-cron.log 2>&1
 
 # Run the huesound color sync hourly

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -9,6 +9,7 @@ from mapping.custom_sorts import create_custom_sort_tables
 from mapping.bulk_table import BulkInsertTable
 from mapping.canonical_recording_redirect import CanonicalRecordingRedirect
 from mapping.canonical_recording_release_redirect import CanonicalRecordingReleaseRedirect
+from mapping.canonical_release_redirect import CanonicalReleaseRedirect
 from mapping.canonical_musicbrainz_data_release import CanonicalMusicBrainzDataRelease
 import config
 
@@ -148,6 +149,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         # Setup all the needed objects
         can = CanonicalRecordingRedirect(mb_conn, lb_conn)
         can_rec_rel = CanonicalRecordingReleaseRedirect(mb_conn, lb_conn)
+        can_rel = CanonicalReleaseRedirect(mb_conn, lb_conn)
         releases = CanonicalMusicBrainzDataRelease(mb_conn)
         mapping = CanonicalMusicBrainzData(mb_conn, lb_conn)
         mapping.add_additional_bulk_table(can)
@@ -157,6 +159,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         releases.run(no_swap=True)
         mapping.run(no_swap=True)
         can_rec_rel.run(no_swap=True)
+        can_rel.run(no_swap=True)
 
         # Now swap everything into production in a single transaction
         log("canonical_musicbrainz_data: Swap into production")
@@ -165,6 +168,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
+            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             mb_conn.commit()
             lb_conn.commit()
             lb_conn.close()
@@ -173,6 +177,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
+            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             mb_conn.commit()
 
         log("canonical_musicbrainz_data: done done done!")

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -8,7 +8,7 @@ from mapping.utils import log
 from mapping.custom_sorts import create_custom_sort_tables
 from mapping.bulk_table import BulkInsertTable
 from mapping.canonical_recording_redirect import CanonicalRecordingRedirect
-from mapping.canonical_release_redirect import CanonicalReleaseRedirect
+from mapping.canonical_recording_release_redirect import CanonicalRecordingReleaseRedirect
 from mapping.canonical_musicbrainz_data_release import CanonicalMusicBrainzDataRelease
 import config
 
@@ -147,7 +147,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
 
         # Setup all the needed objects
         can = CanonicalRecordingRedirect(mb_conn, lb_conn)
-        can_rel = CanonicalReleaseRedirect(mb_conn, lb_conn)
+        can_rec_rel = CanonicalRecordingReleaseRedirect(mb_conn, lb_conn)
         releases = CanonicalMusicBrainzDataRelease(mb_conn)
         mapping = CanonicalMusicBrainzData(mb_conn, lb_conn)
         mapping.add_additional_bulk_table(can)
@@ -156,7 +156,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         create_custom_sort_tables(mb_conn)
         releases.run(no_swap=True)
         mapping.run(no_swap=True)
-        can_rel.run(no_swap=True)
+        can_rec_rel.run(no_swap=True)
 
         # Now swap everything into production in a single transaction
         log("canonical_musicbrainz_data: Swap into production")
@@ -164,7 +164,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             releases.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
-            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
+            can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             mb_conn.commit()
             lb_conn.commit()
             lb_conn.close()
@@ -172,7 +172,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             releases.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
-            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
+            can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             mb_conn.commit()
 
         log("canonical_musicbrainz_data: done done done!")

--- a/mbid_mapping/mapping/canonical_recording_release_redirect.py
+++ b/mbid_mapping/mapping/canonical_recording_release_redirect.py
@@ -1,16 +1,17 @@
 from mapping.bulk_table import BulkInsertTable
 
 
-class CanonicalReleaseRedirect(BulkInsertTable):
+class CanonicalRecordingReleaseRedirect(BulkInsertTable):
     """
-        This class creates the canonical releases table.
+        This class creates the canonical recording releases table.
+        This maps a recording mbid to the "most canonical" release that the recording appears on.
 
         For documentation on what each of the functions in this class does, please refer
         to the BulkInsertTable docs.
     """
 
     def __init__(self, mb_conn, lb_conn=None, batch_size=None):
-        super().__init__("mapping.canonical_release_redirect", mb_conn, lb_conn, batch_size)
+        super().__init__("mapping.canonical_recording_release_redirect", mb_conn, lb_conn, batch_size)
 
     def get_create_table_columns(self):
         return [("id",                       "SERIAL"),
@@ -21,17 +22,17 @@ class CanonicalReleaseRedirect(BulkInsertTable):
         return []
 
     def get_post_process_queries(self):
-        return ["""INSERT INTO mapping.canonical_release_redirect_tmp (recording_mbid, release_mbid)
+        return ["""INSERT INTO mapping.canonical_recording_release_redirect_tmp (recording_mbid, release_mbid)
                         SELECT recording_mbid
                              , canonical_release_mbid AS release_mbid
                           FROM mapping.canonical_recording_redirect_tmp""",
-                """INSERT INTO mapping.canonical_release_redirect_tmp (recording_mbid, release_mbid)
+                """INSERT INTO mapping.canonical_recording_release_redirect_tmp (recording_mbid, release_mbid)
                                  SELECT recording_mbid
                                       , release_mbid
                                    FROM mapping.canonical_musicbrainz_data_tmp"""]
 
     def get_index_names(self):
-        return [("recording_mbid_ndx_canonical_release_redirect", "recording_mbid", True)]
+        return [("recording_mbid_ndx_canonical_recording_release_redirect", "recording_mbid", True)]
 
     def process_row(self, row):
         return []

--- a/mbid_mapping/mapping/canonical_release_redirect.py
+++ b/mbid_mapping/mapping/canonical_release_redirect.py
@@ -1,0 +1,60 @@
+from mapping.bulk_table import BulkInsertTable
+
+
+class CanonicalReleaseRedirect(BulkInsertTable):
+    """
+        This class creates the canonical releases table.
+        This maps any given release mbid to the "most canonical" release in that release group,
+        along with the release group mbid.
+
+        When reading the `canonical_musicbrainz_data_release` table, the first release
+        (ordered by id) for a given release group is the canonical release.
+
+        For documentation on what each of the functions in this class does, please refer
+        to the BulkInsertTable docs.
+    """
+
+    def __init__(self, mb_conn, lb_conn=None, batch_size=None):
+        super().__init__("mapping.canonical_release_redirect", mb_conn, lb_conn, batch_size)
+
+    def get_create_table_columns(self):
+        return [("id",                       "SERIAL"),
+                ("release_mbid",             "UUID NOT NULL"),
+                ("canonical_release_mbid",   "UUID NOT NULL"),
+                ("release_group_mbid",       "UUID NOT NULL"),]
+
+    def get_insert_queries(self):
+        return []
+
+    def get_post_process_queries(self):
+        return ["""INSERT INTO mapping.canonical_release_redirect_tmp (release_mbid, canonical_release_mbid, release_group_mbid)
+                    WITH canonical_release AS (
+                        SELECT release.gid rel_mbid
+                            , rg.gid rg_mbid
+                            , cmdr.id
+                            , rank() over (partition by rg.id order by cmdr.id)
+                        FROM musicbrainz.release
+                        JOIN release_group rg
+                          ON release.release_group = rg.id
+                        JOIN mapping.canonical_musicbrainz_data_release_tmp cmdr
+                          ON cmdr.release = release.id),
+                        first_release AS (select * from canonical_release where rank = 1),
+                        release_rg AS (
+                           SELECT release.gid release_mbid
+                                , rg.gid release_group_mbid
+                            FROM musicbrainz.release
+                            JOIN release_group rg
+                                ON release.release_group = rg.id
+                    )
+                   SELECT release_rg.release_mbid
+                        , first_release.rel_mbid canonical_rel_mbid
+                        , release_rg.release_group_mbid
+                    FROM release_rg
+                    JOIN first_release
+                        ON first_release.rg_mbid = release_rg.release_group_mbid"""]
+
+    def get_index_names(self):
+        return [("release_mbid_ndx_canonical_release_redirect", "release_mbid", True)]
+
+    def process_row(self, row):
+        return []

--- a/mbid_mapping/mapping/dump.py
+++ b/mbid_mapping/mapping/dump.py
@@ -1,0 +1,219 @@
+""" This module contains data dump creation and import functions.
+
+Read more about the data dumps in our documentation here:
+https://listenbrainz.readthedocs.io/en/production/dev/listenbrainz-dumps.html
+"""
+
+# listenbrainz-server - Server for the ListenBrainz project
+#
+# Copyright (C) 2017 MetaBrainz Foundation Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy
+from flask import current_app, render_template
+from psycopg2.sql import SQL
+
+from listenbrainz import DUMP_LICENSE_FILE_PATH
+from brainzutils import musicbrainz_db
+from listenbrainz.db.dump import _escape_table_columns
+from listenbrainz.utils import create_path
+
+
+PUBLIC_TABLES_MAPPING = {
+    'mapping.canonical_musicbrainz_data': {
+        'filename': 'canonical_musicbrainz_data.csv',
+        'columns': (
+            'id',
+            'artist_credit_id',
+            'artist_mbids',
+            'artist_credit_name',
+            'release_mbid',
+            'release_name',
+            'recording_mbid',
+            'recording_name',
+            'combined_lookup',
+            'score',
+            'year',
+        ),
+    },
+    'mapping.canonical_recording_redirect': {
+        'filename': 'canonical_recording_redirect.csv',
+        'columns': (
+            'recording_mbid',
+            'canonical_recording_mbid',
+            'canonical_release_mbid'
+        )
+    }
+}
+
+
+def dump_postgres_db(location, dump_time=datetime.today()):
+    """ Create a MusicBrainz canonical metadata postgres database dump in the specified location
+
+        Arguments:
+            location: Directory where the final dump will be stored
+            dump_time: datetime object representing when the dump was started
+
+        Returns:
+            the path to the dumped data
+    """
+    current_app.logger.info('Beginning dump of PostgreSQL database...')
+    current_app.logger.info('dump path: %s', location)
+
+    current_app.logger.info('Creating dump of canonical metadata data...')
+    try:
+        dump_location = create_mapping_dump(location, dump_time)
+    except IOError as e:
+        current_app.logger.critical(
+            'IOError while creating canonical metadata dump: %s', str(e), exc_info=True)
+        current_app.logger.info('Removing created files and giving up...')
+        shutil.rmtree(location)
+        return
+    except Exception as e:
+        current_app.logger.critical(
+            'Unable to create canonical metadata dump due to error %s', str(e), exc_info=True)
+        current_app.logger.info('Removing created files and giving up...')
+        shutil.rmtree(location)
+        return
+
+    current_app.logger.info(
+        'MusicBrainz canonical metadata PostgreSQL data dump created at %s!', location)
+    return dump_location
+
+
+def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], tables: Optional[dict],
+                dump_time: datetime):
+    """ Creates a dump of the provided tables at the location passed
+
+        Arguments:
+            location: the path where the dump should be created
+            db_engine: an sqlalchemy Engine instance for making a connection
+            tables: a dict containing the names of the tables to be dumped as keys and the columns
+                    to be dumped as values
+            dump_time: the time at which the dump process was started
+
+        Returns:
+            the path to the archive file created
+    """
+
+    archive_name = 'metabrainz-metadata-dump-{time}'.format(
+        time=dump_time.strftime('%Y%m%d-%H%M%S')
+    )
+    archive_path = os.path.join(location, '{archive_name}.tar.zst'.format(
+        archive_name=archive_name,
+    ))
+
+    with open(archive_path, 'w') as archive:
+
+        zstd_command = ["zstd", "--compress", "-10"]
+        zstd = subprocess.Popen(zstd_command, stdin=subprocess.PIPE, stdout=archive)
+
+        with tarfile.open(fileobj=zstd.stdin, mode='w|') as tar:
+
+            temp_dir = tempfile.mkdtemp()
+
+            try:
+                timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
+                with open(timestamp_path, "w") as f:
+                    f.write(dump_time.isoformat(" "))
+                tar.add(timestamp_path,
+                        arcname=os.path.join(archive_name, "TIMESTAMP"))
+                tar.add(DUMP_LICENSE_FILE_PATH,
+                        arcname=os.path.join(archive_name, "COPYING"))
+            except IOError as e:
+                current_app.logger.error(
+                    'IOError while adding dump metadata: %s', str(e), exc_info=True)
+                raise
+            except Exception as e:
+                current_app.logger.error(
+                    'Exception while adding dump metadata: %s', str(e), exc_info=True)
+                raise
+
+            archive_tables_dir = os.path.join(temp_dir, 'metabrainz')
+            create_path(archive_tables_dir)
+
+            with db_engine.connect() as connection:
+                with connection.begin() as transaction:
+                    cursor = connection.connection.cursor()
+                    for table in tables:
+                        try:
+                            copy_table(
+                                cursor=cursor,
+                                location=archive_tables_dir,
+                                columns=tables[table]['columns'],
+                                table_name=table,
+                            )
+                        except IOError as e:
+                            current_app.logger.error(
+                                'IOError while copying table %s', table, exc_info=True)
+                            raise
+                        except Exception as e:
+                            current_app.logger.error(
+                                'Error while copying table %s: %s', table, str(e), exc_info=True)
+                            raise
+                    transaction.rollback()
+
+            # Add the files to the archive in the order that they are defined in the dump definition.
+            # This is so that when imported into a db with FK constraints added, we import dependent
+            # tables first
+            for table, tabledata in tables.items():
+                filename = tabledata['filename']
+                tar.add(os.path.join(archive_tables_dir, table),
+                        arcname=os.path.join(archive_name, 'metabrainz', filename))
+
+            shutil.rmtree(temp_dir)
+
+        zstd.stdin.close()
+
+    zstd.wait()
+    return archive_path
+
+
+def create_mapping_dump(location: str, dump_time: datetime):
+    """ Create postgres database dump of the mapping supplemental tables.
+    """
+    return _create_dump(
+        location=location,
+        db_engine=musicbrainz_db.engine,
+        tables=PUBLIC_TABLES_MAPPING,
+        dump_time=dump_time
+    )
+
+
+def copy_table(cursor, location, columns, table_name):
+    """ Copies a PostgreSQL table to a file
+
+        Arguments:
+            cursor: a psycopg cursor
+            location: the directory where the table should be copied
+            columns: a comma seperated string listing the columns of the table
+                     that should be dumped
+            table_name: the name of the table to be copied
+    """
+    table, fields = _escape_table_columns(table_name, columns)
+    with open(os.path.join(location, table_name), 'w') as f:
+        query = SQL("COPY (SELECT {fields} FROM {table}) TO STDOUT WITH CSV HEADER") \
+            .format(fields=fields, table=table)
+        cursor.copy_expert(query, f)

--- a/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_metadata_cache.py
@@ -12,7 +12,7 @@ from psycopg2.sql import SQL, Literal
 
 from mapping.utils import insert_rows, log
 from mapping.bulk_table import BulkInsertTable
-from mapping.canonical_release_redirect import CanonicalReleaseRedirect
+from mapping.canonical_recording_release_redirect import CanonicalRecordingReleaseRedirect
 import config
 
 
@@ -735,7 +735,7 @@ def create_mb_metadata_cache(use_lb_conn: bool):
         if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
             lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
 
-        can_rel = CanonicalReleaseRedirect(mb_conn)
+        can_rel = CanonicalRecordingReleaseRedirect(mb_conn)
         if not can_rel.table_exists():
             log("mb metadata cache: canonical_release_redirect table doesn't exist, run `canonical-data` manage command first with --use-mb-conn option")
             return


### PR DESCRIPTION

# Problem

We generate a bunch of intermediate metadata files from musicbrainz that might be useful for other people, but they can't get the data


# Solution

Generate periodic data dumps of Canonical recording redirect and Canonical MB metadata.

I generated a new py file specifically for the metadata dumps because of some differences to the existing LB dumps:
- Compress with zstd instead of xz
- Because this is just a periodic one-off dump that doesn't need to be imported to a database, don't include a schema number file
- Different filename structure to show it's not an LB dump
- Add explicit filenames to the archive (e.g. `canonical_musicbrainz_data.csv`), not just the table name (such as `mapping.canonical_musicbrainz_data`)
- Dump in CSV format, not postgres default text format
- Remove the special-casing around different types of dumps (e.g. feedback, parquet, etc)


I tried to special-case all of these differences into the main dump file, but I didn't like the way that we added a whole bunch of additional `if` statements. It's possible that we could go back to @amCap1712's BU pull request with a set of helper classes for making dumps that we could subclass with additional settings, however I think this is a separate task.

Documentation for the contents of these dumps will be done as part of https://github.com/metabrainz/listenbrainz-server/pull/1996

This creates a dump with a structure like this:

```
$ tar tf metabrainz-metadata-dump-20220921-113421.tar.zst
metabrainz-metadata-dump-20220921-113421/TIMESTAMP
metabrainz-metadata-dump-20220921-113421/COPYING
metabrainz-metadata-dump-20220921-113421/metabrainz/canonical_musicbrainz_data.csv
metabrainz-metadata-dump-20220921-113421/metabrainz/canonical_recording_redirect.csv
```

At the moment, I'm writing both data files to the same archive. It's 1.4Gb compressed, and uncompressed:
```
4.8G	metabrainz-metadata-dump-20220921-113421/metabrainz/canonical_musicbrainz_data.csv
620M	metabrainz-metadata-dump-20220921-113421/metabrainz/canonical_recording_redirect.csv
```

If we decide that we want each data file to be in its own archive, we could do this so that users can download just the files that they want, though I don't see a huge difference in sizes. I'm open to feedback here

Pending tasks:
- [x] Write canonical release table
- [x] Dump parquet for users who want this in spark or other tools
- [ ] Table generation scripts can dump into MB or LB database connection, if we want to keep this, we should modify the dump script to also be able to dump from either.


# Action

- After releasing, we'll need to modify the upload scripts to include these dumps into FTP
- Update the [dataset page](https://metabrainz.org/datasets) on metabrainz.org to include more information about these


