### PR TITLE
Remove redundant excepts from dump.py

### DIFF
--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -31,7 +31,7 @@ import tempfile
 import traceback
 from datetime import datetime, timedelta
 from ftplib import FTP
-from typing import Tuple, Optional, Union, Iterable
+from typing import Tuple, Optional
 
 import sqlalchemy
 import ujson
@@ -239,39 +239,23 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=DUMP_DEFAULT_
     current_app.logger.info('Creating dump of private data...')
     try:
         private_dump = create_private_dump(location, dump_time, threads)
-    except IOError as e:
-        current_app.logger.critical(
-            'IOError while creating private dump: %s', str(e), exc_info=True)
+    except Exception:
+        current_app.logger.critical('Unable to create private db dump due to error: ', exc_info=True)
         current_app.logger.info('Removing created files and giving up...')
         shutil.rmtree(location)
         return
-    except Exception as e:
-        current_app.logger.critical(
-            'Unable to create private db dump due to error %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
-    current_app.logger.info(
-        'Dump of private data created at %s!', private_dump)
+    current_app.logger.info('Dump of private data created at %s!', private_dump)
 
     current_app.logger.info('Creating dump of public data...')
     try:
         public_dump = create_public_dump(location, dump_time, threads)
-    except IOError as e:
-        current_app.logger.critical(
-            'IOError while creating public dump: %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
-    except Exception as e:
-        current_app.logger.critical(
-            'Unable to create public dump due to error %s', str(e), exc_info=True)
+    except Exception:
+        current_app.logger.critical('Unable to create public dump due to error: ', exc_info=True)
         current_app.logger.info('Removing created files and giving up...')
         shutil.rmtree(location)
         return
 
-    current_app.logger.info(
-        'ListenBrainz PostgreSQL data dump created at %s!', location)
+    current_app.logger.info('ListenBrainz PostgreSQL data dump created at %s!', location)
     return private_dump, public_dump
 
 
@@ -292,15 +276,8 @@ def dump_timescale_db(location: str, dump_time: datetime = datetime.today(),
     current_app.logger.info('Creating dump of timescale private data...')
     try:
         private_timescale_dump = create_private_timescale_dump(location, dump_time, threads)
-    except IOError as e:
-        current_app.logger.critical(
-            'IOError while creating private timescale dump: %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
-    except Exception as e:
-        current_app.logger.critical(
-            'Unable to create private timescale db dump due to error %s', str(e), exc_info=True)
+    except Exception:
+        current_app.logger.critical('Unable to create private timescale db dump due to error: ', exc_info=True)
         current_app.logger.info('Removing created files and giving up...')
         shutil.rmtree(location)
         return
@@ -310,15 +287,8 @@ def dump_timescale_db(location: str, dump_time: datetime = datetime.today(),
     current_app.logger.info('Creating dump of timescale public data...')
     try:
         public_timescale_dump = create_public_timescale_dump(location, dump_time, threads)
-    except IOError as e:
-        current_app.logger.critical(
-            'IOError while creating public timescale dump: %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
-    except Exception as e:
-        current_app.logger.critical(
-            'Unable to create public timescale dump due to error %s', str(e), exc_info=True)
+    except Exception:
+        current_app.logger.critical('Unable to create public timescale dump due to error: ', exc_info=True)
         current_app.logger.info('Removing created files and giving up...')
         shutil.rmtree(location)
         return
@@ -344,21 +314,13 @@ def dump_feedback_for_spark(location, dump_time=datetime.today(), threads=DUMP_D
     current_app.logger.info('dump path: %s', location)
     try:
         feedback_dump = create_feedback_dump(location, dump_time, threads)
-    except IOError as e:
-        current_app.logger.critical(
-            'IOError while creating feedback dump: %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
-    except Exception as e:
-        current_app.logger.critical(
-            'Unable to create feedback dump due to error %s', str(e), exc_info=True)
+    except Exception:
+        current_app.logger.critical('Unable to create feedback dump due to error: ', exc_info=True)
         current_app.logger.info('Removing created files and giving up...')
         shutil.rmtree(location)
         return
 
-    current_app.logger.info(
-        'Dump of feedback data created at %s!', feedback_dump)
+    current_app.logger.info('Dump of feedback data created at %s!', feedback_dump)
 
     return feedback_dump
 
@@ -405,10 +367,8 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], d
 
     with open(archive_path, 'w') as archive:
 
-        xz_command = ['xz', '--compress',
-                       '-T{threads}'.format(threads=threads)]
-        xz = subprocess.Popen(
-            xz_command, stdin=subprocess.PIPE, stdout=archive)
+        xz_command = ['xz', '--compress', '-T{threads}'.format(threads=threads)]
+        xz = subprocess.Popen(xz_command, stdin=subprocess.PIPE, stdout=archive)
 
         with tarfile.open(fileobj=xz.stdin, mode='w|') as tar:
 
@@ -427,13 +387,8 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], d
                         arcname=os.path.join(archive_name, "TIMESTAMP"))
                 tar.add(DUMP_LICENSE_FILE_PATH,
                         arcname=os.path.join(archive_name, "COPYING"))
-            except IOError as e:
-                current_app.logger.error(
-                    'IOError while adding dump metadata: %s', str(e), exc_info=True)
-                raise
-            except Exception as e:
-                current_app.logger.error(
-                    'Exception while adding dump metadata: %s', str(e), exc_info=True)
+            except Exception:
+                current_app.logger.error('Exception while adding dump metadata: ', exc_info=True)
                 raise
 
             archive_tables_dir = os.path.join(temp_dir, 'lbdump', 'lbdump')
@@ -456,13 +411,8 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], d
                                         columns=tables[table],
                                         table_name=table,
                                     )
-                                except IOError as e:
-                                    current_app.logger.error(
-                                        'IOError while copying table %s', table, exc_info=True)
-                                    raise
-                                except Exception as e:
-                                    current_app.logger.error(
-                                        'Error while copying table %s: %s', table, str(e), exc_info=True)
+                                except Exception:
+                                    current_app.logger.error('Error while copying table %s: ', table, exc_info=True)
                                     raise
                             transaction.rollback()
 
@@ -773,9 +723,8 @@ def import_postgres_dump(private_dump_archive_path=None,
     try:
         current_app.logger.info("Creating sequences")
         _update_sequences()
-    except Exception as e:
-        current_app.logger.critical(
-            'Exception while trying to update sequences: %s', str(e), exc_info=True)
+    except Exception:
+        current_app.logger.critical('Exception while trying to update sequences: ', exc_info=True)
         raise
 
 
@@ -824,8 +773,7 @@ def _import_dump(archive_path, db_engine: sqlalchemy.engine.Engine,
                             db.DUMP_DEFAULT_THREAD_COUNT
     """
 
-    xz_command = ['xz', '--decompress', '--stdout',
-                   archive_path, '-T{threads}'.format(threads=threads)]
+    xz_command = ['xz', '--decompress', '--stdout', archive_path, '-T{threads}'.format(threads=threads)]
     xz = subprocess.Popen(xz_command, stdout=subprocess.PIPE)
 
     connection = db_engine.raw_connection()
@@ -847,20 +795,14 @@ def _import_dump(archive_path, db_engine: sqlalchemy.engine.Engine,
 
                 else:
                     if file_name in tables:
-                        current_app.logger.info(
-                            'Importing data into %s table...', file_name)
+                        current_app.logger.info('Importing data into %s table...', file_name)
                         try:
                             table, fields = _escape_table_columns(file_name, tables[file_name])
                             query = SQL("COPY {table}({fields}) FROM STDIN").format(fields=fields, table=table)
                             cursor.copy_expert(query, tar.extractfile(member))
                             connection.commit()
-                        except IOError as e:
-                            current_app.logger.critical(
-                                'IOError while extracting table %s: %s', file_name, str(e), exc_info=True)
-                            raise
-                        except Exception as e:
-                            current_app.logger.critical(
-                                'Exception while importing table %s: %s', file_name, str(e), exc_info=True)
+                        except Exception:
+                            current_app.logger.critical('Exception while importing table %s: ', file_name, exc_info=True)
                             raise
 
                         current_app.logger.info('Imported table %s', file_name)


### PR DESCRIPTION
We have except `IOError`, then an except `Exception` clause at multiple places. But we do exactly the same thing in those. We use `exc_info=True` so the exception details are captured anyway. Thus, tt makes sense to remove the `IOError` excepts.