### PR TITLE
Call mapping start/init method before starting consumer

### DIFF
--- a/listenbrainz/mbid_mapping_writer/mbid_mapping_writer.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapping_writer.py
@@ -66,4 +66,4 @@ if __name__ == "__main__":
     app = create_app()
     with app.app_context():
         mw = MBIDMappingWriter(app)
-        mw.run()
+        mw.start()


### PR DESCRIPTION
# Problem
Mapping writer wasn't starting up. @amCap1712 told me that he was running this change on a branch that hadn't been merged to master.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


