### PR TITLE
LB-1113: Allow ratings on CB reviews to be optional

### DIFF
--- a/listenbrainz/db/model/review.py
+++ b/listenbrainz/db/model/review.py
@@ -1,8 +1,5 @@
-import sqlalchemy
+from typing import Optional
 from pydantic import BaseModel
-from typing import List
-
-from listenbrainz.db import timescale
 
 
 class CBReviewMetadata(BaseModel):
@@ -12,7 +9,7 @@ class CBReviewMetadata(BaseModel):
     """
     name: str
     entity_type: str
-    rating: int
+    rating: Optional[int]
     text: str
     entity_id: str
     language: str

--- a/listenbrainz/domain/critiquebrainz.py
+++ b/listenbrainz/domain/critiquebrainz.py
@@ -99,12 +99,11 @@ class CritiqueBrainzService(ExternalService):
     def _submit_review_to_CB(self, token: str, review: CBReviewMetadata):
         headers = {
             "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json;charset=UTF-8"
         }
-        payload = review.dict()
+        payload = review.dict(exclude_none=True)
         payload["is_draft"] = False
         payload["license_choice"] = CRITIQUEBRAINZ_REVIEW_LICENSE
-        return requests.post(CRITIQUEBRAINZ_REVIEW_SUBMIT_URL, data=json.dumps(payload), headers=headers)
+        return requests.post(CRITIQUEBRAINZ_REVIEW_SUBMIT_URL, json=payload, headers=headers)
 
     def submit_review(self, user_id: int, review: CBReviewMetadata) -> str:
         """ Submit a review for the user to CritiqueBrainz.

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -207,7 +207,7 @@ def create_user_cb_review_event(user_name):
             entity_type=metadata["entity_type"],
             text=metadata["text"],
             language=metadata["language"],
-            rating=metadata.get("rating", 0)
+            rating=metadata.get("rating")
         )
     except (pydantic.ValidationError, KeyError):
         raise APIBadRequest(f"Invalid metadata: {str(data)}")


### PR DESCRIPTION

# Problem

Even though the CB review writing popup says that rating is optional, submitting a text only review with no rating returned an error.


# Solution

By setting a default of 0 in LB, the CB api returned a validation error - the rating needs to be None, or 1-5
Make rating optional in LB validation


