### PR TITLE
Turn sqlalchemy.exc.Base20DeprecationWarning into errors in tests

### DIFF
--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -47,7 +47,7 @@ def get_by_mbid(playlist_id: str, load_recordings: bool = True) -> Optional[mode
          WHERE pl.mbid = :mbid""")
     with ts.engine.connect() as connection:
         result = connection.execute(query, {"mbid": playlist_id})
-        obj = result.fetchone()
+        obj = result.mappings().first()
         if not obj:
             return None
         obj = dict(obj)

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -434,7 +434,7 @@ def get_users_in_order(user_ids):
         """), {
             'user_ids': user_ids,
         })
-        return [row for row in r.fetchall() if row["musicbrainz_id"] is not None]
+        return [row for row in r.mappings() if row["musicbrainz_id"] is not None]
 
 
 def get_similar_users(user_id: int) -> Optional[SimilarUsers]:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=listenbrainz_spark relations listenbrainz/mbid_mapping
-addopts = -W always::DeprecationWarning --cov=listenbrainz --no-cov-on-fail
+addopts = -W always::DeprecationWarning,error::sqlalchemy.exc.RemovedIn20Warning --cov=listenbrainz --no-cov-on-fail

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=listenbrainz_spark relations listenbrainz/mbid_mapping
-addopts = -W always::DeprecationWarning -W error::sqlalchemy.exc.RemovedIn20Warning --cov=listenbrainz --no-cov-on-fail
+addopts = -W always::DeprecationWarning -W error::sqlalchemy.exc.Base20DeprecationWarning --cov=listenbrainz --no-cov-on-fail

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=listenbrainz_spark relations listenbrainz/mbid_mapping
-addopts = -W always::DeprecationWarning,error::sqlalchemy.exc.RemovedIn20Warning --cov=listenbrainz --no-cov-on-fail
+addopts = -W always::DeprecationWarning -W error::sqlalchemy.exc.RemovedIn20Warning --cov=listenbrainz --no-cov-on-fail

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ yattag == 1.14.0
 xmltodict == 0.13.0
 oauth2client == 4.1.3
 pika == 1.2.1
-brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.6.1
+brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@update-mbdata
 spotipy == 2.19.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0
 troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-09-29
@@ -37,7 +37,7 @@ Flask-UUID==0.2
 msgpack==0.5.6
 requests==2.27.1
 SQLAlchemy==1.4.37
-mbdata@git+https://github.com/amCap1712/mbdata.git@upstream-schema-changes
+mbdata@git+https://github.com/amCap1712/mbdata.git@fix-sqlalchemy-warnings
 sqlalchemy-dst==1.0.1
 typesense==0.14.0
 unidecode==1.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ yattag == 1.14.0
 xmltodict == 0.13.0
 oauth2client == 4.1.3
 pika == 1.2.1
-brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@update-mbdata
+brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.7.0
 spotipy == 2.19.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0
 troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-09-29


### PR DESCRIPTION
The previous PRs in this series fixed a large number of Base20DeprecationWarning warnings. To avoid introducing more warnings between now and a future PR that will switch the future flag to turn these warnings into errors in prod, turn these warning into errors in tests.

BU and mbdata also need to be updated to avoid failing every test since the existing mbdata version init has a deprecated import.