### PR TITLE
LB-1020: Remove 12-hour formatting from listencard timestamps

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -297,7 +297,6 @@ const preciseTimestamp = (
         year: "numeric",
         hour: "numeric",
         minute: "numeric",
-        hour12: true,
       })}`;
     case "excludeYear":
       return `${listenDate.toLocaleString(undefined, {
@@ -305,7 +304,6 @@ const preciseTimestamp = (
         month: "short",
         hour: "numeric",
         minute: "numeric",
-        hour12: true,
       })}`;
     default:
       return `${timeago.ago(listened_at)}`;


### PR DESCRIPTION
We should trust toLocaleString to do the right thing depending on the user's locale