### PR TITLE
LB-1123: Show total artist, recording, release count 

### DIFF
--- a/listenbrainz_spark/stats/sitewide/artist.py
+++ b/listenbrainz_spark/stats/sitewide/artist.py
@@ -33,20 +33,32 @@ def get_artists(table: str, user_listen_count_limit, top_artists_limit: int = SI
               FROM user_counts
           GROUP BY lower(artist_name)
                  , artist_credit_mbids
+        ), entity_count AS (
+            SELECT count(*) AS total_count
+              FROM intermediate_table
+        ), ordered_stats AS (
+            SELECT *
+              FROM intermediate_table
           ORDER BY total_listen_count DESC
              LIMIT {top_artists_limit}
-        )
-        SELECT sort_array(
-                    collect_list(
-                        struct(
-                            total_listen_count AS listen_count
-                          , artist_name
-                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
+        ), grouped_stats AS (
+            SELECT sort_array(
+                        collect_list(
+                            struct(
+                                total_listen_count AS listen_count
+                              , artist_name
+                              , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                            )
                         )
-                    )
-                    , false
-               ) AS stats
-          FROM intermediate_table
+                        , false
+                   ) AS stats
+              FROM ordered_stats
+        )
+            SELECT total_count
+                 , stats
+              FROM grouped_stats 
+              JOIN entity_count
+                ON TRUE
     """)
 
     return result.toLocalIterator()

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -88,7 +88,7 @@ def create_messages(data, entity: str, stats_range: str, from_date: datetime, to
     }
     entry = next(data).asDict(recursive=True)
     stats = entry["stats"]
-    message["count"] = len(stats)
+    message["count"] = entry["total_count"]
 
     entity_list = []
     for item in stats:

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -88,7 +88,7 @@ def create_messages(data, entity: str, stats_range: str, from_date: datetime, to
     }
     entry = next(data).asDict(recursive=True)
     stats = entry["stats"]
-    message["count"] = entry["total_count"]
+    count = entry["total_count"]
 
     entity_list = []
     for item in stats:
@@ -96,6 +96,8 @@ def create_messages(data, entity: str, stats_range: str, from_date: datetime, to
             entity_list.append(entity_model_map[entity](**item))
         except ValidationError:
             logger.error("Invalid entry in entity stats", exc_info=True)
+            count -= 1
+    message["count"] = count
     message["data"] = entity_list
 
     try:

--- a/listenbrainz_spark/stats/sitewide/recording.py
+++ b/listenbrainz_spark/stats/sitewide/recording.py
@@ -50,24 +50,36 @@ def get_recordings(table: str, user_listen_count_limit, top_recordings_limit: in
                  , artist_credit_mbids
                  , lower(release_name)
                  , release_mbid
+        ), entity_count AS (
+            SELECT count(*) AS total_count
+              FROM intermediate_table
+        ), ordered_stats AS (
+            SELECT *
+              FROM intermediate_table
           ORDER BY total_listen_count DESC
              LIMIT {top_recordings_limit}
-        )
-        SELECT sort_array(
-                    collect_list(
-                        struct(
-                            total_listen_count AS listen_count
-                          , recording_name AS track_name
-                          , recording_mbid
-                          , artist_name
-                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
-                          , release_name
-                          , release_mbid
+        ), grouped_stats AS (
+            SELECT sort_array(
+                        collect_list(
+                            struct(
+                                total_listen_count AS listen_count
+                              , recording_name AS track_name
+                              , recording_mbid
+                              , artist_name
+                              , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                              , release_name
+                              , release_mbid
+                            )
                         )
-                    )
-                   , false
-                ) as stats
-          FROM intermediate_table
+                       , false
+                   ) as stats
+              FROM ordered_stats
+        )
+        SELECT total_count
+             , stats
+          FROM grouped_stats
+          JOIN entity_count
+            ON TRUE
     """)
 
     return result.toLocalIterator()

--- a/listenbrainz_spark/stats/sitewide/release.py
+++ b/listenbrainz_spark/stats/sitewide/release.py
@@ -54,22 +54,34 @@ def get_releases(table: str, user_listen_count_limit, top_releases_limit: int = 
                  , release_mbid
                  , lower(artist_name)
                  , artist_credit_mbids
+        ), entity_count AS (
+            SELECT count(*) AS total_count
+              FROM intermediate_table
+        ), ordered_stats AS (
+            SELECT *
+              FROM intermediate_table
           ORDER BY total_listen_count DESC
              LIMIT {top_releases_limit}
-        )
-        SELECT sort_array(
-                    collect_list(
-                        struct(
-                            total_listen_count AS listen_count
-                          , release_name
-                          , release_mbid
-                          , artist_name
-                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
+        ), grouped_stats AS (
+            SELECT sort_array(
+                        collect_list(
+                            struct(
+                                total_listen_count AS listen_count
+                              , release_name
+                              , release_mbid
+                              , artist_name
+                              , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                            )
                         )
-                    )
-                   , false
-                ) as stats
-          FROM intermediate_table
+                       , false
+                   ) as stats
+              FROM ordered_stats
+        )
+            SELECT total_count
+                 , stats
+              FROM grouped_stats
+              JOIN entity_count  
+                ON TRUE
         """)
 
     return result.toLocalIterator()

--- a/listenbrainz_spark/stats/user/artist.py
+++ b/listenbrainz_spark/stats/user/artist.py
@@ -36,6 +36,11 @@ def get_artists(table: str, number_of_results: int) -> Iterator[ArtistRecord]:
           GROUP BY user_id
                  , lower(artist_name)
                  , artist_credit_mbids
+        ), entity_count as (
+            SELECT user_id
+                 , count(*) as artists_count
+              FROM intermediate_table
+          GROUP BY user_id      
         ), ranked_stats as (
             SELECT user_id
                  , any_artist_name AS artist_name
@@ -43,21 +48,28 @@ def get_artists(table: str, number_of_results: int) -> Iterator[ArtistRecord]:
                  , listen_count
                  , row_number() OVER (PARTITION BY user_id ORDER BY listen_count DESC) AS rank
               FROM intermediate_table
-        )
-        SELECT user_id
-             , sort_array(
-                    collect_list(
-                        struct(
-                            listen_count
-                          , artist_name
-                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
+        ), grouped_stats AS (
+            SELECT user_id
+                 , sort_array(
+                        collect_list(
+                            struct(
+                                listen_count
+                              , artist_name
+                              , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                            )
                         )
-                    )
-                    , false
-               ) as artists
-          FROM ranked_stats
-         WHERE rank < {number_of_results}
-      GROUP BY user_id 
+                        , false
+                   ) as artists
+              FROM ranked_stats
+             WHERE rank < {number_of_results}
+          GROUP BY user_id
+        )
+            SELECT user_id
+                 , artists_count
+                 , artists
+              FROM grouped_stats
+              JOIN entity_count
+             USING (user_id)
     """)
 
     return result.toLocalIterator()

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -78,6 +78,7 @@ def parse_one_user_stats(entry, entity: str, stats_range: str) \
             entity_list.append(entity_model_map[entity](**item))
         except ValidationError:
             logger.error("Invalid entry in entity stats", exc_info=True)
+            total_entity_count -= 1
 
     try:
         return UserEntityRecords(

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -69,7 +69,8 @@ def calculate_entity_stats(from_date: datetime, to_date: datetime, table: str, e
 def parse_one_user_stats(entry, entity: str, stats_range: str) \
         -> Optional[UserEntityRecords]:
     _dict = entry.asDict(recursive=True)
-    total_entity_count = len(_dict[entity])
+    count_key = entity + "_count"
+    total_entity_count = _dict[count_key]
 
     entity_list = []
     for item in _dict[entity]:

--- a/listenbrainz_spark/stats/user/recording.py
+++ b/listenbrainz_spark/stats/user/recording.py
@@ -45,6 +45,11 @@ def get_recordings(table: str, number_of_results: int):
                  , artist_credit_mbids
                  , lower(release_name)
                  , release_mbid
+        ), entity_count as (
+            SELECT user_id
+                 , count(*) as recordings_count
+              FROM intermediate_table
+          GROUP BY user_id      
         ), ranked_stats as (
             SELECT user_id
                  , any_recording_name AS track_name
@@ -56,25 +61,32 @@ def get_recordings(table: str, number_of_results: int):
                  , listen_count
                  , row_number() OVER (PARTITION BY user_id ORDER BY listen_count DESC) AS rank
               FROM intermediate_table
-        )
-        SELECT user_id
-             , sort_array(
-                    collect_list(
-                        struct(
-                            listen_count
-                          , track_name
-                          , recording_mbid
-                          , artist_name
-                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
-                          , release_name
-                          , release_mbid
+        ), grouped_stats AS (
+            SELECT user_id
+                 , sort_array(
+                        collect_list(
+                            struct(
+                                listen_count
+                              , track_name
+                              , recording_mbid
+                              , artist_name
+                              , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                              , release_name
+                              , release_mbid
+                            )
                         )
-                    )
-                   , false
-                ) as recordings
-          FROM ranked_stats
-         WHERE rank < {number_of_results}
-      GROUP BY user_id
+                        , false
+                   ) as recordings
+              FROM ranked_stats
+             WHERE rank < {number_of_results}
+          GROUP BY user_id
+        )
+            SELECT user_id
+                 , recordings_count
+                 , recordings
+              FROM grouped_stats
+              JOIN entity_count
+             USING (user_id)
         """)
 
     return result.toLocalIterator()

--- a/listenbrainz_spark/stats/user/release.py
+++ b/listenbrainz_spark/stats/user/release.py
@@ -41,6 +41,11 @@ def get_releases(table: str, number_of_results: int):
                 , release_mbid
                 , lower(artist_name)
                 , artist_credit_mbids
+        ), entity_count as (
+            SELECT user_id
+                 , count(*) as releases_count
+              FROM intermediate_table
+          GROUP BY user_id      
         ), ranked_stats as (
             SELECT user_id
                  , any_release_name AS release_name
@@ -50,23 +55,30 @@ def get_releases(table: str, number_of_results: int):
                  , listen_count
                  , row_number() OVER (PARTITION BY user_id ORDER BY listen_count DESC) AS rank
               FROM intermediate_table
-        )
-        SELECT user_id
-             , sort_array(
-                    collect_list(
-                        struct(
-                            listen_count
-                          , release_name
-                          , release_mbid
-                          , artist_name
-                          , coalesce(artist_credit_mbids, array()) AS artist_mbids
+        ), grouped_stats AS (
+            SELECT user_id
+                 , sort_array(
+                        collect_list(
+                            struct(
+                                listen_count
+                              , release_name
+                              , release_mbid
+                              , artist_name
+                              , coalesce(artist_credit_mbids, array()) AS artist_mbids
+                            )
                         )
-                    )
-                   , false
-                ) as releases
-          FROM ranked_stats
-         WHERE rank < {number_of_results}
-      GROUP BY user_id
+                       , false
+                    ) as releases
+              FROM ranked_stats
+             WHERE rank < {number_of_results}
+          GROUP BY user_id
+        )
+            SELECT user_id
+                 , releases_count
+                 , releases
+              FROM grouped_stats
+              JOIN entity_count
+             USING (user_id)
         """)
 
     return result.toLocalIterator()

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -70,7 +70,8 @@ class UserEntityTestCase(StatsTestCase):
         mock_result = MagicMock()
         mock_result.asDict.return_value = {
             'user_id': 1,
-            'artists': data
+            'artists': data,
+            'artists_count': 3
         }
 
         messages = entity.create_messages([mock_result], 'artists', 'all_time',
@@ -89,7 +90,8 @@ class UserEntityTestCase(StatsTestCase):
         mock_result = MagicMock()
         mock_result.asDict.return_value = {
             'user_id': 1,
-            'releases': data
+            'releases': data,
+            'releases_count': 3
         }
 
         messages = entity.create_messages([mock_result], 'releases', 'all_time',
@@ -108,7 +110,8 @@ class UserEntityTestCase(StatsTestCase):
         mock_result = MagicMock()
         mock_result.asDict.return_value = {
             'user_id': 1,
-            'recordings': data
+            'recordings': data,
+            'recordings_count': 4
         }
 
         messages = entity.create_messages([mock_result], 'recordings', 'all_time',

--- a/listenbrainz_spark/testdata/sitewide_top_artists_incorrect.json
+++ b/listenbrainz_spark/testdata/sitewide_top_artists_incorrect.json
@@ -1,19 +1,20 @@
 {
-    "stats": [
-        {
-          "artist_name": "artist_1",
-          "artist_mbids": [],
-          "listen_count": 1
-        },
-        {
-          "artist_name": null,
-          "artist_mbids": [],
-          "listen_count": 1
-        },
-        {
-          "artist_name": "artist_2",
-          "artist_mbids": [],
-          "listen_count": null
-        }
-    ]
+  "total_count": 3,
+  "stats": [
+    {
+      "artist_name": "artist_1",
+      "artist_mbids": [],
+      "listen_count": 1
+    },
+    {
+      "artist_name": null,
+      "artist_mbids": [],
+      "listen_count": 1
+    },
+    {
+      "artist_name": "artist_2",
+      "artist_mbids": [],
+      "listen_count": null
+    }
+  ]
 }


### PR DESCRIPTION
We limit the actual stats to top 1000 to conserve resources but the total overall counts will now be accurate.

Also, make counts accurate in case entries are discarded during validation.