### PR TITLE
Fix datetime formatting for listening activity stats

### DIFF
--- a/listenbrainz_spark/stats/common/listening_activity.py
+++ b/listenbrainz_spark/stats/common/listening_activity.py
@@ -79,7 +79,7 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
         from_ts = datetime.combine(from_date, time.min)
         step = relativedelta(days=+1)
         date_format = "%d %B %Y"
-        spark_date_format = "d MMMM y"
+        spark_date_format = "dd MMMM y"
         return from_ts, to_ts, step, date_format, spark_date_format
 
     if stats_range == "all_time":
@@ -108,14 +108,14 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
             # compute listening activity for each day, include weekday in date format
             step = relativedelta(days=+1)
             date_format = "%A %d %B %Y"
-            spark_date_format = "EEEE d MMMM y"
+            spark_date_format = "EEEE dd MMMM y"
         elif stats_range == "this_month":
             # if today is 1st then 1st of 2 months ago otherwise the 1st of last month
             from_offset = relativedelta(months=-2) if latest_listen_date.day == 1 else relativedelta(months=-1, day=1)
             # compute listening activity for each day but no weekday
             step = relativedelta(days=+1)
             date_format = "%d %B %Y"
-            spark_date_format = "d MMMM y"
+            spark_date_format = "dd MMMM y"
         else:
             # if today is the 1st of the year, then still show last year stats
             if latest_listen_date.day == 1 and latest_listen_date.month == 1:
@@ -145,20 +145,20 @@ def get_time_range(stats_range: str) -> Tuple[datetime, datetime, relativedelta,
         # compute listening activity for each day, include weekday in date format
         step = relativedelta(days=+1)
         date_format = "%A %d %B %Y"
-        spark_date_format = "EEEE d MMMM y"
+        spark_date_format = "EEEE dd MMMM y"
     elif stats_range == "month":
         from_offset = relativedelta(months=-2, day=1)  # start of the previous to previous month
         to_offset = relativedelta(months=+2)
         # compute listening activity for each day but no weekday
         step = relativedelta(days=+1)
         date_format = "%d %B %Y"
-        spark_date_format = "d MMMM y"
+        spark_date_format = "dd MMMM y"
     elif stats_range == "quarter":
         from_offset = get_two_quarters_ago_offset(latest_listen_date)
         to_offset = relativedelta(months=+6)
         step = relativedelta(days=+1)
         date_format = "%d %B %Y"
-        spark_date_format = "d MMMM y"
+        spark_date_format = "dd MMMM y"
     elif stats_range == "half_yearly":
         from_offset = _get_half_year_offset(latest_listen_date)
         to_offset = relativedelta(months=+12)

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -106,7 +106,7 @@ class ListeningActivityTestCase(StatsTestCase):
         ]
         step = relativedelta(days=+1)
         fmt = "%d %B %Y"
-        spark_fmt = "d MMMM y"
+        spark_fmt = "dd MMMM y"
 
         mock_listen_ts.return_value = datetime(2021, 1, 5, 2, 3, 0)
         self.assertEqual((quarters[0], quarters[2], step, fmt, spark_fmt), listening_activity_utils.get_time_range("quarter"))
@@ -134,7 +134,7 @@ class ListeningActivityTestCase(StatsTestCase):
 
         step = relativedelta(days=+1)
         fmt = "%A %d %B %Y"
-        spark_fmt = "EEEE d MMMM y"
+        spark_fmt = "EEEE dd MMMM y"
 
         mock_listen_ts.return_value = datetime(2021, 11, 24, 2, 3, 0)
         self.assertEqual(
@@ -160,7 +160,7 @@ class ListeningActivityTestCase(StatsTestCase):
 
         step = relativedelta(days=+1)
         fmt = "%d %B %Y"
-        spark_fmt = "d MMMM y"
+        spark_fmt = "dd MMMM y"
 
         mock_listen_ts.return_value = datetime(2021, 11, 21, 2, 3, 0)
         self.assertEqual(


### PR DESCRIPTION
Python's %d datetime formatter returns 0 padded days whereas spark's d formatter returns the minimum number of digits needed in the day i.e. no padding. For padding, we need to use dd. We join on the datetime strings generated by python and spark to add 0-count rows for missing time ranges. This mismatch in day formatting was causing stats to be incomplete. User listening activity stats are unaffected because those do not use this datetime modifier and calculated differently.

Example:

Spark Old (EEEE d MMMM y):    Friday 9 September 2022
Spark Fixed (EEEE dd MMMM y): Friday 09 September 2022
Python (%A %d %B %Y):         Friday 09 September 2022