### PR TITLE
Adds playlists management page

### DIFF
--- a/listenbrainz/webserver/templates/index/playlists-management.html
+++ b/listenbrainz/webserver/templates/index/playlists-management.html
@@ -1,0 +1,34 @@
+{%- extends 'base.html' -%}
+{%- block title -%}Playlists management - ListenBrainz{%- endblock -%}
+{%- block content -%}
+  <h2 class="page-title">Playlists managementg </h2>
+  {# Playlists management information #}
+  <h3>Synchronizing Playlists</h3>
+  <p>
+    There are many ways to sync your own playlists to ListenBrainz:
+  </p>
+  <h4>Music players</h4>
+  <ul>
+    <li><em><a href="https://www.foobar2000.org/">Foobar2000</a></em>, full-fledged audio player for Windows: <a href="https://github.com/regorxxx/Playlist-Manager-SMP"><code>Playlist-Manager-SMP</code></a></li>
+  </ul>
+
+  <h3>Synchronizing via third-party music services</h3>
+  <p>
+    <a href={{ url_for('profile.music_services_details') }}>Connect your ListenBrainz account</a> and import/export your playlists to some third-party services.
+  </p>
+  <ul>
+    <li><em><a href="https://open.spotify.com/">Spotify</a></em></li>
+  </ul>
+  <p>
+    
+  </p>
+
+  <h3>For advanced users</h3>
+  <p>
+    Developers are able to import/export and edit their playlists on Listenbrainz using the Listenbrainz API. Information on how to do this
+    can be found in the <a href="https://listenbrainz.readthedocs.io">API docs</a>.
+  </p>
+  <p>
+	Note playlist importing requires track MBID identification for every item; exporting requires some kind of content resolution of tracks by track MBID, title and/or artist, following <a href="https://xspf.org/spec#34-content-resolver">JSPF or XSPF specs</a>.
+  </p>
+{%- endblock -%}

--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -32,6 +32,7 @@
             <li><a href="{{ url_for('index.add_data_info') }}">Adding data</a></li>
             <li><a href="{{ url_for('index.import_data_info') }}">Importing data</a></li>
             <li><a href="{{ url_for('index.data') }}">Using our data</a></li>
+            <li><a href="{{ url_for('index.playlists_management_info') }}">Playlists management</a></li>
           </ul>
         </li>
         <li class="dropdown">

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -80,6 +80,11 @@ def import_data_info():
     return render_template("index/import-data.html")
 
 
+@index_bp.route("/playlists-management/")
+def playlists_management_info():
+    return render_template("index/playlists-management.html")
+
+
 @index_bp.route("/lastfm-proxy/")
 def proxy():
     return render_template("index/lastfm-proxy.html")

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -42,6 +42,10 @@ class IndexViewsTestCase(IntegrationTestCase):
         resp = self.client.get(url_for('index.import_data_info'))
         self.assert200(resp)
 
+    def test_playlists_management_info(self):
+        resp = self.client.get(url_for('index.playlists_management_info'))
+        self.assert200(resp)
+
     def test_404(self):
         resp = self.client.get('/canyoufindthis')
         self.assert404(resp)


### PR DESCRIPTION
Adds new page to navbar (data menu) for playlists management. Includes a link to [foobar2000 playlist manager ](https://github.com/regorxxx/Playlist-Manager-SMP)to sync playlists on ListenBrainz with local playlists (with content resolution) and Spotify [third party service connection](https://listenbrainz.org/profile/music-services/details/). Also a note about advanced usage related to[ content resolution following XSPF specs.](https://xspf.org/spec#34-content-resolver)

Rationale: if ListenBrainz is gonna make use of playlists (either user made, collaborative or bots), some kind of software support will be required... and it would be great to encourage it with its own page. This would be the first step.

Structure is mostly a clone of 'Adding data' tab.