### PR TITLE
LB-942: Ignore keyboard navigation when a textarea is focused

### DIFF
--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -391,8 +391,9 @@ export default class Listens extends React.Component<
   };
 
   handleKeyDown = (event: KeyboardEvent) => {
-    if (document.activeElement?.localName === "input") {
-      // Don't allow keyboard navigation if an input is currently in focus
+    const elementName = document.activeElement?.localName;
+    if (elementName && ["input", "textarea"].includes(elementName)) {
+      // Don't allow keyboard navigation if an input or textarea is currently in focus
       return;
     }
     switch (event.key) {

--- a/listenbrainz/webserver/static/js/src/user/UserFeedback.tsx
+++ b/listenbrainz/webserver/static/js/src/user/UserFeedback.tsx
@@ -127,8 +127,9 @@ export default class UserFeedback extends React.Component<
   }
 
   handleKeyDown = (event: KeyboardEvent) => {
-    if (document.activeElement?.localName === "input") {
-      // Don't allow keyboard navigation if an input is currently in focus
+    const elementName = document.activeElement?.localName;
+    if (elementName && ["input", "textarea"].includes(elementName)) {
+      // Don't allow keyboard navigation if an input or textarea is currently in focus
       return;
     }
     switch (event.key) {


### PR DESCRIPTION
We previously ignored keyboard nav if an input was in focus; this PR adds the same behavior for textareas (For example pin recording and CB review modals)