### PR TITLE
Run troi bot hourly

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -6,7 +6,7 @@ MAILTO=""
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete_listens_and_update_metadata >> /logs/listen_metadata.log 2>&1
 
 # Generating troi daily playlists runs hourly
-0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py generate_playlists >> /logs/troi.log 2>&1
+0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py run_daily_jams >> /logs/troi.log 2>&1
 
 ## Trigger an incremental dump everyday, near noon, far away from whole dump times, again do not block for the lock.
 0 0 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -5,6 +5,9 @@ MAILTO=""
 # Delete pending listens and update our listen counts, timestamps hourly
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete_listens_and_update_metadata >> /logs/listen_metadata.log 2>&1
 
+# Generating troi daily playlists runs hourly
+0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py generate_playlists >> /logs/troi.log 2>&1
+
 ## Trigger an incremental dump everyday, near noon, far away from whole dump times, again do not block for the lock.
 0 0 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1
 ## Around 1 hour later, trigger an incremental import into the spark cluster, blocking for the lock in case the dump was not complete

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -6,7 +6,7 @@ MAILTO=""
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete_listens_and_update_metadata >> /logs/listen_metadata.log 2>&1
 
 # Generating troi daily playlists runs hourly
-0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py run_daily_jams >> /logs/troi.log 2>&1
+0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py run-daily-jams >> /logs/troi.log 2>&1
 
 ## Trigger an incremental dump everyday, near noon, far away from whole dump times, again do not block for the lock.
 0 0 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -14,6 +14,7 @@ from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data a
     delete_listens as ts_delete_listens, \
     delete_listens_and_update_user_listen_data as ts_delete_listens_and_update_user_listen_data
 from listenbrainz.messybrainz import transfer_to_timescale
+from listenbrainz.troi.troi_bot import run_daily_jams_troi_bot
 from listenbrainz.webserver import create_app
 
 
@@ -282,3 +283,9 @@ def msb_transfer_db():
     """ Transfer MsB tables from MsB DB to TS DB"""
     with create_app().app_context():
         transfer_to_timescale.run()
+
+
+@cli.command()
+def generate_playlists():
+    """ Generate daily playlists for users after checking timezone settings """
+    run_daily_jams_troi_bot()

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -286,7 +286,7 @@ def msb_transfer_db():
 
 
 @cli.command()
-def generate_playlists():
+def run_daily_jams():
     """ Generate daily playlists for users soon after the new day begins in their timezone. This is an internal LB
     method and not a core function of troi.
     """

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -287,5 +287,7 @@ def msb_transfer_db():
 
 @cli.command()
 def generate_playlists():
-    """ Generate daily playlists for users after checking timezone settings """
+    """ Generate daily playlists for users soon after the new day begins in their timezone. This is an internal LB
+    method and not a core function of troi.
+    """
     run_daily_jams_troi_bot()

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -290,4 +290,5 @@ def run_daily_jams():
     """ Generate daily playlists for users soon after the new day begins in their timezone. This is an internal LB
     method and not a core function of troi.
     """
-    run_daily_jams_troi_bot()
+    with create_app().app_context():
+        run_daily_jams_troi_bot()

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -18,7 +18,6 @@ from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJ
 from listenbrainz.db import year_in_music, couchdb
 from listenbrainz.db.fresh_releases import insert_fresh_releases
 from listenbrainz.db.similar_users import import_user_similarities
-from listenbrainz.spark.troi_bot import run_post_recommendation_troi_bot
 
 TIME_TO_CONSIDER_STATS_AS_OLD = 20  # minutes
 TIME_TO_CONSIDER_RECOMMENDATIONS_AS_OLD = 7  # days
@@ -307,8 +306,6 @@ def cf_recording_recommendations_complete(data):
     Run any troi scripts necessary now that recommendations have been generated and
     send an email to notify recommendations have been generated and are being written into db.
     """
-
-    run_post_recommendation_troi_bot()
 
     if current_app.config['TESTING']:
         return

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -18,6 +18,7 @@ from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJ
 from listenbrainz.db import year_in_music, couchdb
 from listenbrainz.db.fresh_releases import insert_fresh_releases
 from listenbrainz.db.similar_users import import_user_similarities
+from listenbrainz.troi.troi_bot import run_post_recommendation_troi_bot
 
 TIME_TO_CONSIDER_STATS_AS_OLD = 20  # minutes
 TIME_TO_CONSIDER_RECOMMENDATIONS_AS_OLD = 7  # days
@@ -306,6 +307,7 @@ def cf_recording_recommendations_complete(data):
     Run any troi scripts necessary now that recommendations have been generated and
     send an email to notify recommendations have been generated and are being written into db.
     """
+    run_post_recommendation_troi_bot()
 
     if current_app.config['TESTING']:
         return

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -368,8 +368,10 @@ class HandlersTestCase(DatabaseTestCase):
             )
         )
 
+    @mock.patch('listenbrainz.spark.troi_bot.get_followers_of_user')
+    @mock.patch('listenbrainz.spark.troi_bot.generate_playlist')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
-    def test_cf_recording_recommendations_complete(self, mock_send_mail):
+    def test_cf_recording_recommendations_complete(self, mock_send_mail, mock_gen_playlist, mock_get_followers):
         with self.app.app_context():
             active_user_count = 10
             top_artist_user_count = 5
@@ -380,6 +382,10 @@ class HandlersTestCase(DatabaseTestCase):
             self.app.config['TESTING'] = True
             self.app.config["WHITELISTED_AUTH_TOKENS"] = ["fake_token0", "fake_token1"]
 
+            mock_gen_playlist.return_value = "https://listenbrainz.org/playlist/97889d4d-1474-4a9b-925a-851148356f9d/"
+            mock_get_followers.side_effect = [[{"musicbrainz_id": "lucifer"}], [{"musicbrainz_id": "lucifer"}],
+                                              [{"musicbrainz_id": "lucifer"}], [{"musicbrainz_id": "lucifer"}]]
+
             cf_recording_recommendations_complete({
                 'active_user_count': active_user_count,
                 'top_artist_user_count': top_artist_user_count,
@@ -387,6 +393,12 @@ class HandlersTestCase(DatabaseTestCase):
                 'total_time': str(total_time)
             })
             mock_send_mail.assert_not_called()
+
+            calls = [
+                call("recs-to-playlist", args=["lucifer", "top"], upload=True, token="fake_token1", created_for="lucifer"),
+                call("recs-to-playlist", args=["lucifer", "similar"], upload=True, token="fake_token1", created_for="lucifer"),
+            ]
+            mock_gen_playlist.assert_has_calls(calls)
 
             # in prod now, should send it
             self.app.config['TESTING'] = False

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -368,10 +368,8 @@ class HandlersTestCase(DatabaseTestCase):
             )
         )
 
-    @mock.patch('listenbrainz.spark.troi_bot.get_followers_of_user')
-    @mock.patch('listenbrainz.spark.troi_bot.generate_playlist')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
-    def test_cf_recording_recommendations_complete(self, mock_send_mail, mock_gen_playlist, mock_get_followers):
+    def test_cf_recording_recommendations_complete(self, mock_send_mail):
         with self.app.app_context():
             active_user_count = 10
             top_artist_user_count = 5
@@ -382,10 +380,6 @@ class HandlersTestCase(DatabaseTestCase):
             self.app.config['TESTING'] = True
             self.app.config["WHITELISTED_AUTH_TOKENS"] = ["fake_token0", "fake_token1"]
 
-            mock_gen_playlist.return_value = "https://listenbrainz.org/playlist/97889d4d-1474-4a9b-925a-851148356f9d/"
-            mock_get_followers.side_effect = [[{"musicbrainz_id": "lucifer"}], [{"musicbrainz_id": "lucifer"}],
-                                              [{"musicbrainz_id": "lucifer"}], [{"musicbrainz_id": "lucifer"}]]
-
             cf_recording_recommendations_complete({
                 'active_user_count': active_user_count,
                 'top_artist_user_count': top_artist_user_count,
@@ -393,13 +387,6 @@ class HandlersTestCase(DatabaseTestCase):
                 'total_time': str(total_time)
             })
             mock_send_mail.assert_not_called()
-
-            calls = [
-                call("recs-to-playlist", args=["lucifer", "top"], upload=True, token="fake_token1", created_for="lucifer"),
-                call("recs-to-playlist", args=["lucifer", "similar"], upload=True, token="fake_token1", created_for="lucifer"),
-                call("daily-jams", args=["lucifer"], upload=True, token="fake_token0", created_for="lucifer")
-            ]
-            mock_gen_playlist.assert_has_calls(calls)
 
             # in prod now, should send it
             self.app.config['TESTING'] = False

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -368,8 +368,8 @@ class HandlersTestCase(DatabaseTestCase):
             )
         )
 
-    @mock.patch('listenbrainz.spark.troi_bot.get_followers_of_user')
-    @mock.patch('listenbrainz.spark.troi_bot.generate_playlist')
+    @mock.patch('listenbrainz.troi.troi_bot.get_followers_of_user')
+    @mock.patch('listenbrainz.troi.troi_bot.generate_playlist')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_cf_recording_recommendations_complete(self, mock_send_mail, mock_gen_playlist, mock_get_followers):
         with self.app.app_context():

--- a/listenbrainz/troi/troi_bot.py
+++ b/listenbrainz/troi/troi_bot.py
@@ -36,7 +36,7 @@ def get_users_for_daily_jams():
     query = """
         SELECT "user".musicbrainz_id AS musicbrainz_id
              , "user".id as id
-             , to_char(NOW() AT TIME ZONE COALESCE(us.timezone_name, 'GMT'), 'YYYY-MM-DD DY') AS jam_date
+             , to_char(NOW() AT TIME ZONE COALESCE(us.timezone_name, 'GMT'), 'YYYY-MM-DD Dy') AS jam_date
           FROM user_relationship
           JOIN "user"
             ON "user".id = user_0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.6.1
 spotipy == 2.19.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@v-2021-02-10.0
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-07-15
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-09-29
 PyYAML==6.0
 eventlet == 0.33.1
 uWSGI == 2.0.20


### PR DESCRIPTION
Instead of running troi bot after recommendation are generated, run troi bot hourly. Every check which for which followers the new day has just started and generate daily jams for them. If we do not know the timezone of a user assume it to be GMT.

Note that daily jams patch currently does not accept a date or timezone parameter so the date in it can be incorrect for the time being.