### PR TITLE
Make develop.sh and test.sh compatible with compose v2

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -8,8 +8,16 @@ if [[ ! -d "docker" ]]; then
     exit -1
 fi
 
+echo "Checking docker compose version"
+if docker compose version &> /dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+
 function invoke_docker_compose {
-    exec docker-compose -f docker/docker-compose.yml \
+    exec $DOCKER_COMPOSE_CMD -f docker/docker-compose.yml \
                 -p listenbrainz \
                 "$@"
 }
@@ -31,7 +39,7 @@ function open_timescale_shell {
 }
 
 function invoke_docker_compose_spark {
-    exec docker-compose -f docker/docker-compose.spark.yml -f docker/docker-compose.spark.override.yml \
+    exec $DOCKER_COMPOSE_CMD -f docker/docker-compose.spark.yml -f docker/docker-compose.spark.override.yml \
                 -p listenbrainzspark \
                 "$@"
 }

--- a/test.sh
+++ b/test.sh
@@ -36,14 +36,22 @@ if [[ ! -d "docker" ]]; then
     exit 255
 fi
 
+echo "Checking docker compose version"
+if docker compose version &> /dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+
 function invoke_docker_compose {
-    docker-compose -f $COMPOSE_FILE_LOC \
+    $DOCKER_COMPOSE_CMD -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
                    "$@"
 }
 
 function invoke_docker_compose_spark {
-    docker-compose -f $SPARK_COMPOSE_FILE_LOC \
+    $DOCKER_COMPOSE_CMD -f $SPARK_COMPOSE_FILE_LOC \
                    -p $SPARK_COMPOSE_PROJECT_NAME \
                    "$@"
 }
@@ -213,7 +221,7 @@ if [ "$1" == "-s" ]; then
 fi
 
 if [ "$1" == "-d" ]; then
-    echo "Running docker-compose down"
+    echo "Running docker compose down"
     unit_dcdown
     exit 0
 fi


### PR DESCRIPTION
The command to execute docker compose in v2 is `docker compose` as opposed to `docker-compose` in v1. I recently upgraded versions on my local machine and faced errors while trying to execute the scripts. Since, no else has complained so far they are likely using v1. Therefore, updating the scripts to check the version of docker compose installed and invoke the appropriate command for compatibility with both versions.

Note that there are some differences between the two commands but AFAIU those are not relevant to our uses.