### PR TITLE
Tweak CAA retry strategy

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -472,17 +472,17 @@ const getAlbumArtFromListenMetadata = async (
       const CAAResponse = await fetchWithRetry(
         `https://coverartarchive.org/release/${releaseMBID}`,
         {
-          retries: 3,
+          retries: 4,
           retryOn: [429],
           retryDelay(attempt: number) {
-            // Retry at random interval between maxRetryTime and minRetryTime defined above, adding minRetryTime for every attempt
-            // attempt starts at 0
-            const maxRetryTime = 800;
-            const minRetryTime = 400;
-            return Math.floor(
-              Math.random() * (maxRetryTime - minRetryTime) +
-                attempt * minRetryTime
-            );
+            // Exponential backoff at random interval between maxRetryTime and minRetryTime,
+            // adding minRetryTime for every attempt. `attempt` starts at 0
+            const maxRetryTime = 2500;
+            const minRetryTime = 1800;
+            const clampedRandomTime =
+              Math.random() * (maxRetryTime - minRetryTime) + minRetryTime;
+            // Make it exponential
+            return Math.floor(clampedRandomTime) * 2 ** attempt;
           },
         }
       );


### PR DESCRIPTION
After some investigation of the CAA 429 responses, I decided to add a bit more delay between retries as well as an exponential backoff, in order not to hammer the CAA servers if there are already issues on the server (the 429s were caused by hitting a global limit of number of requests per second, so more retries = more 429s)