### PR TITLE
Remove configuration options for websocket server

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -253,7 +253,6 @@ SMTP_PORT = "SERVICEDOESNOTEXIST_listenbrainz-org.exim-relay"
 {{end}}
 
 MAIL_FROM_DOMAIN = '''{{template "KEY" "mail_from_domain"}}'''
-WEBSOCKETS_SERVER_URL = '''{{template "KEY" "websockets_server_url"}}'''
 
 SESSION_REMEMBER_ME_DURATION = 365
 

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -132,7 +132,6 @@ UPLOAD_FOLDER = "/tmp/lastfm-backup-upload"
 API_URL = 'https://api.listenbrainz.org'
 LASTFM_PROXY_URL = 'http://localhost:8101/'
 SERVER_ROOT_URL = 'http://localhost:8100'
-WEBSOCKETS_SERVER_URL = 'http://localhost:8102'
 MUSICBRAINZ_OAUTH_URL = 'https://musicbrainz.org/oauth2/userinfo'
 LISTENBRAINZ_LABS_API_URL = 'https://labs.api.listenbrainz.org'
 

--- a/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
+++ b/listenbrainz/webserver/static/js/src/recommendations/Recommendations.tsx
@@ -31,7 +31,6 @@ export type RecommendationsProps = {
   recommendations?: Array<Recommendation>;
   profileUrl?: string;
   user: ListenBrainzUser;
-  webSocketsServerUrl: string;
 } & WithAlertNotificationsInjectedProps;
 
 export interface RecommendationsState {
@@ -359,7 +358,7 @@ document.addEventListener("DOMContentLoaded", () => {
     youtube,
     sentry_traces_sample_rate,
   } = globalReactProps;
-  const { recommendations, user, web_sockets_server_url } = reactProps;
+  const { recommendations, user } = reactProps;
 
   if (sentry_dsn) {
     Sentry.init({
@@ -390,7 +389,6 @@ document.addEventListener("DOMContentLoaded", () => {
           initialAlerts={optionalAlerts}
           recommendations={recommendations}
           user={user}
-          webSocketsServerUrl={web_sockets_server_url}
         />
       </GlobalAppContext.Provider>
     </ErrorBoundary>,

--- a/listenbrainz/webserver/static/js/tests/__mocks__/playlistPageProps.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/playlistPageProps.json
@@ -36,6 +36,5 @@
             ]
         }
     },
-    "webSocketsServerUrl": "http://localhost:7082",
     "labsApiUrl": "http://0.0.0.0"
 }

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensProps.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensProps.json
@@ -1106,6 +1106,5 @@
     "youtube": {
         "api_key": "fake-api-key"
     },
-    "webSocketsServerUrl": "",
     "searchLargerTimeRange": 0
 }

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsOneListen.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsOneListen.json
@@ -31,7 +31,6 @@
     "access_token": "access token",
     "permission": ["streaming", "user-read-email", "user-read-private"]
   },
-  "webSocketsServerUrl": "http://localhost:7082",
   "searchLargerTimeRange": 0
 }
 

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsPlayingNow.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsPlayingNow.json
@@ -41,7 +41,6 @@
     "access_token": "access token",
     "permission": ["streaming", "user-read-email", "user-read-private"]
   },
-  "webSocketsServerUrl": "http://localhost:7082",
   "searchLargerTimeRange": 0
 }
 

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsThreeListens.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsThreeListens.json
@@ -130,6 +130,5 @@
       "user-read-email",
       "user-read-private"
     ]
-  },
-  "webSocketsServerUrl": "http://localhost:7082"
+  }
 }

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsTooManyListens.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsTooManyListens.json
@@ -840,7 +840,6 @@
 	  "access_token": "access token",
 	  "permission": ["streaming", "user-read-email", "user-read-private"]
 	},
-	"webSocketsServerUrl": "http://localhost:7082",
 	"searchLargerTimeRange": 0
   }
   

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recommendationPropsOne.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recommendationPropsOne.json
@@ -25,7 +25,6 @@
         }
       }
     ],
-    "webSocketsServerUrl": "http://localhost:7082",
     "spotify": {
       "access_token": "access token",
       "permission": ["streaming", "user-read-email", "user-read-private"]

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recommendations.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recommendations.json
@@ -725,7 +725,6 @@
 		}
 	  }
 	],
-	"webSocketsServerUrl": "http://localhost:7082",
 	"spotify": {
 	  "access_token": "access token",
 	  "permission": ["streaming", "user-read-email", "user-read-private"]

--- a/listenbrainz/webserver/static/js/tests/__mocks__/userSocialNetworkProps.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/userSocialNetworkProps.json
@@ -6,6 +6,5 @@
     "user": {
         "id": 2,
         "name": "bob"
-    },
-    "webSocketsServerUrl": "http://localhost:7082"
+    }
 }

--- a/listenbrainz/webserver/static/js/tests/playlists/Playlist.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/playlists/Playlist.test.tsx
@@ -26,13 +26,11 @@ const {
   labsApiUrl,
   currentUser,
   playlist,
-  webSocketsServerUrl,
 } = playlistPageProps;
 
 const props = {
   labsApiUrl,
   playlist: playlist as JSPFObject,
-  webSocketsServerUrl,
   newAlert: () => {},
 };
 

--- a/listenbrainz/webserver/static/js/tests/recommendations/Recommendations.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/recommendations/Recommendations.test.tsx
@@ -20,7 +20,6 @@ const {
   spotify,
   youtube,
   user,
-  webSocketsServerUrl,
 } = recommendationProps;
 
 const props = {
@@ -29,7 +28,6 @@ const props = {
   spotify: spotify as SpotifyUser,
   youtube: youtube as YoutubeUser,
   user,
-  webSocketsServerUrl,
   newAlert: () => {},
 };
 

--- a/listenbrainz/webserver/views/metadata_viewer.py
+++ b/listenbrainz/webserver/views/metadata_viewer.py
@@ -25,8 +25,7 @@ def playing_now_metadata_viewer():
     # and add to props as 'metadata'
 
     props = {
-        "playing_now": playing_now,
-        "web_sockets_server_url": current_app.config['WEBSOCKETS_SERVER_URL'],
+        "playing_now": playing_now
     }
 
     return render_template(

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -31,7 +31,6 @@ def load_playlist(playlist_mbid: str):
 
     props = {
         "labs_api_url": current_app.config["LISTENBRAINZ_LABS_API_URL"],
-        "web_sockets_server_url": current_app.config['WEBSOCKETS_SERVER_URL'],
         "playlist": serialize_jspf(playlist),
     }
 

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -112,7 +112,6 @@ def _get_template(active_section, user):
             "id": user.id,
             "name": user.musicbrainz_id,
         },
-        "web_sockets_server_url": current_app.config['WEBSOCKETS_SERVER_URL'],
         "recommendations": recommendations,
     }
 

--- a/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
@@ -224,7 +224,6 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
                 "id": self.user2["id"],
                 "name": 'vansika_1',
             },
-            "web_sockets_server_url": current_app.config['WEBSOCKETS_SERVER_URL'],
             "recommendations": recommendations,
         }
         received_props = ujson.loads(self.get_context_variable('props'))

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -134,7 +134,6 @@ def profile(user_name):
         "oldest_listen_ts": min_ts_per_user,
         "profile_url": url_for('user.profile', user_name=user_name),
         "userPinnedRecording": pin,
-        "web_sockets_server_url": current_app.config['WEBSOCKETS_SERVER_URL'],
         "logged_in_user_follows_user": logged_in_user_follows_user(user),
         "already_reported_user": already_reported_user,
     }


### PR DESCRIPTION

# Problem

This was unused since we moved the production websockets server to a sub-url of the main listenbrainz.org domain instead of a subdomain.



# Solution
Delete it

# Action

Websockets still don't work on local development, we will fix this later


