### PR TITLE
Add cover art id to fresh releases

### DIFF
--- a/listenbrainz/db/fresh_releases.py
+++ b/listenbrainz/db/fresh_releases.py
@@ -28,66 +28,88 @@ def get_sitewide_fresh_releases(pivot_release_date: date, release_date_window_da
     from_date = pivot_release_date + timedelta(days=-release_date_window_days)
     to_date = pivot_release_date + timedelta(days=release_date_window_days)
 
-    query = """ SELECT release_mbid
-                     , release_name
-                     , release_group_mbid
-                     , release_date
-                     , artist_credit_name
-                     , artist_mbids
-                     , release_group_primary_type
-                     , release_group_secondary_type
-                  FROM (
-                        SELECT DISTINCT rl.gid AS release_mbid
-                                      , rg.gid AS release_group_mbid
-                                      , rl.name AS release_name
-                                      , make_date(rgm.first_release_date_year,
-                                                  rgm.first_release_date_month,
-                                                  rgm.first_release_date_day) AS release_date
-                                      , ac.name AS artist_credit_name
-                                      , array_agg(distinct a.gid) AS artist_mbids
-                                      , rgpt.name AS release_group_primary_type
-                                      , rgst.name AS release_group_secondary_type
-                                      , row_number() OVER (PARTITION BY rg.id ORDER BY make_date(rgm.first_release_date_year,
-                                                                                                 rgm.first_release_date_month,
-                                                                                                 rgm.first_release_date_day)
-                                                                                                ) AS rnum
-                                  FROM release rl
-                                  JOIN release_group rg
-                                    ON rl.release_group = rg.id
-                                  JOIN release_group_meta rgm
-                                    ON rgm.id = rg.id
-                             LEFT JOIN release_group_primary_type rgpt
-                                    ON rg.type = rgpt.id
-                             LEFT JOIN release_group_secondary_type_join rgstj
-                                    ON rgstj.release_group = rg.id
-                             LEFT JOIN release_group_secondary_type rgst
-                                    ON rgstj.secondary_type = rgst.id
-                                  JOIN artist_credit ac
-                                    ON rl.artist_credit = ac.id
-                                  JOIN artist_credit_name acn
-                                    ON acn.artist_credit = ac.id
-                                  JOIN artist a
-                                    ON acn.artist = a.id
-                                 WHERE make_date(rgm.first_release_date_year,
-                                                 rgm.first_release_date_month,
-                                                 rgm.first_release_date_day) >= %s
-                                   AND make_date(rgm.first_release_date_year,
-                                                 rgm.first_release_date_month,
-                                                 rgm.first_release_date_day) <= %s
-                              GROUP BY rg.id
-                                     , release_date
-                                     , release_mbid
-                                     , release_name
-                                     , release_date
-                                     , artist_credit_name
-                                     , release_group_primary_type
-                                     , release_group_secondary_type
-                        ) AS q
-                  WHERE q.rnum = 1
-               ORDER BY release_date
-                      , artist_credit_name
-                      , release_name"""
-
+    query = """ 
+        WITH q AS (
+            SELECT DISTINCT rl.id AS release_id
+                          , rl.gid AS release_mbid
+                          , rg.gid AS release_group_mbid
+                          , rl.name AS release_name
+                          , make_date(rgm.first_release_date_year,
+                                      rgm.first_release_date_month,
+                                      rgm.first_release_date_day) AS release_date
+                          , ac.name AS artist_credit_name
+                          , array_agg(distinct a.gid) AS artist_mbids
+                          , rgpt.name AS release_group_primary_type
+                          , rgst.name AS release_group_secondary_type
+                          , row_number() OVER (PARTITION BY rg.id ORDER BY make_date(rgm.first_release_date_year,
+                                                                                     rgm.first_release_date_month,
+                                                                                     rgm.first_release_date_day)
+                                                                                    ) AS rnum
+                      FROM release rl
+                      JOIN release_group rg
+                        ON rl.release_group = rg.id
+                      JOIN release_group_meta rgm
+                        ON rgm.id = rg.id
+                 LEFT JOIN release_group_primary_type rgpt
+                        ON rg.type = rgpt.id
+                 LEFT JOIN release_group_secondary_type_join rgstj
+                        ON rgstj.release_group = rg.id
+                 LEFT JOIN release_group_secondary_type rgst
+                        ON rgstj.secondary_type = rgst.id
+                      JOIN artist_credit ac
+                        ON rl.artist_credit = ac.id
+                      JOIN artist_credit_name acn
+                        ON acn.artist_credit = ac.id
+                      JOIN artist a
+                        ON acn.artist = a.id
+                     WHERE make_date(rgm.first_release_date_year,
+                                     rgm.first_release_date_month,
+                                     rgm.first_release_date_day) >= %s
+                       AND make_date(rgm.first_release_date_year,
+                                     rgm.first_release_date_month,
+                                     rgm.first_release_date_day) <= %s
+                  GROUP BY rg.id
+                         , release_date
+                         , release_mbid
+                         , release_id
+                         , release_name
+                         , release_date
+                         , artist_credit_name
+                         , release_group_primary_type
+                         , release_group_secondary_type
+        ), cover_art AS (
+            SELECT release_mbid
+                 , release_name
+                 , release_group_mbid
+                 , release_date
+                 , artist_credit_name
+                 , artist_mbids
+                 , release_group_primary_type
+                 , release_group_secondary_type
+                 , CASE WHEN cat.type_id = 1 THEN caa.id ELSE NULL END AS caa_id
+                 , row_number() OVER (partition by release_mbid ORDER BY ordering) AS rnum
+              FROM q
+         LEFT JOIN cover_art_archive.cover_art caa
+                ON caa.release = release_id
+         LEFT JOIN cover_art_archive.cover_art_type cat
+                ON cat.id = caa.id
+             WHERE q.rnum = 1
+        )   SELECT release_mbid
+                 , release_name
+                 , release_group_mbid
+                 , release_date
+                 , artist_credit_name
+                 , artist_mbids
+                 , release_group_primary_type
+                 , release_group_secondary_type
+                 , caa_id
+                 , rnum
+              FROM cover_art
+             WHERE rnum = 1
+          ORDER BY release_date
+                 , artist_credit_name
+                 , release_name
+        """
     with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn:
         with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
             curs.execute(query, (from_date, to_date))

--- a/listenbrainz/db/model/fresh_releases.py
+++ b/listenbrainz/db/model/fresh_releases.py
@@ -55,6 +55,9 @@ class FreshRelease(BaseModel):
     # The release group's secondary type
     release_group_secondary_type: Optional[ReleaseGroupSecondaryType]
 
+    # The cover art archive id of the release's front cover art if it has any
+    caa_id: Optional[int]
+
     def to_dict(self):
         """Convert this model to a dict for easy jsonification"""
 

--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -30,7 +30,8 @@ def load_all_releases():
             release_name=release["release_name"],
             release_mbid=release["release_mbid"],
             release_group_primary_type=release["release_group_primary_type"],
-            release_group_secondary_type=release["release_group_secondary_type"]
+            release_group_secondary_type=release["release_group_secondary_type"],
+            caa_id=release["caa_id"]
         ))
 
     return listenbrainz_spark.session.createDataFrame(releases, schema=fresh_releases_schema)
@@ -62,6 +63,7 @@ def get_query():
                  , rr.date
                  , rr.release_group_primary_type
                  , rr.release_group_secondary_type
+                 , rr.caa_id
                  , SUM(partial_confidence) AS confidence
               FROM artist_discovery ad
               JOIN fresh_releases rr
@@ -74,6 +76,7 @@ def get_query():
                  , rr.date
                  , rr.release_group_primary_type
                  , rr.release_group_secondary_type
+                 , rr.caa_id
         )
         SELECT user_id
              , array_sort(
@@ -86,6 +89,7 @@ def get_query():
                           , date
                           , release_group_primary_type
                           , release_group_secondary_type
+                          , caa_id
                           , confidence
                         )
                     )


### PR DESCRIPTION
This saves the frontend from querying CAA to get the cover art id before querying IA for the image which is nice as the number of images on this page is high. Plus, it helps to implement the "Show only releases with cover art" filter.