### PR TITLE
Fix spark user fresh releases

### DIFF
--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '*' ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths:
       - 'listenbrainz_spark/**'
       - 'requirements_spark.txt'

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -22,7 +22,8 @@ fresh_releases_schema = StructType([
     StructField('release_name', StringType(), nullable=False),
     StructField('release_mbid', StringType(), nullable=False),
     StructField('release_group_primary_type', StringType(), nullable=True),
-    StructField('release_group_secondary_type', StringType(), nullable=True)
+    StructField('release_group_secondary_type', StringType(), nullable=True),
+    StructField('caa_id', LongType(), nullable=True)
 ])
 
 recommendation_schema = StructType([

--- a/listenbrainz_spark/testdata/sitewide_fresh_releases.json
+++ b/listenbrainz_spark/testdata/sitewide_fresh_releases.json
@@ -8,7 +8,8 @@
     "release_name": "27, 28, 29",
     "artist_credit_name": "티키틱 TIKITIK",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": 33755527018
   },
   {
     "date": "2022-5-17",
@@ -20,7 +21,8 @@
     "release_name": "ARuFa・恐山の匿名ラジオCD2 〜ぶどうゼリーの章〜",
     "artist_credit_name": "ARuFa / ダ・ヴィンチ・恐山",
     "release_group_primary_type": "Album",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": null
   },
   {
     "date": "2022-5-18",
@@ -31,7 +33,8 @@
     "release_name": "dawn of infinity",
     "artist_credit_name": "fripSide",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": 33684408555
   },
   {
     "date": "2022-5-25",
@@ -43,7 +46,8 @@
     "release_name": "世界、西原商会の世界！ Part 2",
     "artist_credit_name": "ライムスター 逆featuring CRAZY KEN BAND",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": "Remix"
+    "release_group_secondary_type": "Remix",
+    "caa_id": 33713737777
   },
   {
     "date": "2022-5-27",
@@ -54,7 +58,8 @@
     "release_name": "Continuum",
     "artist_credit_name": "Amadea Music Productions",
     "release_group_primary_type": "Album",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": 33702046539
   },
   {
     "date": "2022-5-27",
@@ -66,7 +71,8 @@
     "release_name": "Raja Jatt (from the Movie ’Sher Bagga’)",
     "artist_credit_name": "Ammy Virk & Simar Kaur",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": "Soundtrack"
+    "release_group_secondary_type": "Soundtrack",
+    "caa_id": 33709392020
   },
   {
     "date": "2022-5-30",
@@ -77,7 +83,8 @@
     "release_name": "nothing has changed",
     "artist_credit_name": "sadfem",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": null
   },
   {
     "date": "2022-5-30",
@@ -88,7 +95,8 @@
     "release_name": "Uvod…",
     "artist_credit_name": "Тишина",
     "release_group_primary_type": "Album",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": null
   },
   {
     "date": "2022-5-31",
@@ -99,7 +107,8 @@
     "release_name": "So Cold",
     "artist_credit_name": "44closures",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": 33706994031
   },
   {
     "date": "2022-6-1",
@@ -110,7 +119,8 @@
     "release_name": "Illusion",
     "artist_credit_name": "aespa",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": null
   },
   {
     "date": "2022-6-3",
@@ -121,7 +131,8 @@
     "release_name": "Endless Garden",
     "artist_credit_name": "Witchfinder",
     "release_group_primary_type": "EP",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": null
   },
   {
     "date": "2022-6-8",
@@ -132,7 +143,8 @@
     "release_name": "magic! / 生きなくちゃ",
     "artist_credit_name": "Little Glee Monster",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": 33700346677
   },
   {
     "date": "2022-6-9",
@@ -143,6 +155,7 @@
     "release_name": "So Good",
     "artist_credit_name": "Halsey",
     "release_group_primary_type": "Single",
-    "release_group_secondary_type": null
+    "release_group_secondary_type": null,
+    "caa_id": 33759180025
   }
 ]

--- a/listenbrainz_spark/testdata/user_fresh_releases_output.json
+++ b/listenbrainz_spark/testdata/user_fresh_releases_output.json
@@ -12,6 +12,7 @@
         "date": "2022-6-9",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": null,
+        "caa_id": 33759180025,
         "confidence": 3
       },
       {
@@ -25,6 +26,7 @@
         "date": "2022-5-27",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Soundtrack",
+        "caa_id": 33709392020,
         "confidence": 2
       },
       {
@@ -37,6 +39,7 @@
         "date": "2022-5-30",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": null,
+        "caa_id": null,
         "confidence": 1
       }
     ]
@@ -55,6 +58,7 @@
         "date": "2022-5-17",
         "release_group_primary_type": "Album",
         "release_group_secondary_type": null,
+        "caa_id": null,
         "confidence": 4
       },
       {
@@ -67,6 +71,7 @@
         "date": "2022-5-30",
         "release_group_primary_type": "Album",
         "release_group_secondary_type": null,
+        "caa_id": null,
         "confidence": 1
       }
     ]


### PR DESCRIPTION
The earlier PR to add caa.id to fresh releases response didn't trigger spark tests due to a bug in the actions setup. On merging the tests were triggered and revealed a bug. Fix the issue and actions setup.