### PR TITLE
Remove satackey cache step from GH actions

### DIFF
--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -34,8 +34,5 @@ jobs:
         run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         continue-on-error: true
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Build production image
         run: docker build --target listenbrainz-prod --build-arg GIT_COMMIT_SHA=HEAD .

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -35,9 +35,6 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
       continue-on-error: true
 
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
     # We do not use this to install node but only to register problem matchers
     # so that eslint annotations work.
     - name: Setup Node.js environment to enable annotations

--- a/.github/workflows/push-dev-image.yml
+++ b/.github/workflows/push-dev-image.yml
@@ -37,9 +37,6 @@ jobs:
         run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         continue-on-error: true
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Build development image
         run: |
           docker build \

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -36,9 +36,6 @@ jobs:
     - name: Pull spark base docker image
       run: docker pull metabrainz/listenbrainz-spark-base:latest
 
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
     - name: Build spark containers
       run: ./test.sh spark -b
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,8 +50,8 @@ jobs:
     - name: Pull docker images
       run: docker-compose -f docker/docker-compose.test.yml pull lb_db redis rabbitmq couchdb
 
-    - name: Build test containers
-      run: ./test.sh -b
+    - name: Build test containers and start database
+      run: ./test.sh -u
 
     - name: Run tests
       run: ./test.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,8 +50,5 @@ jobs:
     - name: Pull docker images
       run: docker-compose -f docker/docker-compose.test.yml pull lb_db redis rabbitmq couchdb
 
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
     - name: Run tests
       run: ./test.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,5 +50,8 @@ jobs:
     - name: Pull docker images
       run: docker-compose -f docker/docker-compose.test.yml pull lb_db redis rabbitmq couchdb
 
+    - name: Build test containers
+      run: ./test.sh -b
+
     - name: Run tests
       run: ./test.sh


### PR DESCRIPTION
We have observed that sometimes this cache step takes a long time to complete even longer than the test or build itself so we might as well do without it.
