### PR TITLE
Replace coverflow library

### DIFF
--- a/listenbrainz/webserver/static/css/year-in-music.less
+++ b/listenbrainz/webserver/static/css/year-in-music.less
@@ -6,6 +6,9 @@
 @coverflow-image-height: 400px;
 
 #year-in-music {
+  // For coverflow arrow colors
+  --swiper-theme-color: @blue;
+  
   .accent {
     color: @orange;
   }
@@ -71,10 +74,11 @@
     background-color: whitesmoke;
 
     .swiper-wrapper {
-      height: @coverflow-image-height + 80px;
+      padding: 1em 0;
+      align-items: center;
     }
     .swiper-slide {
-      width: @coverflow-image-height;
+      max-width: @coverflow-image-height;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/listenbrainz/webserver/static/css/year-in-music.less
+++ b/listenbrainz/webserver/static/css/year-in-music.less
@@ -8,7 +8,7 @@
 #year-in-music {
   // For coverflow arrow colors
   --swiper-theme-color: @blue;
-  
+
   .accent {
     color: @orange;
   }

--- a/listenbrainz/webserver/static/css/year-in-music.less
+++ b/listenbrainz/webserver/static/css/year-in-music.less
@@ -1,3 +1,10 @@
+// Import Swiper styles
+@import "/node_modules/swiper/swiper.less";
+@import "/node_modules/swiper/modules/navigation/navigation.less";
+@import "/node_modules/swiper/modules/effect-coverflow/effect-coverflow.less";
+
+@coverflow-image-height: 400px;
+
 #year-in-music {
   .accent {
     color: @orange;
@@ -58,46 +65,32 @@
     margin-left: 0;
   }
 
-  div[class*="coverflow__stage__"] {
-    perspective: 800px;
-  }
-  div[class*="coverflow__container__"] {
-    background: rgba(0, 0, 0, 0.04);
-  }
-  div[class*="coverflow__arrowWrapper__"] {
-    transform-style: preserve-3d;
-  }
-  div[class*="coverflow__figure__"] {
-    box-shadow: 0 20px 40px rgb(0 0 0 / 30%);
-    -webkit-box-reflect: below 1px -webkit-linear-gradient(bottom, rgba(0, 0, 0, 0.1), rgba(
-            0,
-            0,
-            0,
-            0
-          )
-          20%, rgba(0, 0, 0, 0));
-  }
-  div[class*="coverflow__text__"] {
-    font-size: 0.6em;
-    @media (max-width: @screen-tablet) {
-      text-overflow: ellipsis;
-      white-space: nowrap;
+  .swiper {
+    width: 100%;
+    perspective: 900px;
+    background-color: whitesmoke;
+
+    .swiper-wrapper {
+      height: @coverflow-image-height + 80px;
+    }
+    .swiper-slide {
+      width: @coverflow-image-height;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      > img {
+        width: inherit;
+        box-shadow: 0 4px 10px 0 fade(@black, 20%);
+      }
+      > div {
+        // center text in album title + artist name container
+        text-align: center;
+        margin-top: 0.5em;
+      }
     }
   }
-  div[class*="coverflow__left__"] {
-    left: calc(45%) !important;
-    transform: translateZ(70px);
-  }
-  div[class*="coverflow__right__"] {
-    right: calc(45%) !important;
-    transform: translateZ(70px);
-  }
-  div[class*="coverflow__arrow__"] {
-    &:before,
-    &:after {
-      height: 3px;
-    }
-  }
+
   /* "Save as image" component */
   #savable-release-component {
     width: 500px;

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -4,7 +4,6 @@ declare module "react-responsive";
 declare module "spotify-web-playback-sdk";
 declare module "time-ago";
 declare module "debounce-async";
-declare module "react-coverflow";
 
 declare module "react-bs-notifier";
 declare type AlertType = "danger" | "warning" | "success" | "info";

--- a/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
+++ b/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
@@ -1,7 +1,8 @@
 import * as ReactDOM from "react-dom";
 import * as React from "react";
 import { ResponsiveBar } from "@nivo/bar";
-import Coverflow from "react-coverflow";
+import { Navigation, Keyboard, EffectCoverflow } from "swiper";
+import { Swiper, SwiperSlide } from "swiper/react";
 import { CalendarDatum, ResponsiveCalendar } from "@nivo/calendar";
 import {
   get,
@@ -491,44 +492,58 @@ export default class YearInMusic extends React.Component<
 
             {yearInMusicData.top_releases ? (
               <div id="releases-coverflow">
-                <Coverflow
-                  displayQuantityOfSide={3}
-                  currentFigureScale={2}
-                  otherFigureScale={1}
+                <Swiper
+                  modules={[Navigation, Keyboard, EffectCoverflow]}
+                  spaceBetween={100}
+                  slidesPerView={3}
+                  initialSlide={3}
+                  centeredSlides
                   navigation
-                  enableScroll
-                  infiniteScroll
-                  enableHeading
-                  active={activeCoverflowImage}
-                  clickable
-                  media={{
-                    "@media (max-width: 900px)": {
-                      width: "100%",
-                      height: "300px",
-                    },
-                    "@media (min-width: 900px)": {
-                      width: "100%",
-                      height: "500px",
-                    },
+                  effect="coverflow"
+                  coverflowEffect={{
+                    rotate: 20,
+                    depth: 300,
+                    slideShadows: false,
                   }}
                 >
-                  {yearInMusicData.top_releases.slice(0, 50).map((release) => (
-                    <img
-                      key={`coverflow-${release.release_name}`}
-                      data-action={
+                  {yearInMusicData.top_releases.slice(0, 50).map((release) => {
+                    const coverArtSrc =
+                      yearInMusicData.top_releases_coverart?.[
                         release.release_mbid
-                          ? `https://musicbrainz.org/release/${release.release_mbid}/`
-                          : undefined
-                      }
-                      src={
-                        yearInMusicData.top_releases_coverart?.[
-                          release.release_mbid
-                        ] ?? "/static/img/cover-art-placeholder.jpg"
-                      }
-                      alt={release.release_name}
-                    />
-                  ))}
-                </Coverflow>
+                      ];
+                    if (!coverArtSrc) {
+                      return null;
+                    }
+                    return (
+                      <SwiperSlide key={`coverflow-${release.release_name}`}>
+                        <img
+                          src={
+                            yearInMusicData.top_releases_coverart?.[
+                              release.release_mbid
+                            ] ?? "/static/img/cover-art-placeholder.jpg"
+                          }
+                          alt={release.release_name}
+                        />
+                        <div title={release.release_name}>
+                          <a
+                            href={
+                              release.release_mbid
+                                ? `https://musicbrainz.org/release/${release.release_mbid}/`
+                                : undefined
+                            }
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {release.release_name}
+                          </a>
+                          <div className="small text-muted">
+                            {release.artist_name}
+                          </div>
+                        </div>
+                      </SwiperSlide>
+                    );
+                  })}
+                </Swiper>
               </div>
             ) : (
               noDataText

--- a/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
+++ b/listenbrainz/webserver/static/js/src/year-in-music/YearInMusic.tsx
@@ -494,16 +494,28 @@ export default class YearInMusic extends React.Component<
               <div id="releases-coverflow">
                 <Swiper
                   modules={[Navigation, Keyboard, EffectCoverflow]}
-                  spaceBetween={100}
-                  slidesPerView={3}
-                  initialSlide={3}
+                  spaceBetween={15}
+                  slidesPerView={2}
+                  initialSlide={0}
                   centeredSlides
                   navigation
                   effect="coverflow"
                   coverflowEffect={{
-                    rotate: 20,
-                    depth: 300,
+                    rotate: 40,
+                    depth: 100,
                     slideShadows: false,
+                  }}
+                  breakpoints={{
+                    700: {
+                      initialSlide: 3,
+                      spaceBetween: 100,
+                      slidesPerView: 3,
+                      coverflowEffect: {
+                        rotate: 20,
+                        depth: 300,
+                        slideShadows: false,
+                      },
+                    },
                   }}
                 >
                   {yearInMusicData.top_releases.slice(0, 50).map((release) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "lodash": "^4.17.21",
         "react": "^16.14.0",
         "react-bs-notifier": "^6.0.0",
-        "react-coverflow": "^0.2.20",
         "react-date-picker": "^8.1.1",
         "react-dom": "^16.13.1",
         "react-draggable": "^4.4.4",
@@ -57,6 +56,7 @@
         "socket.io-client": "^4.1.2",
         "sortablejs": "^1.12.0",
         "stylelint-prettier": "^2.0.0",
+        "swiper": "^8.4.4",
         "time-ago": "^0.2.1",
         "tinycolor2": "^1.4.2"
       },
@@ -5025,11 +5025,6 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
-    "node_modules/bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5762,15 +5757,6 @@
         "node": ">=12.22"
       }
     },
-    "node_modules/css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "node_modules/css-jss": {
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/css-jss/-/css-jss-10.7.1.tgz",
@@ -6240,6 +6226,14 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
       }
     },
     "node_modules/domelementtype": {
@@ -7824,11 +7818,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -9218,15 +9207,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/inline-style-prefixer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
-      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
-      "dependencies": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -9657,6 +9637,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15069,19 +15050,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/radium": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/radium/-/radium-0.25.2.tgz",
-      "integrity": "sha512-I2+G4axdz+wW2LA8gsXWvcNWE0vBjXixMFgkSaYQrCO1Ag2m+Dz447OY9Hs2QK7rJ8lXL2gGx1bbZdI4sPvoIQ==",
-      "dependencies": {
-        "exenv": "^1.2.1",
-        "inline-style-prefixer": "^4.0.0",
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0"
-      }
-    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -15162,18 +15130,6 @@
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0-0",
         "react-dom": "^16.3.0 || ^17.0.0-0"
-      }
-    },
-    "node_modules/react-coverflow": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/react-coverflow/-/react-coverflow-0.2.20.tgz",
-      "integrity": "sha512-4VnzgoIVnJt7Azt5Vc1zTXpB3ZWA+4YHAuIh2RWXgFOoUiodYaVCYyDAWdYcZxDHPeXg4dliQPUjJCdr3M7Fug==",
-      "dependencies": {
-        "radium": "^0.25.1"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.6.2",
-        "react": "^16.5.2"
       }
     },
     "node_modules/react-date-picker": {
@@ -16347,6 +16303,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -17173,6 +17134,29 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
+    },
+    "node_modules/swiper": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
+      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
+      }
     },
     "node_modules/symbol-observable": {
       "version": "1.2.0",
@@ -22470,11 +22454,6 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -23066,15 +23045,6 @@
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
       "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw=="
     },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "css-jss": {
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/css-jss/-/css-jss-10.7.1.tgz",
@@ -23474,6 +23444,14 @@
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
         "entities": "^4.2.0"
+      }
+    },
+    "dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "requires": {
+        "ssr-window": "^4.0.0"
       }
     },
     "domelementtype": {
@@ -24656,11 +24634,6 @@
         "clone-regexp": "^2.1.0"
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -25729,15 +25702,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "inline-style-prefixer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
-      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
-    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -26058,7 +26022,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -30334,16 +30299,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
     },
-    "radium": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/radium/-/radium-0.25.2.tgz",
-      "integrity": "sha512-I2+G4axdz+wW2LA8gsXWvcNWE0vBjXixMFgkSaYQrCO1Ag2m+Dz447OY9Hs2QK7rJ8lXL2gGx1bbZdI4sPvoIQ==",
-      "requires": {
-        "exenv": "^1.2.1",
-        "inline-style-prefixer": "^4.0.0",
-        "prop-types": "^15.5.8"
-      }
-    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -30408,14 +30363,6 @@
         "get-user-locale": "^1.2.0",
         "merge-class-names": "^1.1.1",
         "prop-types": "^15.6.0"
-      }
-    },
-    "react-coverflow": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/react-coverflow/-/react-coverflow-0.2.20.tgz",
-      "integrity": "sha512-4VnzgoIVnJt7Azt5Vc1zTXpB3ZWA+4YHAuIh2RWXgFOoUiodYaVCYyDAWdYcZxDHPeXg4dliQPUjJCdr3M7Fug==",
-      "requires": {
-        "radium": "^0.25.1"
       }
     },
     "react-date-picker": {
@@ -31365,6 +31312,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -31973,6 +31925,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
+    },
+    "swiper": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
+      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "requires": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      }
     },
     "symbol-observable": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "lodash": "^4.17.21",
     "react": "^16.14.0",
     "react-bs-notifier": "^6.0.0",
-    "react-coverflow": "^0.2.20",
     "react-date-picker": "^8.1.1",
     "react-dom": "^16.13.1",
     "react-draggable": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "socket.io-client": "^4.1.2",
     "sortablejs": "^1.12.0",
     "stylelint-prettier": "^2.0.0",
+    "swiper": "^8.4.4",
     "time-ago": "^0.2.1",
     "tinycolor2": "^1.4.2"
   },


### PR DESCRIPTION
Replacing the deprecated (since 2019) react-coverflow library as part of ongoing migration to React 18.
Instead we will use SwiperJS which is very well supported (including good react support out of the box) with the Coverflow plug-in.
See #2059 for more context. Thanks to @chinmaykunkikar for the  initial research


I made the coverflow very close to the previous version while also making it a bit cleaner looking (no reflections, a bit more space around the central cover,  album name and artist below rather than over the image, etc.).
This component is only used in the Year in Music page, but I think we might find other uses for SwiperJS including with other effects/plugins like cards.




Before:
![image](https://user-images.githubusercontent.com/6179856/195880380-311d7a70-4880-46be-9d5e-2168060b5092.png)


After:
![image](https://user-images.githubusercontent.com/6179856/195880353-f814bbfc-73d2-47b4-b19b-5f58c6fe742a.png)


Mobile device sizes:
![image](https://user-images.githubusercontent.com/6179856/195980253-6422d9e2-bba9-467f-a7a8-14b1ec74bfff.png)
