### PR TITLE
Update labs api uwsgi config

### DIFF
--- a/docker/services/labs_api/uwsgi-labs-api.ini
+++ b/docker/services/labs_api/uwsgi-labs-api.ini
@@ -10,3 +10,9 @@ enable-threads = true
 processes = 10
 log-x-forwarded-for=true
 disable-logging = true
+; quit uwsgi if the python app fails to load
+need-app = true
+; when uwsgi gets a sighup, quit completely and let runit restart us
+exit-on-reload = true
+; increase buffer size for requests that send a lot of mbids in query params
+buffer-size = 8192


### PR DESCRIPTION
It turns out the fix in #2106 was incomplete. While that change prevents labs api from crashing after the error, it does not eliminate it fully. That error still occurs often according to the container logs. Matching the remaining uwsgi config should hopefully fix it completely.