### PR TITLE
Fix element key in user feedback page

### DIFF
--- a/listenbrainz/webserver/static/js/src/user/UserFeedback.tsx
+++ b/listenbrainz/webserver/static/js/src/user/UserFeedback.tsx
@@ -526,7 +526,7 @@ export default class UserFeedback extends React.Component<
                       <ListenCard
                         showUsername={false}
                         showTimestamp
-                        key={`${listen.listened_at}`}
+                        key={`${listen.listened_at}-${listen.track_metadata.track_name}`}
                         listen={listen}
                         currentFeedback={this.getFeedbackForListen(listen)}
                         updateFeedbackCallback={this.updateFeedback}


### PR DESCRIPTION
@Aerozol reported an issue on IRC: when he switches from loved to hated tracks on his feedback page (https://listenbrainz.org/user/aerozol/feedback) one specific track is added to the hated tracks each time he switches even though it's a loved track.
Repeat the process and get many duplicates:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/6179856/196960535-807938ee-7163-41ab-962d-eab6d122054e.png">
This is due to two of the tracks having the exact same listened_at timestamp, which is used as a key for the React element.
If two elements have the same key, React won't be able to target them individually and they won't be updated resulting in some ghost duplicates.
![image](https://user-images.githubusercontent.com/6179856/196961099-a2eccaef-f01c-4402-befb-9e90c985e37f.png)
