### PR TITLE
User fresh releases fixes

### DIFF
--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -24,7 +24,7 @@ def load_all_releases():
     releases = []
     for release in data:
         releases.append(Row(
-            date=release["date"],
+            release_date=release["release_date"],
             artist_credit_name=release["artist_credit_name"],
             artist_mbids=release["artist_mbids"],
             release_name=release["release_name"],
@@ -62,7 +62,7 @@ def get_query():
                  , rr.release_group_mbid
                  , rr.artist_credit_name
                  , rr.artist_mbids
-                 , rr.date
+                 , rr.release_date
                  , rr.release_group_primary_type
                  , rr.release_group_secondary_type
                  , rr.caa_id
@@ -76,7 +76,7 @@ def get_query():
                  , rr.release_group_mbid
                  , rr.artist_credit_name
                  , rr.artist_mbids
-                 , rr.date
+                 , rr.release_date
                  , rr.release_group_primary_type
                  , rr.release_group_secondary_type
                  , rr.caa_id
@@ -90,7 +90,7 @@ def get_query():
                           , release_group_mbid
                           , artist_credit_name
                           , artist_mbids
-                          , date
+                          , release_date
                           , release_group_primary_type
                           , release_group_secondary_type
                           , caa_id

--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -29,6 +29,7 @@ def load_all_releases():
             artist_mbids=release["artist_mbids"],
             release_name=release["release_name"],
             release_mbid=release["release_mbid"],
+            release_group_mbid=release["release_group_mbid"],
             release_group_primary_type=release["release_group_primary_type"],
             release_group_secondary_type=release["release_group_secondary_type"],
             caa_id=release["caa_id"]
@@ -58,6 +59,7 @@ def get_query():
             SELECT ad.user_id
                  , rr.release_name
                  , rr.release_mbid
+                 , rr.release_group_mbid
                  , rr.artist_credit_name
                  , rr.artist_mbids
                  , rr.date
@@ -71,6 +73,7 @@ def get_query():
           GROUP BY ad.user_id
                  , rr.release_name
                  , rr.release_mbid
+                 , rr.release_group_mbid
                  , rr.artist_credit_name
                  , rr.artist_mbids
                  , rr.date
@@ -84,6 +87,7 @@ def get_query():
                         struct(
                             release_name
                           , release_mbid
+                          , release_group_mbid
                           , artist_credit_name
                           , artist_mbids
                           , date

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -21,6 +21,7 @@ fresh_releases_schema = StructType([
     StructField('artist_mbids', ArrayType(StringType()), nullable=False),
     StructField('release_name', StringType(), nullable=False),
     StructField('release_mbid', StringType(), nullable=False),
+    StructField('release_group_mbid', StringType(), nullable=False),
     StructField('release_group_primary_type', StringType(), nullable=True),
     StructField('release_group_secondary_type', StringType(), nullable=True),
     StructField('caa_id', LongType(), nullable=True)

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -16,7 +16,7 @@ listens_new_schema = StructType([
 ])
 
 fresh_releases_schema = StructType([
-    StructField('date', StringType(), nullable=False),
+    StructField('release_date', StringType(), nullable=False),
     StructField('artist_credit_name', StringType(), nullable=False),
     StructField('artist_mbids', ArrayType(StringType()), nullable=False),
     StructField('release_name', StringType(), nullable=False),

--- a/listenbrainz_spark/testdata/sitewide_fresh_releases.json
+++ b/listenbrainz_spark/testdata/sitewide_fresh_releases.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2022-5-16",
+    "release_date": "2022-5-16",
     "artist_mbids": [
       "d95313c7-9103-4ff8-a566-72ea3a3153b8"
     ],
@@ -13,7 +13,7 @@
     "caa_id": 33755527018
   },
   {
-    "date": "2022-5-17",
+    "release_date": "2022-5-17",
     "artist_mbids": [
       "9d091774-d913-4412-acee-edd882ff7cac",
       "b78ce5fa-fde8-4e51-9b9e-f25d3c477cb8"
@@ -27,7 +27,7 @@
     "caa_id": null
   },
   {
-    "date": "2022-5-18",
+    "release_date": "2022-5-18",
     "artist_mbids": [
       "de1d37ff-942a-4c85-a375-ff4f5bf2eaa9"
     ],
@@ -40,7 +40,7 @@
     "caa_id": 33684408555
   },
   {
-    "date": "2022-5-25",
+    "release_date": "2022-5-25",
     "artist_mbids": [
       "c0347d84-96a8-4c8e-8992-178b7862468e",
       "3ebf9b8d-755e-4f98-adcc-a0089a40b8a5"
@@ -54,7 +54,7 @@
     "caa_id": 33713737777
   },
   {
-    "date": "2022-5-27",
+    "release_date": "2022-5-27",
     "artist_mbids": [
       "587e775d-5798-41bb-b039-c6af5095e1c4"
     ],
@@ -67,7 +67,7 @@
     "caa_id": 33702046539
   },
   {
-    "date": "2022-5-27",
+    "release_date": "2022-5-27",
     "artist_mbids": [
       "b5da230b-f1fc-4822-af88-03f91891fccd",
       "7803ba53-9ed3-40e4-b6fe-5e76d27eb811"
@@ -81,7 +81,7 @@
     "caa_id": 33709392020
   },
   {
-    "date": "2022-5-30",
+    "release_date": "2022-5-30",
     "artist_mbids": [
       "28e4d96a-e405-4a43-9b30-baf4f8fa7a29"
     ],
@@ -94,7 +94,7 @@
     "caa_id": null
   },
   {
-    "date": "2022-5-30",
+    "release_date": "2022-5-30",
     "artist_mbids": [
       "cf2bd942-6e78-480d-a6f5-67b04f879f14"
     ],
@@ -107,7 +107,7 @@
     "caa_id": null
   },
   {
-    "date": "2022-5-31",
+    "release_date": "2022-5-31",
     "artist_mbids": [
       "b12eaf15-9e92-421e-8b9e-5178b39e4626"
     ],
@@ -120,7 +120,7 @@
     "caa_id": 33706994031
   },
   {
-    "date": "2022-6-1",
+    "release_date": "2022-6-1",
     "artist_mbids": [
       "b51c672b-85e0-48fe-8648-470a2422229f"
     ],
@@ -133,7 +133,7 @@
     "caa_id": null
   },
   {
-    "date": "2022-6-3",
+    "release_date": "2022-6-3",
     "artist_mbids": [
       "7952ffb1-ee94-4869-ad5c-6abe36465567"
     ],
@@ -146,7 +146,7 @@
     "caa_id": null
   },
   {
-    "date": "2022-6-8",
+    "release_date": "2022-6-8",
     "artist_mbids": [
       "466e197e-1d82-441e-82c4-380b97fd1839"
     ],
@@ -159,7 +159,7 @@
     "caa_id": 33700346677
   },
   {
-    "date": "2022-6-9",
+    "release_date": "2022-6-9",
     "artist_mbids": [
       "3377f3bb-60fc-4403-aea9-7e800612e060"
     ],

--- a/listenbrainz_spark/testdata/sitewide_fresh_releases.json
+++ b/listenbrainz_spark/testdata/sitewide_fresh_releases.json
@@ -5,6 +5,7 @@
       "d95313c7-9103-4ff8-a566-72ea3a3153b8"
     ],
     "release_mbid": "46962eb4-82c1-499c-b5ca-d1520cacb9e2",
+    "release_group_mbid": "77ad2419-ccb4-406a-8a2e-c6a3f16c4480",
     "release_name": "27, 28, 29",
     "artist_credit_name": "티키틱 TIKITIK",
     "release_group_primary_type": "Single",
@@ -18,6 +19,7 @@
       "b78ce5fa-fde8-4e51-9b9e-f25d3c477cb8"
     ],
     "release_mbid": "db4fda62-744b-440c-ae4b-a690be0d7bba",
+    "release_group_mbid": "cce1f6dc-5c00-41a9-a44f-1865dbb9b380",
     "release_name": "ARuFa・恐山の匿名ラジオCD2 〜ぶどうゼリーの章〜",
     "artist_credit_name": "ARuFa / ダ・ヴィンチ・恐山",
     "release_group_primary_type": "Album",
@@ -30,6 +32,7 @@
       "de1d37ff-942a-4c85-a375-ff4f5bf2eaa9"
     ],
     "release_mbid": "6948e168-3316-4458-b5d7-f14d6b9c8aa0",
+    "release_group_mbid": "76802f55-978c-4d15-a84f-65aea5b415e7",
     "release_name": "dawn of infinity",
     "artist_credit_name": "fripSide",
     "release_group_primary_type": "Single",
@@ -43,6 +46,7 @@
       "3ebf9b8d-755e-4f98-adcc-a0089a40b8a5"
     ],
     "release_mbid": "8d322ab8-ca68-40f6-8d3b-527545830302",
+    "release_group_mbid": "f00867a1-e244-4eae-9933-d2911c510635",
     "release_name": "世界、西原商会の世界！ Part 2",
     "artist_credit_name": "ライムスター 逆featuring CRAZY KEN BAND",
     "release_group_primary_type": "Single",
@@ -55,6 +59,7 @@
       "587e775d-5798-41bb-b039-c6af5095e1c4"
     ],
     "release_mbid": "c5955771-c7ec-4de6-9c5f-cc53ee5c1cb7",
+    "release_group_mbid": "3d1552b8-7b9f-4def-92a8-3ba62ba1b86d",
     "release_name": "Continuum",
     "artist_credit_name": "Amadea Music Productions",
     "release_group_primary_type": "Album",
@@ -68,6 +73,7 @@
       "7803ba53-9ed3-40e4-b6fe-5e76d27eb811"
     ],
     "release_mbid": "a202dc7e-cb61-4ecd-87d0-3bedf597f8cc",
+    "release_group_mbid": "e0843fdd-92cc-49e8-8579-7566e777ddc9",
     "release_name": "Raja Jatt (from the Movie ’Sher Bagga’)",
     "artist_credit_name": "Ammy Virk & Simar Kaur",
     "release_group_primary_type": "Single",
@@ -80,6 +86,7 @@
       "28e4d96a-e405-4a43-9b30-baf4f8fa7a29"
     ],
     "release_mbid": "5be2dc20-13c7-4d8a-945c-fcf2d1815a98",
+    "release_group_mbid": "fe3d4b62-d8c8-416c-a115-6d00b0ee0f77",
     "release_name": "nothing has changed",
     "artist_credit_name": "sadfem",
     "release_group_primary_type": "Single",
@@ -92,6 +99,7 @@
       "cf2bd942-6e78-480d-a6f5-67b04f879f14"
     ],
     "release_mbid": "3e39dbe2-1753-4c69-9118-f2c4f46c7111",
+    "release_group_mbid": "36a86ebe-178e-4cd7-a297-99ab07a6d81c",
     "release_name": "Uvod…",
     "artist_credit_name": "Тишина",
     "release_group_primary_type": "Album",
@@ -104,6 +112,7 @@
       "b12eaf15-9e92-421e-8b9e-5178b39e4626"
     ],
     "release_mbid": "db05975c-2210-47c6-8c31-15b7e29465df",
+    "release_group_mbid": "ef1497b6-01ae-4477-94a8-e3e0e9a12125",
     "release_name": "So Cold",
     "artist_credit_name": "44closures",
     "release_group_primary_type": "Single",
@@ -116,6 +125,7 @@
       "b51c672b-85e0-48fe-8648-470a2422229f"
     ],
     "release_mbid": "b9f75d97-5ed9-466d-8c64-069af4505fd1",
+    "release_group_mbid": "1bec7d7c-18cd-4bbf-b9ea-4fb42eb38235",
     "release_name": "Illusion",
     "artist_credit_name": "aespa",
     "release_group_primary_type": "Single",
@@ -128,6 +138,7 @@
       "7952ffb1-ee94-4869-ad5c-6abe36465567"
     ],
     "release_mbid": "4544abf3-f7a0-4748-9a22-30998ca357fa",
+    "release_group_mbid": "fceb5e70-617a-4a08-8f64-6ab9cefc7ac9",
     "release_name": "Endless Garden",
     "artist_credit_name": "Witchfinder",
     "release_group_primary_type": "EP",
@@ -140,6 +151,7 @@
       "466e197e-1d82-441e-82c4-380b97fd1839"
     ],
     "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
+    "release_group_mbid": "11c60b65-d94e-4413-839d-c47adafef340",
     "release_name": "magic! / 生きなくちゃ",
     "artist_credit_name": "Little Glee Monster",
     "release_group_primary_type": "Single",
@@ -152,6 +164,7 @@
       "3377f3bb-60fc-4403-aea9-7e800612e060"
     ],
     "release_mbid": "daa1e865-42d9-46d5-b272-c92c099dbc2d",
+    "release_group_mbid": "5a861eef-fedb-4e54-bdb2-869d49c3f2cd",
     "release_name": "So Good",
     "artist_credit_name": "Halsey",
     "release_group_primary_type": "Single",

--- a/listenbrainz_spark/testdata/user_fresh_releases_output.json
+++ b/listenbrainz_spark/testdata/user_fresh_releases_output.json
@@ -10,7 +10,7 @@
         "artist_mbids": [
           "3377f3bb-60fc-4403-aea9-7e800612e060"
         ],
-        "date": "2022-6-9",
+        "release_date": "2022-6-9",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": null,
         "caa_id": 33759180025,
@@ -25,7 +25,7 @@
           "b5da230b-f1fc-4822-af88-03f91891fccd",
           "7803ba53-9ed3-40e4-b6fe-5e76d27eb811"
         ],
-        "date": "2022-5-27",
+        "release_date": "2022-5-27",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Soundtrack",
         "caa_id": 33709392020,
@@ -39,7 +39,7 @@
         "artist_mbids": [
           "28e4d96a-e405-4a43-9b30-baf4f8fa7a29"
         ],
-        "date": "2022-5-30",
+        "release_date": "2022-5-30",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": null,
         "caa_id": null,
@@ -59,7 +59,7 @@
           "9d091774-d913-4412-acee-edd882ff7cac",
           "b78ce5fa-fde8-4e51-9b9e-f25d3c477cb8"
         ],
-        "date": "2022-5-17",
+        "release_date": "2022-5-17",
         "release_group_primary_type": "Album",
         "release_group_secondary_type": null,
         "caa_id": null,
@@ -73,7 +73,7 @@
         "artist_mbids": [
           "cf2bd942-6e78-480d-a6f5-67b04f879f14"
         ],
-        "date": "2022-5-30",
+        "release_date": "2022-5-30",
         "release_group_primary_type": "Album",
         "release_group_secondary_type": null,
         "caa_id": null,

--- a/listenbrainz_spark/testdata/user_fresh_releases_output.json
+++ b/listenbrainz_spark/testdata/user_fresh_releases_output.json
@@ -5,6 +5,7 @@
       {
         "release_name": "So Good",
         "release_mbid": "daa1e865-42d9-46d5-b272-c92c099dbc2d",
+        "release_group_mbid": "5a861eef-fedb-4e54-bdb2-869d49c3f2cd",
         "artist_credit_name": "Halsey",
         "artist_mbids": [
           "3377f3bb-60fc-4403-aea9-7e800612e060"
@@ -18,6 +19,7 @@
       {
         "release_name": "Raja Jatt (from the Movie ’Sher Bagga’)",
         "release_mbid": "a202dc7e-cb61-4ecd-87d0-3bedf597f8cc",
+        "release_group_mbid": "e0843fdd-92cc-49e8-8579-7566e777ddc9",
         "artist_credit_name": "Ammy Virk & Simar Kaur",
         "artist_mbids": [
           "b5da230b-f1fc-4822-af88-03f91891fccd",
@@ -32,6 +34,7 @@
       {
         "release_name": "nothing has changed",
         "release_mbid": "5be2dc20-13c7-4d8a-945c-fcf2d1815a98",
+        "release_group_mbid": "fe3d4b62-d8c8-416c-a115-6d00b0ee0f77",
         "artist_credit_name": "sadfem",
         "artist_mbids": [
           "28e4d96a-e405-4a43-9b30-baf4f8fa7a29"
@@ -50,6 +53,7 @@
       {
         "release_name": "ARuFa・恐山の匿名ラジオCD2 〜ぶどうゼリーの章〜",
         "release_mbid": "db4fda62-744b-440c-ae4b-a690be0d7bba",
+        "release_group_mbid": "cce1f6dc-5c00-41a9-a44f-1865dbb9b380",
         "artist_credit_name": "ARuFa / ダ・ヴィンチ・恐山",
         "artist_mbids": [
           "9d091774-d913-4412-acee-edd882ff7cac",
@@ -64,6 +68,7 @@
       {
         "release_name": "Uvod…",
         "release_mbid": "3e39dbe2-1753-4c69-9118-f2c4f46c7111",
+        "release_group_mbid": "36a86ebe-178e-4cd7-a297-99ab07a6d81c",
         "artist_credit_name": "Тишина",
         "artist_mbids": [
           "cf2bd942-6e78-480d-a6f5-67b04f879f14"


### PR DESCRIPTION
Add release_group_mbid to user fresh releases. This field is already present in sitewide fresh releases but I had missed
including it in user fresh releases.

Rename date to release_date. Sitewide fresh releases already using release_date but user fresh releases was using date due to some reason.