### PR TITLE
More fixes for fresh releases api

### DIFF
--- a/listenbrainz/db/fresh_releases.py
+++ b/listenbrainz/db/fresh_releases.py
@@ -125,10 +125,4 @@ def insert_fresh_releases(database: str, docs: list[dict]):
 
 def get_fresh_releases(user_id: int):
     """ Retrieve fresh releases for given user. """
-    data = couchdb.fetch_data("fresh_releases", user_id)
-    if not data:
-        return None
-    return {
-        "user_id": user_id,
-        "releases": data["releases"]
-    }
+    return couchdb.fetch_data("fresh_releases", user_id)

--- a/listenbrainz/tests/integration/test_fresh_release_api.py
+++ b/listenbrainz/tests/integration/test_fresh_release_api.py
@@ -29,6 +29,6 @@ class FreshReleasesTestCase(IntegrationTestCase):
         self.assert200(r)
 
         self.assertEqual(r.json, {"payload": {
-            "user_id": self.user["id"],
+            "user_id": self.user["musicbrainz_id"],
             "releases": self.expected
         }})

--- a/listenbrainz/webserver/views/fresh_releases.py
+++ b/listenbrainz/webserver/views/fresh_releases.py
@@ -3,12 +3,14 @@ from flask import Blueprint, jsonify
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.fresh_releases import get_fresh_releases
+from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APINoContent, APINotFound
 
 fresh_releases_bp = Blueprint('fresh_releases_v1', __name__)
 
 
 @fresh_releases_bp.route("/user/<user_name>/fresh_releases")
+@crossdomain
 def get_releases(user_name):
     """ Get fresh releases data for the given user. """
     user = db_user.get_by_mb_id(user_name)

--- a/listenbrainz/webserver/views/fresh_releases.py
+++ b/listenbrainz/webserver/views/fresh_releases.py
@@ -17,7 +17,13 @@ def get_releases(user_name):
 
     try:
         data = get_fresh_releases(user["id"])
-        return jsonify({"payload": data})
+        releases = data["releases"] if data else []
+        return jsonify({
+            "payload": {
+                "releases": releases,
+                "user_id": user_name
+            }
+        })
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise APINoContent('')
+        raise APINoContent("")

--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -30,9 +30,9 @@ def load_all_releases():
             release_name=release["release_name"],
             release_mbid=release["release_mbid"],
             release_group_mbid=release["release_group_mbid"],
-            release_group_primary_type=release["release_group_primary_type"],
-            release_group_secondary_type=release["release_group_secondary_type"],
-            caa_id=release["caa_id"]
+            release_group_primary_type=release.get("release_group_primary_type"),
+            release_group_secondary_type=release.get("release_group_secondary_type"),
+            caa_id=release.get("caa_id")
         ))
 
     return listenbrainz_spark.session.createDataFrame(releases, schema=fresh_releases_schema)

--- a/listenbrainz_spark/testdata/sitewide_fresh_releases.json
+++ b/listenbrainz_spark/testdata/sitewide_fresh_releases.json
@@ -115,8 +115,6 @@
     "release_group_mbid": "ef1497b6-01ae-4477-94a8-e3e0e9a12125",
     "release_name": "So Cold",
     "artist_credit_name": "44closures",
-    "release_group_primary_type": "Single",
-    "release_group_secondary_type": null,
     "caa_id": 33706994031
   },
   {
@@ -142,7 +140,6 @@
     "release_name": "Endless Garden",
     "artist_credit_name": "Witchfinder",
     "release_group_primary_type": "EP",
-    "release_group_secondary_type": null,
     "caa_id": null
   },
   {


### PR DESCRIPTION
Fix accessing optional fields in fresh releases spark query. These fields are sometimes absent from the sitewide fresh releases api so fix access.

Fix user_id field in fresh releases api. The value of the field should be username instead of user id.