### PR TITLE
Fix metadata viewer's use of release MBID

### DIFF
--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -155,13 +155,14 @@ export default function MetadataViewer(props: MetadataViewerProps) {
   const { metadata } = recordingData ?? {};
 
   const artistMBID = first(recordingData?.artist_mbids);
+  const releaseMBID = recordingData?.release_mbid ?? metadata?.release?.mbid;
   let coverArtSrc = "/static/img/cover-art-placeholder.jpg";
-  if (metadata?.release?.mbid) {
-    if (metadata.release.caa_id) {
-      coverArtSrc = `https://coverartarchive.org/release/${metadata.release.mbid}/${metadata.release.caa_id}-500.jpg`;
+  if (releaseMBID) {
+    if (metadata?.release?.caa_id) {
+      coverArtSrc = `https://coverartarchive.org/release/${releaseMBID}/${metadata.release.caa_id}-500.jpg`;
     } else {
       // Backup if we don't have the CAA ID
-      coverArtSrc = `https://coverartarchive.org/release/${metadata.release.mbid}/front`;
+      coverArtSrc = `https://coverartarchive.org/release/${releaseMBID}/front`;
     }
   }
 
@@ -366,7 +367,7 @@ export default function MetadataViewer(props: MetadataViewerProps) {
                 <TagsComponent tags={metadata?.tag?.release_group} />
                 <OpenInMusicBrainzButton
                   entityType="release"
-                  entityMBID={recordingData?.release_mbid}
+                  entityMBID={releaseMBID}
                 />
               </div>
             </div>


### PR DESCRIPTION
Atj reported that when using the Listening Now  page he wasn't seeing cover art, whereas it was loading fine in the listening-now widget on his listens page.
It appears that in the MetadataViewer component I was getting the MBID from a single place which is not guaranteed to have the MBID, and the MBID could be at another place in the metadata.
That's a terrible sentence, but I hope it makes some sense. Here's an image, I'm too tired:
![image](https://user-images.githubusercontent.com/6179856/198355510-1c88f4ea-1a63-4fec-991c-e9f14b6f06dd.png)


