### PR TITLE
Add spotify metadata cache seeder

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -170,6 +170,8 @@ SPARK_RESULT_QUEUE = '''{{template "KEY" "spark_result_queue"}}'''
 SPARK_REQUEST_EXCHANGE = '''{{template "KEY" "spark_request_exchange"}}'''
 SPARK_REQUEST_QUEUE = '''{{template "KEY" "spark_request_queue"}}'''
 
+EXTERNAL_SERVICES_EXCHANGE = '''{{template "KEY" "external_services_exchange"}}'''
+EXTERNAL_SERVICES_SPOTIFY_CACHE_QUEUE = '''{{template "KEY" "external_services_spotify_cache"}}'''
 
 MUSICBRAINZ_CLIENT_ID = '''{{template "KEY" "musicbrainz/client_id"}}'''
 MUSICBRAINZ_CLIENT_SECRET = '''{{template "KEY" "musicbrainz/client_secret"}}'''

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -19,6 +19,9 @@ MAILTO=""
 # Dump user feedback before we generate recommendations
 15 2 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feedback >> /logs/dumps.log 2>&1
 
+# Run spotify metadata cache seeder
+0 4 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark run-spotify-metadata-cache-seeder >> /logs/spotify_metadata_cache.log 2>&1
+
 # batch up all the spark requests, spaced by 1 minute in order to ensure the correct order
 # Request all statistics
 0 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_all_stats >> /logs/stats.log 2>&1

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -65,6 +65,9 @@ SPARK_RESULT_QUEUE = "spark_result"
 SPARK_REQUEST_EXCHANGE = "spark_request"
 SPARK_REQUEST_QUEUE = "spark_request"
 
+EXTERNAL_SERVICES_EXCHANGE = "external_services"
+EXTERNAL_SERVICES_SPOTIFY_CACHE_QUEUE = "external_services_spotify_cache"
+
 # Typesense -- this is only needed if you plan to run the Labs API end point for MBID mapping
 TYPESENSE_HOST = "localhost"
 TYPESENSE_PORT = 8108

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -14,6 +14,7 @@ from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data a
     delete_listens as ts_delete_listens, \
     delete_listens_and_update_user_listen_data as ts_delete_listens_and_update_user_listen_data
 from listenbrainz.messybrainz import transfer_to_timescale
+from listenbrainz.spotify_metadata_cache.seeder import submit_new_releases_to_cache
 from listenbrainz.troi.troi_bot import run_daily_jams_troi_bot
 from listenbrainz.webserver import create_app
 
@@ -292,3 +293,10 @@ def run_daily_jams():
     """
     with create_app().app_context():
         run_daily_jams_troi_bot()
+
+
+@cli.command()
+def run_spotify_metadata_cache_seeder():
+    """ Query spotify new releases api for new releases and submit those to our cache as seeds """
+    with create_app().app_context():
+        submit_new_releases_to_cache()

--- a/listenbrainz/spotify_metadata_cache/seeder.py
+++ b/listenbrainz/spotify_metadata_cache/seeder.py
@@ -1,0 +1,54 @@
+from flask import current_app
+from kombu import Connection, Exchange
+from kombu.entity import PERSISTENT_DELIVERY_MODE
+from spotipy import SpotifyClientCredentials, Spotify
+
+from listenbrainz.utils import get_fallback_connection_name
+
+
+def get_album_ids():
+    sp = Spotify(auth_manager=SpotifyClientCredentials(
+        client_id=current_app.config["SPOTIFY_CLIENT_ID"],
+        client_secret=current_app.config["SPOTIFY_CLIENT_SECRET"]
+    ))
+    markets = sp.available_markets()["markets"]
+
+    album_ids = set()
+    for market in markets:
+        result = sp.new_releases(market, limit=50)
+        album_ids |= {album["id"] for album in result["albums"]["items"]}
+
+        while result.get("next"):
+            result = sp.next(result)
+            album_ids |= {album["id"] for album in result["albums"]["items"]}
+
+    return album_ids
+
+
+def submit_album_ids(album_ids):
+    message = {"spotify_album_ids": list(album_ids)}
+    connection = Connection(
+        hostname=current_app.config["RABBITMQ_HOST"],
+        userid=current_app.config["RABBITMQ_USERNAME"],
+        port=current_app.config["RABBITMQ_PORT"],
+        password=current_app.config["RABBITMQ_PASSWORD"],
+        virtual_host=current_app.config["RABBITMQ_VHOST"],
+        transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
+    )
+    producer = connection.Producer()
+    exchange = Exchange(current_app.config["EXTERNAL_SERVICES_EXCHANGE"], "topic", durable=True)
+    producer.publish(
+        message,
+        routing_key=current_app.config["EXTERNAL_SERVICES_SPOTIFY_CACHE_QUEUE"],
+        exchange=exchange,
+        delivery_mode=PERSISTENT_DELIVERY_MODE,
+        declare=[exchange]
+    )
+
+
+def submit_new_releases_to_cache():
+    current_app.logger.info("Searching new album ids to seed spotify metadata cache")
+    album_ids = get_album_ids()
+    current_app.logger.info("Found %d album ids", len(album_ids))
+    submit_album_ids(album_ids)
+    current_app.logger.info("Submitted new release album ids")

--- a/listenbrainz/spotify_metadata_cache/seeder.py
+++ b/listenbrainz/spotify_metadata_cache/seeder.py
@@ -7,6 +7,7 @@ from listenbrainz.utils import get_fallback_connection_name
 
 
 def get_album_ids():
+    """ Retrieve spotify album ids from new releases for all markets"""
     sp = Spotify(auth_manager=SpotifyClientCredentials(
         client_id=current_app.config["SPOTIFY_CLIENT_ID"],
         client_secret=current_app.config["SPOTIFY_CLIENT_SECRET"]
@@ -26,6 +27,7 @@ def get_album_ids():
 
 
 def submit_album_ids(album_ids):
+    """ Submit album ids to seed spotify metadata cache """
     message = {"spotify_album_ids": list(album_ids)}
     connection = Connection(
         hostname=current_app.config["RABBITMQ_HOST"],
@@ -47,6 +49,7 @@ def submit_album_ids(album_ids):
 
 
 def submit_new_releases_to_cache():
+    """ Query spotify new releases for album ids and submit those to spotify metadata cache """
     current_app.logger.info("Searching new album ids to seed spotify metadata cache")
     album_ids = get_album_ids()
     current_app.logger.info("Found %d album ids", len(album_ids))

--- a/listenbrainz/spotify_metadata_cache/spotify_metadata_cache.py
+++ b/listenbrainz/spotify_metadata_cache/spotify_metadata_cache.py
@@ -19,6 +19,7 @@ class SpotifyMetadataCache(ConsumerMixin):
         self.queue = None
         self.connection = None
         self.unique_exchange = Exchange(self.app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)
+        # this queue gets spotify album ids from listens
         self.listens_queue = Queue(
             self.app.config["SPOTIFY_METADATA_QUEUE"],
             exchange=self.unique_exchange, 
@@ -29,6 +30,7 @@ class SpotifyMetadataCache(ConsumerMixin):
             "topic",
             durable=True
         )
+        # this queue gets spotify album ids directly queued to the external spotify queue
         self.spotify_queue = Queue(
             self.app.config["EXTERNAL_SERVICES_SPOTIFY_CACHE_QUEUE"],
             exchange=self.external_services_exchange, 


### PR DESCRIPTION
Every day query, spotify's new releases endpoint to retrieve new releases and submit those album ids to spotify metadata cache for processing.

Added a separate queue and a direct exchange for this so that we can directly enqueue spotify album ids.