### PR TITLE
Add similar recordings lookup

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -51,4 +51,6 @@ CREATE UNIQUE INDEX spotify_cache_track_spotify_id_idx ON spotify_cache.track (s
 CREATE INDEX spotify_cache_rel_album_artist_track_id_idx ON spotify_cache.rel_album_artist (album_id);
 CREATE INDEX spotify_cache_rel_track_artist_track_id_idx ON spotify_cache.rel_track_artist (track_id);
 
+CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
+
 COMMIT;

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -52,6 +52,7 @@ CREATE INDEX spotify_cache_rel_album_artist_track_id_idx ON spotify_cache.rel_al
 CREATE INDEX spotify_cache_rel_track_artist_track_id_idx ON spotify_cache.rel_track_artist (track_id);
 
 CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_recordings_reverse_uniq_idx ON similarity.recording (mbid1, mbid0);
 CREATE INDEX similar_recordings_algorithm_idx ON similarity.recording USING gin (metadata);
 
 COMMIT;

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -52,5 +52,6 @@ CREATE INDEX spotify_cache_rel_album_artist_track_id_idx ON spotify_cache.rel_al
 CREATE INDEX spotify_cache_rel_track_artist_track_id_idx ON spotify_cache.rel_track_artist (track_id);
 
 CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
+CREATE INDEX similar_recordings_algorithm_idx ON similarity.recording USING gin (metadata);
 
 COMMIT;

--- a/admin/timescale/create_schemas.sql
+++ b/admin/timescale/create_schemas.sql
@@ -2,3 +2,4 @@ CREATE SCHEMA playlist;
 CREATE SCHEMA messybrainz;
 CREATE SCHEMA mapping;
 CREATE SCHEMA spotify_cache;
+CREATE SCHEMA similarity;

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -168,4 +168,13 @@ CREATE TABLE background_worker_state (
 );
 COMMENT ON TABLE background_worker_state IS 'This table is used to store miscellaneous data by various background processes or the ListenBrainz webserver. Use it when storing the data is redis is not reliable enough.';
 
+
+CREATE TABLE similarity.recording (
+    mbid0 UUID NOT NULL,
+    mbid1 UUID NOT NULL,
+    metadata JSONB NOT NULL
+
+    CONSTRAINT alphabetical_uuids CHECK (mbid0 <= mbid1)
+);
+
 COMMIT;

--- a/admin/timescale/updates/2022-10-23-add-recording-similarity.sql
+++ b/admin/timescale/updates/2022-10-23-add-recording-similarity.sql
@@ -11,5 +11,6 @@ CREATE TABLE similarity.recording (
 );
 
 CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
+CREATE INDEX similar_recordings_algorithm_idx ON similarity.recording USING gin (metadata);
 
 COMMIT;

--- a/admin/timescale/updates/2022-10-23-add-recording-similarity.sql
+++ b/admin/timescale/updates/2022-10-23-add-recording-similarity.sql
@@ -11,6 +11,8 @@ CREATE TABLE similarity.recording (
 );
 
 CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
+-- reverse index is only needed for performance reasons
+CREATE UNIQUE INDEX similar_recordings_reverse_uniq_idx ON similarity.recording (mbid1, mbid0);
 CREATE INDEX similar_recordings_algorithm_idx ON similarity.recording USING gin (metadata);
 
 COMMIT;

--- a/admin/timescale/updates/2022-10-23-add-recording-similarity.sql
+++ b/admin/timescale/updates/2022-10-23-add-recording-similarity.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+CREATE SCHEMA similarity;
+
+CREATE TABLE similarity.recording (
+    mbid0 UUID NOT NULL,
+    mbid1 UUID NOT NULL,
+    metadata JSONB NOT NULL
+
+    CONSTRAINT alphabetical_uuids CHECK (mbid0 <= mbid1)
+);
+
+CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
+
+COMMIT;

--- a/listenbrainz/db/recording_similarity.py
+++ b/listenbrainz/db/recording_similarity.py
@@ -1,0 +1,40 @@
+from psycopg2.extras import execute_values
+from psycopg2.sql import SQL, Literal
+from sqlalchemy import text
+
+from listenbrainz.db import timescale
+
+
+def insert_similar_recordings(data, algorithm):
+    query = """
+        INSERT INTO similarity.recording AS sr (mbid0, mbid1, metadata)
+             VALUES %s
+        ON CONFLICT (mbid0, mbid1)
+          DO UPDATE
+                SET metadata = sr.metadata || EXCLUDED.metadata
+    """
+    values = [(x["mbid0"], x["mbid1"], x["score"]) for x in data]
+    template = SQL("(%s, %s, jsonb_build_object({algorithm}, %s))").format(algorithm=Literal(algorithm))
+
+    conn = timescale.engine.raw_connection()
+    try:
+        with conn.cursor() as curs:
+            execute_values(curs, query, values, template)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_similar_recordings(mbid, algorithm, count):
+    query = """
+        SELECT CASE WHEN mbid0 = :mbid THEN mbid1 ELSE mbid0 END AS similar_mbid
+             , jsonb_object_field(metadata, :algorithm)::numeric AS score
+          FROM similarity.recording
+         WHERE (mbid0 = :mbid OR mbid1 = :mbid)
+           AND metadata ? :algorithm
+      ORDER BY score DESC
+         LIMIT :count
+    """
+    with timescale.engine.connect() as conn:
+        result = conn.execute(text(query), {"mbid": mbid, "algorithm": algorithm, "count": count})
+        return result.fetchall()

--- a/listenbrainz/db/recording_similarity.py
+++ b/listenbrainz/db/recording_similarity.py
@@ -28,7 +28,7 @@ def insert_similar_recordings(data, algorithm):
 def get_similar_recordings(mbid, algorithm, count):
     query = """
         SELECT CASE WHEN mbid0 = :mbid THEN mbid1 ELSE mbid0 END AS similar_mbid
-             , jsonb_object_field(metadata, :algorithm)::numeric AS score
+             , jsonb_object_field(metadata, :algorithm)::integer AS score
           FROM similarity.recording
          WHERE (mbid0 = :mbid OR mbid1 = :mbid)
            AND metadata ? :algorithm

--- a/listenbrainz/db/recording_similarity.py
+++ b/listenbrainz/db/recording_similarity.py
@@ -7,6 +7,7 @@ from listenbrainz.db import timescale
 
 
 def insert_similar_recordings(data, algorithm):
+    """ Insert similar recordings in database """
     query = """
         INSERT INTO similarity.recording AS sr (mbid0, mbid1, metadata)
              VALUES %s
@@ -27,8 +28,8 @@ def insert_similar_recordings(data, algorithm):
 
 
 def get_similar_recordings(mbids, algorithm, count):
-    # todo: the lateral join query is cleaner but performed a bit worse in limited testing. do more testing to
-    #  check if its indeed slower, if not use that.
+    """ Fetch at most `count` number of similar recordings for each mbid in the given
+     list using the given algorithm. """
     query = SQL("""
         WITH mbids(mbid) AS (
             VALUES %s

--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -1,20 +1,17 @@
-import psycopg2
 import psycopg2.extras
 from datasethoster import Query
 from flask import current_app
 
-from listenbrainz import config
+from listenbrainz.labs_api.labs.api.utils import get_recordings_from_mbids
 
 psycopg2.extras.register_uuid()
 
 
 class RecordingFromRecordingMBIDQuery(Query):
-    '''
-        Look up a musicbrainz data for a list of recordings, based on MBID.
-    '''
+    """ Look up a musicbrainz data for a list of recordings, based on MBID. """
 
     def names(self):
-        return ("recording-mbid-lookup", "MusicBrainz Recording by MBID Lookup")
+        return "recording-mbid-lookup", "MusicBrainz Recording by MBID Lookup"
 
     def inputs(self):
         return ['[recording_mbid]']
@@ -31,107 +28,19 @@ class RecordingFromRecordingMBIDQuery(Query):
             return []
 
         mbids = [p['[recording_mbid]'] for p in params]
-        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn:
-            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+        output = get_recordings_from_mbids(mbids)
 
-                # First lookup and MBIDs that may have been redirected
-                query = '''SELECT rgr.gid::TEXT AS recording_mbid_old,
-                                  r.gid::TEXT AS recording_mbid_new
-                             FROM recording_gid_redirect rgr
-                             JOIN recording r
-                               ON r.id = rgr.new_id
-                            where rgr.gid in %s'''
+        # Ideally offset and count should be handled by the postgres query itself, but the 1:1 relationship
+        # of what the user requests and what we need to fetch is no longer true, so we can't easily use LIMIT/OFFSET.
+        # We might be able to use a RIGHT JOIN to fix this, but for now I'm happy to leave this as it. We need to
+        # revisit this when we get closer to pushing recommendation tools to production.
+        if offset > 0 and count > 0:
+            return output[offset:offset+count]
 
-                args = [tuple([psycopg2.extensions.adapt(p) for p in mbids])]
-                curs.execute(query, tuple(args))
+        if offset > 0 and count < 0:
+            return output[offset:]
 
+        if offset < 0 and count > 0:
+            return output[:count]
 
-                # Build an index with all redirected recordings
-                redirect_index = {}
-                inverse_redirect_index = {}
-                while True:
-                    row = curs.fetchone()
-                    if not row:
-                        break
-
-                    r = dict(row)
-                    redirect_index[r['recording_mbid_old']] = r['recording_mbid_new']
-                    inverse_redirect_index[r['recording_mbid_new']] = r['recording_mbid_old']
-
-                # Now start looking up actual recordings
-                for i, mbid in enumerate(mbids):
-                    if mbid in redirect_index:
-                        mbids[i] = redirect_index[mbid]
-
-                query = '''SELECT r.gid::TEXT AS recording_mbid,
-                                  r.name AS recording_name,
-                                  r.length,
-                                  r.comment,
-                                  ac.id AS artist_credit_id,
-                                  ac.name AS artist_credit_name,
-                                  array_agg(a.gid ORDER BY acn.position)::TEXT[] AS artist_credit_mbids
-                             FROM recording r
-                             JOIN artist_credit ac
-                               ON r.artist_credit = ac.id
-                             JOIN artist_credit_name acn
-                               ON ac.id = acn.artist_credit
-                             JOIN artist a
-                               ON acn.artist = a.id
-                            WHERE r.gid
-                               IN %s
-                         GROUP BY r.gid, r.id, r.name, r.length, r.comment, ac.id, ac.name
-                         ORDER BY r.gid'''
-
-                args = [tuple([psycopg2.extensions.adapt(p) for p in mbids])]
-                curs.execute(query, tuple(args))
-
-                # Build an index of all the fetched recordings
-                recording_index = {}
-                while True:
-                    row = curs.fetchone()
-                    if not row:
-                        break
-
-                    recording_index[row['recording_mbid']] = dict(row)
-
-                # Finally collate all the results, ensuring that we have one entry with original_recording_mbid for each
-                # input argument
-                output = []
-                for p in params:
-                    mbid = p['[recording_mbid]']
-                    try:
-                        r = dict(recording_index[mbid])
-                    except KeyError:
-                        try:
-                            r = dict(recording_index[redirect_index[mbid]])
-                        except KeyError:
-                            output.append({'recording_mbid': None,
-                                           'recording_name': None,
-                                           'length': None,
-                                           'comment': None,
-                                           'artist_credit_id': None,
-                                           'artist_credit_name': None,
-                                           '[artist_credit_mbids]': None,
-                                           'original_recording_mbid': mbid})
-                            continue
-
-                    r['[artist_credit_mbids]'] = [ac_mbid for ac_mbid in r['artist_credit_mbids']]
-                    del r['artist_credit_mbids']
-                    r['original_recording_mbid'] = inverse_redirect_index.get(mbid, mbid)
-                    output.append(r)
-
-
-                # Ideally offset and count should be handled by the postgres query itself, but the 1:1 relationship
-                # of what the user requests and what we need to fetch is no longer true, so we can't easily use LIMIT/OFFSET.
-                # We might be able to use a RIGHT JOIN to fix this, but for now I'm happy to leave this as it. We need to
-                # revisit this when we get closer to pushing recommendation tools to production.
-                if offset > 0 and count > 0:
-                    return output[offset:offset+count]
-
-                if offset > 0 and count < 0:
-                    return output[offset:]
-
-                if offset < 0 and count > 0:
-                    return output[:count]
-
-                return output
+        return output

--- a/listenbrainz/labs_api/labs/api/similar_recordings.py
+++ b/listenbrainz/labs_api/labs/api/similar_recordings.py
@@ -24,12 +24,15 @@ class SimilarRecordingsViewerQuery(Query):
         return None
 
     def fetch(self, params, offset=-1, count=-1):
-        recording_mbid = params[0]["recording_mbid"]
-        algorithm = params[0]["algorithm"]
+        recording_mbid = params[0]["recording_mbid"].strip()
+        algorithm = params[0]["algorithm"].strip()
         count = count if count > 0 else 100
 
         # resolve redirect for the given mbid if any
         reference = get_recordings_from_mbids([recording_mbid])[0]
+        # remove unwanted fields from output
+        reference.pop("original_recording_mbid", None)
+        reference.pop("artist_credit_id", None)
 
         recordings = get_similar_recordings(reference["recording_mbid"], algorithm, count)
 
@@ -62,6 +65,8 @@ class SimilarRecordingsViewerQuery(Query):
         metadata = get_recordings_from_mbids(mbids)
         for r in metadata:
             r["score"] = index[r["original_recording_mbid"]]
+            r.pop("original_recording_mbid", None)
+            r.pop("artist_credit_id", None)
 
         results.append({
             "type": "markup",

--- a/listenbrainz/labs_api/labs/api/similar_recordings.py
+++ b/listenbrainz/labs_api/labs/api/similar_recordings.py
@@ -26,7 +26,7 @@ class SimilarRecordingsViewerQuery(Query):
     def fetch(self, params, offset=-1, count=-1):
         recording_mbids = [p["recording_mbid"] for p in params]
         algorithm = params[0]["algorithm"].strip()
-        count = count if count > 0 else 10
+        count = count if count > 0 else 100
 
         # resolve redirect for the given mbid if any
         references = get_recordings_from_mbids(recording_mbids)

--- a/listenbrainz/labs_api/labs/api/similar_recordings.py
+++ b/listenbrainz/labs_api/labs/api/similar_recordings.py
@@ -1,0 +1,74 @@
+from datasethoster import Query
+from markupsafe import Markup
+
+from listenbrainz.db.recording_similarity import get_similar_recordings
+from listenbrainz.labs_api.labs.api.utils import get_recordings_from_mbids
+
+
+class SimilarRecordingsViewerQuery(Query):
+    """ Display similar recordings calculated using a given algorithm """
+
+    def setup(self):
+        pass
+
+    def names(self):
+        return "similar-recordings", "Similar Recordings Viewer"
+
+    def inputs(self):
+        return ['recording_mbid', 'algorithm']
+
+    def introduction(self):
+        return """This page allows you to view recordings similar to a given recording and algorithm."""
+
+    def outputs(self):
+        return None
+
+    def fetch(self, params, offset=-1, count=-1):
+        recording_mbid = params[0]["recording_mbid"]
+        algorithm = params[0]["algorithm"]
+        count = count if count > 0 else 100
+
+        # resolve redirect for the given mbid if any
+        reference = get_recordings_from_mbids([recording_mbid])
+
+        recordings = get_similar_recordings(reference["recording_mbid"], algorithm, count)
+
+        index = {}
+        mbids = []
+        for r in recordings:
+            index[r.similar_mbid] = r.score
+            mbids.append(r.similar_mbid)
+
+        metadata = get_recordings_from_mbids(mbids)
+        for r in metadata:
+            r["score"] = index[r["original_recording_mbid"]]
+
+        results = [
+            {
+                "type": "markup",
+                "data": Markup("<p><b>Reference recording</b></p>")
+            },
+            {
+                "type": "dataset",
+                "columns": reference.keys(),
+                "data": reference
+            }
+        ]
+
+        if len(metadata) > 0:
+            results.append({
+                "type": "markup",
+                "data": Markup("<p><b>Similar Recordings</b></p>")
+            })
+            results.append({
+                "type": "dataset",
+                "columns": metadata[0].keys(),
+                "data": metadata
+            })
+        else:
+            results.append({
+                "type": "markup",
+                "data": Markup("<p><b>No similar recordings found!</b></p>")
+            })
+
+        return results

--- a/listenbrainz/labs_api/labs/api/user_listen_sessions.py
+++ b/listenbrainz/labs_api/labs/api/user_listen_sessions.py
@@ -1,8 +1,6 @@
 from datasethoster import Query
-from flask import current_app
 from markupsafe import Markup
 from sqlalchemy import text
-from sqlalchemy.dialects.postgresql import psycopg2
 
 from listenbrainz import db
 from listenbrainz.db import timescale
@@ -10,6 +8,9 @@ from listenbrainz.db import timescale
 
 class UserListensSessionQuery(Query):
     """ Display sessions of user's listens as sessions for given time period """
+
+    def setup(self):
+        pass
 
     def names(self):
         return "sessions-viewer", "ListenBrainz Session Viewer"

--- a/listenbrainz/labs_api/labs/api/utils.py
+++ b/listenbrainz/labs_api/labs/api/utils.py
@@ -1,0 +1,93 @@
+import psycopg2
+from flask import current_app
+
+
+def get_recordings_from_mbids(mbids):
+    """ Given a list of recording mbids, resolve redirects if any and return metadata for all recordings """
+    with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+
+            # First lookup and MBIDs that may have been redirected
+            query = '''SELECT rgr.gid::TEXT AS recording_mbid_old,
+                              r.gid::TEXT AS recording_mbid_new
+                         FROM recording_gid_redirect rgr
+                         JOIN recording r
+                           ON r.id = rgr.new_id
+                        where rgr.gid in %s'''
+
+            args = [tuple([psycopg2.extensions.adapt(p) for p in mbids])]
+            curs.execute(query, tuple(args))
+
+            # Build an index with all redirected recordings
+            redirect_index = {}
+            inverse_redirect_index = {}
+            while True:
+                row = curs.fetchone()
+                if not row:
+                    break
+
+                r = dict(row)
+                redirect_index[r['recording_mbid_old']] = r['recording_mbid_new']
+                inverse_redirect_index[r['recording_mbid_new']] = r['recording_mbid_old']
+
+            # Now start looking up actual recordings
+            for i, mbid in enumerate(mbids):
+                if mbid in redirect_index:
+                    mbids[i] = redirect_index[mbid]
+
+            query = '''SELECT r.gid::TEXT AS recording_mbid,
+                              r.name AS recording_name,
+                              r.length,
+                              r.comment,
+                              ac.id AS artist_credit_id,
+                              ac.name AS artist_credit_name,
+                              array_agg(a.gid ORDER BY acn.position)::TEXT[] AS artist_credit_mbids
+                         FROM recording r
+                         JOIN artist_credit ac
+                           ON r.artist_credit = ac.id
+                         JOIN artist_credit_name acn
+                           ON ac.id = acn.artist_credit
+                         JOIN artist a
+                           ON acn.artist = a.id
+                        WHERE r.gid
+                           IN %s
+                     GROUP BY r.gid, r.id, r.name, r.length, r.comment, ac.id, ac.name
+                     ORDER BY r.gid'''
+
+            args = [tuple([psycopg2.extensions.adapt(p) for p in mbids])]
+            curs.execute(query, tuple(args))
+
+            # Build an index of all the fetched recordings
+            recording_index = {}
+            while True:
+                row = curs.fetchone()
+                if not row:
+                    break
+
+                recording_index[row['recording_mbid']] = dict(row)
+
+            # Finally collate all the results, ensuring that we have one entry with original_recording_mbid for each
+            # input argument
+            output = []
+            for mbid in mbids:
+                try:
+                    r = dict(recording_index[mbid])
+                except KeyError:
+                    try:
+                        r = dict(recording_index[redirect_index[mbid]])
+                    except KeyError:
+                        output.append({'recording_mbid': None,
+                                       'recording_name': None,
+                                       'length': None,
+                                       'comment': None,
+                                       'artist_credit_id': None,
+                                       'artist_credit_name': None,
+                                       '[artist_credit_mbids]': None,
+                                       'original_recording_mbid': mbid})
+                        continue
+
+                r['[artist_credit_mbids]'] = [ac_mbid for ac_mbid in r['artist_credit_mbids']]
+                del r['artist_credit_mbids']
+                r['original_recording_mbid'] = inverse_redirect_index.get(mbid, mbid)
+                output.append(r)
+    return output

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -8,6 +8,7 @@ from listenbrainz.labs_api.labs.api.mbid_mapping import MBIDMappingQuery
 from listenbrainz.labs_api.labs.api.explain_mbid_mapping import ExplainMBIDMappingQuery
 from listenbrainz.labs_api.labs.api.recording_search import RecordingSearchQuery
 from listenbrainz.labs_api.labs.api.artist_credit_recording_lookup import ArtistCreditRecordingLookupQuery
+from listenbrainz.labs_api.labs.api.similar_recordings import SimilarRecordingsViewerQuery
 from listenbrainz.labs_api.labs.api.spotify.spotify_mbid_lookup import SpotifyIdFromMBIDQuery
 from listenbrainz.labs_api.labs.api.spotify.spotify_metadata_lookup import SpotifyIdFromMetadataQuery
 from listenbrainz.labs_api.labs.api.user_listen_sessions import UserListensSessionQuery
@@ -25,6 +26,7 @@ register_query(ArtistCreditRecordingLookupQuery())
 register_query(SpotifyIdFromMetadataQuery())
 register_query(SpotifyIdFromMBIDQuery())
 register_query(UserListensSessionQuery())
+register_query(SimilarRecordingsViewerQuery())
 
 app = create_app()
 load_config(app)

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import psycopg2.extras
 from datasethoster.main import create_app, init_sentry, register_query
 from listenbrainz.labs_api.labs.api.artist_country_from_artist_mbid import ArtistCountryFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_mbid import ArtistCreditIdFromArtistMBIDQuery
@@ -33,3 +33,4 @@ load_config(app)
 init_sentry(app, "DATASETS_SENTRY_DSN")
 db.init_db_connection(app.config['SQLALCHEMY_DATABASE_URI'])
 ts.init_db_connection(app.config['SQLALCHEMY_TIMESCALE_URI'])
+psycopg2.extras.register_uuid()

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -17,6 +17,7 @@ from data.model.user_cf_recommendations_recording_message import UserRecommendat
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from listenbrainz.db import year_in_music, couchdb
 from listenbrainz.db.fresh_releases import insert_fresh_releases
+from listenbrainz.db.recording_similarity import insert_similar_recordings
 from listenbrainz.db.similar_users import import_user_similarities
 from listenbrainz.troi.troi_bot import run_post_recommendation_troi_bot
 
@@ -403,3 +404,7 @@ def handle_listens_per_day(message):
 
 def handle_yearly_listen_counts(message):
     year_in_music.handle_yearly_listen_counts(message["data"])
+
+
+def handle_similar_recordings(message):
+    insert_similar_recordings(message["data"], message["algorithm"])

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -346,6 +346,16 @@ def request_similar_users(max_num_users):
     send_request_to_spark_cluster('similarity.similar_users', max_num_users=max_num_users)
 
 
+@cli.command(name='request_similar_recordings')
+@click.option("--steps", type=int, help="The number of lookahead steps to use.")
+@click.option("--days", type=int, help="The number of days of listens to use.")
+@click.option("--session", type=int, help="The maximum duration in seconds between two listens to consider for similarity.")
+@click.option("--threshold", type=int, help="The minimum similarity to retain pair of recordings in similarity index.")
+def request_similar_recordings(steps, days, session, threshold):
+    """ Send the cluster a request to generate similar recordings index. """
+    send_request_to_spark_cluster('similarity.recording', steps=steps, days=days, session=session, threshold=threshold)
+
+
 @cli.command(name="request_yim_similar_users")
 @click.option("--year", type=int, help="Year for which to calculate the stat",
               default=date.today().year)

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -348,11 +348,16 @@ def request_similar_users(max_num_users):
 
 @cli.command(name='request_similar_recordings')
 @click.option("--days", type=int, help="The number of days of listens to use.", required=True)
-@click.option("--session", type=int, help="The maximum duration in seconds between two listens to consider for similarity.", required=True)
-@click.option("--threshold", type=int, help="The minimum similarity score to include a recording pair in the simlarity index.", required=True)
-def request_similar_recordings(days, session, threshold):
+@click.option("--session", type=int, help="The maximum duration in seconds between two listens in a listening"
+                                          " session.", required=True)
+@click.option("--threshold", type=int, help="The minimum similarity score to include a recording pair in the"
+                                            " simlarity index.", required=True)
+@click.option("--limit", type=int, help="The maximum number of similar recordings to generate per recording"
+                                        " (the limit is instructive. upto 2x recordings may be returned than"
+                                        " the limit).", required=True)
+def request_similar_recordings(days, session, threshold, limit):
     """ Send the cluster a request to generate similar recordings index. """
-    send_request_to_spark_cluster('similarity.recording', days=days, session=session, threshold=threshold)
+    send_request_to_spark_cluster('similarity.recording', days=days, session=session, threshold=threshold, limit=limit)
 
 
 @cli.command(name="request_yim_similar_users")

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -347,10 +347,10 @@ def request_similar_users(max_num_users):
 
 
 @cli.command(name='request_similar_recordings')
-@click.option("--steps", type=int, help="The number of lookahead steps to use.")
-@click.option("--days", type=int, help="The number of days of listens to use.")
-@click.option("--session", type=int, help="The maximum duration in seconds between two listens to consider for similarity.")
-@click.option("--threshold", type=int, help="The minimum similarity to retain pair of recordings in similarity index.")
+@click.option("--steps", type=int, help="The number of lookahead steps to use.", required=True)
+@click.option("--days", type=int, help="The number of days of listens to use.", required=True)
+@click.option("--session", type=int, help="The maximum duration in seconds between two listens to consider for similarity.", required=True)
+@click.option("--threshold", type=int, help="The minimum similarity to retain pair of recordings in similarity index.", required=True)
 def request_similar_recordings(steps, days, session, threshold):
     """ Send the cluster a request to generate similar recordings index. """
     send_request_to_spark_cluster('similarity.recording', steps=steps, days=days, session=session, threshold=threshold)

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -349,9 +349,10 @@ def request_similar_users(max_num_users):
 @cli.command(name='request_similar_recordings')
 @click.option("--days", type=int, help="The number of days of listens to use.", required=True)
 @click.option("--session", type=int, help="The maximum duration in seconds between two listens to consider for similarity.", required=True)
-def request_similar_recordings(days, session):
+@click.option("--threshold", type=int, help="The minimum similarity score to include a recording pair in the simlarity index.", required=True)
+def request_similar_recordings(days, session, threshold):
     """ Send the cluster a request to generate similar recordings index. """
-    send_request_to_spark_cluster('similarity.recording', days=days, session=session)
+    send_request_to_spark_cluster('similarity.recording', days=days, session=session, threshold=threshold)
 
 
 @cli.command(name="request_yim_similar_users")

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -347,13 +347,11 @@ def request_similar_users(max_num_users):
 
 
 @cli.command(name='request_similar_recordings')
-@click.option("--steps", type=int, help="The number of lookahead steps to use.", required=True)
 @click.option("--days", type=int, help="The number of days of listens to use.", required=True)
 @click.option("--session", type=int, help="The maximum duration in seconds between two listens to consider for similarity.", required=True)
-@click.option("--threshold", type=int, help="The minimum similarity to retain pair of recordings in similarity index.", required=True)
-def request_similar_recordings(steps, days, session, threshold):
+def request_similar_recordings(days, session):
     """ Send the cluster a request to generate similar recordings index. """
-    send_request_to_spark_cluster('similarity.recording', steps=steps, days=days, session=session, threshold=threshold)
+    send_request_to_spark_cluster('similarity.recording', days=days, session=session)
 
 
 @cli.command(name="request_yim_similar_users")

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -128,6 +128,16 @@
       "max_num_users"
     ]
   },
+  "similarity.recording": {
+    "name": "similarity.recording",
+    "description": "Generate recording similarity",
+    "params": [
+      "steps",
+      "days",
+      "session",
+      "threshold"
+    ]
+  },
   "year_in_music.similar_users": {
     "name": "year_in_music.similar_users",
     "description": "Generate similar user correlation for Year in Music",

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -134,7 +134,8 @@
     "params": [
       "days",
       "session",
-      "threshold"
+      "threshold",
+      "limit"
     ]
   },
   "year_in_music.similar_users": {

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -133,7 +133,8 @@
     "description": "Generate recording similarity",
     "params": [
       "days",
-      "session"
+      "session",
+      "threshold"
     ]
   },
   "year_in_music.similar_users": {

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -132,10 +132,8 @@
     "name": "similarity.recording",
     "description": "Generate recording similarity",
     "params": [
-      "steps",
       "days",
-      "session",
-      "threshold"
+      "session"
     ]
   },
   "year_in_music.similar_users": {

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -30,7 +30,7 @@ from listenbrainz.spark.handlers import (handle_candidate_sets,
                                          handle_top_stats,
                                          handle_listens_per_day,
                                          handle_yearly_listen_counts,
-                                         handle_fresh_releases)
+                                         handle_fresh_releases, handle_similar_recordings)
 from listenbrainz.utils import get_fallback_connection_name
 from listenbrainz.webserver import create_app
 
@@ -59,6 +59,7 @@ response_handler_map = {
     'cf_recommendations_recording_mail': cf_recording_recommendations_complete,
     'similar_users': handle_similar_users,
     'similar_users_year_end': handle_similar_users_year_end,
+    'similar_recordings': handle_similar_recordings,
     'year_in_music_top_stats': handle_top_stats,
     'year_in_music_listens_per_day': handle_listens_per_day,
     'year_in_music_listen_count': handle_yearly_listen_counts,

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -34,6 +34,8 @@ RECOMMENDATION_RECORDING_CANDIDATE_SET_DIR = os.path.join(
 RECOMMENDATION_RECORDING_DATA_DIR = os.path.join(
     RECOMMENDATION_RECORDING_MODEL_DIR, 'data')
 
+RECORDING_SIMILARITY = "/data/recording-similarity"
+
 RECORDING_DISCOVERY = os.path.join(RECOMMENDATION_RECORDING_PARENT_DIR, 'discovery')
 
 # Absolute path to dataframes used in processing raw data/listens for `recording` recommendations.

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -20,6 +20,7 @@ import listenbrainz_spark.year_in_music.top_stats
 import listenbrainz_spark.year_in_music.listens_per_day
 import listenbrainz_spark.year_in_music.listen_count
 import listenbrainz_spark.fresh_releases.fresh_releases
+import listenbrainz_spark.recording_similarity.recording
 
 functions = {
     'stats.user.entity': listenbrainz_spark.stats.user.entity.get_entity_stats,
@@ -40,6 +41,7 @@ functions = {
     'import.artist_relation': listenbrainz_spark.request_consumer.jobs.import_dump.import_artist_relation_to_hdfs,
     'import.musicbrainz_release_dump': listenbrainz_spark.request_consumer.jobs.import_dump.import_release_json_dump_to_hdfs,
     'similarity.similar_users': listenbrainz_spark.user_similarity.user_similarity.main,
+    'similarity.recording': listenbrainz_spark.recording_similarity.recording.main,
     'year_in_music.new_releases_of_top_artists':
         listenbrainz_spark.year_in_music.new_releases_of_top_artists.get_new_releases_of_top_artists,
     'year_in_music.most_prominent_color': listenbrainz_spark.year_in_music.most_prominent_color.get_most_prominent_color,

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -15,11 +15,11 @@ def get_complete_index_query(table, threshold):
                  , similarity
               FROM {table}
         )
-        SELECT mbid0
-             , mbid1
+        SELECT lexical_mbid0 AS mbid0
+             , lexical_mbid1 AS mbid1
              , SUM(similarity) AS total_similarity
           FROM symmetric_index
-      GROUP BY mbid0, mbid1
+      GROUP BY lexical_mbid0, lexical_mbid1
         HAVING total_similarity >= {threshold}
     """
 

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -1,0 +1,79 @@
+from datetime import datetime, date, time, timedelta
+
+import listenbrainz_spark
+from listenbrainz_spark import config, path
+from listenbrainz_spark.schema import recording_similarity_schema
+from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import get_listens_from_new_dump
+
+
+def get_complete_index_query(table, threshold):
+    return f"""
+        WITH symmetric_index AS (
+            SELECT CASE WHEN mbid0 < mbid1 THEN mbid0 ELSE mbid1 END AS lexical_mbid0
+                 , CASE WHEN mbid0 > mbid1 THEN mbid0 ELSE mbid1 END AS lexical_mbid1
+                 , similarity
+              FROM {table}
+        )
+        SELECT mbid0
+             , mbid1
+             , SUM(similarity) AS total_similarity
+          FROM symmetric_index
+      GROUP BY mbid0, mbid1
+        HAVING total_similarity >= {threshold}
+    """
+
+
+def get_partial_index_query(table, lookahead, session, weight):
+    return f"""
+        WITH mbid_similarity AS (
+            SELECT recording_mbid AS mbid0
+                 , LEAD(recording_mbid, {lookahead}) OVER window AS mbid1
+                 , unix_timestamp(listened_at) AS ts0
+                 , unix_timestamp(LEAD(listened_at, {lookahead}) OVER window) AS ts1
+              FROM {table}
+             WHERE recording_mbid IS NOT NULL
+            WINDOW window AS (PARTITION BY user_id ORDER BY listened_at)
+        ), symmetric_index AS (
+            SELECT CASE WHEN mbid0 < mbid1 THEN mbid0 ELSE mbid1 END AS lexical_mbid0
+                 , CASE WHEN mbid0 > mbid1 THEN mbid0 ELSE mbid1 END AS lexical_mbid1
+              FROM mbid_similarity
+             WHERE mbid0 IS NOT NULL
+               AND mbid1 IS NOT NULL
+               AND mbid0 != mbid1
+               AND ts1 - ts0 <= {session}
+        )
+        SELECT lexical_mbid0 AS mbid0
+             , lexical_mbid1 AS mbid1
+             , COUNT(*) * {weight} AS similarity
+          FROM symmetric_index
+      GROUP BY lexical_mbid0, lexical_mbid1
+    """
+
+
+def main(steps, days, session, threshold):
+    to_date = datetime.combine(date.today(), time.min)
+    from_date = to_date + timedelta(days=-days)
+
+    table = "recording_similarity_listens"
+
+    get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView(table)
+
+    weight = 1.0
+    decrement = 1.0 / steps
+
+    similarity_df = listenbrainz_spark.session.createDataFrame([], schema=recording_similarity_schema)
+    for step in range(1, steps + 1, 1):
+        query = get_partial_index_query(table, step, session, weight)
+        similarity_df = similarity_df.union(run_query(query))
+        weight -= decrement
+
+    partial_index_table = "partial_similarity_index"
+    similarity_df.createOrReplaceTempView(partial_index_table)
+
+    save_path = f"{path.RECORDING_SIMILARITY}/steps-{steps}-days-{days}-session-{session}-threshold-{threshold}"
+    combined_index_query = get_complete_index_query(partial_index_table, threshold)
+    run_query(combined_index_query) \
+        .write \
+        .format('parquet') \
+        .save(config.HDFS_CLUSTER_URI + save_path, mode="overwrite")

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -6,7 +6,7 @@ from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import get_listens_from_new_dump
 
 
-def build_sessioned_index(listen_table, mbc_table, from_ts, to_ts, session):
+def build_sessioned_index(listen_table, mbc_table, session):
     # TODO: Handle case of unmatched recordings breaking sessions!
     return f"""
         WITH listens AS (
@@ -18,8 +18,6 @@ def build_sessioned_index(listen_table, mbc_table, from_ts, to_ts, session):
               LEFT JOIN {mbc_table} mbc
                   USING (recording_mbid)
                   WHERE l.recording_mbid IS NOT NULL
-                    AND listened_at > {from_ts}
-                    AND listened_at < {to_ts}
             ), ordered AS (
                 SELECT user_id
                      , listened_at
@@ -63,7 +61,7 @@ def main(days, session):
 
     save_path = f"{path.RECORDING_SIMILARITY}/session_based_days_{days}_session_{session}"
 
-    query = build_sessioned_index(table, metadata_table, int(from_date.timestamp()), int(to_date.timestamp()), session)
+    query = build_sessioned_index(table, metadata_table, session)
 
     run_query(query) \
         .write \

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -66,5 +66,5 @@ def main(days, session):
 
     run_query(query) \
         .write \
-        .format('parquet') \
+        .format('csv') \
         .save(config.HDFS_CLUSTER_URI + save_path, mode="overwrite")

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -27,7 +27,8 @@ def build_sessioned_index(listen_table, mbc_table, session):
                 WINDOW w AS (PARTITION BY user_id ORDER BY listened_at)
             ), sessions AS (
                 SELECT user_id
-                     , COUNT(*) FILTER ( WHERE difference > {session} ) OVER w AS session_id
+                     -- spark doesn't support window aggregate functions with FILTER clause
+                     , COUNT_IF(difference > {session}) OVER w AS session_id
                      , recording_mbid
                   FROM ordered
                 WINDOW w AS (PARTITION BY user_id ORDER BY listened_at)

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -11,7 +11,7 @@ from listenbrainz_spark.utils import get_listens_from_new_dump
 RECORDINGS_PER_MESSAGE = 10000
 
 
-def build_sessioned_index(listen_table, mbc_table, session, threshold, limit):
+def build_sessioned_index(listen_table, metadata_table, session, threshold, limit):
     # TODO: Handle case of unmatched recordings breaking sessions!
     #  Detect and remove skips!
     return f"""
@@ -21,7 +21,7 @@ def build_sessioned_index(listen_table, mbc_table, session, threshold, limit):
                       , CAST(COALESCE(recording_data.length / 1000, 180) AS BIGINT) AS duration
                       , recording_mbid
                    FROM {listen_table} l
-              LEFT JOIN {mbc_table} mbc
+              LEFT JOIN {metadata_table} mbc
                   USING (recording_mbid)
                   WHERE l.recording_mbid IS NOT NULL
             ), ordered AS (

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -12,7 +12,7 @@ def build_sessioned_index(listen_table, mbc_table, from_ts, to_ts, session):
         WITH listens AS (
                  SELECT user_id
                       , listened_at
-                      , COALESCE((recording_data.length / 1000)::BIGINT, 180) AS duration
+                      , CAST(COALESCE(recording_data.length / 1000, 180) AS BIGINT) AS duration
                       , recording_mbid
                    FROM {listen_table} l
               LEFT JOIN {mbc_table} mbc

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -8,7 +8,7 @@ from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import get_listens_from_new_dump
 
 
-RECORDINGS_PER_MESSAGE = 1000
+RECORDINGS_PER_MESSAGE = 10000
 
 
 def build_sessioned_index(listen_table, mbc_table, session, threshold, limit):

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -11,7 +11,7 @@ def build_sessioned_index(listen_table, mbc_table, session):
     return f"""
         WITH listens AS (
                  SELECT user_id
-                      , listened_at
+                      , BIGINT(listened_at)
                       , CAST(COALESCE(recording_data.length / 1000, 180) AS BIGINT) AS duration
                       , recording_mbid
                    FROM {listen_table} l

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -11,11 +11,11 @@ from listenbrainz_spark.utils import get_listens_from_new_dump
 RECORDINGS_PER_MESSAGE = 1000
 
 
-def build_sessioned_index(listen_table, mbc_table, session, threshold):
+def build_sessioned_index(listen_table, mbc_table, session, threshold, limit):
     # TODO: Handle case of unmatched recordings breaking sessions!
     #  Detect and remove skips!
     return f"""
-        WITH listens AS (
+            WITH listens AS (
                  SELECT user_id
                       , BIGINT(listened_at)
                       , CAST(COALESCE(recording_data.length / 1000, 180) AS BIGINT) AS duration
@@ -45,17 +45,39 @@ def build_sessioned_index(listen_table, mbc_table, session, threshold):
                   JOIN sessions s2
                  USING (user_id, session_id)
                  WHERE s1.recording_mbid != s2.recording_mbid
-            ) SELECT lexical_mbid0 AS mbid0
-                   , lexical_mbid1 AS mbid1
-                   , COUNT(*) AS score
-                FROM grouped_mbids
-            GROUP BY lexical_mbid0
-                   , lexical_mbid1
-              HAVING score > {threshold}
+            ), thresholded_mbids AS (
+                SELECT lexical_mbid0 AS mbid0
+                     , lexical_mbid1 AS mbid1
+                     , COUNT(*) AS score
+                  FROM grouped_mbids
+              GROUP BY lexical_mbid0
+                     , lexical_mbid1
+                HAVING score > {threshold}
+            ), ranked_mbids AS (
+                SELECT mbid0
+                     , mbid1
+                     , score
+                     , rank() OVER w AS rank
+                  FROM thresholded_mbids
+                WINDOW w AS (PARTITION BY mbid0 ORDER BY score DESC)     
+            )   SELECT mbid0
+                     , mbid1
+                     , score
+                  FROM ranked_mbids
+                 WHERE rank <= {limit}   
     """
 
 
-def main(days, session, threshold):
+def main(days, session, threshold, limit):
+    """ Generate similar recordings based on user listening sessions.
+
+    Args:
+        days: the number of days of listens to consider for calculating listening sessions
+        session: the max time difference between two listens in a listening session
+        threshold: the minimum similarity score for two recordings to be considered similar
+        limit: the maximum number of similar recordings to request for a given recording
+            (this limit is instructive only, upto 2x number of recordings may be returned)
+    """
     to_date = datetime.combine(date.today(), time.min)
     from_date = to_date + timedelta(days=-days)
 
@@ -67,10 +89,10 @@ def main(days, session, threshold):
     metadata_df = listenbrainz_spark.sql_context.read.json(config.HDFS_CLUSTER_URI + "/mb_metadata_cache.jsonl")
     metadata_df.createOrReplaceTempView(metadata_table)
 
-    query = build_sessioned_index(table, metadata_table, session, threshold)
+    query = build_sessioned_index(table, metadata_table, session, threshold, limit)
     data = run_query(query).toLocalIterator()
 
-    algorithm = f"session_based_days_{days}_session_{session}_threshold_{threshold}"
+    algorithm = f"session_based_days_{days}_session_{session}_threshold_{threshold}_limit_{limit}"
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -43,7 +43,7 @@ def build_sessioned_index(listen_table, mbc_table, session, threshold):
                      , IF(s1.recording_mbid > s2.recording_mbid, s1.recording_mbid, s2.recording_mbid) AS lexical_mbid1
                   FROM sessions s1
                   JOIN sessions s2
-                 USING (user_id, session_id) 
+                 USING (user_id, session_id)
                  WHERE s1.recording_mbid != s2.recording_mbid
             ) SELECT lexical_mbid0 AS mbid0
                    , lexical_mbid1 AS mbid1
@@ -51,7 +51,7 @@ def build_sessioned_index(listen_table, mbc_table, session, threshold):
                 FROM grouped_mbids
             GROUP BY lexical_mbid0
                    , lexical_mbid1
-              HAVING score > {threshold}    
+              HAVING score > {threshold}
     """
 
 

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -12,7 +12,7 @@ def build_sessioned_index(listen_table, mbc_table, from_ts, to_ts, session):
         WITH listens AS (
                  SELECT user_id
                       , listened_at
-                      , COALESCE((recording_data->>'length')::INT / 1000, 180) AS duration
+                      , COALESCE((recording_data.length / 1000)::BIGINT, 180) AS duration
                       , recording_mbid
                    FROM {listen_table} l
               LEFT JOIN {mbc_table} mbc

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -39,7 +39,7 @@ recommendation_schema = StructType([
 recording_similarity_schema = StructType([
     StructField('mbid0', StringType(), nullable=False),
     StructField('mbid1', StringType(), nullable=False),
-    StructField('similarity', FloatType(), nullable=False)
+    StructField('partial_similarity', FloatType(), nullable=False)
 ])
 
 # schema to contain model parameters.

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -36,6 +36,11 @@ recommendation_schema = StructType([
     ])), nullable=False)
 ])
 
+recording_similarity_schema = StructType([
+    StructField('mbid0', StringType(), nullable=False),
+    StructField('mbid1', StringType(), nullable=False),
+    StructField('similarity', FloatType(), nullable=False)
+])
 
 # schema to contain model parameters.
 model_param_schema = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ oauth2client == 4.1.3
 pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.7.1
 spotipy==2.20.0
-datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@v-2022-10-20.0
+datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@a1e12968af93d2f296a42a8094ebff83f3ed33f3
 troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-10-25
 PyYAML==6.0
 eventlet == 0.33.1


### PR DESCRIPTION
Calculate similar recordings based on user listening sessions. Recordings are considered similar if listens of those recordings occur in the same listening session. The number of times a recording pair occurs in listening sessions is its score.

There are 4 parameters to configure similar recordings:
1. days - the number of days of listens to use
2. session - the maximum time difference between two listens in a session
3. threshold - the minimum score to include a recording pair in similarity index
4. limit - the maximum number of similar recordings to keep for a recording