### PR TITLE
LB-1160: Fix Spotify player playback issues

### DIFF
--- a/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -6,6 +6,7 @@ import {
   has as _has,
   debounce as _debounce,
   isString,
+  has,
 } from "lodash";
 import {
   searchForSpotifyTrack,
@@ -191,7 +192,16 @@ export default class SpotifyPlayer
         return;
       }
       onTrackNotFound();
-    } catch (errorObject) {
+    } catch (error) {
+      let errorObject = error;
+      try {
+        errorObject = JSON.parse(error);
+      } catch (jsonParseError) {
+        // Ignore JSON parsing error, this might not be a stringified object
+      }
+      if (!has(errorObject, "status")) {
+        handleError(errorObject.message ?? errorObject);
+      }
       if (errorObject.status === 401) {
         // Handle token error and try again if fixed
         this.handleTokenError(
@@ -202,9 +212,7 @@ export default class SpotifyPlayer
       }
       if (errorObject.status === 403) {
         this.handleAccountError();
-        return;
       }
-      handleError(errorObject.message ?? errorObject);
     }
   };
 

--- a/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -454,8 +454,7 @@ export default class SpotifyPlayer
       paused,
       position,
       duration,
-      loading,
-      track_window: { current_track },
+      track_window: { current_track, previous_tracks },
     } = playerState;
 
     const { currentSpotifyTrack, durationMs } = this.state;
@@ -476,9 +475,14 @@ export default class SpotifyPlayer
       return;
     }
     // How do we accurately detect the end of a song?
-    // From https://github.com/spotify/web-playback-sdk/issues/35#issuecomment-469834686
-    // To the above I added a check for the 'loading' prop, otherwise we skip a song every time
-    if (position === 0 && paused === true && loading === false) {
+    // From https://github.com/spotify/web-playback-sdk/issues/35#issuecomment-509159445
+    // If the current_track (i.e. just finished track) also appears in previous_tracks, we're at the end of that track
+    if (
+      position === 0 &&
+      paused === true &&
+      previous_tracks?.findIndex((track) => track.id === current_track.id) !==
+        -1
+    ) {
       // Track finished or skipped, play next track
       this.debouncedOnTrackEnd();
       return;

--- a/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -88,7 +88,7 @@ export default class SpotifyPlayer
   public domainName = "spotify.com";
   // Saving the access token outside of React state , we do not need it for any rendering purposes
   // and it simplifies some of the closure issues we've had with old tokens.
-  public accessToken = "";
+  private accessToken = "";
   spotifyPlayer?: SpotifyPlayerType;
   debouncedOnTrackEnd: () => void;
 

--- a/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -86,9 +86,8 @@ export default class SpotifyPlayer
 
   public name = "spotify";
   public domainName = "spotify.com";
-  // Saving the access token outside of state because when connecting to Spotify player
-  // getOAuthToken must be called with an updated token. Storing it here allows direct modification
-  // outside of React to solve closure issue (accesstoken not up to date on later calls of connectSpotifyPlayer because closures)
+  // Saving the access token outside of React state , we do not need it for any rendering purposes
+  // and it simplifies some of the closure issues we've had with old tokens.
   public accessToken = "";
   spotifyPlayer?: SpotifyPlayerType;
   debouncedOnTrackEnd: () => void;
@@ -327,8 +326,7 @@ export default class SpotifyPlayer
     }
     const { refreshSpotifyToken, onTrackNotFound } = this.props;
     try {
-      const userToken = await refreshSpotifyToken();
-      this.accessToken = userToken;
+      // Reconnect spotify player; user token will be refreshed in the process
       this.connectSpotifyPlayer(callbackFunction);
     } catch (err) {
       const { handleError } = this.props;

--- a/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -98,7 +98,7 @@ export default class SpotifyPlayer
       durationMs: 0,
     };
 
-    this.debouncedOnTrackEnd = _debounce(props.onTrackEnd, 500, {
+    this.debouncedOnTrackEnd = _debounce(props.onTrackEnd, 700, {
       leading: true,
       trailing: false,
     });
@@ -454,6 +454,7 @@ export default class SpotifyPlayer
       paused,
       position,
       duration,
+      loading,
       track_window: { current_track },
     } = playerState;
 
@@ -476,7 +477,8 @@ export default class SpotifyPlayer
     }
     // How do we accurately detect the end of a song?
     // From https://github.com/spotify/web-playback-sdk/issues/35#issuecomment-469834686
-    if (position === 0 && paused === true) {
+    // To the above I added a check for the 'loading' prop, otherwise we skip a song every time
+    if (position === 0 && paused === true && loading === false) {
       // Track finished or skipped, play next track
       this.debouncedOnTrackEnd();
       return;

--- a/listenbrainz/webserver/static/js/src/utils/SpotifyAPIService.ts
+++ b/listenbrainz/webserver/static/js/src/utils/SpotifyAPIService.ts
@@ -3,8 +3,6 @@
 
 /* eslint-disable camelcase */
 
-import { searchForSpotifyTrack } from "./utils";
-
 export default class SpotifyAPIService {
   static async checkStatus(response: Response) {
     if (response.status >= 200 && response.status < 300) {
@@ -185,36 +183,4 @@ export default class SpotifyAPIService {
 
     return spotifySnapshotId;
   };
-
-  /* eslint-disable no-await-in-loop */
-  searchForSpotifyURIs = async (tracks: JSPFTrack[]): Promise<string[]> => {
-    const tracksCopy = [...tracks];
-    const uris: string[] = [];
-    while (tracksCopy.length > 0) {
-      const track = tracksCopy[0];
-      try {
-        const spotifyTrack = await searchForSpotifyTrack(
-          this.spotifyUser?.access_token,
-          track.title,
-          track.creator,
-          track.album
-        );
-        if (spotifyTrack?.uri) {
-          uris.push(spotifyTrack.uri);
-        }
-        tracksCopy.shift();
-      } catch (error) {
-        if (error.status === 429) {
-          // Too many requests, take a nap before continuing
-          await new Promise((resolve) => {
-            setTimeout(resolve, 600);
-          });
-        } else {
-          throw error;
-        }
-      }
-    }
-    return uris;
-  };
-  /* eslint-enable no-await-in-loop */
 }

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -139,6 +139,7 @@ declare type SpotifyPlayerSDKState = {
   duration: number;
   track_window: {
     current_track: SpotifyTrack | null;
+    previous_tracks: SpotifyTrack[];
   };
 };
 

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -134,6 +134,7 @@ declare type SpotifyPlayerTrackWindow = {
 
 declare type SpotifyPlayerSDKState = {
   paused: boolean;
+  loading: boolean;
   position: number;
   duration: number;
   track_window: {

--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -47,7 +47,7 @@ const searchForSpotifyTrack = async (
   );
   const responseBody = await response.json();
   if (!response.ok) {
-    throw new Error(responseBody.error);
+    throw responseBody.error;
   }
   // Valid response
   const tracks: SpotifyTrack[] = _.get(responseBody, "tracks.items");

--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -47,7 +47,12 @@ const searchForSpotifyTrack = async (
   );
   const responseBody = await response.json();
   if (!response.ok) {
-    throw responseBody.error;
+    throw new Error(
+      JSON.stringify({
+        status: response.status,
+        message: responseBody.error,
+      })
+    );
   }
   // Valid response
   const tracks: SpotifyTrack[] = _.get(responseBody, "tracks.items");

--- a/listenbrainz/webserver/static/js/tests/brainzplayer/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/brainzplayer/SpotifyPlayer.test.tsx
@@ -237,6 +237,7 @@ describe("SpotifyPlayer", () => {
           type: "track",
           uri: "my-spotify-uri",
         },
+        previous_tracks: [],
       },
     };
     it("calls onPlayerPausedChange if player paused state changes", () => {
@@ -270,20 +271,25 @@ describe("SpotifyPlayer", () => {
       const mockProps = { ...props, onTrackEnd };
       const wrapper = shallow<SpotifyPlayer>(<SpotifyPlayer {...mockProps} />);
       const instance = wrapper.instance();
+
+      instance.handlePlayerStateChanged(spotifyPlayerState);
+      instance.handlePlayerStateChanged(spotifyPlayerState);
+      expect(instance.props.onTrackEnd).not.toHaveBeenCalled();
+
+      const endOfTrackPlayerState = {
+        ...spotifyPlayerState,
+        // This is how we detect the end of a track
+        paused: true,
+        position: 0,
+        previous_tracks: [
+          { id: spotifyPlayerState.track_window.current_track?.id },
+        ],
+      };
       // Spotify has a tendency to send multiple messages in a short burst,
       // and we debounce calls to onTrackEnd
-      instance.handlePlayerStateChanged({
-        ...spotifyPlayerState,
-        position: 0,
-      });
-      instance.handlePlayerStateChanged({
-        ...spotifyPlayerState,
-        position: 0,
-      });
-      instance.handlePlayerStateChanged({
-        ...spotifyPlayerState,
-        position: 0,
-      });
+      instance.handlePlayerStateChanged(endOfTrackPlayerState);
+      instance.handlePlayerStateChanged(endOfTrackPlayerState);
+      instance.handlePlayerStateChanged(endOfTrackPlayerState);
       expect(instance.props.onTrackEnd).toHaveBeenCalledTimes(1);
     });
 

--- a/listenbrainz/webserver/static/js/tests/brainzplayer/SpotifyPlayer.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/brainzplayer/SpotifyPlayer.test.tsx
@@ -217,6 +217,7 @@ describe("SpotifyPlayer", () => {
   describe("handlePlayerStateChanged", () => {
     const spotifyPlayerState: SpotifyPlayerSDKState = {
       paused: true,
+      loading: false,
       position: 10,
       duration: 1000,
       track_window: {

--- a/listenbrainz/webserver/static/js/tests/utils/utils.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/utils/utils.test.tsx
@@ -139,18 +139,7 @@ describe("searchForSpotifyTrack", () => {
     ).resolves.toEqual(spotifySearchResponse.tracks.items[0]);
   });
 
-  it("retries if network error / submit fails", async () => {
-    // Overide mock for fetch:
-    window.fetch = jest.fn().mockImplementation(() => {
-      // 1st call will recieve a network error
-      return Promise.reject(new Error("Oh no!"));
-    });
-    await expect(
-      searchForSpotifyTrack("foobar", "import", "vs", "star")
-    ).rejects.toThrow(Error("Oh no!"));
-  });
-
-  it("skips if any other response code is recieved", async () => {
+  it("skips if any other response code is received", async () => {
     // Overide mock for fetch
     window.fetch = jest.fn().mockImplementation(() => {
       return Promise.resolve({
@@ -161,7 +150,7 @@ describe("searchForSpotifyTrack", () => {
     });
     await expect(
       searchForSpotifyTrack("foobar", "import", "vs", "star")
-    ).rejects.toThrow(Error("Not found!"));
+    ).rejects.toThrow(JSON.stringify({ status: 404, message: "Not found!" }));
   });
   it("returns null if no track found in the json response", async () => {
     // Overide mock for fetch


### PR DESCRIPTION
This PR aims to fix two main issues:

1. The Spotify player SDK does not have an "end of track“ event, so we have to rely on some workaround logic:
https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx#L482-L484
It previously had a flaw which we are solving here with the addition of another check using information available in the SDK player state update.

2. Token refresh issue: the Spotify API tokens are time-limited, and when they expire the SDK has a mechanism in place (a callback function) to take in an updated token.
I coded this with a bad closure design which  relied on errors that the SDK does not return in this case, and also meant we always sent an expired token (from when we first loaded the page):
https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz/webserver/static/js/src/brainzplayer/SpotifyPlayer.tsx#L398-L408
To fix this, we call the LB API to refresh the token directly in the SDK's `getOAuthToken` function


In the process we also improve error handling a bit.