### PR TITLE
Only mount static source files in builder; run as local user

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -16,6 +16,16 @@ else
 fi
 
 
+if [[ -f .env ]]; then
+    . .env
+    if [ -z $STATIC_BUILD_USER ]; then
+        echo STATIC_BUILD_USER=$(id -u) >> .env
+    fi
+else
+    echo STATIC_BUILD_USER=$(id -u) >> .env
+fi
+
+
 function invoke_docker_compose {
     exec $DOCKER_COMPOSE_CMD -f docker/docker-compose.yml \
                 -p listenbrainz \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -115,8 +115,9 @@ services:
       dockerfile: Dockerfile
       target: listenbrainz-frontend-dev
     command: npm run build:dev
+    user: ${STATIC_BUILD_USER:-node}
     volumes:
-      - ..:/code:z
+      - ../listenbrainz/webserver/static:/code/listenbrainz/webserver/static:z
 
 # Uncomment the following lines if you want to connect the LB network to a musicbrainz-docker network to access a MB replica
 # TODO: re-comment these before merging this code


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

If we map ..:/code with a volume mount then the node_modules folder created during image build will be overwritten.
Instead, just mount the webserver static directory into static_builder

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution



By default, static_builder runs as root, which means that built static files are created as root. To avoid this, set a `user` flag in docker-compose for the static_builder using a docker-compose environment variable, and create the .env file at startup if required with develop.sh
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


