### PR TITLE
Fix the invocation of the cover art updater.

### DIFF
--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -65,7 +65,6 @@ def sync_coverart():
 
 
 @cli.command()
-@click.argument('year', type=int)
 def update_coverart():
     """
         Update the release_color table incrementally. Designed to be called hourly by cron.


### PR DESCRIPTION
What looks like a bad merge sometime in the past caused the cover art updater to no longer run, because it expects a year argument it never uses. Removing the line should fix the cover art updating.