### PR TITLE
Add release group cover art, artist credit id and individual artist name to mb_metadata_cache

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -352,7 +352,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                             SELECT r.gid AS recording_mbid
                                  , rel.name
                                  , rel.release_group
-                                 , rg.release_group_mbid
+                                 , rg.gid AS release_group_mbid
                                  , crr.release_mbid::TEXT
                                  , COALESCE(caa.id, rgca.caa_id) AS caa_id
                               FROM musicbrainz.recording r

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -419,7 +419,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , artist_data
                                  , artist_tags
                                  , rd.release_mbid
-                                 , caa_id
+                                 , rd.caa_id
+                                 , rgca.caa_id
                                  , year"""
         return query
 

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -349,7 +349,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , re.date_month
                                  , re.date_day
                    ), release_data AS (
-                            SELECT r.gid AS recording_mbid
+                            SELECT DISTINCT ON (r.gid)
+                                   r.gid AS recording_mbid
                                  , rel.name
                                  , rel.release_group
                                  , rg.gid AS release_group_mbid
@@ -371,6 +372,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                               {values_join}
                              WHERE (type_id = 1 AND mime_type != 'application/pdf')
                                 OR type_id IS NULL
+                          ORDER BY r.gid
+                                 , caa.ordering
                    )
                             SELECT recording_links
                                  , r.name AS recording_name

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -248,7 +248,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                GROUP BY r.gid
                    ), artist_data AS (
                             SELECT r.gid
-                                 , jsonb_array_agg(
+                                 , jsonb_agg(
                                     jsonb_build_array(
                                         a.gid
                                       , acn.name

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -118,6 +118,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
 
         artist = {
             "name": row["artist_credit_name"],
+            "artist_credit_id": row["artist_credit_id"],
         }
         artists_rels = []
         artist_mbids = []
@@ -154,7 +155,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
             if instrument is not None:
                 rel["instrument"] = instrument
             recording_rels.append(rel)
-            artist_mbids.append(uuid.UUID(artist_mbid))
 
         recording_tags = []
         for tag, count, genre_mbid in row["recording_tags"] or []:
@@ -190,7 +190,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
             recording["length"] = row["length"]
 
         return (row["recording_mbid"],
-                list(set(artist_mbids)),
+                artist_mbids,
                 row["release_mbid"],
                 ujson.dumps(recording),
                 ujson.dumps(artist),
@@ -378,6 +378,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                    )
                             SELECT recording_links
                                  , r.name AS recording_name
+                                 , r.artist_credit AS artist_credit_id
                                  , ac.name AS artist_credit_name
                                  , artist_data
                                  , artist_tags
@@ -410,6 +411,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                               {values_join}
                           GROUP BY r.gid
                                  , r.name
+                                 , r.artist_credit
                                  , ac.name
                                  , rd.name
                                  , r.length

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -355,7 +355,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , rel.release_group
                                  , rg.gid AS release_group_mbid
                                  , crr.release_mbid::TEXT
-                                 , COALESCE(caa.id, rgca.caa_id) AS caa_id
+                                 , caa.id AS caa_id
                               FROM musicbrainz.recording r
                               JOIN mapping.canonical_release_redirect crr
                                 ON r.gid = crr.recording_mbid
@@ -367,8 +367,6 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 ON caa.release = rel.id
                          LEFT JOIN cover_art_archive.cover_art_type cat
                                 ON cat.id = caa.id
-                         LEFT JOIN rg_cover_art rgca
-                                ON rgca.release_group = rel.release_group
                               {values_join}
                              WHERE (type_id = 1 AND mime_type != 'application/pdf')
                                 OR type_id IS NULL
@@ -387,7 +385,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , r.length
                                  , r.gid::TEXT AS recording_mbid
                                  , rd.release_mbid::TEXT
-                                 , rd.caa_id
+                                 , COALESCE(rd.caa_id, rgca.caa_id) AS caa_id
                                  , year
                               FROM recording r
                               JOIN artist_credit ac
@@ -404,6 +402,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                 ON rts.recording_mbid = r.gid
                          LEFT JOIN release_data rd
                                 ON rd.recording_mbid = r.gid
+                         LEFT JOIN rg_cover_art rgca
+                                ON rgca.release_group = rd.release_group
                          LEFT JOIN mapping.canonical_musicbrainz_data cmb
                                 ON cmb.recording_mbid = r.gid
                               {values_join}


### PR DESCRIPTION
1. artist_credit_id is needed so that mb_metadata_cache can replace mbid_mapping_metadata in future, see LB-1128.
2. individual artist names and join phrases are needed for LB-1138.
3. add release group cover art to reduce number of calls needed to CAA.