### PR TITLE
Use mb db master/standby for mb metadata cache

### DIFF
--- a/listenbrainz/mbid_mapping/config.py.sample
+++ b/listenbrainz/mbid_mapping/config.py.sample
@@ -9,6 +9,8 @@ SQLALCHEMY_TIMESCALE_URI = "dbname=listenbrainz_ts user=listenbrainz_ts host=lis
 
 # If you are connecting to a musicbrainz-docker instance for MusicBrainz data, this string should work:
 MBID_MAPPING_DATABASE_URI = "dbname=musicbrainz_db user=musicbrainz host=localhost port=25432 password=musicbrainz"
+MB_DATABASE_MASTER_URI = "dbname=musicbrainz_db user=musicbrainz host=localhost port=25432 password=musicbrainz"
+MB_DATABASE_STANDBY_URI = "dbname=musicbrainz_db user=musicbrainz host=localhost port=25432 password=musicbrainz"
 
 # Typesense connection
 TYPESENSE_HOST = "typesense"

--- a/listenbrainz/mbid_mapping/config.py.sample
+++ b/listenbrainz/mbid_mapping/config.py.sample
@@ -9,8 +9,10 @@ SQLALCHEMY_TIMESCALE_URI = "dbname=listenbrainz_ts user=listenbrainz_ts host=lis
 
 # If you are connecting to a musicbrainz-docker instance for MusicBrainz data, this string should work:
 MBID_MAPPING_DATABASE_URI = "dbname=musicbrainz_db user=musicbrainz host=localhost port=25432 password=musicbrainz"
-MB_DATABASE_MASTER_URI = "dbname=musicbrainz_db user=musicbrainz host=localhost port=25432 password=musicbrainz"
-MB_DATABASE_STANDBY_URI = "dbname=musicbrainz_db user=musicbrainz host=localhost port=25432 password=musicbrainz"
+
+# these database uris are only needed for use in production, when doing development these can be left empty
+MB_DATABASE_MASTER_URI = ""
+MB_DATABASE_STANDBY_URI = ""
 
 # Typesense connection
 TYPESENSE_HOST = "typesense"

--- a/listenbrainz/mbid_mapping/docker/consul_config.py.ctmpl
+++ b/listenbrainz/mbid_mapping/docker/consul_config.py.ctmpl
@@ -8,14 +8,37 @@ MBID_MAPPING_DATABASE_URI = "dbname=musicbrainz_json_dump user=musicbrainz host=
 {{end}}
 {{end}}
 
+SQLALCHEMY_DATABASE_URI = ""
+MESSYBRAINZ_SQLALCHEMY_DATABASE_URI = ""
+POSTGRES_ADMIN_URI = ""
+MB_DATABASE_MASTER_URI = ""
+
 {{if service "pgbouncer-master"}}
 {{with index (service "pgbouncer-master") 0}}
 SQLALCHEMY_DATABASE_URI = "postgresql://listenbrainz:listenbrainz@{{.Address}}:{{.Port}}/listenbrainz"
 MESSYBRAINZ_SQLALCHEMY_DATABASE_URI = "postgresql://messybrainz:messybrainz@{{.Address}}:{{.Port}}/messybrainz"
-POSTGRES_ADMIN_URI="postgresql://postgres@{{.Address}}:{{.Port}}/postgres"
+POSTGRES_ADMIN_URI = "postgresql://postgres@{{.Address}}:{{.Port}}/postgres"
+MB_DATABASE_MASTER_URI = "postgresql://mbid_mapper@{{.Address}}:{{.Port}}/musicbrainz_db"
 {{end}}
 {{else}}
 SQLALCHEMY_DATABASE_URI = "SERVICEDOESNOTEXIST_pgbouncer-master"
+MESSYBRAINZ_SQLALCHEMY_DATABASE_URI = "SERVICEDOESNOTEXIST_pgbouncer-master"
+POSTGRES_ADMIN_URI = "SERVICEDOESNOTEXIST_pgbouncer-master"
+MB_DATABASE_MASTER_URI = "SERVICEDOESNOTEXIST_pgbouncer-master"
+{{end}}
+
+MB_DATABASE_STANDBY_URI = ""
+
+{{if service "pgbouncer-slave"}}
+{{with index (service "pgbouncer-slave") 0}}
+MB_DATABASE_STANDBY_URI = "postgresql://mbid_mapper@{{.Address}}:{{.Port}}/musicbrainz_db"
+{{end}}
+{{else if service "pgbouncer-master"}}
+{{with index (service "pgbouncer-master") 0}}
+MB_DATABASE_STANDBY_URI = "postgresql://mbid_mapper@{{.Address}}:{{.Port}}/musicbrainz_db"
+{{end}}
+{{else}}
+MB_DATABASE_STANDBY_URI = "SERVICEDOESNOTEXIST_pgbouncer-slave_pgbouncer-master"
 {{end}}
 
 SQLALCHEMY_TIMESCALE_URI = ""

--- a/listenbrainz/mbid_mapping/mapping/bulk_table.py
+++ b/listenbrainz/mbid_mapping/mapping/bulk_table.py
@@ -164,7 +164,12 @@ class BulkInsertTable:
             with conn.cursor() as curs:
                 if "." in self.table_name:
                     schema = self.table_name.split(".")[0]
-                    curs.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+                    try:
+                        curs.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+                    # silently ignore schema creation errors because the user in prod
+                    # doesn't have sufficient privileges
+                    except psycopg2.errors.InsufficientPrivilege as err:
+                        pass
 
                 columns = []
                 for name, types in self.get_create_table_columns():

--- a/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -137,8 +137,9 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         Arguments:
             use_lb_conn: whether to use LB conn or not
     """
+    mb_uri = config.MB_DATABASE_MASTER_URI or config.MBID_MAPPING_DATABASE_URI
 
-    with psycopg2.connect(config.MBID_MAPPING_DATABASE_URI) as mb_conn:
+    with psycopg2.connect(mb_uri) as mb_conn:
 
         lb_conn = None
         if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:

--- a/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/listenbrainz/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -50,28 +50,28 @@ class CanonicalMusicBrainzData(BulkInsertTable):
                     , rl.gid AS release_mbid
                     , rpr.id AS score
                     , date_year AS year
-                 FROM recording r
-                 JOIN artist_credit ac
+                 FROM musicbrainz.recording r
+                 JOIN musicbrainz.artist_credit ac
                    ON r.artist_credit = ac.id
-                 JOIN artist_credit_name acn
+                 JOIN musicbrainz.artist_credit_name acn
                    ON ac.id = acn.artist_credit
-                 JOIN artist a
+                 JOIN musicbrainz.artist a
                    ON acn.artist = a.id
-                 JOIN track t
+                 JOIN musicbrainz.track t
                    ON t.recording = r.id
-                 JOIN medium m
+                 JOIN musicbrainz.medium m
                    ON m.id = t.medium
-                 JOIN release rl
+                 JOIN musicbrainz.release rl
                    ON rl.id = m.release
                  JOIN mapping.canonical_musicbrainz_data_release_tmp rpr
                    ON rl.id = rpr.release
                  JOIN (SELECT artist_credit, array_agg(gid ORDER BY position) AS artist_mbids
-                         FROM artist_credit_name acn2
-                         JOIN artist a2
+                         FROM musicbrainz.artist_credit_name acn2
+                         JOIN musicbrainz.artist a2
                            ON acn2.artist = a2.id
                      GROUP BY acn2.artist_credit) s
                    ON acn.artist_credit = s.artist_credit
-            LEFT JOIN release_country rc
+            LEFT JOIN musicbrainz.release_country rc
                    ON rc.release = rl.id
              GROUP BY rpr.id, ac.id, s.artist_mbids, rl.gid, artist_credit_name, r.gid, r.name, release_name, year
              ORDER BY ac.id, rpr.id

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -716,9 +716,14 @@ def create_mb_metadata_cache(use_lb_conn: bool):
         Arguments:
             use_lb_conn: whether to use LB conn or not
     """
-
     psycopg2.extras.register_uuid()
-    with psycopg2.connect(config.MBID_MAPPING_DATABASE_URI) as mb_conn:
+
+    if use_lb_conn:
+        mb_uri = config.MB_DATABASE_STANDBY_URI or config.MBID_MAPPING_DATABASE_URI
+    else:
+        mb_uri = config.MBID_MAPPING_DATABASE_URI
+
+    with psycopg2.connect(mb_uri) as mb_conn:
         lb_conn = None
         if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
             lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
@@ -738,7 +743,12 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
     """ Update the MB metadata cache incrementally """
     psycopg2.extras.register_uuid()
 
-    with psycopg2.connect(config.MBID_MAPPING_DATABASE_URI) as mb_conn:
+    if use_lb_conn:
+        mb_uri = config.MB_DATABASE_STANDBY_URI or config.MBID_MAPPING_DATABASE_URI
+    else:
+        mb_uri = config.MBID_MAPPING_DATABASE_URI
+
+    with psycopg2.connect(mb_uri) as mb_conn:
         lb_conn = None
         if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
             lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -211,19 +211,19 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         query = f"""WITH {values_cte} artist_rels AS (
                                 SELECT a.gid
                                      , array_agg(distinct(ARRAY[lt.name, url])) AS artist_links
-                                  FROM recording r
-                                  JOIN artist_credit_name acn
+                                  FROM musicbrainz.recording r
+                                  JOIN musicbrainz.artist_credit_name acn
                                  USING (artist_credit)
                                 -- we cannot directly start as FROM artist a because the values_join JOINs on recording
-                                  JOIN artist a
+                                  JOIN musicbrainz.artist a
                                     ON acn.artist = a.id
-                                  JOIN l_artist_url lau
+                                  JOIN musicbrainz.l_artist_url lau
                                     ON lau.entity0 = a.id
-                                  JOIN url u
+                                  JOIN musicbrainz.url u
                                     ON lau.entity1 = u.id
-                                  JOIN link l
+                                  JOIN musicbrainz.link l
                                     ON lau.link = l.id
-                                  JOIN link_type lt
+                                  JOIN musicbrainz.link_type lt
                                     ON l.link_type = lt.id
                                   {values_join}
                                  WHERE lt.gid IN ({ARTIST_LINK_GIDS_SQL})
@@ -231,18 +231,18 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                    ), recording_rels AS (
                                 SELECT r.gid
                                      , array_agg(ARRAY[lt.name, a1.name, a1.gid::TEXT, lat.name]) AS recording_links
-                                  FROM recording r
-                                  JOIN l_artist_recording lar
+                                  FROM musicbrainz.recording r
+                                  JOIN musicbrainz.l_artist_recording lar
                                     ON lar.entity1 = r.id
-                                  JOIN artist a1
+                                  JOIN musicbrainz.artist a1
                                     ON lar.entity0 = a1.id
-                                  JOIN link l
+                                  JOIN musicbrainz.link l
                                     ON lar.link = l.id
-                                  JOIN link_type lt
+                                  JOIN musicbrainz.link_type lt
                                     ON l.link_type = lt.id
-                             LEFT JOIN link_attribute la
+                             LEFT JOIN musicbrainz.link_attribute la
                                     ON la.link = l.id
-                             LEFT JOIN link_attribute_type lat
+                             LEFT JOIN musicbrainz.link_attribute_type lat
                                     ON la.attribute_type = lat.id
                                   {values_join}
                                  WHERE lt.gid IN ({RECORDING_LINK_GIDS_SQL})
@@ -263,16 +263,16 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                     )
                                     ORDER BY acn.position
                                    ) AS artist_data
-                              FROM recording r
-                              JOIN artist_credit_name acn
+                              FROM musicbrainz.recording r
+                              JOIN musicbrainz.artist_credit_name acn
                              USING (artist_credit)
-                              JOIN artist a
+                              JOIN musicbrainz.artist a
                                 ON acn.artist = a.id
-                         LEFT JOIN artist_type at
+                         LEFT JOIN musicbrainz.artist_type at
                                 ON a.type = at.id
-                         LEFT JOIN gender ag
+                         LEFT JOIN musicbrainz.gender ag
                                 ON a.gender = ag.id
-                         LEFT JOIN area ar
+                         LEFT JOIN musicbrainz.area ar
                                 ON a.area = ar.id
                          LEFT JOIN artist_rels arl
                                 ON arl.gid = a.gid
@@ -282,11 +282,11 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                             SELECT r.gid AS recording_mbid
                                  , array_agg(jsonb_build_array(t.name, count, g.gid)) AS recording_tags
                               FROM musicbrainz.tag t
-                              JOIN recording_tag rt
+                              JOIN musicbrainz.recording_tag rt
                                 ON rt.tag = t.id
-                              JOIN recording r
+                              JOIN musicbrainz.recording r
                                 ON rt.recording = r.id
-                         LEFT JOIN genre g
+                         LEFT JOIN musicbrainz.genre g
                                 ON t.name = g.name
                               {values_join}
                              WHERE count > 0
@@ -294,16 +294,16 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                    ), artist_tags AS (
                             SELECT r.gid AS recording_mbid
                                  , array_agg(jsonb_build_array(t.name, count, a.gid, g.gid)) AS artist_tags
-                              FROM recording r
-                              JOIN artist_credit_name acn
+                              FROM musicbrainz.recording r
+                              JOIN musicbrainz.artist_credit_name acn
                              USING (artist_credit)
-                              JOIN artist a
+                              JOIN musicbrainz.artist a
                                 ON acn.artist = a.id
-                              JOIN artist_tag at
+                              JOIN musicbrainz.artist_tag at
                                 ON at.artist = a.id
-                              JOIN tag t
+                              JOIN musicbrainz.tag t
                                 ON at.tag = t.id
-                         LEFT JOIN genre g
+                         LEFT JOIN musicbrainz.genre g
                                 ON t.name = g.name
                               {values_join}
                              WHERE count > 0
@@ -311,16 +311,16 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                    ), release_group_tags AS (
                             SELECT r.gid AS recording_mbid
                                  , array_agg(jsonb_build_array(t.name, count, g.gid)) AS release_group_tags
-                              FROM recording r
+                              FROM musicbrainz.recording r
                               JOIN mapping.canonical_release_redirect crr
                                 ON r.gid = crr.recording_mbid
-                              JOIN release rel
+                              JOIN musicbrainz.release rel
                                 ON crr.release_mbid = rel.gid
-                              JOIN release_group_tag rgt
+                              JOIN musicbrainz.release_group_tag rgt
                                 ON rgt.release_group = rel.release_group
-                              JOIN tag t
+                              JOIN musicbrainz.tag t
                                 ON rgt.tag = t.id
-                         LEFT JOIN genre g
+                         LEFT JOIN musicbrainz.genre g
                                 ON t.name = g.name
                               {values_join}
                              WHERE count > 0
@@ -370,9 +370,9 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                               JOIN mapping.canonical_release_redirect crr
                                 ON r.gid = crr.recording_mbid
                               JOIN musicbrainz.release rel
-                                ON crr.release_mbid = rel.gid
-                              JOIN musicbrainz.release_group rg
-                                ON rel.release_group = rg.id
+                                        ON crr.release_mbid = rel.gid
+                                      JOIN musicbrainz.release_group rg
+                                        ON rel.release_group = rg.id
                          LEFT JOIN rg_cover_art rgca
                                 ON rgca.release_group = rel.release_group
                               {values_join}
@@ -393,8 +393,8 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , rd.caa_id
                                  , rd.caa_release_mbid
                                  , year
-                              FROM recording r
-                              JOIN artist_credit ac
+                              FROM musicbrainz.recording r
+                              JOIN musicbrainz.artist_credit ac
                                 ON r.artist_credit = ac.id
                          LEFT JOIN artist_data ard
                                 ON ard.gid = r.gid
@@ -480,14 +480,14 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         artist_mbids_query = f"""
         WITH artist_mbids(id) AS (
             SELECT a.id
-              FROM artist a
-              JOIN l_artist_url lau
+              FROM musicbrainz.artist a
+              JOIN musicbrainz.l_artist_url lau
                 ON lau.entity0 = a.id
-              JOIN url u
+              JOIN musicbrainz.url u
                 ON lau.entity1 = u.id
-              JOIN link l
+              JOIN musicbrainz.link l
                 ON lau.link = l.id
-              JOIN link_type lt
+              JOIN musicbrainz.link_type lt
                 ON l.link_type = lt.id
              WHERE lt.gid IN ({ARTIST_LINK_GIDS_SQL})
                    AND (
@@ -497,28 +497,28 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                    )
         UNION
             SELECT a.id
-              FROM artist a
-              JOIN area ar
+              FROM musicbrainz.artist a
+              JOIN musicbrainz.area ar
                 ON a.area = ar.id
              WHERE ar.last_updated > %(timestamp)s
         UNION
             SELECT a.id
-              FROM artist a
-              JOIN artist_tag at
+              FROM musicbrainz.artist a
+              JOIN musicbrainz.artist_tag at
                 ON at.artist = a.id
-              JOIN tag t
+              JOIN musicbrainz.tag t
                 ON at.tag = t.id
-         LEFT JOIN genre g
+         LEFT JOIN musicbrainz.genre g
                 ON t.name = g.name
              WHERE at.last_updated > %(timestamp)s
                 OR  g.last_updated > %(timestamp)s
         UNION
             SELECT a.id
-              FROM artist a
+              FROM musicbrainz.artist a
              WHERE a.last_updated > %(timestamp)s
         ) SELECT r.gid
-            FROM recording r
-            JOIN artist_credit_name acn
+            FROM musicbrainz.recording r
+            JOIN musicbrainz.artist_credit_name acn
            USING (artist_credit)
             JOIN artist_mbids am
               ON acn.artist = am.id          
@@ -534,16 +534,16 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         # |   recording      |                               |  recording                         |
         recording_mbids_query = f"""
                 SELECT r.gid
-                  FROM recording r
-                  JOIN l_artist_recording lar
+                  FROM musicbrainz.recording r
+                  JOIN musicbrainz.l_artist_recording lar
                     ON lar.entity1 = r.id
-                  JOIN link l
+                  JOIN musicbrainz.link l
                     ON lar.link = l.id
-                  JOIN link_type lt
+                  JOIN musicbrainz.link_type lt
                     ON l.link_type = lt.id
-                  JOIN link_attribute la
+                  JOIN musicbrainz.link_attribute la
                     ON la.link = l.id
-                  JOIN link_attribute_type lat
+                  JOIN musicbrainz.link_attribute_type lat
                     ON la.attribute_type = lat.id
                  WHERE lt.gid IN ({RECORDING_LINK_GIDS_SQL})
                    AND (
@@ -554,17 +554,17 @@ class MusicBrainzMetadataCache(BulkInsertTable):
             UNION
                 SELECT r.gid
                   FROM musicbrainz.tag t
-                  JOIN recording_tag rt
+                  JOIN musicbrainz.recording_tag rt
                     ON rt.tag = t.id
-                  JOIN recording r
+                  JOIN musicbrainz.recording r
                     ON rt.recording = r.id
-             LEFT JOIN genre g
+             LEFT JOIN musicbrainz.genre g
                     ON t.name = g.name
                  WHERE rt.last_updated > %(timestamp)s
                     OR  g.last_updated > %(timestamp)s
             UNION
                 SELECT r.gid
-                  FROM recording r
+                  FROM musicbrainz.recording r
                  WHERE r.last_updated > %(timestamp)s
         """
 
@@ -580,24 +580,24 @@ class MusicBrainzMetadataCache(BulkInsertTable):
             WITH release_mbids(id) AS (
                 SELECT rel.id
                   FROM mapping.canonical_release_redirect crr
-                  JOIN release rel
+                  JOIN musicbrainz.release rel
                     ON crr.release_mbid = rel.gid
-                  JOIN release_group rg
+                  JOIN musicbrainz.release_group rg
                     ON rel.release_group = rg.id
-                  JOIN release_group_tag rgt
+                  JOIN musicbrainz.release_group_tag rgt
                     ON rgt.release_group = rel.release_group
-                  JOIN tag t
+                  JOIN musicbrainz.tag t
                     ON rgt.tag = t.id
-             LEFT JOIN genre g
+             LEFT JOIN musicbrainz.genre g
                     ON t.name = g.name
                  WHERE rgt.last_updated > %(timestamp)s
                     OR   g.last_updated > %(timestamp)s
             UNION
                 SELECT rel.id
                   FROM mapping.canonical_release_redirect crr
-                  JOIN release rel
+                  JOIN musicbrainz.release rel
                     ON crr.release_mbid = rel.gid
-                  JOIN release_group rg
+                  JOIN musicbrainz.release_group rg
                     ON rel.release_group = rg.id
              LEFT JOIN cover_art_archive.cover_art caa
                     ON caa.release = rel.id
@@ -607,10 +607,10 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                     OR   rg.last_updated > %(timestamp)s
                     OR (caa.date_uploaded > %(timestamp)s AND (type_id = 1 OR type_id IS NULL))
             ) SELECT r.gid
-                FROM recording r
-                JOIN track t
+                FROM musicbrainz.recording r
+                JOIN musicbrainz.track t
                   ON t.recording = r.id
-                JOIN medium m
+                JOIN musicbrainz.medium m
                   ON m.id = t.medium
                 JOIN release_mbids rm
                   ON rm.id = m.release


### PR DESCRIPTION
We have MBID_MAPPING_DATABASE_URI to connect to aretha replica of musicbrainz database. However, aretha has slow disks and the cache also competes with json dumps for resources. To improve the reliability of the cache building job, we want to MB standby db. However, we also need to create the canonical musicbrainz data tables to build the metadata cache. The standby is a read-only replica so we write the tables to floyd and let those be replicated to standby and then create the cache.

We cannot ensure the tables have been replicated when we trigger the cache build but there will always be some version of the table available. The canonical table will be rebuilt some time before the cache is to be built. If the replication finishes, then the latest version is used else an older version will be used.