### PR TITLE
Add subdomain to art API endpoints

### DIFF
--- a/listenbrainz/webserver/views/art.py
+++ b/listenbrainz/webserver/views/art.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template, Blueprint
 
 art_bp = Blueprint('art', __name__)
 
-@art_bp.route("/")
+@art_bp.route("/", subdomain="art")
 def index():
     """ This page shows of a bit of what can be done with the cover art, as a sort of showcase. """
     return render_template("art/index.html")

--- a/listenbrainz/webserver/views/art.py
+++ b/listenbrainz/webserver/views/art.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template, Blueprint
 
 art_bp = Blueprint('art', __name__)
 
-@art_bp.route("/", subdomain="art")
+@art_bp.route("/")
 def index():
     """ This page shows of a bit of what can be done with the cover art, as a sort of showcase. """
     return render_template("art/index.html")

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from uuid import UUID
 
 from flask import Flask, request, render_template, Blueprint, current_app
@@ -14,8 +15,10 @@ from brainzutils.ratelimit import ratelimit
 
 art_api_bp = Blueprint('art_api_v1', __name__)
 
+ART_SUBDOMAIN = "art" if os.environ["FLASK_ENV"] != "development" else ""
 
-@art_api_bp.route("/grid/", methods=["POST"], subdomain="art")
+
+@art_api_bp.route("/grid/", methods=["POST"], subdomain=ART_SUBDOMAIN)
 @crossdomain
 @ratelimit()
 def cover_art_grid_post():
@@ -104,7 +107,7 @@ def cover_art_grid_post():
 
 @art_api_bp.route("/grid-stats/<user_name>/<time_range>/<int:dimension>/<int:layout>/<int:image_size>",
                   methods=["GET"],
-                  subdomain="art")
+                  subdomain=ART_SUBDOMAIN)
 @crossdomain
 @ratelimit()
 def cover_art_grid_stats(user_name, time_range, dimension, layout, image_size):
@@ -157,7 +160,7 @@ def cover_art_grid_stats(user_name, time_range, dimension, layout, image_size):
                            }
 
 
-@art_api_bp.route("/<custom_name>/<user_name>/<time_range>/<int:image_size>", methods=["GET"], subdomain="art")
+@art_api_bp.route("/<custom_name>/<user_name>/<time_range>/<int:image_size>", methods=["GET"], subdomain=ART_SUBDOMAIN)
 @crossdomain
 @ratelimit()
 def cover_art_custom_stats(custom_name, user_name, time_range, image_size):

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -15,7 +15,7 @@ from brainzutils.ratelimit import ratelimit
 art_api_bp = Blueprint('art_api_v1', __name__)
 
 
-@art_api_bp.route("/grid/", methods=["POST"])
+@art_api_bp.route("/grid/", methods=["POST"], subdomain="art")
 @crossdomain
 @ratelimit()
 def cover_art_grid_post():
@@ -102,7 +102,9 @@ def cover_art_grid_post():
                            }
 
 
-@art_api_bp.route("/grid-stats/<user_name>/<time_range>/<int:dimension>/<int:layout>/<int:image_size>", methods=["GET"])
+@art_api_bp.route("/grid-stats/<user_name>/<time_range>/<int:dimension>/<int:layout>/<int:image_size>",
+                  methods=["GET"],
+                  subdomain="art")
 @crossdomain
 @ratelimit()
 def cover_art_grid_stats(user_name, time_range, dimension, layout, image_size):
@@ -155,7 +157,7 @@ def cover_art_grid_stats(user_name, time_range, dimension, layout, image_size):
                            }
 
 
-@art_api_bp.route("/<custom_name>/<user_name>/<time_range>/<int:image_size>", methods=["GET"])
+@art_api_bp.route("/<custom_name>/<user_name>/<time_range>/<int:image_size>", methods=["GET"], subdomain="art")
 @crossdomain
 @ratelimit()
 def cover_art_custom_stats(custom_name, user_name, time_range, image_size):


### PR DESCRIPTION
Currently url_for() generates relative URLs to the current site, which means the art index page has loads of broken URLs. I think the way to fix this is to add the subdomain argument to the route() command, but I've not used this before, so I am unsure if this is the correct fix. Nor is there an easy way to test this... so, who knows?