### PR TITLE
Add additional_metadata field to playlist and playlist tracks

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -40,7 +40,7 @@ CREATE TABLE playlist.playlist (
     last_updated timestamp with time zone default now() not null,
     copied_from_id int, -- id of another playlist
     created_for_id int,
-    algorithm_metadata jsonb
+    additional_metadata jsonb
 );
 
 CREATE TABLE playlist.playlist_recording (
@@ -49,7 +49,8 @@ CREATE TABLE playlist.playlist_recording (
     position int not null,
     mbid uuid not null,
     added_by_id int not null,  -- int, but not an fk because it's in the wrong database
-    created timestamp with time zone default now() not null
+    created timestamp with time zone default now() not null,
+    additional_metadata jsonb
 );
 
 CREATE TABLE playlist.playlist_collaborator (

--- a/admin/timescale/updates/2022-11-08-add-additional-metadata-playlists.sql
+++ b/admin/timescale/updates/2022-11-08-add-additional-metadata-playlists.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE playlist.playlist RENAME COLUMN algorithm_metadata TO additional_metadata;
+ALTER TABLE playlist.playlist_recording ADD COLUMN additional_metadata JSONB;
+
+UPDATE playlist.playlist SET additional_metadata = jsonb_build_object('algorithm_metadata', additional_metadata);
+
+COMMIT;

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -205,7 +205,7 @@ PRIVATE_TABLES_TIMESCALE = {
         'last_updated',
         'copied_from_id',
         'created_for_id',
-        'algorithm_metadata',
+        'additional_metadata',
     ),
     'playlist.playlist_recording': (
         'id',

--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -39,6 +39,7 @@ class WritablePlaylistRecording(PlaylistRecording):
     playlist_id: NonNegativeInt = None
     position: NonNegativeInt = None
     created: datetime.datetime = None
+    additional_metadata: Optional[Dict] = None
     added_by: str = None
 
 
@@ -64,8 +65,8 @@ class Playlist(BaseModel):
     copied_from_id: Optional[NonNegativeInt]
     # If the playlist was created by a bot, the user for who this playlist was created
     created_for_id: Optional[NonNegativeInt]
-    # If the playlist was created by a bot, some freeform data about it
-    algorithm_metadata: Optional[Dict]
+    # to store extra data about the playlist
+    additional_metadata: Optional[Dict]
     # The users who have permission to collaborate on this playlist
     # TODO: Because the id list isn't an FK to a table, we can't guarantee that these values
     #  actually exist. There's no agreement between collaborator_ids and collaborators.

--- a/listenbrainz/model/playlist.py
+++ b/listenbrainz/model/playlist.py
@@ -22,7 +22,7 @@ class Playlist(db.Model):
     last_updated = db.Column(db.DateTime(timezone=True), nullable=False)
     copied_from_id = db.Column(db.Integer)
     created_for_id = db.Column(db.Integer)
-    algorithm_metadata = db.Column(JSONB)
+    additional_metadata = db.Column(JSONB)
 
     recordings = db.relationship("PlaylistRecording", backref="playlist")
 
@@ -46,4 +46,4 @@ class PlaylistAdminView(AdminModelView):
     ]
     column_searchable_list = columns_without_jsonb
     column_filters = columns_without_jsonb
-    column_list = columns_without_jsonb + ["recordings", "algorithm_metadata"]
+    column_list = columns_without_jsonb + ["recordings", "additional_metadata"]

--- a/listenbrainz/model/playlist_recording.py
+++ b/listenbrainz/model/playlist_recording.py
@@ -1,6 +1,4 @@
-import uuid
-from datetime import datetime
-
+from psycopg2.extensions import JSONB
 from sqlalchemy.dialects.postgresql import UUID
 
 from listenbrainz.model import db
@@ -18,6 +16,7 @@ class PlaylistRecording(db.Model):
     mbid = db.Column(UUID(as_uuid=True), nullable=False)
     added_by_id = db.Column(db.Integer, nullable=False)
     created = db.Column(db.DateTime(timezone=True), nullable=False)
+    additional_metadata = db.Column(JSONB)
 
     def __str__(self):
         return str(self.mbid)

--- a/listenbrainz/model/playlist_recording.py
+++ b/listenbrainz/model/playlist_recording.py
@@ -1,5 +1,4 @@
-from psycopg2.extensions import JSONB
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 from listenbrainz.model import db
 from listenbrainz.webserver.admin import AdminModelView

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -28,7 +28,7 @@ def get_test_data():
             "extension": {
                 PLAYLIST_EXTENSION_URI: {
                     "public": True,
-                    "algorithm_metadata": {"give_you_up": "never"}
+                    "additional_metadata": {"give_you_up": "never"}
                 }
             },
             "track": [
@@ -111,7 +111,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["playlist"]["annotation"], "your lame <i>80s</i> music")
         self.assertEqual(response.json["playlist"]["track"][0]["identifier"],
                          playlist["playlist"]["track"][0]["identifier"])
-        self.assertNotIn("algorithm_metadata", response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI])
+        self.assertNotIn("additional_metadata", response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI])
         try:
             dateutil.parser.isoparse(response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["last_modified_at"])
         except ValueError:
@@ -140,8 +140,8 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["playlist"]["extension"]
                          [PLAYLIST_EXTENSION_URI]["created_for"], self.user["musicbrainz_id"])
         self.assertEqual(response.json["playlist"]["extension"]
-                         [PLAYLIST_EXTENSION_URI]["algorithm_metadata"],
-                         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["algorithm_metadata"])
+                         [PLAYLIST_EXTENSION_URI]["additional_metadata"],
+                         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["additional_metadata"])
 
         # Try to submit a playlist on a different users's behalf without the right perms
         # (a user must be part of config. APPROVED_PLAYLIST_BOTS to be able to create playlists

--- a/listenbrainz/webserver/static/js/tests/__mocks__/year-in-music-data.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/year-in-music-data.json
@@ -2715,7 +2715,7 @@
 				"creator": "ListenBrainz Troi",
 				"extension": {
 					"https://musicbrainz.org/doc/jspf#playlist": {
-						"algorithm_metadata": {"source_patch": "top-discoveries-for-year"},
+						"additional_metadata": {"algorithm_metadata": {"source_patch": "top-discoveries-for-year"}},
 						"public": true
 					}
 				},
@@ -2780,7 +2780,7 @@
 				"creator": "ListenBrainz Troi",
 				"extension": {
 					"https://musicbrainz.org/doc/jspf#playlist": {
-						"algorithm_metadata": {"source_patch": "top-missed-recordings-for-year"},
+						"additional_metadata": {"algorithm_metadata": {"source_patch": "top-missed-recordings-for-year"}},
 						"public": true
 					}
 				},
@@ -2845,7 +2845,7 @@
 				"creator": "ListenBrainz Troi",
 				"extension": {
 					"https://musicbrainz.org/doc/jspf#playlist": {
-						"algorithm_metadata": {"source_patch": "top-new-recordings-for-year"},
+						"additional_metadata": {"algorithm_metadata": {"source_patch": "top-new-recordings-for-year"}},
 						"public": true
 					}
 				},
@@ -2910,7 +2910,7 @@
 				"creator": "ListenBrainz Troi",
 				"extension": {
 					"https://musicbrainz.org/doc/jspf#playlist": {
-						"algorithm_metadata": {"source_patch": "top-recordings-for-year"},
+						"additional_metadata": {"algorithm_metadata": {"source_patch": "top-recordings-for-year"}},
 						"public": true
 					}
 				},

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -113,8 +113,8 @@ def serialize_jspf(playlist: Playlist):
         extension['created_for'] = playlist.created_for
     if playlist.collaborators:
         extension['collaborators'] = playlist.collaborators
-    if playlist.algorithm_metadata:
-        extension['algorithm_metadata'] = playlist.algorithm_metadata
+    if playlist.additional_metadata:
+        extension['additional_metadata'] = playlist.additional_metadata
 
     pl["extension"] = {PLAYLIST_EXTENSION_URI: extension}
 
@@ -292,12 +292,12 @@ def create_playlist():
     if description is not None and user["musicbrainz_id"] not in current_app.config["APPROVED_PLAYLIST_BOTS"]:
         description = _filter_description_html(description)
 
-    # Check to see if the submitted playlist has algorithm_metadata defined and the current user an approved
+    # Check to see if the submitted playlist has additional_metadata defined and the current user an approved
     # playlist submitter; if so, load the metadata from the JSPF playlist and add to the new playlist
-    algorithm_metadata = None
+    additional_metadata = None
     if user["musicbrainz_id"] in current_app.config["APPROVED_PLAYLIST_BOTS"]:
         try:
-            algorithm_metadata = data["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["algorithm_metadata"]
+            additional_metadata = data["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["additional_metadata"]
         except KeyError:
             pass
 
@@ -307,7 +307,7 @@ def create_playlist():
                                 collaborator_ids=collaborator_ids,
                                 collaborators=collaborators,
                                 public=public,
-                                algorithm_metadata=algorithm_metadata)
+                                additional_metadata=additional_metadata)
 
     if data["playlist"].get("created_for", None):
         if user["musicbrainz_id"] not in current_app.config["APPROVED_PLAYLIST_BOTS"]:


### PR DESCRIPTION
We need these fields to store arbitrary metadata about the playlist and track. For instance, the immediate use case is storing external links of the playlist and the track. In future, we may way to store more types of metadata.

We already have an algorithm_metadata field at the playlist level. It does not seem prudent to have two dicts for arbitrary metadata at the same level so going forward algorithm_metadata will be a key of the additional_metadata dict.