### PR TITLE
Listening Now: Use caa_release_mbid field

### DIFF
--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -166,7 +166,7 @@ export default function MetadataViewer(props: MetadataViewerProps) {
     // Backup if we don't have the CAA ID.
     // Try fetching using CAA release MBID and fall back on Release MBID
     coverArtSrc = `https://coverartarchive.org/release/${
-      CAAReleaseMBID ?? releaseMBID
+      releaseMBID ?? CAAReleaseMBID
     }/front`;
   }
 

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -160,7 +160,8 @@ export default function MetadataViewer(props: MetadataViewerProps) {
   const CAAID = metadata?.release?.caa_id;
   let coverArtSrc = "/static/img/cover-art-placeholder.jpg";
   if (CAAReleaseMBID && CAAID) {
-    coverArtSrc = `https://coverartarchive.org/release/${CAAReleaseMBID}/${CAAID}-500.jpg`;
+    // Bypass the Cover Art Archive redirect since we have the info to directly fetch from archive.org
+    coverArtSrc = `https://archive.org/download/mbid-${CAAReleaseMBID}/mbid-${CAAReleaseMBID}-${CAAID}_thumb500.jpg`;
   } else {
     // Backup if we don't have the CAA ID.
     // Try fetching using CAA release MBID and fall back on Release MBID

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -156,14 +156,17 @@ export default function MetadataViewer(props: MetadataViewerProps) {
 
   const artistMBID = first(recordingData?.artist_mbids);
   const releaseMBID = recordingData?.release_mbid ?? metadata?.release?.mbid;
+  const CAAReleaseMBID = metadata?.release?.caa_release_mbid;
+  const CAAID = metadata?.release?.caa_id;
   let coverArtSrc = "/static/img/cover-art-placeholder.jpg";
-  if (releaseMBID) {
-    if (metadata?.release?.caa_id) {
-      coverArtSrc = `https://coverartarchive.org/release/${releaseMBID}/${metadata.release.caa_id}-500.jpg`;
-    } else {
-      // Backup if we don't have the CAA ID
-      coverArtSrc = `https://coverartarchive.org/release/${releaseMBID}/front`;
-    }
+  if (CAAReleaseMBID && CAAID) {
+    coverArtSrc = `https://coverartarchive.org/release/${CAAReleaseMBID}/${CAAID}-500.jpg`;
+  } else {
+    // Backup if we don't have the CAA ID.
+    // Try fetching using CAA release MBID and fall back on Release MBID
+    coverArtSrc = `https://coverartarchive.org/release/${
+      CAAReleaseMBID ?? releaseMBID
+    }/front`;
   }
 
   const flattenedRecRels: MusicBrainzRecordingRel[] =

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
@@ -42,6 +42,7 @@ declare type ListenMetadata = {
   };
   release?: {
     caa_id: ?number;
+    caa_release_mbid: ?string;
     mbid?: string;
     year?: number;
   };


### PR DESCRIPTION
The caa_release_mbid field was added in the metadata API response in #2235 , which uses release groups instead of release to reliably get cover art. That means our listen can be matched with a canonical release which might not have cover art, in which case we get the cover art from another release via the release group.
The Listening Now page is now using the release MBID as it did before, but sometimes with the wrong caa_id (Right CAA id, wrong release MBID). This results in broken images.

We need to use the caa_release_mbid instead which is the release associated with the caa_id field.
