### PR TITLE
Use release group cover art for mapped listens 

### DIFF
--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -49,6 +49,8 @@ def load_recordings_from_mbids(connection, mbids: Iterable[str]) -> dict:
              , artist_data->>'name' AS artist
              , recording_data->>'name' AS title
              , release_data->>'name' AS release
+             , (release_data->>'caa_id')::int
+             , release_data->>'caa_release_mbid'
           FROM mbid_mapping m
           JOIN mapping.mb_metadata_cache mbc
          USING (recording_mbid)
@@ -127,6 +129,11 @@ def _update_mbid_items(models: dict[str, list[ModelT]], metadatas: dict, remaini
                     "artist_mbids": metadata["artist_mbids"]
                 }
             }
+
+            if metadata["caa_id"]:
+                item.track_metadata["additional_info"]["caa_id"] = metadata["caa_id"]
+                item.track_metadata["additional_info"]["caa_release_mbid"] = metadata["caa_release_mbid"]
+
             if item.recording_msid:
                 item.track_metadata["additional_info"]["recording_msid"] = item.recording_msid
 

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -49,7 +49,7 @@ def load_recordings_from_mbids(connection, mbids: Iterable[str]) -> dict:
              , artist_data->>'name' AS artist
              , recording_data->>'name' AS title
              , release_data->>'name' AS release
-             , (release_data->>'caa_id')::int
+             , (release_data->>'caa_id')::bigint
              , release_data->>'caa_release_mbid'
           FROM mbid_mapping m
           JOIN mapping.mb_metadata_cache mbc

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -79,7 +79,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                               , '{"name": "Strangers", "rels": [], "length": 291160}'
                               , '{"name": "Portishead", "artist_credit_id": 347, "artists": [{"area": "United Kingdom", "rels": {"lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html", "youtube": "https://www.youtube.com/user/portishead1002", "wikidata": "https://www.wikidata.org/wiki/Q191352", "streaming": "https://tidal.com/artist/27441", "free streaming": "https://www.deezer.com/artist/1069", "social network": "https://www.facebook.com/portishead", "official homepage": "http://www.portishead.co.uk/", "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/"}, "type": "Group", "begin_year": 1991}]}'
                               , '{"artist": [], "recording": [], "release_group": []}'
-                              , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy", "caa_id": 829521842, "release_group_mbid": null}'
+                              , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy"}'
                               , 'f'
                                )"""
 

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -27,6 +27,12 @@ class MappingTestCase(TimescaleTestCase):
     def insert_recording_in_mapping(self, recording, match_type):
         with ts.engine.begin() as connection:
             if match_type == "exact_match":
+
+                release_data = {"name": recording["release"]}
+                if recording["caa_id"]:
+                    release_data["caa_id"] = recording["caa_id"]
+                    release_data["caa_release_mbid"] = recording["caa_release_mbid"]
+
                 connection.execute(text("""
                     INSERT INTO mapping.mb_metadata_cache
                             (recording_mbid, artist_mbids, release_mbid, recording_data, artist_data, tag_data, release_data, dirty)
@@ -37,7 +43,7 @@ class MappingTestCase(TimescaleTestCase):
                     "release_mbid": recording["release_mbid"],
                     "recording_data": json.dumps({"name": recording["title"]}),
                     "artist_data": json.dumps({"name": recording["artist"]}),
-                    "release_data": json.dumps({"name": recording["release"]}),
+                    "release_data": json.dumps(release_data),
                     "tag_data": json.dumps({"artist": [], "recording": [], "release_group": []})
                 })
 
@@ -61,7 +67,9 @@ class MappingTestCase(TimescaleTestCase):
                 "release": "Batman Returns",
                 "artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
                 "artist": "Danny Elfman",
-                "title": "The Final Confrontation, Part 1"
+                "title": "The Final Confrontation, Part 1",
+                "caa_release_mbid": "a2589025-8517-45ab-9d64-fe927ba087b1-3151246737",
+                "caa_id": 3151246737
             },
             {
                 "recording_mbid": "c5bfd98d-ccde-4cf3-8abb-63fad1b6065a",

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -118,7 +118,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                               , '{"name": "Strangers", "rels": [], "length": 291160}'
                               , '{"name": "Portishead", "artist_credit_id": 204, "artists": [{"area": "United Kingdom", "rels": {"lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html", "youtube": "https://www.youtube.com/user/portishead1002", "wikidata": "https://www.wikidata.org/wiki/Q191352", "streaming": "https://tidal.com/artist/27441", "free streaming": "https://www.deezer.com/artist/1069", "social network": "https://www.facebook.com/portishead", "official homepage": "http://www.portishead.co.uk/", "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/"}, "type": "Group", "begin_year": 1991}]}'
                               , '{"artist": [], "recording": [], "release_group": []}'
-                              , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy", "caa_id": 829521842, "release_group_mbid": null}'
+                              , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy"}'
                               , 'f'
                                )
             """

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -126,7 +126,8 @@ class Listen(object):
 
     @classmethod
     def from_timescale(cls, listened_at, track_name, user_id, created, data,
-                       recording_mbid=None, release_mbid=None, artist_mbids=None, user_name=None):
+                       recording_mbid=None, release_mbid=None, artist_mbids=None,
+                       user_name=None, caa_id=None, caa_release_mbid=None):
         """Factory to make Listen() objects from a timescale dict"""
 
         data['listened_at'] = datetime.utcfromtimestamp(float(listened_at))
@@ -135,7 +136,12 @@ class Listen(object):
             data["track_metadata"]["mbid_mapping"] = {
                 "recording_mbid": str(recording_mbid),
                 "release_mbid": str(release_mbid),
-                "artist_mbids": [ str(m) for m in artist_mbids ] }
+                "artist_mbids": [str(m) for m in artist_mbids]
+            }
+            if caa_id is not None and caa_release_mbid is not None:
+                data["track_metadata"]["mbid_mapping"]["caa_id"] = caa_id
+                data["track_metadata"]["mbid_mapping"]["caa_release_mbid"] = caa_release_mbid
+
         return cls(
             user_id=user_id,
             user_name=user_name,

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -53,7 +53,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
                       , '{"name": "Strangers", "rels": [], "length": 291160}'
                       , '{"name": "Portishead", "artist_credit_id": 204, "artists": [{"area": "United Kingdom", "rels": {"lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html", "youtube": "https://www.youtube.com/user/portishead1002", "wikidata": "https://www.wikidata.org/wiki/Q191352", "streaming": "https://tidal.com/artist/27441", "free streaming": "https://www.deezer.com/artist/1069", "social network": "https://www.facebook.com/portishead", "official homepage": "http://www.portishead.co.uk/", "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/"}, "type": "Group", "begin_year": 1991}]}'
                       , '{"artist": [], "recording": [], "release_group": []}'
-                      , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy", "caa_id": 829521842, "release_group_mbid": null}'
+                      , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy"}'
                       , 'f'
                        )
         """

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -242,7 +242,7 @@ class TimescaleListenStore:
                         , mm.recording_mbid
                         , mbc.release_mbid
                         , mbc.artist_mbids
-                        , (mbc.release_data->>'caa_id')::int
+                        , (mbc.release_data->>'caa_id')::bigint
                         , mbc.release_data->>'caa_release_mbid'
                      FROM listen
                 LEFT JOIN mbid_mapping mm
@@ -372,7 +372,7 @@ class TimescaleListenStore:
                                     , mm.recording_mbid
                                     , mbc.release_mbid
                                     , mbc.artist_mbids
-                                    , (mbc.release_data->>'caa_id')::int
+                                    , (mbc.release_data->>'caa_id')::bigint
                                     , mbc.release_data->>'caa_release_mbid'
                                     , row_number() OVER (PARTITION BY user_id ORDER BY listened_at DESC) AS rownum
                                 FROM listen l

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -242,6 +242,8 @@ class TimescaleListenStore:
                         , mm.recording_mbid
                         , mbc.release_mbid
                         , mbc.artist_mbids
+                        , (mbc.release_data->>'caa_id')::int
+                        , mbc.release_data->>'caa_release_mbid'
                      FROM listen
                 LEFT JOIN mbid_mapping mm
                        ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = mm.recording_msid
@@ -318,7 +320,9 @@ class TimescaleListenStore:
                         recording_mbid=result.recording_mbid,
                         release_mbid=result.release_mbid,
                         artist_mbids=result.artist_mbids,
-                        user_name=user["musicbrainz_id"]
+                        user_name=user["musicbrainz_id"],
+                        caa_id=result.caa_id,
+                        caa_release_mbid=result.caa_release_mbid
                     ))
 
                     if len(listens) == limit:
@@ -368,6 +372,8 @@ class TimescaleListenStore:
                                     , mm.recording_mbid
                                     , mbc.release_mbid
                                     , mbc.artist_mbids
+                                    , (mbc.release_data->>'caa_id')::int
+                                    , mbc.release_data->>'caa_release_mbid'
                                     , row_number() OVER (PARTITION BY user_id ORDER BY listened_at DESC) AS rownum
                                 FROM listen l
                            LEFT JOIN mbid_mapping mm
@@ -383,6 +389,8 @@ class TimescaleListenStore:
                                    , mm.recording_mbid
                                    , mbc.release_mbid
                                    , mbc.artist_mbids
+                                   , mbc.release_data->>'caa_id'
+                                   , mbc.release_data->>'caa_release_mbid'
                             ORDER BY listened_at DESC
                             ) tmp
                                WHERE rownum <= :per_user_limit
@@ -406,7 +414,9 @@ class TimescaleListenStore:
                     recording_mbid=result.recording_mbid,
                     release_mbid=result.release_mbid,
                     artist_mbids=result.artist_mbids,
-                    user_name=user_name
+                    user_name=user_name,
+                    caa_id=result.caa_id,
+                    caa_release_mbid=result.caa_release_mbid
                 ))
         return listens
 

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/MetadataViewer.tsx
@@ -156,8 +156,6 @@ export default function MetadataViewer(props: MetadataViewerProps) {
 
   const artistMBID = first(recordingData?.artist_mbids);
   const releaseMBID = recordingData?.release_mbid ?? metadata?.release?.mbid;
-  const CAAReleaseMBID = metadata?.release?.caa_release_mbid;
-  const CAAID = metadata?.release?.caa_id;
   let coverArtSrc = "/static/img/cover-art-placeholder.jpg";
   if (CAAReleaseMBID && CAAID) {
     // Bypass the Cover Art Archive redirect since we have the info to directly fetch from archive.org

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -47,6 +47,8 @@ declare type MbidMapping = {
   recording_mbid: string;
   release_mbid: string;
   artist_mbids: Array<string>;
+  caa_id?: number;
+  caa_release_mbid?: string;
 };
 
 declare type BaseListenFormat = {

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -275,7 +275,7 @@ class UserViewsTestCase(IntegrationTestCase):
                           , '{"name": "The Final Confrontation, Part 1", "rels": [], "length": 312000}'
                           , '{"name": "Danny Elfman", "artist_credit_id": 204, "artists": [{"area": "United States", "rels": {"youtube": "https://www.youtube.com/channel/UCjhIy2xUURhJvN0S7s_ztuw", "wikidata": "https://www.wikidata.org/wiki/Q193338", "streaming": "https://music.apple.com/gb/artist/486493", "free streaming": "https://www.deezer.com/artist/760", "social network": "https://www.instagram.com/dannyelfman/", "official homepage": "https://www.dannyelfman.com/", "purchase for download": "https://itunes.apple.com/us/artist/id486493"}, "type": "Person", "gender": "Male", "begin_year": 1953}]}'
                           , '{"artist": [], "recording": [], "release_group": []}'
-                          , '{"mbid": "607cc05a-e462-4f39-91b5-e9322544e0a6", "name": "Danny Elfman & Tim Burton 25th Anniversary Music Box", "year": 2011, "caa_id": 1081592107, "release_group_mbid": null}'
+                          , '{"mbid": "607cc05a-e462-4f39-91b5-e9322544e0a6", "name": "Danny Elfman & Tim Burton 25th Anniversary Music Box", "year": 2011}'
                           , 'f'
                            );
 


### PR DESCRIPTION
This should improve cover art coverage and also reduce the need for frontend to resolve the caa ids manually.