### PR TITLE
Link to each artist separately in listen card if possible

### DIFF
--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -56,7 +56,7 @@ def load_recordings_from_mbids(connection, mbids: Iterable[str]) -> dict:
           FROM mapping.mb_metadata_cache mbc
   JOIN LATERAL jsonb_array_elements(artist_data->'artists') WITH ORDINALITY artists(artist, position)
             ON TRUE
-         WHERE recording_mbid IN ('78194fbe-3bcd-4afe-b4a6-7a97711c325f')
+         WHERE recording_mbid IN :mbids
       GROUP BY recording_mbid
              , release_mbid
              , artist_mbids

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -91,7 +91,7 @@ def load_recordings_from_mbids(connection, mbids: Iterable[str]) -> dict:
                 "join_phrase": join_phrase
             })
         data["artists"] = artists
-        row[recording_mbid] = data
+        rows[recording_mbid] = data
 
     return rows
 

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -51,13 +51,49 @@ def load_recordings_from_mbids(connection, mbids: Iterable[str]) -> dict:
              , release_data->>'name' AS release
              , (release_data->>'caa_id')::bigint AS caa_id
              , release_data->>'caa_release_mbid' AS caa_release_mbid
+             , array_agg(artist->>'name' ORDER BY position) AS ac_names
+             , array_agg(artist->>'join_phrase' ORDER BY position) AS ac_join_phrases
           FROM mapping.mb_metadata_cache mbc
-         WHERE recording_mbid IN :mbids
+  JOIN LATERAL jsonb_array_elements(artist_data->'artists') WITH ORDINALITY artists(artist, position)
+            ON TRUE
+         WHERE recording_mbid IN ('78194fbe-3bcd-4afe-b4a6-7a97711c325f')
+      GROUP BY recording_mbid
+             , release_mbid
+             , artist_mbids
+             , artist_data->>'name'
+             , recording_data->>'name'
+             , release_data->>'name'
+             , release_data->>'caa_id'
+             , release_data->>'caa_release_mbid'
     """
 
     result = connection.execute(text(query), {"mbids": tuple(mbids)})
-    rows = result.mappings().all()
-    return {row["recording_mbid"]: row for row in rows}
+
+    rows = {}
+    for row in result.all():
+        recording_mbid = row.recording_mbid
+        data = {
+            "recording_mbid": row.recording_mbid,
+            "release_mbid": row.release_mbid,
+            "artist_mbids": row.artist_mbids,
+            "artist": row.artist,
+            "title": row.title,
+            "release": row.release,
+            "caa_id": row.caa_id,
+            "caa_release_mbid": row.caa_release_mbid
+        }
+
+        artists = []
+        for (mbid, name, join_phrase) in zip(row.artist_mbids, row.ac_names, row.ac_join_phrases):
+            artists.append({
+                "artist_mbid": mbid,
+                "artist_credit_name": name,
+                "join_phrase": join_phrase
+            })
+        data["artists"] = artists
+        row[recording_mbid] = data
+
+    return rows
 
 
 ModelT = TypeVar('ModelT', bound=MsidMbidModel)
@@ -124,7 +160,8 @@ def _update_mbid_items(models: dict[str, list[ModelT]], metadatas: dict, remaini
                 "additional_info": {
                     "recording_mbid": metadata["recording_mbid"],
                     "release_mbid": metadata["release_mbid"],
-                    "artist_mbids": metadata["artist_mbids"]
+                    "artist_mbids": metadata["artist_mbids"],
+                    "artists": metadata["artists"]
                 }
             }
 

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -33,6 +33,12 @@ class MappingTestCase(TimescaleTestCase):
                     release_data["caa_id"] = recording["caa_id"]
                     release_data["caa_release_mbid"] = recording["caa_release_mbid"]
 
+                artists = [
+                    {"name": a["artist_credit_name"], "join_phrase": a["join_phrase"]}
+                    for a in recording["artists"]
+                ]
+                artist_data = {"name": recording["artist"], "artists": artists}
+
                 connection.execute(text("""
                     INSERT INTO mapping.mb_metadata_cache
                             (recording_mbid, artist_mbids, release_mbid, recording_data, artist_data, tag_data, release_data, dirty)
@@ -42,7 +48,7 @@ class MappingTestCase(TimescaleTestCase):
                     "artist_mbids": recording["artist_mbids"],
                     "release_mbid": recording["release_mbid"],
                     "recording_data": json.dumps({"name": recording["title"]}),
-                    "artist_data": json.dumps({"name": recording["artist"]}),
+                    "artist_data": json.dumps(artist_data),
                     "release_data": json.dumps(release_data),
                     "tag_data": json.dumps({"artist": [], "recording": [], "release_group": []})
                 })
@@ -67,6 +73,13 @@ class MappingTestCase(TimescaleTestCase):
                 "release": "Batman Returns",
                 "artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
                 "artist": "Danny Elfman",
+                "artists": [
+                    {
+                        "artist_credit_name": "Danny Elfman",
+                        "join_phrase": "",
+                        "artist_mbid": "5b24fbab-c58f-4c37-a59d-ab232e2d98c4"
+                    }
+                ],
                 "title": "The Final Confrontation, Part 1",
                 "caa_release_mbid": "a2589025-8517-45ab-9d64-fe927ba087b1-3151246737",
                 "caa_id": 3151246737
@@ -77,6 +90,13 @@ class MappingTestCase(TimescaleTestCase):
                 "release": "Random Is Resistance",
                 "artist_mbids": ["797bcf41-0e02-431d-ab99-020e1cb3d0fd"],
                 "artist": "Rotersand",
+                "artists": [
+                    {
+                        "artist_credit_name": "Rotersand",
+                        "join_phrase": "",
+                        "artist_mbid": "797bcf41-0e02-431d-ab99-020e1cb3d0fd"
+                    }
+                ],
                 "title": "A Number and a Name",
                 "caa_id": None,
                 "caa_release_mbid": None
@@ -92,6 +112,13 @@ class MappingTestCase(TimescaleTestCase):
                 "release": "Year Zero",
                 "artist_mbids": ["b7ffd2af-418f-4be2-bdd1-22f8b48613da"],
                 "artist": "Nine Inch Nails",
+                "artists": [
+                    {
+                        "artist_credit_name": "Nine Inch Nails",
+                        "join_phrase": "",
+                        "artist_mbid": "b7ffd2af-418f-4be2-bdd1-22f8b48613da"
+                    }
+                ],
                 "title": "The Warning"
             },
             {
@@ -170,6 +197,7 @@ class MappingTestCase(TimescaleTestCase):
             self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
             self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
             self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
+            self.assertEqual(metadata["additional_info"]["artists"], recording["artists"])
 
     def test_fetch_track_metadata_for_items_with_same_mbid(self):
         recording = self.insert_recordings()[0]
@@ -187,4 +215,5 @@ class MappingTestCase(TimescaleTestCase):
             self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
             self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
             self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
+            self.assertEqual(metadata["additional_info"]["artists"], recording["artists"])
 

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -116,7 +116,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                               , '{8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11}'::UUID[]
                               , '76df3287-6cda-33eb-8e9a-044b5e15ffdd'
                               , '{"name": "Strangers", "rels": [], "length": 291160}'
-                              , '{"name": "Portishead", "artist_credit_id": 204, "artists": [{"area": "United Kingdom", "rels": {"lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html", "youtube": "https://www.youtube.com/user/portishead1002", "wikidata": "https://www.wikidata.org/wiki/Q191352", "streaming": "https://tidal.com/artist/27441", "free streaming": "https://www.deezer.com/artist/1069", "social network": "https://www.facebook.com/portishead", "official homepage": "http://www.portishead.co.uk/", "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/"}, "type": "Group", "begin_year": 1991}]}'
+                              , '{"name": "Portishead", "artist_credit_id": 204, "artists": [{"area": "United Kingdom", "rels": {"lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html", "youtube": "https://www.youtube.com/user/portishead1002", "wikidata": "https://www.wikidata.org/wiki/Q191352", "streaming": "https://tidal.com/artist/27441", "free streaming": "https://www.deezer.com/artist/1069", "social network": "https://www.facebook.com/portishead", "official homepage": "http://www.portishead.co.uk/", "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/"}, "type": "Group", "begin_year": 1991, "name": "Portishead", "join_phrase": ""}]}'
                               , '{"artist": [], "recording": [], "release_group": []}'
                               , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy"}'
                               , 'f'
@@ -179,6 +179,13 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                 "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31",
                 "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
                 "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"],
+                "artists": [
+                    {
+                        "artist_credit_name": "Portishead",
+                        "join_phrase": "",
+                        "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+                    }
+                ],
                 "recording_msid": msids[0]
             }
         })

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -127,17 +127,29 @@ class Listen(object):
     @classmethod
     def from_timescale(cls, listened_at, track_name, user_id, created, data,
                        recording_mbid=None, release_mbid=None, artist_mbids=None,
-                       user_name=None, caa_id=None, caa_release_mbid=None):
+                       ac_names=None, ac_join_phrases=None, user_name=None,
+                       caa_id=None, caa_release_mbid=None):
         """Factory to make Listen() objects from a timescale dict"""
 
         data['listened_at'] = datetime.utcfromtimestamp(float(listened_at))
         data['track_metadata']['track_name'] = track_name
-        if recording_mbid is not None and release_mbid is not None and artist_mbids is not None:
+        if recording_mbid is not None and release_mbid is not None:
             data["track_metadata"]["mbid_mapping"] = {
                 "recording_mbid": str(recording_mbid),
                 "release_mbid": str(release_mbid),
                 "artist_mbids": [str(m) for m in artist_mbids]
             }
+
+            if artist_mbids is not None and ac_names is not None and ac_join_phrases is not None:
+                artists = []
+                for (mbid, name, join_phrase) in zip(artist_mbids, ac_names, ac_join_phrases):
+                    artists.append({
+                        "artist_mbid": mbid,
+                        "artist_credit_name": name,
+                        "join_phrase": join_phrase
+                    })
+                data["track_metadata"]["mbid_mapping"]["artists"] = artists
+
             if caa_id is not None and caa_release_mbid is not None:
                 data["track_metadata"]["mbid_mapping"]["caa_id"] = caa_id
                 data["track_metadata"]["mbid_mapping"]["caa_release_mbid"] = caa_release_mbid

--- a/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/metadata-viewer/types.d.ts
@@ -1,5 +1,7 @@
 /** Main entities */
 declare type MusicBrainzArtist = {
+  name: string;
+  join_phrase: string;
   area: string;
   begin_year: number;
   rels: { [key: string]: string };

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -43,7 +43,7 @@ interface AdditionalInfo {
   work_mbids?: Array<string> | null;
 }
 
-declare type MbidMappingAritst = {
+declare type MbidMappingArtist = {
   artist_mbid: string;
   artist_credit_name: string;
   join_phrase: string;
@@ -53,7 +53,7 @@ declare type MbidMapping = {
   recording_mbid: string;
   release_mbid: string;
   artist_mbids: Array<string>;
-  artists?: Array<MbidMappingAritst>;
+  artists?: Array<MbidMappingArtist>;
   caa_id?: number;
   caa_release_mbid?: string;
 };

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -43,10 +43,17 @@ interface AdditionalInfo {
   work_mbids?: Array<string> | null;
 }
 
+declare type MbidMappingAritst = {
+  artist_mbid: string;
+  artist_credit_name: string;
+  join_phrase: string;
+};
+
 declare type MbidMapping = {
   recording_mbid: string;
   release_mbid: string;
   artist_mbids: Array<string>;
+  artists: Array<MbidMappingAritst>;
   caa_id?: number;
   caa_release_mbid?: string;
 };

--- a/listenbrainz/webserver/static/js/src/utils/types.d.ts
+++ b/listenbrainz/webserver/static/js/src/utils/types.d.ts
@@ -53,7 +53,7 @@ declare type MbidMapping = {
   recording_mbid: string;
   release_mbid: string;
   artist_mbids: Array<string>;
-  artists: Array<MbidMappingAritst>;
+  artists?: Array<MbidMappingAritst>;
   caa_id?: number;
   caa_release_mbid?: string;
 };

--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -158,6 +158,25 @@ const getArtistName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
   _.get(listen, "creator", "");
 
 const getArtistLink = (listen: Listen) => {
+  const artists = listen.track_metadata.mbid_mapping?.artists;
+  if (artists) {
+    return (
+      <>
+        {artists.map((artist) => (
+          <>
+            <a
+              href={`https://musicbrainz.org/artist/${artist.artist_mbid}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {artist.artist_credit_name}
+            </a>
+            {artist.join_phrase}
+          </>
+        ))}
+      </>
+    );
+  }
   const artistName = getArtistName(listen);
   const artistMbids = getArtistMBIDs(listen);
   const firstArtist = _.first(artistMbids);

--- a/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsThreeListens.json
+++ b/listenbrainz/webserver/static/js/tests/__mocks__/recentListensPropsThreeListens.json
@@ -42,7 +42,14 @@
             "830e5c4e-6b7d-431d-86ab-00c751281dc5"
           ],
           "recording_mbid": "9541592c-0102-4b94-93cc-ee0f3cf83d64",
-          "release_mbid": "eff7949b-9440-4bae-9f09-b723a4710858"
+          "release_mbid": "eff7949b-9440-4bae-9f09-b723a4710858",
+          "artists": [
+            {
+              "artist_mbid": "830e5c4e-6b7d-431d-86ab-00c751281dc5",
+              "artist_credit_name": "5 Seconds of Summer",
+              "join_phrase": ""
+            }
+          ]
         },
         "release_name": "Youngblood (Deluxe)",
         "track_name": "Youngblood"
@@ -63,7 +70,14 @@
             "f4fdbb4c-e4b7-47a0-b83b-d91bbfcfa387"
           ],
           "recording_mbid": "9f24c0f7-a644-4074-8fbd-a1dba03de129",
-          "release_mbid": "be5d97b1-408a-4e95-b924-0a61955048de"
+          "release_mbid": "be5d97b1-408a-4e95-b924-0a61955048de",
+          "artists": [
+            {
+              "artist_mbid": "f4fdbb4c-e4b7-47a0-b83b-d91bbfcfa387",
+              "artist_credit_name": "Ariana Grande",
+              "join_phrase": ""
+            }
+          ]
         },
         "release_name": "My Everything (Deluxe)",
         "track_name": "One Last Time"
@@ -109,7 +123,19 @@
               "1d81a1be-1b66-427d-9335-c777a259eadb"
             ],
             "recording_mbid": "55215be2-094c-4c38-a0da-2a83863ee804",
-            "release_mbid": "e300b42d-18cc-401e-990c-118fb4822bff"
+            "release_mbid": "e300b42d-18cc-401e-990c-118fb4822bff",
+            "artists": [
+              {
+                "artist_mbid": "61231ba8-ef93-4620-b58b-b0efa4edbdb6",
+                "artist_credit_name": "Ofenbach",
+                "join_phrase": " , "
+              },
+              {
+                "artist_mbid": "1d81a1be-1b66-427d-9335-c777a259eadb",
+                "artist_credit_name": "Lagique",
+                "join_phrase": ""
+              }
+            ]
           },
           "release_name": "Wasted Love (feat. Lagique)",
           "track_name": "Wasted Love (feat. Lagique)"

--- a/listenbrainz/webserver/static/js/tests/listens/ListenCard.test.tsx
+++ b/listenbrainz/webserver/static/js/tests/listens/ListenCard.test.tsx
@@ -98,6 +98,13 @@ describe("ListenCard", () => {
           release_mbid: "foo",
           recording_mbid: "bar",
           artist_mbids: ["foobar"],
+          artists: [
+            {
+              artist_mbid: "foobar",
+              artist_credit_name: "Moondog",
+              join_phrase: "",
+            },
+          ],
         },
       },
       user_name: "test",

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -273,7 +273,7 @@ class UserViewsTestCase(IntegrationTestCase):
                           , '{5b24fbab-c58f-4c37-a59d-ab232e2d98c4}'::UUID[]
                           , '607cc05a-e462-4f39-91b5-e9322544e0a6'
                           , '{"name": "The Final Confrontation, Part 1", "rels": [], "length": 312000}'
-                          , '{"name": "Danny Elfman", "artist_credit_id": 204, "artists": [{"area": "United States", "rels": {"youtube": "https://www.youtube.com/channel/UCjhIy2xUURhJvN0S7s_ztuw", "wikidata": "https://www.wikidata.org/wiki/Q193338", "streaming": "https://music.apple.com/gb/artist/486493", "free streaming": "https://www.deezer.com/artist/760", "social network": "https://www.instagram.com/dannyelfman/", "official homepage": "https://www.dannyelfman.com/", "purchase for download": "https://itunes.apple.com/us/artist/id486493"}, "type": "Person", "gender": "Male", "begin_year": 1953}]}'
+                          , '{"name": "Danny Elfman", "artist_credit_id": 204, "artists": [{"area": "United States", "rels": {"youtube": "https://www.youtube.com/channel/UCjhIy2xUURhJvN0S7s_ztuw", "wikidata": "https://www.wikidata.org/wiki/Q193338", "streaming": "https://music.apple.com/gb/artist/486493", "free streaming": "https://www.deezer.com/artist/760", "social network": "https://www.instagram.com/dannyelfman/", "official homepage": "https://www.dannyelfman.com/", "purchase for download": "https://itunes.apple.com/us/artist/id486493"}, "type": "Person", "gender": "Male", "begin_year": 1953, "name": "Danny Elfman", "join_phrase": ""}]}'
                           , '{"artist": [], "recording": [], "release_group": []}'
                           , '{"mbid": "607cc05a-e462-4f39-91b5-e9322544e0a6", "name": "Danny Elfman & Tim Burton 25th Anniversary Music Box", "year": 2011}'
                           , 'f'
@@ -308,7 +308,14 @@ class UserViewsTestCase(IntegrationTestCase):
                 "recording_msid": "b7ffd2af-418f-4be2-bdd1-22f8b48613da",
                 "recording_mbid": "1fe669c9-5a2b-4dcb-9e95-77480d1e732e",
                 "release_mbid": "607cc05a-e462-4f39-91b5-e9322544e0a6",
-                "artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"]
+                "artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],
+                "artists": [
+                    {
+                        "artist_credit_name": "Danny Elfman",
+                        "join_phrase": "",
+                        "artist_mbid": "5b24fbab-c58f-4c37-a59d-ab232e2d98c4"
+                    }
+                ]
             }
         }
 


### PR DESCRIPTION
We have artist credit names and join phrases available in mb metadata cache now and can use it for linking to each artist separately in listen cards.

![Screenshot from 2022-11-15 23-04-49](https://user-images.githubusercontent.com/27751938/202006404-ab14a3ab-95b0-43c3-8dc4-003964d0e840.png)

To consider:
1. Should we do it always? Until now we have preferred user submitted names on the main listens page, elsewhere user submitted names aren't available so mapped names are used always. This changes that.
2. The name of the artist fields in the api, how should the artists array look and what should be its keys? The metadata lookup endpoint has structure from what this PR adds to mbid_mapping section.