### PR TITLE
Add contribution parameter and filter artist credit option to similar recordings

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -350,14 +350,23 @@ def request_similar_users(max_num_users):
 @click.option("--days", type=int, help="The number of days of listens to use.", required=True)
 @click.option("--session", type=int, help="The maximum duration in seconds between two listens in a listening"
                                           " session.", required=True)
+@click.option("--contribution", type=int, help="The maximum contribution a user's listens can make to the similarity"
+                                               " score of a recording pair.", required=True)
 @click.option("--threshold", type=int, help="The minimum similarity score to include a recording pair in the"
                                             " simlarity index.", required=True)
 @click.option("--limit", type=int, help="The maximum number of similar recordings to generate per recording"
                                         " (the limit is instructive. upto 2x recordings may be returned than"
                                         " the limit).", required=True)
-def request_similar_recordings(days, session, threshold, limit):
+def request_similar_recordings(days, session, contribution, threshold, limit):
     """ Send the cluster a request to generate similar recordings index. """
-    send_request_to_spark_cluster('similarity.recording', days=days, session=session, threshold=threshold, limit=limit)
+    send_request_to_spark_cluster(
+        "similarity.recording",
+        days=days,
+        session=session,
+        contribution=contribution,
+        threshold=threshold,
+        limit=limit
+    )
 
 
 @cli.command(name="request_yim_similar_users")

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -357,7 +357,9 @@ def request_similar_users(max_num_users):
 @click.option("--limit", type=int, help="The maximum number of similar recordings to generate per recording"
                                         " (the limit is instructive. upto 2x recordings may be returned than"
                                         " the limit).", required=True)
-def request_similar_recordings(days, session, contribution, threshold, limit):
+@click.option("--filter-artist-credit", type=bool, help="Whether to filter tracks by same artists in a listening"
+                                                        " session", required=True)
+def request_similar_recordings(days, session, contribution, threshold, limit, filter_artist_credit):
     """ Send the cluster a request to generate similar recordings index. """
     send_request_to_spark_cluster(
         "similarity.recording",
@@ -365,7 +367,8 @@ def request_similar_recordings(days, session, contribution, threshold, limit):
         session=session,
         contribution=contribution,
         threshold=threshold,
-        limit=limit
+        limit=limit,
+        filter_artist_credit=filter_artist_credit
     )
 
 

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -134,6 +134,7 @@
     "params": [
       "days",
       "session",
+      "contribution",
       "threshold",
       "limit"
     ]

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -136,7 +136,8 @@
       "session",
       "contribution",
       "threshold",
-      "limit"
+      "limit",
+      "filter_artist_credit"
     ]
   },
   "year_in_music.similar_users": {

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -50,7 +50,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
                 SELECT user_id
                      , lexical_mbid0 AS mbid0
                      , lexical_mbid1 AS mbid1
-                     , LEAST(COUNT(*), {max_contribution}) AS score
+                     , LEAST(COUNT(*), {max_contribution}) AS part_score
                   FROM user_grouped_mbids
               GROUP BY user_id
                      , lexical_mbid0
@@ -58,7 +58,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
             ), thresholded_mbids AS (
                 SELECT mbid0
                      , mbid1
-                     , score
+                     , SUM(part_score) AS score
                   FROM user_contribtion_mbids
               GROUP BY mbid0
                      , mbid1  

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -109,7 +109,7 @@ def main(days, session, contribution, threshold, limit, filter_artist_credit):
     query = build_sessioned_index(table, metadata_table, session, contribution, threshold, limit, filter_artist_credit)
     data = run_query(query).toLocalIterator()
 
-    algorithm = f"session_base+d_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_filter_{filter_artist_credit}"
+    algorithm = f"session_based_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_filter_{filter_artist_credit}"
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]


### PR DESCRIPTION
1. contribution - The maximum contribution a user's listens can make to the similarity score of a recording pair.
2. filter_artist_credit - Whether to filter tracks by same artists in a listening session.