### PR TITLE
Timescale Writer Fixes

### DIFF
--- a/docs/users/api/core.rst
+++ b/docs/users/api/core.rst
@@ -60,6 +60,8 @@ Constants that are relevant to using the API:
 
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTEN_PAYLOAD_SIZE
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTEN_SIZE
+.. autodata:: listenbrainz.webserver.views.api_tools.MAX_DURATION_LIMIT
+.. autodata:: listenbrainz.webserver.views.api_tools.MAX_DURATION_MS_LIMIT
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_LISTENS_PER_REQUEST
 .. autodata:: listenbrainz.webserver.views.api_tools.MAX_ITEMS_PER_GET
 .. autodata:: listenbrainz.webserver.views.api_tools.DEFAULT_ITEMS_PER_GET

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -525,6 +525,19 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual('Value for duration is invalid, should be a positive integer.',
                          response.json['error'])
 
+        payload["payload"][0]["track_metadata"]["additional_info"]["duration"] = 5345029000
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+        self.assertEqual('Value for duration is too large, max permitted value is 2073600', response.json['error'])
+
+        del payload["payload"][0]["track_metadata"]["additional_info"]["duration"]
+        payload["payload"][0]["track_metadata"]["additional_info"]["duration_ms"] = 53450290000
+        response = self.send_data(payload)
+        self.assert400(response)
+        self.assertEqual(response.json['code'], 400)
+        self.assertEqual('Value for duration_ms is too large, max permitted value is 2073600000', response.json['error'])
+
     def test_valid_duration(self):
         """ Test for valid submission in which a listen contains a valid duration_ms field
             in additional_info

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -40,7 +40,14 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
         self.metric_submission_time = monotonic() + METRIC_UPDATE_INTERVAL
 
     def get_consumers(self, _, channel):
-        return [Consumer(channel, queues=[self.incoming_queue], on_message=lambda x: self.callback(x))]
+        return [
+            Consumer(
+                channel,
+                queues=[self.incoming_queue],
+                on_message=lambda x: self.callback(x),
+                prefetch_count=500
+            )
+        ]
 
     def callback(self, message: Message):
         listens = ujson.loads(message.body)


### PR DESCRIPTION
Timescale writer recently crashed due to a listen that was submitted with a very large integer value that is out of bounds of Postgres integer data type. Therefore, add api level checks for limit on the duration field value. While recovering, the writer got stuck again when RMQ redelivered over 10k messages at once. It seems there is some bug or undocumented behavior due to which kombu? is unable to handle this load. Worse it fails silently without any logs. To fix, set the prefetch_count to 500.