### PR TITLE
Hardcode urls in listenbrainz.org/art

### DIFF
--- a/listenbrainz/webserver/templates/art/index.html
+++ b/listenbrainz/webserver/templates/art/index.html
@@ -1,134 +1,47 @@
 {%- extends 'base.html' -%}
 {%- block content -%}
-   <h1>ListenBrainz Cover Art Grid demo</h1>
-     <h2>Custom layouts</h2>
-       <h3>Vinyl on the floor</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_custom_stats",
-		                custom_name="lps-on-the-floor",
-				image_size=750,
-				time_range="week",
-				user_name="rob") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
-       <object data="{{ url_for("art_api_v1.cover_art_custom_stats",
-		                custom_name="lps-on-the-floor",
-				image_size=750,
-				time_range="week",
-				user_name="jukevox") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h1>ListenBrainz Cover Art Grid demo</h1>
+    <h2>Custom layouts</h2>
+    <h3>Vinyl on the floor</h3>
+    <object data="{{ api_url }}/1/art/lps-on-the-floor/rob/week/750" width="{{ width }}" height="{{ height }}"></object>
+    <object data="{{ api_url }}/1/art/lps-on-the-floor/jukevox/week/750" width="{{ width }}" height="{{ height }}"></object>
 
-       <h3>Top Five Artists</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_custom_stats",
-		                custom_name="designer-top-5",
-				image_size=750,
-				time_range="week",
-				user_name="rob") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
-       <object data="{{ url_for("art_api_v1.cover_art_custom_stats",
-		                custom_name="designer-top-10",
-				image_size=750,
-				time_range="week",
-				user_name="jukevox") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
-       <object data="{{ url_for("art_api_v1.cover_art_custom_stats",
-		                custom_name="designer-top-10-alt",
-				image_size=750,
-				time_range="week",
-				user_name="zas") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h3>Top Five Artists</h3>
+    <object data="{{ api_url }}/1/art/designer-top-5/rob/week/750" width="{{ width }}" height="{{ height }}"></object>
+    <object data="{{ api_url }}/1/art/designer-top-10/jukevox/week/750" width="{{ width }}" height="{{ height }}"></object>
+    <object data="{{ api_url }}/1/art/designer-top-10-alt/zas/week/750" width="{{ width }}" height="{{ height }}"></object>
 
-     <h2>Grids of Dimension 2</h2>
-       <h3>Layout 0</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="heyarne",
-				dimension="2",
-				layout="0") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h2>Grids of Dimension 2</h2>
+    <h3>Layout 0</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/heyarne/week/2/0/750" width="{{ width }}" height="{{ height }}"></object>
 
-     <h2>Grids of Dimension 3</h2>
-       <h3>Layout 0</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="aerozol",
-				dimension="3",
-				layout="0") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h2>Grids of Dimension 3</h2>
+    <h3>Layout 0</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/aerozol/week/3/0/750" width="{{ width }}" height="{{ height }}"></object>
 
-       <h3>Layout 1</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="chinmaykunkikar",
-				dimension="3",
-				layout="1") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h3>Layout 1</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/chinmaykunkikar/week/3/1/750" width="{{ width }}" height="{{ height }}"></object>
 
-       <h3>Layout 2</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="lucifer",
-				dimension="3",
-				layout="2") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h3>Layout 2</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/lucifer/week/3/2/750" width="{{ width }}" height="{{ height }}"></object>
 
-     <h2>Grids of Dimension 4</h2>
-       <h3>Layout 0</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="rob",
-				dimension="4",
-				layout="0") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h2>Grids of Dimension 4</h2>
+    <h3>Layout 0</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/rob/week/4/0/750" width="{{ width }}" height="{{ height }}"></object>
 
-       <h3>Layout 1</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="akshaaatt",
-				dimension="4",
-				layout="1") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h3>Layout 1</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/akshaaatt/week/4/1/750" width="{{ width }}" height="{{ height }}"></object>
 
-       <h3>Layout 2</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="throwawaytest140",
-				dimension="4",
-				layout="2") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h3>Layout 2</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/throwawaytest140/week/4/2/750" width="{{ width }}" height="{{ height }}"></object>
 
-       <h3>Layout 3</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="week",
-				user_name="damselfish",
-				dimension="4",
-				layout="2") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
+    <h3>Layout 3</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/damselfish/week/4/3/750" width="{{ width }}" height="{{ height }}"></object>
 
+    <h2>Grids of Dimension 5</h2>
+    <h3>Layout 0</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/zas/month/5/0/750" width="{{ width }}" height="{{ height }}"></object>
 
-     <h2>Grids of Dimension 5</h2>
-       <h3>Layout 0</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="month",
-				user_name="zas",
-				dimension="5",
-				layout="0") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
-
-       <h3>Layout 1</h3>
-       <object data="{{ url_for("art_api_v1.cover_art_grid_stats",
-				image_size=750,
-				time_range="month",
-				user_name="outsidecontext",
-				dimension="5",
-				layout="1") }}"
-	       width="{{ width }}" height="{{ height }}"></object>
-
+    <h3>Layout 1</h3>
+    <object data="{{ api_url }}/1/art/grid-stats/outsidecontext/month/5/1/750" width="{{ width }}" height="{{ height }}"></object>
 {%- endblock content -%}

--- a/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
@@ -40,5 +40,5 @@
            y="0"
            width="{{ width }}"
            height="{{ height }}"
-           xlink:href="/static/img/art/cover-art-on-floor.png"/>
+           xlink:href="{{ cover_art_on_floor_url }}"/>
 </svg>

--- a/listenbrainz/webserver/views/art.py
+++ b/listenbrainz/webserver/views/art.py
@@ -1,8 +1,9 @@
-from flask import Flask, render_template, Blueprint
+from flask import render_template, Blueprint, current_app
 
 art_bp = Blueprint('art', __name__)
+
 
 @art_bp.route("/")
 def index():
     """ This page shows of a bit of what can be done with the cover art, as a sort of showcase. """
-    return render_template("art/index.html")
+    return render_template("art/index.html", api_url=current_app.config["API_URL"])

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -204,7 +204,9 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
         except ValueError as error:
             raise APIBadRequest(error)
 
+        cover_art_on_floor_url = f'{current_app.config["SERVER_ROOT_URL"]}/static/img/art/cover-art-on-floor.png'
         return render_template(f"art/svg-templates/{custom_name}.svg",
+                               cover_art_on_floor_url=cover_art_on_floor_url,
                                images=images,
                                releases=releases,
                                width=image_size,


### PR DESCRIPTION
Instead of using url_for, hardcode urls in listenbrainz.org/art because url_for uses listenbrainz.org as the server name whereas the api is served from api.listenbranz.org.
