### PR TITLE
Add missing ordering for front cover art

### DIFF
--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -365,6 +365,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                  , re.date_year
                                  , re.date_month
                                  , re.date_day
+                                 , caa.ordering
                    ), release_data AS (
                             SELECT r.gid AS recording_mbid
                                  , rel.name


### PR DESCRIPTION
When a release has multiple front cover arts, use the ordering attribute to choose preferred one.