### PR TITLE
Add msid updater

### DIFF
--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -36,7 +36,7 @@ CREATE UNIQUE INDEX user_id_service_ndx_listens_importer ON listens_importer (us
 CREATE INDEX latest_listened_at_ndx_listens_importer ON listens_importer (latest_listened_at DESC NULLS LAST);
 
 CREATE UNIQUE INDEX user_id_rec_msid_ndx_feedback ON recording_feedback (user_id, recording_msid);
-CREATE UNIQUE INDEX user_id_mbid_ndx_rec_feedback ON recording_feedback (user_id, recording_mbid);
+CREATE INDEX user_id_mbid_ndx_rec_feedback ON recording_feedback (user_id, recording_mbid);
 
 -- NOTE: If the indexes for the similar_user table changes, update the code in listenbrainz/db/similar_users.py !
 CREATE UNIQUE INDEX user_id_ndx_similar_user ON recommendation.similar_user (user_id);

--- a/admin/sql/updates/2022-11-21-remove-unique-index-recording-table.sql
+++ b/admin/sql/updates/2022-11-21-remove-unique-index-recording-table.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX user_id_mbid_ndx_rec_feedback;
+CREATE INDEX user_id_mbid_ndx_rec_feedback ON recording_feedback (user_id, recording_mbid);
+
+COMMIT;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     volumes:
       - rabbitmq:/var/lib/rabbitmq:z
     ports:
-      - "15672:15672"
+      - "127.0.0.1:25672:15672"
 
   web:
     build:

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -16,12 +16,6 @@ MAILTO=""
 # After the daily dumping is done, make sure everything turned out ok, otherwise mail the observability list.
 0 2 * * * root flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py dump check_dump_ages >> /logs/dumps.log 2>&1
 
-# Dump user feedback before we generate recommendations
-15 2 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feedback >> /logs/dumps.log 2>&1
-
-# Run spotify metadata cache seeder
-0 4 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark run-spotify-metadata-cache-seeder >> /logs/spotify_metadata_cache.log 2>&1
-
 # batch up all the spark requests, spaced by 1 minute in order to ensure the correct order
 # Request all statistics
 0 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_all_stats >> /logs/stats.log 2>&1
@@ -32,10 +26,19 @@ MAILTO=""
 # Calculate user similarity
 3 2 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_similar_users >> /logs/stats.log 2>&1
 
+# Dump user feedback before we generate recommendations
+15 2 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feedback >> /logs/dumps.log 2>&1
+
 # Request user fresh releases daily
 0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py request_fresh_releases --days 30 >> /logs/fresh_releases 2>&1
+
+# Run spotify metadata cache seeder
+0 4 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark run-spotify-metadata-cache-seeder >> /logs/spotify_metadata_cache.log 2>&1
 
 ## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
 0 4 1,15 * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/dumps.log 2>&1
 ## Around 24 hours later, trigger a full import into the spark cluster, and this time wait for the lock, in case the dump hasn't finished.
 0 4 2,16 * * root flock -x /var/lock/lb-dumps.lock /usr/local/bin/python /code/listenbrainz/manage.py spark request_import_full >> /logs/dumps.log 2>&1
+
+# run job to update msids with mapped mbids daily
+0 6 * * * root /usr/local/bin/python /code/listenbrainz/manage.py update-msid-tables >> /logs/msid-updater.log 2>&1

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -13,7 +13,7 @@ from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data a
     add_missing_to_listen_users_metadata as ts_add_missing_to_listen_users_metadata,\
     delete_listens as ts_delete_listens, \
     delete_listens_and_update_user_listen_data as ts_delete_listens_and_update_user_listen_data
-from listenbrainz.messybrainz import transfer_to_timescale
+from listenbrainz.messybrainz import transfer_to_timescale, update_msids_from_mapping
 from listenbrainz.spotify_metadata_cache.seeder import submit_new_releases_to_cache
 from listenbrainz.troi.troi_bot import run_daily_jams_troi_bot
 from listenbrainz.webserver import create_app
@@ -300,3 +300,10 @@ def run_spotify_metadata_cache_seeder():
     """ Query spotify new releases api for new releases and submit those to our cache as seeds """
     with create_app().app_context():
         submit_new_releases_to_cache()
+
+
+@cli.command()
+def update_msid_tables():
+    """ Scan tables using msids to find matching mbids from mapping tables and update them. """
+    with create_app().app_context():
+        update_msids_from_mapping.run_all_updates()

--- a/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
+++ b/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
@@ -1,0 +1,292 @@
+import json
+from datetime import datetime
+
+from sqlalchemy import text
+
+from listenbrainz import db
+import listenbrainz.db.user as db_user
+from listenbrainz.db import timescale
+from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
+from listenbrainz.messybrainz import update_msids_from_mapping
+from listenbrainz.tests.integration import IntegrationTestCase
+
+
+class MsidUpdaterTestCase(IntegrationTestCase):
+
+    def setUp(self):
+        IntegrationTestCase.setUp(self)
+        self.user = db_user.get_or_create(1111, "msid-updater-user")
+
+    def create_dummy_data(self):
+        mapping = [
+            {
+                "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31"
+            },
+            {
+                "recording_msid": "667e797d-75ee-42d5-bdcd-b669f5d70531",
+                "recording_mbid": "e9a37376-5e13-4353-989b-acc2f9fbc5b8"
+            },
+            {
+                "recording_msid": "e698826a-dcb0-4162-9418-f2d959a420e2",
+                "recording_mbid": "cf4bfb24-1258-4246-9e9f-39c2f216b116"
+            },
+            {
+                "recording_msid": "e8c5f386-2966-4a84-b481-0de2f69ce5c1",
+                "recording_mbid": None
+            }
+        ]
+        pinned_recs = [
+            {
+                "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31",
+                "blurb_content": "Amazing first recording",
+            },
+            {
+                "recording_msid": "667e797d-75ee-42d5-bdcd-b669f5d70531",
+                "recording_mbid": None,
+                "blurb_content": "Wonderful second recording",
+            },
+            {
+                "recording_msid": "e8c5f386-2966-4a84-b481-0de2f69ce5c1",
+                "recording_mbid": None,
+                "blurb_content": "Incredible third recording",
+            },
+            {
+                "recording_msid": None,
+                "recording_mbid": "cf4bfb24-1258-4246-9e9f-39c2f216b116",
+                "blurb_content": "Great fourth recording",
+            }
+        ]
+        recording_feedback = [
+            {
+                "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                "recording_mbid": None,
+                "score": 1
+            },
+            {
+                "recording_msid": "222eb00d-9ead-42de-aec9-8f8c1509413d",
+                "recording_mbid": None,
+                "score": -1
+            },
+            {
+                "recording_msid": None,
+                "recording_mbid": "9541592c-0102-4b94-93cc-ee0f3cf83d64",
+                "score": 1
+            },
+            {
+                "recording_msid": "9d008211-c920-4ff7-a17f-b86e4246c58c",
+                "recording_mbid": "e7ebbb99-7346-4323-9541-dffae9e1003b",
+                "score": -1
+            }
+        ]
+        user_timeline_event = [
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Sunflower",
+                    "artist_name": "Swae Lee & Post Malone",
+                    "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f"
+                }
+            },
+            {
+                "event_type": "personal_recording_recommendation",
+                "metadata": {
+                    "track_name": "Sunflower",
+                    "artist_name": "Swae Lee & Post Malone",
+                    "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                    "users": [1, 4],
+                    "blurb_content": "Amazing recording!"
+                }
+            },
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Batman",
+                    "artist_name": "Danny Elfman",
+                    "recording_msid": "667e797d-75ee-42d5-bdcd-b669f5d70531",
+                    "recording_mbid": None
+                }
+            },
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Portishead",
+                    "artist_name": "Strangers",
+                    "recording_msid": "e8c5f386-2966-4a84-b481-0de2f69ce5c1"
+                }
+            },
+            {
+                "event_type": "personal_recording_recommendation",
+                "metadata": {
+                    "track_name": "Strangers",
+                    "artist_name": "Portishead",
+                    "recording_msid": "e8c5f386-2966-4a84-b481-0de2f69ce5c1",
+                    "recording_mbid": None
+                }
+            },
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Wolfs",
+                    "artist_name": "Selena Gomez",
+                    "recording_msid": "e698826a-dcb0-4162-9418-f2d959a420e2",
+                    "recording_mbid": "cf4bfb24-1258-4246-9e9f-39c2f216b116"
+                }
+            }
+        ]
+        mapping_query = """
+            INSERT INTO mbid_mapping (recording_msid, recording_mbid, match_type)
+                 VALUES (:recording_msid, :recording_mbid, :match_type)
+        """
+        with timescale.engine.begin() as conn:
+            for item in mapping:
+                conn.execute(text(mapping_query), {
+                    "recording_msid": item["recording_msid"],
+                    "recording_mbid": item["recording_mbid"],
+                    "match_type": "exact_match" if item["recording_mbid"] else "no_match"
+                })
+
+        pin_rec_query = """
+            INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until)
+                 VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until)
+        """
+        feedback_query = """
+            INSERT INTO recording_feedback (user_id, recording_msid, recording_mbid, score)
+                 VALUES (:user_id, :recording_msid, :recording_mbid, :score)
+        """
+        timeline_query = """
+            INSERT INTO user_timeline_event (user_id, event_type, metadata)
+                 VALUES (:user_id, :event_type, :metadata)
+        """
+        with db.engine.begin() as conn:
+            for item in pinned_recs:
+                conn.execute(text(pin_rec_query), {"user_id": self.user["id"], "pinned_until": datetime.now(), **item})
+
+            for item in recording_feedback:
+                conn.execute(text(feedback_query), {"user_id": self.user["id"], **item})
+
+            for item in user_timeline_event:
+                conn.execute(text(timeline_query), {
+                    "user_id": self.user["id"],
+                    "event_type": item["event_type"],
+                    "metadata": json.dumps(item["metadata"])
+                })
+
+    def test_msid_updater(self):
+        self.create_dummy_data()
+        update_msids_from_mapping.run_all_updates()
+
+        expected_feedback = [
+            {
+                "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31",
+                "score": 1
+            },
+            {
+                "recording_msid": "222eb00d-9ead-42de-aec9-8f8c1509413d",
+                "recording_mbid": None,
+                "score": -1
+            },
+            {
+                "recording_msid": None,
+                "recording_mbid": "9541592c-0102-4b94-93cc-ee0f3cf83d64",
+                "score": 1
+            },
+            {
+                "recording_msid": "9d008211-c920-4ff7-a17f-b86e4246c58c",
+                "recording_mbid": "e7ebbb99-7346-4323-9541-dffae9e1003b",
+                "score": -1
+            }
+        ]
+        expected_pinned_recs = [
+            {
+                "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31",
+                "blurb_content": "Amazing first recording",
+            },
+            {
+                "recording_msid": "667e797d-75ee-42d5-bdcd-b669f5d70531",
+                "recording_mbid": "e9a37376-5e13-4353-989b-acc2f9fbc5b8",
+                "blurb_content": "Wonderful second recording",
+            },
+            {
+                "recording_msid": "e8c5f386-2966-4a84-b481-0de2f69ce5c1",
+                "recording_mbid": None,
+                "blurb_content": "Incredible third recording",
+            },
+            {
+                "recording_msid": None,
+                "recording_mbid": "cf4bfb24-1258-4246-9e9f-39c2f216b116",
+                "blurb_content": "Great fourth recording",
+            }
+        ]
+        expected_timeline_event = [
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Sunflower",
+                    "artist_name": "Swae Lee & Post Malone",
+                    "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                    "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31"
+                }
+            },
+            {
+                "event_type": "personal_recording_recommendation",
+                "metadata": {
+                    "track_name": "Sunflower",
+                    "artist_name": "Swae Lee & Post Malone",
+                    "recording_msid": "d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
+                    "users": [1, 4],
+                    "blurb_content": "Amazing recording!",
+                    "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31"
+                }
+            },
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Batman",
+                    "artist_name": "Danny Elfman",
+                    "recording_msid": "667e797d-75ee-42d5-bdcd-b669f5d70531",
+                    "recording_mbid": "e9a37376-5e13-4353-989b-acc2f9fbc5b8"
+                }
+            },
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Portishead",
+                    "artist_name": "Strangers",
+                    "recording_msid": "e8c5f386-2966-4a84-b481-0de2f69ce5c1"
+                }
+            },
+            {
+                "event_type": "personal_recording_recommendation",
+                "metadata": {
+                    "track_name": "Strangers",
+                    "artist_name": "Portishead",
+                    "recording_msid": "e8c5f386-2966-4a84-b481-0de2f69ce5c1",
+                    "recording_mbid": None
+                }
+            },
+            {
+                "event_type": "recording_recommendation",
+                "metadata": {
+                    "track_name": "Wolfs",
+                    "artist_name": "Selena Gomez",
+                    "recording_msid": "e698826a-dcb0-4162-9418-f2d959a420e2",
+                    "recording_mbid": "cf4bfb24-1258-4246-9e9f-39c2f216b116"
+                }
+            }
+        ]
+
+        self.maxDiff = None
+
+        with db.engine.connect() as conn:
+            result = conn.execute(text("SELECT recording_msid::text, recording_mbid::text, score FROM recording_feedback"))
+            self.assertCountEqual(result.mappings().all(), expected_feedback)
+
+            result = conn.execute(text("SELECT recording_msid::text, recording_mbid::text, blurb_content FROM pinned_recording"))
+            self.assertCountEqual(result.mappings().all(), expected_pinned_recs)
+
+            result = conn.execute(text("SELECT event_type, metadata FROM user_timeline_event"))
+            self.assertCountEqual(result.mappings().all(), expected_timeline_event)

--- a/listenbrainz/messybrainz/update_msids_from_mapping.py
+++ b/listenbrainz/messybrainz/update_msids_from_mapping.py
@@ -1,0 +1,138 @@
+import abc
+import uuid
+
+from flask import current_app
+from psycopg2.extras import execute_values
+from sqlalchemy import text
+
+from listenbrainz import db
+from listenbrainz.db import timescale
+
+
+class BaseMsidMappingUpdater(abc.ABC):
+    """ Base class for msid mapping updater """
+
+    def __init__(self, table: str):
+        """
+            Args:
+                table: name of the table to update
+        """
+        self.table = table
+
+    def fetch_msids_query(self) -> str:
+        """ Query to fetch msids from the update table. The query should return only 1 column and
+         the column should be named recording_msid. """
+        pass
+
+    def update_msids_query(self):
+        """ Query to update msids with corresponding mapped mbids. The query should accept the mapping as
+         VALUES (recording_msid, recording_mbid) object.
+        """
+        pass
+
+    def fetch_msids(self) -> list[uuid.UUID]:
+        """ Fetch msids from the table to update. """
+        query = self.fetch_msids_query()
+        with db.engine.connect() as conn:
+            result = conn.execute(text(query)).fetchall()
+            return [row.recording_msid for row in result]
+
+    def lookup_mbids_for_msids(self, msids: list[uuid.UUID]) -> dict[uuid.UUID, uuid.UUID]:
+        """ Lookup mapped mbids for given msids """
+        query = """
+            SELECT recording_msid
+                 , recording_mbid
+              FROM mbid_mapping
+              JOIN (VALUES %s) AS t(recording_msid)
+             USING (recording_msid)
+             WHERE recording_mbid IS NOT NULL
+        """
+        conn = timescale.engine.raw_connection()
+        try:
+            with conn.cursor() as curs:
+                execute_values(curs, query, [(msid,) for msid in msids], page_size=len(msids))
+                return {row[0]: row[1] for row in curs.fetchall()}
+        finally:
+            conn.close()
+
+    def update_msids(self, mapping: dict[uuid.UUID, uuid.UUID]):
+        """ Update msids with mapped mbids in the specified table. """
+        query = self.update_msids_query()
+        conn = db.engine.raw_connection()
+        try:
+            with conn.cursor() as curs:
+                execute_values(curs, query, mapping.items())
+            conn.commit()
+        finally:
+            conn.close()
+
+    def main(self):
+        """ Main function to run the main msid update process """
+        msids = self.fetch_msids()
+        msids_count = len(msids)
+        if msids_count == 0:
+            current_app.logger.info("No msids to lookup for %s", self.table)
+            return
+        current_app.logger.info("Looking up %d msids for %s", msids_count, self.table)
+
+        mapping = self.lookup_mbids_for_msids(msids)
+        mapping_count = len(mapping)
+        if mapping_count == 0:
+            current_app.logger.info("No mbids found for given msids")
+            return
+        current_app.logger.info("Found %d msids to update", mapping_count)
+
+        self.update_msids(mapping)
+
+
+class ColumnMsidMappingUpdater(BaseMsidMappingUpdater):
+    """ Updater for tables which have columns names recording msid and recording mbid """
+
+    def fetch_msids_query(self) -> str:
+        return f"SELECT DISTINCT recording_msid FROM {self.table} WHERE recording_mbid IS NULL"
+
+    def update_msids_query(self) -> str:
+        return f"""
+              WITH mapping(recording_msid, recording_mbid) AS (VALUES %s)
+            UPDATE {self.table} rf
+               SET recording_mbid = m.recording_mbid
+              FROM mapping m
+             WHERE rf.recording_msid = m.recording_msid
+        """
+
+
+class JSONBMsidMappingUpdater(BaseMsidMappingUpdater):
+    """ Updater for tables which have recording msid and recording mbid in a jsonb column """
+
+    def fetch_msids_query(self) -> str:
+        return f"""
+            SELECT (metadata->>'recording_msid')::UUID AS recording_msid
+              FROM user_timeline_event
+             WHERE (metadata->>'recording_mbid') IS NULL
+               AND (metadata->>'recording_msid') IS NOT NULL 
+        """
+
+    def update_msids_query(self) -> str:
+        return f"""
+              WITH mapping(recording_msid, recording_mbid) AS (VALUES %s)
+            UPDATE user_timeline_event ute
+               SET metadata = jsonb_set(metadata, '{{recording_mbid}}'::text[], to_jsonb(recording_mbid::text), true)
+              FROM mapping m
+             WHERE metadata->>'recording_msid' = m.recording_msid::text
+        """
+
+
+def run_all_updates():
+    """ Check all tables having msids to update those with mbids from the mapping table """
+    current_app.logger.info("Starting msid update process")
+
+    feedback = ColumnMsidMappingUpdater("recording_feedback")
+    feedback.main()
+
+    pinned_recording = ColumnMsidMappingUpdater("pinned_recording")
+    pinned_recording.main()
+
+    user_timeline_event = JSONBMsidMappingUpdater("user_timeline_event")
+    user_timeline_event.main()
+
+    current_app.logger.info("Completed msid update process")


### PR DESCRIPTION
When a listen has not been mapped and a user adds feedback to it, pins it or recommends it; the recording msid is used for it. Now if later the msid gets mapped, the recording mbid is not added with the msid in the original table. Add a job to regularly add mapped msids to msids in various tables.