### PR TITLE
Revert "Use artist_credit_id instead of artist mbids for artist credit filtering"

### DIFF
--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -14,14 +14,14 @@ RECORDINGS_PER_MESSAGE = 10000
 def build_sessioned_index(listen_table, metadata_table, session, max_contribution, threshold, limit, _filter):
     # TODO: Handle case of unmatched recordings breaking sessions!
     #  Detect and remove skips!
-    filter_artist_credit = "AND s1.artist_credit_id != s2.artist_credit_id" if _filter else ""
+    filter_artist_credit = "AND NOT arrays_overlap(s1.artist_mbids, s2.artist_mbids)" if _filter else ""
     return f"""
             WITH listens AS (
                  SELECT user_id
-                      , BIGINT(listened_at) AS listened_at
+                      , BIGINT(listened_at)
                       , CAST(COALESCE(recording_data.length / 1000, 180) AS BIGINT) AS duration
                       , recording_mbid
-                      , artist_credit_id
+                      , artist_mbids
                    FROM {listen_table} l
               LEFT JOIN {metadata_table} mbc
                   USING (recording_mbid)
@@ -31,7 +31,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
                      , listened_at
                      , listened_at - LAG(listened_at, 1) OVER w - LAG(duration, 1) OVER w AS difference
                      , recording_mbid
-                     , artist_credit_id
+                     , artist_mbids
                   FROM listens
                 WINDOW w AS (PARTITION BY user_id ORDER BY listened_at)
             ), sessions AS (
@@ -39,7 +39,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
                      -- spark doesn't support window aggregate functions with FILTER clause
                      , COUNT_IF(difference > {session}) OVER w AS session_id
                      , recording_mbid
-                     , artist_credit_id
+                     , artist_mbids
                   FROM ordered
                 WINDOW w AS (PARTITION BY user_id ORDER BY listened_at)
             ), user_grouped_mbids AS (


### PR DESCRIPTION
Use artist credit mbids for filtering because we want to filter artists if any of the artist on two tracks matches. For instance, consider two tracks having artist credit as `Daft Punk feat. Panda Bear` and `Daft Punk feat. Todd Edwards`, if we compare on artist_credit_id these won't be filtered because the feat. part differs. However, if filter on overlapping artist credit mbids then we can filter both.