### PR TITLE
Try detecting skips in similar recordings

### DIFF
--- a/listenbrainz/labs_api/labs/api/user_listen_sessions.py
+++ b/listenbrainz/labs_api/labs/api/user_listen_sessions.py
@@ -85,15 +85,29 @@ class UserListensSessionQuery(Query):
                      , recording_mbid
                   FROM listens
                 WINDOW w AS (ORDER BY listened_at)
-            ), sessions AS (
+            ), detect_skips AS (
                 SELECT listened_at
                      , duration
                      , difference
-                     , COUNT(*) FILTER ( WHERE difference > :threshold ) OVER (ORDER BY listened_at) AS session_id
+                     -- a 30s leeway to allow for difference in track length in MB and other services or any issue
+                     -- in timestamping
+                     , LEAD(difference, 1) OVER w < -30 AS skipped
                      , artist_name
                      , track_name
                      , recording_mbid
                   FROM ordered
+                WINDOW w AS (ORDER BY listened_at)
+            ), sessions AS (
+                SELECT listened_at
+                     , duration
+                     , difference
+                     , skipped
+                     , COUNT(*) FILTER ( WHERE difference > :threshold ) OVER w AS session_id
+                     , artist_name
+                     , track_name
+                     , recording_mbid
+                  FROM detect_skips
+                WINDOW w AS (ORDER BY listened_at)
             )
                 SELECT session_id
                      , jsonb_agg(
@@ -101,6 +115,7 @@ class UserListensSessionQuery(Query):
                                 'listened_at', to_char(to_timestamp(listened_at), 'YYYY-MM-DD HH24:MI:SS')
                               , 'duration', duration  
                               , 'difference', difference
+                              , 'skipped', skipped
                               , 'artist_name', artist_name
                               , 'track_name', track_name
                               , 'recording_mbid', recording_mbid
@@ -119,7 +134,8 @@ class UserListensSessionQuery(Query):
                 })
                 results.append({
                     "type": "dataset",
-                    "columns": ["listened_at", "duration", "difference", "artist_name", "track_name", "recording_mbid"],
+                    "columns": ["listened_at", "duration", "difference", "skipped",
+                                "artist_name", "track_name", "recording_mbid"],
                     "data": row["data"]
                 })
         return results

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -359,7 +359,8 @@ def request_similar_users(max_num_users):
                                         " the limit).", required=True)
 @click.option("--filter-artist-credit", type=bool, help="Whether to filter tracks by same artists in a listening"
                                                         " session", required=True)
-def request_similar_recordings(days, session, contribution, threshold, limit, filter_artist_credit):
+@click.option("--skip", type=int, help="the minimum difference threshold to mark track as skipped", required=True)
+def request_similar_recordings(days, session, contribution, threshold, limit, filter_artist_credit, skip):
     """ Send the cluster a request to generate similar recordings index. """
     send_request_to_spark_cluster(
         "similarity.recording",
@@ -368,7 +369,8 @@ def request_similar_recordings(days, session, contribution, threshold, limit, fi
         contribution=contribution,
         threshold=threshold,
         limit=limit,
-        filter_artist_credit=filter_artist_credit
+        filter_artist_credit=filter_artist_credit,
+        skip=skip
     )
 
 

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -137,7 +137,8 @@
       "contribution",
       "threshold",
       "limit",
-      "filter_artist_credit"
+      "filter_artist_credit",
+      "skip"
     ]
   },
   "year_in_music.similar_users": {

--- a/listenbrainz_spark/recording_similarity/recording.py
+++ b/listenbrainz_spark/recording_similarity/recording.py
@@ -9,17 +9,18 @@ from listenbrainz_spark.utils import get_listens_from_new_dump
 
 
 RECORDINGS_PER_MESSAGE = 10000
+# the duration value in seconds to use for track whose duration data in not available in MB
+DEFAULT_TRACK_LENGTH = 180
 
 
 def build_sessioned_index(listen_table, metadata_table, session, max_contribution, threshold, limit, _filter, skip_threshold):
     # TODO: Handle case of unmatched recordings breaking sessions!
-    #  Detect and remove skips!
     filter_artist_credit = "AND NOT arrays_overlap(s1.artist_mbids, s2.artist_mbids)" if _filter else ""
     return f"""
             WITH listens AS (
                  SELECT user_id
                       , BIGINT(listened_at)
-                      , CAST(COALESCE(recording_data.length / 1000, 180) AS BIGINT) AS duration
+                      , CAST(COALESCE(recording_data.length / 1000, {DEFAULT_TRACK_LENGTH}) AS BIGINT) AS duration
                       , recording_mbid
                       , artist_mbids
                    FROM {listen_table} l


### PR DESCRIPTION
If the difference value in the following row is negative, the current track had been skipped. The track length in MB and other music services can sometimes differ so allow for a configurable threshold for minimum value over which a song is considered to be skipped.