### PR TITLE
Add missing return in getAlbumArtFromListenMetadata

### DIFF
--- a/listenbrainz/webserver/static/js/src/utils/utils.tsx
+++ b/listenbrainz/webserver/static/js/src/utils/utils.tsx
@@ -548,8 +548,9 @@ const getAlbumArtFromListenMetadata = async (
   // to query CAA for user submitted mbids.
   const userSubmittedReleaseMBID =
     listen.track_metadata.additional_info?.release_mbid;
-  if (userSubmittedReleaseMBID)
-    getAlbumArtFromReleaseMBID(userSubmittedReleaseMBID);
+  if (userSubmittedReleaseMBID) {
+    return getAlbumArtFromReleaseMBID(userSubmittedReleaseMBID);
+  }
   // user submitted release mbids not found, check if there is a match from mbid mapper.
   const caaId = listen.track_metadata.mbid_mapping?.caa_id;
   const caaReleaseMbid = listen.track_metadata.mbid_mapping?.caa_release_mbid;


### PR DESCRIPTION
@aerozol reported in IRC that front end cover art seemed to be broken for him. Investigating, found a missing return due to which user submitted mbids were not being considered for cover art resolution.