### PR TITLE
Options missing from ListenCard options dropdown

### DIFF
--- a/listenbrainz/webserver/static/css/listens-page.less
+++ b/listenbrainz/webserver/static/css/listens-page.less
@@ -422,6 +422,12 @@
             background-color: #eb743b;
           }
         }
+        .un-active {
+          &:hover {
+            color: #ffffff;
+            background-color: lightgray;
+          }
+        }
       }
     }
     .recommendation-controls {

--- a/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
+++ b/listenbrainz/webserver/static/js/src/listens/ListenCard.tsx
@@ -419,62 +419,86 @@ export default class ListenCard extends React.Component<
                     className="dropdown-menu dropdown-menu-right"
                     aria-labelledby="listenControlsDropdown"
                   >
-                    {recordingMBID && (
-                      <ListenControl
-                        icon={faExternalLinkAlt}
-                        title="Open in MusicBrainz"
-                        text="Open in MusicBrainz"
-                        link={`https://musicbrainz.org/recording/${recordingMBID}`}
-                        anchorTagAttributes={{
-                          target: "_blank",
-                          rel: "noopener noreferrer",
-                        }}
-                      />
-                    )}
-                    {spotifyURL && (
-                      <ListenControl
-                        icon={faSpotify}
-                        title="Open in Spotify"
-                        text="Open in Spotify"
-                        link={spotifyURL}
-                        anchorTagAttributes={{
-                          target: "_blank",
-                          rel: "noopener noreferrer",
-                        }}
-                      />
-                    )}
-                    {youtubeURL && (
-                      <ListenControl
-                        icon={faYoutube}
-                        title="Open in YouTube"
-                        text="Open in YouTube"
-                        link={youtubeURL}
-                        anchorTagAttributes={{
-                          target: "_blank",
-                          rel: "noopener noreferrer",
-                        }}
-                      />
-                    )}
-                    {soundcloudURL && (
-                      <ListenControl
-                        icon={faSoundcloud}
-                        title="Open in Soundcloud"
-                        text="Open in Soundcloud"
-                        link={soundcloudURL}
-                        anchorTagAttributes={{
-                          target: "_blank",
-                          rel: "noopener noreferrer",
-                        }}
-                      />
-                    )}
-                    {enableRecommendButton && (
-                      <ListenControl
-                        icon={faCommentDots}
-                        title="Recommend to my followers"
-                        text="Recommend to my followers"
-                        action={this.recommendListenToFollowers}
-                      />
-                    )}
+                    <ListenControl
+                      icon={faExternalLinkAlt}
+                      title="Open in MusicBrainz"
+                      text="Open in MusicBrainz"
+                      buttonClassName={recordingMBID ? undefined : "un-active"}
+                      link={
+                        recordingMBID
+                          ? `https://musicbrainz.org/recording/${recordingMBID}`
+                          : undefined
+                      }
+                      anchorTagAttributes={
+                        recordingMBID
+                          ? {
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                            }
+                          : undefined
+                      }
+                    />
+
+                    <ListenControl
+                      icon={faSpotify}
+                      title="Open in Spotify"
+                      text="Open in Spotify"
+                      buttonClassName={spotifyURL ? undefined : "un-active"}
+                      link={spotifyURL || undefined}
+                      anchorTagAttributes={
+                        spotifyURL
+                          ? {
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                            }
+                          : undefined
+                      }
+                    />
+                    <ListenControl
+                      icon={faYoutube}
+                      title="Open in YouTube"
+                      text="Open in YouTube"
+                      buttonClassName={youtubeURL ? undefined : "un-active"}
+                      link={youtubeURL || undefined}
+                      anchorTagAttributes={
+                        youtubeURL
+                          ? {
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                            }
+                          : undefined
+                      }
+                    />
+
+                    <ListenControl
+                      icon={faSoundcloud}
+                      title="Open in Soundcloud"
+                      text="Open in Soundcloud"
+                      buttonClassName={soundcloudURL ? undefined : "un-active"}
+                      link={soundcloudURL || undefined}
+                      anchorTagAttributes={
+                        soundcloudURL
+                          ? {
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                            }
+                          : undefined
+                      }
+                    />
+
+                    <ListenControl
+                      icon={faCommentDots}
+                      title="Recommend to my followers"
+                      text="Recommend to my followers"
+                      buttonClassName={
+                        enableRecommendButton ? undefined : "un-active"
+                      }
+                      action={
+                        enableRecommendButton
+                          ? this.recommendListenToFollowers
+                          : undefined
+                      }
+                    />
                     {additionalMenuItems}
                   </ul>
                 </>

--- a/listenbrainz/webserver/static/js/src/pins/PinnedRecordingCard.tsx
+++ b/listenbrainz/webserver/static/js/src/pins/PinnedRecordingCard.tsx
@@ -159,15 +159,16 @@ export default class PinnedRecordingCard extends React.Component<
     ) : undefined;
 
     const additionalMenuItems = [];
-    if (currentlyPinned) {
-      additionalMenuItems.push(
-        <ListenControl
-          title="Unpin"
-          text="Unpin"
-          action={() => this.unpinRecording()}
-        />
-      );
-    }
+
+    additionalMenuItems.push(
+      <ListenControl
+        title="Unpin"
+        buttonClassName={currentlyPinned ? undefined : "un-active"}
+        text="Unpin"
+        action={currentlyPinned ? () => this.unpinRecording() : undefined}
+      />
+    );
+
     additionalMenuItems.push(
       <ListenControl
         title="Delete Pin"

--- a/listenbrainz/webserver/static/js/src/playlists/PlaylistItemCard.tsx
+++ b/listenbrainz/webserver/static/js/src/playlists/PlaylistItemCard.tsx
@@ -62,16 +62,16 @@ export default class PlaylistItemCard extends React.Component<
       </div>
     ) : undefined;
     let additionalMenuItems;
-    if (canEdit) {
-      additionalMenuItems = [
-        <ListenControl
-          title="Remove from playlist"
-          text="Remove from playlist"
-          icon={faMinusCircle}
-          action={this.removeTrack}
-        />,
-      ];
-    }
+
+    additionalMenuItems = [
+      <ListenControl
+        title="Remove from playlist"
+        buttonClassName={canEdit ? undefined : "un-active"}
+        text="Remove from playlist"
+        icon={faMinusCircle}
+        action={canEdit ? this.removeTrack : undefined}
+      />,
+    ];
     const listen = JSPFTrackToListen(track);
     return (
       <ListenCard

--- a/listenbrainz/webserver/static/js/src/recent/RecentListens.tsx
+++ b/listenbrainz/webserver/static/js/src/recent/RecentListens.tsx
@@ -236,32 +236,54 @@ export default class RecentListens extends React.Component<
                       dataTarget="#PinRecordingModal"
                     />,
                   ];
-                  if (isListenReviewable) {
-                    additionalMenuItems.push(
-                      <ListenControl
-                        text="Write a review"
-                        icon={faPencilAlt}
-                        action={this.updateRecordingToReview.bind(this, listen)}
-                        dataToggle="modal"
-                        dataTarget="#CBReviewModal"
-                      />
-                    );
-                  }
 
-                  if (isListenPersonallyRecommendable) {
-                    additionalMenuItems.push(
-                      <ListenControl
-                        text="Personally recommend"
-                        icon={faPaperPlane}
-                        action={this.updateRecordingToPersonallyRecommend.bind(
-                          this,
-                          listen
-                        )}
-                        dataToggle="modal"
-                        dataTarget="#PersonalRecommendationModal"
-                      />
-                    );
-                  }
+                  additionalMenuItems.push(
+                    <ListenControl
+                      text="Write a review"
+                      buttonClassName={
+                        isListenReviewable ? undefined : "un-active"
+                      }
+                      icon={faPencilAlt}
+                      action={
+                        isListenReviewable
+                          ? this.updateRecordingToReview.bind(this, listen)
+                          : undefined
+                      }
+                      dataToggle={isListenReviewable ? "modal" : undefined}
+                      dataTarget={
+                        isListenReviewable ? "#CBReviewModal" : undefined
+                      }
+                    />
+                  );
+
+                  additionalMenuItems.push(
+                    <ListenControl
+                      text="Personally recommend"
+                      buttonClassName={
+                        isListenPersonallyRecommendable
+                          ? undefined
+                          : "un-active"
+                      }
+                      icon={faPaperPlane}
+                      action={
+                        isListenPersonallyRecommendable
+                          ? this.updateRecordingToPersonallyRecommend.bind(
+                              this,
+                              listen
+                            )
+                          : undefined
+                      }
+                      dataToggle={
+                        isListenPersonallyRecommendable ? "modal" : undefined
+                      }
+                      dataTarget={
+                        isListenPersonallyRecommendable
+                          ? "#PersonalRecommendationModal"
+                          : undefined
+                      }
+                    />
+                  );
+
                   /* eslint-enable react/jsx-no-bind */
                   return (
                     <ListenCard

--- a/listenbrainz/webserver/static/js/src/user/Listens.tsx
+++ b/listenbrainz/webserver/static/js/src/user/Listens.tsx
@@ -710,48 +710,60 @@ export default class Listens extends React.Component<
 
     /* eslint-disable react/jsx-no-bind */
     const additionalMenuItems = [];
-    if (canPersonallyRecommend) {
-      additionalMenuItems.push(
-        <ListenControl
-          text="Personally recommend"
-          icon={faPaperPlane}
-          action={this.updateRecordingToPersonallyRecommend.bind(this, listen)}
-          dataToggle="modal"
-          dataTarget="#PersonalRecommendationModal"
-        />
-      );
-    }
-    if (canPin) {
-      additionalMenuItems.push(
-        <ListenControl
-          text="Pin this recording"
-          icon={faThumbtack}
-          action={this.updateRecordingToPin.bind(this, listen)}
-          dataToggle="modal"
-          dataTarget="#PinRecordingModal"
-        />
-      );
-    }
-    if (isListenReviewable) {
-      additionalMenuItems.push(
-        <ListenControl
-          text="Write a review"
-          icon={faPencilAlt}
-          action={this.updateRecordingToReview.bind(this, listen)}
-          dataToggle="modal"
-          dataTarget="#CBReviewModal"
-        />
-      );
-    }
-    if (canDelete) {
-      additionalMenuItems.push(
-        <ListenControl
-          text="Delete Listen"
-          icon={faTrashAlt}
-          action={this.deleteListen.bind(this, listen)}
-        />
-      );
-    }
+
+    additionalMenuItems.push(
+      <ListenControl
+        text="Personally recommend"
+        buttonClassName={canPersonallyRecommend ? undefined : "un-active"}
+        icon={faPaperPlane}
+        action={
+          canPersonallyRecommend
+            ? this.updateRecordingToPersonallyRecommend.bind(this, listen)
+            : undefined
+        }
+        dataToggle={canPersonallyRecommend ? "modal" : undefined}
+        dataTarget={
+          canPersonallyRecommend ? "#PersonalRecommendationModal" : undefined
+        }
+      />
+    );
+
+    additionalMenuItems.push(
+      <ListenControl
+        text="Pin this recording"
+        buttonClassName={canPin ? undefined : "un-active"}
+        icon={faThumbtack}
+        action={
+          canPin ? this.updateRecordingToPin.bind(this, listen) : undefined
+        }
+        dataToggle={canPin ? "modal" : undefined}
+        dataTarget={canPin ? "#PinRecordingModal" : undefined}
+      />
+    );
+
+    additionalMenuItems.push(
+      <ListenControl
+        text="Write a review"
+        buttonClassName={isListenReviewable ? undefined : "un-active"}
+        icon={faPencilAlt}
+        action={
+          isListenReviewable
+            ? this.updateRecordingToReview.bind(this, listen)
+            : undefined
+        }
+        dataToggle={isListenReviewable ? "modal" : undefined}
+        dataTarget={isListenReviewable ? "#CBReviewModal" : undefined}
+      />
+    );
+
+    additionalMenuItems.push(
+      <ListenControl
+        text="Delete Listen"
+        buttonClassName={canDelete ? undefined : "un-active"}
+        icon={faTrashAlt}
+        action={canDelete ? this.deleteListen.bind(this, listen) : undefined}
+      />
+    );
     const shouldBeDeleted = isEqual(deletedListen, listen);
     /* eslint-enable react/jsx-no-bind */
     return (


### PR DESCRIPTION


# Problem

We currently have some very inconsistent drop-down options depending on where/what kind of 'listen'/recording panel type is displayed.

It seems like these options should be the same across all of them:

Open in MusicBrainz
Recommend to my followers
Personally recommend
Pin this recording
Write a review

So we should have consistent options across all sections of the project.



# Solution

The probable solution can be to show all options in the dropdown menu and the make the options non accessible which do not perform the current actions and the user will be able to see which options are in working action and which are not for a particular recording :)


# Action

So I made the non accessible options in hovered gray color and the accessible options in already appointed orange color which resulted in consistent options across all sections of the webapp.


