### PR TITLE
LB-1111 : Cover art not shown on recommendation pages

### DIFF
--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -133,6 +133,24 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
         Args:
             mbids_and_ratings_list: Contains recording mbid and corresponding score.
 
+
+
+
+            if caa_id and caa_release_mbid are avialable then:
+
+                
+            Returns:
+                'track_metadata' : {
+                    'additional_info' : {
+                        'caa_id' : "demo caa id",
+                        'caa_release_mbid' : "demo caa rlease allbum mbid"
+                    }
+                }
+
+                That means to render cover art caa id to be present in metadata is compulsory otherwise it will render default image in frontend.
+
+
+
         Returns:
             recommendations: list of recommendations of the format
                 {
@@ -171,5 +189,12 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
                 }
             }
         })
+
+
+        if row["caa_id"] : 
+            recommendations.append['track_metadata']['additional_info']['caa_id'] = row['caa_id']
+
+        if row["caa_release_mbid"] : 
+            recommendations.append['track_metadata']['additional_info']['caa_release_mbid'] = row['caa_release_mbid']
 
     return recommendations

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -136,7 +136,7 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
 
 
 
-            if caa_id and caa_release_mbid or record_mbid are avialable then:
+            if caa_id and caa_release_mbid or release_mbid and record_mbid are avialable then:
 
                 
             Returns:
@@ -148,7 +148,7 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
                     }
                 }
 
-                That means to render cover art caa id to be present in metadata is compulsory otherwise it will render default image in frontend.
+                These changes are done because to show cover art of a particular listen its recording_mbid and then its release_mbid, caa_id , caa_release_mbid are needed in order to perform the frontend logic in utils.tsx and render it on frontend of the web app.
 
 
 

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -136,7 +136,7 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
 
 
 
-            if caa_id and caa_release_mbid or release_mbid and record_mbid are avialable then:
+            if caa_id and caa_release_mbid or release_mbid and recording_mbid are available then:
 
                 
             Returns:

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -188,15 +188,10 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
                     'recording_mbid': row['recording_mbid'],
                     'artist_mbids': row['artist_mbids'],
                     'release_mbid' : row['release_mbid'],
+                    'caa_id' : row['caa_id'],
+                    'caa_release_mbid' : row['caa_release_mbid']
                 }
             }
         })
-
-
-        if row["caa_id"] : 
-            recommendations.append['track_metadata']['additional_info']['caa_id'] = row['caa_id']
-
-        if row["caa_release_mbid"] : 
-            recommendations.append['track_metadata']['additional_info']['caa_release_mbid'] = row['caa_release_mbid']
 
     return recommendations

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -136,14 +136,15 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
 
 
 
-            if caa_id and caa_release_mbid are avialable then:
+            if caa_id and caa_release_mbid or record_mbid are avialable then:
 
                 
             Returns:
                 'track_metadata' : {
                     'additional_info' : {
                         'caa_id' : "demo caa id",
-                        'caa_release_mbid' : "demo caa release allbum mbid"
+                        'caa_release_mbid' : "demo caa release album mbid"
+                        'release_mbid' : "demo release mbid"
                     }
                 }
 
@@ -185,7 +186,8 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
                 'release_name': row['release'],
                 'additional_info': {
                     'recording_mbid': row['recording_mbid'],
-                    'artist_mbids': row['artist_mbids']
+                    'artist_mbids': row['artist_mbids'],
+                    'release_mbid' : row['release_mbid'],
                 }
             }
         })

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -148,8 +148,7 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
                     }
                 }
 
-                These changes are done because to show cover art of a particular listen its recording_mbid and then its release_mbid, caa_id , caa_release_mbid are needed in order to perform the frontend logic in utils.tsx and render it on frontend of the web app.
-
+              These fields are required to show cover art on the front-end web app.
 
 
         Returns:

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -143,7 +143,7 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
                 'track_metadata' : {
                     'additional_info' : {
                         'caa_id' : "demo caa id",
-                        'caa_release_mbid' : "demo caa rlease allbum mbid"
+                        'caa_release_mbid' : "demo caa release allbum mbid"
                     }
                 }
 

--- a/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
@@ -273,7 +273,9 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
                 "release": "Random Is Resistance",
                 "recording_mbid": "03f1b16a-af43-4cd7-b22c-d2991bf011a3",
                 "artist": "Rotersand",
-                "title": "One More Hour"
+                "title": "One More Hour",
+                "caa_id": 25414187159,
+                "caa_release_mbid": "c51e3d19-8080-4faa-9f5d-3e8714343543"
             },
             "2c8412f0-9353-48a2-aedb-1ad8dac9498f": {
                 "artist_mbids": ["63aa26c3-d59b-4da4-84ac-716b54f1ef4d"],
@@ -282,7 +284,9 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
                 "release_mbid": "27280632-fa33-3801-a5b1-081ed0b65bb3",
                 "release": "Year Zero",
                 "recording_mbid": "2c8412f0-9353-48a2-aedb-1ad8dac9498f",
-                "title": "Sun’s Coming Up"
+                "title": "Sun’s Coming Up",
+                "caa_id": 33734215643,
+                "caa_release_mbid": "169d9fb9-bc65-423b-9c44-2d177a329b48"
             }
         }
 
@@ -301,7 +305,10 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
                     'release_name': 'Random Is Resistance',
                     'additional_info': {
                         'recording_mbid': '03f1b16a-af43-4cd7-b22c-d2991bf011a3',
-                        'artist_mbids': ['63aa26c3-d59b-4da4-84ac-716b54f1ef4d']
+                        'artist_mbids': ['63aa26c3-d59b-4da4-84ac-716b54f1ef4d'],
+                        'release_mbid' : '5da4af04-d796-4d07-801d-a878e83dea48',
+                        'caa_id' : 25414187159,
+                        'caa_release_mbid' : 'c51e3d19-8080-4faa-9f5d-3e8714343543'
                     }
                 }
             },
@@ -313,7 +320,10 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
                     'release_name': 'Year Zero',
                     'additional_info': {
                             'recording_mbid': '2c8412f0-9353-48a2-aedb-1ad8dac9498f',
-                            'artist_mbids': ['63aa26c3-d59b-4da4-84ac-716b54f1ef4d']
+                            'artist_mbids': ['63aa26c3-d59b-4da4-84ac-716b54f1ef4d'],
+                            'release_mbid' : '27280632-fa33-3801-a5b1-081ed0b65bb3',
+                            'caa_id' : 33734215643,
+                            'caa_release_mbid' : '169d9fb9-bc65-423b-9c44-2d177a329b48'
                     }
                 }
             }


### PR DESCRIPTION

# Problem

  LB-1111 :  Cover art not shown on recommendation pages 
         
# Solution

The "caa_id" and  "caa_release_mbid" and "release_mbid" were missing from the recommendations metadata which was creating problem in rendering the covert art in frontend.


# Action

Added the "caa_id" and  "caa_release_mbid"  and "release_mbid" which resulted in generating the cover art image and rendering it in frontend and fixing the bug.

