### PR TITLE
Invalidate mbid_mapper matches for redirects and deleted recordings

### DIFF
--- a/listenbrainz/mbid_mapping/manage.py
+++ b/listenbrainz/mbid_mapping/manage.py
@@ -13,7 +13,8 @@ from mapping.utils import log, CRON_LOG_FILE
 from mapping.release_colors import sync_release_color_table, incremental_update_release_color_table
 from reports.tracks_of_the_year import calculate_tracks_of_the_year
 from reports.top_discoveries import calculate_top_discoveries
-from mapping.mb_metadata_cache import create_mb_metadata_cache, incremental_update_mb_metadata_cache
+from mapping.mb_metadata_cache import create_mb_metadata_cache, incremental_update_mb_metadata_cache, \
+    cleanup_mbid_mapping_table
 from mapping.spotify_metadata_index import create_spotify_metadata_index
 
 
@@ -124,8 +125,12 @@ def update_mb_metadata_cache(use_lb_conn):
 
 @cli.command()
 def cron_build_mb_metadata_cache():
+    """ Build the mb metadata cache and tables it depends on in production in appropriate databases.
+     After building the cache, cleanup mbid_mapping table.
+    """
     create_canonical_musicbrainz_data(False)
     create_mb_metadata_cache(True)
+    cleanup_mbid_mapping_table()
 
 
 @cli.command()

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -786,8 +786,9 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
 
 
 def cleanup_mbid_mapping_table():
-    """ Find msids which are mapped to mbids that are now absent from mb_metadata_cache because
-     those have been merged (redirects) or deleted from MB. """
+    """ Find msids which are mapped to mbids that are now absent from mb_metadata_cache
+     because those have been merged (redirects) or deleted from MB and flag such msids
+     to be re-mapped by the mbid mapping writer."""
     query = """
         UPDATE mbid_mapping mm
            SET last_updated = 'epoch'

--- a/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/listenbrainz/mbid_mapping/mapping/mb_metadata_cache.py
@@ -783,3 +783,21 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
         update_metadata_cache_timestamp(lb_conn or mb_conn, new_timestamp)
 
         log("mb metadata cache: incremental update completed")
+
+
+def cleanup_mbid_mapping_table():
+    """ Find msids which are mapped to mbids that are now absent from mb_metadata_cache because
+     those have been merged (redirects) or deleted from MB. """
+    query = """
+        UPDATE mbid_mapping mm
+           SET last_updated = 'epoch'
+         WHERE NOT EXISTS(
+                SELECT 1
+                  FROM mapping.mb_metadata_cache mbc
+                 WHERE mbc.recording_mbid = mm.recording_mbid 
+         )
+    """
+    with psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI) as lb_conn, lb_conn.cursor() as lb_curs:
+        lb_curs.execute(query)
+        log(f"mbid mapping: invalidated {lb_curs.row_count} rows")
+        lb_conn.commit()


### PR DESCRIPTION
Currently, the mbid_mapper does not do anything to detect and fix whether the mbid to which some msid may have been mapped has been merged or deleted in MusicBrainz. Every month we rebuild the mapping.mb_metadata_cache table afresh. Therefore, redirected and deleted mbids are missing from the table. In such cases, even though the msid is mapped it will appear as unmapped.

However, this is a good opportunity to fix the issue in the mapper itself. After the mb_metadata_cache has been built, check which mbids are present in mbid_mapping table but absent from mb_metadata_cache table and invalidate those rows so that those are rechecked by the mapper.
