### PR TITLE
Improve cover art coverage using release group cover art as a fallback

### DIFF
--- a/frontend/js/src/fresh-releases/FreshReleases.tsx
+++ b/frontend/js/src/fresh-releases/FreshReleases.tsx
@@ -166,8 +166,8 @@ export default function FreshReleases({ newAlert }: FreshReleasesProps) {
                     artistCreditName={release.artist_credit_name}
                     artistMBIDs={release.artist_mbids}
                     confidence={release.confidence}
-                    caaId={release.caa_id}
-                    caaReleaseMbid={release.caa_release_mbid}
+                    caaID={release.caa_id}
+                    caaReleaseMBID={release.caa_release_mbid}
                   />
                 );
               })}

--- a/frontend/js/src/fresh-releases/FreshReleases.tsx
+++ b/frontend/js/src/fresh-releases/FreshReleases.tsx
@@ -166,6 +166,8 @@ export default function FreshReleases({ newAlert }: FreshReleasesProps) {
                     artistCreditName={release.artist_credit_name}
                     artistMBIDs={release.artist_mbids}
                     confidence={release.confidence}
+                    caaId={release.caa_id}
+                    caaReleaseMbid={release.caa_release_mbid}
                   />
                 );
               })}

--- a/frontend/js/src/fresh-releases/ReleaseCard.tsx
+++ b/frontend/js/src/fresh-releases/ReleaseCard.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { LazyLoadImage } from "react-lazy-load-image-component";
 import { formatReleaseDate } from "./utils";
-import { generateAlbumArtThumbnailLink } from "../utils/utils";
+import {
+  generateAlbumArtThumbnailLink,
+  getAlbumArtFromReleaseMBID,
+} from "../utils/utils";
 
 type ReleaseCardProps = {
   releaseDate: string;
@@ -12,8 +15,8 @@ type ReleaseCardProps = {
   releaseTypePrimary: string | undefined | null;
   releaseTypeSecondary: string | undefined | null;
   confidence?: number | null;
-  caaId: number | null;
-  caaReleaseMbid: string | null;
+  caaID: number | null;
+  caaReleaseMBID: string | null;
 };
 
 export default function ReleaseCard(props: ReleaseCardProps) {
@@ -26,8 +29,8 @@ export default function ReleaseCard(props: ReleaseCardProps) {
     releaseTypePrimary,
     releaseTypeSecondary,
     confidence,
-    caaId,
-    caaReleaseMbid,
+    caaID,
+    caaReleaseMBID,
   } = props;
 
   const COVERART_PLACEHOLDER = "/static/img/cover-art-placeholder.jpg";
@@ -61,13 +64,23 @@ export default function ReleaseCard(props: ReleaseCardProps) {
 
     return `${releaseTypePrimary} + ${releaseTypeSecondary}`;
   }
+  React.useEffect(() => {}, [releaseMBID, setCoverartSrc]);
 
   React.useEffect(() => {
-    if (caaId && caaReleaseMbid) {
-      const coverartURL = generateAlbumArtThumbnailLink(caaId, caaReleaseMbid);
-      setCoverartSrc(coverartURL);
+    async function getCoverArt() {
+      const coverartURL = await getAlbumArtFromReleaseMBID(releaseMBID);
+      if (coverartURL) {
+        setCoverartSrc(coverartURL);
+      }
     }
-  }, [caaId, caaReleaseMbid, setCoverartSrc]);
+
+    if (caaID && caaReleaseMBID) {
+      const coverartURL = generateAlbumArtThumbnailLink(caaID, caaReleaseMBID);
+      setCoverartSrc(coverartURL);
+    } else {
+      getCoverArt();
+    }
+  }, [releaseMBID, caaID, caaReleaseMBID, setCoverartSrc]);
 
   return (
     <div className="release-card-container">

--- a/frontend/js/src/fresh-releases/ReleaseCard.tsx
+++ b/frontend/js/src/fresh-releases/ReleaseCard.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { LazyLoadImage } from "react-lazy-load-image-component";
-import { getAlbumArtFromReleaseMBID } from "../utils/utils";
 import { formatReleaseDate } from "./utils";
+import { generateAlbumArtThumbnailLink } from "../utils/utils";
 
 type ReleaseCardProps = {
   releaseDate: string;
@@ -12,6 +12,8 @@ type ReleaseCardProps = {
   releaseTypePrimary: string | undefined | null;
   releaseTypeSecondary: string | undefined | null;
   confidence?: number | null;
+  caaId: number | null;
+  caaReleaseMbid: string | null;
 };
 
 export default function ReleaseCard(props: ReleaseCardProps) {
@@ -24,6 +26,8 @@ export default function ReleaseCard(props: ReleaseCardProps) {
     releaseTypePrimary,
     releaseTypeSecondary,
     confidence,
+    caaId,
+    caaReleaseMbid,
   } = props;
 
   const COVERART_PLACEHOLDER = "/static/img/cover-art-placeholder.jpg";
@@ -59,14 +63,11 @@ export default function ReleaseCard(props: ReleaseCardProps) {
   }
 
   React.useEffect(() => {
-    async function getCoverArt() {
-      const coverartURL = await getAlbumArtFromReleaseMBID(releaseMBID);
-      if (coverartURL) {
-        setCoverartSrc(coverartURL);
-      }
+    if (caaId && caaReleaseMbid) {
+      const coverartURL = generateAlbumArtThumbnailLink(caaId, caaReleaseMbid);
+      setCoverartSrc(coverartURL);
     }
-    getCoverArt();
-  }, [releaseMBID, setCoverartSrc]);
+  }, [caaId, caaReleaseMbid, setCoverartSrc]);
 
   return (
     <div className="release-card-container">

--- a/frontend/js/src/fresh-releases/ReleaseFilters.tsx
+++ b/frontend/js/src/fresh-releases/ReleaseFilters.tsx
@@ -33,7 +33,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
   React.useEffect(() => {
     // if no filter is chosen, display all releases
     if (checkedList.length === 0) {
-      if (coverartOnly === false) {
+      if (!coverartOnly) {
         setFilteredList(releases);
       } else {
         setFilteredList(releases.filter((item) => item.caa_id !== null));

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -651,6 +651,7 @@ type FreshReleaseItem = {
   artist_credit_name: string;
   artist_mbids: Array<string>;
   caa_id: number | null;
+  caa_release_mbid: string | null;
   confidence?: number;
   release_date: string;
   release_group_mbid: string;

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -753,4 +753,5 @@ export {
   getAlbumArtFromListenMetadata,
   getAverageRGBOfImage,
   getAdditionalContent,
+  generateAlbumArtThumbnailLink,
 };

--- a/frontend/js/tests/__mocks__/freshReleasesSitewideData.json
+++ b/frontend/js/tests/__mocks__/freshReleasesSitewideData.json
@@ -1,16 +1,16 @@
 [
     {
-        "artist_credit_name": "\u3092\u3068\u306f",
+        "artist_credit_name": "をとは",
         "artist_mbids": [
             "404670b2-bb19-4be8-862b-fe465a6e2a79"
         ],
         "caa_id": 34021497287,
-        "caa_release_mbid": "09786531-f473-4fa2-a64d-788a647ea21c",
         "release_date": "2022-11-06",
         "release_group_mbid": "24225190-eb36-4972-9907-9b22e1d19d99",
         "release_group_primary_type": "EP",
         "release_mbid": "09786531-f473-4fa2-a64d-788a647ea21c",
-        "release_name": "\u3081\u3044\u3069\u306e\u307f\u3084\u3052"
+        "release_name": "めいどのみやげ",
+        "caa_release_mbid": "09786531-f473-4fa2-a64d-788a647ea21c"
     },
     {
         "artist_credit_name": "Achint & Mikey McCleary",
@@ -19,13 +19,13 @@
             "ddf71a40-5148-4b8d-83d5-4f2fda23f431"
         ],
         "caa_id": 34026663688,
-        "caa_release_mbid": "689653af-46c0-4d11-90d2-adf1dda36915",
         "release_date": "2022-11-06",
         "release_group_mbid": "c7df49b8-510d-4634-8d06-644afad617fa",
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "689653af-46c0-4d11-90d2-adf1dda36915",
-        "release_name": "Monica, O My Darling (Music from the Netflix Film)"
+        "release_name": "Monica, O My Darling (Music from the Netflix Film)",
+        "caa_release_mbid": "689653af-46c0-4d11-90d2-adf1dda36915"
     },
     {
         "artist_credit_name": "Adeline Yeo (HP)",
@@ -33,13 +33,13 @@
             "baca10cc-e249-4969-a27f-6503955ae7b5"
         ],
         "caa_id": 33137471417,
-        "caa_release_mbid": "440e2fcd-9bbd-4f8a-aeb1-bf658d98ed21",
         "release_date": "2022-11-06",
         "release_group_mbid": "8add4348-8618-4b97-9316-1d356454c953",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "440e2fcd-9bbd-4f8a-aeb1-bf658d98ed21",
-        "release_name": "Helicopter Gun Fighter"
+        "release_name": "Helicopter Gun Fighter",
+        "caa_release_mbid": "440e2fcd-9bbd-4f8a-aeb1-bf658d98ed21"
     },
     {
         "artist_credit_name": "Areal Kollen",
@@ -47,12 +47,12 @@
             "6aedd326-5af9-4ed0-aa73-9f0e6edc9de4"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "b19c3601-20fd-43ee-8caa-cad25ba0eee3",
         "release_group_primary_type": "Single",
         "release_mbid": "b7806d72-9bed-4c0f-ab89-b0490e6f21f0",
-        "release_name": "Black Hawk Down 2"
+        "release_name": "Black Hawk Down 2",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Beats by Mr. Jay",
@@ -60,13 +60,13 @@
             "69b2f79f-e19d-4c44-9a2e-725581ec30e9"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "8610a240-e352-4309-8cc5-f6301854d3f0",
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Demo",
         "release_mbid": "4ceda762-8cb1-48d3-a28b-7b7c2720efb8",
-        "release_name": "100"
+        "release_name": "100",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Cold Frequenz",
@@ -74,12 +74,12 @@
             "0559dcba-2d64-43cb-8c33-fb13af1cd014"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "0b4b4fe8-2b30-49cb-bc59-527a02f34b6e",
         "release_group_primary_type": "Album",
         "release_mbid": "b599ad48-0368-4d09-b4c9-89c0dd292ba1",
-        "release_name": "Programmed for Violence"
+        "release_name": "Programmed for Violence",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Electric Yawn",
@@ -87,12 +87,12 @@
             "a03a9d90-0d4f-4f92-bd99-6d4640e04bb0"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "78709a06-f0a6-49c6-a87f-740fc22a900b",
         "release_group_primary_type": "Album",
         "release_mbid": "3f59468b-906c-489e-97f2-c24b09b1a471",
-        "release_name": "YTINASNiNSIGHT"
+        "release_name": "YTINASNiNSIGHT",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Ella Es Tan Cargosa & Lula Bertoldi",
@@ -101,12 +101,12 @@
             "8bbee743-ce59-4411-ae3f-fe2bbc9acc17"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "883710cc-62b3-4185-a340-33e6e2c78d75",
         "release_group_primary_type": "Single",
         "release_mbid": "a1609858-ae14-489c-b585-d4a616aaab6d",
-        "release_name": "Fui"
+        "release_name": "Fui",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Horned Garden's Princess",
@@ -114,12 +114,12 @@
             "067e7dc3-b528-4d1b-97f3-58f199ea9e18"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "88971593-e86a-4ee8-80cf-635192f02536",
         "release_group_primary_type": "EP",
         "release_mbid": "a662577f-32ec-4719-803c-f71be29c8efc",
-        "release_name": "\u0428\u0430\u0443\u0440\u043c\u0430 \u0441 \u043e\u043b\u0435\u043d\u0438\u043d\u043e\u0439 06.11.22"
+        "release_name": "Шаурма с олениной 06.11.22",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Kadeshiaa",
@@ -127,25 +127,25 @@
             "f2ab90bd-1bc1-4394-a2af-7f977fe44dc1"
         ],
         "caa_id": 34035418719,
-        "caa_release_mbid": "e3e9bbb4-d0d3-409f-b0c7-3efbaf196935",
         "release_date": "2022-11-06",
         "release_group_mbid": "3a30b85b-589f-46e1-89c9-2ae3a0fd367c",
         "release_group_primary_type": "Album",
         "release_mbid": "e3e9bbb4-d0d3-409f-b0c7-3efbaf196935",
-        "release_name": "SUCCESS STREET (PART ONE)"
+        "release_name": "SUCCESS STREET (PART ONE)",
+        "caa_release_mbid": "e3e9bbb4-d0d3-409f-b0c7-3efbaf196935"
     },
     {
-        "artist_credit_name": "milky\u2731heart",
+        "artist_credit_name": "milky✱heart",
         "artist_mbids": [
             "c2c87d64-aded-4810-9cd5-bda0aba6d554"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "e5781dd8-54f3-4300-9235-5670882188a6",
         "release_group_primary_type": "EP",
         "release_mbid": "df0f802d-be83-4c32-ad3f-2fae0342fcfd",
-        "release_name": "\u2731 bang! EP \u2731"
+        "release_name": "✱ bang! EP ✱",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "mulpHia",
@@ -153,12 +153,12 @@
             "6594f523-9ae5-40ba-95ed-3598d7ffd9cc"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "7e1eb593-85ed-4627-9e2a-8e649b56b9af",
         "release_group_primary_type": "Album",
         "release_mbid": "9b99de65-dac8-4f86-ab5a-d02ad67af002",
-        "release_name": "NOKTURNO 3"
+        "release_name": "NOKTURNO 3",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Proteus",
@@ -166,12 +166,12 @@
             "f3b73f46-9009-4ec7-aae1-bdcb3ced1683"
         ],
         "caa_id": 33997684680,
-        "caa_release_mbid": "c945bda3-39f2-4a4a-910a-be4823865c08",
         "release_date": "2022-11-06",
         "release_group_mbid": "7138e035-550f-4dc1-9488-0585ef15b313",
         "release_group_primary_type": "Album",
         "release_mbid": "c945bda3-39f2-4a4a-910a-be4823865c08",
-        "release_name": "Prometheia I: Arrival"
+        "release_name": "Prometheia I: Arrival",
+        "caa_release_mbid": "c945bda3-39f2-4a4a-910a-be4823865c08"
     },
     {
         "artist_credit_name": "ReddyBeats",
@@ -179,12 +179,12 @@
             "af29ba0a-af76-4566-8603-bb468846b1b1"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "0272a162-f51c-466f-bd22-87e5d9210050",
         "release_group_primary_type": "Album",
         "release_mbid": "86c4bab9-4380-4ceb-8a80-173042d53c78",
-        "release_name": "Raleigh BLVD"
+        "release_name": "Raleigh BLVD",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Silvxrsurfxr",
@@ -192,12 +192,12 @@
             "660ed857-58a9-4164-9e8f-7a47717d7b4f"
         ],
         "caa_id": 34022478351,
-        "caa_release_mbid": "362b842c-8ddd-4a98-9470-03eaa7ba152b",
         "release_date": "2022-11-06",
         "release_group_mbid": "57f20f31-1bbd-47e5-90bf-b82253dceb30",
         "release_group_primary_type": "EP",
         "release_mbid": "362b842c-8ddd-4a98-9470-03eaa7ba152b",
-        "release_name": "WAVES"
+        "release_name": "WAVES",
+        "caa_release_mbid": "362b842c-8ddd-4a98-9470-03eaa7ba152b"
     },
     {
         "artist_credit_name": "Various Artists",
@@ -205,16 +205,16 @@
             "89ad4ac3-39f7-470e-963a-56509c546377"
         ],
         "caa_id": null,
-        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "b3123aeb-d7df-4450-9072-19def57fca0f",
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Live",
         "release_mbid": "3b710095-6d39-4482-a644-8d66a4c5aa8e",
-        "release_name": "\u6211\u4eec\u7684\u6b4c\u7b2c\u56db\u5b63 \u7b2c7\u671f"
+        "release_name": "我们的歌第四季 第7期",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u7d50\u675f\u30d0\u30f3\u30c9",
+        "artist_credit_name": "結束バンド",
         "artist_mbids": [
             "c1b0fe0a-779d-43ed-b193-4370f0d0f88f"
         ],
@@ -223,11 +223,11 @@
         "release_group_mbid": "40afb369-8230-494f-8507-def48bc53f22",
         "release_group_primary_type": "Single",
         "release_mbid": "d23933d6-b48b-4e05-b8ac-e08fdf8fcc9a",
-        "release_name": "\u30ae\u30bf\u30fc\u3068\u5b64\u72ec\u3068\u84bc\u3044\u60d1\u661f",
+        "release_name": "ギターと孤独と蒼い惑星",
         "caa_release_mbid": "d23933d6-b48b-4e05-b8ac-e08fdf8fcc9a"
     },
     {
-        "artist_credit_name": "\ud835\udd07\ud835\udd0d 6YR\u0c25\u0c4d\u200c\u0663\u0663A \u0417\u0410\u041e",
+        "artist_credit_name": "𝔇𝔍 6YRథ్‌٣٣A ЗАО",
         "artist_mbids": [
             "a7e0d7da-579d-42b6-aea0-306eb0847784"
         ],
@@ -374,7 +374,7 @@
         "caa_release_mbid": "f262cc16-ca2e-4f59-af11-001eb013f65f"
     },
     {
-        "artist_credit_name": "Imogen Heap & Dan O\u2019Neill",
+        "artist_credit_name": "Imogen Heap & Dan O’Neill",
         "artist_mbids": [
             "328d146c-79f1-4eb6-9e40-8ee5710c14e5",
             "c564e953-b4ce-4bfb-9c71-96d8339eaf48"
@@ -532,7 +532,7 @@
         "release_group_mbid": "d90428a3-78e2-44f5-89aa-61d286149d40",
         "release_group_primary_type": "Single",
         "release_mbid": "c5913d14-0ede-4f13-81fc-be3d07df143e",
-        "release_name": "Agon\u00eda",
+        "release_name": "Agonía",
         "caa_release_mbid": "c5913d14-0ede-4f13-81fc-be3d07df143e"
     },
     {
@@ -600,7 +600,7 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Remix",
         "release_mbid": "75334caf-6088-43bf-b95a-a2c2fe0f0c03",
-        "release_name": "Anti\u2010Hero",
+        "release_name": "Anti‐Hero",
         "caa_release_mbid": "75334caf-6088-43bf-b95a-a2c2fe0f0c03"
     },
     {
@@ -654,11 +654,11 @@
         "release_group_mbid": "920c155f-59c5-4f87-a066-8f4de05c3d81",
         "release_group_primary_type": "Single",
         "release_mbid": "8cc37395-52d9-4f73-a369-855339977fd0",
-        "release_name": "All \u2019Bout All",
+        "release_name": "All ’Bout All",
         "caa_release_mbid": "8cc37395-52d9-4f73-a369-855339977fd0"
     },
     {
-        "artist_credit_name": "Aleksi Per\u00e4l\u00e4",
+        "artist_credit_name": "Aleksi Perälä",
         "artist_mbids": [
             "a913c0de-d77e-424e-9ba5-c8872793512b"
         ],
@@ -706,7 +706,7 @@
         "release_group_mbid": "d6c47b3b-c2ca-4dfa-a237-96ca8eb312e3",
         "release_group_primary_type": "Single",
         "release_mbid": "38545fef-c13c-4b41-af2d-76f1c7e829fc",
-        "release_name": "\u2622\ufe0fNukaBass\u2622\ufe0f",
+        "release_name": "☢️NukaBass☢️",
         "caa_release_mbid": null
     },
     {
@@ -750,7 +750,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "En Paz Me Acostar\u00e9",
+        "artist_credit_name": "En Paz Me Acostaré",
         "artist_mbids": [
             "7c25b8fb-01aa-4691-bc9a-a344d321896c"
         ],
@@ -772,7 +772,7 @@
         "release_group_mbid": "d51ea764-2f5a-4369-bd40-87d6990ea1af",
         "release_group_primary_type": "Album",
         "release_mbid": "f2e95ca4-7a1c-486d-bdbf-a9d06466421e",
-        "release_name": "Spirit Gatherer \u2022 Tribute to Don Cherry",
+        "release_name": "Spirit Gatherer • Tribute to Don Cherry",
         "caa_release_mbid": "f2e95ca4-7a1c-486d-bdbf-a9d06466421e"
     },
     {
@@ -827,7 +827,7 @@
         "caa_release_mbid": "29749d12-1a67-406e-9df0-a4d983762c20"
     },
     {
-        "artist_credit_name": "Israel Garc\u00eda",
+        "artist_credit_name": "Israel García",
         "artist_mbids": [
             "ca472f3c-46ab-4d10-b9ec-54ccc74b82e6"
         ],
@@ -1061,7 +1061,7 @@
         "caa_release_mbid": "70ce59f9-ae49-4580-b663-28ae0a706fd5"
     },
     {
-        "artist_credit_name": "\u0425\u0430\u0441\u043a\u0438",
+        "artist_credit_name": "Хаски",
         "artist_mbids": [
             "02761fb1-8db3-4df4-8d43-6defb0e17abf"
         ],
@@ -1071,11 +1071,11 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Remix",
         "release_mbid": "8aec7e9b-799d-4daf-a381-fc0429ee0aaa",
-        "release_name": "\u041b\u044e\u0446\u0438\u0444\u0435\u0440 (Comfortless rework)",
+        "release_name": "Люцифер (Comfortless rework)",
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u3048\u306e\u3050",
+        "artist_credit_name": "えのぐ",
         "artist_mbids": [
             "57452363-2e27-4e5b-9142-3ad1e91872ba"
         ],
@@ -1084,11 +1084,11 @@
         "release_group_mbid": "aa444cbd-6063-4fd9-b652-127d48750b25",
         "release_group_primary_type": "Album",
         "release_mbid": "c29e1a77-104b-4e4b-a0f3-842a243560eb",
-        "release_name": "\u306a\u3089\u3001\u771f\u3063\u767d\u304b\u3089\u59cb\u3081\u3088\u3046\u3002",
+        "release_name": "なら、真っ白から始めよう。",
         "caa_release_mbid": "c29e1a77-104b-4e4b-a0f3-842a243560eb"
     },
     {
-        "artist_credit_name": "\u30b7\u30fc\u30ba",
+        "artist_credit_name": "シーズ",
         "artist_mbids": [
             "304373de-26df-4673-80dc-26a9798dae13"
         ],
@@ -1101,7 +1101,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u308f\u3044\u308f\u3044\u308f\u3044",
+        "artist_credit_name": "わいわいわい",
         "artist_mbids": [
             "56c44ec1-a065-4007-ad8b-8f2e4b3223d8"
         ],
@@ -1110,11 +1110,11 @@
         "release_group_mbid": "e45bd2fd-547f-4f98-a556-2069d8ee1159",
         "release_group_primary_type": "Single",
         "release_mbid": "6fd9738e-cbd0-4c7c-a91b-ff7ee4411ed9",
-        "release_name": "\u308f\u30fc\u3044\u308f\u3044\u308f\u3044 \u308f\u3044\u308f\u3044\u308f\u3044!",
+        "release_name": "わーいわいわい わいわいわい!",
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u3055\u3088\u306a\u3089\u30dd\u30cb\u30fc\u30c6\u30fc\u30eb",
+        "artist_credit_name": "さよならポニーテール",
         "artist_mbids": [
             "a8c6ef99-6a24-4c68-83e5-35aa1eca32fa"
         ],
@@ -1123,7 +1123,7 @@
         "release_group_mbid": "d2ccf174-bc8a-44a2-8f59-23f3d3a0b532",
         "release_group_primary_type": "Single",
         "release_mbid": "f0b63af4-b4be-40ab-8ebe-80f475993b58",
-        "release_name": "\u3068\u304a\u3044\u660e\u65e5",
+        "release_name": "とおい明日",
         "caa_release_mbid": null
     },
     {
@@ -1162,7 +1162,7 @@
         "release_group_mbid": "d12f8e7b-cdd0-408c-8d6a-57803534a650",
         "release_group_primary_type": "Single",
         "release_mbid": "1911bf94-6d73-40cc-b5d8-d85562abeabd",
-        "release_name": "T\u00fa tienes el control",
+        "release_name": "Tú tienes el control",
         "caa_release_mbid": null
     },
     {
@@ -1245,7 +1245,7 @@
         "caa_release_mbid": "2e5fbc0f-3335-47c6-a790-14511cb83021"
     },
     {
-        "artist_credit_name": "Juha Kujanp\u00e4\u00e4",
+        "artist_credit_name": "Juha Kujanpää",
         "artist_mbids": [
             "e1862b06-8f40-48fa-a4f8-d99060cda1b6"
         ],
@@ -1332,7 +1332,7 @@
         "release_group_mbid": "4b45f56e-5a9f-49e1-aa2d-53c04c82472b",
         "release_group_primary_type": "Single",
         "release_mbid": "9428d220-d518-47d0-8b81-2d092b4f0be9",
-        "release_name": "\u8ff7\u661f\u53eb",
+        "release_name": "迷星叫",
         "caa_release_mbid": null
     },
     {
@@ -1412,7 +1412,7 @@
         "release_group_mbid": "16ada62f-9ea6-475b-ae6a-cfbdd0870c7b",
         "release_group_primary_type": "Single",
         "release_mbid": "2d4f6884-a4a1-4590-8c9d-b09cb7880077",
-        "release_name": "\u30a4\u30f3\u30b6\u30d0\u30c3\u30af\u30eb\u30fc\u30e0",
+        "release_name": "インザバックルーム",
         "caa_release_mbid": "2d4f6884-a4a1-4590-8c9d-b09cb7880077"
     },
     {
@@ -1425,11 +1425,11 @@
         "release_group_mbid": "9a0b7272-4678-494c-b632-ec6cfd75d016",
         "release_group_primary_type": "EP",
         "release_mbid": "8bd63dcc-c14f-40d4-8466-713952f50bf9",
-        "release_name": "\u9320\u5264",
+        "release_name": "錠剤",
         "caa_release_mbid": "8bd63dcc-c14f-40d4-8466-713952f50bf9"
     },
     {
-        "artist_credit_name": "Un Coraz\u00f3n",
+        "artist_credit_name": "Un Corazón",
         "artist_mbids": [
             "e82120fc-097e-494c-833b-c7ce2a7f04b4"
         ],
@@ -1438,7 +1438,7 @@
         "release_group_mbid": "53b1e9f2-1065-42df-9e3a-6939b9789544",
         "release_group_primary_type": "Single",
         "release_mbid": "a0d0f0a0-03f7-40a7-9517-4d7d8559cb16",
-        "release_name": "X SIEMPRE (Ac\u00fastico)",
+        "release_name": "X SIEMPRE (Acústico)",
         "caa_release_mbid": "a0d0f0a0-03f7-40a7-9517-4d7d8559cb16"
     },
     {
@@ -1468,7 +1468,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u0179OO\u013b",
+        "artist_credit_name": "ŹOOĻ",
         "artist_mbids": [
             "51ebae67-101d-4f10-be6d-1231b57433b6"
         ],
@@ -1481,7 +1481,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u4f50\u54b2\u7d17\u82b1",
+        "artist_credit_name": "佐咲紗花",
         "artist_mbids": [
             "da331d79-0068-4fa9-aba2-8dfb9e47a2de"
         ],
@@ -1494,7 +1494,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u5085\u83c1",
+        "artist_credit_name": "傅菁",
         "artist_mbids": [
             "c4f06a86-01fc-4eb3-bf49-08a6017298d9"
         ],
@@ -1504,11 +1504,11 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "e59b8759-c728-4c1b-9e7a-edc0ae4323e0",
-        "release_name": "\u613f\u537f\u5b89",
+        "release_name": "愿卿安",
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u690d\u677e\u4f38\u592b",
+        "artist_credit_name": "植松伸夫",
         "artist_mbids": [
             "92bb085a-2924-4479-b627-181a1835d2f5"
         ],
@@ -1521,7 +1521,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u6c38\u585a\u62d3\u99ac",
+        "artist_credit_name": "永塚拓馬",
         "artist_mbids": [
             "1ffae607-1be8-4a80-8625-acdc9ea183df"
         ],
@@ -1534,7 +1534,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "\u904a\u4f50\u3053\u305a\u3048\uff08CV\uff1a\u82b1\u8c37\u9ebb\u5983\uff09, \u53cc\u8449\u674f\uff08CV\uff1a\u4e94\u5341\u5d50\u88d5\u7f8e\uff09, \u591a\u7530\u674e\u8863\u83dc\uff08CV\uff1a\u9752\u6728\u7460\u7483\u5b50\uff09, \u6728\u6751\u590f\u6a39\uff08CV\uff1a\u5b89\u91ce\u5e0c\u4e16\u4e43\uff09",
+        "artist_credit_name": "遊佐こずえ（CV：花谷麻妃）, 双葉杏（CV：五十嵐裕美）, 多田李衣菜（CV：青木瑠璃子）, 木村夏樹（CV：安野希世乃）",
         "artist_mbids": [
             "33fd76ca-0472-4853-bdff-f505f2e2208c",
             "34438792-01d5-483c-ac1d-dba7391fd23a",
@@ -1550,7 +1550,7 @@
         "release_group_mbid": "f62cbff0-479a-4951-86e9-7f596c7e8a6b",
         "release_group_primary_type": "Single",
         "release_mbid": "bcbd32d6-74cb-45e7-b1f1-1b90c5cda12f",
-        "release_name": "THE IDOLM@STER CINDERELLA GIRLS STARLIGHT MASTER R/LOCK ON! 10 \u307e\u307b\u3046\u306e\u307e\u304f\u3089",
+        "release_name": "THE IDOLM@STER CINDERELLA GIRLS STARLIGHT MASTER R/LOCK ON! 10 まほうのまくら",
         "caa_release_mbid": null
     },
     {
@@ -1607,7 +1607,7 @@
         "caa_release_mbid": "41371659-4cba-4dfc-9113-c3873cf6b1a3"
     },
     {
-        "artist_credit_name": "\uc7a0\ube44\ub098\uc774",
+        "artist_credit_name": "잠비나이",
         "artist_mbids": [
             "74c9db5a-cece-4381-afa8-a5f381901487"
         ],
@@ -1734,7 +1734,7 @@
         "release_group_mbid": "9c7e7079-66db-40b3-a305-d9fcdee7ad68",
         "release_group_primary_type": "EP",
         "release_mbid": "471bf890-fb57-422b-b7df-6e3739f56b04",
-        "release_name": "I\u2019m Wide Awake, It\u2019s Morning: A Companion",
+        "release_name": "I’m Wide Awake, It’s Morning: A Companion",
         "caa_release_mbid": "471bf890-fb57-422b-b7df-6e3739f56b04"
     },
     {
@@ -1804,7 +1804,7 @@
         "caa_release_mbid": "bd65b422-1053-4b93-82c8-042a02c020f9"
     },
     {
-        "artist_credit_name": "Chancha V\u00eda Circuito",
+        "artist_credit_name": "Chancha Vía Circuito",
         "artist_mbids": [
             "22c82e36-c32c-4206-8a49-6d350cce992f"
         ],
@@ -1839,7 +1839,7 @@
         "release_group_mbid": "1557d6eb-216f-451d-a90b-378e292d5742",
         "release_group_primary_type": "Album",
         "release_mbid": "17c94fba-387d-4510-bbb6-4ce08cf25279",
-        "release_name": "Redcar les adorables \u00e9toiles (prologue)",
+        "release_name": "Redcar les adorables étoiles (prologue)",
         "caa_release_mbid": "17c94fba-387d-4510-bbb6-4ce08cf25279"
     },
     {
@@ -1917,7 +1917,7 @@
         "release_group_mbid": "9b804fb0-9d02-4dcd-ab44-b812783fe40e",
         "release_group_primary_type": "Album",
         "release_mbid": "f42c9a2f-e110-4ce2-b763-9d5d01a02cc0",
-        "release_name": "\u0412\u0441\u0456 \u043d\u0430\u043b\u0435\u0436\u0430\u0442\u044c \u043d\u043e\u0447\u0456",
+        "release_name": "Всі належать ночі",
         "caa_release_mbid": null
     },
     {
@@ -2012,7 +2012,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "FJ\u00d8RT",
+        "artist_credit_name": "FJØRT",
         "artist_mbids": [
             "bcb478f4-dbf9-4bc8-823e-bec7986d652b"
         ],
@@ -2131,7 +2131,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "Guns N\u2019 Roses",
+        "artist_credit_name": "Guns N’ Roses",
         "artist_mbids": [
             "eeb1195b-f213-4ce1-b28c-8565211f8e43"
         ],
@@ -2198,7 +2198,7 @@
         "caa_release_mbid": "81bc6db4-b830-4b6b-aad6-501a1307adc9"
     },
     {
-        "artist_credit_name": "I\u2019ve",
+        "artist_credit_name": "I’ve",
         "artist_mbids": [
             "9eea0562-cb2c-4a61-8587-a6abcb2e6396"
         ],
@@ -2224,7 +2224,7 @@
         "caa_release_mbid": "6ec81230-458f-4268-bbc4-bfb6c945cb66"
     },
     {
-        "artist_credit_name": "Joe Jonas \u00d7 Khalid",
+        "artist_credit_name": "Joe Jonas × Khalid",
         "artist_mbids": [
             "28737730-ec70-4da5-89c5-77ac13c5c34d",
             "79e1bb77-fd8b-42ab-8043-892af5370f0b"
@@ -2419,7 +2419,7 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Live",
         "release_mbid": "16317fa2-7382-42e2-a39f-cbdc4dcc0ea1",
-        "release_name": "11\u202211\u202211",
+        "release_name": "11•11•11",
         "caa_release_mbid": "16317fa2-7382-42e2-a39f-cbdc4dcc0ea1"
     },
     {
@@ -2436,7 +2436,7 @@
         "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "Nicolas Bouga\u00efeff",
+        "artist_credit_name": "Nicolas Bougaïeff",
         "artist_mbids": [
             "69700f44-98c4-47b6-8a61-1e0b858d645a"
         ],
@@ -2488,7 +2488,7 @@
         "caa_release_mbid": "f53776e9-728e-4a3c-bfc8-048fc00d32e2"
     },
     {
-        "artist_credit_name": "RADWIMPS & \u9663\u5185\u4e00\u771f",
+        "artist_credit_name": "RADWIMPS & 陣内一真",
         "artist_mbids": [
             "6f500293-7396-4903-b4fd-118127d06f9e",
             "c9c59c75-f51b-4e38-bc15-b3a036f4d0ad"
@@ -2498,7 +2498,7 @@
         "release_group_mbid": "575df7d0-d1a1-4ca0-82dd-6ef4a1f03f4e",
         "release_group_primary_type": "Album",
         "release_mbid": "69009395-214f-4625-9fc4-139bcef9d413",
-        "release_name": "\u3059\u305a\u3081\u306e\u6238\u7de0\u307e\u308a",
+        "release_name": "すずめの戸締まり",
         "caa_release_mbid": null
     },
     {
@@ -2774,7 +2774,7 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Compilation",
         "release_mbid": "23d75691-f313-4ab8-88fa-d44ba32dfab3",
-        "release_name": "NOW That\u2019s What I Call a Massive 80s Party",
+        "release_name": "NOW That’s What I Call a Massive 80s Party",
         "caa_release_mbid": "23d75691-f313-4ab8-88fa-d44ba32dfab3"
     },
     {

--- a/frontend/js/tests/__mocks__/freshReleasesSitewideData.json
+++ b/frontend/js/tests/__mocks__/freshReleasesSitewideData.json
@@ -1,15 +1,16 @@
 [
     {
-        "artist_credit_name": "をとは",
+        "artist_credit_name": "\u3092\u3068\u306f",
         "artist_mbids": [
             "404670b2-bb19-4be8-862b-fe465a6e2a79"
         ],
         "caa_id": 34021497287,
+        "caa_release_mbid": "09786531-f473-4fa2-a64d-788a647ea21c",
         "release_date": "2022-11-06",
         "release_group_mbid": "24225190-eb36-4972-9907-9b22e1d19d99",
         "release_group_primary_type": "EP",
         "release_mbid": "09786531-f473-4fa2-a64d-788a647ea21c",
-        "release_name": "めいどのみやげ"
+        "release_name": "\u3081\u3044\u3069\u306e\u307f\u3084\u3052"
     },
     {
         "artist_credit_name": "Achint & Mikey McCleary",
@@ -18,6 +19,7 @@
             "ddf71a40-5148-4b8d-83d5-4f2fda23f431"
         ],
         "caa_id": 34026663688,
+        "caa_release_mbid": "689653af-46c0-4d11-90d2-adf1dda36915",
         "release_date": "2022-11-06",
         "release_group_mbid": "c7df49b8-510d-4634-8d06-644afad617fa",
         "release_group_primary_type": "Album",
@@ -31,6 +33,7 @@
             "baca10cc-e249-4969-a27f-6503955ae7b5"
         ],
         "caa_id": 33137471417,
+        "caa_release_mbid": "440e2fcd-9bbd-4f8a-aeb1-bf658d98ed21",
         "release_date": "2022-11-06",
         "release_group_mbid": "8add4348-8618-4b97-9316-1d356454c953",
         "release_group_primary_type": "Single",
@@ -44,6 +47,7 @@
             "6aedd326-5af9-4ed0-aa73-9f0e6edc9de4"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "b19c3601-20fd-43ee-8caa-cad25ba0eee3",
         "release_group_primary_type": "Single",
@@ -56,6 +60,7 @@
             "69b2f79f-e19d-4c44-9a2e-725581ec30e9"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "8610a240-e352-4309-8cc5-f6301854d3f0",
         "release_group_primary_type": "Single",
@@ -69,6 +74,7 @@
             "0559dcba-2d64-43cb-8c33-fb13af1cd014"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "0b4b4fe8-2b30-49cb-bc59-527a02f34b6e",
         "release_group_primary_type": "Album",
@@ -81,6 +87,7 @@
             "a03a9d90-0d4f-4f92-bd99-6d4640e04bb0"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "78709a06-f0a6-49c6-a87f-740fc22a900b",
         "release_group_primary_type": "Album",
@@ -94,6 +101,7 @@
             "8bbee743-ce59-4411-ae3f-fe2bbc9acc17"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "883710cc-62b3-4185-a340-33e6e2c78d75",
         "release_group_primary_type": "Single",
@@ -106,11 +114,12 @@
             "067e7dc3-b528-4d1b-97f3-58f199ea9e18"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "88971593-e86a-4ee8-80cf-635192f02536",
         "release_group_primary_type": "EP",
         "release_mbid": "a662577f-32ec-4719-803c-f71be29c8efc",
-        "release_name": "Шаурма с олениной 06.11.22"
+        "release_name": "\u0428\u0430\u0443\u0440\u043c\u0430 \u0441 \u043e\u043b\u0435\u043d\u0438\u043d\u043e\u0439 06.11.22"
     },
     {
         "artist_credit_name": "Kadeshiaa",
@@ -118,6 +127,7 @@
             "f2ab90bd-1bc1-4394-a2af-7f977fe44dc1"
         ],
         "caa_id": 34035418719,
+        "caa_release_mbid": "e3e9bbb4-d0d3-409f-b0c7-3efbaf196935",
         "release_date": "2022-11-06",
         "release_group_mbid": "3a30b85b-589f-46e1-89c9-2ae3a0fd367c",
         "release_group_primary_type": "Album",
@@ -125,16 +135,17 @@
         "release_name": "SUCCESS STREET (PART ONE)"
     },
     {
-        "artist_credit_name": "milky✱heart",
+        "artist_credit_name": "milky\u2731heart",
         "artist_mbids": [
             "c2c87d64-aded-4810-9cd5-bda0aba6d554"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "e5781dd8-54f3-4300-9235-5670882188a6",
         "release_group_primary_type": "EP",
         "release_mbid": "df0f802d-be83-4c32-ad3f-2fae0342fcfd",
-        "release_name": "✱ bang! EP ✱"
+        "release_name": "\u2731 bang! EP \u2731"
     },
     {
         "artist_credit_name": "mulpHia",
@@ -142,6 +153,7 @@
             "6594f523-9ae5-40ba-95ed-3598d7ffd9cc"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "7e1eb593-85ed-4627-9e2a-8e649b56b9af",
         "release_group_primary_type": "Album",
@@ -154,6 +166,7 @@
             "f3b73f46-9009-4ec7-aae1-bdcb3ced1683"
         ],
         "caa_id": 33997684680,
+        "caa_release_mbid": "c945bda3-39f2-4a4a-910a-be4823865c08",
         "release_date": "2022-11-06",
         "release_group_mbid": "7138e035-550f-4dc1-9488-0585ef15b313",
         "release_group_primary_type": "Album",
@@ -166,6 +179,7 @@
             "af29ba0a-af76-4566-8603-bb468846b1b1"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "0272a162-f51c-466f-bd22-87e5d9210050",
         "release_group_primary_type": "Album",
@@ -178,6 +192,7 @@
             "660ed857-58a9-4164-9e8f-7a47717d7b4f"
         ],
         "caa_id": 34022478351,
+        "caa_release_mbid": "362b842c-8ddd-4a98-9470-03eaa7ba152b",
         "release_date": "2022-11-06",
         "release_group_mbid": "57f20f31-1bbd-47e5-90bf-b82253dceb30",
         "release_group_primary_type": "EP",
@@ -190,15 +205,16 @@
             "89ad4ac3-39f7-470e-963a-56509c546377"
         ],
         "caa_id": null,
+        "caa_release_mbid": null,
         "release_date": "2022-11-06",
         "release_group_mbid": "b3123aeb-d7df-4450-9072-19def57fca0f",
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Live",
         "release_mbid": "3b710095-6d39-4482-a644-8d66a4c5aa8e",
-        "release_name": "我们的歌第四季 第7期"
+        "release_name": "\u6211\u4eec\u7684\u6b4c\u7b2c\u56db\u5b63 \u7b2c7\u671f"
     },
     {
-        "artist_credit_name": "結束バンド",
+        "artist_credit_name": "\u7d50\u675f\u30d0\u30f3\u30c9",
         "artist_mbids": [
             "c1b0fe0a-779d-43ed-b193-4370f0d0f88f"
         ],
@@ -207,10 +223,11 @@
         "release_group_mbid": "40afb369-8230-494f-8507-def48bc53f22",
         "release_group_primary_type": "Single",
         "release_mbid": "d23933d6-b48b-4e05-b8ac-e08fdf8fcc9a",
-        "release_name": "ギターと孤独と蒼い惑星"
+        "release_name": "\u30ae\u30bf\u30fc\u3068\u5b64\u72ec\u3068\u84bc\u3044\u60d1\u661f",
+        "caa_release_mbid": "d23933d6-b48b-4e05-b8ac-e08fdf8fcc9a"
     },
     {
-        "artist_credit_name": "𝔇𝔍 6YRథ్‌٣٣A ЗАО",
+        "artist_credit_name": "\ud835\udd07\ud835\udd0d 6YR\u0c25\u0c4d\u200c\u0663\u0663A \u0417\u0410\u041e",
         "artist_mbids": [
             "a7e0d7da-579d-42b6-aea0-306eb0847784"
         ],
@@ -220,7 +237,8 @@
         "release_group_primary_type": "Other",
         "release_group_secondary_type": "DJ-mix",
         "release_mbid": "7489ff13-8568-45cd-97d9-427fcfdff980",
-        "release_name": "5454"
+        "release_name": "5454",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Acidgvrl",
@@ -232,7 +250,8 @@
         "release_group_mbid": "68d0f2a5-5024-4457-9bc1-4eb0e1e42ead",
         "release_group_primary_type": "EP",
         "release_mbid": "a987f825-1332-4c41-88ae-6f7ec58c7a5b",
-        "release_name": "H A N G O V E R (A International Backrooms Broadcast)"
+        "release_name": "H A N G O V E R (A International Backrooms Broadcast)",
+        "caa_release_mbid": "a987f825-1332-4c41-88ae-6f7ec58c7a5b"
     },
     {
         "artist_credit_name": "Acidgvrl & Swimswim",
@@ -245,7 +264,8 @@
         "release_group_mbid": "52449789-ce9e-4633-99db-ebc4f07d0d11",
         "release_group_primary_type": "Single",
         "release_mbid": "f8602853-3723-4b7b-b3f8-f8e7ad444d69",
-        "release_name": "BREAKCORE DRUGS"
+        "release_name": "BREAKCORE DRUGS",
+        "caa_release_mbid": "f8602853-3723-4b7b-b3f8-f8e7ad444d69"
     },
     {
         "artist_credit_name": "Armaan Malik & Rochak Kohli",
@@ -258,7 +278,8 @@
         "release_group_mbid": "8a435bd2-08bd-4e3a-bc39-3a1a45ab2223",
         "release_group_primary_type": "Single",
         "release_mbid": "7af3fae0-cf3e-482a-a734-830c67ff26ae",
-        "release_name": "Bas Tujhse Pyaar Ho"
+        "release_name": "Bas Tujhse Pyaar Ho",
+        "caa_release_mbid": "7af3fae0-cf3e-482a-a734-830c67ff26ae"
     },
     {
         "artist_credit_name": "A.R. Rahman",
@@ -271,7 +292,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "72818c0a-4457-4a8c-834f-b2e1567ce56e",
-        "release_name": "Mili (Original Motion Picture Soundtrack)"
+        "release_name": "Mili (Original Motion Picture Soundtrack)",
+        "caa_release_mbid": "72818c0a-4457-4a8c-834f-b2e1567ce56e"
     },
     {
         "artist_credit_name": "Comfortless",
@@ -283,7 +305,8 @@
         "release_group_mbid": "278b18f6-0ba7-4cdc-9193-96669dcbecbf",
         "release_group_primary_type": "Single",
         "release_mbid": "22d411b5-70f1-48fc-ade3-d4f4ec4c22c1",
-        "release_name": "Bliss"
+        "release_name": "Bliss",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Dafydd Iwan",
@@ -295,7 +318,8 @@
         "release_group_mbid": "9f5f046f-8c24-4d72-bc34-b2fa137275a0",
         "release_group_primary_type": "Single",
         "release_mbid": "f30e54ad-2fbe-442a-a5cf-549ffcd12637",
-        "release_name": "Yma O Hyd - Cwpan Y Byd"
+        "release_name": "Yma O Hyd - Cwpan Y Byd",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Dissecting Table",
@@ -307,7 +331,8 @@
         "release_group_mbid": "c9e5fe0e-325c-4ce8-ab48-180a5f196561",
         "release_group_primary_type": "Album",
         "release_mbid": "8e2d929c-2c0e-4ff0-a8e4-f18f630b00b6",
-        "release_name": "Disorder of My Mind"
+        "release_name": "Disorder of My Mind",
+        "caa_release_mbid": "8e2d929c-2c0e-4ff0-a8e4-f18f630b00b6"
     },
     {
         "artist_credit_name": "DJ Farenhait",
@@ -319,7 +344,8 @@
         "release_group_mbid": "7b5c7f3c-a77e-4bd8-96bd-fefa6e2ab8b7",
         "release_group_primary_type": "Single",
         "release_mbid": "82b8932d-6631-40f0-a2f5-804229ff338d",
-        "release_name": "DJ Farenhait Ft Behrooz - Irane Man"
+        "release_name": "DJ Farenhait Ft Behrooz - Irane Man",
+        "caa_release_mbid": "82b8932d-6631-40f0-a2f5-804229ff338d"
     },
     {
         "artist_credit_name": "EPiraten",
@@ -331,7 +357,8 @@
         "release_group_mbid": "2ee4e19d-53f6-49b1-9ace-f289146868d3",
         "release_group_primary_type": "EP",
         "release_mbid": "eb928bc0-939f-4a52-8449-48a37440533e",
-        "release_name": "Topography"
+        "release_name": "Topography",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Heather Woods Broderick",
@@ -343,10 +370,11 @@
         "release_group_mbid": "62535062-282d-4029-a660-e63711d7b62a",
         "release_group_primary_type": "Single",
         "release_mbid": "f262cc16-ca2e-4f59-af11-001eb013f65f",
-        "release_name": "Blood Run Through Me (Single Edit)"
+        "release_name": "Blood Run Through Me (Single Edit)",
+        "caa_release_mbid": "f262cc16-ca2e-4f59-af11-001eb013f65f"
     },
     {
-        "artist_credit_name": "Imogen Heap & Dan O’Neill",
+        "artist_credit_name": "Imogen Heap & Dan O\u2019Neill",
         "artist_mbids": [
             "328d146c-79f1-4eb6-9e40-8ee5710c14e5",
             "c564e953-b4ce-4bfb-9c71-96d8339eaf48"
@@ -357,7 +385,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "ea23d745-1e11-49c3-bc8d-7f878fe0b080",
-        "release_name": "Chordata Bytes I"
+        "release_name": "Chordata Bytes I",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "In Flames",
@@ -369,7 +398,8 @@
         "release_group_mbid": "b59c6d77-215b-4039-ae49-7253af198941",
         "release_group_primary_type": "Single",
         "release_mbid": "ae41bb3d-049b-4b49-b874-793ec4c9736e",
-        "release_name": "Foregone, Pt. 2"
+        "release_name": "Foregone, Pt. 2",
+        "caa_release_mbid": "ae41bb3d-049b-4b49-b874-793ec4c9736e"
     },
     {
         "artist_credit_name": "Ingrates",
@@ -381,7 +411,8 @@
         "release_group_mbid": "60743e3c-edfb-4916-8152-8ddfe5dc8111",
         "release_group_primary_type": "Single",
         "release_mbid": "a86cc1f8-2013-455b-bf36-5ffc63a40edd",
-        "release_name": "Don't Be a Stranger b/w I Don't Care"
+        "release_name": "Don't Be a Stranger b/w I Don't Care",
+        "caa_release_mbid": "a86cc1f8-2013-455b-bf36-5ffc63a40edd"
     },
     {
         "artist_credit_name": "Jasmine Sandlas",
@@ -393,7 +424,8 @@
         "release_group_mbid": "e98fcc28-d390-4a3f-b242-8672b686ea29",
         "release_group_primary_type": "Single",
         "release_mbid": "4b136177-c863-40e4-aa4b-2d5616fa480d",
-        "release_name": "Jee Jeha Karda"
+        "release_name": "Jee Jeha Karda",
+        "caa_release_mbid": "4b136177-c863-40e4-aa4b-2d5616fa480d"
     },
     {
         "artist_credit_name": "Kaylene Sc@r & Eazyvibe",
@@ -407,7 +439,8 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Remix",
         "release_mbid": "5ff6ca03-567f-4774-928d-ecb349079990",
-        "release_name": "Life Without You (No Left Turn remix)"
+        "release_name": "Life Without You (No Left Turn remix)",
+        "caa_release_mbid": "5ff6ca03-567f-4774-928d-ecb349079990"
     },
     {
         "artist_credit_name": "Laibach",
@@ -419,7 +452,8 @@
         "release_group_mbid": "918a722f-c81f-4f90-aff4-aa73c0ea4938",
         "release_group_primary_type": "Single",
         "release_mbid": "e9cf05b6-f3e7-4390-a3d9-4cfa1b48d5f9",
-        "release_name": "THE FUTURE"
+        "release_name": "THE FUTURE",
+        "caa_release_mbid": "e9cf05b6-f3e7-4390-a3d9-4cfa1b48d5f9"
     },
     {
         "artist_credit_name": "Levi Batkin",
@@ -431,7 +465,8 @@
         "release_group_mbid": "61362e5c-2933-46ac-9cda-8b47c18ad1a2",
         "release_group_primary_type": "Single",
         "release_mbid": "2ee492e1-d271-4a43-b593-4234ef7efcbe",
-        "release_name": "Past Life"
+        "release_name": "Past Life",
+        "caa_release_mbid": "2ee492e1-d271-4a43-b593-4234ef7efcbe"
     },
     {
         "artist_credit_name": "Madi Diaz, S.G. Goodman & Joy Oladokun",
@@ -445,7 +480,8 @@
         "release_group_mbid": "9d13ddd3-e50c-4074-b26d-2d2dd122dfb6",
         "release_group_primary_type": "Single",
         "release_mbid": "f65b405a-3642-48f0-8aba-9e65c4978785",
-        "release_name": "Be Careful"
+        "release_name": "Be Careful",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "MIKROMETRIK",
@@ -457,7 +493,8 @@
         "release_group_mbid": "4dad217c-8791-4580-ad1d-0e6b497c4114",
         "release_group_primary_type": "Album",
         "release_mbid": "fc646f27-aab5-41be-95d6-ed9200bc11f2",
-        "release_name": "REC 2020"
+        "release_name": "REC 2020",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Polite Bureaux",
@@ -469,7 +506,8 @@
         "release_group_mbid": "303c6998-8992-4664-84e8-99365e951761",
         "release_group_primary_type": "Album",
         "release_mbid": "e89f5a4c-414d-40e6-8a04-c788f06f5f43",
-        "release_name": "Except Your Skint"
+        "release_name": "Except Your Skint",
+        "caa_release_mbid": "e89f5a4c-414d-40e6-8a04-c788f06f5f43"
     },
     {
         "artist_credit_name": "Qeta",
@@ -481,7 +519,8 @@
         "release_group_mbid": "41d17579-dbfc-4e99-b196-ec51f50a4dfc",
         "release_group_primary_type": "EP",
         "release_mbid": "3d63ba23-f55d-4ccb-9661-cc30ea26ba33",
-        "release_name": "Iridom"
+        "release_name": "Iridom",
+        "caa_release_mbid": "3d63ba23-f55d-4ccb-9661-cc30ea26ba33"
     },
     {
         "artist_credit_name": "RARA",
@@ -493,7 +532,8 @@
         "release_group_mbid": "d90428a3-78e2-44f5-89aa-61d286149d40",
         "release_group_primary_type": "Single",
         "release_mbid": "c5913d14-0ede-4f13-81fc-be3d07df143e",
-        "release_name": "Agonía"
+        "release_name": "Agon\u00eda",
+        "caa_release_mbid": "c5913d14-0ede-4f13-81fc-be3d07df143e"
     },
     {
         "artist_credit_name": "Rifti Beats",
@@ -505,7 +545,8 @@
         "release_group_mbid": "efd8353f-dfe2-434f-87b3-36d28b4c1de8",
         "release_group_primary_type": "Single",
         "release_mbid": "81a2d67a-668e-4071-85ec-40f686583706",
-        "release_name": "Chainsaw Man Opening"
+        "release_name": "Chainsaw Man Opening",
+        "caa_release_mbid": "81a2d67a-668e-4071-85ec-40f686583706"
     },
     {
         "artist_credit_name": "Risto",
@@ -517,7 +558,8 @@
         "release_group_mbid": "cdfd0e86-5dc5-4a42-af50-e486cf59f4d5",
         "release_group_primary_type": "Single",
         "release_mbid": "f499b693-1209-4f52-b207-86eefe996cc8",
-        "release_name": "Beton"
+        "release_name": "Beton",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Robyn Miller",
@@ -530,7 +572,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "126f0be4-2d2d-402b-a332-67966417d09e",
-        "release_name": "Lost Tracks, Pt. I - Myst"
+        "release_name": "Lost Tracks, Pt. I - Myst",
+        "caa_release_mbid": "126f0be4-2d2d-402b-a332-67966417d09e"
     },
     {
         "artist_credit_name": "savogy",
@@ -542,7 +585,8 @@
         "release_group_mbid": "78d0445f-7ab8-4729-80de-9f1a7a048f1d",
         "release_group_primary_type": "Single",
         "release_mbid": "62c6b3b5-4a58-4f13-a8e0-b09ce3062d8d",
-        "release_name": "Place"
+        "release_name": "Place",
+        "caa_release_mbid": "62c6b3b5-4a58-4f13-a8e0-b09ce3062d8d"
     },
     {
         "artist_credit_name": "Taylor Swift feat. Bleachers",
@@ -556,7 +600,8 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Remix",
         "release_mbid": "75334caf-6088-43bf-b95a-a2c2fe0f0c03",
-        "release_name": "Anti‐Hero"
+        "release_name": "Anti\u2010Hero",
+        "caa_release_mbid": "75334caf-6088-43bf-b95a-a2c2fe0f0c03"
     },
     {
         "artist_credit_name": "The OC Jazz Collective",
@@ -569,7 +614,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Remix",
         "release_mbid": "f3c398ef-79d9-4e83-adc2-d5e00305540c",
-        "release_name": "Mode Seven: A Jazz Tribute to the SNES"
+        "release_name": "Mode Seven: A Jazz Tribute to the SNES",
+        "caa_release_mbid": "f3c398ef-79d9-4e83-adc2-d5e00305540c"
     },
     {
         "artist_credit_name": "Tiger Moth Tales",
@@ -582,7 +628,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Live",
         "release_mbid": "cdfa0087-b89a-49e5-bbd8-d021dcc648d6",
-        "release_name": "A Visit To Oxfordshire"
+        "release_name": "A Visit To Oxfordshire",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Yagya",
@@ -594,7 +641,8 @@
         "release_group_mbid": "0bf92c7f-3ba4-4b57-af40-305d0f6012de",
         "release_group_primary_type": "Single",
         "release_mbid": "9fa9c45e-3a6a-44f9-9176-66c014895017",
-        "release_name": "MOA118"
+        "release_name": "MOA118",
+        "caa_release_mbid": "9fa9c45e-3a6a-44f9-9176-66c014895017"
     },
     {
         "artist_credit_name": "yeyts.",
@@ -606,10 +654,11 @@
         "release_group_mbid": "920c155f-59c5-4f87-a066-8f4de05c3d81",
         "release_group_primary_type": "Single",
         "release_mbid": "8cc37395-52d9-4f73-a369-855339977fd0",
-        "release_name": "All ’Bout All"
+        "release_name": "All \u2019Bout All",
+        "caa_release_mbid": "8cc37395-52d9-4f73-a369-855339977fd0"
     },
     {
-        "artist_credit_name": "Aleksi Perälä",
+        "artist_credit_name": "Aleksi Per\u00e4l\u00e4",
         "artist_mbids": [
             "a913c0de-d77e-424e-9ba5-c8872793512b"
         ],
@@ -617,7 +666,8 @@
         "release_date": "2022-11-08",
         "release_group_mbid": "f6da4f4d-d7c7-47a5-b401-d23f4bade86e",
         "release_mbid": "614570b9-f4f9-4819-b203-ac0b8a07189b",
-        "release_name": "UNITY IIII III"
+        "release_name": "UNITY IIII III",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Alkilith",
@@ -630,7 +680,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Compilation",
         "release_mbid": "14a36adf-d68f-4058-a1ba-a99ba5c8798a",
-        "release_name": "Beneath the Fells I-III Compilation"
+        "release_name": "Beneath the Fells I-III Compilation",
+        "caa_release_mbid": "14a36adf-d68f-4058-a1ba-a99ba5c8798a"
     },
     {
         "artist_credit_name": "Amberian Dawn",
@@ -642,7 +693,8 @@
         "release_group_mbid": "7ce8405a-a930-4ef1-95e4-449502868404",
         "release_group_primary_type": "Single",
         "release_mbid": "ca93656a-8fcf-40e5-87f9-1cf3b42868bf",
-        "release_name": "Gimme! Gimme! Gimme! (A Man After Midnight)"
+        "release_name": "Gimme! Gimme! Gimme! (A Man After Midnight)",
+        "caa_release_mbid": "ca93656a-8fcf-40e5-87f9-1cf3b42868bf"
     },
     {
         "artist_credit_name": "Comfortless",
@@ -654,7 +706,8 @@
         "release_group_mbid": "d6c47b3b-c2ca-4dfa-a237-96ca8eb312e3",
         "release_group_primary_type": "Single",
         "release_mbid": "38545fef-c13c-4b41-af2d-76f1c7e829fc",
-        "release_name": "☢️NukaBass☢️"
+        "release_name": "\u2622\ufe0fNukaBass\u2622\ufe0f",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Curtis Macdonald",
@@ -666,7 +719,8 @@
         "release_group_mbid": "9973fe92-c05d-4a27-892d-ccb9f0dbe659",
         "release_group_primary_type": "Single",
         "release_mbid": "011ec9c7-3b6b-461a-95f4-09bca3a90f48",
-        "release_name": "Hold onto Hope"
+        "release_name": "Hold onto Hope",
+        "caa_release_mbid": "011ec9c7-3b6b-461a-95f4-09bca3a90f48"
     },
     {
         "artist_credit_name": "De Corbul Destinul",
@@ -679,7 +733,8 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Remix",
         "release_mbid": "f0bd70e9-7378-4355-97e9-26701fbd5378",
-        "release_name": "Hai Bucato La Mia Vita (Adriano Celentano interpretation)"
+        "release_name": "Hai Bucato La Mia Vita (Adriano Celentano interpretation)",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "De Corbul Destinul",
@@ -691,10 +746,11 @@
         "release_group_mbid": "b1b62556-4003-46bb-af18-d1dcce108d6e",
         "release_group_primary_type": "Album",
         "release_mbid": "3529f94a-fce1-4d77-b079-ff6ecf715428",
-        "release_name": "Uno De Los Grande Sexo"
+        "release_name": "Uno De Los Grande Sexo",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "En Paz Me Acostaré",
+        "artist_credit_name": "En Paz Me Acostar\u00e9",
         "artist_mbids": [
             "7c25b8fb-01aa-4691-bc9a-a344d321896c"
         ],
@@ -703,7 +759,8 @@
         "release_group_mbid": "576c090b-a177-49d5-9540-3a4c228dc5df",
         "release_group_primary_type": "Album",
         "release_mbid": "862586ff-0a5b-4453-b7a7-27dd6f56b34b",
-        "release_name": "Navidad"
+        "release_name": "Navidad",
+        "caa_release_mbid": "862586ff-0a5b-4453-b7a7-27dd6f56b34b"
     },
     {
         "artist_credit_name": "Ethnic Heritage Ensemble",
@@ -715,7 +772,8 @@
         "release_group_mbid": "d51ea764-2f5a-4369-bd40-87d6990ea1af",
         "release_group_primary_type": "Album",
         "release_mbid": "f2e95ca4-7a1c-486d-bdbf-a9d06466421e",
-        "release_name": "Spirit Gatherer • Tribute to Don Cherry"
+        "release_name": "Spirit Gatherer \u2022 Tribute to Don Cherry",
+        "caa_release_mbid": "f2e95ca4-7a1c-486d-bdbf-a9d06466421e"
     },
     {
         "artist_credit_name": "Feral",
@@ -727,7 +785,8 @@
         "release_group_mbid": "43e1e723-151a-4b3c-a4a6-77adcf51e208",
         "release_group_primary_type": "EP",
         "release_mbid": "a0df4394-18c7-4081-a3e4-6b328d00ce47",
-        "release_name": "Crossroads"
+        "release_name": "Crossroads",
+        "caa_release_mbid": "a0df4394-18c7-4081-a3e4-6b328d00ce47"
     },
     {
         "artist_credit_name": "Hello Meteor",
@@ -738,7 +797,8 @@
         "release_date": "2022-11-08",
         "release_group_mbid": "977ebcc7-3cde-412f-9f7a-1d129106369b",
         "release_mbid": "1a712dda-466b-497b-8000-888539a9de80",
-        "release_name": "Seven Hour Sunset"
+        "release_name": "Seven Hour Sunset",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Imperium Dekadenz",
@@ -750,7 +810,8 @@
         "release_group_mbid": "b1541001-42b0-49e8-a487-9402972e3e3d",
         "release_group_primary_type": "Single",
         "release_mbid": "b0b43c83-84fb-4f5a-9630-6c162a3f504f",
-        "release_name": "Memories... A Raging River"
+        "release_name": "Memories... A Raging River",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Inva//id",
@@ -762,10 +823,11 @@
         "release_group_mbid": "e1e736e6-b796-40fd-879d-5604fb76ae70",
         "release_group_primary_type": "Single",
         "release_mbid": "29749d12-1a67-406e-9df0-a4d983762c20",
-        "release_name": "The Cruel Division"
+        "release_name": "The Cruel Division",
+        "caa_release_mbid": "29749d12-1a67-406e-9df0-a4d983762c20"
     },
     {
-        "artist_credit_name": "Israel García",
+        "artist_credit_name": "Israel Garc\u00eda",
         "artist_mbids": [
             "ca472f3c-46ab-4d10-b9ec-54ccc74b82e6"
         ],
@@ -773,7 +835,8 @@
         "release_date": "2022-11-08",
         "release_group_mbid": "5ef0cda7-7ba5-4412-b764-77195a9c79f8",
         "release_mbid": "50c1ac57-5db4-49ce-b48e-abef9aac9d11",
-        "release_name": "Cantad Alegres"
+        "release_name": "Cantad Alegres",
+        "caa_release_mbid": "50c1ac57-5db4-49ce-b48e-abef9aac9d11"
     },
     {
         "artist_credit_name": "Jesse Cassettes",
@@ -785,7 +848,8 @@
         "release_group_mbid": "433f46af-4079-4493-aea2-a90069e0c239",
         "release_group_primary_type": "Single",
         "release_mbid": "c89a2034-71da-4dc9-90f4-dc0d0dd80017",
-        "release_name": "Luxury Mind"
+        "release_name": "Luxury Mind",
+        "caa_release_mbid": "c89a2034-71da-4dc9-90f4-dc0d0dd80017"
     },
     {
         "artist_credit_name": "Kunas",
@@ -797,7 +861,8 @@
         "release_group_mbid": "4f6c5daa-e64e-4efd-9fdc-1e3fcd9340b1",
         "release_group_primary_type": "Single",
         "release_mbid": "5d6dc212-6c24-4c06-a562-7d7e99438d2e",
-        "release_name": "Wings / For You"
+        "release_name": "Wings / For You",
+        "caa_release_mbid": "5d6dc212-6c24-4c06-a562-7d7e99438d2e"
     },
     {
         "artist_credit_name": "Moonchild Sanelly & Theology HD",
@@ -810,7 +875,8 @@
         "release_group_mbid": "54d931ac-0e6f-4d08-b6fc-658e986056d5",
         "release_group_primary_type": "Single",
         "release_mbid": "3caf3984-2741-44ba-bcf4-e3e45786d5cf",
-        "release_name": "Kokokokoko"
+        "release_name": "Kokokokoko",
+        "caa_release_mbid": "3caf3984-2741-44ba-bcf4-e3e45786d5cf"
     },
     {
         "artist_credit_name": "Night Shop",
@@ -822,7 +888,8 @@
         "release_group_mbid": "5b96e7ea-697f-4b4d-bb74-2a368a16e7c6",
         "release_group_primary_type": "Single",
         "release_mbid": "207bed32-4f72-4f33-88aa-a86bddf80a55",
-        "release_name": "Harness"
+        "release_name": "Harness",
+        "caa_release_mbid": "207bed32-4f72-4f33-88aa-a86bddf80a55"
     },
     {
         "artist_credit_name": "Raul Hurtado",
@@ -834,7 +901,8 @@
         "release_group_mbid": "7b18d40d-dcd7-4418-a2d4-c7ee33ba389e",
         "release_group_primary_type": "Single",
         "release_mbid": "0dc42b49-ebd2-4721-9669-418e5071e41b",
-        "release_name": "Time for Battle"
+        "release_name": "Time for Battle",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Sciolism",
@@ -846,7 +914,8 @@
         "release_group_mbid": "8204ad04-d93a-4fac-8605-dd8045d70eeb",
         "release_group_primary_type": "Album",
         "release_mbid": "197ddc0b-5ccf-4d93-bf75-62e0fcca2147",
-        "release_name": "Sacred Nothingness"
+        "release_name": "Sacred Nothingness",
+        "caa_release_mbid": "197ddc0b-5ccf-4d93-bf75-62e0fcca2147"
     },
     {
         "artist_credit_name": "Sidhu Moose Wala",
@@ -858,7 +927,8 @@
         "release_group_mbid": "3402f968-6eff-4d08-9b44-3907fdba82d1",
         "release_group_primary_type": "Single",
         "release_mbid": "5d195f27-eb0d-42ad-bbeb-f26a9cbab1b2",
-        "release_name": "Vaar"
+        "release_name": "Vaar",
+        "caa_release_mbid": "5d195f27-eb0d-42ad-bbeb-f26a9cbab1b2"
     },
     {
         "artist_credit_name": "Teenage Sequence",
@@ -870,7 +940,8 @@
         "release_group_mbid": "a1cabfeb-795c-4bd1-975b-9c2271291698",
         "release_group_primary_type": "Single",
         "release_mbid": "15cb3b73-4607-4b40-8704-8e55dff2f519",
-        "release_name": "D.I.S Connect"
+        "release_name": "D.I.S Connect",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "The Escape",
@@ -882,7 +953,8 @@
         "release_group_mbid": "2f222cf5-7421-48db-8a92-516e3270da3a",
         "release_group_primary_type": "Album",
         "release_mbid": "855f1372-c17e-4349-a9e3-aef5f907161c",
-        "release_name": "House of Mind"
+        "release_name": "House of Mind",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "The Escape",
@@ -894,7 +966,8 @@
         "release_group_mbid": "e180b085-4bcb-431e-847f-2f3763669bd6",
         "release_group_primary_type": "Album",
         "release_mbid": "98a0194d-87ff-4bc7-81ac-0fe1ec1f2fdd",
-        "release_name": "Manderley"
+        "release_name": "Manderley",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "The Pistil Cosmos",
@@ -906,7 +979,8 @@
         "release_group_mbid": "ee260d95-944d-4b2c-aaf5-7dbdd7055644",
         "release_group_primary_type": "EP",
         "release_mbid": "d8fd8cb8-c497-4f0c-b602-49babd5238ba",
-        "release_name": "Half Wing Bee"
+        "release_name": "Half Wing Bee",
+        "caa_release_mbid": "d8fd8cb8-c497-4f0c-b602-49babd5238ba"
     },
     {
         "artist_credit_name": "(un)familiar.",
@@ -918,7 +992,8 @@
         "release_group_mbid": "27694f84-0081-454c-9882-f067820a3785",
         "release_group_primary_type": "Single",
         "release_mbid": "7ec96582-4185-44cb-a398-64589046697f",
-        "release_name": "reddit drumkit"
+        "release_name": "reddit drumkit",
+        "caa_release_mbid": "7ec96582-4185-44cb-a398-64589046697f"
     },
     {
         "artist_credit_name": "Unt",
@@ -929,7 +1004,8 @@
         "release_date": "2022-11-08",
         "release_group_mbid": "541720c2-7a1c-4cb0-90e5-fbdb2a069470",
         "release_mbid": "c704b7d6-83c9-4998-86e9-b6e9d5005287",
-        "release_name": "Clips of Perspective"
+        "release_name": "Clips of Perspective",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Vantage",
@@ -941,7 +1017,8 @@
         "release_group_mbid": "9bf8c4da-c021-4cc2-ab86-e84ba9b748a9",
         "release_group_primary_type": "EP",
         "release_mbid": "749ee9bf-9a2d-405e-988a-6ab73cdc30df",
-        "release_name": "Skyline Digital"
+        "release_name": "Skyline Digital",
+        "caa_release_mbid": "749ee9bf-9a2d-405e-988a-6ab73cdc30df"
     },
     {
         "artist_credit_name": "Various Artists",
@@ -953,7 +1030,8 @@
         "release_group_mbid": "bfb52ae6-8c3f-4d38-953a-00aa94975b2c",
         "release_group_primary_type": "EP",
         "release_mbid": "b06239c4-c7ca-430f-a59b-e89fc0ed472f",
-        "release_name": "PAI DUI MUSIC SOUND: VOLUME 1"
+        "release_name": "PAI DUI MUSIC SOUND: VOLUME 1",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Vishal Mishra",
@@ -966,7 +1044,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "aba8989b-02dc-444a-adfb-c1873dd59e7a",
-        "release_name": "Nazar Andaaz"
+        "release_name": "Nazar Andaaz",
+        "caa_release_mbid": "aba8989b-02dc-444a-adfb-c1873dd59e7a"
     },
     {
         "artist_credit_name": "XoArK",
@@ -978,10 +1057,11 @@
         "release_group_mbid": "a610ae7a-6cf7-46d0-be15-c4cdadd65a65",
         "release_group_primary_type": "Album",
         "release_mbid": "70ce59f9-ae49-4580-b663-28ae0a706fd5",
-        "release_name": "d0cFtecERG9H8-dr-G80~o62Shaq"
+        "release_name": "d0cFtecERG9H8-dr-G80~o62Shaq",
+        "caa_release_mbid": "70ce59f9-ae49-4580-b663-28ae0a706fd5"
     },
     {
-        "artist_credit_name": "Хаски",
+        "artist_credit_name": "\u0425\u0430\u0441\u043a\u0438",
         "artist_mbids": [
             "02761fb1-8db3-4df4-8d43-6defb0e17abf"
         ],
@@ -991,10 +1071,11 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Remix",
         "release_mbid": "8aec7e9b-799d-4daf-a381-fc0429ee0aaa",
-        "release_name": "Люцифер (Comfortless rework)"
+        "release_name": "\u041b\u044e\u0446\u0438\u0444\u0435\u0440 (Comfortless rework)",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "えのぐ",
+        "artist_credit_name": "\u3048\u306e\u3050",
         "artist_mbids": [
             "57452363-2e27-4e5b-9142-3ad1e91872ba"
         ],
@@ -1003,10 +1084,11 @@
         "release_group_mbid": "aa444cbd-6063-4fd9-b652-127d48750b25",
         "release_group_primary_type": "Album",
         "release_mbid": "c29e1a77-104b-4e4b-a0f3-842a243560eb",
-        "release_name": "なら、真っ白から始めよう。"
+        "release_name": "\u306a\u3089\u3001\u771f\u3063\u767d\u304b\u3089\u59cb\u3081\u3088\u3046\u3002",
+        "caa_release_mbid": "c29e1a77-104b-4e4b-a0f3-842a243560eb"
     },
     {
-        "artist_credit_name": "シーズ",
+        "artist_credit_name": "\u30b7\u30fc\u30ba",
         "artist_mbids": [
             "304373de-26df-4673-80dc-26a9798dae13"
         ],
@@ -1015,10 +1097,11 @@
         "release_group_mbid": "72fe7d03-2fcd-438e-be82-1a741bee7293",
         "release_group_primary_type": "Single",
         "release_mbid": "6f0d4980-f4a9-4fc8-8975-aa0977b01dc5",
-        "release_name": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 08"
+        "release_name": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 08",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "わいわいわい",
+        "artist_credit_name": "\u308f\u3044\u308f\u3044\u308f\u3044",
         "artist_mbids": [
             "56c44ec1-a065-4007-ad8b-8f2e4b3223d8"
         ],
@@ -1027,10 +1110,11 @@
         "release_group_mbid": "e45bd2fd-547f-4f98-a556-2069d8ee1159",
         "release_group_primary_type": "Single",
         "release_mbid": "6fd9738e-cbd0-4c7c-a91b-ff7ee4411ed9",
-        "release_name": "わーいわいわい わいわいわい!"
+        "release_name": "\u308f\u30fc\u3044\u308f\u3044\u308f\u3044 \u308f\u3044\u308f\u3044\u308f\u3044!",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "さよならポニーテール",
+        "artist_credit_name": "\u3055\u3088\u306a\u3089\u30dd\u30cb\u30fc\u30c6\u30fc\u30eb",
         "artist_mbids": [
             "a8c6ef99-6a24-4c68-83e5-35aa1eca32fa"
         ],
@@ -1039,7 +1123,8 @@
         "release_group_mbid": "d2ccf174-bc8a-44a2-8f59-23f3d3a0b532",
         "release_group_primary_type": "Single",
         "release_mbid": "f0b63af4-b4be-40ab-8ebe-80f475993b58",
-        "release_name": "とおい明日"
+        "release_name": "\u3068\u304a\u3044\u660e\u65e5",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Acidgvrl",
@@ -1051,7 +1136,8 @@
         "release_group_mbid": "6b8b2cfc-b2dc-4845-ac12-f557dc69f5ec",
         "release_group_primary_type": "Single",
         "release_mbid": "12a248d4-faae-45f7-b46d-cf8c9d63d6cc",
-        "release_name": "THANK YOU! (Porter Robinson x Goodbye to a World Remix)"
+        "release_name": "THANK YOU! (Porter Robinson x Goodbye to a World Remix)",
+        "caa_release_mbid": "12a248d4-faae-45f7-b46d-cf8c9d63d6cc"
     },
     {
         "artist_credit_name": "Blue Rumble",
@@ -1063,7 +1149,8 @@
         "release_group_mbid": "47fdf2d1-2066-471e-a98b-be1181530a32",
         "release_group_primary_type": "Single",
         "release_mbid": "1765e52d-e179-4704-ad53-d7ae4195cdda",
-        "release_name": "Blue Lightning / Brasas"
+        "release_name": "Blue Lightning / Brasas",
+        "caa_release_mbid": "1765e52d-e179-4704-ad53-d7ae4195cdda"
     },
     {
         "artist_credit_name": "Brenda Tremolaterra",
@@ -1075,7 +1162,8 @@
         "release_group_mbid": "d12f8e7b-cdd0-408c-8d6a-57803534a650",
         "release_group_primary_type": "Single",
         "release_mbid": "1911bf94-6d73-40cc-b5d8-d85562abeabd",
-        "release_name": "Tú tienes el control"
+        "release_name": "T\u00fa tienes el control",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "CURE97",
@@ -1087,7 +1175,8 @@
         "release_group_mbid": "9a013e95-0b6f-439a-b2a5-cdea64cb7aec",
         "release_group_primary_type": "Single",
         "release_mbid": "0ac2f245-552b-488f-a1da-0c040cdd914c",
-        "release_name": "POWER"
+        "release_name": "POWER",
+        "caa_release_mbid": "0ac2f245-552b-488f-a1da-0c040cdd914c"
     },
     {
         "artist_credit_name": "Dunosaur",
@@ -1099,7 +1188,8 @@
         "release_group_mbid": "b00b31f2-949e-4e43-953b-270cedf62cd8",
         "release_group_primary_type": "EP",
         "release_mbid": "7ac3e026-f88e-438d-84d9-7c5072809e86",
-        "release_name": "Dinosaurus Rox"
+        "release_name": "Dinosaurus Rox",
+        "caa_release_mbid": "7ac3e026-f88e-438d-84d9-7c5072809e86"
     },
     {
         "artist_credit_name": "envy",
@@ -1111,7 +1201,8 @@
         "release_group_mbid": "4591d3f0-25c0-4163-9381-c6daaa70b01d",
         "release_group_primary_type": "Single",
         "release_mbid": "ccac6e01-c739-4886-b149-f33f28100316",
-        "release_name": "Seimei"
+        "release_name": "Seimei",
+        "caa_release_mbid": "ccac6e01-c739-4886-b149-f33f28100316"
     },
     {
         "artist_credit_name": "Floating Points",
@@ -1123,7 +1214,8 @@
         "release_group_mbid": "ac163988-4403-4766-ab81-7f72d46e47be",
         "release_group_primary_type": "EP",
         "release_mbid": "882bf7af-d168-4884-a990-8165bc11b654",
-        "release_name": "Someone Close"
+        "release_name": "Someone Close",
+        "caa_release_mbid": "882bf7af-d168-4884-a990-8165bc11b654"
     },
     {
         "artist_credit_name": "Fury Weekend feat. Ollie Wride",
@@ -1136,7 +1228,8 @@
         "release_group_mbid": "cb8d7255-6119-4c8c-8810-220037f8b6a7",
         "release_group_primary_type": "Single",
         "release_mbid": "887dfe9e-88c6-46a7-8c47-fcee10a378ad",
-        "release_name": "Soul Survivor"
+        "release_name": "Soul Survivor",
+        "caa_release_mbid": "887dfe9e-88c6-46a7-8c47-fcee10a378ad"
     },
     {
         "artist_credit_name": "GRMLN",
@@ -1148,10 +1241,11 @@
         "release_group_mbid": "3fd5bd70-5170-4d52-9533-664ff81e4372",
         "release_group_primary_type": "Single",
         "release_mbid": "2e5fbc0f-3335-47c6-a790-14511cb83021",
-        "release_name": "Dark Moon"
+        "release_name": "Dark Moon",
+        "caa_release_mbid": "2e5fbc0f-3335-47c6-a790-14511cb83021"
     },
     {
-        "artist_credit_name": "Juha Kujanpää",
+        "artist_credit_name": "Juha Kujanp\u00e4\u00e4",
         "artist_mbids": [
             "e1862b06-8f40-48fa-a4f8-d99060cda1b6"
         ],
@@ -1160,7 +1254,8 @@
         "release_group_mbid": "dc42d13a-dcf2-42d2-b5a5-9ebc2aa08340",
         "release_group_primary_type": "Album",
         "release_mbid": "3bf15959-2ef8-43cc-8304-6caddcde2e3e",
-        "release_name": "Old Ways, New Ways"
+        "release_name": "Old Ways, New Ways",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Leyla Blue",
@@ -1172,7 +1267,8 @@
         "release_group_mbid": "8bf6768d-e86e-4f47-a803-4167f7d30bf3",
         "release_group_primary_type": "Single",
         "release_mbid": "4eb8c20e-288e-466b-af41-8b566a31b170",
-        "release_name": "Jane Doe"
+        "release_name": "Jane Doe",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Lolahol",
@@ -1184,7 +1280,8 @@
         "release_group_mbid": "da4fa27d-8055-42b4-a9f8-36c402928a16",
         "release_group_primary_type": "EP",
         "release_mbid": "b69a65fa-b116-40e5-8bda-0bccb25719ab",
-        "release_name": "Go"
+        "release_name": "Go",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Louis Tomlinson",
@@ -1196,7 +1293,8 @@
         "release_group_mbid": "ca0118aa-ebf1-4322-849f-240a1e0115cf",
         "release_group_primary_type": "Single",
         "release_mbid": "0ac93f74-c69f-4991-a4b1-ffe7d249ec68",
-        "release_name": "Silver Tongues"
+        "release_name": "Silver Tongues",
+        "caa_release_mbid": "0ac93f74-c69f-4991-a4b1-ffe7d249ec68"
     },
     {
         "artist_credit_name": "more eaze",
@@ -1208,7 +1306,8 @@
         "release_group_mbid": "4aa7deb6-0897-40ee-b5d5-74a88a673b85",
         "release_group_primary_type": "Album",
         "release_mbid": "b02ddb27-7f10-4ccc-8210-057188a4bac8",
-        "release_name": "Strawberry Season"
+        "release_name": "Strawberry Season",
+        "caa_release_mbid": "b02ddb27-7f10-4ccc-8210-057188a4bac8"
     },
     {
         "artist_credit_name": "Mother Mother",
@@ -1220,7 +1319,8 @@
         "release_group_mbid": "30a2727d-2c70-4f2e-b2a3-5798b3cde946",
         "release_group_primary_type": "Single",
         "release_mbid": "8f3f6b62-6f04-44ef-a7ed-31acbd6f1e39",
-        "release_name": "Cry Christmas"
+        "release_name": "Cry Christmas",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "MyGO!!!!!",
@@ -1232,7 +1332,8 @@
         "release_group_mbid": "4b45f56e-5a9f-49e1-aa2d-53c04c82472b",
         "release_group_primary_type": "Single",
         "release_mbid": "9428d220-d518-47d0-8b81-2d092b4f0be9",
-        "release_name": "迷星叫"
+        "release_name": "\u8ff7\u661f\u53eb",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "O.S.T.R.",
@@ -1245,7 +1346,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Mixtape/Street",
         "release_mbid": "eaa44667-c57e-41a4-ac63-cf4ba51cad54",
-        "release_name": "042 Requiem"
+        "release_name": "042 Requiem",
+        "caa_release_mbid": "eaa44667-c57e-41a4-ac63-cf4ba51cad54"
     },
     {
         "artist_credit_name": "Sam A La Bamalot & Subp Yao",
@@ -1258,7 +1360,8 @@
         "release_group_mbid": "8e310eae-7ae0-487b-9712-6de9ac8d5e7a",
         "release_group_primary_type": "Single",
         "release_mbid": "6604bd73-0a5a-4888-9ec0-db6c412979ca",
-        "release_name": "Archy // Time Flies"
+        "release_name": "Archy // Time Flies",
+        "caa_release_mbid": "6604bd73-0a5a-4888-9ec0-db6c412979ca"
     },
     {
         "artist_credit_name": "Sega Bodega",
@@ -1270,7 +1373,8 @@
         "release_group_mbid": "71f6e337-59aa-48fa-ab7a-624ed03fd0ae",
         "release_group_primary_type": "Single",
         "release_mbid": "1ef3d76a-906a-4fcb-90e1-4fd81e76861a",
-        "release_name": "Kepko"
+        "release_name": "Kepko",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "SEVENTEEN",
@@ -1282,7 +1386,8 @@
         "release_group_mbid": "9f2de70d-3b12-4eeb-8532-e5cf047dd6f4",
         "release_group_primary_type": "EP",
         "release_mbid": "cd7f7b65-70c0-4a5a-8787-f901dcf176e5",
-        "release_name": "DREAM"
+        "release_name": "DREAM",
+        "caa_release_mbid": "cd7f7b65-70c0-4a5a-8787-f901dcf176e5"
     },
     {
         "artist_credit_name": "Sunfruits",
@@ -1294,7 +1399,8 @@
         "release_group_mbid": "37b2db14-8dd5-414e-8bbe-7e451e1c1573",
         "release_group_primary_type": "Single",
         "release_mbid": "0e29dd85-1f90-429a-9ce9-7d6757437873",
-        "release_name": "Believe It All"
+        "release_name": "Believe It All",
+        "caa_release_mbid": "0e29dd85-1f90-429a-9ce9-7d6757437873"
     },
     {
         "artist_credit_name": "syudou",
@@ -1306,7 +1412,8 @@
         "release_group_mbid": "16ada62f-9ea6-475b-ae6a-cfbdd0870c7b",
         "release_group_primary_type": "Single",
         "release_mbid": "2d4f6884-a4a1-4590-8c9d-b09cb7880077",
-        "release_name": "インザバックルーム"
+        "release_name": "\u30a4\u30f3\u30b6\u30d0\u30c3\u30af\u30eb\u30fc\u30e0",
+        "caa_release_mbid": "2d4f6884-a4a1-4590-8c9d-b09cb7880077"
     },
     {
         "artist_credit_name": "TOOBOE",
@@ -1318,10 +1425,11 @@
         "release_group_mbid": "9a0b7272-4678-494c-b632-ec6cfd75d016",
         "release_group_primary_type": "EP",
         "release_mbid": "8bd63dcc-c14f-40d4-8466-713952f50bf9",
-        "release_name": "錠剤"
+        "release_name": "\u9320\u5264",
+        "caa_release_mbid": "8bd63dcc-c14f-40d4-8466-713952f50bf9"
     },
     {
-        "artist_credit_name": "Un Corazón",
+        "artist_credit_name": "Un Coraz\u00f3n",
         "artist_mbids": [
             "e82120fc-097e-494c-833b-c7ce2a7f04b4"
         ],
@@ -1330,7 +1438,8 @@
         "release_group_mbid": "53b1e9f2-1065-42df-9e3a-6939b9789544",
         "release_group_primary_type": "Single",
         "release_mbid": "a0d0f0a0-03f7-40a7-9517-4d7d8559cb16",
-        "release_name": "X SIEMPRE (Acústico)"
+        "release_name": "X SIEMPRE (Ac\u00fastico)",
+        "caa_release_mbid": "a0d0f0a0-03f7-40a7-9517-4d7d8559cb16"
     },
     {
         "artist_credit_name": "Venus VNR",
@@ -1342,7 +1451,8 @@
         "release_group_mbid": "c6d65590-6a1a-42d0-9378-03280d9e8950",
         "release_group_primary_type": "Album",
         "release_mbid": "46588136-a534-45b9-ba2a-5d71accc0d28",
-        "release_name": "Anomalie"
+        "release_name": "Anomalie",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "YOASOBI",
@@ -1354,10 +1464,11 @@
         "release_group_mbid": "9b1f1282-66dd-4e02-8318-b1cf8a8cb788",
         "release_group_primary_type": "Single",
         "release_mbid": "e72bd26c-69fa-4b07-8c9c-669d0b9e8482",
-        "release_name": "The Blessing"
+        "release_name": "The Blessing",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "ŹOOĻ",
+        "artist_credit_name": "\u0179OO\u013b",
         "artist_mbids": [
             "51ebae67-101d-4f10-be6d-1231b57433b6"
         ],
@@ -1366,10 +1477,11 @@
         "release_group_mbid": "272f5ee5-9943-4b9d-a692-d6e3e77056ad",
         "release_group_primary_type": "Single",
         "release_mbid": "38ae8b61-20d6-4967-9cc4-ca6fb75bb7f9",
-        "release_name": "IMPERIAL CHAIN"
+        "release_name": "IMPERIAL CHAIN",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "佐咲紗花",
+        "artist_credit_name": "\u4f50\u54b2\u7d17\u82b1",
         "artist_mbids": [
             "da331d79-0068-4fa9-aba2-8dfb9e47a2de"
         ],
@@ -1378,10 +1490,11 @@
         "release_group_mbid": "6e946c01-5afa-41e0-a420-6b0a4eb3dba6",
         "release_group_primary_type": "Single",
         "release_mbid": "b4bfb44d-b7a6-4176-b2a9-120381aa6d96",
-        "release_name": "Never the Fever!!"
+        "release_name": "Never the Fever!!",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "傅菁",
+        "artist_credit_name": "\u5085\u83c1",
         "artist_mbids": [
             "c4f06a86-01fc-4eb3-bf49-08a6017298d9"
         ],
@@ -1391,10 +1504,11 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "e59b8759-c728-4c1b-9e7a-edc0ae4323e0",
-        "release_name": "愿卿安"
+        "release_name": "\u613f\u537f\u5b89",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "植松伸夫",
+        "artist_credit_name": "\u690d\u677e\u4f38\u592b",
         "artist_mbids": [
             "92bb085a-2924-4479-b627-181a1835d2f5"
         ],
@@ -1403,10 +1517,11 @@
         "release_group_mbid": "4a20d932-0ac5-422b-a655-c82925acadbe",
         "release_group_primary_type": "Album",
         "release_mbid": "dc2b6247-da2e-495d-a17c-51d36c389087",
-        "release_name": "Modulation - FINAL FANTASY Arrangement Album"
+        "release_name": "Modulation - FINAL FANTASY Arrangement Album",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "永塚拓馬",
+        "artist_credit_name": "\u6c38\u585a\u62d3\u99ac",
         "artist_mbids": [
             "1ffae607-1be8-4a80-8625-acdc9ea183df"
         ],
@@ -1415,10 +1530,11 @@
         "release_group_mbid": "6308ea01-754e-4474-8afa-42eb51387a79",
         "release_group_primary_type": "EP",
         "release_mbid": "f2a3fc1f-f40a-40d0-b329-08cdaa2f4000",
-        "release_name": "Jewel"
+        "release_name": "Jewel",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "遊佐こずえ（CV：花谷麻妃）, 双葉杏（CV：五十嵐裕美）, 多田李衣菜（CV：青木瑠璃子）, 木村夏樹（CV：安野希世乃）",
+        "artist_credit_name": "\u904a\u4f50\u3053\u305a\u3048\uff08CV\uff1a\u82b1\u8c37\u9ebb\u5983\uff09, \u53cc\u8449\u674f\uff08CV\uff1a\u4e94\u5341\u5d50\u88d5\u7f8e\uff09, \u591a\u7530\u674e\u8863\u83dc\uff08CV\uff1a\u9752\u6728\u7460\u7483\u5b50\uff09, \u6728\u6751\u590f\u6a39\uff08CV\uff1a\u5b89\u91ce\u5e0c\u4e16\u4e43\uff09",
         "artist_mbids": [
             "33fd76ca-0472-4853-bdff-f505f2e2208c",
             "34438792-01d5-483c-ac1d-dba7391fd23a",
@@ -1434,7 +1550,8 @@
         "release_group_mbid": "f62cbff0-479a-4951-86e9-7f596c7e8a6b",
         "release_group_primary_type": "Single",
         "release_mbid": "bcbd32d6-74cb-45e7-b1f1-1b90c5cda12f",
-        "release_name": "THE IDOLM@STER CINDERELLA GIRLS STARLIGHT MASTER R/LOCK ON! 10 まほうのまくら"
+        "release_name": "THE IDOLM@STER CINDERELLA GIRLS STARLIGHT MASTER R/LOCK ON! 10 \u307e\u307b\u3046\u306e\u307e\u304f\u3089",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Ava Max",
@@ -1446,7 +1563,8 @@
         "release_group_mbid": "a7f73d84-6c98-42ae-9d33-e7faf0570971",
         "release_group_primary_type": "Single",
         "release_mbid": "dcc48293-8c70-4104-9c63-8dc1f27a913b",
-        "release_name": "Weapons"
+        "release_name": "Weapons",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "GUSTAVOEGATOTV",
@@ -1458,7 +1576,8 @@
         "release_group_mbid": "07132e81-feb2-45ce-b893-55039cae0be1",
         "release_group_primary_type": "Single",
         "release_mbid": "9930ac95-72e0-4084-977d-544323359952",
-        "release_name": "Pista"
+        "release_name": "Pista",
+        "caa_release_mbid": "9930ac95-72e0-4084-977d-544323359952"
     },
     {
         "artist_credit_name": "Leni Oppenheimer",
@@ -1470,7 +1589,8 @@
         "release_group_mbid": "3fb63b7c-b991-4b7b-abce-ec689307f51e",
         "release_group_primary_type": "Single",
         "release_mbid": "219444fc-8823-464f-96b7-ec7998668e3a",
-        "release_name": "Thousand Faces"
+        "release_name": "Thousand Faces",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "The Book of Seth",
@@ -1483,10 +1603,11 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Demo",
         "release_mbid": "41371659-4cba-4dfc-9113-c3873cf6b1a3",
-        "release_name": "The Battle of Sancre Tor"
+        "release_name": "The Battle of Sancre Tor",
+        "caa_release_mbid": "41371659-4cba-4dfc-9113-c3873cf6b1a3"
     },
     {
-        "artist_credit_name": "잠비나이",
+        "artist_credit_name": "\uc7a0\ube44\ub098\uc774",
         "artist_mbids": [
             "74c9db5a-cece-4381-afa8-a5f381901487"
         ],
@@ -1495,7 +1616,8 @@
         "release_group_mbid": "bb062f46-d42f-43da-b72f-2f6cfcc23ae9",
         "release_group_primary_type": "EP",
         "release_mbid": "b05c4028-a9c2-4fa3-97ee-90353a9defb9",
-        "release_name": "Apparition"
+        "release_name": "Apparition",
+        "caa_release_mbid": "b05c4028-a9c2-4fa3-97ee-90353a9defb9"
     },
     {
         "artist_credit_name": "Action/Adventure",
@@ -1507,7 +1629,8 @@
         "release_group_mbid": "d3311e8b-b5e3-4412-8e10-447e11a0b65d",
         "release_group_primary_type": "Album",
         "release_mbid": "9c6032de-0ae6-440d-b56e-3d9d8e763a1f",
-        "release_name": "Imposter Syndrome"
+        "release_name": "Imposter Syndrome",
+        "caa_release_mbid": "9c6032de-0ae6-440d-b56e-3d9d8e763a1f"
     },
     {
         "artist_credit_name": "Actress",
@@ -1519,7 +1642,8 @@
         "release_group_mbid": "c0da7652-33f0-4599-8b70-28d94cee6e0e",
         "release_group_primary_type": "EP",
         "release_mbid": "e35a693a-8379-418b-b1fd-f3e9d35759ee",
-        "release_name": "Dummy Corporation"
+        "release_name": "Dummy Corporation",
+        "caa_release_mbid": "e35a693a-8379-418b-b1fd-f3e9d35759ee"
     },
     {
         "artist_credit_name": "Anthony McGill, Pacifica Quartet",
@@ -1532,7 +1656,8 @@
         "release_group_mbid": "ac3af246-260d-4b02-8577-ce432e07b14d",
         "release_group_primary_type": "Album",
         "release_mbid": "c00c102c-8b7b-43f1-b1dd-29999cb9c552",
-        "release_name": "American Stories"
+        "release_name": "American Stories",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Bad Colours",
@@ -1544,7 +1669,8 @@
         "release_group_mbid": "1131c59c-8791-4251-a1c7-02e3bfc5470f",
         "release_group_primary_type": "Album",
         "release_mbid": "5efbf524-a439-442c-a490-ec4ead306a3b",
-        "release_name": "Always With U"
+        "release_name": "Always With U",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "BARK",
@@ -1556,7 +1682,8 @@
         "release_group_mbid": "23d98881-443c-4cd2-bb2d-fd5b6f1242bf",
         "release_group_primary_type": "Album",
         "release_mbid": "c9665049-a9b9-41dd-9755-b2be78332f0d",
-        "release_name": "Rambler of Aeons"
+        "release_name": "Rambler of Aeons",
+        "caa_release_mbid": "c9665049-a9b9-41dd-9755-b2be78332f0d"
     },
     {
         "artist_credit_name": "Bill Frisell",
@@ -1568,7 +1695,8 @@
         "release_group_mbid": "e8eea776-5a03-4d4d-9991-6991b0fe5a99",
         "release_group_primary_type": "Album",
         "release_mbid": "d37d88b3-2956-4757-98db-eaa15813b466",
-        "release_name": "Four"
+        "release_name": "Four",
+        "caa_release_mbid": "d37d88b3-2956-4757-98db-eaa15813b466"
     },
     {
         "artist_credit_name": "Black Eyed Peas",
@@ -1580,7 +1708,8 @@
         "release_group_mbid": "7c5476cc-597a-4d8b-bc55-c0e21ca23ab9",
         "release_group_primary_type": "Album",
         "release_mbid": "e51fd6e8-f7ae-43b8-8104-42e9d8065c1d",
-        "release_name": "ELEVATION"
+        "release_name": "ELEVATION",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Bright Eyes",
@@ -1592,7 +1721,8 @@
         "release_group_mbid": "6989d50a-ab8b-4a74-8947-17bce9c6af4d",
         "release_group_primary_type": "EP",
         "release_mbid": "9070d8c3-088b-4448-9d67-29cf9dd22a0b",
-        "release_name": "Digital Ash in a Digital Urn: A Companion"
+        "release_name": "Digital Ash in a Digital Urn: A Companion",
+        "caa_release_mbid": "9070d8c3-088b-4448-9d67-29cf9dd22a0b"
     },
     {
         "artist_credit_name": "Bright Eyes",
@@ -1604,7 +1734,8 @@
         "release_group_mbid": "9c7e7079-66db-40b3-a305-d9fcdee7ad68",
         "release_group_primary_type": "EP",
         "release_mbid": "471bf890-fb57-422b-b7df-6e3739f56b04",
-        "release_name": "I’m Wide Awake, It’s Morning: A Companion"
+        "release_name": "I\u2019m Wide Awake, It\u2019s Morning: A Companion",
+        "caa_release_mbid": "471bf890-fb57-422b-b7df-6e3739f56b04"
     },
     {
         "artist_credit_name": "Bright Eyes",
@@ -1616,7 +1747,8 @@
         "release_group_mbid": "662ca286-8102-4e78-bb3d-737f5b3acacd",
         "release_group_primary_type": "EP",
         "release_mbid": "376e708f-c9b1-4910-b8a0-86b37a524490",
-        "release_name": "LIFTED or the Story Is in the Soil, Keep Your Ear to the Ground: A Companion"
+        "release_name": "LIFTED or the Story Is in the Soil, Keep Your Ear to the Ground: A Companion",
+        "caa_release_mbid": "376e708f-c9b1-4910-b8a0-86b37a524490"
     },
     {
         "artist_credit_name": "Brownbone",
@@ -1628,7 +1760,8 @@
         "release_group_mbid": "ac239b9a-3a3b-43b4-b35b-f4f5688854dd",
         "release_group_primary_type": "Single",
         "release_mbid": "ae13cf9e-33e4-4b91-b734-2663d4246651",
-        "release_name": "CopyCat"
+        "release_name": "CopyCat",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Bruce Springsteen",
@@ -1640,7 +1773,8 @@
         "release_group_mbid": "d6c1b942-edc7-4bca-bd34-6c43760272af",
         "release_group_primary_type": "Album",
         "release_mbid": "e05ba741-17ab-49de-8f66-3768aaa54f30",
-        "release_name": "Only the Strong Survive"
+        "release_name": "Only the Strong Survive",
+        "caa_release_mbid": "e05ba741-17ab-49de-8f66-3768aaa54f30"
     },
     {
         "artist_credit_name": "Cass McCombs & Weak Signal",
@@ -1653,7 +1787,8 @@
         "release_group_mbid": "e5f7535a-09ba-44e5-933f-790f8c86cebf",
         "release_group_primary_type": "Single",
         "release_mbid": "bfecc431-30b3-4a6b-be91-58f5078ae917",
-        "release_name": "Vacation From Thought / Give It Back"
+        "release_name": "Vacation From Thought / Give It Back",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "CD Ghost",
@@ -1665,10 +1800,11 @@
         "release_group_mbid": "afb7d66c-1455-4d07-b195-bffa5311c616",
         "release_group_primary_type": "Album",
         "release_mbid": "bd65b422-1053-4b93-82c8-042a02c020f9",
-        "release_name": "Night Music"
+        "release_name": "Night Music",
+        "caa_release_mbid": "bd65b422-1053-4b93-82c8-042a02c020f9"
     },
     {
-        "artist_credit_name": "Chancha Vía Circuito",
+        "artist_credit_name": "Chancha V\u00eda Circuito",
         "artist_mbids": [
             "22c82e36-c32c-4206-8a49-6d350cce992f"
         ],
@@ -1677,7 +1813,8 @@
         "release_group_mbid": "1af6eba1-4e32-4821-ad2c-09a76d1dd30b",
         "release_group_primary_type": "Album",
         "release_mbid": "41005244-1e91-4533-92b4-56e1f679618b",
-        "release_name": "La Estrella"
+        "release_name": "La Estrella",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Chelsea Grin",
@@ -1689,7 +1826,8 @@
         "release_group_mbid": "7fa319d9-36f9-4a7b-bdd7-6991d4436451",
         "release_group_primary_type": "Album",
         "release_mbid": "120890a7-8658-4e64-9d86-d366031057e5",
-        "release_name": "Suffer in Hell"
+        "release_name": "Suffer in Hell",
+        "caa_release_mbid": "120890a7-8658-4e64-9d86-d366031057e5"
     },
     {
         "artist_credit_name": "Christine and the Queens",
@@ -1701,7 +1839,8 @@
         "release_group_mbid": "1557d6eb-216f-451d-a90b-378e292d5742",
         "release_group_primary_type": "Album",
         "release_mbid": "17c94fba-387d-4510-bbb6-4ce08cf25279",
-        "release_name": "Redcar les adorables étoiles (prologue)"
+        "release_name": "Redcar les adorables \u00e9toiles (prologue)",
+        "caa_release_mbid": "17c94fba-387d-4510-bbb6-4ce08cf25279"
     },
     {
         "artist_credit_name": "Crystagella",
@@ -1713,7 +1852,8 @@
         "release_group_mbid": "14685dd3-c2ef-4470-80a7-c5d8843f302c",
         "release_group_primary_type": "Single",
         "release_mbid": "e50ff764-ae7e-40c1-8ceb-e709e065a849",
-        "release_name": "Hue"
+        "release_name": "Hue",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Darren Deac",
@@ -1725,7 +1865,8 @@
         "release_group_mbid": "859c3718-40c4-40f7-ba0b-de7bed77b9e4",
         "release_group_primary_type": "Single",
         "release_mbid": "9e028d09-acbe-4a63-be82-c3644e0da605",
-        "release_name": "We Praise Him"
+        "release_name": "We Praise Him",
+        "caa_release_mbid": "9e028d09-acbe-4a63-be82-c3644e0da605"
     },
     {
         "artist_credit_name": "DIRTYRXNIN",
@@ -1737,7 +1878,8 @@
         "release_group_mbid": "a187e196-bddd-4492-a975-54df058c8d6a",
         "release_group_primary_type": "Single",
         "release_mbid": "c7d41285-6a0b-49b3-8697-33650f1fac08",
-        "release_name": "Everglow"
+        "release_name": "Everglow",
+        "caa_release_mbid": "c7d41285-6a0b-49b3-8697-33650f1fac08"
     },
     {
         "artist_credit_name": "Dream Unending",
@@ -1749,7 +1891,8 @@
         "release_group_mbid": "dc0acfc8-4b2a-4a9d-9b03-c95e2604e358",
         "release_group_primary_type": "Album",
         "release_mbid": "127f58ae-f5d7-4b39-943b-6044a18262da",
-        "release_name": "Song of Salvation"
+        "release_name": "Song of Salvation",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Drowse",
@@ -1761,7 +1904,8 @@
         "release_group_mbid": "26f3bfe0-827d-4d25-8c24-013d5f7b2f00",
         "release_group_primary_type": "Album",
         "release_mbid": "b9cdf1b3-5fe1-488d-8cd8-260e78555fd6",
-        "release_name": "Wane Into It"
+        "release_name": "Wane Into It",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Drudkh",
@@ -1773,7 +1917,8 @@
         "release_group_mbid": "9b804fb0-9d02-4dcd-ab44-b812783fe40e",
         "release_group_primary_type": "Album",
         "release_mbid": "f42c9a2f-e110-4ce2-b763-9d5d01a02cc0",
-        "release_name": "Всі належать ночі"
+        "release_name": "\u0412\u0441\u0456 \u043d\u0430\u043b\u0435\u0436\u0430\u0442\u044c \u043d\u043e\u0447\u0456",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "dumb",
@@ -1785,7 +1930,8 @@
         "release_group_mbid": "40f3ff8e-17a6-4577-81a2-e98063bae9c9",
         "release_group_primary_type": "Album",
         "release_mbid": "18f6e57c-00cf-4cdc-9ada-e4373db8c0b3",
-        "release_name": "Pray 4 Tomorrow"
+        "release_name": "Pray 4 Tomorrow",
+        "caa_release_mbid": "18f6e57c-00cf-4cdc-9ada-e4373db8c0b3"
     },
     {
         "artist_credit_name": "Duval Timothy",
@@ -1797,7 +1943,8 @@
         "release_group_mbid": "e006ba65-06ad-4b2f-b922-446f03e1f4d1",
         "release_group_primary_type": "Album",
         "release_mbid": "22d4e6e6-3ea7-4ae5-aa8d-b3ded2880fb6",
-        "release_name": "Meeting with a Judas Tree"
+        "release_name": "Meeting with a Judas Tree",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Dysgnostic",
@@ -1809,7 +1956,8 @@
         "release_group_mbid": "a1751f0e-c3f5-43a2-90bd-edd6948487f5",
         "release_group_primary_type": "Album",
         "release_mbid": "e3a63d48-2cc7-456c-be36-5caa514839ec",
-        "release_name": "Scar Echoes"
+        "release_name": "Scar Echoes",
+        "caa_release_mbid": "e3a63d48-2cc7-456c-be36-5caa514839ec"
     },
     {
         "artist_credit_name": "El-Tron",
@@ -1821,7 +1969,8 @@
         "release_group_mbid": "3f4df4ba-e427-4fe0-b10f-f60efe854702",
         "release_group_primary_type": "Single",
         "release_mbid": "a2b775f8-637f-47db-8fe3-33fbed4e0548",
-        "release_name": "In My Mind"
+        "release_name": "In My Mind",
+        "caa_release_mbid": "a2b775f8-637f-47db-8fe3-33fbed4e0548"
     },
     {
         "artist_credit_name": "Epica",
@@ -1833,7 +1982,8 @@
         "release_group_mbid": "476752c9-d33e-443a-b028-4cd06b52cedf",
         "release_group_primary_type": "EP",
         "release_mbid": "b80b9dd9-0841-4e9b-93d0-aa7b7e66d9c5",
-        "release_name": "The Alchemy Project"
+        "release_name": "The Alchemy Project",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Estrangement",
@@ -1845,7 +1995,8 @@
         "release_group_mbid": "8932edad-bbc8-45ac-8f49-1f3ae2c6e9e6",
         "release_group_primary_type": "Album",
         "release_mbid": "5969502f-fa0f-401b-9a57-aa14da9c00df",
-        "release_name": "Disfigurementality"
+        "release_name": "Disfigurementality",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "FaltyDL",
@@ -1857,10 +2008,11 @@
         "release_group_mbid": "f8a6d0e0-d3d9-430d-a5bb-b71c521721fa",
         "release_group_primary_type": "Album",
         "release_mbid": "3c8817ea-b52e-449a-894e-b5033e97f28c",
-        "release_name": "A Nurse to My Patience"
+        "release_name": "A Nurse to My Patience",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "FJØRT",
+        "artist_credit_name": "FJ\u00d8RT",
         "artist_mbids": [
             "bcb478f4-dbf9-4bc8-823e-bec7986d652b"
         ],
@@ -1869,7 +2021,8 @@
         "release_group_mbid": "756d1c75-c8bc-46be-a8e5-2a67fa1f715a",
         "release_group_primary_type": "Album",
         "release_mbid": "602bfdf8-d49d-4445-b618-1e2d82eaf6a5",
-        "release_name": "Nichts"
+        "release_name": "Nichts",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Flaminia & VSK",
@@ -1882,7 +2035,8 @@
         "release_group_mbid": "cefd6a9e-49d2-456f-ac22-fe5b1e436769",
         "release_group_primary_type": "EP",
         "release_mbid": "f501cebd-4ba8-43b1-9690-00d84535751e",
-        "release_name": "47032"
+        "release_name": "47032",
+        "caa_release_mbid": "f501cebd-4ba8-43b1-9690-00d84535751e"
     },
     {
         "artist_credit_name": "FORAGEMON",
@@ -1895,7 +2049,8 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Remix",
         "release_mbid": "829e5edf-c449-40b9-9687-19f8b96e48a0",
-        "release_name": "Jdnk (Remix)"
+        "release_name": "Jdnk (Remix)",
+        "caa_release_mbid": "829e5edf-c449-40b9-9687-19f8b96e48a0"
     },
     {
         "artist_credit_name": "FreqGen",
@@ -1907,7 +2062,8 @@
         "release_group_mbid": "2e0701bf-b268-4e1c-a365-15f20870f738",
         "release_group_primary_type": "Album",
         "release_mbid": "65d92cbe-9b60-4e23-bfaa-4b1c4bd06a01",
-        "release_name": "Future 1990s"
+        "release_name": "Future 1990s",
+        "caa_release_mbid": "65d92cbe-9b60-4e23-bfaa-4b1c4bd06a01"
     },
     {
         "artist_credit_name": "Furi Helium",
@@ -1919,7 +2075,8 @@
         "release_group_mbid": "7517e7d4-a3d7-45ff-b9c0-e234d27585ff",
         "release_group_primary_type": "Album",
         "release_mbid": "1ba9256f-1a91-46c5-aaaa-d60c82b2775f",
-        "release_name": "Far From Sanity"
+        "release_name": "Far From Sanity",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Gli Alberi",
@@ -1931,7 +2088,8 @@
         "release_group_mbid": "03f5f8cf-2b65-463f-89d4-b6ed429e1e1f",
         "release_group_primary_type": "Single",
         "release_mbid": "d977016d-b365-4789-ad45-ac7ad374945a",
-        "release_name": "Sindrome del Terzo Uomo"
+        "release_name": "Sindrome del Terzo Uomo",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Gold Panda",
@@ -1943,7 +2101,8 @@
         "release_group_mbid": "6d408289-59c9-4c38-9f24-3e2a19e28936",
         "release_group_primary_type": "Album",
         "release_mbid": "6a8eadff-268d-4d11-9b5d-43985aa1de5e",
-        "release_name": "The Work"
+        "release_name": "The Work",
+        "caa_release_mbid": "6a8eadff-268d-4d11-9b5d-43985aa1de5e"
     },
     {
         "artist_credit_name": "Gordon Koang",
@@ -1955,7 +2114,8 @@
         "release_group_mbid": "b324bb3a-1b4e-433d-97df-c32bfa5757fd",
         "release_group_primary_type": "Album",
         "release_mbid": "35e97387-6cfa-4439-a876-fb03dd7895b9",
-        "release_name": "Community"
+        "release_name": "Community",
+        "caa_release_mbid": "35e97387-6cfa-4439-a876-fb03dd7895b9"
     },
     {
         "artist_credit_name": "Grasp Logic",
@@ -1967,10 +2127,11 @@
         "release_group_mbid": "c40b3eb1-11be-4728-a2ca-d9efbd0fd7d5",
         "release_group_primary_type": "EP",
         "release_mbid": "84b020d1-4351-43e9-a166-ded3cb6af2e1",
-        "release_name": "TR4M V2"
+        "release_name": "TR4M V2",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "Guns N’ Roses",
+        "artist_credit_name": "Guns N\u2019 Roses",
         "artist_mbids": [
             "eeb1195b-f213-4ce1-b28c-8565211f8e43"
         ],
@@ -1980,7 +2141,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Compilation",
         "release_mbid": "fb457b64-78da-4671-87fb-f40e3e724322",
-        "release_name": "Use Your Illusion"
+        "release_name": "Use Your Illusion",
+        "caa_release_mbid": "fb457b64-78da-4671-87fb-f40e3e724322"
     },
     {
         "artist_credit_name": "Haavard",
@@ -1992,7 +2154,8 @@
         "release_group_mbid": "ccd0d6f1-a68c-477c-9e1b-056ae1381f48",
         "release_group_primary_type": "Album",
         "release_mbid": "28046732-f286-4fe8-875b-62811fee61ad",
-        "release_name": "Haavard"
+        "release_name": "Haavard",
+        "caa_release_mbid": "28046732-f286-4fe8-875b-62811fee61ad"
     },
     {
         "artist_credit_name": "Happy Daggers",
@@ -2004,7 +2167,8 @@
         "release_group_mbid": "cc009830-36a1-4d89-af94-77376e9062e1",
         "release_group_primary_type": "Single",
         "release_mbid": "e74bdfa5-22ad-4f8a-8d8a-8e6285832744",
-        "release_name": "Turn It Up"
+        "release_name": "Turn It Up",
+        "caa_release_mbid": "e74bdfa5-22ad-4f8a-8d8a-8e6285832744"
     },
     {
         "artist_credit_name": "Helge Lien & Knut Hem",
@@ -2017,7 +2181,8 @@
         "release_group_mbid": "dfebb8d2-1641-4d65-8abe-8059be86b685",
         "release_group_primary_type": "Album",
         "release_mbid": "8571f885-0d56-46e6-8473-ebe19dafbe46",
-        "release_name": "Villingsberg"
+        "release_name": "Villingsberg",
+        "caa_release_mbid": "8571f885-0d56-46e6-8473-ebe19dafbe46"
     },
     {
         "artist_credit_name": "Homeboy Sandman",
@@ -2029,10 +2194,11 @@
         "release_group_mbid": "82f732a7-b6f7-4816-9cbf-4ed0485938cd",
         "release_group_primary_type": "Album",
         "release_mbid": "81bc6db4-b830-4b6b-aad6-501a1307adc9",
-        "release_name": "Still Champion"
+        "release_name": "Still Champion",
+        "caa_release_mbid": "81bc6db4-b830-4b6b-aad6-501a1307adc9"
     },
     {
-        "artist_credit_name": "I’ve",
+        "artist_credit_name": "I\u2019ve",
         "artist_mbids": [
             "9eea0562-cb2c-4a61-8587-a6abcb2e6396"
         ],
@@ -2041,7 +2207,8 @@
         "release_group_mbid": "52857904-46e3-40eb-b9f5-21da007dd1a7",
         "release_group_primary_type": "Album",
         "release_mbid": "c4a72efb-4202-4c4e-8ec3-c300dbfdcef9",
-        "release_name": "I've Member's Concept Compilation ALBUM vol,02 SUMMER END GROOVE"
+        "release_name": "I've Member's Concept Compilation ALBUM vol,02 SUMMER END GROOVE",
+        "caa_release_mbid": "c4a72efb-4202-4c4e-8ec3-c300dbfdcef9"
     },
     {
         "artist_credit_name": "Jazzrausch Bigband",
@@ -2053,10 +2220,11 @@
         "release_group_mbid": "6941ca12-3a2a-404c-863e-65daeed697a6",
         "release_group_primary_type": "Album",
         "release_mbid": "6ec81230-458f-4268-bbc4-bfb6c945cb66",
-        "release_name": "Alle Jahre wieder!"
+        "release_name": "Alle Jahre wieder!",
+        "caa_release_mbid": "6ec81230-458f-4268-bbc4-bfb6c945cb66"
     },
     {
-        "artist_credit_name": "Joe Jonas × Khalid",
+        "artist_credit_name": "Joe Jonas \u00d7 Khalid",
         "artist_mbids": [
             "28737730-ec70-4da5-89c5-77ac13c5c34d",
             "79e1bb77-fd8b-42ab-8043-892af5370f0b"
@@ -2067,7 +2235,8 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Soundtrack",
         "release_mbid": "1dbbb909-e377-4adb-bab6-0e98d483626c",
-        "release_name": "Not Alone (from the motion picture Devotion)"
+        "release_name": "Not Alone (from the motion picture Devotion)",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "John Moods",
@@ -2079,7 +2248,8 @@
         "release_group_mbid": "d3316e81-fc5e-4b78-80fa-cbfd98824e0c",
         "release_group_primary_type": "Album",
         "release_mbid": "a2d89d99-fee2-4a96-aed2-dbaed694c6e0",
-        "release_name": "The Great Design"
+        "release_name": "The Great Design",
+        "caa_release_mbid": "a2d89d99-fee2-4a96-aed2-dbaed694c6e0"
     },
     {
         "artist_credit_name": "Jordana",
@@ -2091,7 +2261,8 @@
         "release_group_mbid": "49b317a6-d379-4c57-899f-f2b067374e2e",
         "release_group_primary_type": "EP",
         "release_mbid": "f6f862f0-eae6-4ba1-a27a-352e82f0a6a5",
-        "release_name": "I'm Doing Well, Thanks for Asking"
+        "release_name": "I'm Doing Well, Thanks for Asking",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Jordin Sparks",
@@ -2103,7 +2274,8 @@
         "release_group_mbid": "701aa5ae-7a95-496a-917d-613c9bb569bf",
         "release_group_primary_type": "Single",
         "release_mbid": "5432730f-b9d7-4512-a378-abddeb9884a7",
-        "release_name": "Stop This Feeling"
+        "release_name": "Stop This Feeling",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Kampfar",
@@ -2115,7 +2287,8 @@
         "release_group_mbid": "7c965aa3-03bc-4ffe-b797-a449976a0a06",
         "release_group_primary_type": "Album",
         "release_mbid": "2525075f-6768-4f89-b25d-80edcea53431",
-        "release_name": "Til Klovers Takt"
+        "release_name": "Til Klovers Takt",
+        "caa_release_mbid": "2525075f-6768-4f89-b25d-80edcea53431"
     },
     {
         "artist_credit_name": "Kim Petras",
@@ -2127,7 +2300,8 @@
         "release_group_mbid": "4f7e52b4-5e65-455b-b106-f5e091ed6b81",
         "release_group_primary_type": "Single",
         "release_mbid": "01e9a9da-eb6e-44df-8c3a-76eaa738a39c",
-        "release_name": "If Jesus Was a Rockstar"
+        "release_name": "If Jesus Was a Rockstar",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Kx5 feat. James French",
@@ -2140,7 +2314,8 @@
         "release_group_mbid": "756d9414-bcfb-4490-8fcd-a92abba23d05",
         "release_group_primary_type": "Single",
         "release_mbid": "15b03d17-4822-4258-95f8-1e9b01463bab",
-        "release_name": "Avalanche (extended mix)"
+        "release_name": "Avalanche (extended mix)",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Larkin Poe",
@@ -2152,7 +2327,8 @@
         "release_group_mbid": "54268582-6f02-4321-80cc-e7ad73c2970f",
         "release_group_primary_type": "Album",
         "release_mbid": "193c6803-697c-420c-b5d3-d6a6c6d383b1",
-        "release_name": "Blood Harmony"
+        "release_name": "Blood Harmony",
+        "caa_release_mbid": "193c6803-697c-420c-b5d3-d6a6c6d383b1"
     },
     {
         "artist_credit_name": "Leatherwolf",
@@ -2164,7 +2340,8 @@
         "release_group_mbid": "0bf21225-0a4d-46f0-927c-49963ca1f473",
         "release_group_primary_type": "Album",
         "release_mbid": "474ab9ee-48ef-4791-ba0e-14933c589173",
-        "release_name": "Kill the Hunted"
+        "release_name": "Kill the Hunted",
+        "caa_release_mbid": "474ab9ee-48ef-4791-ba0e-14933c589173"
     },
     {
         "artist_credit_name": "LM SAJO",
@@ -2176,7 +2353,8 @@
         "release_group_mbid": "260c502e-432a-46a6-9d24-ab7c055f85cc",
         "release_group_primary_type": "Album",
         "release_mbid": "b213df16-5e53-4dcd-b28f-88f8f409f675",
-        "release_name": "Untitled - Part 1"
+        "release_name": "Untitled - Part 1",
+        "caa_release_mbid": "b213df16-5e53-4dcd-b28f-88f8f409f675"
     },
     {
         "artist_credit_name": "Louis Tomlinson",
@@ -2188,7 +2366,8 @@
         "release_group_mbid": "352ea153-ff8d-4ba3-9cbd-30eabdd1bb4d",
         "release_group_primary_type": "Album",
         "release_mbid": "ad78e51f-9626-450a-960b-5c79cd719f67",
-        "release_name": "Faith in the Future"
+        "release_name": "Faith in the Future",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "L.S. Dunes",
@@ -2200,7 +2379,8 @@
         "release_group_mbid": "c5b21a97-839e-469d-a91a-b3cac90959bd",
         "release_group_primary_type": "Album",
         "release_mbid": "cb47702a-5115-4d2a-924a-58e95aefb509",
-        "release_name": "Past Lives"
+        "release_name": "Past Lives",
+        "caa_release_mbid": "cb47702a-5115-4d2a-924a-58e95aefb509"
     },
     {
         "artist_credit_name": "Malist",
@@ -2212,7 +2392,8 @@
         "release_group_mbid": "b64a39e2-e0f9-4be9-9e5c-52d89a10cef8",
         "release_group_primary_type": "Album",
         "release_mbid": "228c56b9-3440-4402-b146-4b2e8f007322",
-        "release_name": "As I Become Darkness"
+        "release_name": "As I Become Darkness",
+        "caa_release_mbid": "228c56b9-3440-4402-b146-4b2e8f007322"
     },
     {
         "artist_credit_name": "Mark Sheeky",
@@ -2224,7 +2405,8 @@
         "release_group_mbid": "44641987-4b29-47ec-83e9-6a4673d87f53",
         "release_group_primary_type": "EP",
         "release_mbid": "9c2958b7-d82b-4d1b-a515-3992b290e0e7",
-        "release_name": "Heart of Snow"
+        "release_name": "Heart of Snow",
+        "caa_release_mbid": "9c2958b7-d82b-4d1b-a515-3992b290e0e7"
     },
     {
         "artist_credit_name": "MGMT",
@@ -2237,7 +2419,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Live",
         "release_mbid": "16317fa2-7382-42e2-a39f-cbdc4dcc0ea1",
-        "release_name": "11•11•11"
+        "release_name": "11\u202211\u202211",
+        "caa_release_mbid": "16317fa2-7382-42e2-a39f-cbdc4dcc0ea1"
     },
     {
         "artist_credit_name": "Mister Strange",
@@ -2249,10 +2432,11 @@
         "release_group_mbid": "4af93870-866c-49f0-9fd6-773420ca4997",
         "release_group_primary_type": "EP",
         "release_mbid": "4a1dd0ac-7a65-49da-be6c-8dbc70a66cdb",
-        "release_name": "Nothing at All"
+        "release_name": "Nothing at All",
+        "caa_release_mbid": null
     },
     {
-        "artist_credit_name": "Nicolas Bougaïeff",
+        "artist_credit_name": "Nicolas Bouga\u00efeff",
         "artist_mbids": [
             "69700f44-98c4-47b6-8a61-1e0b858d645a"
         ],
@@ -2261,7 +2445,8 @@
         "release_group_mbid": "4427c6b1-bfee-417a-814e-6745ec7f37df",
         "release_group_primary_type": "Album",
         "release_mbid": "36a580b3-c052-4367-bb01-0da29e015951",
-        "release_name": "Begin Within"
+        "release_name": "Begin Within",
+        "caa_release_mbid": "36a580b3-c052-4367-bb01-0da29e015951"
     },
     {
         "artist_credit_name": "Our 11th Hour",
@@ -2273,7 +2458,8 @@
         "release_group_mbid": "33717aa2-02c7-4ecb-b02b-028fac43d699",
         "release_group_primary_type": "Album",
         "release_mbid": "0be17fa4-625e-4b1b-a0eb-89635ac40aa8",
-        "release_name": "Of Halos & Hand Grenades"
+        "release_name": "Of Halos & Hand Grenades",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Phoxjaw",
@@ -2285,7 +2471,8 @@
         "release_group_mbid": "343c11de-9fbb-4ef0-88a3-dd94932e11ce",
         "release_group_primary_type": "Album",
         "release_mbid": "a8d47272-115b-4eb9-9da2-43172848f242",
-        "release_name": "notverynicecream"
+        "release_name": "notverynicecream",
+        "caa_release_mbid": "a8d47272-115b-4eb9-9da2-43172848f242"
     },
     {
         "artist_credit_name": "Plaid",
@@ -2297,10 +2484,11 @@
         "release_group_mbid": "62a00165-6e7a-47b0-8272-431ac5ca6c36",
         "release_group_primary_type": "Album",
         "release_mbid": "f53776e9-728e-4a3c-bfc8-048fc00d32e2",
-        "release_name": "Feorm Falorx"
+        "release_name": "Feorm Falorx",
+        "caa_release_mbid": "f53776e9-728e-4a3c-bfc8-048fc00d32e2"
     },
     {
-        "artist_credit_name": "RADWIMPS & 陣内一真",
+        "artist_credit_name": "RADWIMPS & \u9663\u5185\u4e00\u771f",
         "artist_mbids": [
             "6f500293-7396-4903-b4fd-118127d06f9e",
             "c9c59c75-f51b-4e38-bc15-b3a036f4d0ad"
@@ -2310,7 +2498,8 @@
         "release_group_mbid": "575df7d0-d1a1-4ca0-82dd-6ef4a1f03f4e",
         "release_group_primary_type": "Album",
         "release_mbid": "69009395-214f-4625-9fc4-139bcef9d413",
-        "release_name": "すずめの戸締まり"
+        "release_name": "\u3059\u305a\u3081\u306e\u6238\u7de0\u307e\u308a",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Rat Cage",
@@ -2322,7 +2511,8 @@
         "release_group_mbid": "b83f8701-15f1-48f6-8707-e70b5bc5fa84",
         "release_group_primary_type": "Single",
         "release_mbid": "439da426-29a1-41a0-a2ee-2282b5416678",
-        "release_name": "In The Shadow Of The Bomb"
+        "release_name": "In The Shadow Of The Bomb",
+        "caa_release_mbid": "439da426-29a1-41a0-a2ee-2282b5416678"
     },
     {
         "artist_credit_name": "Razzie",
@@ -2334,7 +2524,8 @@
         "release_group_mbid": "db43a750-c902-4dba-a65e-47874311751e",
         "release_group_primary_type": "Single",
         "release_mbid": "a8489abd-0fc8-4163-bd3c-2f1e0acc9ca2",
-        "release_name": "Eden"
+        "release_name": "Eden",
+        "caa_release_mbid": "a8489abd-0fc8-4163-bd3c-2f1e0acc9ca2"
     },
     {
         "artist_credit_name": "Remina",
@@ -2346,7 +2537,8 @@
         "release_group_mbid": "be796e30-42f9-4926-b331-5a1fdb301c36",
         "release_group_primary_type": "Album",
         "release_mbid": "99f1e63b-cf91-482d-80fa-a9583f68aa92",
-        "release_name": "Strata"
+        "release_name": "Strata",
+        "caa_release_mbid": "99f1e63b-cf91-482d-80fa-a9583f68aa92"
     },
     {
         "artist_credit_name": "Roanoke",
@@ -2358,7 +2550,8 @@
         "release_group_mbid": "45765056-7bf4-4c23-b5b4-013f8fac7410",
         "release_group_primary_type": "EP",
         "release_mbid": "f2c71d39-2cbd-4a6a-8e71-711a2d39b37b",
-        "release_name": "Wolf Motel"
+        "release_name": "Wolf Motel",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Robb Johnson",
@@ -2370,7 +2563,8 @@
         "release_group_mbid": "a71e1089-894d-4052-bc09-5b31668d27a2",
         "release_group_primary_type": "Album",
         "release_mbid": "19dfc983-2c5d-4c93-bc7d-d27a59be32b3",
-        "release_name": "Minimum Wages / Bodger: My Part in His Downfall"
+        "release_name": "Minimum Wages / Bodger: My Part in His Downfall",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Roderick Newport",
@@ -2382,7 +2576,8 @@
         "release_group_mbid": "252ece86-8989-4960-a075-5541688d93c1",
         "release_group_primary_type": "Single",
         "release_mbid": "34d57779-4d0c-4941-aad5-1e6fac9b65ee",
-        "release_name": "Snowy Christmas Night"
+        "release_name": "Snowy Christmas Night",
+        "caa_release_mbid": "34d57779-4d0c-4941-aad5-1e6fac9b65ee"
     },
     {
         "artist_credit_name": "Sarathy Korwar",
@@ -2394,7 +2589,8 @@
         "release_group_mbid": "e725f103-4782-42e2-87f1-268657445967",
         "release_group_primary_type": "Album",
         "release_mbid": "87e34299-ad9a-4a79-80ed-b433c5c92189",
-        "release_name": "Kalak"
+        "release_name": "Kalak",
+        "caa_release_mbid": "87e34299-ad9a-4a79-80ed-b433c5c92189"
     },
     {
         "artist_credit_name": "S.C.A.B.",
@@ -2406,7 +2602,8 @@
         "release_group_mbid": "7eb9a2dc-9ca7-4022-bba8-fb238bbd80d0",
         "release_group_primary_type": "Album",
         "release_mbid": "58f01292-9cc6-484f-8786-55e8cfd7c857",
-        "release_name": "S.C.A.B."
+        "release_name": "S.C.A.B.",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Seething Akira",
@@ -2417,7 +2614,8 @@
         "release_date": "2022-11-11",
         "release_group_mbid": "d8eaed94-4e21-43ab-9779-ed47a464e342",
         "release_mbid": "3286c348-f22b-4b0b-83ce-15791d19120c",
-        "release_name": "Nozomi"
+        "release_name": "Nozomi",
+        "caa_release_mbid": "3286c348-f22b-4b0b-83ce-15791d19120c"
     },
     {
         "artist_credit_name": "Smut",
@@ -2429,7 +2627,8 @@
         "release_group_mbid": "bc1dffed-3527-426d-804a-25175b504f63",
         "release_group_primary_type": "Album",
         "release_mbid": "3f4bd110-9ac8-4b4b-9a5d-d8f3f577c33c",
-        "release_name": "How the Light Felt"
+        "release_name": "How the Light Felt",
+        "caa_release_mbid": "3f4bd110-9ac8-4b4b-9a5d-d8f3f577c33c"
     },
     {
         "artist_credit_name": "STR4TA",
@@ -2441,7 +2640,8 @@
         "release_group_mbid": "14a3be88-960b-438b-88e0-f60f54f9c281",
         "release_group_primary_type": "Album",
         "release_mbid": "6be4ee74-a633-4546-9b50-88dfd67c496d",
-        "release_name": "STR4TASFEAR"
+        "release_name": "STR4TASFEAR",
+        "caa_release_mbid": "6be4ee74-a633-4546-9b50-88dfd67c496d"
     },
     {
         "artist_credit_name": "The Catburgers",
@@ -2453,7 +2653,8 @@
         "release_group_mbid": "a1024aea-5bb1-44c7-b8a4-5c77ab4d64a8",
         "release_group_primary_type": "EP",
         "release_mbid": "81013e5a-fea7-4861-b8f6-c204e0350b77",
-        "release_name": "Dreamworld Sessions"
+        "release_name": "Dreamworld Sessions",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "The Cherry Blues Project",
@@ -2465,7 +2666,8 @@
         "release_group_mbid": "ad2cdea5-243c-4f3c-bb44-a981f17315c6",
         "release_group_primary_type": "Album",
         "release_mbid": "d893461c-ecfa-4b59-9570-68b97e3732ae",
-        "release_name": "Gasoline Stations"
+        "release_name": "Gasoline Stations",
+        "caa_release_mbid": "d893461c-ecfa-4b59-9570-68b97e3732ae"
     },
     {
         "artist_credit_name": "The Third-Rates",
@@ -2477,7 +2679,8 @@
         "release_group_mbid": "7cfa2650-a59f-46ff-9ae7-fa8805f624ae",
         "release_group_primary_type": "Single",
         "release_mbid": "63e909c6-2a03-4cf4-97fb-8627a8e77782",
-        "release_name": "Escape From The City"
+        "release_name": "Escape From The City",
+        "caa_release_mbid": "63e909c6-2a03-4cf4-97fb-8627a8e77782"
     },
     {
         "artist_credit_name": "The Trashmen",
@@ -2490,7 +2693,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Compilation",
         "release_mbid": "338d16bb-db96-4bab-8d97-7c6be428db5c",
-        "release_name": "The Best of the Trashmen"
+        "release_name": "The Best of the Trashmen",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Thys & Two Fingers",
@@ -2503,7 +2707,8 @@
         "release_group_mbid": "79a4fdf6-9225-4fd1-b694-84004bb82226",
         "release_group_primary_type": "Single",
         "release_mbid": "dedcc993-5f10-489c-a42f-931c0a2029a9",
-        "release_name": "Hodo"
+        "release_name": "Hodo",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Twilight Force",
@@ -2515,7 +2720,8 @@
         "release_group_mbid": "c7e786a3-b86d-4201-b836-3e40a888a6db",
         "release_group_primary_type": "Single",
         "release_mbid": "434f7108-fb1b-4f56-8167-48d73be3a3e8",
-        "release_name": "Twilight Force"
+        "release_name": "Twilight Force",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Various Artists",
@@ -2527,7 +2733,8 @@
         "release_group_mbid": "5b0de392-41e3-4e25-a887-d45257742d38",
         "release_group_primary_type": "Album",
         "release_mbid": "63fadd35-c3a5-46f3-85da-6768362c124e",
-        "release_name": "DDD100"
+        "release_name": "DDD100",
+        "caa_release_mbid": "63fadd35-c3a5-46f3-85da-6768362c124e"
     },
     {
         "artist_credit_name": "Various Artists",
@@ -2540,7 +2747,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Compilation",
         "release_mbid": "4eed2558-5e1c-4a86-8bf8-2a2420b89e59",
-        "release_name": "Life Moves Pretty Fast: The John Hughes Mixtapes"
+        "release_name": "Life Moves Pretty Fast: The John Hughes Mixtapes",
+        "caa_release_mbid": "4eed2558-5e1c-4a86-8bf8-2a2420b89e59"
     },
     {
         "artist_credit_name": "Various Artists",
@@ -2552,7 +2760,8 @@
         "release_group_mbid": "585b019c-a2d8-499d-8353-a4b21ad3a42b",
         "release_group_primary_type": "Album",
         "release_mbid": "f11b4705-263b-478d-8cbf-bc2bf63fb772",
-        "release_name": "Live Forever: A Tribute to Billy Joe Shaver"
+        "release_name": "Live Forever: A Tribute to Billy Joe Shaver",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Various Artists",
@@ -2565,7 +2774,8 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": "Compilation",
         "release_mbid": "23d75691-f313-4ab8-88fa-d44ba32dfab3",
-        "release_name": "NOW That’s What I Call a Massive 80s Party"
+        "release_name": "NOW That\u2019s What I Call a Massive 80s Party",
+        "caa_release_mbid": "23d75691-f313-4ab8-88fa-d44ba32dfab3"
     },
     {
         "artist_credit_name": "Verra Cruz",
@@ -2577,7 +2787,8 @@
         "release_group_mbid": "a0d134b1-aab6-457c-9069-6e90b8262840",
         "release_group_primary_type": "Single",
         "release_mbid": "bedb010e-9955-4a45-96aa-8e3d10f0cdfe",
-        "release_name": "The World Is Crashing In"
+        "release_name": "The World Is Crashing In",
+        "caa_release_mbid": "bedb010e-9955-4a45-96aa-8e3d10f0cdfe"
     },
     {
         "artist_credit_name": "Warhaus",
@@ -2589,7 +2800,8 @@
         "release_group_mbid": "3af3d2e7-de2c-4f93-affb-dfdf75a5d8cc",
         "release_group_primary_type": "Album",
         "release_mbid": "47ae0ed2-2b53-4b83-8806-4a671bbe7322",
-        "release_name": "Ha Ha Heartbreak"
+        "release_name": "Ha Ha Heartbreak",
+        "caa_release_mbid": "47ae0ed2-2b53-4b83-8806-4a671bbe7322"
     },
     {
         "artist_credit_name": "Wesley",
@@ -2601,7 +2813,8 @@
         "release_group_mbid": "024f04f0-9459-4060-8322-f3595a124017",
         "release_group_primary_type": "Album",
         "release_mbid": "d4f6622b-0bc7-4b6a-bcec-39f4b1c92892",
-        "release_name": "Glows in the Dark"
+        "release_name": "Glows in the Dark",
+        "caa_release_mbid": "d4f6622b-0bc7-4b6a-bcec-39f4b1c92892"
     },
     {
         "artist_credit_name": "El Baguette",
@@ -2613,7 +2826,8 @@
         "release_group_mbid": "115decf3-dce9-42ca-bc29-df2ef3d621b9",
         "release_group_primary_type": "Album",
         "release_mbid": "3917ae76-a57c-4a83-95c1-5de8235263ef",
-        "release_name": "La Recette"
+        "release_name": "La Recette",
+        "caa_release_mbid": "3917ae76-a57c-4a83-95c1-5de8235263ef"
     },
     {
         "artist_credit_name": "GAKHED",
@@ -2625,7 +2839,8 @@
         "release_group_mbid": "a80818ec-ba6b-49e7-a092-c5c08d39ecf3",
         "release_group_primary_type": "Album",
         "release_mbid": "8524c8fe-7dd6-4d0d-b478-0241f484bbf4",
-        "release_name": "SUBLIMINAL TEARS"
+        "release_name": "SUBLIMINAL TEARS",
+        "caa_release_mbid": null
     },
     {
         "artist_credit_name": "Hungry March Band",
@@ -2637,6 +2852,7 @@
         "release_group_mbid": "0fe3eb2c-71ad-42b4-8195-54186ce22781",
         "release_group_primary_type": "Album",
         "release_mbid": "54ac8ecb-d590-40fa-932c-513cf5d62eb6",
-        "release_name": "On The Waterfront"
+        "release_name": "On The Waterfront",
+        "caa_release_mbid": "54ac8ecb-d590-40fa-932c-513cf5d62eb6"
     }
 ]

--- a/frontend/js/tests/__mocks__/freshReleasesUserData.json
+++ b/frontend/js/tests/__mocks__/freshReleasesUserData.json
@@ -29,7 +29,7 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "5b2c8f92-5567-479f-8262-a00a7f8724b1",
-                "release_name": "Vande Mataram (From \u201cCode Name Tiranga\u201d)",
+                "release_name": "Vande Mataram (From “Code Name Tiranga”)",
                 "caa_release_mbid": "5b2c8f92-5567-479f-8262-a00a7f8724b1"
             },
             {
@@ -105,7 +105,7 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "4c3e85bb-a6fa-4ba5-8c78-be5853e75833",
-                "release_name": "Rasiya Reprise (From \u201cBrahmastra\u201d)",
+                "release_name": "Rasiya Reprise (From “Brahmastra”)",
                 "caa_release_mbid": "4c3e85bb-a6fa-4ba5-8c78-be5853e75833"
             },
             {
@@ -216,7 +216,7 @@
                 "caa_release_mbid": "ddf24806-c813-43b1-882d-e51152a29868"
             },
             {
-                "artist_credit_name": "Ti\u00ebsto \u00d7 Black Eyed Peas",
+                "artist_credit_name": "Tiësto × Black Eyed Peas",
                 "artist_mbids": [
                     "aabb1d9f-be12-45b3-a84d-a1fc3e8181fd",
                     "d5be5333-4171-427e-8e12-732087c6b78e"
@@ -263,7 +263,7 @@
                 "caa_release_mbid": null
             },
             {
-                "artist_credit_name": "Mot\u00f6rhead",
+                "artist_credit_name": "Motörhead",
                 "artist_mbids": [
                     "57961a97-3796-4bf7-9f02-a985a8979ae9"
                 ],
@@ -274,7 +274,7 @@
                 "release_group_primary_type": "EP",
                 "release_group_secondary_type": "Compilation",
                 "release_mbid": "403a79a8-0cbd-4a6c-b694-39a2cbd6dc75",
-                "release_name": "Mot\u00f6r\u2010ween",
+                "release_name": "Motör‐ween",
                 "caa_release_mbid": "403a79a8-0cbd-4a6c-b694-39a2cbd6dc75"
             },
             {
@@ -294,7 +294,7 @@
                 "caa_release_mbid": "205b9c35-bb8a-4074-aa93-f06f09c56345"
             },
             {
-                "artist_credit_name": "blink\u2010182",
+                "artist_credit_name": "blink‐182",
                 "artist_mbids": [
                     "0743b15a-3c32-48c8-ad58-cb325350befa"
                 ],
@@ -416,7 +416,7 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "19a5f597-8273-4693-a482-139dcb2c3a14",
-                "release_name": "It\u2019s Ours",
+                "release_name": "It’s Ours",
                 "caa_release_mbid": "19a5f597-8273-4693-a482-139dcb2c3a14"
             },
             {
@@ -446,7 +446,7 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "d31bdc81-2ad9-4f68-8473-617541f499dd",
-                "release_name": "Marvel Studios\u2019 Werewolf By Night (Original Soundtrack)",
+                "release_name": "Marvel Studios’ Werewolf By Night (Original Soundtrack)",
                 "caa_release_mbid": "d31bdc81-2ad9-4f68-8473-617541f499dd"
             },
             {
@@ -580,7 +580,7 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "cf71cdc8-2f0b-4159-9d33-3f1a0a0df924",
-                "release_name": "Aa Chaliye (From \u201cHoneymoon\u201d)",
+                "release_name": "Aa Chaliye (From “Honeymoon”)",
                 "caa_release_mbid": "cf71cdc8-2f0b-4159-9d33-3f1a0a0df924"
             },
             {
@@ -598,7 +598,7 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "699297f4-6b8c-441f-aa12-db9ae90e7259",
-                "release_name": "Hypnotize (From \u201cHoneymoon\u201d)",
+                "release_name": "Hypnotize (From “Honeymoon”)",
                 "caa_release_mbid": "699297f4-6b8c-441f-aa12-db9ae90e7259"
             },
             {

--- a/frontend/js/tests/__mocks__/freshReleasesUserData.json
+++ b/frontend/js/tests/__mocks__/freshReleasesUserData.json
@@ -13,7 +13,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "a2225115-891b-4f6b-a795-f2b7a68d0bcb",
-                "release_name": "Return of the Dream Canteen"
+                "release_name": "Return of the Dream Canteen",
+                "caa_release_mbid": "a2225115-891b-4f6b-a795-f2b7a68d0bcb"
             },
             {
                 "artist_credit_name": "Vipin Patwa & Shankar Mahadevan",
@@ -28,7 +29,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "5b2c8f92-5567-479f-8262-a00a7f8724b1",
-                "release_name": "Vande Mataram (From \u201cCode Name Tiranga\u201d)"
+                "release_name": "Vande Mataram (From \u201cCode Name Tiranga\u201d)",
+                "caa_release_mbid": "5b2c8f92-5567-479f-8262-a00a7f8724b1"
             },
             {
                 "artist_credit_name": "Green Day",
@@ -42,7 +44,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "6b3ff898-8886-4a7b-8144-8e5763780440",
-                "release_name": "You Irritate Me (demo)"
+                "release_name": "You Irritate Me (demo)",
+                "caa_release_mbid": "6b3ff898-8886-4a7b-8144-8e5763780440"
             },
             {
                 "artist_credit_name": "Pav Dharia",
@@ -56,7 +59,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "ccf3ad22-7128-471d-9d68-27da19a24b3b",
-                "release_name": "Duawan"
+                "release_name": "Duawan",
+                "caa_release_mbid": "ccf3ad22-7128-471d-9d68-27da19a24b3b"
             },
             {
                 "artist_credit_name": "Queen",
@@ -70,7 +74,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "1ff94a0f-950e-448b-935c-9218740ca778",
-                "release_name": "Face It Alone"
+                "release_name": "Face It Alone",
+                "caa_release_mbid": "1ff94a0f-950e-448b-935c-9218740ca778"
             },
             {
                 "artist_credit_name": "Kimbra",
@@ -84,7 +89,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "06a68bdd-c42b-48e5-8459-264f31b1d65b",
-                "release_name": "A RECKONING"
+                "release_name": "A RECKONING",
+                "caa_release_mbid": null
             },
             {
                 "artist_credit_name": "Pritam & Arijit Singh",
@@ -99,7 +105,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "4c3e85bb-a6fa-4ba5-8c78-be5853e75833",
-                "release_name": "Rasiya Reprise (From \u201cBrahmastra\u201d)"
+                "release_name": "Rasiya Reprise (From \u201cBrahmastra\u201d)",
+                "caa_release_mbid": "4c3e85bb-a6fa-4ba5-8c78-be5853e75833"
             },
             {
                 "artist_credit_name": "Charlie Puth",
@@ -113,7 +120,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "f1df0b2e-d00c-4686-810d-1f633ecb4aee",
-                "release_name": "CHARLIE"
+                "release_name": "CHARLIE",
+                "caa_release_mbid": "f1df0b2e-d00c-4686-810d-1f633ecb4aee"
             },
             {
                 "artist_credit_name": "Deep Purple",
@@ -127,7 +135,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": "Live",
                 "release_mbid": "410ed3da-0392-4344-b1e9-ee6cb48dc05c",
-                "release_name": "Live in Hong Kong 2001"
+                "release_name": "Live in Hong Kong 2001",
+                "caa_release_mbid": "410ed3da-0392-4344-b1e9-ee6cb48dc05c"
             },
             {
                 "artist_credit_name": "Deep Purple",
@@ -141,7 +150,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": "Live",
                 "release_mbid": "26514cad-731b-49b0-89a2-18f244647b46",
-                "release_name": "Live in Tokyo 2001"
+                "release_name": "Live in Tokyo 2001",
+                "caa_release_mbid": "26514cad-731b-49b0-89a2-18f244647b46"
             },
             {
                 "artist_credit_name": "Young the Giant",
@@ -155,7 +165,8 @@
                 "release_group_primary_type": "EP",
                 "release_group_secondary_type": null,
                 "release_mbid": "28c2c3eb-b302-4637-849a-cb0959ad1916",
-                "release_name": "ACT III: BATTLE"
+                "release_name": "ACT III: BATTLE",
+                "caa_release_mbid": "28c2c3eb-b302-4637-849a-cb0959ad1916"
             },
             {
                 "artist_credit_name": "Arctic Monkeys",
@@ -169,7 +180,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "9500aade-b992-4391-b63d-ac48e6925ed1",
-                "release_name": "I Ain't Quite Where I Think I Am"
+                "release_name": "I Ain't Quite Where I Think I Am",
+                "caa_release_mbid": "9500aade-b992-4391-b63d-ac48e6925ed1"
             },
             {
                 "artist_credit_name": "Hans Zimmer, Adam Lukas & James Everingham",
@@ -185,7 +197,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "df5f930f-f9ef-4e39-8f89-17f5034a11fd",
-                "release_name": "Frozen Planet II (Original Television Soundtrack)"
+                "release_name": "Frozen Planet II (Original Television Soundtrack)",
+                "caa_release_mbid": "df5f930f-f9ef-4e39-8f89-17f5034a11fd"
             },
             {
                 "artist_credit_name": "Hans Zimmer",
@@ -199,7 +212,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Live",
                 "release_mbid": "ddf24806-c813-43b1-882d-e51152a29868",
-                "release_name": "The Last Samurai Suite"
+                "release_name": "The Last Samurai Suite",
+                "caa_release_mbid": "ddf24806-c813-43b1-882d-e51152a29868"
             },
             {
                 "artist_credit_name": "Ti\u00ebsto \u00d7 Black Eyed Peas",
@@ -214,7 +228,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "b4f3a486-aef2-456d-9b15-06d4d5d7eea2",
-                "release_name": "Pump It Louder"
+                "release_name": "Pump It Louder",
+                "caa_release_mbid": "b4f3a486-aef2-456d-9b15-06d4d5d7eea2"
             },
             {
                 "artist_credit_name": "Arctic Monkeys",
@@ -228,7 +243,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "d6d1140f-5b4f-422e-a8b0-a8c43732701f",
-                "release_name": "The Car"
+                "release_name": "The Car",
+                "caa_release_mbid": "d6d1140f-5b4f-422e-a8b0-a8c43732701f"
             },
             {
                 "artist_credit_name": "Carly Rae Jepsen feat. Rufus Wainwright",
@@ -243,7 +259,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "1e981fea-35ca-474e-9078-3916e72869a2",
-                "release_name": "The Loneliest Time"
+                "release_name": "The Loneliest Time",
+                "caa_release_mbid": null
             },
             {
                 "artist_credit_name": "Mot\u00f6rhead",
@@ -257,7 +274,8 @@
                 "release_group_primary_type": "EP",
                 "release_group_secondary_type": "Compilation",
                 "release_mbid": "403a79a8-0cbd-4a6c-b694-39a2cbd6dc75",
-                "release_name": "Mot\u00f6r\u2010ween"
+                "release_name": "Mot\u00f6r\u2010ween",
+                "caa_release_mbid": "403a79a8-0cbd-4a6c-b694-39a2cbd6dc75"
             },
             {
                 "artist_credit_name": "Beethoven; Dover Quartet",
@@ -272,7 +290,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "205b9c35-bb8a-4074-aa93-f06f09c56345",
-                "release_name": "Complete String Quartets, Volume 3: The Late Quartets"
+                "release_name": "Complete String Quartets, Volume 3: The Late Quartets",
+                "caa_release_mbid": "205b9c35-bb8a-4074-aa93-f06f09c56345"
             },
             {
                 "artist_credit_name": "blink\u2010182",
@@ -286,7 +305,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "cfa9fe1a-dd26-4167-b8d5-08cef4f14717",
-                "release_name": "Edging"
+                "release_name": "Edging",
+                "caa_release_mbid": "cfa9fe1a-dd26-4167-b8d5-08cef4f14717"
             },
             {
                 "artist_credit_name": "Beethoven, Stravinsky; Vilde Frang, Deutsche Kammerphilharmonie Bremen, Pekka Kuusisto",
@@ -304,7 +324,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "d6709127-57a4-4dda-9c5a-30acda5c2326",
-                "release_name": "Violin Concertos"
+                "release_name": "Violin Concertos",
+                "caa_release_mbid": "d6709127-57a4-4dda-9c5a-30acda5c2326"
             },
             {
                 "artist_credit_name": "Pritam",
@@ -318,7 +339,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "d8ec11cb-ac29-497f-82fa-19ea9fff274c",
-                "release_name": "Brahmastra (Original Motion Picture Soundtrack)"
+                "release_name": "Brahmastra (Original Motion Picture Soundtrack)",
+                "caa_release_mbid": "d8ec11cb-ac29-497f-82fa-19ea9fff274c"
             },
             {
                 "artist_credit_name": "Flo Rida",
@@ -332,7 +354,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "c85346a9-ecae-474a-b625-aec1aaa26471",
-                "release_name": "High Heels"
+                "release_name": "High Heels",
+                "caa_release_mbid": "c85346a9-ecae-474a-b625-aec1aaa26471"
             },
             {
                 "artist_credit_name": "Florence + the Machine",
@@ -346,7 +369,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": "Live",
                 "release_mbid": "27dd50ed-1446-4f14-8cda-23fe2f476ccc",
-                "release_name": "Dance Fever (live at Madison Square Garden)"
+                "release_name": "Dance Fever (live at Madison Square Garden)",
+                "caa_release_mbid": "27dd50ed-1446-4f14-8cda-23fe2f476ccc"
             },
             {
                 "artist_credit_name": "Men I Trust",
@@ -360,7 +384,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "10f56fe5-2b56-4009-b29a-fb6f9b932bc7",
-                "release_name": "Girl"
+                "release_name": "Girl",
+                "caa_release_mbid": "10f56fe5-2b56-4009-b29a-fb6f9b932bc7"
             },
             {
                 "artist_credit_name": "Bonobo",
@@ -374,7 +399,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "3d205a95-2f37-4801-9056-4077b14b6a26",
-                "release_name": "Defender"
+                "release_name": "Defender",
+                "caa_release_mbid": null
             },
             {
                 "artist_credit_name": "Artbat, David Guetta & Idris Elba",
@@ -390,7 +416,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "19a5f597-8273-4693-a482-139dcb2c3a14",
-                "release_name": "It\u2019s Ours"
+                "release_name": "It\u2019s Ours",
+                "caa_release_mbid": "19a5f597-8273-4693-a482-139dcb2c3a14"
             },
             {
                 "artist_credit_name": "Robbie Williams",
@@ -404,7 +431,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "30d69d76-bb7a-4262-b3b9-e49488fa8b09",
-                "release_name": "Life Thru a Lens (rehearsal recording, spring 1997)"
+                "release_name": "Life Thru a Lens (rehearsal recording, spring 1997)",
+                "caa_release_mbid": "30d69d76-bb7a-4262-b3b9-e49488fa8b09"
             },
             {
                 "artist_credit_name": "Michael Giacchino",
@@ -418,7 +446,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "d31bdc81-2ad9-4f68-8473-617541f499dd",
-                "release_name": "Marvel Studios\u2019 Werewolf By Night (Original Soundtrack)"
+                "release_name": "Marvel Studios\u2019 Werewolf By Night (Original Soundtrack)",
+                "caa_release_mbid": "d31bdc81-2ad9-4f68-8473-617541f499dd"
             },
             {
                 "artist_credit_name": "Vianney feat. Ed Sheeran",
@@ -433,7 +462,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "b6693f58-48b8-40ea-affa-3ba442cad5b1",
-                "release_name": "Call on Me"
+                "release_name": "Call on Me",
+                "caa_release_mbid": "b6693f58-48b8-40ea-affa-3ba442cad5b1"
             },
             {
                 "artist_credit_name": "Boston Pops Orchestra & John Williams",
@@ -448,7 +478,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "ae8c614e-616f-44f4-bc32-e403e0eaf8cb",
-                "release_name": "The Christmas Song (Chestnuts Roasting)"
+                "release_name": "The Christmas Song (Chestnuts Roasting)",
+                "caa_release_mbid": "ae8c614e-616f-44f4-bc32-e403e0eaf8cb"
             },
             {
                 "artist_credit_name": "Benj Pasek, Justin Paul & Shawn Mendes",
@@ -464,7 +495,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "350d33dd-a6ae-41c3-b6a2-3de423159c77",
-                "release_name": "Lyle, Lyle, Crocodile: Original Motion Picture Soundtrack"
+                "release_name": "Lyle, Lyle, Crocodile: Original Motion Picture Soundtrack",
+                "caa_release_mbid": "350d33dd-a6ae-41c3-b6a2-3de423159c77"
             },
             {
                 "artist_credit_name": "Backstreet Boys",
@@ -478,7 +510,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "cf419ac6-de61-46d7-a30e-5e2aba048505",
-                "release_name": "A Very Backstreet Christmas"
+                "release_name": "A Very Backstreet Christmas",
+                "caa_release_mbid": "cf419ac6-de61-46d7-a30e-5e2aba048505"
             },
             {
                 "artist_credit_name": "Nicki Minaj & Skeng feat. Spice, Destra Garcia, Patrice Roberts, Lady Leshurr, Pamputtae, Dovey Magnum, Lisa Mercedez & London Hill",
@@ -501,7 +534,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Remix",
                 "release_mbid": "25d7902c-37f7-4b23-91d7-3d981d30a0a7",
-                "release_name": "Likkle Miss (THE FINE NINE REMIX)"
+                "release_name": "Likkle Miss (THE FINE NINE REMIX)",
+                "caa_release_mbid": "25d7902c-37f7-4b23-91d7-3d981d30a0a7"
             },
             {
                 "artist_credit_name": "girl in red",
@@ -515,7 +549,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": null,
                 "release_mbid": "49c64d26-1789-488e-b338-c5c3390c061c",
-                "release_name": "October Passed Me By"
+                "release_name": "October Passed Me By",
+                "caa_release_mbid": "49c64d26-1789-488e-b338-c5c3390c061c"
             },
             {
                 "artist_credit_name": "Tove Lo",
@@ -529,7 +564,8 @@
                 "release_group_primary_type": "Album",
                 "release_group_secondary_type": null,
                 "release_mbid": "313a8c33-fd75-4119-882c-8924339a09b7",
-                "release_name": "Dirt Femme"
+                "release_name": "Dirt Femme",
+                "caa_release_mbid": "313a8c33-fd75-4119-882c-8924339a09b7"
             },
             {
                 "artist_credit_name": "B Praak & Jaani",
@@ -544,7 +580,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "cf71cdc8-2f0b-4159-9d33-3f1a0a0df924",
-                "release_name": "Aa Chaliye (From \u201cHoneymoon\u201d)"
+                "release_name": "Aa Chaliye (From \u201cHoneymoon\u201d)",
+                "caa_release_mbid": "cf71cdc8-2f0b-4159-9d33-3f1a0a0df924"
             },
             {
                 "artist_credit_name": "B Praak, Jaani, Gippy Grewal & Shipra Goyal",
@@ -561,7 +598,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Soundtrack",
                 "release_mbid": "699297f4-6b8c-441f-aa12-db9ae90e7259",
-                "release_name": "Hypnotize (From \u201cHoneymoon\u201d)"
+                "release_name": "Hypnotize (From \u201cHoneymoon\u201d)",
+                "caa_release_mbid": "699297f4-6b8c-441f-aa12-db9ae90e7259"
             },
             {
                 "artist_credit_name": "Madonna",
@@ -575,7 +613,8 @@
                 "release_group_primary_type": "Single",
                 "release_group_secondary_type": "Remix",
                 "release_mbid": "e92ad33d-c247-47f2-90e8-0e1eb9c01fd4",
-                "release_name": "Bad Girl / Fever"
+                "release_name": "Bad Girl / Fever",
+                "caa_release_mbid": "e92ad33d-c247-47f2-90e8-0e1eb9c01fd4"
             }
         ],
         "user_id": "test"

--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -189,6 +189,12 @@ class CoverArtGenerator:
 
         return f"https://archive.org/download/mbid-{caa_release_mbid}/mbid-{caa_release_mbid}-{caa_id}_thumb{cover_art_size}.jpg"
 
+    def load_caa_ids(self, release_mbids):
+        """ Load caa_ids for the given release mbids """
+        with psycopg2.connect(self.mb_db_connection_str) as conn, \
+                conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+            return get_caa_ids_for_release_mbids(curs, release_mbids)
+
     def load_images(self, mbids, tile_addrs=None, layout=None):
         """ Given a list of MBIDs and optional tile addresses, resolve all the cover art design, all the
             cover art to be used and then return the list of images and locations where they should be
@@ -211,9 +217,7 @@ class CoverArtGenerator:
             tiles.append((x1, y1, x2, y2))
 
         release_mbids = [mbid for mbid in mbids if mbid]
-        with psycopg2.connect(self.mb_db_connection_str) as conn, \
-                conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
-            covers = get_caa_ids_for_release_mbids(curs, release_mbids)
+        covers = self.load_caa_ids(release_mbids)
 
         # Now resolve cover art images into URLs and image dimensions
         images = []

--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -211,7 +211,9 @@ class CoverArtGenerator:
             tiles.append((x1, y1, x2, y2))
 
         release_mbids = [mbid for mbid in mbids if mbid]
-        covers = get_caa_ids_for_release_mbids(release_mbids)
+        with psycopg2.connect(self.mb_db_connection_str) as conn, \
+                conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+            covers = get_caa_ids_for_release_mbids(curs, release_mbids)
 
         # Now resolve cover art images into URLs and image dimensions
         images = []

--- a/listenbrainz/art/misc/sample_cover_art_grid_post_request.json
+++ b/listenbrainz/art/misc/sample_cover_art_grid_post_request.json
@@ -2,8 +2,8 @@
 	"background": "transparent",
 	"image_size": 750,
 	"dimension": 4,
-        "skip-missing": false,
-        "show-caa": false,
+	"skip-missing": false,
+	"show-caa": false,
 	"tiles": [
 		"0,1,4,5",
 		"10,11,14,15",
@@ -19,7 +19,7 @@
 	"release_mbids": [
 		"d101e395-0c04-4237-a3d2-167b1d88056c",
 		"4211382c-39e8-4a72-a32d-e4046fd96356",
-                "6d895dfa-8688-4867-9730-2b98050dae04",
+		"6d895dfa-8688-4867-9730-2b98050dae04",
 		"773e54bb-3f43-4813-826c-ca762bfa8318",
 		"ec782dbe-9204-4ec3-bf50-576c7cf3dfb3",
 		"10dffffc-c2aa-4ddd-81fd-42b5e125f240",

--- a/listenbrainz/db/cover_art.py
+++ b/listenbrainz/db/cover_art.py
@@ -7,6 +7,30 @@ from psycopg2.extras import execute_values
 def get_caa_ids_for_release_mbids(curs, release_mbids: Iterable[str]):
     """ Given a list of release mbids, find the associated cover art for the releases. If cover art
      is missing for the release, fallback to the release group cover art if present.
+
+     Returns a dictionary keyed by provided releases mbids, each key further maps to a dict having 3
+     keys original_mbid (mbid of the provided release), caa_id and caa_release_mbid.
+
+     Example:
+
+        {
+            "be5f714d-02eb-4c89-9a06-5e544f132604": {
+                "original_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604",
+                "caa_id": 2273480607,
+                "caa_release_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604"
+            },
+            "4211382c-39e8-4a72-a32d-e4046fd96356": {
+                "original_mbid": "4211382c-39e8-4a72-a32d-e4046fd96356",
+                "caa_id": null,
+                "caa_release_mbid": null
+            },
+            "773e54bb-3f43-4813-826c-ca762bfa8318": {
+                "original_mbid": "773e54bb-3f43-4813-826c-ca762bfa8318",
+                "caa_id": 9660646535,
+                "caa_release_mbid": "3eee4ed1-b48e-4894-8a05-f535f16a4985"
+            }
+        }
+
     """
     query = """
           WITH release_mbids(mbid) AS (

--- a/listenbrainz/db/cover_art.py
+++ b/listenbrainz/db/cover_art.py
@@ -10,14 +10,7 @@ def get_caa_ids_for_release_mbids(curs, release_mbids: Iterable[str]):
     """
     query = """
           WITH release_mbids(mbid) AS (
-                    VALUES ('d101e395-0c04-4237-a3d2-167b1d88056c'::uuid)
-                         , ('4211382c-39e8-4a72-a32d-e4046fd96356'::uuid)
-                         , ('6d895dfa-8688-4867-9730-2b98050dae04'::uuid)
-                         , ('773e54bb-3f43-4813-826c-ca762bfa8318'::uuid)
-                         , ('ec782dbe-9204-4ec3-bf50-576c7cf3dfb3'::uuid)
-                         , ('10dffffc-c2aa-4ddd-81fd-42b5e125f240'::uuid)
-                         , ('be5f714d-02eb-4c89-9a06-5e544f132604'::uuid)
-                         , ('3eee4ed1-b48e-4894-8a05-f535f16a4985'::uuid)
+                    VALUES %s
             ), release_cover_art AS (
                     SELECT DISTINCT ON (rm.mbid)
                            rm.mbid AS original_mbid

--- a/listenbrainz/db/cover_art.py
+++ b/listenbrainz/db/cover_art.py
@@ -10,7 +10,14 @@ def get_caa_ids_for_release_mbids(curs, release_mbids: Iterable[str]):
     """
     query = """
           WITH release_mbids(mbid) AS (
-                    VALUES %s
+                    VALUES ('d101e395-0c04-4237-a3d2-167b1d88056c'::uuid)
+                         , ('4211382c-39e8-4a72-a32d-e4046fd96356'::uuid)
+                         , ('6d895dfa-8688-4867-9730-2b98050dae04'::uuid)
+                         , ('773e54bb-3f43-4813-826c-ca762bfa8318'::uuid)
+                         , ('ec782dbe-9204-4ec3-bf50-576c7cf3dfb3'::uuid)
+                         , ('10dffffc-c2aa-4ddd-81fd-42b5e125f240'::uuid)
+                         , ('be5f714d-02eb-4c89-9a06-5e544f132604'::uuid)
+                         , ('3eee4ed1-b48e-4894-8a05-f535f16a4985'::uuid)
             ), release_cover_art AS (
                     SELECT DISTINCT ON (rm.mbid)
                            rm.mbid AS original_mbid

--- a/listenbrainz/db/cover_art.py
+++ b/listenbrainz/db/cover_art.py
@@ -1,0 +1,74 @@
+from typing import Iterable
+from uuid import UUID
+
+from psycopg2.extras import execute_values
+
+
+def get_caa_ids_for_release_mbids(curs, release_mbids: Iterable[str]):
+    """ Given a list of release mbids, find the associated cover art for the releases. If cover art
+     is missing for the release, fallback to the release group cover art if present.
+    """
+    query = """
+          WITH release_mbids(mbid) AS (
+                    VALUES %s
+            ), release_cover_art AS (
+                    SELECT DISTINCT ON (rm.mbid)
+                           rm.mbid AS original_mbid
+                         , caa.id AS caa_id
+                         , rm.mbid AS caa_release_mbid
+                      FROM release_mbids rm
+                      JOIN musicbrainz.release rel
+                        ON rel.gid = rm.mbid
+                      JOIN cover_art_archive.cover_art caa
+                        ON caa.release = rel.id
+                      JOIN cover_art_archive.cover_art_type cat
+                        ON cat.id = caa.id
+                     WHERE type_id = 1
+                       AND mime_type != 'application/pdf'
+                  ORDER BY rm.mbid
+                         , caa.ordering
+            ), release_group_cover_art AS (
+                    SELECT DISTINCT ON(rg.id)
+                           mbid AS original_mbid
+                         , caa.id AS caa_id
+                         , caa_rel.gid AS caa_release_mbid
+                      FROM release_mbids rm
+                      JOIN musicbrainz.release rel
+                        ON rel.gid = rm.mbid::uuid
+                      JOIN musicbrainz.release_group rg
+                        ON rg.id = rel.release_group
+                      JOIN musicbrainz.release caa_rel
+                        ON rg.id = caa_rel.release_group
+                 LEFT JOIN (
+                          SELECT release, date_year, date_month, date_day
+                            FROM musicbrainz.release_country
+                       UNION ALL
+                          SELECT release, date_year, date_month, date_day
+                            FROM musicbrainz.release_unknown_country
+                         ) re
+                        ON (re.release = caa_rel.id)
+                 FULL JOIN cover_art_archive.release_group_cover_art rgca
+                        ON rgca.release = caa_rel.id
+                 LEFT JOIN cover_art_archive.cover_art caa
+                        ON caa.release = caa_rel.id
+                 LEFT JOIN cover_art_archive.cover_art_type cat
+                        ON cat.id = caa.id
+                     WHERE type_id = 1
+                       AND mime_type != 'application/pdf'
+                  ORDER BY rg.id
+                         , rgca.release
+                         , re.date_year
+                         , re.date_month
+                         , re.date_day
+                         , caa.ordering
+            ) SELECT rm.mbid::TEXT AS original_mbid
+                   , COALESCE(rca.caa_id, rgca.caa_id) AS caa_id
+                   , COALESCE(rca.caa_release_mbid, rgca.caa_release_mbid)::TEXT AS caa_release_mbid
+                FROM release_mbids rm
+           LEFT JOIN release_cover_art rca
+                  ON rm.mbid = rca.original_mbid
+           LEFT JOIN release_group_cover_art rgca
+                  ON rm.mbid = rgca.original_mbid
+    """
+    result = execute_values(curs, query, [(UUID(mbid),) for mbid in release_mbids], fetch=True)
+    return {row["original_mbid"]: row for row in result}

--- a/listenbrainz/db/fresh_releases.py
+++ b/listenbrainz/db/fresh_releases.py
@@ -93,11 +93,11 @@ def get_sitewide_fresh_releases(pivot_release_date: date, release_date_window_da
 
         fresh_releases = []
         for mbid, row in result.items():
-            row[mbid]["caa_id"] = covers[mbid]["caa_id"]
+            row["caa_id"] = covers[mbid]["caa_id"]
             if covers[mbid]["caa_release_mbid"]:
-                row[mbid]["caa_release_mbid"] = uuid.UUID(covers[mbid]["caa_release_mbid"])
+                row["caa_release_mbid"] = uuid.UUID(covers[mbid]["caa_release_mbid"])
             else:
-                row[mbid]["caa_release_mbid"] = None
+                row["caa_release_mbid"] = None
             fresh_releases.append(FreshRelease(**row))
 
         return fresh_releases

--- a/listenbrainz/db/model/fresh_releases.py
+++ b/listenbrainz/db/model/fresh_releases.py
@@ -58,6 +58,12 @@ class FreshRelease(BaseModel):
     # The cover art archive id of the release's front cover art if it has any
     caa_id: Optional[int]
 
+    # The release mbid of the cover art to use for this release. this will be the same
+    # as the release mbid if the release has a cover art. if the release doesn't have a
+    # cover art but another release in the release group has it, this mbid will point to
+    # that release.
+    caa_release_mbid: Optional[uuid.UUID]
+
     def to_dict(self):
         """Convert this model to a dict for easy jsonification"""
 

--- a/listenbrainz/webserver/views/test/test_art.py
+++ b/listenbrainz/webserver/views/test/test_art.py
@@ -1,16 +1,11 @@
-import json
-from unittest import mock
+import requests_mock
+
 from unittest.mock import patch
 
 from flask import url_for
-from flask_login import login_required
-from requests.exceptions import HTTPError
-from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
-import listenbrainz.db.user as db_user
-import listenbrainz.webserver.login
-from listenbrainz.tests.integration import IntegrationTestCase
 from listenbrainz.art.cover_art_generator import CoverArtGenerator
+from listenbrainz.tests.integration import IntegrationTestCase
 
 
 class ArtViewsTestCase(IntegrationTestCase):
@@ -19,9 +14,26 @@ class ArtViewsTestCase(IntegrationTestCase):
         resp = self.client.get(url_for('art.index'))
         self.assert200(resp)
 
-    def test_cover_art_grid_stats(self):
-        with patch.object(CoverArtGenerator, 'get_caa_id') as mock_get_caa_id:
-            mock_get_caa_id.return_value = 6945
+    @requests_mock.Mocker()
+    def test_cover_art_grid_stats(self, mock_requests):
+        mock_requests.get("https://api.listenbrainz.org/1/stats/user/rob/releases", json={
+            "payload": {
+                "total_release_count": 1,
+                "releases": [
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    }
+                ]
+            }
+        })
+        with patch.object(CoverArtGenerator, "load_caa_ids") as mock_get_caa_id:
+            mock_get_caa_id.return_value = {
+                "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6": {
+                    "original_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
+                    "caa_id": 6945,
+                    "caa_release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                }
+            }
             resp = self.client.get(
                 url_for('art_api_v1.cover_art_grid_stats',
                         user_name="rob",
@@ -30,27 +42,92 @@ class ArtViewsTestCase(IntegrationTestCase):
                         layout=0,
                         image_size=500))
             self.assert200(resp)
-            assert resp.text.startswith("<svg")
+            self.assertTrue(resp.text.startswith("<svg"))
 
             # Make sure we find the caa_id in the output SVG
             self.assertNotEqual(resp.text.find("6945"), -1)
 
-    def test_cover_art_custom_artist_stats(self):
-        with patch.object(CoverArtGenerator, 'get_caa_id') as mock_get_caa_id:
-            mock_get_caa_id.return_value = 6945
-            resp = self.client.get(
-                url_for('art_api_v1.cover_art_custom_stats',
-                        custom_name="designer-top-5",
-                        user_name="rob",
-                        time_range="week",
-                        image_size=500))
-            self.assert200(resp)
-            assert resp.text.startswith("<svg")
-            self.assertNotEqual(resp.text.find("ROB"), -1)
+    @requests_mock.Mocker()
+    def test_cover_art_custom_artist_stats(self, mock_requests):
+        mock_requests.get("https://api.listenbrainz.org/1/stats/user/rob/artists", json={
+            "payload": {
+                "total_artist_count": 5,
+                "artists": [
+                    {
+                        "artist_name": "Portishead"
+                    },
+                    {
+                        "artist_name": "Portishead"
+                    },
+                    {
+                        "artist_name": "Portishead"
+                    },
+                    {
+                        "artist_name": "Portishead"
+                    },
+                    {
+                        "artist_name": "Portishead"
+                    }
+                ]
+            }
+        })
+        resp = self.client.get(
+            url_for('art_api_v1.cover_art_custom_stats',
+                    custom_name="designer-top-5",
+                    user_name="rob",
+                    time_range="week",
+                    image_size=500))
+        self.assert200(resp)
+        self.assertTrue(resp.text.startswith("<svg"))
+        self.assertNotEqual(resp.text.find("ROB"), -1)
 
-    def test_cover_art_custom_release_stats(self):
-        with patch.object(CoverArtGenerator, 'get_caa_id') as mock_get_caa_id:
-            mock_get_caa_id.return_value = 6945
+    @requests_mock.Mocker()
+    def test_cover_art_custom_release_stats(self, mock_requests):
+        mock_requests.get("https://api.listenbrainz.org/1/stats/user/rob/releases", json={
+            "payload": {
+                "total_release_count": 10,
+                "releases": [
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    },
+                    {
+                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                    }
+                ]
+            }
+        })
+        with patch.object(CoverArtGenerator, "load_caa_ids") as mock_get_caa_id:
+            mock_get_caa_id.return_value = {
+                "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6": {
+                    "original_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
+                    "caa_id": 6945,
+                    "caa_release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
+                }
+            }
             resp = self.client.get(
                 url_for('art_api_v1.cover_art_custom_stats',
                         custom_name="designer-top-10",
@@ -58,16 +135,57 @@ class ArtViewsTestCase(IntegrationTestCase):
                         time_range="week",
                         image_size=500))
             self.assert200(resp)
-            assert resp.text.startswith("<svg")
+            self.assertTrue(resp.text.startswith("<svg"))
             self.assertNotEqual(resp.text.find("ROB"), -1)
 
     def test_cover_art_grid_post(self):
         with open("listenbrainz/art/misc/sample_cover_art_grid_post_request.json", "r") as f:
             post_json = f.read()
 
-        with patch.object(CoverArtGenerator, 'get_caa_id') as mock_get_caa_id:
-            mock_get_caa_id.return_value = 6945
+        with patch.object(CoverArtGenerator, "load_caa_ids") as mock_get_caa_id:
+            mock_get_caa_id.return_value = {
+                "be5f714d-02eb-4c89-9a06-5e544f132604": {
+                    "original_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604",
+                    "caa_id": 2273480607,
+                    "caa_release_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604"
+                },
+                "4211382c-39e8-4a72-a32d-e4046fd96356": {
+                    "original_mbid": "4211382c-39e8-4a72-a32d-e4046fd96356",
+                    "caa_id": 8194366407,
+                    "caa_release_mbid": "4211382c-39e8-4a72-a32d-e4046fd96356"
+                },
+                "773e54bb-3f43-4813-826c-ca762bfa8318": {
+                    "original_mbid": "773e54bb-3f43-4813-826c-ca762bfa8318",
+                    "caa_id": 9660646535,
+                    "caa_release_mbid": "773e54bb-3f43-4813-826c-ca762bfa8318"
+                },
+                "10dffffc-c2aa-4ddd-81fd-42b5e125f240": {
+                    "original_mbid": "10dffffc-c2aa-4ddd-81fd-42b5e125f240",
+                    "caa_id": 28871824662,
+                    "caa_release_mbid": "10dffffc-c2aa-4ddd-81fd-42b5e125f240"
+                },
+                "d101e395-0c04-4237-a3d2-167b1d88056c": {
+                    "original_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604",
+                    "caa_id": 2273480607,
+                    "caa_release_mbid": "d101e395-0c04-4237-a3d2-167b1d88056c"
+                },
+                "3eee4ed1-b48e-4894-8a05-f535f16a4985": {
+                    "original_mbid": "3eee4ed1-b48e-4894-8a05-f535f16a4985",
+                    "caa_id": 31067711419,
+                    "caa_release_mbid": "3eee4ed1-b48e-4894-8a05-f535f16a4985"
+                },
+                "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3": {
+                    "original_mbid": "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3",
+                    "caa_id": 31206007614,
+                    "caa_release_mbid": "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3"
+                },
+                "6d895dfa-8688-4867-9730-2b98050dae04": {
+                    "original_mbid": "6d895dfa-8688-4867-9730-2b98050dae04",
+                    "caa_id": None,
+                    "caa_release_mbid": None
+                }
+            }
             resp = self.client.post(url_for('art_api_v1.cover_art_grid_post'), data=post_json, content_type="application/json")
             self.assert200(resp)
-            assert resp.text.startswith("<svg")
-            self.assertNotEqual(resp.text.find("6945"), -1)
+            self.assertTrue(resp.text.startswith("<svg"))
+            self.assertNotEqual(resp.text.find("2273480607"), -1)

--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -32,7 +32,8 @@ def load_all_releases():
             release_group_mbid=release["release_group_mbid"],
             release_group_primary_type=release.get("release_group_primary_type"),
             release_group_secondary_type=release.get("release_group_secondary_type"),
-            caa_id=release.get("caa_id")
+            caa_id=release.get("caa_id"),
+            caa_release_mbid=release.get("caa_release_mbid")
         ))
 
     return listenbrainz_spark.session.createDataFrame(releases, schema=fresh_releases_schema)
@@ -66,6 +67,7 @@ def get_query():
                  , rr.release_group_primary_type
                  , rr.release_group_secondary_type
                  , rr.caa_id
+                 , rr.caa_release_mbid
                  , SUM(partial_confidence) AS confidence
               FROM artist_discovery ad
               JOIN fresh_releases rr
@@ -80,6 +82,7 @@ def get_query():
                  , rr.release_group_primary_type
                  , rr.release_group_secondary_type
                  , rr.caa_id
+                 , rr.caa_release_mbid
         )
         SELECT user_id
              , array_sort(
@@ -94,6 +97,7 @@ def get_query():
                           , release_group_primary_type
                           , release_group_secondary_type
                           , caa_id
+                          , caa_release_mbid
                           , confidence
                         )
                     )

--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -14,7 +14,7 @@ from listenbrainz_spark.utils import get_latest_listen_ts, get_listens_from_new_
 USERS_PER_MESSAGE = 5
 
 
-FRESH_RELEASES_ENDPOINT = "https://test-api.listenbrainz.org/1/explore/fresh-releases/"
+FRESH_RELEASES_ENDPOINT = "https://api.listenbrainz.org/1/explore/fresh-releases/"
 
 
 def load_all_releases():

--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -14,7 +14,7 @@ from listenbrainz_spark.utils import get_latest_listen_ts, get_listens_from_new_
 USERS_PER_MESSAGE = 5
 
 
-FRESH_RELEASES_ENDPOINT = "https://api.listenbrainz.org/1/explore/fresh-releases/"
+FRESH_RELEASES_ENDPOINT = "https://test-api.listenbrainz.org/1/explore/fresh-releases/"
 
 
 def load_all_releases():

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -24,7 +24,8 @@ fresh_releases_schema = StructType([
     StructField('release_group_mbid', StringType(), nullable=False),
     StructField('release_group_primary_type', StringType(), nullable=True),
     StructField('release_group_secondary_type', StringType(), nullable=True),
-    StructField('caa_id', LongType(), nullable=True)
+    StructField('caa_id', LongType(), nullable=True),
+    StructField('caa_release_mbid', StringType(), nullable=True)
 ])
 
 recommendation_schema = StructType([

--- a/listenbrainz_spark/testdata/sitewide_fresh_releases.json
+++ b/listenbrainz_spark/testdata/sitewide_fresh_releases.json
@@ -10,7 +10,8 @@
     "artist_credit_name": "티키틱 TIKITIK",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": null,
-    "caa_id": 33755527018
+    "caa_id": 33755527018,
+    "caa_release_mbid": "46962eb4-82c1-499c-b5ca-d1520cacb9e2"
   },
   {
     "release_date": "2022-5-17",
@@ -24,7 +25,8 @@
     "artist_credit_name": "ARuFa / ダ・ヴィンチ・恐山",
     "release_group_primary_type": "Album",
     "release_group_secondary_type": null,
-    "caa_id": null
+    "caa_id": null,
+    "caa_release_mbid": null
   },
   {
     "release_date": "2022-5-18",
@@ -37,7 +39,8 @@
     "artist_credit_name": "fripSide",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": null,
-    "caa_id": 33684408555
+    "caa_id": 33684408555,
+    "caa_release_mbid": "6948e168-3316-4458-b5d7-f14d6b9c8aa0"
   },
   {
     "release_date": "2022-5-25",
@@ -51,7 +54,8 @@
     "artist_credit_name": "ライムスター 逆featuring CRAZY KEN BAND",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": "Remix",
-    "caa_id": 33713737777
+    "caa_id": 33713737777,
+    "caa_release_mbid": "8d322ab8-ca68-40f6-8d3b-527545830302"
   },
   {
     "release_date": "2022-5-27",
@@ -64,7 +68,8 @@
     "artist_credit_name": "Amadea Music Productions",
     "release_group_primary_type": "Album",
     "release_group_secondary_type": null,
-    "caa_id": 33702046539
+    "caa_id": 33702046539,
+    "caa_release_mbid": "c5955771-c7ec-4de6-9c5f-cc53ee5c1cb7"
   },
   {
     "release_date": "2022-5-27",
@@ -78,7 +83,8 @@
     "artist_credit_name": "Ammy Virk & Simar Kaur",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": "Soundtrack",
-    "caa_id": 33709392020
+    "caa_id": 33709392020,
+    "caa_release_mbid": "a202dc7e-cb61-4ecd-87d0-3bedf597f8cc"
   },
   {
     "release_date": "2022-5-30",
@@ -91,7 +97,8 @@
     "artist_credit_name": "sadfem",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": null,
-    "caa_id": null
+    "caa_id": null,
+    "caa_release_mbid": null
   },
   {
     "release_date": "2022-5-30",
@@ -104,7 +111,8 @@
     "artist_credit_name": "Тишина",
     "release_group_primary_type": "Album",
     "release_group_secondary_type": null,
-    "caa_id": null
+    "caa_id": null,
+    "caa_release_mbid": null
   },
   {
     "release_date": "2022-5-31",
@@ -115,7 +123,8 @@
     "release_group_mbid": "ef1497b6-01ae-4477-94a8-e3e0e9a12125",
     "release_name": "So Cold",
     "artist_credit_name": "44closures",
-    "caa_id": 33706994031
+    "caa_id": 33706994031,
+    "caa_release_mbid": "db05975c-2210-47c6-8c31-15b7e29465df"
   },
   {
     "release_date": "2022-6-1",
@@ -128,7 +137,8 @@
     "artist_credit_name": "aespa",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": null,
-    "caa_id": null
+    "caa_id": null,
+    "caa_release_mbid": null
   },
   {
     "release_date": "2022-6-3",
@@ -140,7 +150,8 @@
     "release_name": "Endless Garden",
     "artist_credit_name": "Witchfinder",
     "release_group_primary_type": "EP",
-    "caa_id": null
+    "caa_id": null,
+    "caa_release_mbid": null
   },
   {
     "release_date": "2022-6-8",
@@ -153,7 +164,8 @@
     "artist_credit_name": "Little Glee Monster",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": null,
-    "caa_id": 33700346677
+    "caa_id": 33700346677,
+    "caa_release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
   },
   {
     "release_date": "2022-6-9",
@@ -166,6 +178,7 @@
     "artist_credit_name": "Halsey",
     "release_group_primary_type": "Single",
     "release_group_secondary_type": null,
-    "caa_id": 33759180025
+    "caa_id": 33759180025,
+    "caa_release_mbid": "daa1e865-42d9-46d5-b272-c92c099dbc2d"
   }
 ]

--- a/listenbrainz_spark/testdata/user_fresh_releases_output.json
+++ b/listenbrainz_spark/testdata/user_fresh_releases_output.json
@@ -14,6 +14,7 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": null,
         "caa_id": 33759180025,
+        "caa_release_mbid": "daa1e865-42d9-46d5-b272-c92c099dbc2d",
         "confidence": 3
       },
       {
@@ -29,6 +30,7 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": "Soundtrack",
         "caa_id": 33709392020,
+        "caa_release_mbid": "a202dc7e-cb61-4ecd-87d0-3bedf597f8cc",
         "confidence": 2
       },
       {
@@ -43,6 +45,7 @@
         "release_group_primary_type": "Single",
         "release_group_secondary_type": null,
         "caa_id": null,
+        "caa_release_mbid": null,
         "confidence": 1
       }
     ]
@@ -63,6 +66,7 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": null,
         "caa_id": null,
+        "caa_release_mbid": null,
         "confidence": 4
       },
       {
@@ -77,6 +81,7 @@
         "release_group_primary_type": "Album",
         "release_group_secondary_type": null,
         "caa_id": null,
+        "caa_release_mbid": null,
         "confidence": 1
       }
     ]


### PR DESCRIPTION
Sometimes a release does not have cover art associated with it but another release in the same release group does. In such cases, fallback to the release group cover art. We already do this in mb_metadata_cache.