### PR TITLE
LB-678: Refactor code in "listenbrainz_spark/utils.py" into multiple files

### DIFF
--- a/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
@@ -4,6 +4,7 @@ import os
 import requests_mock
 
 from listenbrainz_spark import utils
+from listenbrainz_spark import hdfs
 from listenbrainz_spark.fresh_releases import fresh_releases
 from listenbrainz_spark.fresh_releases.fresh_releases import FRESH_RELEASES_ENDPOINT
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
@@ -14,10 +15,10 @@ class FreshReleasesTestCase(SparkNewTestCase):
 
     def setUp(self):
         super(FreshReleasesTestCase, self).setUp()
-        if not utils.path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
-            utils.create_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY)
+        if not hdfs.path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
+            hdfs.create_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY)
 
-        utils.upload_to_HDFS(
+        hdfs.upload_to_HDFS(
             os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "0.parquet"),
             os.path.join(TEST_DATA_PATH, "fresh_releases_listens.parquet")
         )

--- a/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
@@ -4,7 +4,9 @@ import os
 import requests_mock
 
 from listenbrainz_spark import utils
-from listenbrainz_spark import hdfs
+from listenbrainz_spark.hdfs.utils import create_dir
+from listenbrainz_spark.hdfs.utils import path_exists
+from listenbrainz_spark.hdfs.utils import upload_to_HDFS
 from listenbrainz_spark.fresh_releases import fresh_releases
 from listenbrainz_spark.fresh_releases.fresh_releases import FRESH_RELEASES_ENDPOINT
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
@@ -15,10 +17,10 @@ class FreshReleasesTestCase(SparkNewTestCase):
 
     def setUp(self):
         super(FreshReleasesTestCase, self).setUp()
-        if not hdfs.path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
-            hdfs.create_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY)
+        if not path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
+            create_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY)
 
-        hdfs.upload_to_HDFS(
+        upload_to_HDFS(
             os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "0.parquet"),
             os.path.join(TEST_DATA_PATH, "fresh_releases_listens.parquet")
         )

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -10,7 +10,11 @@ from tarfile import TarError
 
 import listenbrainz_spark
 from listenbrainz_spark import utils
-from listenbrainz_spark import hdfs
+from listenbrainz_spark.hdfs.utils import create_dir
+from listenbrainz_spark.hdfs.utils import delete_dir
+from listenbrainz_spark.hdfs.utils import path_exists
+from listenbrainz_spark.hdfs.utils import upload_to_HDFS
+from listenbrainz_spark.hdfs.utils import rename
 from listenbrainz_spark.exceptions import SparkSessionNotInitializedException, DumpInvalidException
 
 
@@ -68,11 +72,11 @@ class ListenbrainzHDFSUploader:
             raise NotImplementedError('Callback to process JSON missing. Aborting...')
 
         # Delete TEMP_DIR_PATH if it exists
-        if hdfs.path_exists(TEMP_DIR_PATH):
-            hdfs.delete_dir(TEMP_DIR_PATH, recursive=True)
+        if path_exists(TEMP_DIR_PATH):
+            delete_dir(TEMP_DIR_PATH, recursive=True)
 
         # Copy data from dest_path to TEMP_DIR_PATH to be merged with new data
-        if not overwrite and hdfs.path_exists(dest_path):
+        if not overwrite and path_exists(dest_path):
             t0 = time.monotonic()
             logger.info("Copying old listens into '{}'".format(TEMP_DIR_PATH))
             utils.copy(dest_path, TEMP_DIR_PATH, overwrite=True)
@@ -90,16 +94,16 @@ class ListenbrainzHDFSUploader:
                     tar.extract(member)
                 except TarError as err:
                     # Cleanup
-                    if hdfs.path_exists(TEMP_DIR_PATH):
-                        hdfs.delete_dir(TEMP_DIR_PATH, recursive=True)
-                    if hdfs.path_exists(tmp_dump_dir):
-                        hdfs.delete_dir(tmp_dump_dir, recursive=True)
+                    if path_exists(TEMP_DIR_PATH):
+                        delete_dir(TEMP_DIR_PATH, recursive=True)
+                    if path_exists(tmp_dump_dir):
+                        delete_dir(tmp_dump_dir, recursive=True)
                     raise DumpInvalidException("{} while extracting {}, aborting import".format(type(err).__name__, member.name))
 
                 tmp_hdfs_path = os.path.join(tmp_dump_dir, member.name)
-                hdfs.upload_to_HDFS(tmp_hdfs_path, member.name)
+                upload_to_HDFS(tmp_hdfs_path, member.name)
                 callback(member.name, TEMP_DIR_PATH, tmp_hdfs_path, not overwrite, schema)
-                hdfs.delete_dir(tmp_hdfs_path, recursive=True)
+                delete_dir(tmp_hdfs_path, recursive=True)
                 os.remove(member.name)
                 time_taken = time.monotonic() - t0
                 total_files += 1
@@ -110,9 +114,9 @@ class ListenbrainzHDFSUploader:
         ))
 
         # Delete dest_path if present
-        if hdfs.path_exists(dest_path):
+        if path_exists(dest_path):
             logger.info('Removing {} from HDFS...'.format(dest_path))
-            hdfs.delete_dir(dest_path, recursive=True)
+            delete_dir(dest_path, recursive=True)
             logger.info('Done!')
 
         logger.info("Moving the processed files to {}".format(dest_path))
@@ -120,14 +124,14 @@ class ListenbrainzHDFSUploader:
 
         # Check if parent directory exists, if not create a directory
         dest_path_parent = pathlib.Path(dest_path).parent
-        if not hdfs.path_exists(dest_path_parent):
-            hdfs.create_dir(dest_path_parent)
+        if not path_exists(dest_path_parent):
+            create_dir(dest_path_parent)
 
-        hdfs.rename(TEMP_DIR_PATH, dest_path)
+        rename(TEMP_DIR_PATH, dest_path)
         utils.logger.info("Done! Time taken: {:.2f}".format(time.monotonic() - t0))
 
         # Cleanup
-        hdfs.delete_dir(tmp_dump_dir, recursive=True)
+        delete_dir(tmp_dump_dir, recursive=True)
 
     def extract_and_upload_archive(self, archive, local_dir, hdfs_dir, cleanup_on_failure=True):
         """
@@ -151,14 +155,14 @@ class ListenbrainzHDFSUploader:
                         tar.extract(member, path=local_dir)
                     except tarfile.TarError as err:
                         if cleanup_on_failure:
-                            if hdfs.path_exists(hdfs_dir):
-                                hdfs.delete_dir(hdfs_dir, recursive=True)
+                            if path_exists(hdfs_dir):
+                                delete_dir(hdfs_dir, recursive=True)
                             shutil.rmtree(local_dir, ignore_errors=True)
                         raise DumpInvalidException(f"{type(err).__name__} while extracting {member.name}, aborting import")
 
                     hdfs_path = os.path.join(hdfs_dir, member.name)
                     local_path = os.path.join(local_dir, member.name)
-                    hdfs.upload_to_HDFS(hdfs_path, local_path)
+                    upload_to_HDFS(hdfs_path, local_path)
 
                     time_taken = time.monotonic() - t0
                     total_files += 1

--- a/listenbrainz_spark/hdfs/__init__.py
+++ b/listenbrainz_spark/hdfs/__init__.py
@@ -10,6 +10,7 @@ from tarfile import TarError
 
 import listenbrainz_spark
 from listenbrainz_spark import utils
+from listenbrainz_spark import hdfs
 from listenbrainz_spark.exceptions import SparkSessionNotInitializedException, DumpInvalidException
 
 
@@ -67,11 +68,11 @@ class ListenbrainzHDFSUploader:
             raise NotImplementedError('Callback to process JSON missing. Aborting...')
 
         # Delete TEMP_DIR_PATH if it exists
-        if utils.path_exists(TEMP_DIR_PATH):
-            utils.delete_dir(TEMP_DIR_PATH, recursive=True)
+        if hdfs.path_exists(TEMP_DIR_PATH):
+            hdfs.delete_dir(TEMP_DIR_PATH, recursive=True)
 
         # Copy data from dest_path to TEMP_DIR_PATH to be merged with new data
-        if not overwrite and utils.path_exists(dest_path):
+        if not overwrite and hdfs.path_exists(dest_path):
             t0 = time.monotonic()
             logger.info("Copying old listens into '{}'".format(TEMP_DIR_PATH))
             utils.copy(dest_path, TEMP_DIR_PATH, overwrite=True)
@@ -89,16 +90,16 @@ class ListenbrainzHDFSUploader:
                     tar.extract(member)
                 except TarError as err:
                     # Cleanup
-                    if utils.path_exists(TEMP_DIR_PATH):
-                        utils.delete_dir(TEMP_DIR_PATH, recursive=True)
-                    if utils.path_exists(tmp_dump_dir):
-                        utils.delete_dir(tmp_dump_dir, recursive=True)
+                    if hdfs.path_exists(TEMP_DIR_PATH):
+                        hdfs.delete_dir(TEMP_DIR_PATH, recursive=True)
+                    if hdfs.path_exists(tmp_dump_dir):
+                        hdfs.delete_dir(tmp_dump_dir, recursive=True)
                     raise DumpInvalidException("{} while extracting {}, aborting import".format(type(err).__name__, member.name))
 
                 tmp_hdfs_path = os.path.join(tmp_dump_dir, member.name)
-                utils.upload_to_HDFS(tmp_hdfs_path, member.name)
+                hdfs.upload_to_HDFS(tmp_hdfs_path, member.name)
                 callback(member.name, TEMP_DIR_PATH, tmp_hdfs_path, not overwrite, schema)
-                utils.delete_dir(tmp_hdfs_path, recursive=True)
+                hdfs.delete_dir(tmp_hdfs_path, recursive=True)
                 os.remove(member.name)
                 time_taken = time.monotonic() - t0
                 total_files += 1
@@ -109,9 +110,9 @@ class ListenbrainzHDFSUploader:
         ))
 
         # Delete dest_path if present
-        if utils.path_exists(dest_path):
+        if hdfs.path_exists(dest_path):
             logger.info('Removing {} from HDFS...'.format(dest_path))
-            utils.delete_dir(dest_path, recursive=True)
+            hdfs.delete_dir(dest_path, recursive=True)
             logger.info('Done!')
 
         logger.info("Moving the processed files to {}".format(dest_path))
@@ -119,14 +120,14 @@ class ListenbrainzHDFSUploader:
 
         # Check if parent directory exists, if not create a directory
         dest_path_parent = pathlib.Path(dest_path).parent
-        if not utils.path_exists(dest_path_parent):
-            utils.create_dir(dest_path_parent)
+        if not hdfs.path_exists(dest_path_parent):
+            hdfs.create_dir(dest_path_parent)
 
-        utils.rename(TEMP_DIR_PATH, dest_path)
+        hdfs.rename(TEMP_DIR_PATH, dest_path)
         utils.logger.info("Done! Time taken: {:.2f}".format(time.monotonic() - t0))
 
         # Cleanup
-        utils.delete_dir(tmp_dump_dir, recursive=True)
+        hdfs.delete_dir(tmp_dump_dir, recursive=True)
 
     def extract_and_upload_archive(self, archive, local_dir, hdfs_dir, cleanup_on_failure=True):
         """
@@ -150,14 +151,14 @@ class ListenbrainzHDFSUploader:
                         tar.extract(member, path=local_dir)
                     except tarfile.TarError as err:
                         if cleanup_on_failure:
-                            if utils.path_exists(hdfs_dir):
-                                utils.delete_dir(hdfs_dir, recursive=True)
+                            if hdfs.path_exists(hdfs_dir):
+                                hdfs.delete_dir(hdfs_dir, recursive=True)
                             shutil.rmtree(local_dir, ignore_errors=True)
                         raise DumpInvalidException(f"{type(err).__name__} while extracting {member.name}, aborting import")
 
                     hdfs_path = os.path.join(hdfs_dir, member.name)
                     local_path = os.path.join(local_dir, member.name)
-                    utils.upload_to_HDFS(hdfs_path, local_path)
+                    hdfs.upload_to_HDFS(hdfs_path, local_path)
 
                     time_taken = time.monotonic() - t0
                     total_files += 1

--- a/listenbrainz_spark/hdfs/tests/test_init.py
+++ b/listenbrainz_spark/hdfs/tests/test_init.py
@@ -9,7 +9,7 @@ from unittest.mock import patch, MagicMock
 
 import logging
 
-from listenbrainz_spark import config, utils, schema
+from listenbrainz_spark import config, utils, schema, hdfs
 from listenbrainz_spark.exceptions import DumpInvalidException
 from listenbrainz_spark.hdfs import ListenbrainzHDFSUploader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
@@ -77,10 +77,10 @@ class HDFSTestCase(SparkNewTestCase):
         df = utils.read_files_from_HDFS('/artist_relations.parquet')
         self.assertEqual(df.count(), 1)
 
-        status = utils.path_exists(tmp_dump_dir)
+        status = hdfs.path_exists(tmp_dump_dir)
         self.assertFalse(status)
 
-        utils.delete_dir('/artist_relations.parquet', recursive=True)
+        hdfs.delete_dir('/artist_relations.parquet', recursive=True)
 
     def test_upload_archive_failed(self):
         faulty_tar = MagicMock()
@@ -92,5 +92,5 @@ class HDFSTestCase(SparkNewTestCase):
         self.assertRaises(DumpInvalidException, self.uploader.upload_archive, tmp_dump_dir,
                           faulty_tar, '/test', schema.artist_relation_schema, self.uploader.process_json)
 
-        status = utils.path_exists('/test')
+        status = hdfs.path_exists('/test')
         self.assertFalse(status)

--- a/listenbrainz_spark/hdfs/tests/test_init.py
+++ b/listenbrainz_spark/hdfs/tests/test_init.py
@@ -9,12 +9,13 @@ from unittest.mock import patch, MagicMock
 
 import logging
 
-from listenbrainz_spark import config, utils, schema, hdfs
+from listenbrainz_spark import config, utils, schema
+from listenbrainz_spark.hdfs.utils import delete_dir
 from listenbrainz_spark.exceptions import DumpInvalidException
 from listenbrainz_spark.hdfs import ListenbrainzHDFSUploader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
 from listenbrainz_spark.tests import SparkNewTestCase
-
+from listenbrainz_spark.hdfs.utils import path_exists
 
 class HDFSTestCase(SparkNewTestCase):
 
@@ -77,10 +78,10 @@ class HDFSTestCase(SparkNewTestCase):
         df = utils.read_files_from_HDFS('/artist_relations.parquet')
         self.assertEqual(df.count(), 1)
 
-        status = hdfs.path_exists(tmp_dump_dir)
+        status = path_exists(tmp_dump_dir)
         self.assertFalse(status)
 
-        hdfs.delete_dir('/artist_relations.parquet', recursive=True)
+        delete_dir('/artist_relations.parquet', recursive=True)
 
     def test_upload_archive_failed(self):
         faulty_tar = MagicMock()
@@ -92,5 +93,5 @@ class HDFSTestCase(SparkNewTestCase):
         self.assertRaises(DumpInvalidException, self.uploader.upload_archive, tmp_dump_dir,
                           faulty_tar, '/test', schema.artist_relation_schema, self.uploader.process_json)
 
-        status = hdfs.path_exists('/test')
+        status = path_exists('/test')
         self.assertFalse(status)

--- a/listenbrainz_spark/hdfs/upload.py
+++ b/listenbrainz_spark/hdfs/upload.py
@@ -5,7 +5,12 @@ import tarfile
 import tempfile
 import logging
 
-from listenbrainz_spark import schema, path, utils, hdfs
+from listenbrainz_spark import schema, path, utils
+from listenbrainz_spark.hdfs.utils import create_dir
+from listenbrainz_spark.hdfs.utils import delete_dir
+from listenbrainz_spark.hdfs.utils import path_exists
+from listenbrainz_spark.hdfs.utils import upload_to_HDFS
+from listenbrainz_spark.hdfs.utils import rename
 from listenbrainz_spark.hdfs import ListenbrainzHDFSUploader, TEMP_DIR_PATH as HDFS_TEMP_DIR
 from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH
 from listenbrainz_spark.utils import read_files_from_HDFS
@@ -52,10 +57,10 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
         hdfs_mbdump_dir = os.path.join(hdfs_dir, "mbdump")  # release.tar.xz file has actual dump file inside mbdump dir
         with tarfile.open(name=archive, mode="r:xz") as tar, tempfile.TemporaryDirectory() as local_dir:
             # Remove existing dumps
-            if hdfs.path_exists(hdfs_dir):
-                hdfs.delete_dir(hdfs_dir, recursive=True)
+            if path_exists(hdfs_dir):
+                delete_dir(hdfs_dir, recursive=True)
 
-            hdfs.create_dir(hdfs_dir)
+            create_dir(hdfs_dir)
 
             for member in tar:
                 t0 = time.monotonic()
@@ -67,7 +72,7 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
                 logger.info(f"Uploading {member.name}")
                 hdfs_path = os.path.join(hdfs_dir, member.name)
                 local_path = os.path.join(local_dir, member.name)
-                hdfs.upload_to_HDFS(hdfs_path, local_path)
+                upload_to_HDFS(hdfs_path, local_path)
                 logger.info(f"Done. Total time: {time.monotonic() - t0:.2f} sec")
 
     def upload_new_listens_incremental_dump(self, archive: str):
@@ -89,7 +94,7 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
             .parquet(INCREMENTAL_DUMPS_SAVE_PATH)
 
         # delete parquet from hdfs temporary path
-        hdfs.delete_dir(hdfs_path, recursive=True)
+        delete_dir(hdfs_path, recursive=True)
 
     def upload_new_listens_full_dump(self, archive: str):
         """ Upload new format parquet listens dumps to of a full
@@ -101,9 +106,9 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
         src_path = self.upload_archive_to_temp(archive)
         dest_path = path.LISTENBRAINZ_NEW_DATA_DIRECTORY
         # Delete existing dumps if any
-        if hdfs.path_exists(dest_path):
+        if path_exists(dest_path):
             logger.info(f'Removing {dest_path} from HDFS...')
-            hdfs.delete_dir(dest_path, recursive=True)
+            delete_dir(dest_path, recursive=True)
             logger.info('Done!')
 
         logger.info(f"Moving the processed files from {src_path} to {dest_path}")
@@ -111,10 +116,10 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
 
         # Check if parent directory exists, if not create a directory
         dest_path_parent = str(Path(dest_path).parent)
-        if not hdfs.path_exists(dest_path_parent):
-            hdfs.create_dir(dest_path_parent)
+        if not path_exists(dest_path_parent):
+            create_dir(dest_path_parent)
 
-        hdfs.rename(src_path, dest_path)
+        rename(src_path, dest_path)
         utils.logger.info(f"Done! Time taken: {time.monotonic() - t0:.2f}")
 
     def upload_archive_to_temp(self, archive: str) -> str:
@@ -133,8 +138,8 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
         """
         with tempfile.TemporaryDirectory() as local_temp_dir:
             logger.info("Cleaning HDFS temporary directory...")
-            if hdfs.path_exists(HDFS_TEMP_DIR):
-                hdfs.delete_dir(HDFS_TEMP_DIR, recursive=True)
+            if path_exists(HDFS_TEMP_DIR):
+                delete_dir(HDFS_TEMP_DIR, recursive=True)
 
             logger.info("Uploading listens to temporary directory in HDFS...")
             self.extract_and_upload_archive(archive, local_temp_dir, HDFS_TEMP_DIR)

--- a/listenbrainz_spark/hdfs/utils.py
+++ b/listenbrainz_spark/hdfs/utils.py
@@ -10,7 +10,7 @@ from pyspark.sql.utils import AnalysisException
 
 import listenbrainz_spark
 from hdfs.util import HdfsError
-from listenbrainz_spark import config, hdfs_connection, path, hdfs
+from listenbrainz_spark import config, hdfs_connection, path
 from listenbrainz_spark.schema import listens_new_schema
 from listenbrainz_spark.exceptions import (DataFrameNotAppendedException,
                                            DataFrameNotCreatedException,

--- a/listenbrainz_spark/hdfs/utils.py
+++ b/listenbrainz_spark/hdfs/utils.py
@@ -1,0 +1,125 @@
+import errno
+import logging
+import os
+from datetime import datetime
+from typing import List
+
+from py4j.protocol import Py4JJavaError
+from pyspark.sql import DataFrame, functions
+from pyspark.sql.utils import AnalysisException
+
+import listenbrainz_spark
+from hdfs.util import HdfsError
+from listenbrainz_spark import config, hdfs_connection, path, hdfs
+from listenbrainz_spark.schema import listens_new_schema
+from listenbrainz_spark.exceptions import (DataFrameNotAppendedException,
+                                           DataFrameNotCreatedException,
+                                           FileNotFetchedException,
+                                           FileNotSavedException,
+                                           HDFSDirectoryNotDeletedException,
+                                           PathNotFoundException,
+                                           ViewNotRegisteredException)
+
+logger = logging.getLogger(__name__)
+
+# A typical listen is of the form:
+# {
+#   "artist_mbids": [],
+#   "artist_name": "Cake",
+#   "listened_at": "2005-02-28T20:39:08Z",
+#   "recording_msid": "c559b2f8-41ff-4b55-ab3c-0b57d9b85d11",
+#   "recording_mbid": "1750f8ca-410e-4bdc-bf90-b0146cb5ee35",
+#   "release_mbid": "",
+#   "release_name": null,
+#   "tags": [],
+#   "track_name": "Tougher Than It Is"
+#   "user_id": 5,
+# }
+# All the keys in the dict are column/field names in a Spark dataframe.
+
+
+def create_dir(path):
+    """ Creates a directory in HDFS.
+        Args:
+            path (string): Path of the directory to be created.
+        Note: >> Caller is responsibe for initializing HDFS connection.
+              >> The function does not throw an error if the directory path already exists.
+    """
+    hdfs_connection.client.makedirs(path)
+
+
+def delete_dir(path, recursive=False):
+    """ Deletes a directory recursively from HDFS.
+        Args:
+            path (string): Path of the directory to be deleted.
+        Note: >> Caller is responsible for initializing HDFS connection.
+              >> Raises HdfsError if trying to delete a non-empty directory.
+                 For non-empty directory set recursive to 'True'.
+    """
+    deleted = hdfs_connection.client.delete(path, recursive=recursive)
+    if not deleted:
+        raise HDFSDirectoryNotDeletedException('', path)
+
+
+def path_exists(path):
+    """ Checks if the path exists in HDFS. The function returns False if the path
+        does not exist otherwise returns True.
+        Args:
+            path (string): Path to check status for.
+        Note: Caller is responsible for initializing HDFS connection.
+    """
+    path_found = hdfs_connection.client.status(path, strict=False)
+    if path_found:
+        return True
+    return False
+
+
+def hdfs_walk(path, depth=0):
+    """ Depth-first walk of HDFS filesystem.
+        Args:
+            path (str): Path to start DFS.
+            depth (int): Maximum depth to explore files/folders. 0 for no limit.
+        Returns:
+            walk: a generator yeilding tuples (path, dirs, files).
+    """
+    try:
+        walk = hdfs_connection.client.walk(hdfs_path=path, depth=depth)
+        return walk
+    except HdfsError as err:
+        raise PathNotFoundException(str(err), path)
+
+
+def upload_to_HDFS(hdfs_path, local_path):
+    """ Upload local file to HDFS.
+        Args:
+            hdfs_path (str): HDFS path to upload local file.
+            local_path (str): Local path of file to be uploaded.
+    """
+    hdfs_connection.client.upload(hdfs_path=hdfs_path, local_path=local_path)
+
+
+def rename(hdfs_src_path: str, hdfs_dst_path: str):
+    """ Move a file or folder in HDFS
+        Args:
+            hdfs_src_path – Source path.
+            hdfs_dst_path – Destination path. If the path already exists and is a directory, the source will be moved into it.
+    """
+    hdfs_connection.client.rename(hdfs_src_path, hdfs_dst_path)
+
+
+def copy(hdfs_src_path: str, hdfs_dst_path: str, overwrite: bool = False):
+    """ Copy a file or folder in HDFS
+        Args:
+            hdfs_src_path – Source path.
+            hdfs_dst_path – Destination path. If the path already exists and is a directory, the source will be copied into it.
+            overwrite - Wether to overwrite the path if it already exists.
+    """
+    walk = hdfs_walk(hdfs_src_path)
+
+    for (root, dirs, files) in walk:
+        for _file in files:
+            src_file_path = os.path.join(root, _file)
+            dst_file_path = os.path.join(hdfs_dst_path, os.path.relpath(src_file_path, hdfs_src_path))
+            with hdfs_connection.client.read(src_file_path) as reader:
+                with hdfs_connection.client.write(dst_file_path, overwrite=overwrite) as writer:
+                    writer.write(reader.read())

--- a/listenbrainz_spark/missing_mb_data/tests/test_missing_mb_data.py
+++ b/listenbrainz_spark/missing_mb_data/tests/test_missing_mb_data.py
@@ -1,16 +1,16 @@
 import json
 import os.path
 
-from listenbrainz_spark import utils, hdfs
+from listenbrainz_spark import utils
 from listenbrainz_spark.missing_mb_data import missing_mb_data
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
 from listenbrainz_spark.tests import SparkNewTestCase
-
+from listenbrainz_spark.hdfs.utils import upload_to_HDFS
 
 class MissingMBDataTestCase(SparkNewTestCase):
 
     def test_get_data_missing_from_musicbrainz(self):
-        hdfs.upload_to_HDFS(os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "0.parquet"), self.path_to_data_file("rec_listens.parquet"))
+        upload_to_HDFS(os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "0.parquet"), self.path_to_data_file("rec_listens.parquet"))
         # use a very long day range so that listens are used
         messages = missing_mb_data.main(10000)
         with open(self.path_to_data_file('missing_musicbrainz_data.json')) as f:

--- a/listenbrainz_spark/missing_mb_data/tests/test_missing_mb_data.py
+++ b/listenbrainz_spark/missing_mb_data/tests/test_missing_mb_data.py
@@ -1,7 +1,7 @@
 import json
 import os.path
 
-from listenbrainz_spark import utils
+from listenbrainz_spark import utils, hdfs
 from listenbrainz_spark.missing_mb_data import missing_mb_data
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
 from listenbrainz_spark.tests import SparkNewTestCase
@@ -10,7 +10,7 @@ from listenbrainz_spark.tests import SparkNewTestCase
 class MissingMBDataTestCase(SparkNewTestCase):
 
     def test_get_data_missing_from_musicbrainz(self):
-        utils.upload_to_HDFS(os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "0.parquet"), self.path_to_data_file("rec_listens.parquet"))
+        hdfs.upload_to_HDFS(os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "0.parquet"), self.path_to_data_file("rec_listens.parquet"))
         # use a very long day range so that listens are used
         messages = missing_mb_data.main(10000)
         with open(self.path_to_data_file('missing_musicbrainz_data.json')) as f:

--- a/listenbrainz_spark/recommendations/recording/tests/__init__.py
+++ b/listenbrainz_spark/recommendations/recording/tests/__init__.py
@@ -4,7 +4,7 @@ from pyspark import Row
 from pyspark.sql.types import StructType, StructField, IntegerType
 
 import listenbrainz_spark
-from listenbrainz_spark import utils
+from listenbrainz_spark import utils, hdfs
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY, RECOMMENDATION_RECORDING_MAPPED_LISTENS
 from listenbrainz_spark.tests import SparkNewTestCase, TEST_DATA_PATH, PLAYCOUNTS_COUNT, TEST_PLAYCOUNTS_PATH
 
@@ -14,8 +14,8 @@ class RecommendationsTestCase(SparkNewTestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super(RecommendationsTestCase, cls).setUpClass()
-        utils.upload_to_HDFS(LISTENBRAINZ_NEW_DATA_DIRECTORY, os.path.join(TEST_DATA_PATH, 'rec_listens.parquet'))
-        utils.upload_to_HDFS(RECOMMENDATION_RECORDING_MAPPED_LISTENS, os.path.join(TEST_DATA_PATH, 'mapped_listens.parquet'))
+        hdfs.upload_to_HDFS(LISTENBRAINZ_NEW_DATA_DIRECTORY, os.path.join(TEST_DATA_PATH, 'rec_listens.parquet'))
+        hdfs.upload_to_HDFS(RECOMMENDATION_RECORDING_MAPPED_LISTENS, os.path.join(TEST_DATA_PATH, 'mapped_listens.parquet'))
 
     @classmethod
     def get_candidate_set(cls):

--- a/listenbrainz_spark/recommendations/recording/tests/__init__.py
+++ b/listenbrainz_spark/recommendations/recording/tests/__init__.py
@@ -4,18 +4,18 @@ from pyspark import Row
 from pyspark.sql.types import StructType, StructField, IntegerType
 
 import listenbrainz_spark
-from listenbrainz_spark import utils, hdfs
+from listenbrainz_spark import utils
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY, RECOMMENDATION_RECORDING_MAPPED_LISTENS
 from listenbrainz_spark.tests import SparkNewTestCase, TEST_DATA_PATH, PLAYCOUNTS_COUNT, TEST_PLAYCOUNTS_PATH
-
+from listenbrainz_spark.hdfs.utils import upload_to_HDFS
 
 class RecommendationsTestCase(SparkNewTestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
         super(RecommendationsTestCase, cls).setUpClass()
-        hdfs.upload_to_HDFS(LISTENBRAINZ_NEW_DATA_DIRECTORY, os.path.join(TEST_DATA_PATH, 'rec_listens.parquet'))
-        hdfs.upload_to_HDFS(RECOMMENDATION_RECORDING_MAPPED_LISTENS, os.path.join(TEST_DATA_PATH, 'mapped_listens.parquet'))
+        upload_to_HDFS(LISTENBRAINZ_NEW_DATA_DIRECTORY, os.path.join(TEST_DATA_PATH, 'rec_listens.parquet'))
+        upload_to_HDFS(RECOMMENDATION_RECORDING_MAPPED_LISTENS, os.path.join(TEST_DATA_PATH, 'mapped_listens.parquet'))
 
     @classmethod
     def get_candidate_set(cls):

--- a/listenbrainz_spark/recommendations/recording/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_candidate.py
@@ -19,7 +19,7 @@ from pyspark.sql import Row
 from unittest.mock import patch
 import pyspark.sql.functions as f
 from pyspark.sql.types import StructField, StructType, StringType
-
+from listenbrainz_spark import hdfs
 
 class CandidateSetsTestClass(RecommendationsTestCase):
 
@@ -93,10 +93,10 @@ class CandidateSetsTestClass(RecommendationsTestCase):
         similar_artist_candidate_set_dfs_df = self.get_candidate_set()
 
         candidate_sets.save_candidate_sets(top_artist_candidate_set_df_df, similar_artist_candidate_set_dfs_df)
-        top_artist_exist = utils.path_exists(path.RECOMMENDATION_RECORDING_TOP_ARTIST_CANDIDATE_SET)
+        top_artist_exist = hdfs.path_exists(path.RECOMMENDATION_RECORDING_TOP_ARTIST_CANDIDATE_SET)
         self.assertTrue(top_artist_exist)
 
-        similar_artist_exist = utils.path_exists(path.RECOMMENDATION_RECORDING_SIMILAR_ARTIST_CANDIDATE_SET)
+        similar_artist_exist = hdfs.path_exists(path.RECOMMENDATION_RECORDING_SIMILAR_ARTIST_CANDIDATE_SET)
         self.assertTrue(similar_artist_exist)
 
     def get_top_artist(self):

--- a/listenbrainz_spark/recommendations/recording/tests/test_candidate.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_candidate.py
@@ -9,6 +9,7 @@ from listenbrainz_spark.path import RECOMMENDATION_RECORDING_MAPPED_LISTENS, REC
     RECOMMENDATION_RECORDING_USERS_DATAFRAME
 from listenbrainz_spark.recommendations.recording.tests import RecommendationsTestCase
 from listenbrainz_spark.tests import TEST_DATA_PATH
+from listenbrainz_spark.hdfs.utils import path_exists
 from listenbrainz_spark.recommendations.recording import candidate_sets
 from listenbrainz_spark.recommendations.recording import create_dataframes
 from listenbrainz_spark import utils, path, stats
@@ -19,7 +20,7 @@ from pyspark.sql import Row
 from unittest.mock import patch
 import pyspark.sql.functions as f
 from pyspark.sql.types import StructField, StructType, StringType
-from listenbrainz_spark import hdfs
+from listenbrainz_spark.hdfs.utils import path_exists
 
 class CandidateSetsTestClass(RecommendationsTestCase):
 
@@ -93,10 +94,10 @@ class CandidateSetsTestClass(RecommendationsTestCase):
         similar_artist_candidate_set_dfs_df = self.get_candidate_set()
 
         candidate_sets.save_candidate_sets(top_artist_candidate_set_df_df, similar_artist_candidate_set_dfs_df)
-        top_artist_exist = hdfs.path_exists(path.RECOMMENDATION_RECORDING_TOP_ARTIST_CANDIDATE_SET)
+        top_artist_exist = path_exists(path.RECOMMENDATION_RECORDING_TOP_ARTIST_CANDIDATE_SET)
         self.assertTrue(top_artist_exist)
 
-        similar_artist_exist = hdfs.path_exists(path.RECOMMENDATION_RECORDING_SIMILAR_ARTIST_CANDIDATE_SET)
+        similar_artist_exist = path_exists(path.RECOMMENDATION_RECORDING_SIMILAR_ARTIST_CANDIDATE_SET)
         self.assertTrue(similar_artist_exist)
 
     def get_top_artist(self):

--- a/listenbrainz_spark/recommendations/recording/tests/test_dataframe.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_dataframe.py
@@ -1,7 +1,7 @@
 from pyspark.sql import Row
 
 import listenbrainz_spark
-from listenbrainz_spark import schema, utils
+from listenbrainz_spark import schema, utils, hdfs
 from listenbrainz_spark.path import RECOMMENDATION_RECORDING_MAPPED_LISTENS, \
     RECOMMENDATION_RECORDINGS_DATAFRAME, RECOMMENDATION_RECORDING_USERS_DATAFRAME, \
     RECOMMENDATION_RECORDING_TRANSFORMED_LISTENCOUNTS_DATAFRAME, RECOMMENDATION_RECORDING_DATAFRAME_METADATA
@@ -25,7 +25,7 @@ class CreateDataframeTestCase(RecommendationsTestCase):
         self.assertCountEqual(expected_users_df.columns, users_df.columns)
         self.assertEqual(metadata['users_count'], 2)
 
-        status = utils.path_exists(RECOMMENDATION_RECORDING_USERS_DATAFRAME)
+        status = hdfs.path_exists(RECOMMENDATION_RECORDING_USERS_DATAFRAME)
         self.assertTrue(status)
 
     def test_get_recordings_dataframe(self):
@@ -36,7 +36,7 @@ class CreateDataframeTestCase(RecommendationsTestCase):
         self.assertCountEqual(['artist_credit_id', 'recording_id', 'recording_mbid'], recordings_df.columns)
         self.assertEqual(metadata['recordings_count'], 20)
 
-        status = utils.path_exists(RECOMMENDATION_RECORDINGS_DATAFRAME)
+        status = hdfs.path_exists(RECOMMENDATION_RECORDINGS_DATAFRAME)
         self.assertTrue(status)
 
     def test_get_listens_df(self):
@@ -66,7 +66,7 @@ class CreateDataframeTestCase(RecommendationsTestCase):
         metadata = self.get_dataframe_metadata(df_id)
         create_dataframes.save_dataframe_metadata_to_hdfs(metadata, RECOMMENDATION_RECORDING_DATAFRAME_METADATA)
 
-        status = utils.path_exists(RECOMMENDATION_RECORDING_DATAFRAME_METADATA)
+        status = hdfs.path_exists(RECOMMENDATION_RECORDING_DATAFRAME_METADATA)
         self.assertTrue(status)
 
         df = utils.read_files_from_HDFS(RECOMMENDATION_RECORDING_DATAFRAME_METADATA)

--- a/listenbrainz_spark/recommendations/recording/tests/test_dataframe.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_dataframe.py
@@ -1,13 +1,13 @@
 from pyspark.sql import Row
 
 import listenbrainz_spark
-from listenbrainz_spark import schema, utils, hdfs
+from listenbrainz_spark import schema, utils
 from listenbrainz_spark.path import RECOMMENDATION_RECORDING_MAPPED_LISTENS, \
     RECOMMENDATION_RECORDINGS_DATAFRAME, RECOMMENDATION_RECORDING_USERS_DATAFRAME, \
     RECOMMENDATION_RECORDING_TRANSFORMED_LISTENCOUNTS_DATAFRAME, RECOMMENDATION_RECORDING_DATAFRAME_METADATA
 from listenbrainz_spark.recommendations.recording import create_dataframes
 from listenbrainz_spark.recommendations.recording.tests import RecommendationsTestCase
-
+from listenbrainz_spark.hdfs.utils import path_exists
 
 class CreateDataframeTestCase(RecommendationsTestCase):
 
@@ -25,7 +25,7 @@ class CreateDataframeTestCase(RecommendationsTestCase):
         self.assertCountEqual(expected_users_df.columns, users_df.columns)
         self.assertEqual(metadata['users_count'], 2)
 
-        status = hdfs.path_exists(RECOMMENDATION_RECORDING_USERS_DATAFRAME)
+        status = path_exists(RECOMMENDATION_RECORDING_USERS_DATAFRAME)
         self.assertTrue(status)
 
     def test_get_recordings_dataframe(self):
@@ -36,7 +36,7 @@ class CreateDataframeTestCase(RecommendationsTestCase):
         self.assertCountEqual(['artist_credit_id', 'recording_id', 'recording_mbid'], recordings_df.columns)
         self.assertEqual(metadata['recordings_count'], 20)
 
-        status = hdfs.path_exists(RECOMMENDATION_RECORDINGS_DATAFRAME)
+        status = path_exists(RECOMMENDATION_RECORDINGS_DATAFRAME)
         self.assertTrue(status)
 
     def test_get_listens_df(self):
@@ -66,7 +66,7 @@ class CreateDataframeTestCase(RecommendationsTestCase):
         metadata = self.get_dataframe_metadata(df_id)
         create_dataframes.save_dataframe_metadata_to_hdfs(metadata, RECOMMENDATION_RECORDING_DATAFRAME_METADATA)
 
-        status = hdfs.path_exists(RECOMMENDATION_RECORDING_DATAFRAME_METADATA)
+        status = path_exists(RECOMMENDATION_RECORDING_DATAFRAME_METADATA)
         self.assertTrue(status)
 
         df = utils.read_files_from_HDFS(RECOMMENDATION_RECORDING_DATAFRAME_METADATA)

--- a/listenbrainz_spark/recommendations/recording/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_models.py
@@ -3,7 +3,8 @@ from unittest.mock import patch, MagicMock
 
 from listenbrainz_spark.recommendations.recording.tests import RecommendationsTestCase
 from listenbrainz_spark.recommendations.recording.train_models import Model, NUM_FOLDS
-from listenbrainz_spark import hdfs
+from listenbrainz_spark.hdfs.utils import delete_dir
+from listenbrainz_spark.hdfs.utils import path_exists
 from listenbrainz_spark.tests import TEST_PLAYCOUNTS_PATH, PLAYCOUNTS_COUNT
 from listenbrainz_spark import utils, config, path, schema
 from listenbrainz_spark.recommendations.recording import train_models
@@ -92,7 +93,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
         utils.save_parquet(df, path.RECOMMENDATION_RECORDING_DATA_DIR)
         train_models.delete_model()
 
-        dir_exists = hdfs.path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
+        dir_exists = path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
         self.assertFalse(dir_exists)
 
     def test_save_model_metadata_to_hdfs(self):
@@ -112,7 +113,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
             "test_rmse": 4.5
         })
 
-        status = hdfs.path_exists(path.RECOMMENDATION_RECORDING_MODEL_METADATA)
+        status = path_exists(path.RECOMMENDATION_RECORDING_MODEL_METADATA)
         self.assertTrue(status)
 
         df = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_MODEL_METADATA)

--- a/listenbrainz_spark/recommendations/recording/tests/test_models.py
+++ b/listenbrainz_spark/recommendations/recording/tests/test_models.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 from listenbrainz_spark.recommendations.recording.tests import RecommendationsTestCase
 from listenbrainz_spark.recommendations.recording.train_models import Model, NUM_FOLDS
+from listenbrainz_spark import hdfs
 from listenbrainz_spark.tests import TEST_PLAYCOUNTS_PATH, PLAYCOUNTS_COUNT
 from listenbrainz_spark import utils, config, path, schema
 from listenbrainz_spark.recommendations.recording import train_models
@@ -91,7 +92,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
         utils.save_parquet(df, path.RECOMMENDATION_RECORDING_DATA_DIR)
         train_models.delete_model()
 
-        dir_exists = utils.path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
+        dir_exists = hdfs.path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
         self.assertFalse(dir_exists)
 
     def test_save_model_metadata_to_hdfs(self):
@@ -111,7 +112,7 @@ class TrainModelsTestCase(RecommendationsTestCase):
             "test_rmse": 4.5
         })
 
-        status = utils.path_exists(path.RECOMMENDATION_RECORDING_MODEL_METADATA)
+        status = hdfs.path_exists(path.RECOMMENDATION_RECORDING_MODEL_METADATA)
         self.assertTrue(status)
 
         df = utils.read_files_from_HDFS(path.RECOMMENDATION_RECORDING_MODEL_METADATA)

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -28,7 +28,9 @@ from pyspark.ml.recommendation import ALS
 from pyspark.ml.tuning import ParamGridBuilder, CrossValidator, CrossValidatorModel
 
 import listenbrainz_spark
-from listenbrainz_spark import config, utils, path, schema, hdfs
+from listenbrainz_spark import config, utils, path, schema
+from listenbrainz_spark.hdfs.utils import delete_dir
+from listenbrainz_spark.hdfs.utils import path_exists
 from listenbrainz_spark.exceptions import PathNotFoundException
 from listenbrainz_spark.recommendations.recording.create_dataframes import describe_listencount_transformer
 from listenbrainz_spark.recommendations.utils import save_html
@@ -195,9 +197,9 @@ def delete_model():
     """ Delete model.
         Note: At any point in time, only one model is in HDFS
     """
-    dir_exists = hdfs.path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
+    dir_exists = path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
     if dir_exists:
-        hdfs.delete_dir(path.RECOMMENDATION_RECORDING_DATA_DIR, recursive=True)
+        delete_dir(path.RECOMMENDATION_RECORDING_DATA_DIR, recursive=True)
 
 
 def save_model_metadata_to_hdfs(model: Model, context: dict):
@@ -304,7 +306,7 @@ def main(ranks=None, lambdas=None, iterations=None, alphas=None, use_transformed
     save_training_html(context)
 
     # Delete checkpoint dir as saved lineages would eat up space, we won't be using them anyway.
-    hdfs.delete_dir(path.CHECKPOINT_DIR, recursive=True)
+    delete_dir(path.CHECKPOINT_DIR, recursive=True)
 
     return [{
         'type': 'cf_recommendations_recording_model',

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -28,7 +28,7 @@ from pyspark.ml.recommendation import ALS
 from pyspark.ml.tuning import ParamGridBuilder, CrossValidator, CrossValidatorModel
 
 import listenbrainz_spark
-from listenbrainz_spark import config, utils, path, schema
+from listenbrainz_spark import config, utils, path, schema, hdfs
 from listenbrainz_spark.exceptions import PathNotFoundException
 from listenbrainz_spark.recommendations.recording.create_dataframes import describe_listencount_transformer
 from listenbrainz_spark.recommendations.utils import save_html
@@ -195,9 +195,9 @@ def delete_model():
     """ Delete model.
         Note: At any point in time, only one model is in HDFS
     """
-    dir_exists = utils.path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
+    dir_exists = hdfs.path_exists(path.RECOMMENDATION_RECORDING_DATA_DIR)
     if dir_exists:
-        utils.delete_dir(path.RECOMMENDATION_RECORDING_DATA_DIR, recursive=True)
+        hdfs.delete_dir(path.RECOMMENDATION_RECORDING_DATA_DIR, recursive=True)
 
 
 def save_model_metadata_to_hdfs(model: Model, context: dict):
@@ -304,7 +304,7 @@ def main(ranks=None, lambdas=None, iterations=None, alphas=None, use_transformed
     save_training_html(context)
 
     # Delete checkpoint dir as saved lineages would eat up space, we won't be using them anyway.
-    utils.delete_dir(path.CHECKPOINT_DIR, recursive=True)
+    hdfs.delete_dir(path.CHECKPOINT_DIR, recursive=True)
 
     return [{
         'type': 'cf_recommendations_recording_model',

--- a/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from listenbrainz_spark.tests import SparkNewTestCase
 
 from listenbrainz_spark.recommendations import dataframe_utils
-from listenbrainz_spark import utils
+from listenbrainz_spark import utils, hdfs
 
 from pyspark.sql import Row
 
@@ -37,5 +37,5 @@ class DataframeUtilsTestCase(SparkNewTestCase):
         df = utils.create_dataframe(Row(column1=1, column2=2), schema=None)
         dataframe_utils.save_dataframe(df, path_)
 
-        status = utils.path_exists(path_)
+        status = hdfs.path_exists(path_)
         self.assertTrue(status)

--- a/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
@@ -2,9 +2,9 @@ import re
 from datetime import datetime
 
 from listenbrainz_spark.tests import SparkNewTestCase
-
+from listenbrainz_spark.hdfs.utils import path_exists
 from listenbrainz_spark.recommendations import dataframe_utils
-from listenbrainz_spark import utils, hdfs
+from listenbrainz_spark import utils
 
 from pyspark.sql import Row
 
@@ -37,5 +37,5 @@ class DataframeUtilsTestCase(SparkNewTestCase):
         df = utils.create_dataframe(Row(column1=1, column2=2), schema=None)
         dataframe_utils.save_dataframe(df, path_)
 
-        status = hdfs.path_exists(path_)
+        status = path_exists(path_)
         self.assertTrue(status)

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -9,9 +9,9 @@ from listenbrainz_spark.exceptions import (DumpInvalidException,
                                            DumpNotFoundException)
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.tests import SparkNewTestCase
-from listenbrainz_spark.utils import (delete_dir, path_exists,
-                                      read_files_from_HDFS)
+from listenbrainz_spark.utils import (read_files_from_HDFS)
 
+from listenbrainz_spark.hdfs import (delete_dir, path_exists)
 
 def mock_import_dump_to_hdfs(dump_id: int):
     """ Mock function returning dump name all dump ids less than 210, else raising DumpNotFoundException """

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -11,7 +11,7 @@ from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.tests import SparkNewTestCase
 from listenbrainz_spark.utils import (read_files_from_HDFS)
 
-from listenbrainz_spark.hdfs import (delete_dir, path_exists)
+from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists)
 
 def mock_import_dump_to_hdfs(dump_id: int):
     """ Mock function returning dump name all dump ids less than 210, else raising DumpNotFoundException """

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
@@ -8,7 +8,7 @@ from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.tests import SparkNewTestCase
 from listenbrainz_spark.utils import (create_dataframe,
                                    read_files_from_HDFS, save_parquet)
-from listenbrainz_spark.hdfs import (delete_dir, path_exists, rename)
+from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists, rename)
 
 from pyspark.sql import Row
 

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
@@ -6,8 +6,10 @@ from listenbrainz_spark.ftp import DumpType
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.tests import SparkNewTestCase
-from listenbrainz_spark.utils import (create_dataframe, delete_dir,
-                                      path_exists, read_files_from_HDFS, save_parquet, rename)
+from listenbrainz_spark.utils import (create_dataframe,
+                                   read_files_from_HDFS, save_parquet)
+from listenbrainz_spark.hdfs import (delete_dir, path_exists, rename)
+
 from pyspark.sql import Row
 
 

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -8,7 +8,8 @@ from listenbrainz_spark.ftp import DumpType
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.utils import (create_dataframe, read_files_from_HDFS,
-                                      save_parquet, path_exists, delete_dir, rename)
+                                      save_parquet)
+from listenbrainz_spark.hdfs import (delete_dir, path_exists, rename)
 from pyspark.sql import Row
 from pyspark.sql.functions import col
 

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -9,7 +9,7 @@ from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.utils import (create_dataframe, read_files_from_HDFS,
                                       save_parquet)
-from listenbrainz_spark.hdfs import (delete_dir, path_exists, rename)
+from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists, rename)
 from pyspark.sql import Row
 from pyspark.sql.functions import col
 

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import listenbrainz_spark
-from listenbrainz_spark import hdfs_connection, utils, config
+from listenbrainz_spark import hdfs_connection, utils, config, hdfs
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
 from listenbrainz_spark.utils import get_listens_from_new_dump
@@ -37,11 +37,11 @@ class SparkNewTestCase(unittest.TestCase):
 
     @classmethod
     def delete_dir(cls):
-        walk = utils.hdfs_walk('/', depth=1)
+        walk = hdfs.hdfs_walk('/', depth=1)
         # dirs in '/'
         dirs = next(walk)[1]
         for directory in dirs:
-            utils.delete_dir(os.path.join('/', directory), recursive=True)
+            hdfs.delete_dir(os.path.join('/', directory), recursive=True)
 
     @staticmethod
     def create_temp_listens_tar(name: str):
@@ -74,8 +74,8 @@ class SparkNewTestCase(unittest.TestCase):
 
     @staticmethod
     def delete_uploaded_listens():
-        if utils.path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
-            utils.delete_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY, recursive=True)
+        if hdfs.path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
+            hdfs.delete_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY, recursive=True)
 
     @staticmethod
     def path_to_data_file(file_name):

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import listenbrainz_spark
-from listenbrainz_spark import hdfs_connection, utils, config, hdfs
+from listenbrainz_spark import hdfs_connection, utils, config
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
 from listenbrainz_spark.utils import get_listens_from_new_dump
-
+from listenbrainz_spark.hdfs.utils import delete_dir
+from listenbrainz_spark.hdfs.utils import path_exists
+from listenbrainz_spark.hdfs.utils import hdfs_walk
 TEST_PLAYCOUNTS_PATH = '/tests/playcounts.parquet'
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'testdata')
 PLAYCOUNTS_COUNT = 100
@@ -37,11 +39,11 @@ class SparkNewTestCase(unittest.TestCase):
 
     @classmethod
     def delete_dir(cls):
-        walk = hdfs.hdfs_walk('/', depth=1)
+        walk = hdfs_walk('/', depth=1)
         # dirs in '/'
         dirs = next(walk)[1]
         for directory in dirs:
-            hdfs.delete_dir(os.path.join('/', directory), recursive=True)
+            delete_dir(os.path.join('/', directory), recursive=True)
 
     @staticmethod
     def create_temp_listens_tar(name: str):
@@ -74,8 +76,8 @@ class SparkNewTestCase(unittest.TestCase):
 
     @staticmethod
     def delete_uploaded_listens():
-        if hdfs.path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
-            hdfs.delete_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY, recursive=True)
+        if path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
+            delete_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY, recursive=True)
 
     @staticmethod
     def path_to_data_file(file_name):

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -41,7 +41,10 @@ logger = logging.getLogger(__name__)
 def append(df, dest_path):
     """ Append a dataframe to existing dataframe in HDFS or write a new one
         if dataframe does not exist.
+<<<<<<< HEAD
+=======
 
+>>>>>>> parent of b42ba5e6 (Update __init__.py and Add new file ../hdfs/utils/__init__.py)
         Args:
             df (dataframe): Dataframe to append.
             dest_path (string): Path where the existing dataframe is found or
@@ -53,6 +56,125 @@ def append(df, dest_path):
         raise DataFrameNotAppendedException(err.java_exception, df.schema)
 
 
+<<<<<<< HEAD
+def read_files_from_HDFS(path):
+    """ Loads the dataframe stored at the given path in HDFS.
+        Args:
+            path (str): An HDFS path.
+    """
+    # if we point spark to a directory, it will read each file in the directory as a
+    # parquet file and return the dataframe. so if a non-parquet file in also present
+    # in the same directory, we will get the not a parquet file error
+    try:
+        df = listenbrainz_spark.sql_context.read.parquet(config.HDFS_CLUSTER_URI + path)
+        return df
+    except AnalysisException as err:
+        raise PathNotFoundException(str(err), path)
+    except Py4JJavaError as err:
+        raise FileNotFetchedException(err.java_exception, path)
+
+
+def get_listen_files_list() -> List[str]:
+    """ Get list of name of parquet files containing the listens.
+    The list of file names is in order of newest to oldest listens.
+    """
+    files = hdfs_connection.client.list(path.LISTENBRAINZ_NEW_DATA_DIRECTORY)
+    has_incremental = False
+    file_names = []
+
+    for file in files:
+        # handle incremental dumps separately because later we want to sort
+        # based on numbers in file name
+        if file == "incremental.parquet":
+            has_incremental = True
+            continue
+        if file.endswith(".parquet"):
+            file_names.append(file)
+
+    # parquet files which come from full dump are named as 0.parquet, 1.parquet so
+    # on. listens are stored in ascending order of listened_at. so higher the number
+    # in the name of the file, newer the listens. Therefore, we sort the list
+    # according to numbers in name of parquet files, in reverse order to start
+    # loading newer listens first.
+    file_names.sort(key=lambda x: int(x.split(".")[0]), reverse=True)
+
+    # all incremental dumps are stored in incremental.parquet. these are the newest
+    # listens. but an incremental dump might not always exist for example at the time
+    # when a full dump has just been imported. so check if incremental dumps are
+    # present, if yes then add those to the start of list
+    if has_incremental:
+        file_names.insert(0, "incremental.parquet")
+
+    return file_names
+
+
+def get_listens_from_new_dump(start: datetime, end: datetime) -> DataFrame:
+    """ Load listens with listened_at between from_ts and to_ts from HDFS in a spark dataframe.
+        Args:
+            start: minimum time to include a listen in the dataframe
+            end: maximum time to include a listen in the dataframe
+        Returns:
+            dataframe of listens with listened_at between start and end
+    """
+    files = get_listen_files_list()
+
+    # create empty dataframe for merging loaded files into it
+    dfs = listenbrainz_spark.session.createDataFrame([], listens_new_schema)
+
+    for file_name in files:
+        df = read_files_from_HDFS(
+            os.path.join(path.LISTENBRAINZ_NEW_DATA_DIRECTORY, file_name)
+        )
+
+        # check if the currently loaded file has any listens newer than the starting
+        # timestamp. if not stop trying to load more files, because listens are sorted
+        # by listened_at in ascending order and we are traversing the files in reverse
+        # order. that is we are loading listens from latest to oldest so if the current
+        # file does not have any listens newer than from_ts, the remaining files will
+        # not have those either.
+        df = df.where(f"listened_at >= to_timestamp('{start}')")
+        if df.count() == 0:
+            break
+
+        # cannot merge this condition with the above one because, consider the following case:
+        # we want listens between the time range - 14 days ago to 7 days ago. the latest file
+        # might have listens only from last 4 days. if the conditions were merged, we would
+        # have stopped looking in other files which is wrong. it is quite possible that the 2nd
+        # or some subsequent file has listens older than to_ts but newer than from_ts
+        df = df.where(f"listened_at <= to_timestamp('{end}')")
+
+        dfs = dfs.union(df)
+
+    return dfs
+
+
+def save_parquet(df, path, mode='overwrite'):
+    """ Save dataframe as parquet to given path in HDFS.
+        Args:
+            df (dataframe): Dataframe to save.
+            path (str): Path in HDFS to save the dataframe.
+            mode (str): The mode with which to write the paquet.
+    """
+    try:
+        df.write.format('parquet').save(config.HDFS_CLUSTER_URI + path, mode=mode)
+    except Py4JJavaError as err:
+        raise FileNotSavedException(err.java_exception, path)
+
+
+def read_json(hdfs_path, schema):
+    """ Upload JSON file to HDFS as parquet.
+        Args:
+            hdfs_path (str): HDFS path to upload JSON.
+            schema: Blueprint of parquet.
+        Returns:
+            df (parquet): Dataframe.
+    """
+    df = listenbrainz_spark.session.read.json(config.HDFS_CLUSTER_URI + hdfs_path, schema=schema)
+    return df
+
+
+=======
+>>>>>>> parent of b42ba5e6 (Update __init__.py and Add new file ../hdfs/utils/__init__.py)
 def create_dataframe(row, schema):
     """ Create a dataframe containing a single row.
 
@@ -92,6 +214,8 @@ def register_dataframe(df, table_name):
         raise ViewNotRegisteredException(err.java_exception, table_name)
 
 
+<<<<<<< HEAD
+=======
 def read_files_from_HDFS(path):
     """ Loads the dataframe stored at the given path in HDFS.
 
@@ -186,6 +310,7 @@ def get_listens_from_new_dump(start: datetime, end: datetime) -> DataFrame:
     return dfs
 
 
+>>>>>>> parent of b42ba5e6 (Update __init__.py and Add new file ../hdfs/utils/__init__.py)
 def get_latest_listen_ts() -> datetime:
     """" Get the listened_at time of the latest listen present
      in the imported dumps

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -41,10 +41,7 @@ logger = logging.getLogger(__name__)
 def append(df, dest_path):
     """ Append a dataframe to existing dataframe in HDFS or write a new one
         if dataframe does not exist.
-<<<<<<< HEAD
-=======
 
->>>>>>> parent of b42ba5e6 (Update __init__.py and Add new file ../hdfs/utils/__init__.py)
         Args:
             df (dataframe): Dataframe to append.
             dest_path (string): Path where the existing dataframe is found or
@@ -56,125 +53,6 @@ def append(df, dest_path):
         raise DataFrameNotAppendedException(err.java_exception, df.schema)
 
 
-<<<<<<< HEAD
-def read_files_from_HDFS(path):
-    """ Loads the dataframe stored at the given path in HDFS.
-        Args:
-            path (str): An HDFS path.
-    """
-    # if we point spark to a directory, it will read each file in the directory as a
-    # parquet file and return the dataframe. so if a non-parquet file in also present
-    # in the same directory, we will get the not a parquet file error
-    try:
-        df = listenbrainz_spark.sql_context.read.parquet(config.HDFS_CLUSTER_URI + path)
-        return df
-    except AnalysisException as err:
-        raise PathNotFoundException(str(err), path)
-    except Py4JJavaError as err:
-        raise FileNotFetchedException(err.java_exception, path)
-
-
-def get_listen_files_list() -> List[str]:
-    """ Get list of name of parquet files containing the listens.
-    The list of file names is in order of newest to oldest listens.
-    """
-    files = hdfs_connection.client.list(path.LISTENBRAINZ_NEW_DATA_DIRECTORY)
-    has_incremental = False
-    file_names = []
-
-    for file in files:
-        # handle incremental dumps separately because later we want to sort
-        # based on numbers in file name
-        if file == "incremental.parquet":
-            has_incremental = True
-            continue
-        if file.endswith(".parquet"):
-            file_names.append(file)
-
-    # parquet files which come from full dump are named as 0.parquet, 1.parquet so
-    # on. listens are stored in ascending order of listened_at. so higher the number
-    # in the name of the file, newer the listens. Therefore, we sort the list
-    # according to numbers in name of parquet files, in reverse order to start
-    # loading newer listens first.
-    file_names.sort(key=lambda x: int(x.split(".")[0]), reverse=True)
-
-    # all incremental dumps are stored in incremental.parquet. these are the newest
-    # listens. but an incremental dump might not always exist for example at the time
-    # when a full dump has just been imported. so check if incremental dumps are
-    # present, if yes then add those to the start of list
-    if has_incremental:
-        file_names.insert(0, "incremental.parquet")
-
-    return file_names
-
-
-def get_listens_from_new_dump(start: datetime, end: datetime) -> DataFrame:
-    """ Load listens with listened_at between from_ts and to_ts from HDFS in a spark dataframe.
-        Args:
-            start: minimum time to include a listen in the dataframe
-            end: maximum time to include a listen in the dataframe
-        Returns:
-            dataframe of listens with listened_at between start and end
-    """
-    files = get_listen_files_list()
-
-    # create empty dataframe for merging loaded files into it
-    dfs = listenbrainz_spark.session.createDataFrame([], listens_new_schema)
-
-    for file_name in files:
-        df = read_files_from_HDFS(
-            os.path.join(path.LISTENBRAINZ_NEW_DATA_DIRECTORY, file_name)
-        )
-
-        # check if the currently loaded file has any listens newer than the starting
-        # timestamp. if not stop trying to load more files, because listens are sorted
-        # by listened_at in ascending order and we are traversing the files in reverse
-        # order. that is we are loading listens from latest to oldest so if the current
-        # file does not have any listens newer than from_ts, the remaining files will
-        # not have those either.
-        df = df.where(f"listened_at >= to_timestamp('{start}')")
-        if df.count() == 0:
-            break
-
-        # cannot merge this condition with the above one because, consider the following case:
-        # we want listens between the time range - 14 days ago to 7 days ago. the latest file
-        # might have listens only from last 4 days. if the conditions were merged, we would
-        # have stopped looking in other files which is wrong. it is quite possible that the 2nd
-        # or some subsequent file has listens older than to_ts but newer than from_ts
-        df = df.where(f"listened_at <= to_timestamp('{end}')")
-
-        dfs = dfs.union(df)
-
-    return dfs
-
-
-def save_parquet(df, path, mode='overwrite'):
-    """ Save dataframe as parquet to given path in HDFS.
-        Args:
-            df (dataframe): Dataframe to save.
-            path (str): Path in HDFS to save the dataframe.
-            mode (str): The mode with which to write the paquet.
-    """
-    try:
-        df.write.format('parquet').save(config.HDFS_CLUSTER_URI + path, mode=mode)
-    except Py4JJavaError as err:
-        raise FileNotSavedException(err.java_exception, path)
-
-
-def read_json(hdfs_path, schema):
-    """ Upload JSON file to HDFS as parquet.
-        Args:
-            hdfs_path (str): HDFS path to upload JSON.
-            schema: Blueprint of parquet.
-        Returns:
-            df (parquet): Dataframe.
-    """
-    df = listenbrainz_spark.session.read.json(config.HDFS_CLUSTER_URI + hdfs_path, schema=schema)
-    return df
-
-
-=======
->>>>>>> parent of b42ba5e6 (Update __init__.py and Add new file ../hdfs/utils/__init__.py)
 def create_dataframe(row, schema):
     """ Create a dataframe containing a single row.
 
@@ -214,8 +92,6 @@ def register_dataframe(df, table_name):
         raise ViewNotRegisteredException(err.java_exception, table_name)
 
 
-<<<<<<< HEAD
-=======
 def read_files_from_HDFS(path):
     """ Loads the dataframe stored at the given path in HDFS.
 
@@ -310,7 +186,6 @@ def get_listens_from_new_dump(start: datetime, end: datetime) -> DataFrame:
     return dfs
 
 
->>>>>>> parent of b42ba5e6 (Update __init__.py and Add new file ../hdfs/utils/__init__.py)
 def get_latest_listen_ts() -> datetime:
     """" Get the listened_at time of the latest listen present
      in the imported dumps
@@ -338,66 +213,7 @@ def save_parquet(df, path, mode='overwrite'):
     except Py4JJavaError as err:
         raise FileNotSavedException(err.java_exception, path)
 
-
-def create_dir(path):
-    """ Creates a directory in HDFS.
-
-        Args:
-            path (string): Path of the directory to be created.
-
-        Note: >> Caller is responsibe for initializing HDFS connection.
-              >> The function does not throw an error if the directory path already exists.
-    """
-    hdfs_connection.client.makedirs(path)
-
-
-def delete_dir(path, recursive=False):
-    """ Deletes a directory recursively from HDFS.
-
-        Args:
-            path (string): Path of the directory to be deleted.
-
-        Note: >> Caller is responsible for initializing HDFS connection.
-              >> Raises HdfsError if trying to delete a non-empty directory.
-                 For non-empty directory set recursive to 'True'.
-    """
-    deleted = hdfs_connection.client.delete(path, recursive=recursive)
-    if not deleted:
-        raise HDFSDirectoryNotDeletedException('', path)
-
-
-def path_exists(path):
-    """ Checks if the path exists in HDFS. The function returns False if the path
-        does not exist otherwise returns True.
-
-        Args:
-            path (string): Path to check status for.
-
-        Note: Caller is responsible for initializing HDFS connection.
-    """
-    path_found = hdfs_connection.client.status(path, strict=False)
-    if path_found:
-        return True
-    return False
-
-
-def hdfs_walk(path, depth=0):
-    """ Depth-first walk of HDFS filesystem.
-
-        Args:
-            path (str): Path to start DFS.
-            depth (int): Maximum depth to explore files/folders. 0 for no limit.
-
-        Returns:
-            walk: a generator yeilding tuples (path, dirs, files).
-    """
-    try:
-        walk = hdfs_connection.client.walk(hdfs_path=path, depth=depth)
-        return walk
-    except HdfsError as err:
-        raise PathNotFoundException(str(err), path)
-
-
+        
 def read_json(hdfs_path, schema):
     """ Upload JSON file to HDFS as parquet.
 
@@ -410,42 +226,3 @@ def read_json(hdfs_path, schema):
     """
     df = listenbrainz_spark.session.read.json(config.HDFS_CLUSTER_URI + hdfs_path, schema=schema)
     return df
-
-
-def upload_to_HDFS(hdfs_path, local_path):
-    """ Upload local file to HDFS.
-
-        Args:
-            hdfs_path (str): HDFS path to upload local file.
-            local_path (str): Local path of file to be uploaded.
-    """
-    hdfs_connection.client.upload(hdfs_path=hdfs_path, local_path=local_path)
-
-
-def rename(hdfs_src_path: str, hdfs_dst_path: str):
-    """ Move a file or folder in HDFS
-
-        Args:
-            hdfs_src_path – Source path.
-            hdfs_dst_path – Destination path. If the path already exists and is a directory, the source will be moved into it.
-    """
-    hdfs_connection.client.rename(hdfs_src_path, hdfs_dst_path)
-
-
-def copy(hdfs_src_path: str, hdfs_dst_path: str, overwrite: bool = False):
-    """ Copy a file or folder in HDFS
-
-        Args:
-            hdfs_src_path – Source path.
-            hdfs_dst_path – Destination path. If the path already exists and is a directory, the source will be copied into it.
-            overwrite - Wether to overwrite the path if it already exists.
-    """
-    walk = hdfs_walk(hdfs_src_path)
-
-    for (root, dirs, files) in walk:
-        for _file in files:
-            src_file_path = os.path.join(root, _file)
-            dst_file_path = os.path.join(hdfs_dst_path, os.path.relpath(src_file_path, hdfs_src_path))
-            with hdfs_connection.client.read(src_file_path) as reader:
-                with hdfs_connection.client.write(dst_file_path, overwrite=overwrite) as writer:
-                    writer.write(reader.read())

--- a/listenbrainz_spark/utils/tests/test_init.py
+++ b/listenbrainz_spark/utils/tests/test_init.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from listenbrainz_spark.tests import SparkNewTestCase
 from listenbrainz_spark import utils
+from listenbrainz_spark import hdfs
+
 
 from pyspark.sql import Row
 
@@ -14,11 +16,11 @@ class UtilsTestCase(SparkNewTestCase):
     temp_path_ = "/temp"
 
     def tearDown(self):
-        if utils.path_exists(self.path_):
-            utils.delete_dir(self.path_, recursive=True)
+        if hdfs.path_exists(self.path_):
+            hdfs.delete_dir(self.path_, recursive=True)
 
-        if utils.path_exists(self.temp_path_):
-            utils.delete_dir(self.temp_path_, recursive=True)
+        if hdfs.path_exists(self.temp_path_):
+            hdfs.delete_dir(self.temp_path_, recursive=True)
 
     def test_append_dataframe(self):
         hdfs_path = self.path_ + '/test_df.parquet'
@@ -42,19 +44,19 @@ class UtilsTestCase(SparkNewTestCase):
         self.assertEqual(received_df.count(), 1)
 
     def test_create_dir(self):
-        utils.create_dir(self.path_)
-        status = utils.path_exists(self.path_)
+        hdfs.create_dir(self.path_)
+        status = hdfs.path_exists(self.path_)
         self.assertTrue(status)
 
     def test_delete_dir(self):
-        utils.create_dir(self.path_)
-        utils.delete_dir(self.path_)
-        status = utils.path_exists(self.path_)
+        hdfs.create_dir(self.path_)
+        hdfs.delete_dir(self.path_)
+        status = hdfs.path_exists(self.path_)
         self.assertFalse(status)
 
     def test_path_exists(self):
-        utils.create_dir(self.path_)
-        status = utils.path_exists(self.path_)
+        hdfs.create_dir(self.path_)
+        status = hdfs.path_exists(self.path_)
         self.assertTrue(status)
 
     def test_save_parquet(self):
@@ -69,26 +71,26 @@ class UtilsTestCase(SparkNewTestCase):
         with open(local_path, 'w') as f:
             f.write('test file')
         self.path_ = '/test/upload.parquet'
-        utils.upload_to_HDFS(self.path_, local_path)
-        status = utils.path_exists(self.path_)
+        hdfs.upload_to_HDFS(self.path_, local_path)
+        status = hdfs.path_exists(self.path_)
         self.assertTrue(status)
 
     def test_rename(self):
-        utils.create_dir(self.path_)
-        test_exists = utils.path_exists(self.path_)
+        hdfs.create_dir(self.path_)
+        test_exists = hdfs.path_exists(self.path_)
         self.assertTrue(test_exists)
-        utils.rename(self.path_, self.temp_path_)
-        test_exists = utils.path_exists(self.path_)
+        hdfs.rename(self.path_, self.temp_path_)
+        test_exists = hdfs.path_exists(self.path_)
         self.assertFalse(test_exists)
-        temp_exists = utils.path_exists(self.temp_path_)
+        temp_exists = hdfs.path_exists(self.temp_path_)
         self.assertTrue(temp_exists)
-        utils.delete_dir(self.temp_path_)
+        hdfs.delete_dir(self.temp_path_)
 
     def test_copy(self):
         # Test directories
-        utils.create_dir(self.path_)
-        utils.create_dir(os.path.join(self.path_, "a"))
-        utils.create_dir(os.path.join(self.path_, "b"))
+        hdfs.create_dir(self.path_)
+        hdfs.create_dir(os.path.join(self.path_, "a"))
+        hdfs.create_dir(os.path.join(self.path_, "b"))
 
         # DataFrames to create parquets
         df_a = utils.create_dataframe([Row(column1=1, column2=2)], schema=None)
@@ -100,7 +102,7 @@ class UtilsTestCase(SparkNewTestCase):
         utils.save_parquet(df_b, os.path.join(self.path_, "b", "df_b.parquet"))
         utils.save_parquet(df_c, os.path.join(self.path_, "df_c.parquet"))
 
-        utils.copy(self.path_, self.temp_path_, overwrite=True)
+        hdfs.copy(self.path_, self.temp_path_, overwrite=True)
 
         # Read copied DataFrame
         cp_df_a = utils.read_files_from_HDFS(os.path.join(self.temp_path_, "a", "df_a.parquet"))


### PR DESCRIPTION
1 -> Ticket ->

LB -678

2 -> Problem ->

There was a file present at this location ->
listenbrainz-server/listenbrainz_spark/utils/__ini__.py
It had some functions related to hdfs that can modify local file system as well as handoop file system.

3 -> Task ->

My task was to move all the files related to hdfs to a new file present in the hdfs folder to avoid confusion.

4 -> Solution/What I did? ->

1 -> Identified functions related to hdfs in __init__.py.
2 -> Made a new file utils.py inside hdfs folder.
3 -> Moved all the functions to this new file.
4 -> Updated imports for the transferred functions.