### PR TITLE
Add total listening time and new discovered artists count for YIM

### DIFF
--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -387,6 +387,14 @@ def handle_yim_listen_counts(message):
     year_in_music.insert("total_listen_count", message["year"], message["data"])
 
 
+def handle_yim_listening_time(message):
+    year_in_music.insert("total_listening_time", message["year"], message["data"])
+
+
+def handle_new_artists_discovered_count(message):
+    year_in_music.insert("total_new_artists_discovered", message["year"], message["data"])
+
+
 def handle_similar_recordings(message):
     similarity.insert("recording", message["data"], message["algorithm"])
 

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -192,6 +192,24 @@ def request_import_pg_tables():
     send_request_to_spark_cluster('import.pg_metadata_tables')
 
 
+@cli.command(name="request_yim_listening_time")
+@click.option("--year", type=int, help="Year for which to calculate the stat",
+              default=date.today().year)
+def request_yim_listening_time(year: int):
+    """ Send request to calculate yearly total listening time stat for each user to the spark cluster
+    """
+    send_request_to_spark_cluster("year_in_music.listening_time", year=year)
+
+
+@cli.command(name="request_yim_new_artists_discovered")
+@click.option("--year", type=int, help="Year for which to calculate the stat",
+              default=date.today().year)
+def request_yim_new_artists_discovered(year: int):
+    """ Send request to calculate count of new artists user listened to this year.
+    """
+    send_request_to_spark_cluster("year_in_music.new_artists_discovered_count", year=year)
+
+
 @cli.command(name="request_import_full")
 @click.option("--id", "id_", type=int, required=False,
               help="Optional. ID of the full dump to import, defaults to latest dump available on FTP server")

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -169,6 +169,16 @@
     "description": "Calculate the total listen count for the given year for each user",
     "params": ["year"]
   },
+  "year_in_music.listening_time": {
+    "name": "year_in_music.listening_time",
+    "description": "Calculate the total duration of the listens for the given year for each user",
+    "params": ["year"]
+  },
+  "year_in_music.new_artists_discovered_count": {
+    "name": "year_in_music.new_artists_discovered_count",
+    "description": "Calculate the number of artists the user listened to in the given year",
+    "params": ["year"]
+  },
   "year_in_music.top_stats": {
     "name": "year_in_music.top_stats",
     "description": "Calculate the top artists/recordings/releases stats for the current year for each user",

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -31,7 +31,8 @@ from listenbrainz.spark.handlers import (handle_candidate_sets,
                                          handle_yim_listen_counts,
                                          handle_fresh_releases,
                                          handle_similar_recordings,
-                                         handle_similar_artists)
+                                         handle_similar_artists, handle_yim_listening_time,
+                                         handle_new_artists_discovered_count)
 from listenbrainz.utils import get_fallback_connection_name
 from listenbrainz.webserver import create_app
 
@@ -64,6 +65,8 @@ response_handler_map = {
     'year_in_music_new_releases_of_top_artists': handle_yim_new_releases_of_top_artists,
     'year_in_music_day_of_week': handle_yim_day_of_week,
     'year_in_music_most_listened_year': handle_yim_most_listened_year,
+    'year_in_music_listening_time': handle_yim_listening_time,
+    'year_in_music_new_artists_discovered_count': handle_new_artists_discovered_count,
 }
 
 RABBITMQ_HEARTBEAT_TIME = 60 * 60  # 1 hour, in seconds

--- a/listenbrainz_spark/hdfs/utils.py
+++ b/listenbrainz_spark/hdfs/utils.py
@@ -1,26 +1,14 @@
-import errno
 import logging
 import os
-from datetime import datetime
-from typing import List
 
-from py4j.protocol import Py4JJavaError
-from pyspark.sql import DataFrame, functions
-from pyspark.sql.utils import AnalysisException
-
-import listenbrainz_spark
 from hdfs.util import HdfsError
-from listenbrainz_spark import config, hdfs_connection, path
-from listenbrainz_spark.schema import listens_new_schema
-from listenbrainz_spark.exceptions import (DataFrameNotAppendedException,
-                                           DataFrameNotCreatedException,
-                                           FileNotFetchedException,
-                                           FileNotSavedException,
-                                           HDFSDirectoryNotDeletedException,
-                                           PathNotFoundException,
-                                           ViewNotRegisteredException)
+
+from listenbrainz_spark import hdfs_connection
+from listenbrainz_spark.exceptions import (HDFSDirectoryNotDeletedException,
+                                           PathNotFoundException)
 
 logger = logging.getLogger(__name__)
+
 
 # A typical listen is of the form:
 # {

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -17,6 +17,8 @@ import listenbrainz_spark.year_in_music.most_listened_year
 import listenbrainz_spark.year_in_music.top_stats
 import listenbrainz_spark.year_in_music.listens_per_day
 import listenbrainz_spark.year_in_music.listen_count
+import listenbrainz_spark.year_in_music.listening_time
+import listenbrainz_spark.year_in_music.new_artists_discovered
 import listenbrainz_spark.fresh_releases.fresh_releases
 import listenbrainz_spark.similarity.recording
 import listenbrainz_spark.similarity.artist
@@ -52,6 +54,8 @@ functions = {
     'year_in_music.top_stats': listenbrainz_spark.year_in_music.top_stats.calculate_top_entity_stats,
     'year_in_music.listens_per_day': listenbrainz_spark.year_in_music.listens_per_day.calculate_listens_per_day,
     'year_in_music.listen_count': listenbrainz_spark.year_in_music.listen_count.get_listen_count,
+    'year_in_music.new_artists_discovered_count': listenbrainz_spark.year_in_music.new_artists_discovered.get_new_artists_discovered_count,
+    'year_in_music.listening_time': listenbrainz_spark.year_in_music.listening_time.get_listening_time,
     'import.pg_metadata_tables': listenbrainz_spark.postgres.release.create_release_metadata_cache,
     'releases.fresh': listenbrainz_spark.fresh_releases.fresh_releases.main,
 }

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -186,6 +186,14 @@ def get_listens_from_new_dump(start: datetime, end: datetime) -> DataFrame:
     return dfs
 
 
+def get_all_listens_from_new_dump() -> DataFrame:
+    full_df = read_files_from_HDFS(path.LISTENBRAINZ_NEW_DATA_DIRECTORY)
+    if hdfs_connection.client.status(path.INCREMENTAL_DUMPS_SAVE_PATH, strict=False):
+        inc_df = read_files_from_HDFS(path.INCREMENTAL_DUMPS_SAVE_PATH)
+        full_df = full_df.union(inc_df)
+    return full_df
+
+
 def get_latest_listen_ts() -> datetime:
     """" Get the listened_at time of the latest listen present
      in the imported dumps

--- a/listenbrainz_spark/year_in_music/listening_time.py
+++ b/listenbrainz_spark/year_in_music/listening_time.py
@@ -1,0 +1,41 @@
+import listenbrainz_spark
+from listenbrainz_spark import config
+from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.year_in_music.utils import setup_listens_for_year
+
+
+def get_listening_time(year):
+    """ Calculate the total listening time in seconds of the user for the given year. """
+    setup_listens_for_year(year)
+    metadata_table = "mb_metadata_cache"
+    metadata_df = listenbrainz_spark.sql_context.read.json(config.HDFS_CLUSTER_URI + "/mb_metadata_cache.jsonl")
+    metadata_df.createOrReplaceTempView(metadata_table)
+
+    data = run_query(_get_total_listening_time()).collect()
+    yield {
+        "type": "year_in_music_listening_time",
+        "year": year,
+        "data": data[0]["yearly_listening_time"]
+    }
+
+
+def _get_total_listening_time():
+    # get recording length from mb_metadata_cache, if listen is unmapped default to 3 minutes.
+    return """
+          WITH listening_times AS (
+                  SELECT user_id
+                       , sum(COALESCE(recording_data.length / 1000, BIGINT(180))) AS total_listening_time
+                    FROM listens_of_year l
+               LEFT JOIN mb_metadata_cache rdd
+                      ON l.recording_mbid = rdd.recording_mbid
+                GROUP BY user_id
+          )
+            SELECT to_json(
+                    map_from_entries(
+                        collect_list(
+                            struct(user_id, total_listening_time)
+                        )
+                    )
+                ) AS yearly_listening_time
+          FROM listening_times  
+    """

--- a/listenbrainz_spark/year_in_music/new_artists_discovered.py
+++ b/listenbrainz_spark/year_in_music/new_artists_discovered.py
@@ -1,0 +1,46 @@
+from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import get_all_listens_from_new_dump
+
+
+def get_new_artists_discovered_count(year):
+    """ Count the number of artists a user has listened to for the first time in the given year. """
+    get_all_listens_from_new_dump()\
+        .createOrReplaceTempView("artists_discovery_listens")
+    data = run_query(_get_new_discovered_artists_count(year)).collect()
+    yield {
+        "type": "year_in_music_new_artists_discovered_count",
+        "year": year,
+        "data": data[0]["new_artists_discovered_count"]
+    }
+
+
+def _get_new_discovered_artists_count(year):
+    # for A ft. B, both A and B will be counted separately.
+    return f"""
+          WITH separate_artists AS (
+            SELECT user_id
+                 , listened_at
+                 , explode(artist_credit_mbids) AS artist_mbid
+              FROM artists_discovery_listens
+         ), discovered_artists AS (
+            SELECT user_id
+                 , artist_mbid
+              FROM separate_artists
+          GROUP BY user_id
+                 , artist_mbid
+            HAVING date_part('YEAR', min(listened_at)) = {year}
+        ), discovered_artists_count AS ( 
+            SELECT user_id
+                 , count(artist_mbid) AS artist_count
+              FROM discovered_artists
+          GROUP BY user_id     
+        )      
+            SELECT to_json(
+                        map_from_entries(
+                            collect_list(
+                                struct(user_id, artist_count)
+                            )
+                        )
+                    ) AS new_artists_discovered_count
+              FROM discovered_artists_count
+    """


### PR DESCRIPTION
Total listening time is the sum of duration of all listens that a user listened to in a given year, if the duration is not available from MB data fallback to using 180s.

Newly discovered artist count is the number of artists to whom the user listened to for the first time in the year.