### PR TITLE
Update new releases of top artists stat to use release groups

### DIFF
--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -318,7 +318,7 @@ declare type UserEntityDatum = {
 
 declare type UserEntityData = Array<UserEntityDatum>;
 
-declare type Entity = "artist" | "release" | "recording";
+declare type Entity = "artist" | "release" | "recording" | "release-group";
 
 declare type UserListeningActivityResponse = {
   payload: {

--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -27,7 +27,7 @@ import {
 } from "../../notifications/AlertNotificationsHOC";
 
 import APIServiceClass from "../../utils/APIService";
-import { getPageProps } from "../../utils/utils";
+import {generateAlbumArtThumbnailLink, getAlbumArtFromReleaseMBID, getPageProps} from "../../utils/utils";
 import { getEntityLink } from "../../stats/utils";
 import ShareOrSaveSVG from "./ShareOrSaveSVG";
 
@@ -56,9 +56,9 @@ export type YearInMusicProps = {
       listen_count: number;
       release_name: string;
       release_mbid: string;
-      cover_art_src?: string;
+      caa_id?: number;
+      caa_release_mbid?: string;
     }>;
-    top_releases_coverart: { [key: string]: string };
     top_recordings: Array<{
       artist_name: string;
       artist_mbids: string[];
@@ -519,20 +519,20 @@ export default class YearInMusic extends React.Component<
                   }}
                 >
                   {yearInMusicData.top_releases.slice(0, 50).map((release) => {
-                    const coverArtSrc =
-                      yearInMusicData.top_releases_coverart?.[
-                        release.release_mbid
-                      ];
-                    if (!coverArtSrc) {
+                    if (!release.caa_id || !release.caa_release_mbid) {
                       return null;
                     }
+
+                    const coverArt = generateAlbumArtThumbnailLink(
+                      release.caa_id,
+                      release.caa_release_mbid
+                    );
+
                     return (
                       <SwiperSlide key={`coverflow-${release.release_name}`}>
                         <img
                           src={
-                            yearInMusicData.top_releases_coverart?.[
-                              release.release_mbid
-                            ] ?? "/static/img/cover-art-placeholder.jpg"
+                            coverArt ?? "/static/img/cover-art-placeholder.jpg"
                           }
                           alt={release.release_name}
                         />

--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -78,12 +78,12 @@ export type YearInMusicProps = {
     most_listened_year: { [key: string]: number };
     total_listen_count: number;
     new_releases_of_top_artists: Array<{
-      type: string;
       title: string;
-      release_mbid: string;
-      first_release_date: string;
+      release_group_mbid: string;
+      caa_id?: number;
+      caa_release_mbid?: string;
       artist_credit_mbids: string[];
-      artist_credit_names: string[];
+      artist_credit_name: string;
     }>;
   };
 } & WithAlertNotificationsInjectedProps;
@@ -794,38 +794,43 @@ export default class YearInMusic extends React.Component<
             <div className="scrollable-area">
               {yearInMusicData.new_releases_of_top_artists
                 ? yearInMusicData.new_releases_of_top_artists.map((release) => {
-                    const artistName = release.artist_credit_names.join(", ");
                     const details = (
                       <>
                         <div title={release.title} className="ellipsis-2-lines">
                           {getEntityLink(
-                            "release",
+                            "release-group",
                             release.title,
-                            release.release_mbid
+                            release.release_group_mbid
                           )}
                         </div>
                         <span
                           className="small text-muted ellipsis"
-                          title={artistName}
+                          title={release.artist_credit_name}
                         >
                           {getEntityLink(
                             "artist",
-                            artistName,
+                            release.artist_credit_name,
                             release.artist_credit_mbids[0]
                           )}
                         </span>
                       </>
                     );
-                    const listenHere = {
+                    const listenHere: Listen = {
                       listened_at: 0,
-                      listened_at_iso: release.first_release_date,
                       track_metadata: {
-                        artist_name: artistName,
+                        artist_name: release.artist_credit_name,
                         track_name: release.title,
                         release_name: release.title,
                         additional_info: {
-                          release_mbid: release.release_mbid,
+                          release_group_mbid: release.release_group_mbid,
                           artist_mbids: release.artist_credit_mbids,
+                        },
+                        mbid_mapping: {
+                          recording_mbid: "",
+                          release_mbid: "",
+                          artist_mbids: [],
+                          caa_id: release.caa_id,
+                          caa_release_mbid: release.caa_release_mbid,
                         },
                       },
                     };
@@ -833,7 +838,7 @@ export default class YearInMusic extends React.Component<
                     return (
                       <ListenCard
                         listenDetails={details}
-                        key={release.release_mbid}
+                        key={release.release_group_mbid}
                         compact
                         listen={listenHere}
                         showTimestamp={false}

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -888,16 +888,21 @@ def _get_artist_map_stats(user_id, stats_range):
     return stats
 
 
-@stats_api_bp.route("/user/<user_name>/year-in-music/")
-def year_in_music(user_name: str):
+@stats_api_bp.route("/user/<user_name>/year-in-music")
+@stats_api_bp.route("/user/<user_name>/year-in-music/<int:year>")
+def year_in_music(user_name: str, year: int = 2021):
     """ Get data for year in music stuff """
+    if year != 2021 and year != 2022:
+        raise APINotFound(f"Cannot find Year in Music report for year: {year}")
+
     user = db_user.get_by_mb_id(user_name)
     if user is None:
         raise APINotFound(f"Cannot find user: {user_name}")
+
     return jsonify({
         "payload": {
             "user_name": user_name,
-            "data": db_year_in_music.get(user["id"], 2021) or {}
+            "data": db_year_in_music.get(user["id"], year) or {}
         }
     })
 

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -99,3 +99,4 @@ MUSICBRAINZ_RELEASE_DUMP_JSON_FILE = "/musicbrainz/release/mbdump/release"
 RELEASE_COLOR_DUMP = "/release_color.json"
 
 RELEASE_METADATA_CACHE_DATAFRAME = "/release_metadata_cache"
+RELEASE_GROUPS_YEAR_DATAFRAME = "/release_groups_year"

--- a/listenbrainz_spark/postgres/release_group.py
+++ b/listenbrainz_spark/postgres/release_group.py
@@ -1,0 +1,65 @@
+from listenbrainz_spark.path import RELEASE_GROUPS_YEAR_DATAFRAME
+from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
+
+
+def create_year_release_groups(year):
+    """ Import release groups which were released in the given year from postgres to HDFS """
+    query = f"""
+        WITH rg_cover_art AS (
+            SELECT DISTINCT ON (rg.id)
+                   rg.id AS release_group
+                 , caa.id AS caa_id
+                 , caa_rel.gid AS caa_release_mbid
+              FROM musicbrainz.release_group rg
+              JOIN musicbrainz.release caa_rel
+                ON rg.id = caa_rel.release_group
+         LEFT JOIN (
+                  SELECT release, date_year, date_month, date_day
+                    FROM musicbrainz.release_country
+               UNION ALL
+                  SELECT release, date_year, date_month, date_day
+                    FROM musicbrainz.release_unknown_country
+                 ) re
+                ON (re.release = caa_rel.id)
+         FULL JOIN cover_art_archive.release_group_cover_art rgca
+                ON rgca.release = caa_rel.id
+         LEFT JOIN cover_art_archive.cover_art caa
+                ON caa.release = caa_rel.id
+         LEFT JOIN cover_art_archive.cover_art_type cat
+                ON cat.id = caa.id
+             WHERE type_id = 1
+               AND mime_type != 'application/pdf'
+          ORDER BY rg.id
+                 , rgca.release
+                 , re.date_year
+                 , re.date_month
+                 , re.date_day
+                 , caa.ordering
+        )
+            SELECT rg.gid AS release_group_mbid
+                 , rg.name AS title
+                 , ac.name AS artist_credit_name
+                 , rgca.caa_id AS caa_id
+                 , rgca.caa_release_mbid AS caa_release_mbid
+                 , array_agg(a.gid ORDER BY acn.position) AS artist_credit_mbids
+              FROM musicbrainz.release_group rg
+              JOIN musicbrainz.release_group_meta rgm
+                ON rgm.id = rg.id
+              JOIN musicbrainz.artist_credit ac
+                ON rg.artist_credit = ac.id
+              JOIN musicbrainz.artist_credit_name acn
+                ON ac.id = acn.artist_credit
+              JOIN musicbrainz.artist a
+                ON acn.artist = a.id
+         LEFT JOIN rg_cover_art rgca
+                ON rgca.release_group = rg.id
+             WHERE rgm.first_release_date_year = {year}
+          GROUP BY rg.gid
+                 , rg.name
+                 , make_date(rgm.first_release_date_year, rgm.first_release_date_month, rgm.first_release_date_day)
+                 , ac.name
+                 , rgca.caa_id
+                 , rgca.caa_release_mbid
+    """
+
+    save_pg_table_to_hdfs(query, RELEASE_GROUPS_YEAR_DATAFRAME)

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -1,3 +1,5 @@
+from datetime import datetime, date, time
+
 import listenbrainz_spark
 from data.model.new_releases_stat import NewReleasesStat
 from listenbrainz_spark import config
@@ -5,12 +7,12 @@ from listenbrainz_spark.path import RELEASE_GROUPS_YEAR_DATAFRAME
 from listenbrainz_spark.postgres.release_group import create_year_release_groups
 
 from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import get_all_listens_from_new_dump
 from listenbrainz_spark.year_in_music.utils import setup_listens_for_year
 
 
 def get_new_releases_of_top_artists(year):
-    setup_listens_for_year(year)
-
+    get_all_listens_from_new_dump().createOrReplaceTempView("listens")
     create_year_release_groups(year)
     listenbrainz_spark\
         .sql_context\
@@ -18,10 +20,9 @@ def get_new_releases_of_top_artists(year):
         .parquet(config.HDFS_CLUSTER_URI + RELEASE_GROUPS_YEAR_DATAFRAME)\
         .createOrReplaceTempView("release_groups_of_year")
 
-    run_query(_get_top_50_artists()).createOrReplaceTempView("top_50_artists")
-    new_releases = run_query(_get_new_releases_of_top_artists()).toLocalIterator()
+    new_releases = run_query(_get_new_releases_of_top_artists(year))
 
-    for entry in new_releases:
+    for entry in new_releases.toLocalIterator():
         data = entry.asDict(recursive=True)
         yield NewReleasesStat(
             type="year_in_music_new_releases_of_top_artists",
@@ -31,45 +32,40 @@ def get_new_releases_of_top_artists(year):
         ).dict(exclude_none=True)
 
 
-def _get_top_50_artists():
-    return """
-        WITH intermediate_table as (
+def _get_new_releases_of_top_artists(year):
+    start = datetime.combine(date(year, 1, 1), time.min)
+    end = datetime.combine(date(year, 12, 31), time.max)
+    return f"""
+        WITH artist_counts as (
             SELECT user_id
                  , artist_credit_mbids
                  , count(*) as listen_count
-              FROM listens_of_year
-             WHERE artist_credit_mbids IS NOT NULL
+              FROM listens
+             WHERE listened_at >= to_timestamp({start})
+               AND listened_at <= to_timestamp({end})
+               AND artist_credit_mbids IS NOT NULL
           GROUP BY user_id
                  , artist_credit_mbids
-        ), intermediate_table_2 AS (
+        ), top_artists AS (
             SELECT user_id
                  , artist_credit_mbids
-                 , listen_count
                  , row_number() OVER(PARTITION BY user_id ORDER BY listen_count DESC) AS row_number
-              FROM intermediate_table
+              FROM artist_counts
         )
             SELECT user_id
-                 , artist_credit_mbids
-                 , listen_count
-              FROM intermediate_table_2
+                 , collect_list(
+                        struct(
+                           rgoy.title
+                         , rgoy.artist_credit_name  
+                         , rgoy.release_group_mbid
+                         , rgoy.artist_credit_mbids
+                         , rgoy.caa_id
+                         , rgoy.caa_release_mbid
+                        )
+                    ) AS new_releases
+              FROM release_groups_of_year rgoy
+              JOIN top_artists t50a
+                ON cardinality(array_intersect(rgoy.artist_credit_mbids, t50a.artist_credit_mbids)) > 0
              WHERE row_number <= 50
-    """
-
-def _get_new_releases_of_top_artists():
-    return """
-        SELECT user_id
-             , collect_list(
-                    struct(
-                       rgoy.title
-                     , rgoy.artist_credit_name  
-                     , rgoy.release_group_mbid
-                     , rgoy.artist_credit_mbids
-                     , rgoy.caa_id
-                     , rgoy.caa_release_mbid
-                    )
-               ) AS new_releases
-          FROM release_groups_of_year rgoy
-          JOIN top_50_artists t50a
-            ON cardinality(array_intersect(rgoy.artist_credit_mbids, t50a.artist_credit_mbids)) > 0
-      GROUP BY user_id
+          GROUP BY user_id
     """

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -35,6 +35,10 @@ def get_new_releases_of_top_artists(year):
 def _get_new_releases_of_top_artists(year):
     start = datetime.combine(date(year, 1, 1), time.min)
     end = datetime.combine(date(year, 12, 31), time.max)
+
+    # instead of exploding the artist mbids, it is possible to use arrays_overlap on the two artist credit mbids
+    # however in that case spark will do a BroadcastNestedLoopJoin which is very slow (takes 3 hours). the query
+    # below using equality on artist mbid takes 2 minutes.
     return f"""
         WITH artist_counts as (
             SELECT user_id

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -67,7 +67,7 @@ def _get_new_releases_of_top_artists(year):
               FROM release_groups_of_year    
         )
             SELECT user_id
-                 , collect_list(
+                 , collect_set(
                         struct(
                            rg.title
                          , rg.artist_credit_name  

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -35,24 +35,20 @@ def _get_top_50_artists():
     return """
         WITH intermediate_table as (
             SELECT user_id
-                 , artist_name
                  , artist_credit_mbids
                  , count(*) as listen_count
               FROM listens_of_year
              WHERE artist_credit_mbids IS NOT NULL
           GROUP BY user_id
-                 , artist_name
                  , artist_credit_mbids
         ), intermediate_table_2 AS (
             SELECT user_id
-                 , artist_name
                  , artist_credit_mbids
                  , listen_count
                  , row_number() OVER(PARTITION BY user_id ORDER BY listen_count DESC) AS row_number
               FROM intermediate_table
         )
             SELECT user_id
-                 , artist_name
                  , artist_credit_mbids
                  , listen_count
               FROM intermediate_table_2
@@ -62,7 +58,7 @@ def _get_top_50_artists():
 def _get_new_releases_of_top_artists():
     return """
         SELECT user_id
-             , collect_set(
+             , collect_list(
                     struct(
                        rgoy.title
                      , rgoy.artist_credit_name  

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -41,8 +41,8 @@ def _get_new_releases_of_top_artists(year):
                  , artist_credit_mbids
                  , count(*) as listen_count
               FROM listens
-             WHERE listened_at >= to_timestamp({start})
-               AND listened_at <= to_timestamp({end})
+             WHERE listened_at >= to_timestamp('{start}')
+               AND listened_at <= to_timestamp('{end}')
                AND artist_credit_mbids IS NOT NULL
           GROUP BY user_id
                  , artist_credit_mbids

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -65,7 +65,7 @@ def _get_new_releases_of_top_artists(year):
                     ) AS new_releases
               FROM release_groups_of_year rgoy
               JOIN top_artists t50a
-                ON cardinality(array_intersect(rgoy.artist_credit_mbids, t50a.artist_credit_mbids)) > 0
              WHERE row_number <= 50
+               AND arrays_overlap(rgoy.artist_credit_mbids, t50a.artist_credit_mbids)
           GROUP BY user_id
     """


### PR DESCRIPTION
Releases have too many versions for different countries and days. It is better to do the stat on release groups to avoid duplicates.