### PR TITLE
Add job to dump data for tracks of the year

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -141,6 +141,15 @@ def request_yim_new_release_stats(year: int):
     send_request_to_spark_cluster("year_in_music.new_releases_of_top_artists", year=year)
 
 
+@cli.command(name="request_yim_tracks_of_the_year")
+@click.option("--year", type=int, help="Year for which to calculate the stat",
+              default=date.today().year)
+def request_yim_tracks_of_the_year(year: int):
+    """ Send request to calculate new release stats to the spark cluster
+    """
+    send_request_to_spark_cluster("year_in_music.tracks_of_the_year", year=year)
+
+
 @cli.command(name="request_yim_day_of_week")
 @click.option("--year", type=int, help="Year for which to calculate the stat",
               default=date.today().year)

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -29,6 +29,11 @@
     "description": "Calculate list of releases released this year by top 50 artists of this year for each user",
     "params": ["year"]
   },
+  "year_in_music.tracks_of_the_year": {
+    "name": "year_in_music.tracks_of_the_year",
+    "description": "Calculate all tracks a user has listened to in the given year",
+    "params": ["year"]
+  },
   "year_in_music.day_of_week": {
     "name": "year_in_music.day_of_week",
     "description": "Calculate the day of week with most listens for the user",

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -19,6 +19,7 @@ import listenbrainz_spark.year_in_music.listens_per_day
 import listenbrainz_spark.year_in_music.listen_count
 import listenbrainz_spark.year_in_music.listening_time
 import listenbrainz_spark.year_in_music.new_artists_discovered
+import listenbrainz_spark.year_in_music.tracks_of_the_year
 import listenbrainz_spark.fresh_releases.fresh_releases
 import listenbrainz_spark.similarity.recording
 import listenbrainz_spark.similarity.artist
@@ -48,6 +49,7 @@ functions = {
     'similarity.artist': listenbrainz_spark.similarity.artist.main,
     'year_in_music.new_releases_of_top_artists':
         listenbrainz_spark.year_in_music.new_releases_of_top_artists.get_new_releases_of_top_artists,
+    'year_in_music.tracks_of_the_year': listenbrainz_spark.year_in_music.tracks_of_the_year.calculate_tracks_of_the_year,
     'year_in_music.most_listened_year': listenbrainz_spark.year_in_music.most_listened_year.get_most_listened_year,
     'year_in_music.day_of_week': listenbrainz_spark.year_in_music.day_of_week.get_day_of_week,
     'year_in_music.similar_users': listenbrainz_spark.year_in_music.similar_users.get_similar_users,

--- a/listenbrainz_spark/year_in_music/tracks_of_the_year.py
+++ b/listenbrainz_spark/year_in_music/tracks_of_the_year.py
@@ -30,4 +30,8 @@ def calculate_tracks_of_the_year(year):
              , artist_credit_mbids
     """
 
-    run_query(query).write.format("json").save(config.HDFS_CLUSTER_URI + "/tracks_of_the_year", mode="overwrite")
+    run_query(query)\
+        .repartition(1)\
+        .write\
+        .format("json")\
+        .save(config.HDFS_CLUSTER_URI + "/tracks_of_the_year", mode="overwrite")

--- a/listenbrainz_spark/year_in_music/tracks_of_the_year.py
+++ b/listenbrainz_spark/year_in_music/tracks_of_the_year.py
@@ -30,4 +30,4 @@ def calculate_tracks_of_the_year(year):
              , artist_credit_mbids
     """
 
-    run_query(query).write.format("csv").save(config.HDFS_CLUSTER_URI + "/tracks_of_the_year", mode="overwrite")
+    run_query(query).write.format("json").save(config.HDFS_CLUSTER_URI + "/tracks_of_the_year", mode="overwrite")

--- a/listenbrainz_spark/year_in_music/tracks_of_the_year.py
+++ b/listenbrainz_spark/year_in_music/tracks_of_the_year.py
@@ -26,8 +26,8 @@ def calculate_tracks_of_the_year(year):
       GROUP BY user_id
              , recording_name
              , recording_mbid
-             , artist_credit_name
-             , artist_mbids
+             , artist_name
+             , artist_credit_mbids
     """
 
     run_query(query).write.format("csv").save(config.HDFS_CLUSTER_URI + "/tracks_of_the_year", mode="overwrite")

--- a/listenbrainz_spark/year_in_music/tracks_of_the_year.py
+++ b/listenbrainz_spark/year_in_music/tracks_of_the_year.py
@@ -1,0 +1,33 @@
+from datetime import datetime, date, time
+
+from listenbrainz_spark import config
+from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import get_all_listens_from_new_dump
+
+
+def calculate_tracks_of_the_year(year):
+    """ Calculate all tracks a user has listened to in the given year. """
+    get_all_listens_from_new_dump().createOrReplaceTempView("listens")
+
+    start = datetime.combine(date(year, 1, 1), time.min)
+    end = datetime.combine(date(year, 12, 31), time.max)
+
+    query = f"""
+        SELECT user_id
+             , recording_name
+             , recording_mbid
+             , artist_credit_name
+             , artist_mbids
+             , count(*) AS listen_count
+          FROM listens
+         WHERE listened_at >= to_timestamp('{start}')
+           AND listened_at <= to_timestamp('{end}')
+           AND recording_mbid IS NOT NULL
+      GROUP BY user_id
+             , recording_name
+             , recording_mbid
+             , artist_credit_name
+             , artist_mbids
+    """
+
+    run_query(query).write.format("csv").save(config.HDFS_CLUSTER_URI + "/tracks_of_the_year", mode="overwrite")

--- a/listenbrainz_spark/year_in_music/tracks_of_the_year.py
+++ b/listenbrainz_spark/year_in_music/tracks_of_the_year.py
@@ -16,8 +16,8 @@ def calculate_tracks_of_the_year(year):
         SELECT user_id
              , recording_name
              , recording_mbid
-             , artist_credit_name
-             , artist_mbids
+             , artist_name
+             , artist_credit_mbids
              , count(*) AS listen_count
           FROM listens
          WHERE listened_at >= to_timestamp('{start}')


### PR DESCRIPTION
The tracks of the year playlist needs all tracks a user listened to in a given year. The query is too intensive to run on LB db directly. Run the query on spark cluster and save output to HDFS. Copy the files manually over to wolf.