### PR TITLE
CoverArtGenerator improvements and fixes

### DIFF
--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -140,7 +140,7 @@ def cover_art_grid_stats(user_name, time_range, dimension, layout, image_size):
         if images is None:
             raise APIInternalServerError("Failed to grid cover art SVG")
     except ValueError as error:
-        raise APIBadRequest(error)
+        raise APIBadRequest(str(error))
 
     return render_template("art/svg-templates/simple-grid.svg",
                            background=cac.background,
@@ -180,13 +180,13 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
     if err is not None:
         raise APIBadRequest(err)
 
-    if custom_name in ("designer-top-5"):
+    if custom_name in ("designer-top-5",):
         try:
             artists, metadata = cac.create_artist_stats_cover(user_name, time_range)
             if artists is None:
                 raise APIInternalServerError("Failed to artist cover art SVG")
         except ValueError as error:
-            raise APIBadRequest(error)
+            raise APIBadRequest(str(error))
 
         return render_template(f"art/svg-templates/{custom_name}.svg",
                                artists=artists,
@@ -202,7 +202,7 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
             if images is None:
                 raise APIInternalServerError("Failed to release cover art SVG")
         except ValueError as error:
-            raise APIBadRequest(error)
+            raise APIBadRequest(str(error))
 
         cover_art_on_floor_url = f'{current_app.config["SERVER_ROOT_URL"]}/static/img/art/cover-art-on-floor.png'
         return render_template(f"art/svg-templates/{custom_name}.svg",

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -902,13 +902,13 @@ def year_in_music(user_name: str):
     })
 
 
-def _process_user_entity(stats: StatApi[EntityRecord], offset, count) -> Tuple[list, int]:
+def _process_user_entity(stats: StatApi[EntityRecord], offset: int, count: int) -> Tuple[list[dict], int]:
     """ Process the statistics data according to query params
 
         Args:
-            stats (dict): the dictionary containing statistic data
-            offset (int): number of entities to skip from the beginning
-            count (int): number of entities to return
+            stats: the dictionary containing statistic data
+            offset: number of entities to skip from the beginning
+            count: number of entities to return
 
         Returns:
             entity_list, total_entity_count: a tuple of a list and integer

--- a/listenbrainz/webserver/views/test/test_art.py
+++ b/listenbrainz/webserver/views/test/test_art.py
@@ -1,9 +1,9 @@
-import requests_mock
-
 from unittest.mock import patch
 
 from flask import url_for
 
+from data.model.user_artist_stat import ArtistRecord
+from data.model.user_release_stat import ReleaseRecord
 from listenbrainz.art.cover_art_generator import CoverArtGenerator
 from listenbrainz.tests.integration import IntegrationTestCase
 
@@ -14,63 +14,44 @@ class ArtViewsTestCase(IntegrationTestCase):
         resp = self.client.get(url_for('art.index'))
         self.assert200(resp)
 
-    @requests_mock.Mocker()
-    def test_cover_art_grid_stats(self, mock_requests):
-        mock_requests.get("https://api.listenbrainz.org/1/stats/user/rob/releases", json={
-            "payload": {
-                "total_release_count": 1,
-                "releases": [
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    }
-                ]
+    @patch.object(CoverArtGenerator, "load_caa_ids")
+    @patch.object(CoverArtGenerator, "download_user_stats")
+    def test_cover_art_grid_stats(self, mock_download_user_stats, mock_get_caa_ids):
+        mock_download_user_stats.return_value = [
+            ReleaseRecord(
+                release_mbid="b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
+                release_name="Release 1",
+                listen_count=5,
+                artist_name="Artist 1",
+                artist_mbids=["b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"]
+            )
+        ], 1
+        mock_get_caa_ids.return_value = {
+            "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6": {
+                "original_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
+                "caa_id": 6945,
+                "caa_release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
             }
-        })
-        with patch.object(CoverArtGenerator, "load_caa_ids") as mock_get_caa_id:
-            mock_get_caa_id.return_value = {
-                "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6": {
-                    "original_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
-                    "caa_id": 6945,
-                    "caa_release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                }
-            }
-            resp = self.client.get(
-                url_for('art_api_v1.cover_art_grid_stats',
-                        user_name="rob",
-                        time_range="week",
-                        dimension=4,
-                        layout=0,
-                        image_size=500))
-            self.assert200(resp)
-            self.assertTrue(resp.text.startswith("<svg"))
+        }
+        resp = self.client.get(
+            url_for('art_api_v1.cover_art_grid_stats',
+                    user_name="rob",
+                    time_range="week",
+                    dimension=4,
+                    layout=0,
+                    image_size=500))
+        self.assert200(resp)
+        self.assertTrue(resp.text.startswith("<svg"))
 
-            # Make sure we find the caa_id in the output SVG
-            self.assertNotEqual(resp.text.find("6945"), -1)
+        # Make sure we find the caa_id in the output SVG
+        self.assertNotEqual(resp.text.find("6945"), -1)
 
-    @requests_mock.Mocker()
-    def test_cover_art_custom_artist_stats(self, mock_requests):
-        mock_requests.get("https://api.listenbrainz.org/1/stats/user/rob/artists", json={
-            "payload": {
-                "total_artist_count": 5,
-                "artists": [
-                    {
-                        "artist_name": "Portishead"
-                    },
-                    {
-                        "artist_name": "Portishead"
-                    },
-                    {
-                        "artist_name": "Portishead"
-                    },
-                    {
-                        "artist_name": "Portishead"
-                    },
-                    {
-                        "artist_name": "Portishead"
-                    }
-                ]
-            }
-        })
+    @patch.object(CoverArtGenerator, "download_user_stats")
+    def test_cover_art_custom_artist_stats(self, mock_download_user_stats):
+        mock_download_user_stats.return_value = [
+            ArtistRecord(artist_mbids=["b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"], artist_name="Artist", listen_count=1)
+            for _ in range(5)
+        ], 5
         resp = self.client.get(
             url_for('art_api_v1.cover_art_custom_stats',
                     custom_name="designer-top-5",
@@ -81,111 +62,84 @@ class ArtViewsTestCase(IntegrationTestCase):
         self.assertTrue(resp.text.startswith("<svg"))
         self.assertNotEqual(resp.text.find("ROB"), -1)
 
-    @requests_mock.Mocker()
-    def test_cover_art_custom_release_stats(self, mock_requests):
-        mock_requests.get("https://api.listenbrainz.org/1/stats/user/rob/releases", json={
-            "payload": {
-                "total_release_count": 10,
-                "releases": [
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    },
-                    {
-                        "release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                    }
-                ]
+    @patch.object(CoverArtGenerator, "load_caa_ids")
+    @patch.object(CoverArtGenerator, "download_user_stats")
+    def test_cover_art_custom_release_stats(self, mock_download_user_stats, mock_get_caa_ids):
+        mock_download_user_stats.return_value = [
+            ReleaseRecord(
+                release_mbid="b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
+                release_name="Release 1",
+                listen_count=5,
+                artist_name="Artist 1",
+                artist_mbids=["b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"]
+            )
+            for _ in range(10)
+        ], 10
+        mock_get_caa_ids.return_value = {
+            "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6": {
+                "original_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
+                "caa_id": 6945,
+                "caa_release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
             }
-        })
-        with patch.object(CoverArtGenerator, "load_caa_ids") as mock_get_caa_id:
-            mock_get_caa_id.return_value = {
-                "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6": {
-                    "original_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6",
-                    "caa_id": 6945,
-                    "caa_release_mbid": "b757afbf-1b6a-4bd1-9d3f-2ad9cac9c3d6"
-                }
-            }
-            resp = self.client.get(
-                url_for('art_api_v1.cover_art_custom_stats',
-                        custom_name="designer-top-10",
-                        user_name="rob",
-                        time_range="week",
-                        image_size=500))
-            self.assert200(resp)
-            self.assertTrue(resp.text.startswith("<svg"))
-            self.assertNotEqual(resp.text.find("ROB"), -1)
+        }
+        resp = self.client.get(
+            url_for('art_api_v1.cover_art_custom_stats',
+                    custom_name="designer-top-10",
+                    user_name="rob",
+                    time_range="week",
+                    image_size=500))
+        self.assert200(resp)
+        self.assertTrue(resp.text.startswith("<svg"))
+        self.assertNotEqual(resp.text.find("ROB"), -1)
 
-    def test_cover_art_grid_post(self):
+    @patch.object(CoverArtGenerator, "load_caa_ids")
+    def test_cover_art_grid_post(self, mock_get_caa_ids):
         with open("listenbrainz/art/misc/sample_cover_art_grid_post_request.json", "r") as f:
             post_json = f.read()
 
-        with patch.object(CoverArtGenerator, "load_caa_ids") as mock_get_caa_id:
-            mock_get_caa_id.return_value = {
-                "be5f714d-02eb-4c89-9a06-5e544f132604": {
-                    "original_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604",
-                    "caa_id": 2273480607,
-                    "caa_release_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604"
-                },
-                "4211382c-39e8-4a72-a32d-e4046fd96356": {
-                    "original_mbid": "4211382c-39e8-4a72-a32d-e4046fd96356",
-                    "caa_id": 8194366407,
-                    "caa_release_mbid": "4211382c-39e8-4a72-a32d-e4046fd96356"
-                },
-                "773e54bb-3f43-4813-826c-ca762bfa8318": {
-                    "original_mbid": "773e54bb-3f43-4813-826c-ca762bfa8318",
-                    "caa_id": 9660646535,
-                    "caa_release_mbid": "773e54bb-3f43-4813-826c-ca762bfa8318"
-                },
-                "10dffffc-c2aa-4ddd-81fd-42b5e125f240": {
-                    "original_mbid": "10dffffc-c2aa-4ddd-81fd-42b5e125f240",
-                    "caa_id": 28871824662,
-                    "caa_release_mbid": "10dffffc-c2aa-4ddd-81fd-42b5e125f240"
-                },
-                "d101e395-0c04-4237-a3d2-167b1d88056c": {
-                    "original_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604",
-                    "caa_id": 2273480607,
-                    "caa_release_mbid": "d101e395-0c04-4237-a3d2-167b1d88056c"
-                },
-                "3eee4ed1-b48e-4894-8a05-f535f16a4985": {
-                    "original_mbid": "3eee4ed1-b48e-4894-8a05-f535f16a4985",
-                    "caa_id": 31067711419,
-                    "caa_release_mbid": "3eee4ed1-b48e-4894-8a05-f535f16a4985"
-                },
-                "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3": {
-                    "original_mbid": "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3",
-                    "caa_id": 31206007614,
-                    "caa_release_mbid": "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3"
-                },
-                "6d895dfa-8688-4867-9730-2b98050dae04": {
-                    "original_mbid": "6d895dfa-8688-4867-9730-2b98050dae04",
-                    "caa_id": None,
-                    "caa_release_mbid": None
-                }
+        mock_get_caa_ids.return_value = {
+            "be5f714d-02eb-4c89-9a06-5e544f132604": {
+                "original_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604",
+                "caa_id": 2273480607,
+                "caa_release_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604"
+            },
+            "4211382c-39e8-4a72-a32d-e4046fd96356": {
+                "original_mbid": "4211382c-39e8-4a72-a32d-e4046fd96356",
+                "caa_id": 8194366407,
+                "caa_release_mbid": "4211382c-39e8-4a72-a32d-e4046fd96356"
+            },
+            "773e54bb-3f43-4813-826c-ca762bfa8318": {
+                "original_mbid": "773e54bb-3f43-4813-826c-ca762bfa8318",
+                "caa_id": 9660646535,
+                "caa_release_mbid": "773e54bb-3f43-4813-826c-ca762bfa8318"
+            },
+            "10dffffc-c2aa-4ddd-81fd-42b5e125f240": {
+                "original_mbid": "10dffffc-c2aa-4ddd-81fd-42b5e125f240",
+                "caa_id": 28871824662,
+                "caa_release_mbid": "10dffffc-c2aa-4ddd-81fd-42b5e125f240"
+            },
+            "d101e395-0c04-4237-a3d2-167b1d88056c": {
+                "original_mbid": "be5f714d-02eb-4c89-9a06-5e544f132604",
+                "caa_id": 2273480607,
+                "caa_release_mbid": "d101e395-0c04-4237-a3d2-167b1d88056c"
+            },
+            "3eee4ed1-b48e-4894-8a05-f535f16a4985": {
+                "original_mbid": "3eee4ed1-b48e-4894-8a05-f535f16a4985",
+                "caa_id": 31067711419,
+                "caa_release_mbid": "3eee4ed1-b48e-4894-8a05-f535f16a4985"
+            },
+            "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3": {
+                "original_mbid": "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3",
+                "caa_id": 31206007614,
+                "caa_release_mbid": "ec782dbe-9204-4ec3-bf50-576c7cf3dfb3"
+            },
+            "6d895dfa-8688-4867-9730-2b98050dae04": {
+                "original_mbid": "6d895dfa-8688-4867-9730-2b98050dae04",
+                "caa_id": None,
+                "caa_release_mbid": None
             }
-            resp = self.client.post(url_for('art_api_v1.cover_art_grid_post'), data=post_json, content_type="application/json")
-            self.assert200(resp)
-            self.assertTrue(resp.text.startswith("<svg"))
-            self.assertNotEqual(resp.text.find("2273480607"), -1)
+        }
+        resp = self.client.post(url_for('art_api_v1.cover_art_grid_post'), data=post_json, content_type="application/json")
+        self.assert200(resp)
+        self.assertTrue(resp.text.startswith("<svg"))
+        self.assertNotEqual(resp.text.find("2273480607"), -1)


### PR DESCRIPTION
1. The custom_name check was invalid at one place because of a missing ,. Due to this the check was instead of doing substring of the type instead of member of tuple.

2. ValueError was passed as message to APIBadRequest which in turn tried to serialize the error as json causing a 500 error. Stringify the error before passing to APIBadRequest.

3. Instead of making an api request to query user stats, fetch stats directly from couchdb. There were ratelimit errors for the user stats fetch in sentry. (Probably because of multiple requests from the same server ip in a short span.) Appropriate place to apply rate limit is art api where we already have it.
