### PR TITLE
Load all listen parquet files at once

### DIFF
--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -9,7 +9,7 @@ import listenbrainz_spark
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.schema import fresh_releases_schema
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_latest_listen_ts, get_listens_from_new_dump
+from listenbrainz_spark.utils import get_latest_listen_ts, get_listens_from_dump
 
 USERS_PER_MESSAGE = 5
 
@@ -119,7 +119,7 @@ def main(days: Optional[int], database: str):
         from_date = to_date + timedelta(days=-days)
     else:
         from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
-    get_listens_from_new_dump(from_date, to_date) \
+    get_listens_from_dump(from_date, to_date) \
         .createOrReplaceTempView("fresh_releases_listens")
 
     load_all_releases().createOrReplaceTempView("fresh_releases")

--- a/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
@@ -49,11 +49,10 @@ class FreshReleasesTestCase(SparkNewTestCase):
             "database": database
         })
 
-        self.assertEqual(next(itr), {
-            "type": "fresh_releases",
-            "database": database,
-            "data": expected
-        })
+        message = next(itr)
+        self.assertEqual(message["type"], "fresh_releases")
+        self.assertEqual(message["database"], database)
+        self.assertCountEqual(message["data"], expected)
 
         self.assertEqual(next(itr), {
             "type": "couchdb_data_end",

--- a/listenbrainz_spark/hdfs/tests/test_upload.py
+++ b/listenbrainz_spark/hdfs/tests/test_upload.py
@@ -13,7 +13,7 @@ from listenbrainz_spark.tests import SparkNewTestCase
 
 from pyspark.sql.types import StructField, StructType, StringType
 
-from listenbrainz_spark.utils import get_listen_files_list, get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listen_files_list, get_listens_from_dump
 
 
 class HDFSDataUploaderTestCase(SparkNewTestCase):

--- a/listenbrainz_spark/missing_mb_data/missing_mb_data.py
+++ b/listenbrainz_spark/missing_mb_data/missing_mb_data.py
@@ -2,7 +2,7 @@ import logging
 
 from listenbrainz_spark.recommendations.dataframe_utils import get_dates_to_train_data
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ def main(days: int):
     """
     logger.info('Fetching listens to find missing MB data...')
     to_date, from_date = get_dates_to_train_data(days)
-    listens_df = get_listens_from_new_dump(from_date, to_date)
+    listens_df = get_listens_from_dump(from_date, to_date)
     listens_df.createOrReplaceTempView("missing_mb_listens")
 
     missing_musicbrainz_data_itr = get_missing_mb_data()

--- a/listenbrainz_spark/recommendations/recording/create_dataframes.py
+++ b/listenbrainz_spark/recommendations/recording/create_dataframes.py
@@ -46,7 +46,7 @@ from listenbrainz_spark.exceptions import (SparkSessionNotInitializedException,
 from listenbrainz_spark.recommendations.dataframe_utils import (get_dataframe_id,
                                                                 save_dataframe,
                                                                 get_dates_to_train_data)
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 logger = logging.getLogger(__name__)
 
@@ -303,7 +303,7 @@ def calculate_dataframes(from_date, to_date, job_type, minimum_listens_threshold
     metadata['to_date'] = to_date
     metadata['from_date'] = from_date
 
-    complete_listens_df = get_listens_from_new_dump(from_date, to_date)
+    complete_listens_df = get_listens_from_dump(from_date, to_date)
     logger.info(f'Listen count from {from_date} to {to_date}: {complete_listens_df.count()}')
 
     logger.info('Discarding listens without mbids...')

--- a/listenbrainz_spark/recommendations/recording/discovery.py
+++ b/listenbrainz_spark/recommendations/recording/discovery.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from listenbrainz_spark import config, path
 from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_latest_listen_ts, get_listens_from_new_dump
+from listenbrainz_spark.utils import get_latest_listen_ts, get_listens_from_dump
 
 
 def get_recording_discovery():
@@ -11,7 +11,7 @@ def get_recording_discovery():
      for later use in recommendations. """
     to_date = get_latest_listen_ts()
     from_date = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
-    get_listens_from_new_dump(from_date, to_date) \
+    get_listens_from_dump(from_date, to_date) \
         .createOrReplaceTempView("recording_discovery")
 
     run_query("""

--- a/listenbrainz_spark/similarity/artist.py
+++ b/listenbrainz_spark/similarity/artist.py
@@ -5,7 +5,7 @@ from more_itertools import chunked
 import listenbrainz_spark
 from listenbrainz_spark import config
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 RECORDINGS_PER_MESSAGE = 10000
@@ -113,7 +113,7 @@ def main(days, session, contribution, threshold, limit, filter_artist_credit, sk
     table = "artist_similarity_listens"
     metadata_table = "mb_metadata_cache"
 
-    get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView(table)
+    get_listens_from_dump(from_date, to_date).createOrReplaceTempView(table)
 
     metadata_df = listenbrainz_spark.sql_context.read.json(config.HDFS_CLUSTER_URI + "/mb_metadata_cache.jsonl")
     metadata_df.createOrReplaceTempView(metadata_table)

--- a/listenbrainz_spark/similarity/recording.py
+++ b/listenbrainz_spark/similarity/recording.py
@@ -5,7 +5,7 @@ from more_itertools import chunked
 import listenbrainz_spark
 from listenbrainz_spark import config
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 RECORDINGS_PER_MESSAGE = 10000
@@ -113,7 +113,7 @@ def main(days, session, contribution, threshold, limit, filter_artist_credit, sk
     table = "recording_similarity_listens"
     metadata_table = "mb_metadata_cache"
 
-    get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView(table)
+    get_listens_from_dump(from_date, to_date).createOrReplaceTempView(table)
 
     metadata_df = listenbrainz_spark.sql_context.read.json(config.HDFS_CLUSTER_URI + "/mb_metadata_cache.jsonl")
     metadata_df.createOrReplaceTempView(metadata_table)

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -11,7 +11,7 @@ from listenbrainz_spark.stats import get_dates_for_stats_range
 from listenbrainz_spark.stats.sitewide.artist import get_artists
 from listenbrainz_spark.stats.sitewide.recording import get_recordings
 from listenbrainz_spark.stats.sitewide.release import get_releases
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 from pydantic import ValidationError
 
 
@@ -48,7 +48,7 @@ def get_entity_stats(entity: str, stats_range: str) -> Optional[List[SitewideEnt
     logger.debug(f"Calculating sitewide_{entity}_{stats_range}...")
 
     from_date, to_date = get_dates_for_stats_range(stats_range)
-    listens_df = get_listens_from_new_dump(from_date, to_date)
+    listens_df = get_listens_from_dump(from_date, to_date)
     table_name = f"sitewide_{entity}_{stats_range}"
     listens_df.createOrReplaceTempView(table_name)
 

--- a/listenbrainz_spark/stats/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/sitewide/listening_activity.py
@@ -9,7 +9,7 @@ from data.model.common_stat_spark import StatMessage
 from data.model.user_listening_activity import ListeningActivityRecord
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.stats.common.listening_activity import setup_time_range
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 from pyspark.sql.types import (StringType, StructField, StructType,
                                TimestampType)
 
@@ -77,7 +77,7 @@ def get_listening_activity(stats_range: str) -> Iterator[Optional[Dict]]:
     """
     logger.debug(f"Calculating listening_activity_{stats_range}")
     from_date, to_date, _, _, spark_date_format = setup_time_range(stats_range)
-    get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView("listens")
+    get_listens_from_dump(from_date, to_date).createOrReplaceTempView("listens")
     data = calculate_listening_activity(spark_date_format)
     messages = create_messages(data=data, stats_range=stats_range, from_date=from_date, to_date=to_date)
     logger.debug("Done!")

--- a/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
+++ b/listenbrainz_spark/stats/sitewide/tests/test_sitewide_entity.py
@@ -14,7 +14,7 @@ class SitewideEntityTestCase(StatsTestCase):
         super(SitewideEntityTestCase, cls).setUpClass()
         entity.entity_handler_map['test'] = MagicMock(return_value="sample_test_data")
 
-    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'week')
@@ -24,7 +24,7 @@ class SitewideEntityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='week',
                                                 from_date=from_date, to_date=to_date)
 
-    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_month(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'month')
@@ -34,7 +34,7 @@ class SitewideEntityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='month',
                                                 from_date=from_date, to_date=to_date)
 
-    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_year(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'year')
@@ -44,7 +44,7 @@ class SitewideEntityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='sample_test_data', entity='test', stats_range='year',
                                                 from_date=from_date, to_date=to_date)
 
-    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.sitewide.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.sitewide.entity.create_messages')
     def test_get_entity_all_time(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'all_time')

--- a/listenbrainz_spark/stats/user/daily_activity.py
+++ b/listenbrainz_spark/stats/user/daily_activity.py
@@ -13,7 +13,7 @@ from data.model.common_stat_spark import UserStatRecords, StatMessage
 from data.model.user_daily_activity import DailyActivityRecord
 from listenbrainz_spark.stats import run_query, get_dates_for_stats_range
 from listenbrainz_spark.stats.user import USERS_PER_MESSAGE
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 from pyspark.sql.functions import collect_list, sort_array, struct
 
 
@@ -70,7 +70,7 @@ def get_daily_activity(stats_range: str, database: str = None) -> Iterator[Optio
     logger.debug(f"Calculating daily_activity_{stats_range}")
 
     from_date, to_date = get_dates_for_stats_range(stats_range)
-    get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView("listens")
+    get_listens_from_dump(from_date, to_date).createOrReplaceTempView("listens")
     data = calculate_daily_activity()
     messages = create_messages(data=data, stats_range=stats_range, from_date=from_date,
                                to_date=to_date, database=database)

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -16,7 +16,7 @@ from listenbrainz_spark.stats.user import USERS_PER_MESSAGE
 from listenbrainz_spark.stats.user.artist import get_artists
 from listenbrainz_spark.stats.user.recording import get_recordings
 from listenbrainz_spark.stats.user.release import get_releases
-from listenbrainz_spark.utils import get_listens_from_new_dump, read_files_from_HDFS
+from listenbrainz_spark.utils import get_listens_from_dump, read_files_from_HDFS
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def get_entity_stats(entity: str, stats_range: str, message_type: str = "user_en
     logger.debug(f"Calculating user_{entity}_{stats_range}...")
 
     from_date, to_date = get_dates_for_stats_range(stats_range)
-    listens_df = get_listens_from_new_dump(from_date, to_date)
+    listens_df = get_listens_from_dump(from_date, to_date)
     table = f"user_{entity}_{stats_range}"
     listens_df.createOrReplaceTempView(table)
 

--- a/listenbrainz_spark/stats/user/listening_activity.py
+++ b/listenbrainz_spark/stats/user/listening_activity.py
@@ -11,7 +11,7 @@ from data.model.user_listening_activity import ListeningActivityRecord
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.stats.common.listening_activity import setup_time_range
 from listenbrainz_spark.stats.user import USERS_PER_MESSAGE
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ def get_listening_activity(stats_range: str, message_type="user_listening_activi
     """
     logger.debug(f"Calculating listening_activity_{stats_range}")
     from_date, to_date, _, _, _ = setup_time_range(stats_range)
-    get_listens_from_new_dump(from_date, to_date).createOrReplaceTempView("listens")
+    get_listens_from_dump(from_date, to_date).createOrReplaceTempView("listens")
     data = calculate_listening_activity()
     messages = create_messages(data=data, stats_range=stats_range,
                                from_date=from_date, to_date=to_date,

--- a/listenbrainz_spark/stats/user/tests/test_daily_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_daily_activity.py
@@ -35,7 +35,7 @@ class DailyActivityTestCase(StatsTestCase):
         self.assertEqual(messages[2]["type"], "couchdb_data_end")
         self.assertEqual(messages[2]["database"], "daily_activity_all_time")
 
-    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.daily_activity.calculate_daily_activity', return_value='daily_activity_table')
     @patch('listenbrainz_spark.stats.user.daily_activity.create_messages')
     def test_get_daily_activity_week(self, mock_create_messages, _, mock_get_listens):
@@ -47,7 +47,7 @@ class DailyActivityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='week',
                                                 from_date=from_date, to_date=to_date, database=None)
 
-    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.daily_activity.calculate_daily_activity', return_value='daily_activity_table')
     @patch('listenbrainz_spark.stats.user.daily_activity.create_messages')
     def test_get_daily_activity_month(self, mock_create_messages, _, mock_get_listens):
@@ -59,7 +59,7 @@ class DailyActivityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='month',
                                                 from_date=from_date, to_date=to_date, database=None)
 
-    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.daily_activity.calculate_daily_activity', return_value='daily_activity_table')
     @patch('listenbrainz_spark.stats.user.daily_activity.create_messages')
     def test_get_daily_activity_year(self, mock_create_messages, _, mock_get_listens):
@@ -71,7 +71,7 @@ class DailyActivityTestCase(StatsTestCase):
         mock_create_messages.assert_called_with(data='daily_activity_table', stats_range='year',
                                                 from_date=from_date, to_date=to_date, database=None)
 
-    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.daily_activity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.daily_activity.calculate_daily_activity', return_value='daily_activity_table')
     @patch('listenbrainz_spark.stats.user.daily_activity.create_messages')
     def test_get_daily_activity_all_time(self, mock_create_messages, _, mock_get_listens):

--- a/listenbrainz_spark/stats/user/tests/test_entity.py
+++ b/listenbrainz_spark/stats/user/tests/test_entity.py
@@ -14,7 +14,7 @@ class UserEntityTestCase(StatsTestCase):
         super(UserEntityTestCase, cls).setUpClass()
         entity.entity_handler_map['test'] = MagicMock(return_value="sample_test_data")
 
-    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.entity.create_messages')
     def test_get_entity_week(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'week')
@@ -26,7 +26,7 @@ class UserEntityTestCase(StatsTestCase):
                                                 from_date=from_date, to_date=to_date, message_type="user_entity",
                                                 database=None)
 
-    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.entity.create_messages')
     def test_get_entity_month(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'month')
@@ -38,7 +38,7 @@ class UserEntityTestCase(StatsTestCase):
                                                 from_date=from_date, to_date=to_date, message_type="user_entity",
                                                 database=None)
 
-    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.entity.create_messages')
     def test_get_entity_year(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'year')
@@ -50,7 +50,7 @@ class UserEntityTestCase(StatsTestCase):
                                                 from_date=from_date, to_date=to_date, message_type="user_entity",
                                                 database=None)
 
-    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.entity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.entity.create_messages')
     def test_get_entity_all_time(self, mock_create_messages, mock_get_listens):
         entity.get_entity_stats('test', 'all_time')

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity.py
@@ -31,7 +31,7 @@ class ListeningActivityTestCase(StatsTestCase):
         self.assertEqual(messages[2]["type"], "couchdb_data_end")
         self.assertEqual(messages[2]["database"], "listening_activity_all_time")
 
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.listening_activity.calculate_listening_activity', return_value='activity_table')
     @patch('listenbrainz_spark.stats.user.listening_activity.create_messages')
     def test_get_listening_activity_week(self, mock_create_messages, _, mock_get_listens):
@@ -52,7 +52,7 @@ class ListeningActivityTestCase(StatsTestCase):
                                                 from_date=from_date, to_date=to_date,
                                                 message_type='user_listening_activity', database=None)
 
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.listening_activity.calculate_listening_activity', return_value='activity_table')
     @patch('listenbrainz_spark.stats.user.listening_activity.create_messages')
     def test_get_listening_activity_month(self, mock_create_messages, _, mock_get_listens):
@@ -73,7 +73,7 @@ class ListeningActivityTestCase(StatsTestCase):
                                                 from_date=from_date, to_date=to_date,
                                                 message_type='user_listening_activity', database=None)
 
-    @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_new_dump')
+    @patch('listenbrainz_spark.stats.user.listening_activity.get_listens_from_dump')
     @patch('listenbrainz_spark.stats.user.listening_activity.calculate_listening_activity', return_value='activity_table')
     @patch('listenbrainz_spark.stats.user.listening_activity.create_messages')
     def test_get_listening_activity_year(self, mock_create_messages, _, mock_get_listens):

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -10,7 +10,7 @@ import listenbrainz_spark
 from listenbrainz_spark import hdfs_connection, utils, config
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
 from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 from listenbrainz_spark.hdfs.utils import delete_dir
 from listenbrainz_spark.hdfs.utils import path_exists
 from listenbrainz_spark.hdfs.utils import hdfs_walk
@@ -90,4 +90,4 @@ class SparkNewTestCase(unittest.TestCase):
 
     @classmethod
     def get_all_test_listens(cls):
-        return get_listens_from_new_dump(cls.begin_date, cls.end_date)
+        return get_listens_from_dump(cls.begin_date, cls.end_date)

--- a/listenbrainz_spark/year_in_music/artist_map.py
+++ b/listenbrainz_spark/year_in_music/artist_map.py
@@ -9,14 +9,14 @@ from listenbrainz_spark import config
 from listenbrainz_spark.path import ARTIST_COUNTRY_CODE_DATAFRAME
 from listenbrainz_spark.postgres.artist import create_artist_country_cache
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_all_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 USERS_PER_MESSAGE = 100
 
 
 def get_artist_map_stats(year):
-    get_all_listens_from_new_dump().createOrReplaceTempView("listens")
+    get_listens_from_dump().createOrReplaceTempView("listens")
     create_artist_country_cache()
 
     listenbrainz_spark\

--- a/listenbrainz_spark/year_in_music/listens_per_day.py
+++ b/listenbrainz_spark/year_in_music/listens_per_day.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 from listenbrainz_spark.stats.common.listening_activity import _create_time_range_df
 from listenbrainz_spark.stats.user.listening_activity import calculate_listening_activity, create_messages
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 def calculate_listens_per_day(year):
@@ -15,7 +15,7 @@ def calculate_listens_per_day(year):
     spark_date_format = "dd MMMM y"
 
     _create_time_range_df(from_date, to_date, step, date_format, spark_date_format)
-    listens = get_listens_from_new_dump(from_date, to_date)
+    listens = get_listens_from_dump(from_date, to_date)
     listens.createOrReplaceTempView("listens")
 
     data = calculate_listening_activity()

--- a/listenbrainz_spark/year_in_music/new_artists_discovered.py
+++ b/listenbrainz_spark/year_in_music/new_artists_discovered.py
@@ -1,10 +1,10 @@
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_all_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 def get_new_artists_discovered_count(year):
     """ Count the number of artists a user has listened to for the first time in the given year. """
-    get_all_listens_from_new_dump()\
+    get_listens_from_dump()\
         .createOrReplaceTempView("artists_discovery_listens")
     data = run_query(_get_new_discovered_artists_count(year)).collect()
     yield {

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -7,12 +7,12 @@ from listenbrainz_spark.path import RELEASE_GROUPS_YEAR_DATAFRAME
 from listenbrainz_spark.postgres.release_group import create_year_release_groups
 
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_all_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 from listenbrainz_spark.year_in_music.utils import setup_listens_for_year
 
 
 def get_new_releases_of_top_artists(year):
-    get_all_listens_from_new_dump().createOrReplaceTempView("listens")
+    get_listens_from_dump().createOrReplaceTempView("listens")
     create_year_release_groups(year)
     listenbrainz_spark\
         .sql_context\

--- a/listenbrainz_spark/year_in_music/top_stats.py
+++ b/listenbrainz_spark/year_in_music/top_stats.py
@@ -3,7 +3,7 @@ from datetime import datetime, date, time
 from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
 from listenbrainz_spark.postgres.release import create_release_metadata_cache
 from listenbrainz_spark.stats.user.entity import calculate_entity_stats
-from listenbrainz_spark.utils import get_listens_from_new_dump, read_files_from_HDFS
+from listenbrainz_spark.utils import get_listens_from_dump, read_files_from_HDFS
 
 
 def calculate_top_entity_stats(year):
@@ -11,7 +11,7 @@ def calculate_top_entity_stats(year):
     to_date = datetime.combine(date(year, 12, 31), time.max)
     table = "listens_of_year"
 
-    listens = get_listens_from_new_dump(from_date, to_date)
+    listens = get_listens_from_dump(from_date, to_date)
     listens.createOrReplaceTempView(table)
 
     df_name = "release_data_cache"

--- a/listenbrainz_spark/year_in_music/tracks_of_the_year.py
+++ b/listenbrainz_spark/year_in_music/tracks_of_the_year.py
@@ -3,14 +3,14 @@ from datetime import datetime, date, time
 from more_itertools import chunked
 
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_all_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 ENTRIES_PER_MESSAGE = 100000
 
 def calculate_tracks_of_the_year(year):
     """ Calculate all tracks a user has listened to in the given year. """
-    get_all_listens_from_new_dump().createOrReplaceTempView("listens")
+    get_listens_from_dump().createOrReplaceTempView("listens")
 
     start = datetime.combine(date(year, 1, 1), time.min)
     end = datetime.combine(date(year, 12, 31), time.max)

--- a/listenbrainz_spark/year_in_music/utils.py
+++ b/listenbrainz_spark/year_in_music/utils.py
@@ -2,13 +2,13 @@ from datetime import datetime, date, time
 
 import listenbrainz_spark
 from listenbrainz_spark import path
-from listenbrainz_spark.utils import get_listens_from_new_dump
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 def setup_listens_for_year(year):
     start = datetime(year, 1, 1)
     end = datetime.combine(date(year, 12, 31), time.max)
-    listens = get_listens_from_new_dump(start, end)
+    listens = get_listens_from_dump(start, end)
     listens.createOrReplaceTempView("listens_of_year")
 
 


### PR DESCRIPTION
We currently load listens one file at a time to avoid loading unneeded files. For instance, consider we are running weekly stats so loading just the few latest files is enough. However, having run some spark jobs by hand I have noticed that spark is almost always fast to load all files at once. Maybe there are caching effects across jobs (jobs like all_time load all files) which explain this. So load files at once.

We still need to load incremental separately because those are stored in a separate subdirectory and spark does not read files recursively.