### PR TITLE
Fix caps and improve wording in music_services

### DIFF
--- a/listenbrainz/webserver/templates/user/music_services.html
+++ b/listenbrainz/webserver/templates/user/music_services.html
@@ -12,11 +12,11 @@
             </div>
             <div class="panel-body">
                 <p>
-                    Connect to your spotify account to read your listening history, play music on ListenBrainz (requires
+                    Connect to your Spotify account to read your listening history, play music on ListenBrainz (requires
                     Spotify Premium) or both. We encourage users to choose both options for the best experience, but you
-                    may also choose only one option:
-                    Make sure your browser is allowing autoplaying media on listenbrainz.org.
-                    If you have a Spotify account connected, you'll have much better results. Otherwise, we will search for a match on Youtube.
+                    may also choose only one option.
+                    For music playing, make sure your browser allows autoplaying media on listenbrainz.org.
+                    If you have a Spotify account connected, you'll have much better results. Otherwise, we will search for a match on YouTube.
                     If you ever face an issue, try disconnecting and reconnecting your Spotify account and make sure you select the permissions to 'record listens and play music' or 'play music only'.
                 </p>
                 <br/>
@@ -110,9 +110,9 @@
             </div>
             <div class="panel-body">
                 <p>
-                    ListenBrainz integrates with Youtube to let you play music tracks from ListenBrainz pages.
+                    ListenBrainz integrates with YouTube to let you play music tracks from ListenBrainz pages.
                     You do not need to do anything to enable this. ListenBrainz will automatically search for
-                    tracks on Youtube and play one if it finds a match.
+                    tracks on YouTube and play one if it finds a match.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
We had several things such as spotify lowercased, Youtube without the T.

Also, the second part of the Spotify text is fairy confusing and seems to apply only to the playing music bit. I changed it a bit to hopefully make it more clear, although it could benefit from being moved to a more specific section I think?