### PR TITLE
Send track duration in BrainzPlayer

### DIFF
--- a/frontend/js/src/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/brainzplayer/BrainzPlayer.tsx
@@ -620,6 +620,7 @@ export default class BrainzPlayer extends React.Component<
       currentTrackArtist,
       currentTrackAlbum,
       currentTrackURL,
+      durationMs,
     } = this.state;
     const dataSource = this.dataSources[currentDataSourceIndex];
 
@@ -652,6 +653,7 @@ export default class BrainzPlayer extends React.Component<
     assign(newListen.track_metadata, {
       brainzplayer_metadata,
       additional_info: {
+        duration_ms: durationMs > 0 ? durationMs : undefined,
         media_player: "BrainzPlayer",
         submission_client: "BrainzPlayer",
         // TODO:  passs the GIT_COMMIT_SHA env variable to the globalprops and add it here as submission_client_version

--- a/frontend/js/tests/brainzplayer/BrainzPlayer.test.tsx
+++ b/frontend/js/tests/brainzplayer/BrainzPlayer.test.tsx
@@ -828,6 +828,7 @@ describe("BrainzPlayer", () => {
           artist_name: "Rick Astley",
           track_name: "Never Gonna Give You Up",
           additional_info: {
+            duration_ms: 123990,
             media_player: "BrainzPlayer",
             submission_client: "BrainzPlayer",
             music_service: "spotify.com",


### PR DESCRIPTION
# Problem

Currently when you listen to something through BrainzPlayer track duration is not submitted.

# Solution

If the playing track has duration data available, send it. 

# Action

There are two tests that use the modified function, conveniently one of them sets the `duration` field and the other doesn't. I'm not sure if another test might be need to check just this specifically.
Also, maybe it would be possible to also send track number and etc here, but that would involve using the `currentListen` variable, which sounds kind of complicated.