### PR TITLE
Fix bug in fetching listen events for feed

### DIFF
--- a/data/model/listen.py
+++ b/data/model/listen.py
@@ -64,6 +64,7 @@ class TrackMetadata(BaseModel):
     track_name: constr(min_length=1)
     release_name: Optional[str]
     additional_info: Optional[AdditionalInfo]
+    mbid_mapping: Optional[dict]
 
 
 # this is not an exhaustive definition


### PR DESCRIPTION
Listen events on feed page were missing mapping data even though the same listens had mapping data on other pages. On investigation, I found that the APIListen model didn't account for mbid_mapping dict and thus the mapping data was removed before json serialization. Added a key to the model. Also, exclude optional None fields to avoid unnecessary keys in response (there are quite a lot of those).