### PR TITLE
SpotifyPlayer: catch failed calls to refresh token

### DIFF
--- a/frontend/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/frontend/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -407,10 +407,18 @@ export default class SpotifyPlayer
     this.spotifyPlayer = new window.Spotify.Player({
       name: "ListenBrainz Player",
       getOAuthToken: async (authCallback) => {
-        const userToken = await refreshSpotifyToken();
-        this.accessToken = userToken;
-        this.authenticationRetries = 0;
-        authCallback(userToken);
+        try {
+          const userToken = await refreshSpotifyToken();
+          this.accessToken = userToken;
+          this.authenticationRetries = 0;
+          authCallback(userToken);
+        } catch (error) {
+          handleError(error, "Error connecting to Spotify");
+          setTimeout(
+            this.connectSpotifyPlayer.bind(this, callbackFunction),
+            1000
+          );
+        }
       },
       volume: 0.7, // Careful with this, now…
     });


### PR DESCRIPTION
When calling the LB API to refresh a spotify token, the response may throw an error. Currently that error bubbles up and is caught by the page's ErrorBoundary, but that means the page is entirely broken. Instead we catch it, display an error message and try again in a second.
