### PR TITLE
Allow users to manually map all listens

### DIFF
--- a/frontend/js/src/user/Listens.tsx
+++ b/frontend/js/src/user/Listens.tsx
@@ -716,7 +716,7 @@ export default class Listens extends React.Component<
       Boolean(releaseGroupMBID);
     const canPin = Boolean(recordingMBID) || Boolean(recordingMSID);
     const canPersonallyRecommend = Boolean(recordingMSID);
-    const canManuallyMap = recordingMSID && !recordingMBID;
+    const canManuallyMap = Boolean(recordingMSID);
 
     /* eslint-disable react/jsx-no-bind */
     const additionalMenuItems = [];


### PR DESCRIPTION
Useful when people want to override the automatic mbid mapper's choice.