### PR TITLE
Add artist map to YIM stats

### DIFF
--- a/frontend/js/src/stats/Choropleth.tsx
+++ b/frontend/js/src/stats/Choropleth.tsx
@@ -24,6 +24,7 @@ export type ChoroplethProps = {
   data: UserArtistMapData;
   width?: number;
   selectedMetric: "artist" | "listen";
+  colorScaleRange?: string[];
 };
 
 const commonLegendProps = {
@@ -91,8 +92,7 @@ export default function CustomChoropleth(props: ChoroplethProps) {
 
   const isMobile = useMediaQuery({ maxWidth: 767 });
 
-  const { data } = props;
-  const { width } = props;
+  const { data, width, colorScaleRange } = props;
   const containerWidth = width || 1200; // Set default width to 1200
   const containerHeight = containerWidth / 2;
 
@@ -112,7 +112,7 @@ export default function CustomChoropleth(props: ChoroplethProps) {
 
   const colorScale = scaleThreshold<number, string>()
     .domain(domain)
-    .range(schemeOranges[6]);
+    .range(colorScaleRange ?? schemeOranges[6]);
 
   // Create a custom legend component because the default doesn't work with scaleThreshold
   const customLegend = () => (

--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -45,9 +45,7 @@ import MagicShareButton from "./MagicShareButton";
 
 import ListenCard from "../../listens/ListenCard";
 import UserListModalEntry from "../../follow/UserListModalEntry";
-import {
-  JSPFTrackToListen,
-} from "../../playlists/utils";
+import { JSPFTrackToListen } from "../../playlists/utils";
 import { COLOR_BLACK, COLOR_LB_ORANGE } from "../../utils/constants";
 import SimpleModal from "../../utils/SimpleModal";
 import Card from "../../components/Card";
@@ -874,29 +872,22 @@ export default class YearInMusic extends React.Component<
             </div>
             <div className="card content-card" id="user-artist-map">
               <h3 className="text-center">
-                What country are {yourOrUsersName} favorite artists from?{" "}
+                What countries are {yourOrUsersName} favorite artists from?{" "}
+                <FontAwesomeIcon
+                  icon={faQuestionCircle}
+                  data-tip
+                  data-for="most-listened-year-helptext"
+                  size="xs"
+                />
+                <Tooltip id="most-listened-year-helptext">
+                  Click on a country to see more details
+                </Tooltip>
               </h3>
               {artistMapDataForGraph ? (
-                <Card
-                  style={{
-                    marginTop: 20,
-                    minHeight: 600,
-                  }}
-                >
-                  <div className="row">
-                    <div className="col-md-9 col-xs-6">
-                      <h3 style={{ marginLeft: 20 }}>
-                        <span className="capitalize-bold">Artist Origins</span>
-                        <small>
-                          &nbsp;Click on a country to see more details
-                        </small>
-                      </h3>
-                    </div>
-                    <div
-                      className="col-md-2 col-xs-4 text-right"
-                      style={{ marginTop: 20 }}
-                    >
-                      <span>Rank by</span>
+                <div className="graph-container">
+                  <div className="graph">
+                    <div style={{ paddingLeft: "3em" }}>
+                      <span>Rank by number of</span>
                       <span className="dropdown">
                         <button
                           className="dropdown-toggle btn-transparent capitalize-bold"
@@ -942,28 +933,21 @@ export default class YearInMusic extends React.Component<
                         </ul>
                       </span>
                     </div>
-                    <div className="col-md-1 col-xs-2 text-right">
-                      <h4 style={{ marginTop: 20 }}>
-                        <a href="#artist-origin">
-                          <FontAwesomeIcon
-                            icon={faLink as IconProp}
-                            size="sm"
-                            color={COLOR_BLACK}
-                            style={{ marginRight: 20 }}
-                          />
-                        </a>
-                      </h4>
-                    </div>
+                    <CustomChoropleth
+                      width={700}
+                      data={artistMapDataForGraph}
+                      selectedMetric={selectedMetric}
+                      colorScaleRange={[
+                        "#ffeec2",
+                        "#ffdb80",
+                        "#ffcc49",
+                        "#ff9c40",
+                        "#ff6b36",
+                        "#ff0a23",
+                      ]}
+                    />
                   </div>
-                  <div className="row">
-                    <div className="col-xs-12">
-                      <CustomChoropleth
-                        data={artistMapDataForGraph}
-                        selectedMetric={selectedMetric}
-                      />
-                    </div>
-                  </div>
-                </Card>
+                </div>
               ) : (
                 noDataText
               )}

--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -7,10 +7,8 @@ import { CalendarDatum, ResponsiveCalendar } from "@nivo/calendar";
 import Tooltip from "react-tooltip";
 import {
   get,
-  has,
   isEmpty,
   isNil,
-  isString,
   range,
   uniq,
   capitalize,
@@ -21,12 +19,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCopy,
   faHeadphones,
-  faLink,
   faQuestionCircle,
   faShareAlt,
 } from "@fortawesome/free-solid-svg-icons";
 import { LazyLoadImage } from "react-lazy-load-image-component";
-import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import ErrorBoundary from "../../utils/ErrorBoundary";
 import GlobalAppContext, {
   GlobalAppContextT,
@@ -46,9 +42,8 @@ import MagicShareButton from "./MagicShareButton";
 import ListenCard from "../../listens/ListenCard";
 import UserListModalEntry from "../../follow/UserListModalEntry";
 import { JSPFTrackToListen } from "../../playlists/utils";
-import { COLOR_BLACK, COLOR_LB_ORANGE } from "../../utils/constants";
+import { COLOR_LB_ORANGE } from "../../utils/constants";
 import SimpleModal from "../../utils/SimpleModal";
-import Card from "../../components/Card";
 import CustomChoropleth from "../../stats/Choropleth";
 
 export type YearInMusicProps = {

--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -95,6 +95,12 @@ export type YearInMusicProps = {
       artist_credit_mbids: string[];
       artist_credit_name: string;
     }>;
+    artist_map: Array<{
+      artist_mbid: string;
+      artist_name: string;
+      listen_count: number;
+      country_code: string;
+    }>;
   };
 } & WithAlertNotificationsInjectedProps;
 
@@ -342,7 +348,8 @@ export default class YearInMusic extends React.Component<
       !yearInMusicData.listens_per_day ||
       !yearInMusicData.total_listen_count ||
       !yearInMusicData.day_of_week ||
-      !yearInMusicData.new_releases_of_top_artists
+      !yearInMusicData.new_releases_of_top_artists ||
+      !yearInMusicData.artist_map
     ) {
       missingSomeData = true;
     }

--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -871,10 +871,10 @@ export default class YearInMusic extends React.Component<
                 <FontAwesomeIcon
                   icon={faQuestionCircle}
                   data-tip
-                  data-for="most-listened-year-helptext"
+                  data-for="user-artist-map-helptext"
                   size="xs"
                 />
-                <Tooltip id="most-listened-year-helptext">
+                <Tooltip id="user-artist-map-helptext">
                   Click on a country to see more details
                 </Tooltip>
               </h3>

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -392,6 +392,10 @@ def handle_yim_listening_time(message):
     year_in_music.insert("total_listening_time", message["year"], message["data"])
 
 
+def handle_yim_artist_map(message):
+    year_in_music.handle_multi_large_insert("artist_map", message["year"], message["data"])
+
+
 def handle_new_artists_discovered_count(message):
     year_in_music.insert("total_new_artists_discovered", message["year"], message["data"])
 

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -435,6 +435,15 @@ def request_yim_playlists(year: int):
     send_request_to_spark_cluster("year_in_music.tracks_of_the_year", year=year)
 
 
+@cli.command(name="request_yim_artist_map")
+@click.option("--year", type=int, help="Year for which to generate the playlists",
+              default=date.today().year)
+def request_yim_artist_map(year: int):
+    """ Send the cluster a request to generate artist map data and then
+     once the data has been imported generate YIM artist map. """
+    send_request_to_spark_cluster("year_in_music.artist_map", year=year)
+
+
 @cli.command(name="request_year_in_music")
 @click.option("--year", type=int, help="Year for which to calculate the stat",
               default=date.today().year)
@@ -451,6 +460,7 @@ def request_year_in_music(ctx, year: int):
     ctx.invoke(request_yim_similar_users, year=year)
     ctx.invoke(request_yim_new_artists_discovered, year=year)
     ctx.invoke(request_yim_listening_time, year=year)
+    ctx.invoke(request_yim_artist_map, year=year)
     ctx.invoke(request_yim_playlists, year=year)
 
 

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -189,6 +189,11 @@
     "description": "Calculate the top artists/recordings/releases stats for the current year for each user",
     "params": ["year"]
   },
+  "year_in_music.artist_map": {
+    "name": "year_in_music.artist_map",
+    "description": "Calculate the top artist map stats for the current year for each user",
+    "params": ["year"]
+  },
   "releases.fresh": {
     "name": "releases.fresh",
     "description": "Calculate the intersection of fresh releases and user's listening history",

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -36,7 +36,8 @@ from listenbrainz.spark.handlers import (handle_candidate_sets,
                                          handle_new_artists_discovered_count,
                                          handle_yim_tracks_of_the_year_start,
                                          handle_yim_tracks_of_the_year_data,
-                                         handle_yim_tracks_of_the_year_end)
+                                         handle_yim_tracks_of_the_year_end,
+                                         handle_yim_artist_map)
 from listenbrainz.utils import get_fallback_connection_name
 from listenbrainz.webserver import create_app
 
@@ -70,6 +71,7 @@ response_handler_map = {
     'year_in_music_day_of_week': handle_yim_day_of_week,
     'year_in_music_most_listened_year': handle_yim_most_listened_year,
     'year_in_music_listening_time': handle_yim_listening_time,
+    'year_in_music_artist_map': handle_yim_artist_map,
     'year_in_music_new_artists_discovered_count': handle_new_artists_discovered_count,
     'year_in_music_tracks_of_the_year_start': handle_yim_tracks_of_the_year_start,
     'year_in_music_tracks_of_the_year_data': handle_yim_tracks_of_the_year_data,

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -100,3 +100,4 @@ RELEASE_COLOR_DUMP = "/release_color.json"
 
 RELEASE_METADATA_CACHE_DATAFRAME = "/release_metadata_cache"
 RELEASE_GROUPS_YEAR_DATAFRAME = "/release_groups_year"
+ARTIST_COUNTRY_CODE_DATAFRAME = "/artist_country_code"

--- a/listenbrainz_spark/postgres/artist.py
+++ b/listenbrainz_spark/postgres/artist.py
@@ -1,0 +1,18 @@
+from listenbrainz_spark.path import ARTIST_COUNTRY_CODE_DATAFRAME
+from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
+
+
+def create_artist_country_cache():
+    """ Import artist country from postgres to HDFS for use in artist map stats calculation. """
+    query = """
+        SELECT a.gid AS artist_mbid
+             , a.name AS artist_name
+             , iso.code AS country_code
+          FROM musicbrainz.artist a
+          JOIN musicbrainz.area_containment ac
+            ON ac.descendant = a.area
+          JOIN musicbrainz.iso_3166_1 iso
+            ON iso.area = ac.parent
+    """
+
+    save_pg_table_to_hdfs(query, ARTIST_COUNTRY_CODE_DATAFRAME)

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -18,6 +18,7 @@ import listenbrainz_spark.year_in_music.top_stats
 import listenbrainz_spark.year_in_music.listens_per_day
 import listenbrainz_spark.year_in_music.listen_count
 import listenbrainz_spark.year_in_music.listening_time
+import listenbrainz_spark.year_in_music.artist_map
 import listenbrainz_spark.year_in_music.new_artists_discovered
 import listenbrainz_spark.year_in_music.tracks_of_the_year
 import listenbrainz_spark.fresh_releases.fresh_releases
@@ -58,6 +59,7 @@ functions = {
     'year_in_music.listen_count': listenbrainz_spark.year_in_music.listen_count.get_listen_count,
     'year_in_music.new_artists_discovered_count': listenbrainz_spark.year_in_music.new_artists_discovered.get_new_artists_discovered_count,
     'year_in_music.listening_time': listenbrainz_spark.year_in_music.listening_time.get_listening_time,
+    'year_in_music.artist_map': listenbrainz_spark.year_in_music.artist_map.get_artist_map_stats,
     'import.pg_metadata_tables': listenbrainz_spark.postgres.release.create_release_metadata_cache,
     'releases.fresh': listenbrainz_spark.fresh_releases.fresh_releases.main,
 }

--- a/listenbrainz_spark/year_in_music/artist_map.py
+++ b/listenbrainz_spark/year_in_music/artist_map.py
@@ -1,0 +1,80 @@
+from datetime import datetime, date, time
+
+from more_itertools import chunked
+
+import listenbrainz_spark
+from listenbrainz_spark import config
+from listenbrainz_spark.path import ARTIST_COUNTRY_CODE_DATAFRAME
+from listenbrainz_spark.postgres.artist import create_artist_country_cache
+from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import get_all_listens_from_new_dump
+
+
+USERS_PER_MESSAGE = 100
+
+
+def get_artist_map_stats(year):
+    get_all_listens_from_new_dump().createOrReplaceTempView("listens")
+    create_artist_country_cache()
+
+    listenbrainz_spark\
+        .sql_context\
+        .read\
+        .parquet(config.HDFS_CLUSTER_URI + ARTIST_COUNTRY_CODE_DATAFRAME)\
+        .createOrReplaceTempView("artist_metadata_cache")
+
+    start = datetime.combine(date(year, 1, 1), time.min)
+    end = datetime.combine(date(year, 12, 31), time.max)
+
+    query = f"""
+          WITH exploded_listens as (
+            SELECT user_id
+                 , explode(artist_credit_mbids) AS artist_mbid
+              FROM listens
+             WHERE listened_at >= to_timestamp('{start}')
+               AND listened_at <= to_timestamp('{end}')
+               AND artist_credit_mbids IS NOT NULL
+          ), artist_counts AS (
+            SELECT user_id
+                 , artist_mbid
+                 , count(artist_mbid) AS listen_count
+              FROM exploded_listens
+          GROUP BY user_id
+                 , artist_mbid  
+          ), artist_data AS (
+            SELECT user_id
+                 , artist_name
+                 , country_code AS country
+                 , artist_mbid
+                 , listen_count
+              FROM artist_counts ac
+              JOIN artist_metadata_cache amc
+             USING (artist_mbid)
+          ), user_country_data AS (
+            SELECT user_id
+                 , country
+                 , COUNT(artist_mbid) AS artist_count
+                 , SUM(listen_count) AS listen_count
+                 , sort_array(
+                        collect_list(struct(listen_count, artist_name, artist_mbid))
+                      , false
+                   ) as artists
+              FROM artist_data
+          GROUP BY user_id
+                 , country
+          ) SELECT user_id
+                 , sort_array(
+                        collect_list(struct(listen_count, country, artist_count, artists))
+                        , false
+                   ) as data
+              FROM user_country_data
+          GROUP BY user_id       
+    """
+
+    data = run_query(query)
+    for entry in chunked(data.toLocalIterator(), USERS_PER_MESSAGE):
+        yield {
+            "type": "year_in_music_artist_map",
+            "year": year,
+            "data": [row.asDict(recursive=True) for row in entry],
+        }

--- a/requirements_spark.txt
+++ b/requirements_spark.txt
@@ -10,3 +10,4 @@ pydantic == 1.8.2
 sentry-sdk == 0.20.3
 unidecode == 1.2.0
 more-itertools==8.8.0
+pycountry==22.3.5


### PR DESCRIPTION
Add the usual artist map we have in stats to YIM report. One difference in implementation is that the area containment data is copied over to spark and the countries are resolved in spark query itself because that seems more practical than calling the labs api for all users and their all this years' artists. We also resolve the ISO 3166 2 letter to 3 letter codes spark side.

# TODO
- [ ] The color scheme and layout of the artist map on YIM page needs to be fixed. 

![image](https://user-images.githubusercontent.com/27751938/210139605-9dc392ad-88cf-4fa5-92fa-d5fab09e7f7f.png)
