### PR TITLE
Fix source_patch access location in playlists

### DIFF
--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -435,12 +435,13 @@ def create(playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist
             # old collaborative playlists in the same transaction as creating new playlists, it needs to
             # to be here.
             if playlist.creator_id == TROI_BOT_USER_ID and playlist.created_for_id is not None and \
-                    playlist.additional_metadata is not None and "source_patch" in playlist.additional_metadata:
+                    playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
+                    and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
                 _remove_old_collaborative_playlists(
                     connection,
                     playlist.creator_id,
                     playlist.created_for_id,
-                    playlist.additional_metadata["source_patch"]
+                    playlist.additional_metadata["algorithm_metadata"]["source_patch"]
                 )
 
             result = connection.execute(query, fields)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.7.1
 spotipy==2.20.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@a1e12968af93d2f296a42a8094ebff83f3ed33f3
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2022-12-24
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2023-01-04
 PyYAML==6.0
 eventlet == 0.33.1
 uWSGI == 2.0.20


### PR DESCRIPTION
Old daily jams were not getting deleted because the source patch's location moved some time ago. Fix the access to ensure that old daily jams get deleted timely.