### PR TITLE
Add link to 2021 YIM on 2022 page, fix html title

### DIFF
--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -1191,7 +1191,11 @@ export default class YearInMusic extends React.Component<
               rel="noopener noreferrer"
             >
               on twitter
-            </a>
+            </a>{" "}
+            <br />
+            <br />
+            Feeling nostalgic? See your previous Year in Music:{" "}
+            <a href={`/user/${user.name}/year-in-music/2021`}>2021</a>
           </div>
           <div className="thanks-kc-green">
             With thanks to KC Green for the original &apos;this is fine&apos;

--- a/listenbrainz/webserver/templates/explore/cover-art-collage.html
+++ b/listenbrainz/webserver/templates/explore/cover-art-collage.html
@@ -1,5 +1,9 @@
 {%- extends 'base-react.html' -%}
 
+{% block title %}
+ListenBrainz Album covers of 2022
+{% endblock %}
+
 {% block head %}
    {{ super() }}
     <style type="text/css">

--- a/listenbrainz/webserver/templates/user/year-in-music.html
+++ b/listenbrainz/webserver/templates/user/year-in-music.html
@@ -1,8 +1,11 @@
 {%- extends 'base-react.html' -%}
 
+{% block title %}
+ListenBrainz Year in Music {{ year }} for {{ user_name }}
+{% endblock %}
+
 {% block head %}
    {{ super() }}
-   <title>ListenBrainz Year in Music {{ year }} for {{ user_name }}</title>
    <meta name="description" content="Check out the music review for {{ year }} that @ListenBrainz created from my listening history!" />
    <meta name="twitter:card" content="summary_large_image"></meta>
    <meta name="twitter:site" content="@listenbrainz" />


### PR DESCRIPTION


# Problem

`<title>` wasn't showing properly due to bad jinja template

Add a link to 2021 YIM on the 2022 page
