### PR TITLE
Require minimum number of users for mbid_manual_mapping_top view

### DIFF
--- a/admin/timescale/updates/2023-01-04-update-materialized-mapping-view.sql
+++ b/admin/timescale/updates/2023-01-04-update-materialized-mapping-view.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
+DROP MATERIALIZED VIEW mbid_manual_mapping_top;
+
 -- create a materialized view of the top mappings of a recording msid. top mappings are chosen
 -- by the highest number of users that have added it. if multiple mappings have same count, break
 -- ties by preferring the mapping that was created most recently. to avoid abuse, mappings are only


### PR DESCRIPTION
To avoid abuse of the manual mapping feature, require that the same mapping be created by a minimum number of different users and only then it will be considered for mbid_manual_mapping_top. This is required as the view is used for mapping other's users listens as well.