### PR TITLE
Add a note about not having a report for a user.

### DIFF
--- a/frontend/js/src/year-in-music/2021/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2021/YearInMusic.tsx
@@ -234,7 +234,7 @@ export default class YearInMusic extends React.Component<
             We don&apos;t have enough listening data for {user.name} to produce
             any statistics or playlists. (If you received an email from us
             telling you that you had a report waiting for you, we apologize 
-            for the goof-up. We don't -- 2022 continues to suck, sorry!)
+            for the goof-up. We don&apos;t -- 2022 continues to suck, sorry!)
           </h3>
           <p>
             Check out how you can submit listens by{" "}

--- a/frontend/js/src/year-in-music/2021/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2021/YearInMusic.tsx
@@ -232,7 +232,9 @@ export default class YearInMusic extends React.Component<
         <div className="flex-center flex-wrap">
           <h3>
             We don&apos;t have enough listening data for {user.name} to produce
-            any statistics or playlists.
+            any statistics or playlists. (If you received an email from us
+            telling you that you had a report waiting for you, we apologize 
+            for the goof-up. We don't -- 2022 continues to suck, sorry!)
           </h3>
           <p>
             Check out how you can submit listens by{" "}


### PR DESCRIPTION
We accidentally sent out email to people who didn't actually have a report, so adding a small apology to the landing page is probable the best we can do for now.