### PR TITLE
Improve playlist URI parsing utilities

### DIFF
--- a/frontend/js/src/playlists/utils.tsx
+++ b/frontend/js/src/playlists/utils.tsx
@@ -29,14 +29,14 @@ export function getTrackExtension(
 }
 
 export function getPlaylistId(playlist?: JSPFPlaylist): string {
-  return playlist?.identifier?.substr(PLAYLIST_URI_PREFIX.length) ?? "";
+  return playlist?.identifier?.replace(PLAYLIST_URI_PREFIX, "") ?? "";
 }
 
 export function getRecordingMBIDFromJSPFTrack(track: JSPFTrack): string {
-  return track.identifier?.substr(PLAYLIST_TRACK_URI_PREFIX.length) ?? "";
+  return track.identifier?.replace(PLAYLIST_TRACK_URI_PREFIX, "") ?? "";
 }
 export function getArtistMBIDFromURI(URI: string): string {
-  return URI?.substr(PLAYLIST_ARTIST_URI_PREFIX.length) ?? "";
+  return URI?.replace(PLAYLIST_ARTIST_URI_PREFIX, "") ?? "";
 }
 
 // Originally by Sinjai https://stackoverflow.com/a/67462589


### PR DESCRIPTION
We have some utilities that derive an MBID from a URL, but using substring which can cause issues because the format of the string is not guaranteed.
Instead, use string.replace to replace the prefix strings which will make the utility safer to use. (And won't break our YIM22 playlists artist links…)