### PR TITLE
YIM22: coverflow: load lazy image

### DIFF
--- a/frontend/js/src/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/year-in-music/2022/YearInMusic.tsx
@@ -535,7 +535,7 @@ export default class YearInMusic extends React.Component<
                     lazy={{
                       enabled: true,
                       loadPrevNext: true,
-                      loadPrevNextAmount: 4,
+                      loadPrevNextAmount: 2,
                     }}
                     watchSlidesProgress
                     navigation
@@ -547,9 +547,14 @@ export default class YearInMusic extends React.Component<
                     }}
                     breakpoints={{
                       700: {
-                        initialSlide: 2,
+                        initialSlide: 1,
                         spaceBetween: 100,
                         slidesPerView: 3,
+                        lazy: {
+                          enabled: true,
+                          loadPrevNext: true,
+                          loadPrevNextAmount: 6,
+                        },
                         coverflowEffect: {
                           rotate: 20,
                           depth: 300,


### PR DESCRIPTION
trying to fix issue with one image not lazy-loading

<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->there are variable with same name having different values and also having the error in the same properties in the line 114?



# Solution

<!-- 
   
-->i resolve the error by  giving the variable different names and also by using super properties in 114 line to describe the props variable 


# Action

<!--
  
--> could you please provide also the  resources that are suitable for this?


