### PR TITLE
Generate canonical release redirect only in the mb schema

### DIFF
--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -149,7 +149,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         # Setup all the needed objects
         can = CanonicalRecordingRedirect(mb_conn, lb_conn)
         can_rec_rel = CanonicalRecordingReleaseRedirect(mb_conn, lb_conn)
-        can_rel = CanonicalReleaseRedirect(mb_conn, lb_conn)
+        can_rel = CanonicalReleaseRedirect(mb_conn)
         releases = CanonicalMusicBrainzDataRelease(mb_conn)
         mapping = CanonicalMusicBrainzData(mb_conn, lb_conn)
         mapping.add_additional_bulk_table(can)
@@ -168,7 +168,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
-            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
+            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             mb_conn.commit()
             lb_conn.commit()
             lb_conn.close()

--- a/mbid_mapping/mapping/canonical_release_redirect.py
+++ b/mbid_mapping/mapping/canonical_release_redirect.py
@@ -34,7 +34,7 @@ class CanonicalReleaseRedirect(BulkInsertTable):
                             , cmdr.id
                             , rank() over (partition by rg.id order by cmdr.id)
                         FROM musicbrainz.release
-                        JOIN release_group rg
+                        JOIN musicbrainz.release_group rg
                           ON release.release_group = rg.id
                         JOIN mapping.canonical_musicbrainz_data_release_tmp cmdr
                           ON cmdr.release = release.id),
@@ -43,7 +43,7 @@ class CanonicalReleaseRedirect(BulkInsertTable):
                            SELECT release.gid release_mbid
                                 , rg.gid release_group_mbid
                             FROM musicbrainz.release
-                            JOIN release_group rg
+                            JOIN musicbrainz.release_group rg
                                 ON release.release_group = rg.id
                     )
                    SELECT release_rg.release_mbid


### PR DESCRIPTION
# Problem

When we have a separate mb and lb connection, some queries join with the musicbrainz tables, and therefore always need to be written to the musicbrainz connection, not the lb connection


# Solution

always write CanonicalReleaseRedirect to the mb database, like we already do with CanonicalMusicBrainzDataRelease

# Action

re-release mapper container and run a weekly update


