### PR TITLE
Add option to select the database connection to dump canonical data from

### DIFF
--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -29,9 +29,11 @@ RSYNC_FULLEXPORT_PORT="{{template "KEY" "rsync_fullexport_port"}}"
 RSYNC_FULLEXPORT_DIR="$FTP_DIR/fullexport"
 RSYNC_INCREMENTAL_DIR="$FTP_DIR/incremental"
 RSYNC_SPARK_DIR="$FTP_DIR/spark"
+RSYNC_MAPPING_DIR="$FTP_DIR/mapping"
 RSYNC_FULLEXPORT_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-full'
 RSYNC_INCREMENTAL_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-incremental'
 RSYNC_SPARK_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-spark'
+RSYNC_MAPPING_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-canonical'
 
 # Check to make sure that this container is the prod cron container, otherwise never rsync anything!
 # these variables may also be read by the dump command in python so export to ensure availability

--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -29,11 +29,11 @@ RSYNC_FULLEXPORT_PORT="{{template "KEY" "rsync_fullexport_port"}}"
 RSYNC_FULLEXPORT_DIR="$FTP_DIR/fullexport"
 RSYNC_INCREMENTAL_DIR="$FTP_DIR/incremental"
 RSYNC_SPARK_DIR="$FTP_DIR/spark"
-RSYNC_MAPPING_DIR="$FTP_DIR/mapping"
+RSYNC_MBCANONICAL_DIR="$FTP_DIR/mbcanonical"
 RSYNC_FULLEXPORT_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-full'
 RSYNC_INCREMENTAL_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-incremental'
 RSYNC_SPARK_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-spark'
-RSYNC_MAPPING_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-canonical'
+RSYNC_MBCANONICAL_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-canonical'
 
 # Check to make sure that this container is the prod cron container, otherwise never rsync anything!
 # these variables may also be read by the dump command in python so export to ensure availability

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -94,10 +94,10 @@ elif [ "$DUMP_TYPE" == "incremental" ]; then
     SUB_DIR="incremental"
 elif [ "$DUMP_TYPE" == "feedback" ]; then
     SUB_DIR="spark"
-elif [ "$DUMP_TYPE" == "mapping" ]; then
-    SUB_DIR="mapping"
+elif [ "$DUMP_TYPE" == "mbcanonical" ]; then
+    SUB_DIR="mbcanonical"
 else
-    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'incremental', 'feedback' or 'mapping'"
+    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'incremental', 'feedback' or 'mbcanonical'"
     exit
 fi
 
@@ -127,9 +127,9 @@ elif [ "$DUMP_TYPE" == "feedback" ]; then
         echo "Feedback dump failed, exiting!"
         exit 1
     fi
-elif [ "$DUMP_TYPE" == "mapping" ]; then
-    if ! /usr/local/bin/python manage.py dump create_mapping -l "$DUMP_TEMP_DIR" "$@"; then
-        echo "Mapping dump failed, exiting!"
+elif [ "$DUMP_TYPE" == "mbcanonical" ]; then
+    if ! /usr/local/bin/python manage.py dump create_mbcanonical -l "$DUMP_TEMP_DIR" "$@"; then
+        echo "MB Canonical dump failed, exiting!"
         exit 1
     fi
 else
@@ -212,7 +212,7 @@ add_rsync_include_rule \
     "listenbrainz-statistics-dump-$DUMP_TIMESTAMP.tar.xz"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
-    "metabrainz-metadata-dump-$DUMP_TIMESTAMP.tar.zst"
+    "musicbrainz-canonical-dump-$DUMP_TIMESTAMP.tar.zst"
 
 EXCLUDE_RULE="exclude *"
 echo "$EXCLUDE_RULE" >> "$FTP_CURRENT_DUMP_DIR/.rsync-filter"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -94,8 +94,10 @@ elif [ "$DUMP_TYPE" == "incremental" ]; then
     SUB_DIR="incremental"
 elif [ "$DUMP_TYPE" == "feedback" ]; then
     SUB_DIR="spark"
+elif [ "$DUMP_TYPE" == "mapping" ]; then
+    SUB_DIR="mapping"
 else
-    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'incremental' or 'feedback'"
+    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'incremental', 'feedback' or 'mapping'"
     exit
 fi
 
@@ -123,6 +125,11 @@ elif [ "$DUMP_TYPE" == "incremental" ]; then
 elif [ "$DUMP_TYPE" == "feedback" ]; then
     if ! /usr/local/bin/python manage.py dump create_feedback -l "$DUMP_TEMP_DIR" -t "$DUMP_THREADS" "$@"; then
         echo "Feedback dump failed, exiting!"
+        exit 1
+    fi
+elif [ "$DUMP_TYPE" == "mapping" ]; then
+    if ! /usr/local/bin/python manage.py dump create_mapping -l "$DUMP_TEMP_DIR" "$@"; then
+        echo "Mapping dump failed, exiting!"
         exit 1
     fi
 else
@@ -203,6 +210,9 @@ add_rsync_include_rule \
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
     "listenbrainz-statistics-dump-$DUMP_TIMESTAMP.tar.xz"
+add_rsync_include_rule \
+    "$FTP_CURRENT_DUMP_DIR" \
+    "metabrainz-metadata-dump-$DUMP_TIMESTAMP.tar.zst"
 
 EXCLUDE_RULE="exclude *"
 echo "$EXCLUDE_RULE" >> "$FTP_CURRENT_DUMP_DIR/.rsync-filter"

--- a/admin/rsync-dump-files.sh
+++ b/admin/rsync-dump-files.sh
@@ -37,11 +37,11 @@ elif [ $DUMP_TYPE == "incremental" ]; then
 elif [ $DUMP_TYPE == "feedback" ]; then
     SOURCE_DIR=$RSYNC_SPARK_DIR
     SSH_KEY=$RSYNC_SPARK_KEY
-elif [ $DUMP_TYPE == "mapping" ]; then
-    SOURCE_DIR=$RSYNC_MAPPING_DIR
-    SSH_KEY=$RSYNC_MAPPING_KEY
+elif [ $DUMP_TYPE == "mbcanonical" ]; then
+    SOURCE_DIR=$RSYNC_MBCANONICAL_DIR
+    SSH_KEY=$RSYNC_MBCANONICAL_KEY
 else
-    echo "Could not determine which directory (full, incremental or feedback) to copy over, exiting!"
+    echo "Could not determine which directory (full, incremental, feedback, mbcanonical) to copy over, exiting!"
     exit 1
 fi
 

--- a/admin/rsync-dump-files.sh
+++ b/admin/rsync-dump-files.sh
@@ -37,6 +37,9 @@ elif [ $DUMP_TYPE == "incremental" ]; then
 elif [ $DUMP_TYPE == "feedback" ]; then
     SOURCE_DIR=$RSYNC_SPARK_DIR
     SSH_KEY=$RSYNC_SPARK_KEY
+elif [ $DUMP_TYPE == "mapping" ]; then
+    SOURCE_DIR=$RSYNC_MAPPING_DIR
+    SSH_KEY=$RSYNC_MAPPING_KEY
 else
     echo "Could not determine which directory (full, incremental or feedback) to copy over, exiting!"
     exit 1

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -52,13 +52,16 @@ IS_MUSICBRAINZ_UP = {{template "KEY_JSON" "musicbrainz_up"}}
     {{if service "pgbouncer-slave"}}
     {{with index (service "pgbouncer-slave") 0}}
 MB_DATABASE_URI = 'postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrainz_db'
+MB_DATABASE_MAPPING_URI = 'postgresql://mbid_mapper@{{.Address}}:{{.Port}}/musicbrainz_db'
     {{end}}
     {{else if service "pgbouncer-master"}}
     {{with index (service "pgbouncer-master") 0}}
 MB_DATABASE_URI = 'postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrainz_db'
+MB_DATABASE_MAPPING_URI = 'postgresql://mbid_mapper@{{.Address}}:{{.Port}}/musicbrainz_db'
     {{end}}
     {{else}}
 MB_DATABASE_URI = "SERVICEDOESNOTEXIST_pgbouncer-slave_pgbouncer-master"
+MB_DATABASE_MAPPING_URI = "SERVICEDOESNOTEXIST_pgbouncer-slave_pgbouncer-master"
     {{end}}
 {{else}}
 MB_DATABASE_URI = ""

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -66,7 +66,18 @@ def send_dump_creation_notification(dump_name, dump_type):
 @cli.command(name="create_mapping")
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'),
               help="path to the directory where the dump should be made")
-def create_mapping(location):
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="Dump the metadata table from the listenbrainz database")
+def create_mapping(location, use_lb_conn):
+    """Create a dump of the canonical mapping tables. This includes the following items:
+        - metadata for canonical recordings
+        - canonical recording redirect
+        - canonical release redirect
+    These tables are created by the mapping `canonical-data` management command.
+    If canonical-data is called with --use-lb-conn then the canonical metadata and recording redirect tables will 
+       be in the listenbrainz timescale database connection
+    If called with --use-mb-conn then all tables will be in the musicbrainz database connection.
+    The canonical release redirect table will always be in the musicbrainz database connection.
+    """
     app = create_app()
     with app.app_context():
         end_time = datetime.now()
@@ -75,7 +86,7 @@ def create_mapping(location):
         dump_path = os.path.join(location, dump_name)
         create_path(dump_path)
 
-        mapping_dump.create_mapping_dump(dump_path, end_time)
+        mapping_dump.create_mapping_dump(dump_path, end_time, use_lb_conn)
         expected_num_dumps = 1
 
         try:

--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -37,12 +37,14 @@ from psycopg2.sql import SQL
 
 from listenbrainz import DUMP_LICENSE_FILE_PATH
 from brainzutils import musicbrainz_db
+from listenbrainz.db import timescale
 from listenbrainz.db.dump import _escape_table_columns
 from listenbrainz.utils import create_path
 
 
 PUBLIC_TABLES_MAPPING = {
     'mapping.canonical_musicbrainz_data': {
+        'engine': 'lb_if_set',
         'filename': 'canonical_musicbrainz_data.csv',
         'columns': (
             'id',
@@ -59,6 +61,7 @@ PUBLIC_TABLES_MAPPING = {
         ),
     },
     'mapping.canonical_recording_redirect': {
+        'engine': 'lb_if_set',
         'filename': 'canonical_recording_redirect.csv',
         'columns': (
             'recording_mbid',
@@ -67,6 +70,7 @@ PUBLIC_TABLES_MAPPING = {
         )
     },
     'mapping.canonical_release_redirect': {
+        'engine': 'mb',
         'filename': 'canonical_release_redirect.csv',
         'columns': (
             'release_mbid',
@@ -77,35 +81,8 @@ PUBLIC_TABLES_MAPPING = {
 }
 
 
-def dump_postgres_db(location, dump_time=datetime.today()):
-    """ Create a MusicBrainz canonical metadata postgres database dump in the specified location
-
-        Arguments:
-            location: Directory where the final dump will be stored
-            dump_time: datetime object representing when the dump was started
-
-        Returns:
-            the path to the dumped data
-    """
-    current_app.logger.info('Beginning dump of PostgreSQL database...')
-    current_app.logger.info('dump path: %s', location)
-
-    current_app.logger.info('Creating dump of canonical metadata data...')
-    try:
-        dump_location = create_mapping_dump(location, dump_time)
-    except Exception as e:
-        current_app.logger.critical(
-            'Unable to create canonical metadata dump due to error %s', str(e), exc_info=True)
-        current_app.logger.info('Removing created files and giving up...')
-        shutil.rmtree(location)
-        return
-
-    current_app.logger.info(
-        'MusicBrainz canonical metadata PostgreSQL data dump created at %s!', location)
-    return dump_location
-
-
-def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], tables: Optional[dict],
+def _create_dump(location: str, lb_engine: sqlalchemy.engine.Engine, 
+                mb_engine: sqlalchemy.engine.Engine, tables: dict,
                 dump_time: datetime):
     """ Creates a dump of the provided tables at the location passed
 
@@ -152,22 +129,31 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], t
             archive_tables_dir = os.path.join(temp_dir, 'metabrainz')
             create_path(archive_tables_dir)
 
-            with db_engine.connect() as connection:
-                with connection.begin() as transaction:
-                    cursor = connection.connection.cursor()
-                    for table in tables:
-                        try:
+            for table in tables:
+                try:
+                    engine_name = tables[table]['engine']
+                    if engine_name == 'mb':
+                        engine = mb_engine
+                    elif engine_name == 'lb_if_set' and lb_engine:
+                        engine = lb_engine
+                    elif engine_name == 'lb_if_set':
+                        engine = mb_engine
+                    else:
+                        raise ValueError(f'Unknown table engine name: {engine_name}')
+                    with engine.connect() as connection:
+                        with connection.begin() as transaction:
+                            cursor = connection.connection.cursor()
                             copy_table(
                                 cursor=cursor,
                                 location=archive_tables_dir,
                                 columns=tables[table]['columns'],
                                 table_name=table,
                             )
-                        except Exception as e:
-                            current_app.logger.error(
-                                'Error while copying table %s: %s', table, str(e), exc_info=True)
-                            raise
-                    transaction.rollback()
+                            transaction.rollback()
+                except Exception as e:
+                    current_app.logger.error(
+                        'Error while copying table %s: %s', table, str(e), exc_info=True)
+                    raise
 
             # Add the files to the archive in the order that they are defined in the dump definition.
             for table, tabledata in tables.items():
@@ -183,12 +169,17 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], t
     return archive_path
 
 
-def create_mapping_dump(location: str, dump_time: datetime):
+def create_mapping_dump(location: str, dump_time: datetime, use_lb_conn: bool):
     """ Create postgres database dump of the mapping supplemental tables.
     """
+    if use_lb_conn:
+        lb_engine = timescale.engine
+    else:
+        lb_engine = None
     return _create_dump(
         location=location,
-        db_engine=musicbrainz_db.engine,
+        lb_engine=lb_engine,
+        mb_engine=musicbrainz_db.engine,
         tables=PUBLIC_TABLES_MAPPING,
         dump_time=dump_time
     )

--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -97,7 +97,7 @@ def _create_dump(location: str, lb_engine: sqlalchemy.engine.Engine,
             the path to the archive file created
     """
 
-    archive_name = 'metabrainz-metadata-dump-{time}'.format(
+    archive_name = 'musicbrainz-canonical-dump-{time}'.format(
         time=dump_time.strftime('%Y%m%d-%H%M%S')
     )
     archive_path = os.path.join(location, '{archive_name}.tar.zst'.format(
@@ -126,7 +126,7 @@ def _create_dump(location: str, lb_engine: sqlalchemy.engine.Engine,
                     'Exception while adding dump metadata: %s', str(e), exc_info=True)
                 raise
 
-            archive_tables_dir = os.path.join(temp_dir, 'metabrainz')
+            archive_tables_dir = os.path.join(temp_dir, 'canonical')
             create_path(archive_tables_dir)
 
             for table in tables:
@@ -159,7 +159,7 @@ def _create_dump(location: str, lb_engine: sqlalchemy.engine.Engine,
             for table, tabledata in tables.items():
                 filename = tabledata['filename']
                 tar.add(os.path.join(archive_tables_dir, table),
-                        arcname=os.path.join(archive_name, 'metabrainz', filename))
+                        arcname=os.path.join(archive_name, 'canonical', filename))
 
             shutil.rmtree(temp_dir)
 

--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -176,6 +176,7 @@ def create_mapping_dump(location: str, dump_time: datetime, use_lb_conn: bool):
         lb_engine = timescale.engine
     else:
         lb_engine = None
+    musicbrainz_db.init_db_engine(current_app.config['MB_DATABASE_MAPPING_URI'])
     return _create_dump(
         location=location,
         lb_engine=lb_engine,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

In https://github.com/metabrainz/listenbrainz-server/pull/2157 we had one pending item:

- [x] Table generation scripts can dump into MB or LB database connection, if we want to keep this, we should modify the dump script to also be able to dump from either.

The initial version of the dump script only dumped from the musicbrainz connection, however when we create the canonical tables in the mapping container we add them to the listenbrainz connection (with the exception of the canonical release table which always goes in the musicbrainz connection, as we need to join against the release/release group tables to create it)


# Solution

duplicate the --use-lb-connection flag which is in the canonical creation command. Tables need to know if they should dump from the connection specified in the flag, or always from the mb connection

# Action

~~I don't have a setup with 2 separate db connections, so we might need to test this in prod with a testing container~~ pending the config problem below, this works and correctly generates a dump

Another pending item is to configure this management command in the cron infrastructure, probably adding it as a valid argument to `create-dumps.sh`, and then adding it to the crontab


