### PR TITLE
Fix duplicates in CF recommendations

### DIFF
--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -117,6 +117,7 @@ def process_recommendations(recommendation_df, limit):
           FROM distinct_recommendations rm
      LEFT JOIN recording_discovery rd
          USING (user_id, recording_mbid)
+      GROUP BY user_id
     """
     return run_query(query)
 

--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -85,6 +85,18 @@ def process_recommendations(recommendation_df, limit):
                  , prediction AS score
                  , row_number() OVER(PARTITION BY spark_user_id ORDER BY prediction DESC) AS rank
               FROM recommendation
+        ), distinct_recommendations AS (
+            SELECT user_id
+                 , recording_mbid
+                 , max(score) AS score
+              FROM ranked_recommendation
+              JOIN recording r
+             USING (recording_id)
+              JOIN user u
+             USING (spark_user_id)
+             WHERE rank <= {limit}
+          GROUP BY user_id
+                 , recording_mbid
         )
         SELECT user_id
              , array_sort(
@@ -102,15 +114,9 @@ def process_recommendations(recommendation_df, limit):
                                      END
                     -- sort in descending order of score
                ) AS recs
-          FROM ranked_recommendation rm
-          JOIN recording r
-         USING (recording_id)
-          JOIN user u
-         USING (spark_user_id)
+          FROM distinct_recommendations rm
      LEFT JOIN recording_discovery rd
          USING (user_id, recording_mbid)
-         WHERE rank <= {limit}
-       GROUP BY user_id
     """
     return run_query(query)
 

--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -79,19 +79,12 @@ def process_recommendations(recommendation_df, limit):
     """
     recommendation_df.createOrReplaceTempView("recommendation")
     query = f"""
-        WITH distinct_recommendations AS (
-             SELECT spark_user_id
-                  , recording_id
-                  , max(prediction) AS prediction
-              FROM recommendation
-          GROUP BY spark_user_id
-                 , recording_id       
-        ), ranked_recommendation AS (
+        WITH ranked_recommendation AS (
             SELECT spark_user_id
                  , recording_id
                  , prediction AS score
                  , row_number() OVER(PARTITION BY spark_user_id ORDER BY prediction DESC) AS rank
-              FROM distinct_recommendations
+              FROM recommendation
         )
         SELECT user_id
              , array_sort(
@@ -117,7 +110,7 @@ def process_recommendations(recommendation_df, limit):
      LEFT JOIN recording_discovery rd
          USING (user_id, recording_mbid)
          WHERE rank <= {limit}
-      GROUP BY user_id
+       GROUP BY user_id
     """
     return run_query(query)
 


### PR DESCRIPTION
Further debugging revealed that the duplicates were not being produced by Spark CF algorithm but the post processing steps actually. The recordings dataframe can have multiple entries for same recording because it dedups on (artist_credit_id, recording_mbid). While each recording always has a fixed artist_credit_id, its possible that some listens only have recording_mbid
and null artist_credit_id (user submitted mbids and not matched by mapper). Then the join to recordings df in post processing would produce duplicates.