### PR TITLE
Various mapping fixes

### DIFF
--- a/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
@@ -7,7 +7,7 @@ class ExplainMBIDMappingQuery(Query):
        Thin wrapper around the MBIDMapper used in printing the debug info for a mapping 
     """
 
-    def __init__(self, remove_stop_words=False):
+    def __init__(self, remove_stop_words=True):
         self.mapper = MBIDMapper(remove_stop_words=remove_stop_words, debug=True)
 
     def names(self):

--- a/listenbrainz/labs_api/labs/api/similar_artists.py
+++ b/listenbrainz/labs_api/labs/api/similar_artists.py
@@ -18,7 +18,7 @@ class SimilarArtistsViewerQuery(Query):
         return "similar-artists", "Similar Artists Viewer"
 
     def inputs(self):
-        return ['artist_mbid', 'algorithm']
+        return ['[artist_mbid]', 'algorithm']
 
     def introduction(self):
         return """This page allows you to view artists similar to a given artist and algorithm."""
@@ -46,7 +46,7 @@ class SimilarArtistsViewerQuery(Query):
                 JOIN mbids m
                   ON a.gid = m.gid::UUID
         """
-        results = execute_values(mb_curs, query, [(mbid,) for mbid in redirected_mbids], fetch=True)
+        results = execute_values(mb_curs, query, tuple([(mbid,) for mbid in redirected_mbids]), fetch=True)
         metadata_idx = {row["artist_mbid"]: row for row in results}
 
         metadata = []
@@ -77,7 +77,7 @@ class SimilarArtistsViewerQuery(Query):
         }
 
     def fetch(self, params, offset=-1, count=-1):
-        artist_mbids = [p["artist_credit_mbid"].strip() for p in params]
+        artist_mbids = [p["[artist_mbid]"].strip() for p in params]
         algorithm = params[0]["algorithm"].strip()
         count = count if count > 0 else 100
 

--- a/listenbrainz/labs_api/labs/api/similar_artists.py
+++ b/listenbrainz/labs_api/labs/api/similar_artists.py
@@ -18,7 +18,7 @@ class SimilarArtistsViewerQuery(Query):
         return "similar-artists", "Similar Artists Viewer"
 
     def inputs(self):
-        return ['[artist_mbid]', 'algorithm']
+        return ['artist_mbid', 'algorithm']
 
     def introduction(self):
         return """This page allows you to view artists similar to a given artist and algorithm."""
@@ -46,7 +46,7 @@ class SimilarArtistsViewerQuery(Query):
                 JOIN mbids m
                   ON a.gid = m.gid::UUID
         """
-        results = execute_values(mb_curs, query, tuple([(mbid,) for mbid in redirected_mbids]), fetch=True)
+        results = execute_values(mb_curs, query, [(mbid,) for mbid in redirected_mbids], fetch=True)
         metadata_idx = {row["artist_mbid"]: row for row in results}
 
         metadata = []
@@ -77,7 +77,7 @@ class SimilarArtistsViewerQuery(Query):
         }
 
     def fetch(self, params, offset=-1, count=-1):
-        artist_mbids = [p["[artist_mbid]"].strip() for p in params]
+        artist_mbids = [p["artist_mbid"].strip() for p in params]
         algorithm = params[0]["algorithm"].strip()
         count = count if count > 0 else 100
 

--- a/listenbrainz/labs_api/labs/api/similar_artists.py
+++ b/listenbrainz/labs_api/labs/api/similar_artists.py
@@ -77,7 +77,7 @@ class SimilarArtistsViewerQuery(Query):
         }
 
     def fetch(self, params, offset=-1, count=-1):
-        artist_mbids = [p["artist_mbid"].strip() for p in params]
+        artist_mbids = [p["artist_credit_mbid"].strip() for p in params]
         algorithm = params[0]["algorithm"].strip()
         count = count if count > 0 else 100
 

--- a/listenbrainz/labs_api/labs/api/similar_artists.py
+++ b/listenbrainz/labs_api/labs/api/similar_artists.py
@@ -77,7 +77,7 @@ class SimilarArtistsViewerQuery(Query):
         }
 
     def fetch(self, params, offset=-1, count=-1):
-        artist_mbids = [p["artist_mbid"].strip() for p in params]
+        artist_mbids = params[0]["artist_mbid"].strip().split(",")
         algorithm = params[0]["algorithm"].strip()
         count = count if count > 0 else 100
 

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -281,6 +281,15 @@ class MBIDMapper:
             'match_type': match_type
         }
 
+    def remove_obvious_bullshit_from_recording_name(self, recording_name):
+        """
+            If recordings have clear patterns of bad data being appended to them 
+            (e.g. spotify's '- 2008 Remaster') remove that shit before feeding
+            it to the mapper.
+        """
+
+        return re.sub("\s+-\s+\d\d\d\d.*master", "", recording_name)
+
     def search(self, artist_credit_name, recording_name):
         """
             Main query body: Prepare the search query terms and prepare
@@ -289,6 +298,8 @@ class MBIDMapper:
             query terms. Return a match dict (properly formatted for this
             query) or None if not match.
         """
+
+        recording_name = self.remove_obvious_bullshit_from_recording_name(recording_name)
 
         artist_credit_name_p = prepare_query(artist_credit_name)
         recording_name_p = prepare_query(recording_name)


### PR DESCRIPTION
This PR fixes two separate issues:

- Make stop word removal the same for mbid mapping and mapping explain
- Remove known BS from recording names before looking them up. First up: "- YYYY remaster" at the end of recording names.