### PR TITLE
Return artist mbids as comma separated instead of postgres array format

### DIFF
--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -47,7 +47,7 @@ PUBLIC_TABLES_MAPPING = {
         'columns': (
             'id',
             'artist_credit_id',
-            'artist_mbids',
+            SQL("array_to_string(artist_mbids, ',') AS artist_mbids"),
             'artist_credit_name',
             'release_mbid',
             'release_name',


### PR DESCRIPTION
Without the cast multiple MBIDs will be returned from the query as

    {mbid,mbid}

which means that you would need to strip the {} before using it. This change makes it display as

    "mbid,mbid"

and the field is correctly quoted even when dumping to CSV

