### PR TITLE
Upgrade actions versions

### DIFF
--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -28,7 +28,7 @@ jobs:
       if: github.event.pull_request.draft == false
 
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -19,16 +19,16 @@ jobs:
       run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
     
     - name: Docker Setup Buildx
-      uses: docker/setup-buildx-action@v1.3.0
+      uses: docker/setup-buildx-action@v2
       
     - name: Docker Login
-      uses: docker/login-action@v1.9.0
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
         
     - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
+      uses: docker/build-push-action@v4
       with:
         build-args: GIT_COMMIT_SHA=${{ steps.get_tag.outputs.TAG }}
         cache-from: metabrainz/listenbrainz:cache

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
@@ -38,7 +38,7 @@ jobs:
     # We do not use this to install node but only to register problem matchers
     # so that eslint annotations work.
     - name: Setup Node.js environment to enable annotations
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
 
     - name: Build frontend containers
       run: ./test.sh fe -b

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create configuration file
       run: cp listenbrainz/config.py.sample listenbrainz/config.py


### PR DESCRIPTION

# Problem

Some actions show warnings when they are run. Checkout v2 says that it's running on an old version of node which is no longer supported.
The docker actions show a number of warnings about features that will be disabled some time in 2023.



# Solution

Upgrade to the latest version of actions, according to their documentation


# Action

The changes from checkout v2 to v3 should be fine - we already have some actions using checkout v3 anyway.
We'll need to run a prod build to test the upgrades to the docker actions - I didn't check to see if any of the parameters have changed or not between versions


