### PR TITLE
Create mbcanonical data dumps twice a month

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -46,5 +46,9 @@ MAILTO=""
 # run daily cron job to refresh top msid-mbid mappings
 0 7 * * * root /usr/local/bin/python /code/listenbrainz/manage.py refresh-top-manual-mappings >> /logs/top_manual_mappings.log 2>&1
 
+## Trigger a canonical dump on 3rd and 17th of every month do not block to wait for lock.
+# The canonical tables are re-generated every day at 4am, so do this later in order to get today's data
+0 8 3,17 * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh mbcanonical >> /logs/dumps.log 2>&1
+
 # run weekly cron job to remove expired do not recommends
 0 8 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py clear-expired-do-not-recommends >> /logs/do_not_recommend.log 2>&1


### PR DESCRIPTION
# Problem

We have newly created mb canonical data dumps. We decided to generate them twice a month.
I chose the 3rd/17th so that it doesn't conflict with the full dumps, however this dataset takes less than 10 minutes to generate.

The cron job to re-generate our mapping tables runs in the mbid_mapping container, and happens each day at 4am. In my experience this only takes a few hours to run, so I set this job to run at 8am. If we think that this isn't enough time to get "today's" dump in place, we could delay it further.

Alternatively we could just run it at 1am, and use the data from the day before.


