### PR TITLE
Fix util methods in case of missing metadata

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -553,7 +553,7 @@ const getAlbumArtFromListenMetadata = async (
   // directly access additional_info.release_mbid instead of using getReleaseMBID because we only want
   // to query CAA for user submitted mbids.
   const userSubmittedReleaseMBID =
-    listen.track_metadata.additional_info?.release_mbid;
+    listen.track_metadata?.additional_info?.release_mbid;
   if (userSubmittedReleaseMBID) {
     const userSubmittedReleaseAlbumArt = await getAlbumArtFromReleaseMBID(
       userSubmittedReleaseMBID
@@ -564,8 +564,8 @@ const getAlbumArtFromListenMetadata = async (
     }
   }
   // user submitted release mbids not found, check if there is a match from mbid mapper.
-  const caaId = listen.track_metadata.mbid_mapping?.caa_id;
-  const caaReleaseMbid = listen.track_metadata.mbid_mapping?.caa_release_mbid;
+  const caaId = listen.track_metadata?.mbid_mapping?.caa_id;
+  const caaReleaseMbid = listen.track_metadata?.mbid_mapping?.caa_release_mbid;
   if (caaId && caaReleaseMbid) {
     return generateAlbumArtThumbnailLink(caaId, caaReleaseMbid);
   }

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -164,7 +164,7 @@ const getArtistName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
   _.get(listen, "creator", "");
 
 const getArtistLink = (listen: Listen) => {
-  const artists = listen.track_metadata.mbid_mapping?.artists;
+  const artists = listen.track_metadata?.mbid_mapping?.artists;
   if (artists?.length) {
     return (
       <>


### PR DESCRIPTION
The `track_metadata` in a listen can be missing in some edge cases*, so we need to make it an optional access in some utility functions 

* track_metadata is null when the data is missing from mb_metadata_cache tables, which usually is a bug or if the track was pinned from now playing and actual listen hasn't yet arrived in LB yet (temporary error resolves itself in a few mins usually)