### PR TITLE
LB-1221: Feedback API endpoint returns confusing total_count

### DIFF
--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -504,7 +504,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         data = json.loads(response.data)
 
         self.assertEqual(data["count"], 2)
-        self.assertEqual(data["total_count"], len(inserted_rows))
+        self.assertEqual(data["total_count"], 2)
         self.assertEqual(data["offset"], 0)
 
         feedback = data["feedback"]  # sorted in descending order of their creation
@@ -527,7 +527,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         data = json.loads(response.data)
 
         self.assertEqual(data["count"], 2)
-        self.assertEqual(data["total_count"], len(inserted_rows))
+        self.assertEqual(data["total_count"], 2)
         self.assertEqual(data["offset"], 0)
 
         feedback = data["feedback"]  # sorted in descending order of their creation

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -111,7 +111,7 @@ def get_feedback_for_user(user_name):
             log_raise_400("Score can have a value of 1 or -1.", request.args)
 
     feedback = db_feedback.get_feedback_for_user(user_id=user["id"], limit=count, offset=offset, score=score, metadata=metadata)
-    total_count = db_feedback.get_feedback_count_for_user(user["id"])
+    total_count = db_feedback.get_feedback_count_for_user(user["id"], score)
 
     feedback = [fb.to_api() for fb in feedback]
 


### PR DESCRIPTION
Pass missing score param to get_feedback_count_for_user.