### PR TITLE
Add lookups to allow choosing a particular release for mapping

### DIFF
--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
@@ -1,19 +1,9 @@
 #!/usr/bin/env python3
 
-import re
-
-import psycopg2
-import psycopg2.extras
-from datasethoster import Query
-from unidecode import unidecode
-from listenbrainz import config
+from listenbrainz.labs_api.labs.api.recording_lookup_base import RecordingLookupBaseQuery
 
 
-class ArtistCreditRecordingLookupQuery(Query):
-
-    def __init__(self, debug=False):
-        self.debug = debug
-        self.log_lines = []
+class ArtistCreditRecordingLookupQuery(RecordingLookupBaseQuery):
 
     def names(self):
         return ("acr-lookup", "MusicBrainz Artist Credit Recording lookup")
@@ -25,59 +15,8 @@ class ArtistCreditRecordingLookupQuery(Query):
         return """This lookup performs an semi-exact string match on Artist Credit and Recording. The given parameters will have non-word
                   characters removed, unaccented and lower cased before being looked up in the database."""
 
-    def outputs(self):
-        return ['index', 'artist_credit_arg', 'recording_arg',
-                'artist_credit_name', 'release_name', 'recording_name',
-                'artist_credit_id', 'artist_mbids', 'release_mbid', 'recording_mbid', 'year']
+    def get_lookup_string(self, param) -> str:
+        return param["[artist_credit_name]"] + param["[recording_name]"]
 
-    def get_debug_log_lines(self):
-        lines = self.log_lines
-        self.log_lines = []
-        return lines
-
-    def fetch(self, params, offset=-1, count=-1):
-        lookup_strings = []
-        string_index = {}
-        for i, param in enumerate(params):
-            cleaned = unidecode(re.sub(
-                r'[^\w]+', '', param["[artist_credit_name]"] + param["[recording_name]"]).lower())
-            lookup_strings.append(cleaned)
-            string_index[cleaned] = i
-
-        lookup_strings = tuple(lookup_strings)
-
-        with psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI) as conn:
-            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
-                curs.execute("""SELECT artist_credit_name,
-                                       artist_credit_id,
-                                       artist_mbids::TEXT[],
-                                       release_name,
-                                       release_mbid,
-                                       recording_name,
-                                       recording_mbid::TEXT,
-                                       year,
-                                       combined_lookup
-                                  FROM mapping.canonical_musicbrainz_data
-                                 WHERE combined_lookup IN %s""", (lookup_strings,))
-
-                results = []
-                while True:
-                    data = curs.fetchone()
-                    if not data:
-                        break
-
-                    data = dict(data)
-                    index = string_index[data["combined_lookup"]]
-                    data["recording_arg"] = params[index]["[recording_name]"]
-                    data["artist_credit_arg"] = params[index]["[artist_credit_name]"]
-                    data["index"] = index
-                    results.append(data)
-
-                    if self.debug:
-                        self.log_lines.append(
-                            "exact match: '%s' '%s' %s" %
-                            (data['artist_credit_name'],
-                             data['recording_name'],
-                             data['recording_mbid']))
-
-                return results
+    def get_table_name(self) -> str:
+        return "mapping.canonical_musicbrainz_data"

--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_lookup.py
@@ -6,7 +6,7 @@ from listenbrainz.labs_api.labs.api.recording_lookup_base import RecordingLookup
 class ArtistCreditRecordingLookupQuery(RecordingLookupBaseQuery):
 
     def names(self):
-        return ("acr-lookup", "MusicBrainz Artist Credit Recording lookup")
+        return "acr-lookup", "MusicBrainz Artist Credit Recording lookup"
 
     def inputs(self):
         return ['[artist_credit_name]', '[recording_name]']

--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_release_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_release_lookup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from listenbrainz.labs_api.labs.api.recording_lookup_base import RecordingLookupBaseQuery
+
+
+class ArtistCreditRecordingReleaseLookupQuery(RecordingLookupBaseQuery):
+
+    def get_table_name(self) -> str:
+        return "mapping.canonical_musicbrainz_data_release"
+
+    def get_lookup_string(self, param) -> str:
+        return param["[artist_credit_name]"] + param["[recording_name]"] + param["[release_name]"]
+
+    def names(self):
+        return "acr-lookup", "MusicBrainz Artist Credit Recording Release lookup"
+
+    def inputs(self):
+        return ['[artist_credit_name]', '[recording_name]', '[release_name]']
+
+    def introduction(self):
+        return """
+            This lookup performs an semi-exact string match on Artist Credit, Recording and Release. The given
+            parameters will have non-word characters removed, unaccented and lower cased before being looked up
+            in the database.
+        """

--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_release_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_release_lookup.py
@@ -6,7 +6,7 @@ from listenbrainz.labs_api.labs.api.recording_lookup_base import RecordingLookup
 class ArtistCreditRecordingReleaseLookupQuery(RecordingLookupBaseQuery):
 
     def get_table_name(self) -> str:
-        return "mapping.canonical_musicbrainz_data_release"
+        return "mapping.canonical_musicbrainz_data_release_support"
 
     def get_lookup_string(self, param) -> str:
         return param["[artist_credit_name]"] + param["[recording_name]"] + param["[release_name]"]

--- a/listenbrainz/labs_api/labs/api/artist_credit_recording_release_lookup.py
+++ b/listenbrainz/labs_api/labs/api/artist_credit_recording_release_lookup.py
@@ -12,7 +12,7 @@ class ArtistCreditRecordingReleaseLookupQuery(RecordingLookupBaseQuery):
         return param["[artist_credit_name]"] + param["[recording_name]"] + param["[release_name]"]
 
     def names(self):
-        return "acr-lookup", "MusicBrainz Artist Credit Recording Release lookup"
+        return "acrr-lookup", "MusicBrainz Artist Credit Recording Release lookup"
 
     def inputs(self):
         return ['[artist_credit_name]', '[recording_name]', '[release_name]']

--- a/listenbrainz/labs_api/labs/api/base_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/api/base_mbid_mapping.py
@@ -1,0 +1,19 @@
+from datasethoster import Query
+from listenbrainz.mbid_mapping_writer.mbid_mapper import MBIDMapper
+
+
+class BaseMBIDMappingQuery(Query):
+    """
+       Thin wrapper around the MBIDMapper -- see mbid_mapper.py for details.
+    """
+
+    def __init__(self, timeout=10, remove_stop_words=True, debug=False):
+        self.mapper = MBIDMapper(timeout=timeout, remove_stop_words=remove_stop_words, debug=debug)
+
+    def outputs(self):
+        return ['index', 'artist_credit_arg', 'recording_arg',
+                'artist_credit_name', 'artist_mbids', 'release_name', 'recording_name',
+                'release_mbid', 'recording_mbid', 'artist_credit_id', 'year']
+
+    def get_debug_log_lines(self):
+        return self.mapper.read_log()

--- a/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
@@ -14,7 +14,7 @@ class ExplainMBIDMappingQuery(Query):
         return ("explain-mbid-mapping", "Explain MusicBrainz ID Mapping lookup")
 
     def inputs(self):
-        return ['artist_credit_name', 'recording_name']
+        return ['artist_credit_name', 'recording_name', 'release_name']
 
     def introduction(self):
         return """Given the name of an artist and the name of a recording (track)
@@ -25,7 +25,7 @@ class ExplainMBIDMappingQuery(Query):
 
     def fetch(self, params, offset=-1, count=-1):
         """ Call the MBIDMapper and carry out this mapping search """
-        hit = self.mapper.search(params[0]["artist_credit_name"], params[0]["recording_name"])
+        hit = self.mapper.search(params[0]["artist_credit_name"], params[0]["recording_name"], params[0].get("release_name"))
 
         results = [
             {

--- a/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
@@ -11,7 +11,7 @@ class ExplainMBIDMappingQuery(Query):
         self.mapper = MBIDMapper(remove_stop_words=remove_stop_words, debug=True)
 
     def names(self):
-        return ("explain-mbid-mapping", "Explain MusicBrainz ID Mapping lookup")
+        return "explain-mbid-mapping", "Explain MusicBrainz ID Mapping lookup"
 
     def inputs(self):
         return ['artist_credit_name', 'recording_name', 'release_name']

--- a/listenbrainz/labs_api/labs/api/mbid_mapping_release.py
+++ b/listenbrainz/labs_api/labs/api/mbid_mapping_release.py
@@ -4,19 +4,19 @@ from listenbrainz.labs_api.labs.api.base_mbid_mapping import BaseMBIDMappingQuer
 from listenbrainz.mbid_mapping_writer.mbid_mapper import MBIDMapper
 
 
-class MBIDMappingQuery(BaseMBIDMappingQuery):
+class MBIDMappingReleaseQuery(BaseMBIDMappingQuery):
     """
        Thin wrapper around the MBIDMapper -- see mbid_mapper.py for details.
     """
 
     def names(self):
-        return "mbid-mapping", "MusicBrainz ID Mapping lookup"
+        return "mbid-mapping-release", "MusicBrainz ID Mapping Release lookup"
 
     def inputs(self):
-        return ['[artist_credit_name]', '[recording_name]']
+        return ['[artist_credit_name]', '[recording_name]', '[release_name]']
 
     def introduction(self):
-        return """Given the name of an artist and the name of a recording (track)
+        return """Given the name of an artist, a release and the name of a recording (track)
                   this query will attempt to find a suitable match in MusicBrainz."""
 
     def fetch(self, params, offset=-1, count=-1):
@@ -24,15 +24,15 @@ class MBIDMappingQuery(BaseMBIDMappingQuery):
 
         args = []
         for i, param in enumerate(params):
-            args.append((i, param['[artist_credit_name]'],
-                         param['[recording_name]']))
+            args.append((i, param['[artist_credit_name]'], param['[recording_name]'], param['release_name']))
 
         results = []
-        for index, artist_credit_name, recording_name in args:
+        for index, artist_credit_name, recording_name, release_name in args:
             hit = self.mapper.search(artist_credit_name, recording_name)
             if hit:
                 hit["artist_credit_arg"] = artist_credit_name
                 hit["recording_arg"] = recording_name
+                hit["release_arg"] = release_name
                 hit["index"] = index
                 results.append(hit)
 

--- a/listenbrainz/labs_api/labs/api/mbid_mapping_release.py
+++ b/listenbrainz/labs_api/labs/api/mbid_mapping_release.py
@@ -24,7 +24,7 @@ class MBIDMappingReleaseQuery(BaseMBIDMappingQuery):
 
         args = []
         for i, param in enumerate(params):
-            args.append((i, param['[artist_credit_name]'], param['[recording_name]'], param['release_name']))
+            args.append((i, param['[artist_credit_name]'], param['[recording_name]'], param['[release_name]']))
 
         results = []
         for index, artist_credit_name, recording_name, release_name in args:

--- a/listenbrainz/labs_api/labs/api/recording_lookup_base.py
+++ b/listenbrainz/labs_api/labs/api/recording_lookup_base.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import abc
+import re
+from abc import ABC
+
+import psycopg2
+import psycopg2.extras
+from datasethoster import Query
+from unidecode import unidecode
+from listenbrainz import config
+
+
+class RecordingLookupBaseQuery(Query, ABC):
+
+    def __init__(self, debug=False):
+        self.debug = debug
+        self.log_lines = []
+
+    def setup(self):
+        pass
+
+    def outputs(self):
+        return ['index', 'artist_credit_arg', 'recording_arg',
+                'artist_credit_name', 'release_name', 'recording_name',
+                'artist_credit_id', 'artist_mbids', 'release_mbid', 'recording_mbid', 'year']
+
+    def get_debug_log_lines(self):
+        lines = self.log_lines
+        self.log_lines = []
+        return lines
+
+    @abc.abstractmethod
+    def get_lookup_string(self, param) -> str:
+        pass
+
+    @abc.abstractmethod
+    def get_table_name(self) -> str:
+        pass
+
+    def fetch(self, params, offset=-1, count=-1):
+        lookup_strings = []
+        string_index = {}
+        for i, param in enumerate(params):
+            cleaned = unidecode(re.sub(r'[^\w]+', '', self.get_lookup_string(param)).lower())
+            lookup_strings.append(cleaned)
+            string_index[cleaned] = i
+
+        lookup_strings = tuple(lookup_strings)
+
+        with psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI) as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+                curs.execute(f"""
+                    SELECT artist_credit_name
+                         , artist_credit_id
+                         , artist_mbids::TEXT[]
+                         , release_name
+                         , release_mbid
+                         , recording_name
+                         , recording_mbid::TEXT
+                         , year
+                         , combined_lookup
+                      FROM {self.get_table_name()}
+                     WHERE combined_lookup IN %s""", (lookup_strings,))
+
+                results = []
+                while True:
+                    data = curs.fetchone()
+                    if not data:
+                        break
+
+                    data = dict(data)
+                    index = string_index[data["combined_lookup"]]
+                    data["recording_arg"] = params[index]["[recording_name]"]
+                    data["artist_credit_arg"] = params[index]["[artist_credit_name]"]
+                    if params[index].get("[release_name]") is not None:
+                        data["release_name_arg"] = params[index]["[release_name]"]
+                    data["index"] = index
+                    results.append(data)
+
+                    if self.debug:
+                        self.log_lines.append(
+                            "exact match: '%s' '%s' '%s' %s" %
+                            (data['artist_credit_name'],
+                             data['recording_name'],
+                             data['release_name'],
+                             data['recording_mbid']))
+
+                return results

--- a/listenbrainz/labs_api/labs/api/recording_search.py
+++ b/listenbrainz/labs_api/labs/api/recording_search.py
@@ -3,7 +3,7 @@ import typesense.exceptions
 from datasethoster import Query
 
 from listenbrainz import config
-from listenbrainz.mbid_mapping_writer.mbid_mapper import prepare_query, COLLECTION_NAME
+from listenbrainz.mbid_mapping_writer.mbid_mapper import prepare_query, COLLECTION_NAME_WITHOUT_RELEASE
 
 
 NUM_TYPOS = 5
@@ -55,8 +55,7 @@ class RecordingSearchQuery(Query):
             'num_typos': NUM_TYPOS
         }
 
-        hits = self.client.collections[COLLECTION_NAME].documents.search(
-            search_parameters)
+        hits = self.client.collections[COLLECTION_NAME_WITHOUT_RELEASE].documents.search(search_parameters)
 
         output = []
         for hit in hits['hits']:

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -3,6 +3,8 @@ import psycopg2.extras
 from datasethoster.main import create_app, init_sentry, register_query
 from listenbrainz.labs_api.labs.api.artist_country_from_artist_mbid import ArtistCountryFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_mbid import ArtistCreditIdFromArtistMBIDQuery
+from listenbrainz.labs_api.labs.api.artist_credit_recording_release_lookup import \
+    ArtistCreditRecordingReleaseLookupQuery
 from listenbrainz.labs_api.labs.api.recording_from_recording_mbid import RecordingFromRecordingMBIDQuery
 from listenbrainz.labs_api.labs.api.mbid_mapping import MBIDMappingQuery
 from listenbrainz.labs_api.labs.api.explain_mbid_mapping import ExplainMBIDMappingQuery
@@ -24,6 +26,7 @@ register_query(MBIDMappingQuery())
 register_query(ExplainMBIDMappingQuery())
 register_query(RecordingSearchQuery())
 register_query(ArtistCreditRecordingLookupQuery())
+register_query(ArtistCreditRecordingReleaseLookupQuery())
 register_query(SpotifyIdFromMetadataQuery())
 register_query(SpotifyIdFromMBIDQuery())
 register_query(UserListensSessionQuery())

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -5,6 +5,7 @@ from listenbrainz.labs_api.labs.api.artist_country_from_artist_mbid import Artis
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_mbid import ArtistCreditIdFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_recording_release_lookup import \
     ArtistCreditRecordingReleaseLookupQuery
+from listenbrainz.labs_api.labs.api.mbid_mapping_release import MBIDMappingReleaseQuery
 from listenbrainz.labs_api.labs.api.recording_from_recording_mbid import RecordingFromRecordingMBIDQuery
 from listenbrainz.labs_api.labs.api.mbid_mapping import MBIDMappingQuery
 from listenbrainz.labs_api.labs.api.explain_mbid_mapping import ExplainMBIDMappingQuery
@@ -23,6 +24,7 @@ register_query(ArtistCountryFromArtistMBIDQuery())
 register_query(ArtistCreditIdFromArtistMBIDQuery())
 register_query(RecordingFromRecordingMBIDQuery())
 register_query(MBIDMappingQuery())
+register_query(MBIDMappingReleaseQuery())
 register_query(ExplainMBIDMappingQuery())
 register_query(RecordingSearchQuery())
 register_query(ArtistCreditRecordingLookupQuery())

--- a/listenbrainz/labs_api/labs/tests/test_explain_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/tests/test_explain_mbid_mapping.py
@@ -178,5 +178,5 @@ class MainTestCase(flask_testing.TestCase):
         self.assertEqual(q.names()[0], "explain-mbid-mapping")
         self.assertEqual(q.names()[1], "Explain MusicBrainz ID Mapping lookup")
         self.assertNotEqual(q.introduction(), "")
-        self.assertEqual(q.inputs(), ['artist_credit_name', 'recording_name'])
+        self.assertEqual(q.inputs(), ['artist_credit_name', 'recording_name', 'release_name'])
         self.assertEqual(q.outputs(), None)

--- a/listenbrainz/labs_api/labs/tests/test_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/tests/test_mbid_mapping.py
@@ -33,7 +33,7 @@ typesense_response_0 = [
             "document": {
                 "artist_credit_arg": "u2",
                 "artist_credit_id": 197,
-                "artist_mbids": ["a3cb23fc-acd3-4ce0-8f36-1e5aa6a18432"],
+                "artist_mbids": "{a3cb23fc-acd3-4ce0-8f36-1e5aa6a18432}",
                 "artist_credit_name": "U2",
                 "recording_arg": "gloria",
                 "recording_mbid": "398a5f12-80ba-4d29-8b6b-bfe2176341a6",
@@ -51,7 +51,7 @@ typesense_response_0 = [
                 "document": {
                     "artist_credit_arg": "portishead",
                     "artist_credit_id": 65,
-                    "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"],
+                    "artist_mbids": "{8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11}",
                     "artist_credit_name": "Portishead",
                     "recording_arg": "strangers",
                     "recording_mbid": "e97f805a-ab48-4c52-855e-07049142113d",
@@ -71,7 +71,7 @@ typesense_response_0 = [
             "document": {
                 "artist_credit_arg": "portishead",
                 "artist_credit_id": 65,
-                "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"],
+                "artist_mbids": "{8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11}",
                 "artist_credit_name": "Portishead",
                 "recording_arg": "glory box (feat. your mom)",
                 "recording_mbid": "145f5c43-0ac2-4886-8b09-63d0e92ded5d",
@@ -92,7 +92,7 @@ typesense_response_1 = [
                 "document": {
                     "artist_credit_arg": "portishead",
                     "artist_credit_id": 65,
-                    "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"],
+                    "artist_mbids": "{8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11}",
                     "artist_credit_name": "Portishead",
                     "recording_arg": "strangers",
                     "recording_mbid": "e97f805a-ab48-4c52-855e-07049142113d",

--- a/listenbrainz/labs_api/labs/tests/test_recording_search.py
+++ b/listenbrainz/labs_api/labs/tests/test_recording_search.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import flask_testing
 from datasethoster.main import create_app
 from listenbrainz.labs_api.labs.api.recording_search import RecordingSearchQuery
-from listenbrainz.mbid_mapping_writer.mbid_mapper import COLLECTION_NAME
 
 
 json_request = [

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -101,7 +101,7 @@ class MBIDMapper:
         # Yes, this is actually correct.
         return ""
 
-    def compare(self, artist_credit_name, artist_credit_name_hit, recording_name, recording_name_hit, release_name=None, release_name_hit=None):
+    def compare(self, artist_credit_name, artist_credit_name_hit, recording_name, recording_name_hit, release_name=None, release_name_hit=None) -> tuple[int, int, int]:
         """
             Compare the fields, print debug info if turned on, and return edit distance as (a_dist, r_dist)
         """
@@ -137,26 +137,26 @@ class MBIDMapper:
         if (is_ac_detuned or is_r_detuned or is_rel_detuned) and \
                 ac_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
                 r_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
-                (rel_dist is None or rel_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE):
+                rel_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE:
             self._log(match_details % "low quality")
             return ac_dist, r_dist, rel_dist, MATCH_TYPE_LOW_QUALITY
 
         # For exact matches, return exact match. duh.
-        if ac_dist == 0 and r_dist == 0 and (rel_dist is None or rel_dist == 0):
+        if ac_dist == 0 and r_dist == 0 and (rel_dist == -1 or rel_dist == 0):
             self._log(match_details % "exact match")
             return ac_dist, r_dist, rel_dist, MATCH_TYPE_EXACT_MATCH
 
         # If both fields are above the high quality threshold, call it high quality
         if ac_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE and \
                 r_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE and \
-                (rel_dist is None or rel_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE):
+                rel_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE:
             self._log(match_details % "high quality")
             return ac_dist, r_dist, rel_dist, MATCH_TYPE_HIGH_QUALITY
 
         # If both fields are above the medium quality threshold, call it medium quality
         if ac_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
                 r_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
-                (rel_dist is None or rel_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE):
+                rel_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE:
             self._log(match_details % "med quality")
             return ac_dist, r_dist, rel_dist, MATCH_TYPE_MED_QUALITY
 

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -12,7 +12,8 @@ from listenbrainz import config
 from listenbrainz.mbid_mapping_writer.stop_words import ENGLISH_STOP_WORDS
 
 DEFAULT_TIMEOUT = 2
-COLLECTION_NAME = "canonical_musicbrainz_data_latest"
+COLLECTION_NAME_WITHOUT_RELEASE = "canonical_musicbrainz_data_latest"
+COLLECTION_NAME_WITH_RELEASE = "canonical_musicbrainz_data_release_latest"
 MATCH_TYPES = ('no_match', 'low_quality', 'med_quality', 'high_quality', 'exact_match')
 MATCH_TYPE_NO_MATCH = 0
 MATCH_TYPE_LOW_QUALITY = 1
@@ -100,59 +101,68 @@ class MBIDMapper:
         # Yes, this is actually correct.
         return ""
 
-    def compare(self, artist_credit_name, recording_name, artist_credit_name_hit, recording_name_hit):
+    def compare(self, artist_credit_name, artist_credit_name_hit, recording_name, recording_name_hit, release_name=None, release_name_hit=None):
         """
             Compare the fields, print debug info if turned on, and return edit distance as (a_dist, r_dist)
         """
+        self._log(Markup(f"""QUERY: artist: <b>{artist_credit_name}</b> recording: <b>{recording_name}</b> release: <b>{release_name}</b>"""))
+        self._log(Markup(f"""HIT: artist: <b>{artist_credit_name_hit}</b> recording: <b>{recording_name_hit}</b> recording: <b>{release_name_hit}</b>"""))
 
-        self._log(Markup(f"""QUERY: artist: <b>{artist_credit_name}</b> recording: <b>{recording_name}</b>"""))
-        self._log(Markup(f"""HIT: artist: <b>{artist_credit_name_hit}</b> recording: <b>{recording_name_hit}</b>"""))
+        if release_name is not None and release_name_hit is not None:
+            release_distance = distance(release_name, release_name_hit)
+        else:
+            release_distance = None
 
-        return distance(artist_credit_name, artist_credit_name_hit), distance(recording_name, recording_name_hit)
+        return distance(artist_credit_name, artist_credit_name_hit), distance(recording_name, recording_name_hit), release_distance
 
-    def check_hit_in_threshold(self, artist_credit_name, recording_name, ac_hit, r_hit, is_ac_detuned, is_r_detuned):
+    def check_hit_in_threshold(self, artist_credit_name, recording_name, release_name, ac_hit, r_hit, rel_hit, is_ac_detuned, is_r_detuned, is_rel_detuned):
         """
             Check whether the artist and recording name found by typesense search match to the input
             artist and recording name. An exact match is performed first then falling back to a fuzzy
             match within desired threshold. The is_ac_detuned and is_r_detuned args denote whether the
             input artist and recording name are unmodified or detuned.
         """
-        ac_dist, r_dist = self.compare(
+        ac_dist, r_dist, rel_dist = self.compare(
             artist_credit_name,
-            recording_name,
             prepare_query(ac_hit),
-            prepare_query(r_hit)
+            recording_name,
+            prepare_query(r_hit),
+            release_name,
+            prepare_query(rel_hit)
         )
-        match_details = Markup(f"""<b>%s</b>: ac_detuned {is_ac_detuned}, r_detuned {is_r_detuned},
+        match_details = Markup(f"""<b>%s</b>: ac_detuned {is_ac_detuned}, r_detuned {is_r_detuned}, rel_detuned {is_rel_detuned}
         ac_dist {ac_dist:.3f} r_dist {r_dist:.3f}""")
 
         # If we detuned one or more fields and it matches, the best it can get is a low quality match
-        if (is_ac_detuned or is_r_detuned) and \
+        if (is_ac_detuned or is_r_detuned or is_rel_detuned) and \
                 ac_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
-                r_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE:
+                r_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
+                (rel_dist is None or rel_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE):
             self._log(match_details % "low quality")
-            return ac_dist, r_dist, MATCH_TYPE_LOW_QUALITY
+            return ac_dist, r_dist, rel_dist, MATCH_TYPE_LOW_QUALITY
 
         # For exact matches, return exact match. duh.
-        if ac_dist == 0 and r_dist == 0:
+        if ac_dist == 0 and r_dist == 0 and (rel_dist is None or rel_dist == 0):
             self._log(match_details % "exact match")
-            return ac_dist, r_dist, MATCH_TYPE_EXACT_MATCH
+            return ac_dist, r_dist, rel_dist, MATCH_TYPE_EXACT_MATCH
 
         # If both fields are above the high quality threshold, call it high quality
         if ac_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE and \
-                r_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE:
+                r_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE and \
+                (rel_dist is None or rel_dist <= self.MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE):
             self._log(match_details % "high quality")
-            return ac_dist, r_dist, MATCH_TYPE_HIGH_QUALITY
+            return ac_dist, r_dist, rel_dist, MATCH_TYPE_HIGH_QUALITY
 
         # If both fields are above the medium quality threshold, call it medium quality
         if ac_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
-                r_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE:
+                r_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and \
+                (rel_dist is None or rel_dist <= self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE):
             self._log(match_details % "med quality")
-            return ac_dist, r_dist, MATCH_TYPE_MED_QUALITY
+            return ac_dist, r_dist, rel_dist, MATCH_TYPE_MED_QUALITY
 
-        return ac_dist, r_dist, MATCH_TYPE_NO_MATCH
+        return ac_dist, r_dist, rel_dist, MATCH_TYPE_NO_MATCH
 
-    def evaluate_hit(self, hit, artist_credit_name, recording_name, is_ac_detuned, is_r_detuned):
+    def evaluate_hit(self, hit, artist_credit_name, recording_name, release_name, is_ac_detuned, is_r_detuned, is_rel_detuned):
         """
             Evaluate the given prepared search terms and hit. If the hit doesn't match,
             attempt to detune it and try again for detuned artist and detuned recording.
@@ -160,17 +170,22 @@ class MBIDMapper:
         """
         ac_hit = hit['document']['artist_credit_name']
         r_hit = hit['document']['recording_name']
+        rel_hit = hit['document']['release_name']
 
         ac_hit_detuned = self.detune_query_string(ac_hit, True)
         r_hit_detuned = self.detune_query_string(r_hit, False)
+        rel_hit_detuned = self.detune_query_string(rel_hit, False)
 
-        ac_dist, r_dist, match_type = self.check_hit_in_threshold(
+        ac_dist, r_dist, rel_dist, match_type = self.check_hit_in_threshold(
             artist_credit_name,
             recording_name,
+            rel_hit,
             ac_hit,
             r_hit,
+            rel_hit_detuned,
             is_ac_detuned,
-            is_r_detuned
+            is_r_detuned,
+            is_rel_detuned
         )
         if match_type != MATCH_TYPE_NO_MATCH:
             return hit, match_type
@@ -178,13 +193,16 @@ class MBIDMapper:
         # Poor results so far, lets try detuning MB ac field and try again
         if ac_dist > self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and ac_hit_detuned:
             self._log(Markup(f"""<b>no match</b>, ac_dist too high {ac_dist:.3f} continuing: detune ac"""))
-            ac_dist, r_dist, match_type = self.check_hit_in_threshold(
+            ac_dist, r_dist, rel_dist, match_type = self.check_hit_in_threshold(
                 artist_credit_name,
                 recording_name,
+                release_name,
                 ac_hit_detuned,
                 r_hit,
+                rel_hit,
                 True,
-                is_r_detuned
+                is_r_detuned,
+                is_rel_detuned
             )
             if match_type != MATCH_TYPE_NO_MATCH:
                 return hit, match_type
@@ -192,13 +210,16 @@ class MBIDMapper:
         # Poor results so far, lets try detuning MB recording field and try again
         if r_dist > self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and r_hit_detuned:
             self._log(Markup(f"""<b>no match</b>, r_dist too high {r_dist:.3f} continuing: detune r"""))
-            ac_dist, r_dist, match_type = self.check_hit_in_threshold(
+            ac_dist, r_dist, rel_dist, match_type = self.check_hit_in_threshold(
                 artist_credit_name,
                 recording_name,
+                release_name,
                 ac_hit,
                 r_hit_detuned,
+                rel_hit,
                 is_ac_detuned,
-                True
+                True,
+                is_rel_detuned
             )
             if match_type != MATCH_TYPE_NO_MATCH:
                 return hit, match_type
@@ -208,23 +229,24 @@ class MBIDMapper:
                 r_dist > self.MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE and r_hit_detuned:
             self._log(Markup(f"""<b>no match</b>, ac_dist {r_dist:.3f} and r_dist {r_dist:.3f} too high
             continuing: detune ac and r"""))
-            ac_dist, r_dist, match_type = self.check_hit_in_threshold(
+            ac_dist, r_dist, rel_dist, match_type = self.check_hit_in_threshold(
                 artist_credit_name,
                 recording_name,
+                release_name,
                 ac_hit_detuned,
                 r_hit_detuned,
+                rel_hit_detuned,
                 True,
-                True
+                True,
+                is_rel_detuned
             )
             if match_type != MATCH_TYPE_NO_MATCH:
                 return hit, match_type
 
-        self._log(Markup(f"""<b>no good match</b>, ac_dist {ac_dist:.3f}, r_dist {r_dist:.3f}, moving on"""))
+        self._log(Markup(f"""<b>no good match</b>, ac_dist {ac_dist:.3f}, r_dist {r_dist:.3f}, rel_dist {rel_dist:.3f} moving on"""))
         return None, MATCH_TYPE_NO_MATCH
 
-    def lookup(self, artist_credit_name_p, recording_name_p):
-
-        query = artist_credit_name_p + " " + recording_name_p
+    def clean_query(self, query):
         if self.remove_stop_words:
             cleaned_query = []
             for word in query.split(" "):
@@ -232,7 +254,9 @@ class MBIDMapper:
                     cleaned_query.append(word)
 
             query = " ".join(cleaned_query)
+        return query
 
+    def lookup(self, collection, query):
         search_parameters = {
             'q': query,
             'query_by': "combined",
@@ -242,7 +266,7 @@ class MBIDMapper:
 
         while True:
             try:
-                hits = self.client.collections[COLLECTION_NAME].documents.search(search_parameters)
+                hits = self.client.collections[collection].documents.search(search_parameters)
                 break
             except requests.exceptions.ReadTimeout:
                 print("Got socket timeout, sleeping 5 seconds, trying again.")
@@ -255,8 +279,10 @@ class MBIDMapper:
 
         return hits["hits"][0]
 
-    def lookup_and_evaluate_hit(self, artist_credit_name_p, recording_name_p, is_ac_detuned, is_r_detuned):
-        hit = self.lookup(artist_credit_name_p, recording_name_p)
+    def lookup_and_evaluate_hit(self, artist_credit_name_p, recording_name_p, release_name_p, is_ac_detuned, is_r_detuned, is_rel_detuned):
+        collection = COLLECTION_NAME_WITH_RELEASE if release_name_p else COLLECTION_NAME_WITHOUT_RELEASE
+        query = self.clean_query(artist_credit_name_p + " " + recording_name_p)
+        hit = self.lookup(collection, query)
         if not hit:
             return None
 
@@ -264,8 +290,10 @@ class MBIDMapper:
             hit,
             artist_credit_name_p,
             recording_name_p,
+            release_name_p,
             is_ac_detuned,
-            is_r_detuned
+            is_r_detuned,
+            is_rel_detuned
         )
         if not hit:
             return None
@@ -291,7 +319,7 @@ class MBIDMapper:
 
         return re.sub("\s+-\s+\d\d\d\d.*master", "", recording_name)
 
-    def search(self, artist_credit_name, recording_name):
+    def search(self, artist_credit_name, recording_name, release_name=None):
         """
             Main query body: Prepare the search query terms and prepare
             detuned query terms. Then attempt to find the given search terms
@@ -299,32 +327,39 @@ class MBIDMapper:
             query terms. Return a match dict (properly formatted for this
             query) or None if not match.
         """
-
         recording_name = self.remove_obvious_bullshit_from_recording_name(recording_name)
 
         artist_credit_name_p = prepare_query(artist_credit_name)
         recording_name_p = prepare_query(recording_name)
+        release_name_p = prepare_query(release_name) if release_name else None
 
         ac_detuned = prepare_query(self.detune_query_string(artist_credit_name, True))
         r_detuned = prepare_query(self.detune_query_string(recording_name, False))
-        self._log(f"ac_detuned: '{ac_detuned}' r_detuned: '{r_detuned}'")
+        rel_detuned = prepare_query(self.detune_query_string(release_name, False)) if release_name else None
+        self._log(f"ac_detuned: '{ac_detuned}' r_detuned: '{r_detuned}' rel_detuned: '{rel_detuned}'")
+
+        # lookup without any detunings, with release name
+        if release_name_p:
+            hit = self.lookup_and_evaluate_hit(artist_credit_name_p, recording_name_p, release_name_p, False, False, False)
+            if hit:
+                return hit
 
         # lookup without any detuning
-        hit = self.lookup_and_evaluate_hit(artist_credit_name_p, recording_name_p, False, False)
+        hit = self.lookup_and_evaluate_hit(artist_credit_name_p, recording_name_p, None, False, False, False)
         if hit:
             return hit
 
         # lookup with only artist credit detuned
         if ac_detuned:
             self._log("Detune only artist_credit")
-            hit = self.lookup_and_evaluate_hit(ac_detuned, recording_name_p, True, False)
+            hit = self.lookup_and_evaluate_hit(ac_detuned, recording_name_p, None, True, False, False)
             if hit:
                 return hit
 
         # lookup with both artist credit and recording detuned
         if ac_detuned and r_detuned:
             self._log("Detune artist_credit and recording")
-            hit = self.lookup_and_evaluate_hit(ac_detuned, r_detuned, True, True)
+            hit = self.lookup_and_evaluate_hit(ac_detuned, r_detuned, None, True, True, False)
             if hit:
                 return hit
 
@@ -332,7 +367,7 @@ class MBIDMapper:
         # preserving order of cases with older versions is probably sensible.
         if r_detuned:
             self._log("Detune only recording")
-            hit = self.lookup_and_evaluate_hit(artist_credit_name_p, r_detuned, False, True)
+            hit = self.lookup_and_evaluate_hit(artist_credit_name_p, r_detuned, None, False, True, False)
             if hit:
                 return hit
 

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -111,7 +111,7 @@ class MBIDMapper:
         if release_name is not None and release_name_hit is not None:
             release_distance = distance(release_name, release_name_hit)
         else:
-            release_distance = None
+            release_distance = -1  # if we set release_distance to None then it causes issue when formatting log string
 
         return distance(artist_credit_name, artist_credit_name_hit), distance(recording_name, recording_name_hit), release_distance
 
@@ -307,7 +307,7 @@ class MBIDMapper:
         return {
             'artist_credit_name': hit['document']['artist_credit_name'],
             'artist_credit_id': hit['document']['artist_credit_id'],
-            'artist_mbids': hit['document']['artist_mbids'],
+            'artist_mbids': hit['document']['artist_mbids'][1:-1].split(","),
             'release_name': hit['document']['release_name'],
             'release_mbid': hit['document']['release_mbid'],
             'recording_name': hit['document']['recording_name'],

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -280,8 +280,14 @@ class MBIDMapper:
         return hits["hits"][0]
 
     def lookup_and_evaluate_hit(self, artist_credit_name_p, recording_name_p, release_name_p, is_ac_detuned, is_r_detuned, is_rel_detuned):
-        collection = COLLECTION_NAME_WITH_RELEASE if release_name_p else COLLECTION_NAME_WITHOUT_RELEASE
-        query = self.clean_query(artist_credit_name_p + " " + recording_name_p)
+        if release_name_p:
+            collection = COLLECTION_NAME_WITH_RELEASE
+            query = artist_credit_name_p + " " + recording_name_p + " " + release_name_p
+        else:
+            collection = COLLECTION_NAME_WITHOUT_RELEASE
+            query = artist_credit_name_p + " " + recording_name_p
+
+        query = self.clean_query(query)
         hit = self.lookup(collection, query)
         if not hit:
             return None

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -106,7 +106,7 @@ class MBIDMapper:
             Compare the fields, print debug info if turned on, and return edit distance as (a_dist, r_dist)
         """
         self._log(Markup(f"""QUERY: artist: <b>{artist_credit_name}</b> recording: <b>{recording_name}</b> release: <b>{release_name}</b>"""))
-        self._log(Markup(f"""HIT: artist: <b>{artist_credit_name_hit}</b> recording: <b>{recording_name_hit}</b> recording: <b>{release_name_hit}</b>"""))
+        self._log(Markup(f"""HIT: artist: <b>{artist_credit_name_hit}</b> recording: <b>{recording_name_hit}</b> release: <b>{release_name_hit}</b>"""))
 
         if release_name is not None and release_name_hit is not None:
             release_distance = distance(release_name, release_name_hit)
@@ -179,10 +179,10 @@ class MBIDMapper:
         ac_dist, r_dist, rel_dist, match_type = self.check_hit_in_threshold(
             artist_credit_name,
             recording_name,
-            rel_hit,
+            release_name,
             ac_hit,
             r_hit,
-            rel_hit_detuned,
+            rel_hit,
             is_ac_detuned,
             is_r_detuned,
             is_rel_detuned
@@ -235,7 +235,7 @@ class MBIDMapper:
                 release_name,
                 ac_hit_detuned,
                 r_hit_detuned,
-                rel_hit_detuned,
+                rel_hit,
                 True,
                 True,
                 is_rel_detuned
@@ -338,12 +338,15 @@ class MBIDMapper:
         rel_detuned = prepare_query(self.detune_query_string(release_name, False)) if release_name else None
         self._log(f"ac_detuned: '{ac_detuned}' r_detuned: '{r_detuned}' rel_detuned: '{rel_detuned}'")
 
-        # lookup without any detunings, with release name
         if release_name_p:
+            self._log(f"looking up with release name")
+            # lookup without any detunings, with release name
             hit = self.lookup_and_evaluate_hit(artist_credit_name_p, recording_name_p, release_name_p, False, False, False)
             if hit:
                 return hit
 
+
+        self._log(f"looking up without release name")
         # lookup without any detuning
         hit = self.lookup_and_evaluate_hit(artist_credit_name_p, recording_name_p, None, False, False, False)
         if hit:

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -7,7 +7,6 @@ import orjson
 from kombu import Connection
 from kombu.entity import PERSISTENT_DELIVERY_MODE, Exchange
 
-from listenbrainz.troi.year_in_music import yim_patch_runner
 from listenbrainz.utils import get_fallback_connection_name
 from data.model.common_stat import ALLOWED_STATISTICS_RANGE
 from listenbrainz.webserver import create_app

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -147,13 +147,13 @@ def get_mbid_mapping():
         }
     ]
 
-    if release_name:
-        q = ArtistCreditRecordingReleaseLookupQuery(debug=False)
-        exact_results = q.fetch(params)
-        if exact_results:
-            return process_results(exact_results[0], metadata, incs)
-
     try:
+        if release_name:
+            q = ArtistCreditRecordingReleaseLookupQuery(debug=False)
+            exact_results = q.fetch(params)
+            if exact_results:
+                return process_results(exact_results[0], metadata, incs)
+
         q = ArtistCreditRecordingLookupQuery(debug=False)
         exact_results = q.fetch(params)
         if exact_results:
@@ -165,7 +165,7 @@ def get_mbid_mapping():
             return process_results(fuzzy_result, metadata, incs)
 
     except Exception as e:
-        current_app.logger.error("Server failed to lookup recording: {}".format(e))
+        current_app.logger.error("Server failed to lookup recording: {}".format(e), exc_info=True)
         raise APIInternalServerError("Server failed to lookup recording")
 
     return jsonify({})

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -5,6 +5,9 @@ from listenbrainz.db.mbid_manual_mapping import create_mbid_manual_mapping, get_
 from listenbrainz.db.metadata import get_metadata_for_recording
 from listenbrainz.db.model.mbid_manual_mapping import MbidManualMapping
 from listenbrainz.labs_api.labs.api.artist_credit_recording_lookup import ArtistCreditRecordingLookupQuery
+from listenbrainz.labs_api.labs.api.artist_credit_recording_release_lookup import \
+    ArtistCreditRecordingReleaseLookupQuery
+from listenbrainz.mbid_mapping_writer.mbid_mapper import MBIDMapper
 from listenbrainz.mbid_mapping_writer.mbid_mapper_metadata_api import MBIDMapperMetadataAPI
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
@@ -127,6 +130,7 @@ def get_mbid_mapping():
     """
     artist_name = request.args.get("artist_name")
     recording_name = request.args.get("recording_name")
+    release_name = request.args.get("release_name")
     if not artist_name:
         raise APIBadRequest("artist_name is invalid or not present in arguments")
     if not recording_name:
@@ -138,9 +142,16 @@ def get_mbid_mapping():
     params = [
         {
             "[artist_credit_name]": artist_name,
-            "[recording_name]": recording_name
+            "[recording_name]": recording_name,
+            "[release_name]": release_name
         }
     ]
+
+    if release_name:
+        q = ArtistCreditRecordingReleaseLookupQuery(debug=False)
+        exact_results = q.fetch(params)
+        if exact_results:
+            return process_results(exact_results[0], metadata, incs)
 
     try:
         q = ArtistCreditRecordingLookupQuery(debug=False)
@@ -148,8 +159,8 @@ def get_mbid_mapping():
         if exact_results:
             return process_results(exact_results[0], metadata, incs)
 
-        q = MBIDMapperMetadataAPI(timeout=10, remove_stop_words=True, debug=False)
-        fuzzy_result = q.search(artist_name, recording_name)
+        q = MBIDMapper(timeout=10, remove_stop_words=True, debug=False)
+        fuzzy_result = q.search(artist_name, recording_name, release_name)
         if fuzzy_result:
             return process_results(fuzzy_result, metadata, incs)
 

--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -7,7 +7,7 @@ import subprocess
 import click
 
 from mapping.canonical_musicbrainz_data import create_canonical_musicbrainz_data
-from mapping.typesense_index import build_index as action_build_index
+from mapping.typesense_index import build_all as action_build_index
 from mapping.mapping_test.mapping_test import test_mapping as action_test_mapping
 from mapping.utils import log, CRON_LOG_FILE
 from mapping.release_colors import sync_release_color_table, incremental_update_release_color_table

--- a/mbid_mapping/mapping/bulk_table.py
+++ b/mbid_mapping/mapping/bulk_table.py
@@ -309,7 +309,6 @@ class BulkInsertTable:
             their process_row function called, this function takes its place for saving
             resultant rows in the table.
         """
-
         self.insert_rows.extend(rows)
         if len(self.insert_rows) >= self.batch_size:
             self._flush_insert_rows()

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -4,7 +4,7 @@ import psycopg2
 from unidecode import unidecode
 
 from mapping.canonical_musicbrainz_data_base import CanonicalMusicBrainzDataBase
-from mapping.canonical_musicbrainz_data_release_support import CanonicalMusicBrainzDataRelease
+from mapping.canonical_musicbrainz_data_release_support import CanonicalMusicBrainzDataReleaseSupport
 from mapping.utils import log
 from mapping.custom_sorts import create_custom_sort_tables
 from mapping.canonical_recording_redirect import CanonicalRecordingRedirect
@@ -85,7 +85,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         releases = CanonicalRelease(mb_conn)
         mapping = CanonicalMusicBrainzData(mb_conn, lb_conn)
         mapping.add_additional_bulk_table(can)
-        mapping_release = CanonicalMusicBrainzDataRelease(mb_conn, lb_conn)
+        mapping_release = CanonicalMusicBrainzDataReleaseSupport(mb_conn, lb_conn)
 
         # Carry out the bulk of the work
         create_custom_sort_tables(mb_conn)

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -100,7 +100,7 @@ class CanonicalMusicBrainzData(CanonicalMusicBrainzDataBase):
                  -- some recording mbids appear on multiple releases and the insert query inserts them once for
                  -- for each appearance with the appropriate release mbid. the deletion criteria is combined_lookup
                  -- which is unavailable in the insert sql query so we cannot easily apply a filter there itself.
-                 -- such rows  cleaned up in the deleted_recs with above so to above adding a redirect to the same
+                 -- such rows cleaned up in the deleted_recs with above so to above adding a redirect to the same
                  -- recording as a canonical_recording, this condition.
                    AND t1.recording_mbid != t2.recording_mbid;
         """]

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -108,6 +108,14 @@ class CanonicalMusicBrainzData(CanonicalMusicBrainzDataBase):
     def get_combined_lookup(self, row):
         return unidecode(re.sub(r'[^\w]+', '', row['artist_credit_name'] + row['recording_name']).lower())
 
+    def get_index_names(self):
+        table = self.table_name.split(".")[-1]
+        return [
+            (f"{table}_idx_combined_lookup",              "combined_lookup", False),
+            (f"{table}_idx_artist_credit_recording_name", "artist_credit_name, recording_name", False),
+            (f"{table}_idx_recording_mbid", "recording_mbid", True)
+        ]
+
 
 def create_canonical_musicbrainz_data(use_lb_conn: bool):
     """

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -142,8 +142,8 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         mapping_release = CanonicalMusicBrainzDataRelease(mb_conn, lb_conn)
 
         # Carry out the bulk of the work
-        # create_custom_sort_tables(mb_conn)
-        # releases.run(no_swap=True)
+        create_custom_sort_tables(mb_conn)
+        releases.run(no_swap=True)
         mapping_release.run(no_swap=True)
         mapping.run(no_swap=True)
         can_rec_rel.run(no_swap=True)

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -142,8 +142,8 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         mapping_release = CanonicalMusicBrainzDataRelease(mb_conn, lb_conn)
 
         # Carry out the bulk of the work
-        create_custom_sort_tables(mb_conn)
-        releases.run(no_swap=True)
+        # create_custom_sort_tables(mb_conn)
+        # releases.run(no_swap=True)
         mapping_release.run(no_swap=True)
         mapping.run(no_swap=True)
         can_rec_rel.run(no_swap=True)

--- a/mbid_mapping/mapping/canonical_musicbrainz_data_base.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data_base.py
@@ -1,12 +1,12 @@
 import re
 
 import psycopg2
+from psycopg2.errors import OperationalError
 from unidecode import unidecode
 
-from mapping.canonical_musicbrainz_data_base import CanonicalMusicBrainzDataBase
-from mapping.canonical_musicbrainz_data_release import CanonicalMusicBrainzDataRelease
 from mapping.utils import log
 from mapping.custom_sorts import create_custom_sort_tables
+from mapping.bulk_table import BulkInsertTable
 from mapping.canonical_recording_redirect import CanonicalRecordingRedirect
 from mapping.canonical_recording_release_redirect import CanonicalRecordingReleaseRedirect
 from mapping.canonical_release_redirect import CanonicalReleaseRedirect
@@ -14,14 +14,16 @@ from mapping.canonical_release import CanonicalRelease
 
 import config
 
+TEST_ARTIST_IDS = [1160983, 49627, 65, 21238]  # Gun'n'roses, beyoncé, portishead, Erik Satie
 
-class CanonicalMusicBrainzData(CanonicalMusicBrainzDataBase):
-    """
-        This class creates the MBID mapping tables without release name in the lookup.
-    """
 
-    def __init__(self, mb_conn, lb_conn=None, batch_size=None):
-        super().__init__("mapping.canonical_musicbrainz_data", mb_conn, lb_conn, batch_size)
+class CanonicalMusicBrainzDataBase(BulkInsertTable):
+    """
+        This class creates the MBID mapping tables.
+
+        For documentation on what each of the functions in this class does, please refer
+        to the BulkInsertTable docs.
+    """
 
     def get_create_table_columns(self):
         return [("id",                 "SERIAL"),
@@ -60,7 +62,7 @@ class CanonicalMusicBrainzData(CanonicalMusicBrainzDataBase):
                    ON m.id = t.medium
                  JOIN musicbrainz.release rl
                    ON rl.id = m.release
-                 JOIN mapping.canonical_musicbrainz_data_release_tmp rpr
+                 JOIN mapping.canonical_release_tmp rpr
                    ON rl.id = rpr.release
                  JOIN (SELECT artist_credit, array_agg(gid ORDER BY position) AS artist_mbids
                          FROM musicbrainz.artist_credit_name acn2
@@ -70,43 +72,38 @@ class CanonicalMusicBrainzData(CanonicalMusicBrainzDataBase):
                    ON acn.artist_credit = s.artist_credit
             LEFT JOIN musicbrainz.release_country rc
                    ON rc.release = rl.id
-               --- there is some bad data in MB for which the title is too large and exceeds the postgres indexing limits
-               --- therefore filter out such recordings before-hand, otherwise index creation may fail
-                WHERE length(concat(ac.name, r.name)) < 500      
              GROUP BY rpr.id, ac.id, s.artist_mbids, rl.gid, artist_credit_name, r.gid, r.name, release_name, year
              ORDER BY ac.id, rpr.id
         """)]
 
-    def get_post_process_queries(self):
-        return ["""
-            WITH all_recs AS (
-                SELECT *
-                     , row_number() OVER (PARTITION BY combined_lookup ORDER BY score) AS rnum
-                  FROM mapping.canonical_musicbrainz_data_tmp
-            ), deleted_recs AS (
-                DELETE
-                  FROM mapping.canonical_musicbrainz_data_tmp
-                 WHERE id IN (SELECT id FROM all_recs WHERE rnum > 1)
-             RETURNING recording_mbid, combined_lookup
-            )
-           INSERT INTO mapping.canonical_recording_redirect_tmp (recording_mbid, canonical_recording_mbid, canonical_release_mbid)
-                SELECT t1.recording_mbid
-                     , t2.recording_mbid AS canonical_recording
-                     , t2.release_mbid AS canonical_release
-                  FROM deleted_recs t1
-                  JOIN all_recs t2
-                    ON t1.combined_lookup = t2.combined_lookup
-                 WHERE t2.rnum = 1
-                 -- some recording mbids appear on multiple releases and the insert query inserts them once for
-                 -- for each appearance with the appropriate release mbid. the deletion criteria is combined_lookup
-                 -- which is unavailable in the insert sql query so we cannot easily apply a filter there itself.
-                 -- such rows  cleaned up in the deleted_recs with above so to above adding a redirect to the same
-                 -- recording as a canonical_recording, this condition.
-                   AND t1.recording_mbid != t2.recording_mbid;
-        """]
+    def get_index_names(self):
+        table = self.table_name.split(".")[-1]
+        return [
+            (f"{table}_idx_combined_lookup",              "combined_lookup", False),
+            (f"{table}_idx_artist_credit_recording_name_release_name", "artist_credit_name, recording_name, release_name", False),
+            (f"{table}_idx_recording_mbid", "recording_mbid", True)
+        ]
 
     def get_combined_lookup(self, row):
-        return unidecode(re.sub(r'[^\w]+', '', row['artist_credit_name'] + row['recording_name']).lower())
+        pass
+
+    def process_row(self, row):
+        combined_lookup = self.get_combined_lookup(row)
+        return {
+            self.table_name: [(
+                row["artist_credit_id"],
+                row["artist_mbids"],
+                row["artist_credit_name"],
+                row["release_mbid"],
+                row["release_name"],
+                row["recording_mbid"],
+                row["recording_name"],
+                combined_lookup,
+                row["score"],
+                row["year"]
+            )]
+        }
+
 
 
 def create_canonical_musicbrainz_data(use_lb_conn: bool):
@@ -131,12 +128,10 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         releases = CanonicalRelease(mb_conn)
         mapping = CanonicalMusicBrainzData(mb_conn, lb_conn)
         mapping.add_additional_bulk_table(can)
-        mapping_release = CanonicalMusicBrainzDataRelease(mb_conn, lb_conn)
 
         # Carry out the bulk of the work
         create_custom_sort_tables(mb_conn)
         releases.run(no_swap=True)
-        mapping_release.run(no_swap=True)
         mapping.run(no_swap=True)
         can_rec_rel.run(no_swap=True)
         can_rel.run(no_swap=True)
@@ -145,7 +140,6 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         log("canonical_musicbrainz_data: Swap into production")
         if lb_conn:
             releases.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
-            mapping_release.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
@@ -155,7 +149,6 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             lb_conn.close()
         else:
             releases.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
-            mapping_release.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
             can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)

--- a/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
@@ -12,6 +12,14 @@ class CanonicalMusicBrainzDataRelease(CanonicalMusicBrainzDataBase):
     def __init__(self, mb_conn, lb_conn=None, batch_size=None):
         super().__init__("mapping.canonical_musicbrainz_data_release", mb_conn, lb_conn, batch_size)
 
+    def get_index_names(self):
+        table = self.table_name.split(".")[-1]
+        return [
+            (f"{table}_idx_combined_lookup",              "combined_lookup", False),
+            (f"{table}_idx_artist_credit_recording_name_release_name", "artist_credit_name, recording_name, release_name", False),
+            (f"{table}_idx_recording_mbid_release_mbid", "recording_mbid, release_mbid", True)
+        ]
+
     def get_post_process_queries(self):
         return []
 

--- a/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
@@ -1,95 +1,19 @@
 import re
-
-import psycopg2
 from unidecode import unidecode
 
-from mapping.utils import create_schema, insert_rows, log
-from mapping.bulk_table import BulkInsertTable
-import config
-
-TEST_ARTIST_IDS = [1160983, 49627, 65, 21238]  # Gun'n'roses, beyoncé, portishead, Erik Satie
+from mapping.canonical_musicbrainz_data_base import CanonicalMusicBrainzDataBase
 
 
-class CanonicalMusicBrainzDataRelease(BulkInsertTable):
+class CanonicalMusicBrainzDataRelease(CanonicalMusicBrainzDataBase):
     """
-        This class creates the MBID mapping release table.
-
-        For documentation on what each of the functions in this class does, please refer
-        to the BulkInsertTable docs.
+        This class creates the MBID mapping tables including the release name in lookups.
     """
 
     def __init__(self, mb_conn, lb_conn=None, batch_size=None):
         super().__init__("mapping.canonical_musicbrainz_data_release", mb_conn, lb_conn, batch_size)
-        self.release_index = {}
 
-    def get_create_table_columns(self):
-        """
-            Return the PG query to fetch the insert data. This function should return
-            a liost of tuples of two strings: [(column name, column type/constraints/defaults)]
-        """
+    def get_post_process_queries(self):
+        return []
 
-        return [("id",           "SERIAL"),
-                ("release",      "INTEGER NOT NULL"),
-                ("release_mbid", "UUID NOT NULL")]
-
-    def get_insert_queries(self):
-        """
-        """
-
-        # The 1 in the WHERE clause refers to MB's Various Artists ID of 1 -- all the various artist albums.
-        # The sorting the release group prinary type by id just happens to be a good sort order for primary
-        # type. This isn't the case for the secondary type, thus the custom sort order.
-        query = """             SELECT r.id AS release
-                                     , r.gid AS release_mbid
-                                  FROM musicbrainz.release_group rg
-                                  JOIN musicbrainz.release r
-                                    ON rg.id = r.release_group
-                             LEFT JOIN musicbrainz.release_country rc
-                                    ON rc.release = r.id
-                                  JOIN musicbrainz.medium m
-                                    ON m.release = r.id
-                             LEFT JOIN musicbrainz.medium_format mf
-                                    ON m.format = mf.id
-                             LEFT JOIN mapping.format_sort fs
-                                    ON mf.id = fs.format
-                                  JOIN musicbrainz.artist_credit ac
-                                    ON rg.artist_credit = ac.id
-                             LEFT JOIN musicbrainz.release_group_primary_type rgpt
-                                    ON rg.type = rgpt.id
-                             LEFT JOIN musicbrainz.release_group_secondary_type_join rgstj
-                                    ON rg.id = rgstj.release_group
-                             LEFT JOIN musicbrainz.release_group_secondary_type rgst
-                                    ON rgstj.secondary_type = rgst.id
-                             LEFT JOIN mapping.release_group_secondary_type_sort rgsts
-                                    ON rgst.id = rgsts.secondary_type
-                                 WHERE rg.artist_credit %s 1
-                                       %s
-                              ORDER BY rg.type
-                                     , rgsts.sort NULLS FIRST
-                                     , fs.sort NULLS LAST
-                                     , to_date(date_year::TEXT || '-' ||
-                                               COALESCE(date_month,12)::TEXT || '-' ||
-                                               COALESCE(date_day,28)::TEXT, 'YYYY-MM-DD')
-                                     , country, rg.artist_credit, rg.name, r.id"""
-
-        queries = []
-        for op in ['!=', '=']:
-            if config.USE_MINIMAL_DATASET:
-                log(f"{self.table_name}: Using a minimal dataset for artist credit pairs: artist_id %s 1" % op)
-                queries.append(("MB", query % (op, 'AND rg.artist_credit IN (%s)' % ",".join([str(i) for i in TEST_ARTIST_IDS]))))
-            else:
-                log(f"{self.table_name}: Using a full dataset for artist credit pairs: artist_id %s 1" % op)
-                queries.append(("MB", query % (op, "")))
-
-        return queries
-
-    def get_index_names(self):
-        return [("canonical_musicbrainz_data_release_idx_release", "release", False),
-                ("canonical_musicbrainz_data_release_idx_id",      "id", False)]
-
-    def process_row(self, row):
-        if row["release"] in self.release_index:
-            return ()
-
-        self.release_index[row["release"]] = 1
-        return [(row["release"], row["release_mbid"])]
+    def get_combined_lookup(self, row):
+        return unidecode(re.sub(r'[^\w]+', '', row['artist_credit_name'] + row['recording_name'] + row['release_name']).lower())

--- a/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
@@ -13,21 +13,21 @@ class CanonicalMusicBrainzDataRelease(CanonicalMusicBrainzDataBase):
         super().__init__("mapping.canonical_musicbrainz_data_release_support", mb_conn, lb_conn, batch_size)
 
     def get_index_names(self):
-        table = self.table_name.split(".")[-1]
+        table = "can_mb_data_release"
         return [
             (f"{table}_idx_combined_lookup",              "combined_lookup", False),
-            (f"{table}_idx_artist_credit_recording_name_release_name", "artist_credit_name, recording_name, release_name", False),
+            (f"{table}_idx_ac_rec_rel", "artist_credit_name, recording_name, release_name", False),
             (f"{table}_idx_recording_mbid_release_mbid", "recording_mbid, release_mbid", True)
         ]
 
     def get_post_process_queries(self):
         return ["""
             WITH all_recs AS (
-                SELECT *
+                SELECT id
                      , row_number() OVER (PARTITION BY combined_lookup ORDER BY score) AS rnum
-                  FROM mapping.canonical_musicbrainz_data_release_tmp
+                  FROM mapping.canonical_musicbrainz_data_release_support_tmp
             )   DELETE
-                  FROM mapping.canonical_musicbrainz_data_release_tmp
+                  FROM mapping.canonical_musicbrainz_data_release_support_tmp
                  WHERE id IN (SELECT id FROM all_recs WHERE rnum > 1)
         """]
 

--- a/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data_release.py
@@ -10,7 +10,7 @@ class CanonicalMusicBrainzDataRelease(CanonicalMusicBrainzDataBase):
     """
 
     def __init__(self, mb_conn, lb_conn=None, batch_size=None):
-        super().__init__("mapping.canonical_musicbrainz_data_release", mb_conn, lb_conn, batch_size)
+        super().__init__("mapping.canonical_musicbrainz_data_release_support", mb_conn, lb_conn, batch_size)
 
     def get_index_names(self):
         table = self.table_name.split(".")[-1]

--- a/mbid_mapping/mapping/canonical_musicbrainz_data_release_support.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data_release_support.py
@@ -4,7 +4,7 @@ from unidecode import unidecode
 from mapping.canonical_musicbrainz_data_base import CanonicalMusicBrainzDataBase
 
 
-class CanonicalMusicBrainzDataRelease(CanonicalMusicBrainzDataBase):
+class CanonicalMusicBrainzDataReleaseSupport(CanonicalMusicBrainzDataBase):
     """
         This class creates the MBID mapping tables including the release name in lookups.
     """

--- a/mbid_mapping/mapping/canonical_release.py
+++ b/mbid_mapping/mapping/canonical_release.py
@@ -1,0 +1,95 @@
+import re
+
+import psycopg2
+from unidecode import unidecode
+
+from mapping.utils import create_schema, insert_rows, log
+from mapping.bulk_table import BulkInsertTable
+import config
+
+TEST_ARTIST_IDS = [1160983, 49627, 65, 21238]  # Gun'n'roses, beyoncé, portishead, Erik Satie
+
+
+class CanonicalRelease(BulkInsertTable):
+    """
+        This class creates the MBID mapping release table.
+
+        For documentation on what each of the functions in this class does, please refer
+        to the BulkInsertTable docs.
+    """
+
+    def __init__(self, mb_conn, lb_conn=None, batch_size=None):
+        super().__init__("mapping.canonical_release", mb_conn, lb_conn, batch_size)
+        self.release_index = {}
+
+    def get_create_table_columns(self):
+        """
+            Return the PG query to fetch the insert data. This function should return
+            a liost of tuples of two strings: [(column name, column type/constraints/defaults)]
+        """
+
+        return [("id",           "SERIAL"),
+                ("release",      "INTEGER NOT NULL"),
+                ("release_mbid", "UUID NOT NULL")]
+
+    def get_insert_queries(self):
+        """
+        """
+
+        # The 1 in the WHERE clause refers to MB's Various Artists ID of 1 -- all the various artist albums.
+        # The sorting the release group prinary type by id just happens to be a good sort order for primary
+        # type. This isn't the case for the secondary type, thus the custom sort order.
+        query = """             SELECT r.id AS release
+                                     , r.gid AS release_mbid
+                                  FROM musicbrainz.release_group rg
+                                  JOIN musicbrainz.release r
+                                    ON rg.id = r.release_group
+                             LEFT JOIN musicbrainz.release_country rc
+                                    ON rc.release = r.id
+                                  JOIN musicbrainz.medium m
+                                    ON m.release = r.id
+                             LEFT JOIN musicbrainz.medium_format mf
+                                    ON m.format = mf.id
+                             LEFT JOIN mapping.format_sort fs
+                                    ON mf.id = fs.format
+                                  JOIN musicbrainz.artist_credit ac
+                                    ON rg.artist_credit = ac.id
+                             LEFT JOIN musicbrainz.release_group_primary_type rgpt
+                                    ON rg.type = rgpt.id
+                             LEFT JOIN musicbrainz.release_group_secondary_type_join rgstj
+                                    ON rg.id = rgstj.release_group
+                             LEFT JOIN musicbrainz.release_group_secondary_type rgst
+                                    ON rgstj.secondary_type = rgst.id
+                             LEFT JOIN mapping.release_group_secondary_type_sort rgsts
+                                    ON rgst.id = rgsts.secondary_type
+                                 WHERE rg.artist_credit %s 1
+                                       %s
+                              ORDER BY rg.type
+                                     , rgsts.sort NULLS FIRST
+                                     , fs.sort NULLS LAST
+                                     , to_date(date_year::TEXT || '-' ||
+                                               COALESCE(date_month,12)::TEXT || '-' ||
+                                               COALESCE(date_day,28)::TEXT, 'YYYY-MM-DD')
+                                     , country, rg.artist_credit, rg.name, r.id"""
+
+        queries = []
+        for op in ['!=', '=']:
+            if config.USE_MINIMAL_DATASET:
+                log(f"{self.table_name}: Using a minimal dataset for artist credit pairs: artist_id %s 1" % op)
+                queries.append(("MB", query % (op, 'AND rg.artist_credit IN (%s)' % ",".join([str(i) for i in TEST_ARTIST_IDS]))))
+            else:
+                log(f"{self.table_name}: Using a full dataset for artist credit pairs: artist_id %s 1" % op)
+                queries.append(("MB", query % (op, "")))
+
+        return queries
+
+    def get_index_names(self):
+        return [("canonical_release_idx_release", "release", False),
+                ("canonical_release_idx_id",      "id", False)]
+
+    def process_row(self, row):
+        if row["release"] in self.release_index:
+            return ()
+
+        self.release_index[row["release"]] = 1
+        return [(row["release"], row["release_mbid"])]

--- a/mbid_mapping/mapping/canonical_release_redirect.py
+++ b/mbid_mapping/mapping/canonical_release_redirect.py
@@ -7,7 +7,7 @@ class CanonicalReleaseRedirect(BulkInsertTable):
         This maps any given release mbid to the "most canonical" release in that release group,
         along with the release group mbid.
 
-        When reading the `canonical_musicbrainz_data_release` table, the first release
+        When reading the `canonical_release` table, the first release
         (ordered by id) for a given release group is the canonical release.
 
         For documentation on what each of the functions in this class does, please refer
@@ -36,7 +36,7 @@ class CanonicalReleaseRedirect(BulkInsertTable):
                         FROM musicbrainz.release
                         JOIN musicbrainz.release_group rg
                           ON release.release_group = rg.id
-                        JOIN mapping.canonical_musicbrainz_data_release_tmp cmdr
+                        JOIN mapping.canonical_release_tmp cmdr
                           ON cmdr.release = release.id),
                         first_release AS (select * from canonical_release where rank = 1),
                         release_rg AS (

--- a/mbid_mapping/mapping/typesense_index.py
+++ b/mbid_mapping/mapping/typesense_index.py
@@ -134,5 +134,5 @@ def build_all():
         return document['recording_name'] + " " + document['artist_credit_name'] + " " + document['release_name']
 
     build_index("canonical_musicbrainz_data_", "mapping.canonical_musicbrainz_data", combine_artist_recording)
-    build_index("canonical_musicbrainz_data_release_", "mapping.canonical_musicbrainz_data_release", combine_artist_recording_release)
+    build_index("canonical_musicbrainz_data_release_", "mapping.canonical_musicbrainz_data_release_support", combine_artist_recording_release)
 

--- a/mbid_mapping/mapping/typesense_index.py
+++ b/mbid_mapping/mapping/typesense_index.py
@@ -1,4 +1,3 @@
-import sys
 import re
 import time
 import datetime
@@ -13,14 +12,13 @@ from mapping.utils import log
 
 
 BATCH_SIZE = 5000
-COLLECTION_NAME_PREFIX = 'canonical_musicbrainz_data_'
 
 
 def prepare_string(text):
     return unidecode(re.sub(" +", " ", re.sub(r'[^\w ]+', '', text)).lower())
 
 
-def build_index():
+def build_index(collection_name_prefix, table, combiner):
 
     client = typesense.Client({
         'nodes': [{
@@ -32,16 +30,16 @@ def build_index():
         'connection_timeout_seconds': 1000000
     })
 
-    collection_name = COLLECTION_NAME_PREFIX + datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+    collection_name = collection_name_prefix + datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
     try:
         log("typesense index: build index '%s'" % collection_name)
-        build(client, collection_name)
+        build(client, collection_name, table, combiner)
     except typesense.exceptions.TypesenseClientError as err:
         log("typesense index: Cannot build index: ", str(err))
         return -1
 
     try:
-        latest = COLLECTION_NAME_PREFIX + "latest"
+        latest = collection_name_prefix + "latest"
         log("typesense index: alias index '%s' to %s" % (collection_name, latest))
         aliased_collection = {"collection_name": collection_name}
         client.aliases.upsert(latest, aliased_collection)
@@ -54,19 +52,19 @@ def build_index():
             if collection["name"] == collection_name:
                 continue
 
-            if collection["name"].startswith(COLLECTION_NAME_PREFIX):
+            if collection["name"].startswith(collection_name_prefix):
                 log("typesense index: delete collection '%s'" % collection["name"])
                 client.collections[collection["name"]].delete()
             else:
                 log("typesense index: ignore collection '%s'" % collection["name"])
 
-    except typesense.exceptions.ObjectNotFound:
+    except typesense.exceptions.ObjectNotFound as err:
         log("typesense index: Failed to delete collection '%s'.", str(err))
 
     return 0
 
 
-def build(client, collection_name):
+def build(client, collection_name, table, combiner):
 
     schema = {
         'name': collection_name,
@@ -89,19 +87,21 @@ def build(client, collection_name):
     with psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI) as conn:
         with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
 
-            curs.execute("SELECT max(score) FROM mapping.canonical_musicbrainz_data")
+            curs.execute(f"SELECT max(score) FROM {table}")
             max_score = curs.fetchone()[0]
 
-            query = ("""SELECT recording_name,
-                               recording_mbid,
-                               release_name,
-                               release_mbid,
-                               artist_credit_id,
-                               artist_credit_name,
-                               artist_mbids,
-                               score,
-                               year
-                          FROM mapping.canonical_musicbrainz_data""")
+            query = f"""
+                SELECT recording_name
+                     , recording_mbid
+                     , release_name
+                     , release_mbid
+                     , artist_credit_id
+                     , artist_credit_name
+                     , artist_mbids
+                     , score
+                     , year
+                  FROM {table}
+            """
 
             curs.execute(query)
             documents = []
@@ -109,7 +109,7 @@ def build(client, collection_name):
                 document = dict(row)
                 document['artist_mbids'] = "{" + row["artist_mbids"][1:-1] + "}"
                 document['score'] = max_score - document['score']
-                document['combined'] = prepare_string(document['recording_name'] + " " + document['artist_credit_name'])
+                document['combined'] = prepare_string(combiner(document))
                 documents.append(document)
 
                 if len(documents) == BATCH_SIZE:
@@ -124,3 +124,15 @@ def build(client, collection_name):
 
     log("typesense index: indexing complete. waiting for background tasks to finish.")
     time.sleep(5)
+
+
+def build_all():
+    def combine_artist_recording(document):
+        return document['recording_name'] + " " + document['artist_credit_name']
+
+    def combine_artist_recording_release(document):
+        return document['recording_name'] + " " + document['artist_credit_name'] + " " + document['release_name']
+
+    build_index("canonical_musicbrainz_data_", "mapping.canonical_musicbrainz_data", combine_artist_recording)
+    build_index("canonical_musicbrainz_data_release_", "mapping.canonical_musicbrainz_data_release", combine_artist_recording_release)
+


### PR DESCRIPTION
This PR adds all necessary tables and labs API queries to support choosing a particular release while mapping listens to recordings. There are 2 steps pending to enable full release mapping support:
1) Use the new endpoints in the mapper and figure a way to store the mapped release mbid
2) Figure out the best way to retrieve the correct release metadata for a match (currently we only store canonical release data in mb_metadata_cache table).