### PR TITLE
Improve ListenCard flex behavior

### DIFF
--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -307,7 +307,6 @@
       flex-direction: column;
       line-height: 1.3em;
       overflow: hidden;
-      flex: 5;
 
       .username-and-timestamp {
         padding-right: initial;
@@ -328,7 +327,7 @@
       justify-content: flex-end;
       align-items: center;
       padding: 0;
-      flex: 3.5;
+
       .listen-controls {
         margin-left: 1.5em;
       }


### PR DESCRIPTION
I think there was a ticket for this but I can't find it, so maybe I imagined it…

I have been seeing issues for a while due to my original (bad) handling of flex behavior in the ListenCard component.
In short, with limited horizontal space I was seeing the timestamp on the right side wrap to a new line below the feedback and menu buttons, causing a taller listencard that didn't look quite right, and all that depending on the length of the time string, so uneven across a page.
See the four at the top here:
![image](https://user-images.githubusercontent.com/6179856/221356005-132aff49-6346-454b-95a7-af7e78bdad8d.png)


Removing my flex constraints is a simple fix that ensure flexbox does the best it can to fit everything dynamically:
![image](https://user-images.githubusercontent.com/6179856/221356016-f15e2599-5d79-4f61-974e-4d7c8a29a0c0.png)
