### PR TITLE
LB-1003 : Playlist page html title isn't descriptive

### DIFF
--- a/listenbrainz/webserver/templates/explore/huesound.html
+++ b/listenbrainz/webserver/templates/explore/huesound.html
@@ -1,5 +1,5 @@
 {%- extends 'base-react.html' -%}
-
+{%- block title -%}Hue sound - ListenBrainz{%- endblock -%}
 {% block content %}
 
     <div id="react-container"></div>

--- a/listenbrainz/webserver/templates/playlists/playlists.html
+++ b/listenbrainz/webserver/templates/playlists/playlists.html
@@ -1,5 +1,5 @@
 {% extends 'user/base.html' %}
-
+{%- block title -%}{{ user.musicbrainz_id }} - Your Playlists{%- endblock -%}
 {% block profile_content %}
 
     <div id="react-container"></div>

--- a/listenbrainz/webserver/templates/playlists/recommendations.html
+++ b/listenbrainz/webserver/templates/playlists/recommendations.html
@@ -1,5 +1,5 @@
 {% extends 'user/base.html' %}
-
+{%- block title -%}{{ user.musicbrainz_id }} - Your Recommendations{%- endblock -%}
 {% block profile_content %}
 
     <div id="react-container"></div>

--- a/listenbrainz/webserver/templates/user/charts.html
+++ b/listenbrainz/webserver/templates/user/charts.html
@@ -1,5 +1,5 @@
 {% extends 'user/base.html' %}
-
+{%- block title -%}{{ user.musicbrainz_id }} - Your Charts{%- endblock -%}
 {% block profile_content %}
 
     <div id="react-container" ></div>

--- a/listenbrainz/webserver/templates/user/profile.html
+++ b/listenbrainz/webserver/templates/user/profile.html
@@ -1,5 +1,5 @@
 {% extends 'user/base.html' %}
-
+{%- block title -%}{{ user.musicbrainz_id }} - Your Listens{%- endblock -%}
 {% block profile_content %}
 
     <div id="react-container" ></div>

--- a/listenbrainz/webserver/templates/user/reports.html
+++ b/listenbrainz/webserver/templates/user/reports.html
@@ -1,5 +1,5 @@
 {% extends 'user/base.html' %}
-
+{%- block title -%}{{ user.musicbrainz_id }} - Your Reports{%- endblock -%}
 {% block profile_content %}
 
     <div id="react-container" ></div>

--- a/listenbrainz/webserver/templates/user/taste.html
+++ b/listenbrainz/webserver/templates/user/taste.html
@@ -1,5 +1,5 @@
 {% extends 'user/base.html' %}
-
+{%- block title -%}{{ user.musicbrainz_id }} - Your Tastes{%- endblock -%}
 {% block profile_content %}
 
     <div id="react-container" ></div>


### PR DESCRIPTION
# Problem
The html <title> for a user's playlist page says
User "alastairp" - ListenBrainz
which doesn't make sense, it should have at least some mention of playlists.

# Solution

I would like to propose the title to be "<User name> - Your Playlists ". And the same pattern  follows through for all the tabs in the profile.


