### PR TITLE
Improve artist credit similarity using weights

### DIFF
--- a/listenbrainz_spark/postgres/artist_credit.py
+++ b/listenbrainz_spark/postgres/artist_credit.py
@@ -6,8 +6,14 @@ def create_artist_credit_cache():
     """ Import artist country from postgres to HDFS for use in artist map stats calculation. """
     query = """
         SELECT ac.id AS artist_credit_id
-             , ac.gid AS artist_credit_mbid
-          FROM musicbrainz.artist_credit ac   
+             , a.gid AS artist_mbid
+             , acn.position
+             , acn.join_phrase
+          FROM musicbrainz.artist_credit ac
+          JOIN musicbrainz.artist_credit_name acn
+            ON acn.artist_credit = ac.id
+          JOIN musicbrainz.artist a
+            ON acn.artist = a.id 
     """
 
     save_pg_table_to_hdfs(query, ARTIST_CREDIT_MBID_DATAFRAME)


### PR DESCRIPTION
Weight featuring artists less than main artists in a credit. For example: Consider two artist credits: (i) A ft. B and C (ii) D feat. E. The similarities will be calculated as follows:

| Artist 1 | Artist 2 | Similarity           |
|----------|----------|----------------------|
| A        | D        | 1                    |
| A        | E        | 0.25                 |
| B        | D        | 0.25                 |
| B        | E        | 0.25 * 0.25 = 0.0625 |
| C        | D        | 0.25                 |
| C        | E        | 0.0625               |
