### PR TITLE
Fix drag handle size in playlist listencard

### DIFF
--- a/frontend/css/playlists.less
+++ b/frontend/css/playlists.less
@@ -132,7 +132,8 @@
 .playlist-item-card .main-content .drag-handle {
   align-items: center;
   cursor: move;
-  flex: 0.6;
+  flex: 0;
   display: block;
   align-self: center;
+  min-width: 3em;
 }


### PR DESCRIPTION
I pooped the deck in #2367 and did not check the playlist ListenCard.
The result is a very wide drag handle to the left:
![image](https://user-images.githubusercontent.com/6179856/222129915-68776ae5-21fa-46f1-924d-d34d568f0150.png)

A simple flex change required, with a minimum width to ensure the handle is properly visible:
![image](https://user-images.githubusercontent.com/6179856/222133740-898216d8-94b2-4066-bc5a-05c3784a664b.png)
