### PR TITLE
Reject NaNs in submission json

### DIFF
--- a/listenbrainz/testdata/invalid_listen_nan_in_json.json
+++ b/listenbrainz/testdata/invalid_listen_nan_in_json.json
@@ -1,0 +1,14 @@
+{
+    "listen_type": "single",
+    "payload": [
+        {
+            "listened_at": NaN,
+            "track_metadata": {
+                "artist_name": "Kanye West",
+                "track_name": "Fade",
+                "release_name": "The Life of Pablo",
+                "artist_mbid": "5441c29d-3602-4898-b1a1-b77fa23b8e50"
+            }
+        }
+    ]
+}

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -467,6 +467,13 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
 
+    def test_nan_in_json(self):
+        """ Test for invalid submission in which a listen has null listened_at field """
+        with open(self.path_to_data_file('invalid_listen_nan_in_json.json'), 'r') as f:
+            payload = json.load(f)
+        response = self.send_data(payload)
+        self.assert400(response)
+
     def test_null_listened_at(self):
         """ Test for invalid submission in which a listen has null listened_at field """
         with open(self.path_to_data_file('invalid_listen_null_listened_at.json'), 'r') as f:

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -1,7 +1,7 @@
-import time
 from operator import itemgetter
 
 import psycopg2
+import orjson
 import ujson
 from brainzutils.musicbrainz_db import engine as mb_engine
 from brainzutils.ratelimit import ratelimit
@@ -83,7 +83,7 @@ def submit_listen():
         )
 
     try:
-        data = ujson.loads(raw_data.decode("utf-8"))
+        data = orjson.loads(raw_data.decode("utf-8"))
     except ValueError as e:
         log_raise_400("Cannot parse JSON document: %s" % e)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ kombu==5.1.0
 itsdangerous==2.1.2
 countryinfo==0.1.2
 urllib3==1.26.9
+orjson==3.8.7


### PR DESCRIPTION
NaN cause a database error when we try to insert those in Postgres. NaN is also not a part of a JSON spec but rather a javascript value sometimes sent erroneously in JSON. So reject NaN. ujson doesn't provide a way to do this, orjson is a faster alternative which does. Hence, using it. Will replace remaining usages of ujson with orjson later.