### PR TITLE
Improve getArtistMBIDs utility

### DIFF
--- a/frontend/js/src/cb-review/CBReviewModal.tsx
+++ b/frontend/js/src/cb-review/CBReviewModal.tsx
@@ -169,14 +169,11 @@ export default NiceModal.create(({ listen, newAlert }: CBReviewModalProps) => {
       const artist_mbid = getArtistMBIDs(listen)?.[0];
       let artistEntityToSet: ReviewableEntity;
       if (artist_mbid) {
-        const artist_mbids = getArtistMBIDs(listen);
-        if (artist_mbids) {
-          artistEntityToSet = {
-            type: "artist",
-            mbid: artist_mbids[0],
-            name: getArtistName(listen),
-          };
-        }
+        artistEntityToSet = {
+          type: "artist",
+          mbid: artist_mbid,
+          name: getArtistName(listen),
+        };
       }
 
       /** Get recording entity */

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as _ from "lodash";
 import * as timeago from "time-ago";
-import { isFinite, isUndefined } from "lodash";
+import { isFinite, isUndefined, castArray } from "lodash";
 import { Rating } from "react-simple-star-rating";
 import SpotifyPlayer from "../brainzplayer/SpotifyPlayer";
 import YoutubePlayer from "../brainzplayer/YoutubePlayer";
@@ -134,9 +134,29 @@ const searchForYoutubeTrack = async (
 const getAdditionalContent = (metadata: EventMetadata): string =>
   _.get(metadata, "blurb_content") ?? _.get(metadata, "text") ?? "";
 
-const getArtistMBIDs = (listen: Listen): string[] | undefined =>
-  _.get(listen, "track_metadata.additional_info.artist_mbids") ??
-  _.get(listen, "track_metadata.mbid_mapping.artist_mbids");
+const getArtistMBIDs = (listen: Listen): string[] | undefined => {
+  const additionalInfoArtistMBIDs = _.get(
+    listen,
+    "track_metadata.additional_info.artist_mbids"
+  );
+  const mbidMappingArtistMBIDs = _.get(
+    listen,
+    "track_metadata.mbid_mapping.artist_mbids"
+  );
+  if (additionalInfoArtistMBIDs || mbidMappingArtistMBIDs) {
+    return additionalInfoArtistMBIDs ?? mbidMappingArtistMBIDs;
+  }
+
+  // Backup: cast artist_mbid as an array if it exists
+  const additionalInfoArtistMBID = _.get(
+    listen,
+    "track_metadata.additional_info.artist_mbid"
+  );
+  if (additionalInfoArtistMBID) {
+    return [additionalInfoArtistMBID];
+  }
+  return undefined;
+};
 
 const getRecordingMSID = (listen: Listen): string =>
   _.get(listen, "track_metadata.additional_info.recording_msid");


### PR DESCRIPTION
While testing #2390 I found a listen with an artist MBID in a place our getArtistMBIDs utility function does not expect it.
See the lack of artist link in the ListenCard, and the absence of the artist entity in the CB review modal:
![image](https://user-images.githubusercontent.com/6179856/224114675-b38b0255-3930-44be-9947-c5fcedd4347c.png)
![image](https://user-images.githubusercontent.com/6179856/224114690-a8ae504d-1f93-4e79-b307-0e7a4e3cafc3.png)

The listen in question has an mbid in track_metadata.additional_info.artist_mbid:
```json
{
  "track_metadata": {
    "additional_info": {
      "recording_mbid": "ddeb7a16-4786-4bb5-8d87-8c1b8ae48894",
      "release_mbid": "dcd5a656-8ef6-44ba-921f-55e571955181",
      "artist_mbid": "e86492c1-0376-4df0-8042-8ba058c83960"
    },
    "artist_name": "John Prine",
    "track_name": "Flashback Blues",
    "release_name": "John Prine"
  },
  "user_name": "stebe",
  "listened_at": 1678381909,
  "listened_at_iso": "2023-03-09T17:11:49Z"
}
```
The utility expects an array at track_metadata.additional_info.artist_mbids or track_metadata.mbid_mapping.artist_mbids which is insufficient.

Squeezed in a small refactor/cleanup in CB Review modal