### PR TITLE
Fix user name search  in PersonalRecommendationModal

### DIFF
--- a/docs/developers/devel-env.rst
+++ b/docs/developers/devel-env.rst
@@ -254,7 +254,7 @@ code.
 
 This builds and runs the containers needed for the tests. This script configures
 test-specific data volumes so that test data is isolated from your development
-data.
+data. Note that all tests are run: Unit tests and integration tests.
 
 To run tests faster, you can use some options to start up the test infrastructure
 once so that subsequent running of the tests is faster:
@@ -280,12 +280,6 @@ You can also make use of the following frontend testing options for efficient te
    ./test.sh fe -u          run frontend tests, update snapshots
    ./test.sh fe -b          build frontend test containers
    ./test.sh fe -t          run type-checker
-
-Also, run the **integration tests** for ListenBrainz.
-
-.. code-block:: bash
-
-   ./test.sh int
 
 When the tests complete, you will see if your changes are valid or not. These tests
 are a helpful way to validate new changes without a lot of work.

--- a/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
+++ b/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { uniq, includes, lowerCase } from "lodash";
+import { uniq, includes, toLower } from "lodash";
 import NiceModal, { useModal } from "@ebay/nice-modal-react";
 import GlobalAppContext from "../utils/GlobalAppContext";
 import NamePill from "./NamePill";
@@ -95,7 +95,7 @@ export default NiceModal.create(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         if (event?.target?.value) {
           const newSuggestions = followers.filter((username) =>
-            includes(lowerCase(username), lowerCase(event.target.value))
+            includes(toLower(username), toLower(event.target.value))
           );
           setSuggestions(newSuggestions);
         } else {

--- a/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
+++ b/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
@@ -94,11 +94,9 @@ export default NiceModal.create(
     const searchUsers = React.useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         if (event?.target?.value) {
-          const newSuggestions = followers
-            .map(lowerCase)
-            .filter((username) =>
-              includes(username, lowerCase(event.target.value))
-            );
+          const newSuggestions = followers.filter((username) =>
+            includes(lowerCase(username), lowerCase(event.target.value))
+          );
           setSuggestions(newSuggestions);
         } else {
           setSuggestions([]);

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -966,23 +966,23 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        # only riksucks is following
+        # Only riksucks is following
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
 
         metadata = {
-            "track_name": "natkhat",
-            "artist_name": "seedhe maut",
+            "track_name": "Natkhat",
+            "artist_name": "Seedhe Maut",
             "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
-            "blurb_content": "try out these new people in indian hip-hop!"
+            "blurb_content": "Try out these new people in Indian Hip-Hop!"
         }
 
         r = self.client.post(
             url_for('user_timeline_event_api_bp.create_personal_recommendation_event', user_name=self.user['musicbrainz_id']),
             data=json.dumps({"metadata": metadata}),
-            headers={'authorization': 'token {}'.format(self.user['auth_token'])},
+            headers={'Authorization': 'Token {}'.format(self.user['auth_token'])},
         )
         self.assert400(r)
         data = json.loads(r.data)
@@ -993,28 +993,27 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        # only riksucks is following
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
 
         metadata = {
-            "track_name": "natkhat",
-            "artist_name": "seedhe maut",
+            "track_name": "Natkhat",
+            "artist_name": "seedhe Maut",
             "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": ["peter k"],
-            "blurb_content": "try out these new people in indian hip-hop!"
+            "blurb_content": "Try out these new people in Indian Hip-Hop!"
         }
 
         r = self.client.post(
             url_for('user_timeline_event_api_bp.create_personal_recommendation_event', user_name=self.user['musicbrainz_id']),
             data=json.dumps({"metadata": metadata}),
-            headers={'authorization': 'token {}'.format(self.user['auth_token'])},
+            headers={'Authorization': 'Token {}'.format(self.user['auth_token'])},
         )
         self.assert400(r)
         data = json.loads(r.data)
         self.assertEqual("You cannot recommend tracks to non-followers! These people don't follow you ['peter k']", data['error'])
-  
+
     def test_personal_recommendation_stays_after_unfollowing(self):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -966,28 +966,55 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        # Only riksucks is following
+        # only riksucks is following
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
 
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "Seedhe Maut",
+            "track_name": "natkhat",
+            "artist_name": "seedhe maut",
             "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
-            "blurb_content": "Try out these new people in Indian Hip-Hop!"
+            "blurb_content": "try out these new people in indian hip-hop!"
         }
 
         r = self.client.post(
             url_for('user_timeline_event_api_bp.create_personal_recommendation_event', user_name=self.user['musicbrainz_id']),
             data=json.dumps({"metadata": metadata}),
-            headers={'Authorization': 'Token {}'.format(self.user['auth_token'])},
+            headers={'authorization': 'token {}'.format(self.user['auth_token'])},
         )
         self.assert400(r)
         data = json.loads(r.data)
         self.assertEqual("You cannot recommend tracks to non-followers! These people don't follow you ['hrik2001']", data['error'])
 
+
+    def test_personal_recommendation_not_for_non_followers_peter_k(self):
+        user_one = db_user.get_or_create(2, "riksucks")
+        user_two = db_user.get_or_create(3, "hrik2001")
+
+        # only riksucks is following
+        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
+
+        metadata = {
+            "track_name": "natkhat",
+            "artist_name": "seedhe maut",
+            "release_name": "न",
+            "recording_mbid": str(uuid.uuid4()),
+            "recording_msid": str(uuid.uuid4()),
+            "users": ["peter k"],
+            "blurb_content": "try out these new people in indian hip-hop!"
+        }
+
+        r = self.client.post(
+            url_for('user_timeline_event_api_bp.create_personal_recommendation_event', user_name=self.user['musicbrainz_id']),
+            data=json.dumps({"metadata": metadata}),
+            headers={'authorization': 'token {}'.format(self.user['auth_token'])},
+        )
+        self.assert400(r)
+        data = json.loads(r.data)
+        self.assertEqual("You cannot recommend tracks to non-followers! These people don't follow you ['peter k']", data['error'])
+  
     def test_personal_recommendation_stays_after_unfollowing(self):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -555,8 +555,10 @@ def create_personal_recommendation_event(user_name):
         metadata = PersonalRecordingRecommendationMetadata(**metadata)
         follower_results = db_user_relationship.multiple_users_by_username_following_user(user['id'], metadata.users)
         non_followers = []
+        current_app.logger.error('metadata ' + str(metadata))
+        current_app.logger.error('follower_results ' + str(follower_results))
         for follower in metadata.users:
-            if follower not in follower_results:
+            if not follower_results or not follower_results[follower]:
                 non_followers.append(follower)
         if non_followers:
             raise APIBadRequest(f"You cannot recommend tracks to non-followers! These people don't follow you {str(non_followers)}")

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -555,8 +555,6 @@ def create_personal_recommendation_event(user_name):
         metadata = PersonalRecordingRecommendationMetadata(**metadata)
         follower_results = db_user_relationship.multiple_users_by_username_following_user(user['id'], metadata.users)
         non_followers = []
-        current_app.logger.error('metadata ' + str(metadata))
-        current_app.logger.error('follower_results ' + str(follower_results))
         for follower in metadata.users:
             if not follower_results or not follower_results[follower]:
                 non_followers.append(follower)

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -556,7 +556,7 @@ def create_personal_recommendation_event(user_name):
         follower_results = db_user_relationship.multiple_users_by_username_following_user(user['id'], metadata.users)
         non_followers = []
         for follower in metadata.users:
-            if not follower_results[follower]:
+            if follower not in follower_results:
                 non_followers.append(follower)
         if non_followers:
             raise APIBadRequest(f"You cannot recommend tracks to non-followers! These people don't follow you {str(non_followers)}")


### PR DESCRIPTION
While doing testing, found another bug:
The username search mechanism in PersonalRecommendationModal transforms the usernames and makes the API return 500s related to the user name sent being mangled.

