### PR TITLE
Increase listen queue and increase nuber of running clients

### DIFF
--- a/docker/services/uwsgi/uwsgi.ini
+++ b/docker/services/uwsgi/uwsgi.ini
@@ -7,7 +7,8 @@ module = listenbrainz.server
 callable = application
 chdir = /code/listenbrainz
 enable-threads = true
-processes = 30
+processes = 100
+listen = 1024
 log-x-forwarded-for=true
 disable-logging = true
 ; quit uwsgi if the python app fails to load


### PR DESCRIPTION
This morning listenbrainz was down for a while because:

  *** uWSGI listen queue of socket "0.0.0.0:3031" (fd: 3) full !!! (101/100) ***

So I increased the number of listening connections to 1024 (recommended) from the default 100. Also increased running clients to 100.