### PR TITLE
Rework listen metadata maintenance

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -3,7 +3,7 @@ MAILTO=""
 # NOTE: This file is organized in chronological order of the start hour of each job, keeping jobs spread over the night and not overlapping.
 
 # Delete pending listens and update our listen counts, timestamps hourly
-0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete_listens_and_update_metadata >> /logs/listen_metadata.log 2>&1
+0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete_listens >> /logs/listen_metadata.log 2>&1
 
 # Generating troi daily playlists runs hourly
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py run-daily-jams >> /logs/troi.log 2>&1

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -109,9 +109,7 @@ def delete_listens():
          RETURNING l.user_id, l.created
         ), update_counts AS (
             SELECT user_id
-                 -- count only listens which were created earlier than the the existing count high
-                 -- watermark in listen metadata table
-                 , count(*) FILTER (WHERE dl.created < lm.created) AS deleted_count
+                 , count(*) AS deleted_count
               FROM deleted_listens dl
               JOIN listen_user_metadata lm
              USING (user_id)

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -225,13 +225,13 @@ def delete_pending_listens():
         ts_delete_listens()
 
 
-@cli.command(name="delete_listens_and_update_metadata")
-def delete_listens_and_update_metadata():
+@cli.command(name="delete_listens")
+def complete_delete_listens():
     """ Complete all pending listen deletes and also run update script for
     updating listen metadata since last cron run """
     application = webserver.create_app()
     with application.app_context():
-        ts_delete_listens_and_update_user_listen_data()
+        ts_delete_listens()
 
 
 @cli.command(name="add_missing_to_listen_users_metadata")


### PR DESCRIPTION
Currently, an hourly cron job scans all listens interested since its last run and updates the metadata (min_listened_at, max_listened_at, count) for all users. At the same time, listen deletion runs and updates the metadata accordingly. These jobs are a bit slow and these queries also showed up in recent postgres errors causing LB downtime in past week.

Therefore, replacing half of the mechanism with update at time of listen insertion. Listen deletion still happens with an hourly cron job. Hoping this does not affect overall speed of listen insertion by much but brings down cronjob runtime.
