### PR TITLE
Redo schema of listen table

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -4,6 +4,7 @@ CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id
 CREATE INDEX created_ndx_listen ON listen (created);
 
 CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id);
+CREATE UNIQUE INDEX listened_at_user_id_recording_msid_ndx_listen ON listen_new (listened_at DESC, user_id, recording_msid);
 
 CREATE INDEX recording_msid_ndx_listen on listen ((data->'track_metadata'->'additional_info'->>'recording_msid'));
 

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -8,7 +8,7 @@ CREATE UNIQUE INDEX listened_at_user_id_recording_msid_ndx_listen ON listen_new 
 
 CREATE INDEX recording_msid_ndx_listen on listen ((data->'track_metadata'->'additional_info'->>'recording_msid'));
 
-CREATE UNIQUE INDEX user_id_ndx_listen_user_metadata ON listen_user_metadata (user_id);
+CREATE UNIQUE INDEX user_id_ndx_listen_user_metadata_new ON listen_user_metadata_new (user_id);
 
 -- View indexes are created in listenbrainz/db/timescale.py
 

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -10,7 +10,7 @@ CREATE TABLE listen (
 );
 
 CREATE TABLE listen_new (
-    listened_at     BIGINT                   NOT NULL,
+    listened_at     TIMESTAMP WITH TIME ZONE NOT NULL,
     created         TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     user_id         INTEGER                  NOT NULL,
     recording_msid  UUID                     NOT NULL,
@@ -20,15 +20,15 @@ CREATE TABLE listen_new (
 CREATE TABLE listen_delete_metadata (
     id                  SERIAL                      NOT NULL,
     user_id             INTEGER                     NOT NULL,
-    listened_at         BIGINT                      NOT NULL,
+    listened_at         TIMESTAMP WITH TIME ZONE    NOT NULL,
     recording_msid      UUID                        NOT NULL
 );
 
 CREATE TABLE listen_user_metadata (
     user_id             INTEGER                     NOT NULL,
     count               BIGINT                      NOT NULL, -- count of listens the user has earlier than `created`
-    min_listened_at     BIGINT, -- minimum listened_at timestamp seen for the user in listens till `created`
-    max_listened_at     BIGINT, -- maximum listened_at timestamp seen for the user in listens till `created`
+    min_listened_at     TIMESTAMP WITH TIME ZONE, -- minimum listened_at timestamp seen for the user in listens till `created`
+    max_listened_at     TIMESTAMP WITH TIME ZONE, -- maximum listened_at timestamp seen for the user in listens till `created`
     created             TIMESTAMP WITH TIME ZONE    NOT NULL  -- the created timestamp when data for this user was updated last
 );
 

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -9,6 +9,14 @@ CREATE TABLE listen (
         data            JSONB                    NOT NULL
 );
 
+CREATE TABLE listen_new (
+    listened_at     BIGINT                   NOT NULL,
+    created         TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    user_id         INTEGER                  NOT NULL,
+    recording_msid  UUID                     NOT NULL,
+    data            JSONB                    NOT NULL
+);
+
 CREATE TABLE listen_delete_metadata (
     id                  SERIAL                      NOT NULL,
     user_id             INTEGER                     NOT NULL,

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -1,15 +1,6 @@
 BEGIN;
 
 CREATE TABLE listen (
-        listened_at     BIGINT                   NOT NULL,
-        track_name      TEXT                     NOT NULL,
-        user_name       TEXT                     NOT NULL,
-        user_id         INTEGER                  NOT NULL,
-        created         TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
-        data            JSONB                    NOT NULL
-);
-
-CREATE TABLE listen_new (
     listened_at     TIMESTAMP WITH TIME ZONE NOT NULL,
     created         TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     user_id         INTEGER                  NOT NULL,

--- a/admin/timescale/reset_tables.sql
+++ b/admin/timescale/reset_tables.sql
@@ -1,6 +1,7 @@
 BEGIN;
 
 DELETE FROM listen                      CASCADE;
+DELETE FROM listen_new                  CASCADE;
 DELETE FROM listen_delete_metadata      CASCADE;
 DELETE FROM listen_user_metadata        CASCADE;
 DELETE FROM mbid_mapping                CASCADE;

--- a/admin/timescale/updates/2023-01-15-new-listens-table.sql
+++ b/admin/timescale/updates/2023-01-15-new-listens-table.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+CREATE TABLE listen_new (
+    listened_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    tz_offset       INTERVAL, -- offset to apply to listened_at to get listen's local timestamp
+    created         TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    user_id         INTEGER                  NOT NULL,
+    recording_msid  UUID                     NOT NULL,
+    data            JSONB                    NOT NULL
+);
+
+SELECT create_hypertable('listen', 'listened_at', chunk_time_interval => INTERVAL '30 days');
+
+INSERT INTO listen_new (listened_at, tz_offset, created,  user_id, recording_msid, data)
+     SELECT listened_at
+          , NULL
+          , created
+          , user_id
+          , (data->'track_metadata'->>'recording_msid')::UUID
+          , jsonb_insert((data->'track_metadata')::jsonb - 'recording_msid', '{track_name}', to_jsonb(track_name))
+       FROM listen;
+
+COMMIT;

--- a/admin/timescale/updates/2023-01-15-new-listens-table.sql
+++ b/admin/timescale/updates/2023-01-15-new-listens-table.sql
@@ -11,13 +11,6 @@ CREATE TABLE listen_new (
 
 SELECT create_hypertable('listen_new', 'listened_at', chunk_time_interval => INTERVAL '30 days');
 
-INSERT INTO listen_new (listened_at, tz_offset, created,  user_id, recording_msid, data)
-     SELECT listened_at
-          , NULL
-          , created
-          , user_id
-          , (data->'track_metadata'->>'recording_msid')::UUID
-          , jsonb_insert((data->'track_metadata')::jsonb - 'recording_msid', '{track_name}', to_jsonb(track_name))
-       FROM listen;
+CREATE UNIQUE INDEX listened_at_user_id_recording_msid_ndx_listen ON listen_new (listened_at DESC, user_id, recording_msid);
 
 COMMIT;

--- a/admin/timescale/updates/2023-01-15-new-listens-table.sql
+++ b/admin/timescale/updates/2023-01-15-new-listens-table.sql
@@ -13,4 +13,18 @@ SELECT create_hypertable('listen_new', 'listened_at', chunk_time_interval => INT
 
 CREATE UNIQUE INDEX listened_at_user_id_recording_msid_ndx_listen ON listen_new (listened_at DESC, user_id, recording_msid);
 
+CREATE TABLE listen_delete_metadata_new (
+    id                  SERIAL                      NOT NULL,
+    user_id             INTEGER                     NOT NULL,
+    listened_at         TIMESTAMP WITH TIME ZONE    NOT NULL,
+    recording_msid      UUID                        NOT NULL
+);
+
+CREATE TABLE listen_user_metadata_new (
+    user_id             INTEGER                     NOT NULL,
+    count               BIGINT                      NOT NULL, -- count of listens the user has earlier than `created`
+    min_listened_at     TIMESTAMP WITH TIME ZONE, -- minimum listened_at timestamp seen for the user in listens till `created`
+    max_listened_at     TIMESTAMP WITH TIME ZONE, -- maximum listened_at timestamp seen for the user in listens till `created`
+    created             TIMESTAMP WITH TIME ZONE    NOT NULL  -- the created timestamp when data for this user was updated last
+);
 COMMIT;

--- a/admin/timescale/updates/2023-01-15-new-listens-table.sql
+++ b/admin/timescale/updates/2023-01-15-new-listens-table.sql
@@ -9,7 +9,7 @@ CREATE TABLE listen_new (
     data            JSONB                    NOT NULL
 );
 
-SELECT create_hypertable('listen', 'listened_at', chunk_time_interval => INTERVAL '30 days');
+SELECT create_hypertable('listen_new', 'listened_at', chunk_time_interval => INTERVAL '30 days');
 
 INSERT INTO listen_new (listened_at, tz_offset, created,  user_id, recording_msid, data)
      SELECT listened_at

--- a/docker/services/uwsgi/uwsgi.ini
+++ b/docker/services/uwsgi/uwsgi.ini
@@ -10,6 +10,7 @@ enable-threads = true
 processes = 100
 listen = 1024
 log-x-forwarded-for=true
+disable-logging = true
 ; quit uwsgi if the python app fails to load
 need-app = true
 ; when uwsgi gets a sighup, quit completely and let runit restart us

--- a/docker/services/uwsgi/uwsgi.ini
+++ b/docker/services/uwsgi/uwsgi.ini
@@ -2,7 +2,7 @@
 uid = www-data
 gid = www-data
 master = true
-http = 0.0.0.0:3031
+socket = 0.0.0.0:3031
 module = listenbrainz.server
 callable = application
 chdir = /code/listenbrainz

--- a/docker/services/uwsgi/uwsgi.ini
+++ b/docker/services/uwsgi/uwsgi.ini
@@ -2,7 +2,7 @@
 uid = www-data
 gid = www-data
 master = true
-socket = 0.0.0.0:3031
+http = 0.0.0.0:3031
 module = listenbrainz.server
 callable = application
 chdir = /code/listenbrainz
@@ -10,7 +10,6 @@ enable-threads = true
 processes = 100
 listen = 1024
 log-x-forwarded-for=true
-disable-logging = true
 ; quit uwsgi if the python app fails to load
 need-app = true
 ; when uwsgi gets a sighup, quit completely and let runit restart us

--- a/docker/services/uwsgi/uwsgi.service
+++ b/docker/services/uwsgi/uwsgi.service
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 sleep 1
-exec run-lb-command uwsgi --die-on-term /etc/uwsgi/uwsgi.ini
+exec run-consul-template -config /etc/consul-template-uwsgi.conf

--- a/docker/services/uwsgi/uwsgi.service
+++ b/docker/services/uwsgi/uwsgi.service
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 sleep 1
-exec run-consul-template -config /etc/consul-template-uwsgi.conf
+exec run-lb-command uwsgi --die-on-term /etc/uwsgi/uwsgi.ini

--- a/listenbrainz/labs_api/labs/api/user_listen_sessions.py
+++ b/listenbrainz/labs_api/labs/api/user_listen_sessions.py
@@ -68,7 +68,7 @@ class UserListensSessionQuery(Query):
                           , (l.data->'track_metadata'->'additional_info'->>'duration_ms')::INT / 1000
                           , {DEFAULT_TRACK_LENGTH}
                         ) AS duration
-                   FROM listen l
+                   FROM listen_new l
               LEFT JOIN mbid_mapping mm
                      ON (l.data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = recording_msid
               LEFT JOIN mbid_mapping_metadata mmm

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -131,7 +131,7 @@ class Listen(object):
             track_metadata["mbid_mapping"] = {"recording_mbid": str(recording_mbid)}
 
             if recording_name is not None:
-                data["track_metadata"]["mbid_mapping"]["recording_name"] = recording_name
+                track_metadata["mbid_mapping"]["recording_name"] = recording_name
 
             if release_mbid is not None:
                 track_metadata["mbid_mapping"]["release_mbid"] = str(release_mbid)

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -80,7 +80,7 @@ class Listen(object):
         else:
             if timestamp:
                 self.timestamp = timestamp
-                self.ts_since_epoch = calendar.timegm(self.timestamp.utctimetuple())
+                self.ts_since_epoch = int(self.timestamp.timestamp())
             else:
                 self.timestamp = None
                 self.ts_since_epoch = None
@@ -126,7 +126,6 @@ class Listen(object):
                        ac_names=None, ac_join_phrases=None, user_name=None,
                        caa_id=None, caa_release_mbid=None):
         """Factory to make Listen() objects from a timescale dict"""
-        listened_at = datetime.utcfromtimestamp(float(listened_at))
         track_metadata["additional_info"]["recording_msid"] = recording_msid
         if recording_mbid is not None:
             track_metadata["mbid_mapping"] = {"recording_mbid": str(recording_mbid)}
@@ -195,7 +194,7 @@ class Listen(object):
         track_metadata = deepcopy(self.data)
         track_metadata['additional_info']['recording_msid'] = self.recording_msid
         del track_metadata['additional_info']['recording_msid']
-        return self.ts_since_epoch, self.user_id, self.recording_msid, orjson.dumps(track_metadata).decode("utf-8")
+        return self.timestamp, self.user_id, self.recording_msid, orjson.dumps(track_metadata).decode("utf-8")
 
     def __repr__(self):
         from pprint import pformat

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -69,8 +69,7 @@ class Listen(object):
         'release_name',
     )
 
-    def __init__(self, user_id=None, user_name=None, timestamp=None, recording_msid=None,
-                 dedup_tag=0, inserted_timestamp=None, data=None):
+    def __init__(self, user_id=None, user_name=None, timestamp=None, recording_msid=None, inserted_timestamp=None, data=None):
         self.user_id = user_id
         self.user_name = user_name
 
@@ -87,7 +86,6 @@ class Listen(object):
                 self.ts_since_epoch = None
 
         self.recording_msid = recording_msid
-        self.dedup_tag = dedup_tag
         self.inserted_timestamp = inserted_timestamp
         if data is None:
             self.data = {'additional_info': {}}
@@ -105,7 +103,6 @@ class Listen(object):
     @classmethod
     def from_json(cls, j):
         """Factory to make Listen() objects from a dict"""
-
         # Let's go play whack-a-mole with our lovely whicket of timestamp fields. Hopefully one will work!
         try:
             j['listened_at'] = datetime.utcfromtimestamp(float(j['listened_at']))
@@ -117,30 +114,28 @@ class Listen(object):
 
         return cls(
             user_id=j.get('user_id'),
-            user_name=j.get('user_name', ''),
+            user_name=j.get('user_name'),
             timestamp=j['listened_at'],
             recording_msid=j.get('recording_msid'),
-            dedup_tag=j.get('dedup_tag', 0),
             data=j.get('track_metadata')
         )
 
     @classmethod
-    def from_timescale(cls, listened_at, track_name, user_id, created, data,
+    def from_timescale(cls, listened_at, user_id, created, recording_msid, track_metadata,
                        recording_mbid=None, recording_name=None, release_mbid=None, artist_mbids=None,
                        ac_names=None, ac_join_phrases=None, user_name=None,
                        caa_id=None, caa_release_mbid=None):
         """Factory to make Listen() objects from a timescale dict"""
-
-        data["listened_at"] = datetime.utcfromtimestamp(float(listened_at))
-        data["track_metadata"]["track_name"] = track_name
+        listened_at = datetime.utcfromtimestamp(float(listened_at))
+        track_metadata["additional_info"]["recording_msid"] = recording_msid
         if recording_mbid is not None:
-            data["track_metadata"]["mbid_mapping"] = {"recording_mbid": str(recording_mbid)}
+            track_metadata["mbid_mapping"] = {"recording_mbid": str(recording_mbid)}
 
             if recording_name is not None:
                 data["track_metadata"]["mbid_mapping"]["recording_name"] = recording_name
 
             if release_mbid is not None:
-                data["track_metadata"]["mbid_mapping"]["release_mbid"] = str(release_mbid)
+                track_metadata["mbid_mapping"]["release_mbid"] = str(release_mbid)
 
             if artist_mbids is not None and ac_names is not None and ac_join_phrases is not None:
                 artists = []
@@ -151,21 +146,20 @@ class Listen(object):
                         "join_phrase": join_phrase
                     })
 
-                data["track_metadata"]["mbid_mapping"]["artists"] = artists
-                data["track_metadata"]["mbid_mapping"]["artist_mbids"] = [str(m) for m in artist_mbids]
+                track_metadata["mbid_mapping"]["artists"] = artists
+                track_metadata["mbid_mapping"]["artist_mbids"] = [str(m) for m in artist_mbids]
 
             if caa_id is not None and caa_release_mbid is not None:
-                data["track_metadata"]["mbid_mapping"]["caa_id"] = caa_id
-                data["track_metadata"]["mbid_mapping"]["caa_release_mbid"] = caa_release_mbid
+                track_metadata["mbid_mapping"]["caa_id"] = caa_id
+                track_metadata["mbid_mapping"]["caa_release_mbid"] = caa_release_mbid
 
         return cls(
             user_id=user_id,
             user_name=user_name,
-            timestamp=data['listened_at'],
-            recording_msid=data['track_metadata']['additional_info'].get('recording_msid'),
-            dedup_tag=data.get('dedup_tag', 0),
+            timestamp=listened_at,
+            recording_msid=recording_msid,
             inserted_timestamp=created,
-            data=data.get('track_metadata')
+            data=track_metadata
         )
 
     def to_api(self):
@@ -200,20 +194,8 @@ class Listen(object):
     def to_timescale(self):
         track_metadata = deepcopy(self.data)
         track_metadata['additional_info']['recording_msid'] = self.recording_msid
-        track_name = track_metadata['track_name']
-        del track_metadata['track_name']
-        return (self.ts_since_epoch, track_name, self.user_name, self.user_id, orjson.dumps({
-            'user_id': self.user_id,
-            'track_metadata': track_metadata
-        }).decode("utf-8"))
-
-    def validate(self):
-        return (self.user_id is not None and self.timestamp is not None
-                and self.recording_msid is not None and self.data is not None)
-
-    @property
-    def date(self):
-        return self.timestamp
+        del track_metadata['additional_info']['recording_msid']
+        return self.ts_since_epoch, self.user_id, self.recording_msid, orjson.dumps(track_metadata).decode("utf-8")
 
     def __repr__(self):
         from pprint import pformat
@@ -254,25 +236,3 @@ class NowPlayingListen:
     def __str__(self):
         return "<Now Playing Listen: user_name: %s, artist_name: %s, track_name: %s>" % \
                (self.user_name, self.data['artist_name'], self.data['track_name'])
-
-
-def convert_dump_row_to_spark_row(row):
-    data = {
-        'listened_at': str(datetime.utcfromtimestamp(row['timestamp'])),
-        'user_name': row['user_name'],
-        'artist_name': row['track_metadata'].get('artist_name', ''),
-        'artist_mbids': convert_comma_seperated_string_to_list(row['track_metadata']['additional_info'].get('artist_mbids', '')),
-        'release_name': row['track_metadata'].get('release_name', ''),
-        'release_mbid': row['track_metadata']['additional_info'].get('release_mbid', ''),
-        'track_name': row['track_metadata']['track_name'],
-        'recording_msid': row['recording_msid'],
-        'recording_mbid': row['track_metadata']['additional_info'].get('recording_mbid', ''),
-        'tags': convert_comma_seperated_string_to_list(row['track_metadata']['additional_info'].get('tags', [])),
-    }
-
-    if 'inserted_timestamp' in row and row['inserted_timestamp'] is not None:
-        data['inserted_timestamp'] = str(datetime.utcfromtimestamp(row['inserted_timestamp']))
-    else:
-        data['inserted_timestamp'] = str(datetime.utcfromtimestamp(0))
-
-    return data

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -44,8 +44,8 @@ class DumpListenStore:
             Use listened_at timestamp, since not all listens have the created timestamp.
         """
 
-        query = """SELECT listened_at, track_name, user_id, created, data
-                      FROM listen
+        query = """SELECT listened_at, user_id, created, recording_msid::TEXT, data
+                      FROM listen_new
                      WHERE listened_at >= :start_time
                        AND listened_at <= :end_time
                   ORDER BY listened_at ASC"""
@@ -54,7 +54,7 @@ class DumpListenStore:
             'end_time': end_time
         }
 
-        return (query, args)
+        return query, args
 
     def get_incremental_listens_query(self, start_time, end_time):
         """
@@ -62,8 +62,8 @@ class DumpListenStore:
             This uses the `created` column to fetch listens.
         """
 
-        query = """SELECT listened_at, track_name, user_id, created, data
-                      FROM listen
+        query = """SELECT listened_at, user_id, created, recording_msid::TEXT, data
+                      FROM listen_new
                      WHERE created > :start_ts
                        AND created <= :end_ts
                   ORDER BY created ASC"""
@@ -72,7 +72,7 @@ class DumpListenStore:
             'start_ts': start_time,
             'end_ts': end_time,
         }
-        return (query, args)
+        return query, args
 
     def write_dump_metadata(self, archive_name, start_time, end_time, temp_dir, tar, full_dump=True):
         """ Write metadata files (schema version, timestamps, license) into the dump archive.
@@ -204,10 +204,10 @@ class DumpListenStore:
                                 continue
                             listen = Listen.from_timescale(
                                 listened_at=result.listened_at,
-                                track_name=result.track_name,
+                                recording_msid=result.recording_msid,
                                 user_id=result.user_id,
                                 created=result.created,
-                                data=result.data,
+                                track_metadata=result.data,
                                 user_name=user_name
                             ).to_json()
                             out_file.write(orjson.dumps(listen).decode("utf-8") + "\n")
@@ -338,32 +338,32 @@ class DumpListenStore:
         -- an alternative is to use to CASE, but need to put case for each column because SQL CASE doesn't allow
         -- setting multiple columns at once.
                 WITH listen_with_mbid AS (
-                     SELECT listened_at
+                     SELECT l.listened_at
                           , l.user_id
-                          , data->'track_metadata'->'additional_info'->>'recording_msid' AS recording_msid
+                          , l.recording_msid
                           -- converting jsonb array to text array is non-trivial, so return a jsonb array not text
                           -- here and let psycopg2 adapt it to a python list which is what we want anyway
-                          , data->'track_metadata'->'additional_info'->'artist_mbids' AS l_artist_credit_mbids
-                          , data->'track_metadata'->>'artist_name' AS l_artist_name
-                          , data->'track_metadata'->>'release_name' AS l_release_name
-                          , data->'track_metadata'->'additional_info'->>'release_mbid' AS l_release_mbid
-                          , track_name AS l_recording_name
-                          , data->'track_metadata'->'additional_info'->>'recording_mbid' AS l_recording_mbid
+                          , data->'additional_info'->'artist_mbids' AS l_artist_credit_mbids
+                          , data->>'artist_name' AS l_artist_name
+                          , data->>'release_name' AS l_release_name
+                          , data->'additional_info'->>'release_mbid' AS l_release_mbid
+                          , data->>'track_name' AS l_recording_name
+                          , data->'additional_info'->>'recording_mbid' AS l_recording_mbid
                           -- prefer to use user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
                           , COALESCE(user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS m_recording_mbid
-                       FROM listen l
+                       FROM listen_new l
                   LEFT JOIN mbid_mapping mm
-                         ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = mm.recording_msid
+                         ON l.recording_msid = mm.recording_msid
                   LEFT JOIN mbid_manual_mapping user_mm
-                         ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = user_mm.recording_msid
+                         ON l.recording_msid = user_mm.recording_msid
                         AND user_mm.user_id = l.user_id 
                   LEFT JOIN mbid_manual_mapping_top other_mm
-                         ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = other_mm.recording_msid
+                         ON l.recording_msid = other_mm.recording_msid
                       WHERE {criteria} > %(start)s
                         AND {criteria} <= %(end)s
                 )    SELECT l.listened_at
                           , l.user_id
-                          , l.recording_msid
+                          , l.recording_msid::TEXT
                           , l_artist_credit_mbids
                           , l_artist_name
                           , l_release_name
@@ -532,7 +532,7 @@ class DumpListenStore:
                     parquet_index = self.write_parquet_files(archive_name, temp_dir, tar, dump_type,
                                                              start, end, parquet_index)
                 except Exception as err:
-                    self.log.info("likely test failure: " + str(err))
+                    self.log.exception("likely test failure: " + str(err))
                     raise
 
             shutil.rmtree(temp_dir)

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -62,6 +62,7 @@ class RedisListenStore:
         recent = {}
         for listen in unique:
             recent[orjson.dumps(listen.to_json())] = float(listen.ts_since_epoch)
+        print(recent)
 
         # Don't take this very seriously -- if it fails, really no big deal. Let is go.
         if recent:

--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -10,11 +10,11 @@ from listenbrainz.listen import Listen, NowPlayingListen
 
 class RedisListenStore:
 
-    RECENT_LISTENS_KEY = "rl-"
+    RECENT_LISTENS_KEY = "new-rl-"
     RECENT_LISTENS_MAX = 100
-    PLAYING_NOW_KEY = "pn."
+    PLAYING_NOW_KEY = "new-pn."
     LISTEN_COUNT_PER_DAY_EXPIRY_TIME = 3 * 24 * 60 * 60  # 3 days in seconds
-    LISTEN_COUNT_PER_DAY_KEY = "lc-day-"
+    LISTEN_COUNT_PER_DAY_KEY = "new-lc-day-"
 
     def __init__(self, logger):
         self.log = logger

--- a/listenbrainz/listenstore/tests/test_dumplistenstore.py
+++ b/listenbrainz/listenstore/tests/test_dumplistenstore.py
@@ -48,9 +48,9 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         for listen in listens:
             submit.append((*listen.to_timescale(), listen.inserted_timestamp))
 
-        query = """INSERT INTO listen (listened_at, track_name, user_name, user_id, data, created)
+        query = """INSERT INTO listen_new (listened_at, user_id, recording_msid, data, created)
                         VALUES %s
-                   ON CONFLICT (listened_at, track_name, user_id)
+                   ON CONFLICT (listened_at, user_id, recording_msid)
                     DO NOTHING
                 """
 

--- a/listenbrainz/listenstore/tests/test_dumplistenstore.py
+++ b/listenbrainz/listenstore/tests/test_dumplistenstore.py
@@ -92,7 +92,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         self.logstore.import_listens_dump(dump_location)
         recalculate_all_user_data()
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=base + 11)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=datetime.utcfromtimestamp(base + 11))
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, base + 5)
         self.assertEqual(listens[1].ts_since_epoch, base + 4)
@@ -119,7 +119,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         self.logstore.import_listens_dump(dump_location)
         recalculate_all_user_data()
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=base + 11)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=datetime.utcfromtimestamp(base + 11))
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, base + 5)
         self.assertEqual(listens[1].ts_since_epoch, base + 4)
@@ -147,7 +147,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         self.logstore.import_listens_dump(dump_location)
         recalculate_all_user_data()
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=datetime.utcfromtimestamp(1400000300))
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -174,7 +174,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         self.logstore.import_listens_dump(dump_location)
         recalculate_all_user_data()
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=user, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=user, to_ts=datetime.utcfromtimestamp(1400000300))
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -182,7 +182,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=datetime.utcfromtimestamp(1400000300))
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)

--- a/listenbrainz/listenstore/tests/test_timescale_utils.py
+++ b/listenbrainz/listenstore/tests/test_timescale_utils.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from brainzutils import cache
 from sqlalchemy import text
@@ -42,7 +43,12 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
                       FROM listen_user_metadata
                      WHERE user_id = :user_id
                 """), {"user_id": user["id"]})
-            return result.fetchone()._asdict()
+            row = result.fetchone()
+            return {
+                "count": row.count,
+                "min_listened_at": row.min_listened_at.replace(tzinfo=None),
+                "max_listened_at": row.max_listened_at.replace(tzinfo=None)
+            }
 
     def test_delete_listens_update_metadata(self):
         user_1 = db_user.get_or_create(1, "user_1")
@@ -54,35 +60,35 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
         update_user_listen_data()
 
         metadata_1 = self._get_count_and_timestamp(user_1)
-        self.assertEqual(metadata_1["min_listened_at"], 1400000000)
-        self.assertEqual(metadata_1["max_listened_at"], 1400000200)
+        self.assertEqual(metadata_1["min_listened_at"], datetime.utcfromtimestamp(1400000000))
+        self.assertEqual(metadata_1["max_listened_at"], datetime.utcfromtimestamp(1400000200))
         self.assertEqual(metadata_1["count"], 5)
 
         metadata_2 = self._get_count_and_timestamp(user_2)
-        self.assertEqual(metadata_2["min_listened_at"], 1400000000)
-        self.assertEqual(metadata_2["max_listened_at"], 1400000200)
+        self.assertEqual(metadata_2["min_listened_at"], datetime.utcfromtimestamp(1400000000))
+        self.assertEqual(metadata_2["max_listened_at"], datetime.utcfromtimestamp(1400000200))
         self.assertEqual(metadata_2["count"], 5)
 
         # to test the case when the update script has not run since delete, so metadata in listen_user_metadata does
         # account for this listen and deleting should not affect it either.
         self._create_test_data(user_1, "timescale_listenstore_test_listens_2.json")
-        self.logstore.delete_listen(1400000500, user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
+        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000500), user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
 
         # test min_listened_at is updated if that listen is deleted for a user
-        self.logstore.delete_listen(1400000000, user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
+        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000000), user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
         # test max_listened_at is updated if that listen is deleted for a user
-        self.logstore.delete_listen(1400000200, user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
+        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000200), user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
         # test normal listen delete updates correctly
-        self.logstore.delete_listen(1400000100, user_2["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
+        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000100), user_2["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
 
         delete_listens()
 
         metadata_1 = self._get_count_and_timestamp(user_1)
-        self.assertEqual(metadata_1["min_listened_at"], 1400000050)
-        self.assertEqual(metadata_1["max_listened_at"], 1400000150)
+        self.assertEqual(metadata_1["min_listened_at"], datetime.utcfromtimestamp(1400000050))
+        self.assertEqual(metadata_1["max_listened_at"], datetime.utcfromtimestamp(1400000150))
         self.assertEqual(metadata_1["count"], 3)
 
         metadata_2 = self._get_count_and_timestamp(user_2)
-        self.assertEqual(metadata_2["min_listened_at"], 1400000000)
-        self.assertEqual(metadata_2["max_listened_at"], 1400000200)
+        self.assertEqual(metadata_2["min_listened_at"], datetime.utcfromtimestamp(1400000000))
+        self.assertEqual(metadata_2["max_listened_at"], datetime.utcfromtimestamp(1400000200))
         self.assertEqual(metadata_2["count"], 4)

--- a/listenbrainz/listenstore/tests/test_timescale_utils.py
+++ b/listenbrainz/listenstore/tests/test_timescale_utils.py
@@ -40,7 +40,7 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
             result = connection.execute(
                 text("""
                     SELECT count, min_listened_at, max_listened_at
-                      FROM listen_user_metadata
+                      FROM listen_user_metadata_new
                      WHERE user_id = :user_id
                 """), {"user_id": user["id"]})
             row = result.fetchone()
@@ -69,7 +69,7 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(metadata_2["max_listened_at"], datetime.utcfromtimestamp(1400000200))
         self.assertEqual(metadata_2["count"], 5)
 
-        # to test the case when the update script has not run since delete, so metadata in listen_user_metadata does
+        # to test the case when the update script has not run since delete, so metadata in listen_user_metadata_new does
         # account for this listen and deleting should not affect it either.
         self._create_test_data(user_1, "timescale_listenstore_test_listens_2.json")
         self.logstore.delete_listen(datetime.utcfromtimestamp(1400000500), user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from datetime import datetime, timedelta
 from time import time
 
 import sqlalchemy
@@ -76,20 +77,23 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_insert_timescale(self):
         count = self._create_test_data(self.testuser_name, self.testuser_id)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1399999999)
+        from_ts = datetime.utcfromtimestamp(1399999999)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), count)
 
     def test_fetch_listens_0(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000000, limit=1)
+        from_ts = datetime.utcfromtimestamp(1400000000)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].ts_since_epoch, 1400000050)
-        self.assertEqual(min_ts, 1400000000)
-        self.assertEqual(max_ts, 1400000200)
+        self.assertEqual(min_ts, datetime.utcfromtimestamp(1400000000))
+        self.assertEqual(max_ts, datetime.utcfromtimestamp(1400000200))
 
     def test_fetch_listens_1(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000000)
+        from_ts = datetime.utcfromtimestamp(1400000000)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -98,14 +102,16 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_fetch_listens_2(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000100)
+        from_ts = datetime.utcfromtimestamp(1400000100)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
 
     def test_fetch_listens_3(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=1400000300)
+        to_ts = datetime.utcfromtimestamp(1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -115,22 +121,26 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_fetch_listens_4(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000049, to_ts=1400000101)
+        from_ts = datetime.utcfromtimestamp(1400000049)
+        to_ts = datetime.utcfromtimestamp(1400000101)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, to_ts=to_ts)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1400000100)
         self.assertEqual(listens[1].ts_since_epoch, 1400000050)
 
     def test_fetch_listens_5(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
+        from_ts = datetime.utcfromtimestamp(1400000101)
         with self.assertRaises(ValueError):
-            self.logstore.fetch_listens(user=self.testuser, from_ts=1400000101, to_ts=1400000001)
+            self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, to_ts=from_ts)
 
     def test_fetch_listens_with_gaps(self):
         self._create_test_data(self.testuser_name, self.testuser_id,
                                test_data_file_name='timescale_listenstore_test_listens_over_greater_time_range.json')
 
         # test from_ts with gaps
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1399999999)
+        from_ts = datetime.utcfromtimestamp(1399999999)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1420000050)
         self.assertEqual(listens[1].ts_since_epoch, 1420000000)
@@ -138,13 +148,16 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000000)
 
         # test from_ts and to_ts with gaps
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000049, to_ts=1420000001)
+        from_ts = datetime.utcfromtimestamp(1400000049)
+        to_ts = datetime.utcfromtimestamp(1420000001)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, to_ts=to_ts)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1420000000)
         self.assertEqual(listens[1].ts_since_epoch, 1400000050)
 
         # test to_ts with gaps
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=1420000051)
+        to_ts = datetime.utcfromtimestamp(1420000051)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1420000050)
         self.assertEqual(listens[1].ts_since_epoch, 1420000000)
@@ -154,7 +167,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
     def test_fetch_listens_with_mapping(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
         self._insert_mapping_metadata("c7a41965-9f1e-456c-8b1d-27c0f0dde280")
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000000, limit=1)
+        from_ts = datetime.utcfromtimestamp(1400000000)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, limit=1)
         self.assertEqual(len(listens), 1)
         # mbid submitted by the user is preferred over the mapping created by LB
         self.assertEqual(listens[0].data["mbid_mapping"]["artist_mbids"], ['678d88b2-87b0-403b-b63d-5da7465aecc3'])
@@ -179,13 +193,14 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2, user2["id"])
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], per_user_limit=1, min_ts=int(time()) - 10000000000)
+        min_ts = datetime(1960, 1, 1)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], per_user_limit=1, min_ts=min_ts)
         self.assertEqual(len(recent), 2)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=int(time()) - 10000000000)
+        recent = self.logstore.fetch_recent_listens_for_users([user, user2], min_ts=min_ts)
         self.assertEqual(len(recent), 4)
 
-        recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=recent[0].ts_since_epoch - 1)
+        recent = self.logstore.fetch_recent_listens_for_users([user], min_ts=recent[0].timestamp - timedelta(seconds=1))
         self.assertEqual(len(recent), 1)
         self.assertEqual(recent[0].ts_since_epoch, 1400000200)
 
@@ -203,7 +218,9 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         testuser = db_user.get_or_create(uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name, testuser["id"])
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=1400000300)
+
+        to_ts = datetime.utcfromtimestamp(1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -212,7 +229,9 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
         self.logstore.delete(testuser["id"])
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=1400000300)
+
+        to_ts = datetime.utcfromtimestamp(1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 0)
 
     def test_delete_single_listen(self):
@@ -221,7 +240,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name, testuser["id"])
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=1400000300)
+        to_ts = datetime.utcfromtimestamp(1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -229,11 +249,11 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        self.logstore.delete_listen(1400000050, testuser["id"], "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
+        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000050), testuser["id"], "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
 
         pending = self._get_pending_deletes()
         self.assertEqual(len(pending), 1)
-        self.assertEqual(pending[0]["listened_at"], 1400000050)
+        self.assertEqual(pending[0]["listened_at"], datetime.utcfromtimestamp(1400000050))
         self.assertEqual(pending[0]["user_id"], testuser["id"])
         self.assertEqual(str(pending[0]["recording_msid"]), "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
 
@@ -242,7 +262,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         # clear cache entry so that count is fetched from db again
         cache.delete(REDIS_USER_LISTEN_COUNT + str(testuser["id"]))
 
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=1400000300)
+        to_ts = datetime.utcfromtimestamp(1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
         self.assertEqual(listens[1].ts_since_epoch, 1400000150)
@@ -251,13 +272,17 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
         self.assertEqual(self.logstore.get_listen_count_for_user(testuser["id"]), 4)
         min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser["id"])
-        self.assertEqual(min_ts, 1400000000)
-        self.assertEqual(max_ts, 1400000200)
+        self.assertEqual(min_ts, datetime.utcfromtimestamp(1400000000))
+        self.assertEqual(max_ts, datetime.utcfromtimestamp(1400000200))
 
     def _get_pending_deletes(self):
         with timescale.engine.connect() as connection:
             result = connection.execute(text("SELECT * FROM listen_delete_metadata"))
-            return [row._asdict() for row in result.fetchall()]
+            return [{
+                "user_id": row.user_id,
+                "recording_msid": row.recording_msid,
+                "listened_at": row.listened_at.replace(tzinfo=None)
+            } for row in result.fetchall()]
 
     def _get_count_and_timestamps(self, user_id):
         with timescale.engine.connect() as connection:
@@ -298,8 +323,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
     def test_get_timestamps_for_user(self):
         self._create_test_data(self.testuser["musicbrainz_id"], self.testuser["id"])
         min_ts, max_ts = self.logstore.get_timestamps_for_user(self.testuser["id"])
-        self.assertEqual(1400000200, max_ts)
-        self.assertEqual(1400000000, min_ts)
+        self.assertEqual(datetime.utcfromtimestamp(1400000200), max_ts)
+        self.assertEqual(datetime.utcfromtimestamp(1400000000), min_ts)
 
         # test timestamps consider listens which were created since last cron run as well
         self._create_test_data(
@@ -310,8 +335,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         )
         # do not recalculate/update user data
         min_ts, max_ts = self.logstore.get_timestamps_for_user(self.testuser["id"])
-        self.assertEqual(1400000500, max_ts)
-        self.assertEqual(1400000000, min_ts)
+        self.assertEqual(datetime.utcfromtimestamp(1400000500), max_ts)
+        self.assertEqual(datetime.utcfromtimestamp(1400000000), min_ts)
 
     def test_fetch_listens_for_since_cron_run(self):
         """ Test listens created since last cron run to update user metadata are returned """
@@ -324,8 +349,9 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
             "timescale_listenstore_test_listens_2.json",
             recalculate=False
         )
-        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000300, limit=1)
+        from_ts = datetime.utcfromtimestamp(1400000300)
+        listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].ts_since_epoch, 1400000500)
-        self.assertEqual(min_ts, 1400000000)
-        self.assertEqual(max_ts, 1400000500)
+        self.assertEqual(min_ts, datetime.utcfromtimestamp(1400000000))
+        self.assertEqual(max_ts, datetime.utcfromtimestamp(1400000500))

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -277,7 +277,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def _get_pending_deletes(self):
         with timescale.engine.connect() as connection:
-            result = connection.execute(text("SELECT * FROM listen_delete_metadata"))
+            result = connection.execute(text("SELECT * FROM listen_delete_metadata_new"))
             return [{
                 "user_id": row.user_id,
                 "recording_msid": row.recording_msid,
@@ -289,7 +289,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
             result = connection.execute(
                 text("""
                     SELECT count, min_listened_at, max_listened_at
-                      FROM listen_user_metadata
+                      FROM listen_user_metadata_new
                      WHERE user_id = :user_id
                 """), {"user_id": user_id})
             return result.fetchone()._asdict()

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -15,6 +15,30 @@ from listenbrainz.listenstore import LISTEN_MINIMUM_TS
 CHUNK_SECONDS = 432000
 global_missing_users = set()
 
+
+def process_created(created: datetime):
+    print("Fixing-up using created - this may take a while.")
+    query = """
+        INSERT INTO listen_new (listened_at, created, user_id, recording_msid, data)
+             SELECT to_timestamp(listened_at)
+                  , created
+                  , user_id
+                  , (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid
+                  , jsonb_set(data->'track_metadata', '{track_name}'::text[], to_jsonb(track_name), true) #- '{additional_info,recording_msid}'::text[]
+               FROM listen
+              WHERE listened_at >= :start
+                AND created < :end
+           ORDER BY listened_at ASC  
+        ON CONFLICT (listened_at, user_id, recording_msid)
+         DO NOTHING
+    """
+    s = time.monotonic()
+    with timescale.engine.connect() as connection:
+        connection.execute(text(query), {"start": LISTEN_MINIMUM_TS, "end": created})
+    e = time.monotonic()
+
+    print(f" - fixed up using created in {round(e-s, 2)}s")
+
 def process_chunk(chunk_start):
     chunk_start_dt = datetime.fromtimestamp(chunk_start)
     chunk_start_dt = chunk_start_dt.replace(microsecond=0)
@@ -42,7 +66,6 @@ def process_chunk(chunk_start):
     e = time.monotonic()
 
     print(f" - processed chunk in {round(e-s, 2)}s")
-    return True
 
 
 def migrate_listens():
@@ -52,7 +75,11 @@ def migrate_listens():
           FROM listen
          WHERE listened_at >= :least_accepted_ts
     """
-    query2 = """SELECT COALESCE(EXTRACT('epoch' from max(listened_at)), 0) AS already_done_ts from listen_new"""
+    query2 = """
+        SELECT COALESCE(EXTRACT('epoch' from max(listened_at)), 0) AS already_done_ts
+             , max(created) AS already_max_created
+          FROM listen_new
+    """
     with timescale.engine.connect() as connection:
         result = connection.execute(text(query1), {"least_accepted_ts": LISTEN_MINIMUM_TS})
         row = result.fetchone()
@@ -61,6 +88,7 @@ def migrate_listens():
         result = connection.execute(text(query2))
         row = result.fetchone()
         already_done_ts = row.already_done_ts
+        already_max_created = row.already_max_created
 
     if already_done_ts:
         chunk_start = already_done_ts - already_done_ts % CHUNK_SECONDS
@@ -75,6 +103,12 @@ def migrate_listens():
         chunk_count += 1
         print_status_update(chunk_count, number_chunks, start_time)
         chunk_start += CHUNK_SECONDS
+
+    # since listens with older listened_at values can be inserted between runs, also do a scan with created field
+    # to insert the remaining listens
+    if already_max_created:
+        print("Finished chunkwise scan.")
+        process_created(already_max_created)
 
     print("Finished.")
 

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -27,14 +27,14 @@ def process_created(created: datetime):
                   , jsonb_set(data->'track_metadata', '{track_name}'::text[], to_jsonb(track_name), true) #- '{additional_info,recording_msid}'::text[]
                FROM listen
               WHERE listened_at >= :start
-                AND created < :end
+                AND created >= :last_created
            ORDER BY listened_at ASC  
         ON CONFLICT (listened_at, user_id, recording_msid)
          DO NOTHING
     """
     s = time.monotonic()
     with timescale.engine.connect() as connection:
-        connection.execute(text(query), {"start": LISTEN_MINIMUM_TS, "end": created})
+        connection.execute(text(query), {"start": LISTEN_MINIMUM_TS, "last_created": created})
     e = time.monotonic()
 
     print(f" - fixed up using created in {round(e-s, 2)}s")

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -37,6 +37,7 @@ def process_created(created: datetime):
 
     print(f" - fixed up using created in {round(e-s, 2)}s")
 
+
 def process_chunk(chunk_start):
     chunk_start_dt = datetime.fromtimestamp(chunk_start)
     chunk_start_dt = chunk_start_dt.replace(microsecond=0)
@@ -102,6 +103,7 @@ def migrate_listens():
         print_status_update(chunk_count, number_chunks, start_time)
         chunk_start += CHUNK_SECONDS
 
+    # max created for fixup in future - Thu 27 Apr 2023 08:50:19 PM UTC
     # since listens with older listened_at values can be inserted between runs, also do a scan with created field
     # to insert the remaining listens
     if already_max_created:

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -62,7 +62,11 @@ def migrate_listens():
         row = result.fetchone()
         already_done_ts = row.already_done_ts
 
-    chunk_start = already_done_ts - already_done_ts % CHUNK_SECONDS
+    if already_done_ts:
+        chunk_start = already_done_ts - already_done_ts % CHUNK_SECONDS
+    else:
+        chunk_start = LISTEN_MINIMUM_TS
+
     number_chunks = math.ceil((max_listened_at - chunk_start) / CHUNK_SECONDS)
     chunk_count = 0
     start_time = time.monotonic()

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -5,10 +5,8 @@ import math
 import time
 from datetime import datetime, timedelta
 
-import psycopg2.extras
 from sqlalchemy import text
 
-from listenbrainz import db
 from listenbrainz.db import timescale
 from listenbrainz.listenstore import LISTEN_MINIMUM_TS
 
@@ -91,7 +89,7 @@ def migrate_listens():
         already_max_created = row.already_max_created
 
     if already_done_ts:
-        chunk_start = already_done_ts - already_done_ts % CHUNK_SECONDS
+        chunk_start = int(already_done_ts - already_done_ts % CHUNK_SECONDS)
     else:
         chunk_start = LISTEN_MINIMUM_TS
 

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -28,7 +28,7 @@ def process_chunk(chunk_start):
                   , created
                   , user_id
                   , (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid
-                  , jsonb_set(data->'track_metadata', '{track_name}', track_name, true) #- '{additional_info,recording_msid}'
+                  , jsonb_set(data->'track_metadata', '{track_name}'::text[], to_jsonb(track_name), true) #- '{additional_info,recording_msid}'::text[]
                FROM listen
               WHERE listened_at >= :start 
                 AND listened_at < :end

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -3,7 +3,7 @@ Utility tool for migrating listens to new schema table. It can be run multiple t
 """
 import math
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import text
 
@@ -12,7 +12,7 @@ from listenbrainz.listenstore import LISTEN_MINIMUM_TS
 
 CHUNK_SECONDS = 432000
 global_missing_users = set()
-MAX_CREATED_WHEN_ENABLED_ON_TEST = datetime(2023, 4, 27)
+MAX_CREATED_WHEN_ENABLED_ON_TEST = datetime(2023, 4, 27, tzinfo=timezone.utc)
 
 
 def process_created(created: datetime):

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -1,0 +1,89 @@
+"""
+Utility tool for migrating listens to new schema table. It can be run multiple times.
+"""
+import math
+import time
+from datetime import datetime, timedelta
+
+import psycopg2.extras
+from sqlalchemy import text
+
+from listenbrainz import db
+from listenbrainz.db import timescale
+from listenbrainz.listenstore import LISTEN_MINIMUM_TS
+
+CHUNK_SECONDS = 432000
+global_missing_users = set()
+
+def process_chunk(chunk_start):
+    chunk_start_dt = datetime.fromtimestamp(chunk_start)
+    chunk_start_dt = chunk_start_dt.replace(microsecond=0)
+    chunk_end_dt = datetime.fromtimestamp(chunk_start + CHUNK_SECONDS)
+    chunk_end_dt = chunk_end_dt.replace(microsecond=0)
+    print(f"Processing chunk: {chunk_start_dt.isoformat()} - {chunk_end_dt.isoformat()}")
+
+    query = """
+        INSERT INTO listen_new (listened_at, created, user_id, recording_msid, data)
+             SELECT to_timestamp(listened_at)
+                  , created
+                  , user_id
+                  , (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid
+                  , jsonb_set(data->'track_metadata', '{track_name}', track_name, true) #- '{additional_info,recording_msid}'
+               FROM listen
+              WHERE listened_at >= :start 
+                AND listened_at < :end
+           ORDER BY listened_at ASC  
+        ON CONFLICT (listened_at, user_id, recording_msid)
+         DO NOTHING
+    """
+    s = time.monotonic()
+    with timescale.engine.connect() as connection:
+        connection.execute(text(query), {"start": chunk_start, "end": chunk_start + CHUNK_SECONDS})
+    e = time.monotonic()
+
+    print(f" - processed chunk in {round(e-s, 2)}s")
+    return True
+
+
+def migrate_listens():
+    query1 = """
+        SELECT min(listened_at) as min_listened_at
+             , max(listened_at) as max_listened_at
+          FROM listen
+         WHERE listened_at >= :least_accepted_ts
+    """
+    query2 = """SELECT COALESCE(EXTRACT('epoch' from max(listened_at)), 0) AS already_done_ts from listen_new"""
+    with timescale.engine.connect() as connection:
+        result = connection.execute(text(query1), {"least_accepted_ts": LISTEN_MINIMUM_TS})
+        row = result.fetchone()
+        max_listened_at = row.max_listened_at
+
+        result = connection.execute(text(query2))
+        row = result.fetchone()
+        already_done_ts = row.already_done_ts
+
+    chunk_start = already_done_ts - already_done_ts % CHUNK_SECONDS
+    number_chunks = math.ceil((max_listened_at - chunk_start) / CHUNK_SECONDS)
+    chunk_count = 0
+    start_time = time.monotonic()
+    while chunk_start < max_listened_at:
+        process_chunk(chunk_start)
+        chunk_count += 1
+        print_status_update(chunk_count, number_chunks, start_time)
+        chunk_start += CHUNK_SECONDS
+
+    print("Finished.")
+
+
+def print_status_update(chunk_count, number_chunks, start_time):
+    """Print a basic status update based on how many chunks have been computed"""
+    if number_chunks > 0:
+        chunk_time = time.monotonic()
+        chunk_percentage = chunk_count / number_chunks
+        duration = round(chunk_time - start_time)
+        durdelta = timedelta(seconds=duration)
+        remaining = round((duration / (chunk_percentage or 0.01)) - duration)
+        remdelta = timedelta(seconds=remaining)
+        print(f" - Done {chunk_count}/{number_chunks} in {str(durdelta)}; {str(remdelta)} remaining")
+    else:
+        print(f" No chunks processed")

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -20,9 +20,9 @@ from listenbrainz.listenstore import LISTENS_DUMP_SCHEMA_VERSION, LISTEN_MINIMUM
 from listenbrainz.listenstore import ORDER_ASC, ORDER_TEXT, ORDER_DESC, DEFAULT_LISTENS_PER_FETCH
 
 # Append the user name for both of these keys
-REDIS_USER_LISTEN_COUNT = "lc."
-REDIS_USER_TIMESTAMPS = "ts."
-REDIS_TOTAL_LISTEN_COUNT = "lc-total"
+REDIS_USER_LISTEN_COUNT = "new-lc."
+REDIS_USER_TIMESTAMPS = "new-ts."
+REDIS_TOTAL_LISTEN_COUNT = "new-lc-total"
 # cache listen counts for 5 minutes only, so that listen counts are always up-to-date in 5 minutes.
 REDIS_USER_LISTEN_COUNT_EXPIRY = 300
 

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -1,6 +1,7 @@
 import subprocess
 import tarfile
 import time
+from datetime import datetime, timedelta
 from typing import Dict, Tuple, Optional
 
 import psycopg2
@@ -30,14 +31,15 @@ DATA_START_YEAR = 2005
 DATA_START_YEAR_IN_SECONDS = 1104537600
 
 # How many listens to fetch on the first attempt. If we don't fetch enough, increase it by WINDOW_SIZE_MULTIPLIER
-DEFAULT_FETCH_WINDOW = 30 * 86400  # 30 days
+DEFAULT_FETCH_WINDOW = timedelta(days=30)  # 30 days
 
 # When expanding the search, how fast should the bounds be moved out
 WINDOW_SIZE_MULTIPLIER = 3
 
 LISTEN_COUNT_BUCKET_WIDTH = 2592000
 
-MAX_FUTURE_SECONDS = 600  # 10 mins in future - max fwd clock skew
+MAX_FUTURE_SECONDS = timedelta(seconds=1)  # 10 mins in future - max fwd clock skew
+EPOCH = datetime.utcfromtimestamp(0)
 
 
 class TimescaleListenStore:
@@ -85,11 +87,11 @@ class TimescaleListenStore:
             cache.set(REDIS_USER_LISTEN_COUNT + str(user_id), count, REDIS_USER_LISTEN_COUNT_EXPIRY)
             return count
 
-    def get_timestamps_for_user(self, user_id: int) -> Tuple[Optional[int], Optional[int]]:
+    def get_timestamps_for_user(self, user_id: int) -> Tuple[Optional[datetime], Optional[datetime]]:
         """ Return the min_ts and max_ts for the given list of users """
         query = """
-            SELECT COALESCE(min_listened_at, 0) AS min_ts
-                 , COALESCE(max_listened_at, 0) AS max_ts
+            SELECT COALESCE(min_listened_at, 'epoch'::timestamptz) AS min_ts
+                 , COALESCE(max_listened_at, 'epoch'::timestamptz) AS max_ts
               FROM listen_user_metadata
              WHERE user_id = :user_id
         """
@@ -97,8 +99,11 @@ class TimescaleListenStore:
             result = connection.execute(text(query), {"user_id": user_id})
             row = result.fetchone()
             if row is None:
-                return 0, 0
-            return row.min_ts, row.max_ts
+                min_ts = max_ts = EPOCH
+            else:
+                min_ts = row.min_ts
+                max_ts = row.max_ts
+            return min_ts.replace(tzinfo=None), max_ts.replace(tzinfo=None)
 
     def get_total_listen_count(self):
         """ Returns the total number of listens stored in the ListenStore.
@@ -172,7 +177,7 @@ class TimescaleListenStore:
 
         return inserted_rows
 
-    def fetch_listens(self, user: Dict, from_ts: int = None, to_ts: int = None, limit: int = DEFAULT_LISTENS_PER_FETCH):
+    def fetch_listens(self, user: Dict, from_ts: datetime = None, to_ts: datetime = None, limit: int = DEFAULT_LISTENS_PER_FETCH):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
             the value they are converted to the local server's timezone. So to compare
             datetime object we need to create a object in the same timezone as the server.
@@ -194,11 +199,11 @@ class TimescaleListenStore:
 
         min_user_ts, max_user_ts = self.get_timestamps_for_user(user["id"])
 
-        if min_user_ts == 0 and max_user_ts == 0:
+        if min_user_ts == EPOCH and max_user_ts == EPOCH:
             return [], min_user_ts, max_user_ts
 
         if to_ts is None and from_ts is None:
-            to_ts = max_user_ts + 1
+            to_ts = max_user_ts + timedelta(seconds=1)
 
         window_size = DEFAULT_FETCH_WINDOW
         query = """
@@ -293,16 +298,16 @@ class TimescaleListenStore:
                             done = True
                             break
 
-                        if from_ts < min_user_ts - 1:
+                        if from_ts < min_user_ts - timedelta(seconds=1):
                             done = True
                             break
 
-                        if to_ts > int(time.time()) + MAX_FUTURE_SECONDS:
+                        if to_ts > datetime.now() + MAX_FUTURE_SECONDS:
                             done = True
                             break
 
                         if to_dynamic:
-                            from_ts += window_size - 1
+                            from_ts += window_size - timedelta(seconds=1)
                             window_size *= WINDOW_SIZE_MULTIPLIER
                             to_ts += window_size
 
@@ -346,7 +351,7 @@ class TimescaleListenStore:
 
         return listens, min_user_ts, max_user_ts
 
-    def fetch_recent_listens_for_users(self, users, min_ts: int = None, max_ts: int = None, per_user_limit=2, limit=10):
+    def fetch_recent_listens_for_users(self, users, min_ts: datetime = None, max_ts: datetime = None, per_user_limit=2, limit=10):
         """ Fetch recent listens for a list of users, given a limit which applies per user. If you
             have a limit of 3 and 3 users you should get 9 listens if they are available.
 
@@ -546,7 +551,7 @@ class TimescaleListenStore:
             self.log.error("Cannot delete listens for user: %s" % str(e))
             raise
 
-    def delete_listen(self, listened_at: int, user_id: int, recording_msid: str):
+    def delete_listen(self, listened_at: datetime, user_id: int, recording_msid: str):
         """ Delete a particular listen for user with specified MusicBrainz ID.
 
         .. note::

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -215,7 +215,7 @@ class TimescaleListenStore:
                              , l.data
                              -- prefer to use user submitted mbid, then user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
                              , COALESCE((data->'track_metadata'->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
-                          FROM listen l
+                          FROM listen_new l
                      LEFT JOIN mbid_mapping mm
                             ON l.recording_msid = mm.recording_msid
                      LEFT JOIN mbid_manual_mapping user_mm
@@ -381,7 +381,7 @@ class TimescaleListenStore:
                          , recording_msid
                          , data
                          , row_number() OVER (PARTITION BY user_id ORDER BY listened_at DESC) AS rownum
-                      FROM listen l
+                      FROM listen_new l
                      WHERE {filters} 
               ), selected_listens AS (
                     SELECT l.*

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -140,7 +140,7 @@ class TimescaleListenStore:
 
         query = """
             WITH inserted_listens AS (
-                INSERT INTO listen (listened_at, user_id, recording_msid, data)
+                INSERT INTO listen_new (listened_at, user_id, recording_msid, data)
                      VALUES %s
                 ON CONFLICT (listened_at, user_id, recording_msid)
                  DO NOTHING
@@ -149,9 +149,9 @@ class TimescaleListenStore:
                 INSERT INTO listen_user_metadata_new AS lum (user_id, count, min_listened_at, max_listened_at, created)
                      SELECT user_id, count(*), min(listened_at), max(listened_at), NOW()
                        FROM inserted_listens
-                   GROUP BY user_id  
+                   GROUP BY user_id
                 ON CONFLICT (user_id)
-                  DO UPDATE 
+                  DO UPDATE
                         SET count = lum.count + excluded.count
                           , min_listened_at = least(lum.min_listened_at, excluded.min_listened_at)
                           , max_listened_at = greatest(lum.max_listened_at, excluded.max_listened_at)

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -24,24 +24,24 @@ def delete_listens():
     #
     # 1) Delete Mismatch
     #
-    # The listen_delete_metadata table holds the rows to be deleted FROM listen_new. We fetch the rows from it and delete
-    # corresponding listens FROM listen_new table. After that, we update counts and timestamps in listen_user_metadata table
+    # The listen_delete_metadata_new table holds the rows to be deleted FROM listen_new. We fetch the rows from it and delete
+    # corresponding listens FROM listen_new table. After that, we update counts and timestamps in listen_user_metadata_new table
     # as necessary. Between the time rows are deleted FROM listen_new table and the time we get to clear up the
-    # listen_delete_metadata table, new rows may have been inserted in the latter. So, we would have deleted rows from
-    # listen_delete_metadata table without deleting the actual listens.
+    # listen_delete_metadata_new table, new rows may have been inserted in the latter. So, we would have deleted rows from
+    # listen_delete_metadata_new table without deleting the actual listens.
     #
     # This issue exists because our transaction isolation level is READ COMMITTED. This issue can be prevented by using
     # the REPEATABLE READ isolation level but that comes with its own issues. To alleviate this issue, the id
-    # column has been added to the listen_delete_metadata table. Before the start of the transaction, we record the
-    # maximum id in the table. This id is used to select the rows from listen_delete_metadata table and the same rows
+    # column has been added to the listen_delete_metadata_new table. Before the start of the transaction, we record the
+    # maximum id in the table. This id is used to select the rows from listen_delete_metadata_new table and the same rows
     # are then later deleted.
     #
     # 2) "Fake/Double" Delete
     #
     # The DELETE listen endpoint does not verify whether a listen already exists in the listen table. It also does not
-    # check whether that row for that delete already exists in listen_delete_metadata table. This can actually be a
+    # check whether that row for that delete already exists in listen_delete_metadata_new table. This can actually be a
     # quite common situation, for example: the user clicking delete for the same listen twice. If we count the number of
-    # deleted listens to subtract using listen_delete_metadata table, the count may become inaccurate.
+    # deleted listens to subtract using listen_delete_metadata_new table, the count may become inaccurate.
     #
     # Therefore, we use the RETURNING clause with the DELETE FROM listen_new statement to return the user_id and created
     # of the actual deletes and then calculate the deleted listen count from it and subtract it from existing count to
@@ -50,7 +50,7 @@ def delete_listens():
     # However, PG's CTEs have a limitation that they unrelated WITH'ed queries may be executed in any order and if there
     # are multiple updates to a row in a CTE, only 1 query's update will be visible afterwards. So the queries to update
     # timestamps cannot be put in the WITH of update counts query. Further, this means that we cannot utilise the
-    # RETURNING clause to return listened_at for these queries and need to read the listen_delete_metadata table.
+    # RETURNING clause to return listened_at for these queries and need to read the listen_delete_metadata_new table.
     # (**There is an alternative if needed: create a temporary table out of the RETURNING clause data.**)
     # But but wait... For updating min/max listened_at timestamp, we scan the listen table so even if there are double
     # entries or fake entries for delete, it doesn't matter. The new min/max timestamps are going to come from the
@@ -58,17 +58,17 @@ def delete_listens():
     #
     # 3) Interaction with regular metadata update cron job
     #
-    # A periodic cron job run updates the metadata in the listen_user_metadata table. Specifically, the count,
+    # A periodic cron job run updates the metadata in the listen_user_metadata_new table. Specifically, the count,
     # min_listened_at and max_listened_at values for a user have been calculated only on the basis of listens created
-    # prior to the created value of that user's listen_user_metadata row. But many users will have listens created
+    # prior to the created value of that user's listen_user_metadata_new row. But many users will have listens created
     # since the last cron job run, some of these may end up in deletes as well.
     #
-    # Listens which have a created value later than the created value in the listen_user_metadata table haven't yet
-    # been counted in the listen_user_metadata table. So when deleted the count of these listens should not be
-    # subtracted from listen_user_metadata. The FILTER clause with count(*) is responsible for that.
+    # Listens which have a created value later than the created value in the listen_user_metadata_new table haven't yet
+    # been counted in the listen_user_metadata_new table. So when deleted the count of these listens should not be
+    # subtracted from listen_user_metadata_new. The FILTER clause with count(*) is responsible for that.
     #
     # Similarly, a listen with listened_at greater than max_listened_at can be created later than the created value
-    # in the listen_user_metadata table. If this listen is deleted and the listen with max_listened_at is also deleted,
+    # in the listen_user_metadata_new table. If this listen is deleted and the listen with max_listened_at is also deleted,
     # max(listened_at) of deleted listens != max_listened_at of listened_user_metadata. So, we will have missed to
     # update listen timestamps in this case. To avoid this, we need to check max_listened_at is in the list of
     # listened_at of delete listens. The same situation can happen with min_listened_at.
@@ -76,7 +76,7 @@ def delete_listens():
     # 4) Redundant work in updating min/max listened_at
     #
     # To update min/max listened_at fields, it doesn't really matter whether the listens were created prior or after
-    # the created value in the listen_user_metadata table. It is a matter of choosing the best performance
+    # the created value in the listen_user_metadata_new table. It is a matter of choosing the best performance
     # characteristics. When updating the these fields we use the existing min/max listened_at values to reduce the
     # search space.
     #
@@ -95,13 +95,13 @@ def delete_listens():
 
     # select the maximum id in the table till now, we are only to process
     # deletes with row id earlier than this.
-    select_max_id = "SELECT max(id) AS max_id FROM listen_delete_metadata"
+    select_max_id = "SELECT max(id) AS max_id FROM listen_delete_metadata_new"
 
     # count deleted listens, checked created and update listen counts
     delete_listens_and_update_listen_counts = """
         WITH deleted_listens AS (
             DELETE FROM listen_new l
-             USING listen_delete_metadata ldm
+             USING listen_delete_metadata_new ldm
              WHERE ldm.id <= :max_id
                AND l.user_id = ldm.user_id
                AND l.listened_at = ldm.listened_at
@@ -111,11 +111,11 @@ def delete_listens():
             SELECT user_id
                  , count(*) AS deleted_count
               FROM deleted_listens dl
-              JOIN listen_user_metadata lm
+              JOIN listen_user_metadata_new lm
              USING (user_id)
           GROUP BY user_id
         ) 
-            UPDATE listen_user_metadata lm
+            UPDATE listen_user_metadata_new lm
                SET count = count - deleted_count
               FROM update_counts uc
              WHERE lm.user_id = uc.user_id
@@ -126,8 +126,8 @@ def delete_listens():
     update_listen_min_ts = """
         WITH update_ts AS (
             SELECT user_id, min_listened_at, lm.created
-              FROM listen_delete_metadata dl
-              JOIN listen_user_metadata lm
+              FROM listen_delete_metadata_new dl
+              JOIN listen_user_metadata_new lm
              USING (user_id)
              WHERE dl.id <= :max_id
           GROUP BY user_id, min_listened_at, lm.created
@@ -149,7 +149,7 @@ def delete_listens():
                    ) AS new_ts
                 ON TRUE
         )
-            UPDATE listen_user_metadata lm
+            UPDATE listen_user_metadata_new lm
                SET min_listened_at = new_listened_at
               FROM calculate_new_ts mt
              WHERE lm.user_id = mt.user_id
@@ -160,8 +160,8 @@ def delete_listens():
     update_listen_max_ts = """
         WITH update_ts AS (
             SELECT user_id, max_listened_at, lm.created
-              FROM listen_delete_metadata dl
-              JOIN listen_user_metadata lm
+              FROM listen_delete_metadata_new dl
+              JOIN listen_user_metadata_new lm
              USING (user_id)
              WHERE dl.id <= :max_id
           GROUP BY user_id, max_listened_at, lm.created
@@ -183,12 +183,12 @@ def delete_listens():
                    ) AS new_ts
                 ON TRUE
         )
-            UPDATE listen_user_metadata lm
+            UPDATE listen_user_metadata_new lm
                SET max_listened_at = new_listened_at
               FROM calculate_new_ts mt
              WHERE lm.user_id = mt.user_id
     """
-    delete_user_metadata = "DELETE FROM listen_delete_metadata WHERE id <= :max_id"
+    delete_user_metadata = "DELETE FROM listen_delete_metadata_new WHERE id <= :max_id"
 
     with timescale.engine.begin() as connection:
         result = connection.execute(text(select_max_id))
@@ -199,7 +199,7 @@ def delete_listens():
             return
 
         max_id = row.max_id
-        logger.info("Found max id in listen_delete_metadata table: %s", max_id)
+        logger.info("Found max id in listen_delete_metadata_new table: %s", max_id)
 
         logger.info("Deleting Listens and updating affected listens counts")
         connection.execute(text(delete_listens_and_update_listen_counts), {"max_id": max_id})
@@ -217,7 +217,7 @@ def delete_listens():
 
 
 def update_user_listen_data():
-    """ Scan listens created since last run and update metadata in listen_user_metadata accordingly """
+    """ Scan listens created since last run and update metadata in listen_user_metadata_new accordingly """
     query = """
         WITH new AS (
             SELECT user_id
@@ -225,13 +225,13 @@ def update_user_listen_data():
                  , min(listened_at) AS min_listened_at
                  , max(listened_at) AS max_listened_at
               FROM listen_new l
-              JOIN listen_user_metadata lm
+              JOIN listen_user_metadata_new lm
              USING (user_id)
              WHERE l.created > lm.created
                AND l.created <= :until
           GROUP BY user_id
         )
-        UPDATE listen_user_metadata old
+        UPDATE listen_user_metadata_new old
            SET count = old.count + new.count
              , min_listened_at = least(old.min_listened_at, new.min_listened_at)
              , max_listened_at = greatest(old.max_listened_at, new.max_listened_at)
@@ -256,7 +256,7 @@ def delete_listens_and_update_user_listen_data():
 
 
 def add_missing_to_listen_users_metadata():
-    """ Fetch users from LB and add an entry those users which are missing from listen_user_metadata """
+    """ Fetch users from LB and add an entry those users which are missing from listen_user_metadata_new """
     # Select a list of users
     user_list = []
     query = 'SELECT id FROM "user"'
@@ -274,7 +274,7 @@ def add_missing_to_listen_users_metadata():
                 len(user_list))
 
     query = """
-        INSERT INTO listen_user_metadata (user_id, count, min_listened_at, max_listened_at, created)
+        INSERT INTO listen_user_metadata_new (user_id, count, min_listened_at, max_listened_at, created)
              VALUES %s
         ON CONFLICT (user_id)
          DO NOTHING
@@ -306,7 +306,7 @@ def recalculate_all_user_data():
     logger.info("Fetched %d users. Resetting created timestamps for all users.", len(user_list))
 
     query = """
-        INSERT INTO listen_user_metadata (user_id, count, min_listened_at, max_listened_at, created)
+        INSERT INTO listen_user_metadata_new (user_id, count, min_listened_at, max_listened_at, created)
              VALUES %s
         ON CONFLICT (user_id)
           DO UPDATE

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -8,7 +8,7 @@ import sqlalchemy
 from listenbrainz import db
 from listenbrainz import webserver
 from listenbrainz.db import timescale as ts, do_not_recommend
-from listenbrainz.listenstore import timescale_fill_userid
+from listenbrainz.listenstore import timescale_fill_userid, timescale_listens_migrate
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data as ts_recalculate_all_user_data, \
     update_user_listen_data as ts_update_user_listen_data, \
     add_missing_to_listen_users_metadata as ts_add_missing_to_listen_users_metadata,\
@@ -294,6 +294,14 @@ def spotify_add_userid():
     app = create_app()
     with app.app_context():
         spotify_fill_user_id.main()
+
+
+@cli.command()
+def listen_migrate():
+    """ Migrate the listens table to new schema. """
+    app = create_app()
+    with app.app_context():
+        timescale_listens_migrate.migrate_listens()
 
 
 @cli.command()

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -21,6 +21,7 @@
 
 import logging
 import time
+from datetime import datetime
 
 from flask import url_for
 from werkzeug.exceptions import BadRequest
@@ -140,7 +141,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
         time.sleep(1)
         recalculate_all_user_data()
-        to_ts = int(time.time())
+        to_ts = datetime.utcnow()
         listens, _, _ = self.ls.fetch_listens(self.user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -48,7 +48,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
 
-        to_ts = int(time.time())
+        to_ts = datetime.utcnow()
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
@@ -68,8 +68,8 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         self.assertEqual(1, self.rs.get_listen_count_for_day(datetime.utcnow()))
 
         (min_ts, max_ts) = self.ls.get_timestamps_for_user(user["id"])
-        self.assertEqual(min_ts, 1486449409)
-        self.assertEqual(max_ts, 1486449409)
+        self.assertEqual(min_ts, datetime.utcfromtimestamp(1486449409))
+        self.assertEqual(max_ts, datetime.utcfromtimestamp(1486449409))
 
 
     def test_dedup_user_special_characters(self):
@@ -81,7 +81,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         self.assert200(r)
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
-        to_ts = int(time.time())
+        to_ts = datetime.utcnow()
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
@@ -92,7 +92,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         r = self.send_listen(user, 'same_batch_duplicates.json')
         self.assert200(r)
 
-        to_ts = int(time.time())
+        to_ts = datetime.utcnow()
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
@@ -111,7 +111,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         r = self.send_listen(user2, 'valid_single.json')
         self.assert200(r)
 
-        to_ts = int(time.time())
+        to_ts = datetime.utcnow()
         listens, _, _ = self.ls.fetch_listens(user1, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
@@ -139,6 +139,6 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         r = self.send_listen(user, 'same_timestamp_diff_track_valid_single_3.json')
         self.assert200(r)
 
-        to_ts = int(time.time())
+        to_ts = datetime.utcnow()
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 4)

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -40,7 +40,6 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         return response
 
     def test_dedup(self):
-
         user = db_user.get_or_create(1, 'testtimescaleuser %d' % randint(1,50000))
 
         # send the same listen twice

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -90,7 +90,7 @@ class ListenTestCase(unittest.TestCase):
         self.assertIn('additional_info', json_data)
 
         # Check that the required fields are dumped into data
-        self.assertEqual(listened_at, listen.ts_since_epoch)
+        self.assertEqual(listened_at, listen.timestamp)
         self.assertEqual(recording_msid, listen.recording_msid)
         self.assertEqual(user_id, listen.user_id)
         self.assertEqual(json_data['artist_name'], listen.data['artist_name'])

--- a/listenbrainz/tests/unit/test_listen.py
+++ b/listenbrainz/tests/unit/test_listen.py
@@ -13,28 +13,25 @@ class ListenTestCase(unittest.TestCase):
         timescale_row = {
             "listened_at": 1525557084,
             "created": 1525557084,
-            "track_name": "Every Step Every Way",
             "user_name": "iliekcomputers",
             "user_id": 1,
-            "data": {
-                'track_metadata': {
-                    "artist_name": "Majid Jordan",
-                    "release_name": "Majid Jordan",
-                    'additional_info': {
-                        "artist_mbids": ["abaa7001-0d80-4e58-be5d-d2d246fd9d87"],
-                        'release_mbid': '8294645a-f996-44b6-9060-7f189b9f59f3',
-                        "recording_mbid": None,
-                        "recording_msid": "db9a7483-a8f4-4a2c-99af-c8ab58850200",
-                        "tags": ["sing, song"],
-                        "best_song": "definitely",
-                        "genius_link": "https://genius.com/Majid-jordan-every-step-every-way-lyrics",
-                        "lastfm_link": "https://www.last.fm/music/Majid+Jordan/_/Every+Step+Every+Way",
-                        "other_stuff": "teststuffplsignore",
-                        "we_dict_now.hello": "afb",
-                        "we_dict_now.we_nested_now.hi": "312"
-                    }
-                },
-                "user_id": 1
+            "recording_msid": "db9a7483-a8f4-4a2c-99af-c8ab58850200",
+            "track_metadata": {
+                "track_name": "Every Step Every Way",
+                "artist_name": "Majid Jordan",
+                "release_name": "Majid Jordan",
+                "additional_info": {
+                    "artist_mbids": ["abaa7001-0d80-4e58-be5d-d2d246fd9d87"],
+                    'release_mbid': '8294645a-f996-44b6-9060-7f189b9f59f3',
+                    "recording_mbid": None,
+                    "tags": ["sing, song"],
+                    "best_song": "definitely",
+                    "genius_link": "https://genius.com/Majid-jordan-every-step-every-way-lyrics",
+                    "lastfm_link": "https://www.last.fm/music/Majid+Jordan/_/Every+Step+Every+Way",
+                    "other_stuff": "teststuffplsignore",
+                    "we_dict_now.hello": "afb",
+                    "we_dict_now.we_nested_now.hi": "312"
+                }
             }
         }
 
@@ -48,22 +45,18 @@ class ListenTestCase(unittest.TestCase):
         self.assertEqual(listen.ts_since_epoch, ts)
 
         # Check artist mbids
-        self.assertEqual(listen.data['additional_info']['artist_mbids'],
-                         timescale_row['data']['track_metadata']['additional_info']['artist_mbids'])
+        self.assertEqual(listen.data['additional_info']['artist_mbids'], timescale_row['track_metadata']['additional_info']['artist_mbids'])
 
         # Check tags
-        self.assertEqual(listen.data['additional_info']['tags'], timescale_row['data']
-                         ['track_metadata']['additional_info']['tags'])
+        self.assertEqual(listen.data['additional_info']['tags'], timescale_row['track_metadata']['additional_info']['tags'])
 
         # Check track name
-        self.assertEqual(listen.data['track_name'], timescale_row['data']
-                         ['track_metadata']['track_name'])
+        self.assertEqual(listen.data['track_name'], timescale_row['track_metadata']['track_name'])
 
         # Check additional info
-        self.assertEqual(listen.data['additional_info']['best_song'],
-                         timescale_row['data']['track_metadata']['additional_info']['best_song'])
+        self.assertEqual(listen.data['additional_info']['best_song'], timescale_row['track_metadata']['additional_info']['best_song'])
 
-        self.assertEqual(listen.data['track_name'], timescale_row['track_name'])
+        self.assertEqual(listen.data['track_name'], timescale_row['track_metadata']['track_name'])
 
         # make sure additional info does not contain stuff like artist names, track names
         self.assertNotIn('track_name', listen.data['additional_info'])
@@ -74,19 +67,18 @@ class ListenTestCase(unittest.TestCase):
         listen = Listen(
             timestamp=int(time.time()),
             user_name='testuser',
-            dedup_tag=3,
             user_id=1,
+            recording_msid=str(uuid.uuid4()),
             data={
                 'artist_name': 'Radiohead',
                 'track_name': 'True Love Waits',
                 'additional_info': {
                     'release_type': ["ALBUM", "REMIX"],
-                    'recording_msid': str(uuid.uuid4()),
                 }
             }
         )
 
-        listened_at, track_name, user_name, user_id, data = listen.to_timescale()
+        listened_at, user_id, recording_msid, data = listen.to_timescale()
 
         # Check data is of type string
         self.assertIsInstance(data, str)
@@ -95,23 +87,16 @@ class ListenTestCase(unittest.TestCase):
         json_data = orjson.loads(data)
 
         # Check that the required fields are dumped into data
-        self.assertIn('track_metadata', json_data)
-        self.assertIn('additional_info', json_data['track_metadata'])
+        self.assertIn('additional_info', json_data)
 
         # Check that the required fields are dumped into data
         self.assertEqual(listened_at, listen.ts_since_epoch)
-        self.assertEqual(track_name, listen.data['track_name'])
-        self.assertEqual(user_name, listen.user_name)
+        self.assertEqual(recording_msid, listen.recording_msid)
         self.assertEqual(user_id, listen.user_id)
-        self.assertEqual(json_data['user_id'], listen.user_id)
-        self.assertEqual(json_data['track_metadata']['artist_name'], listen.data['artist_name'])
+        self.assertEqual(json_data['artist_name'], listen.data['artist_name'])
 
     def test_from_json(self):
-        json_row = {
-                    "track_metadata": {
-                      "additional_info": {}
-                      }
-                    }
+        json_row = {"track_metadata": {"additional_info": {}}}
 
         json_row.update({'listened_at': 123456})
         listen = Listen.from_json(json_row)

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -149,7 +149,7 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
             inserted_index['%d-%s-%s' % (inserted[0], inserted[1], inserted[2])] = 1
 
         for listen in data:
-            k = '%d-%s-%s' % (listen.ts_since_epoch, listen.data['track_name'], listen.user_name)
+            k = '%d-%s-%s' % (listen.ts_since_epoch, listen.user_id, listen.recording_msid)
             if k in inserted_index:
                 unique.append(listen)
 

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -146,7 +146,7 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
         unique = []
         inserted_index = {}
         for inserted in rows_inserted:
-            inserted_index['%d-%s-%s' % (inserted[0], inserted[1], inserted[2])] = 1
+            inserted_index['%d-%s-%s' % (int(inserted[0].timestamp()), inserted[1], inserted[2])] = 1
 
         for listen in data:
             k = '%d-%s-%s' % (listen.ts_since_epoch, listen.user_id, listen.recording_msid)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from operator import itemgetter
 
 import psycopg2
@@ -163,8 +164,8 @@ def get_listens(user_name):
     listens, _, max_ts_per_user = timescale_connection._ts.fetch_listens(
         user,
         limit=count,
-        from_ts=min_ts,
-        to_ts=max_ts
+        from_ts=datetime.utcfromtimestamp(min_ts) if min_ts else None,
+        to_ts=datetime.utcfromtimestamp(max_ts) if max_ts else None
     )
     listen_data = []
     for listen in listens:
@@ -174,7 +175,7 @@ def get_listens(user_name):
         'user_id': user_name,
         'count': len(listen_data),
         'listens': listen_data,
-        'latest_listen_ts': max_ts_per_user,
+        'latest_listen_ts': int(max_ts_per_user.timestamp()),
     }})
 
 
@@ -490,10 +491,9 @@ def delete_listen():
     if "listened_at" not in data:
         log_raise_400("Listen timestamp missing.")
     try:
-        listened_at = data["listened_at"]
-        listened_at = int(listened_at)
+        listened_at = datetime.utcfromtimestamp(int(data["listened_at"]))
     except ValueError:
-        log_raise_400("%s: Listen timestamp invalid." % listened_at)
+        log_raise_400("%s: Listen timestamp invalid." % data["listened_at"])
 
     if "recording_msid" not in data:
         log_raise_400("Recording MSID missing.")

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -167,7 +167,7 @@ def fetch_listens(musicbrainz_id, to_ts):
         if not batch:
             break
         yield from batch
-        to_ts = batch[-1].ts_since_epoch  # new to_ts will be the the timestamp of the last listen fetched
+        to_ts = batch[-1].timestamp.replace(tzinfo=None)  # new to_ts will be the the timestamp of the last listen fetched
 
 
 def fetch_feedback(user_id):
@@ -204,7 +204,7 @@ def export_data():
         # Build a generator that streams the json response. We never load all
         # listens into memory at once, and we can start serving the response
         # immediately.
-        to_ts = int(time())
+        to_ts = datetime.utcnow()
         listens = fetch_listens(current_user.musicbrainz_id, to_ts)
         output = stream_json_array(listen.to_api() for listen in listens)
 

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -46,7 +46,7 @@ from listenbrainz.webserver.views.api_tools import validate_auth_header, \
 
 MAX_LISTEN_EVENTS_PER_USER = 2  # the maximum number of listens we want to return in the feed per user
 MAX_LISTEN_EVENTS_OVERALL = 10  # the maximum number of listens we want to return in the feed overall across users
-DEFAULT_LISTEN_EVENT_WINDOW = 14 * 24 * 60 * 60  # 14 days, to limit the search space of listen events and avoid timeouts
+DEFAULT_LISTEN_EVENT_WINDOW = timedelta(days=14) # to limit the search space of listen events and avoid timeouts
 
 user_timeline_event_api_bp = Blueprint('user_timeline_event_api_bp', __name__)
 
@@ -576,13 +576,19 @@ def get_listen_events(
     # is set, calculate the other from it using a default window length.
     # if neither is set, use current time as max_ts and subtract window
     # length to get min_ts.
-    if not min_ts and max_ts:
-        min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW
-    elif min_ts and not max_ts:
-        max_ts = min_ts + DEFAULT_LISTEN_EVENT_WINDOW
-    elif not min_ts and not max_ts:
-        max_ts = int(datetime.now().timestamp())
-        min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW
+    if min_ts and max_ts:
+        min_ts = datetime.utcfromtimestamp(min_ts)
+        max_ts = datetime.utcfromtimestamp(max_ts)
+    else:
+        if min_ts:
+            min_ts = datetime.utcfromtimestamp(min_ts)
+            max_ts = min_ts + DEFAULT_LISTEN_EVENT_WINDOW
+        elif max_ts:
+            max_ts = datetime.utcfromtimestamp(max_ts)
+            min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW
+        else:
+            max_ts = datetime.utcnow()
+            min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW
 
     listens = timescale_connection._ts.fetch_recent_listens_for_users(
         users,

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -17,7 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Tuple, Dict, Iterable
 
 import pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ itsdangerous==2.1.2
 countryinfo==0.1.2
 urllib3==1.26.9
 orjson==3.8.7
+dnspython==2.2.1


### PR DESCRIPTION
1. Move the track_name field to inside track_metadata and recording_msid to a top level column because we want to deduplicate on recording_msid instead of just track_name for consistency.

2. Remove user_name column from the listen table.

3. In the data field, currently data is stored as {"track_metadata": ..data}. Change this so that ...data is directly stored at top level inside jsonb field.