### PR TITLE
Fix Year in Music stuff

### DIFF
--- a/frontend/js/src/explore/year-in-music/2022/YearInMusic.tsx
+++ b/frontend/js/src/explore/year-in-music/2022/YearInMusic.tsx
@@ -54,7 +54,7 @@ export type YearInMusicProps = {
     day_of_week: string;
     top_artists: Array<{
       artist_name: string;
-      artist_mbids: string[];
+      artist_mbid: string;
       listen_count: number;
     }>;
     top_releases: Array<{
@@ -701,7 +701,7 @@ export default class YearInMusic extends React.Component<
                           const details = getEntityLink(
                             "artist",
                             artist.artist_name,
-                            artist.artist_mbids[0]
+                            artist.artist_mbid
                           );
                           const thumbnail = (
                             <span className="badge badge-info">
@@ -718,7 +718,7 @@ export default class YearInMusic extends React.Component<
                               track_name: "",
                               artist_name: artist.artist_name,
                               additional_info: {
-                                artist_mbids: artist.artist_mbids,
+                                artist_mbids: [artist.artist_mbid],
                               },
                             },
                           };
@@ -726,7 +726,7 @@ export default class YearInMusic extends React.Component<
                           return (
                             <ListenCard
                               compact
-                              key={`top-artists-${artist.artist_name}-${artist.artist_mbids}`}
+                              key={`top-artists-${artist.artist_name}-${artist.artist_mbid}`}
                               listen={listenHere}
                               customThumbnail={thumbnail}
                               listenDetails={details}

--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -60,7 +60,7 @@ def insert(key, year, data):
                JOIN "user"
                  ON "user".id = user_id::int
         ON CONFLICT (user_id, year)
-      DO UPDATE SET data = statistics.year_in_music.data || EXCLUDED.data
+      DO UPDATE SET data = COALESCE(statistics.year_in_music.data, '{{}}'::jsonb) || EXCLUDED.data
     """).format(year=Literal(year), key=Literal(key))
     try:
         with connection.cursor() as cursor:
@@ -77,7 +77,7 @@ def insert_new_releases_of_top_artists(user_id, year, data):
             INSERT INTO statistics.year_in_music (user_id, year, data)
                  VALUES (:user_id ::int, :year, jsonb_build_object('new_releases_of_top_artists', :data :: jsonb))
             ON CONFLICT (user_id, year)
-          DO UPDATE SET data = statistics.year_in_music.data || EXCLUDED.data
+          DO UPDATE SET data = COALESCE(statistics.year_in_music.data, '{}'::jsonb) || EXCLUDED.data
         """), {"user_id": user_id, "year": year, "data": orjson.dumps(data).decode("utf-8")})
 
 
@@ -97,7 +97,7 @@ def insert_similar_recordings(year, data):
                  ON other_user.id = similar_user.user_id::int
            GROUP BY "user".id
         ON CONFLICT (user_id, year)
-      DO UPDATE SET data = statistics.year_in_music.data || EXCLUDED.data
+      DO UPDATE SET data = COALESCE(statistics.year_in_music.data, '{{}}'::jsonb) || EXCLUDED.data
     """).format(year=Literal(year))
     try:
         with connection.cursor() as cursor:
@@ -120,7 +120,7 @@ def handle_multi_large_insert(key, year, data):
                JOIN "user"
                  ON "user".id = user_id::int
         ON CONFLICT (user_id, year)
-      DO UPDATE SET data = statistics.year_in_music.data || EXCLUDED.data
+      DO UPDATE SET data = COALESCE(statistics.year_in_music.data, '{{}}'::jsonb) || EXCLUDED.data
     """).format(key=Literal(key), year=Literal(year))
     try:
         with connection.cursor() as cursor:
@@ -143,7 +143,7 @@ def handle_insert_top_stats(entity, year, data):
                JOIN "user"
                  ON "user".id = user_id::int
         ON CONFLICT (user_id, year)
-      DO UPDATE SET data = statistics.year_in_music.data || EXCLUDED.data
+      DO UPDATE SET data = COALESCE(statistics.year_in_music.data, '{{}}'::jsonb) || EXCLUDED.data
     """).format(key=Literal(f"top_{entity}"), count_key=Literal(f"total_{entity}_count"), year=Literal(year))
     try:
         with connection.cursor() as cursor:
@@ -196,7 +196,7 @@ def insert_playlists(year, data):
                FROM (VALUES %s) AS t(user_id, slug, playlist)
            GROUP BY user_id
         ON CONFLICT (user_id, year)
-      DO UPDATE SET data = statistics.year_in_music.data || EXCLUDED.data
+      DO UPDATE SET data = COALESCE(statistics.year_in_music.data, '{{}}'::jsonb) || EXCLUDED.data
     """).format(year=Literal(year))
 
     try:

--- a/listenbrainz_spark/year_in_music/new_artists_discovered.py
+++ b/listenbrainz_spark/year_in_music/new_artists_discovered.py
@@ -1,11 +1,15 @@
+from datetime import datetime, date, time
+
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import get_listens_from_dump
 
 
 def get_new_artists_discovered_count(year):
     """ Count the number of artists a user has listened to for the first time in the given year. """
-    get_listens_from_dump()\
-        .createOrReplaceTempView("artists_discovery_listens")
+    from_date = datetime(year, 1, 1)
+    to_date = datetime.combine(date(year, 12, 31), time.max)
+    get_listens_from_dump(from_date, to_date).createOrReplaceTempView("artists_discovery_listens")
+
     data = run_query(_get_new_discovered_artists_count(year)).collect()
     yield {
         "type": "year_in_music_new_artists_discovered_count",

--- a/listenbrainz_spark/year_in_music/top_stats.py
+++ b/listenbrainz_spark/year_in_music/top_stats.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date, time
 
 from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
-from listenbrainz_spark.stats.user.entity import calculate_entity_stats
+from listenbrainz_spark.stats.user.entity import calculate_entity_stats, get_entity_stats, entity_cache_map
 from listenbrainz_spark.utils import get_listens_from_dump, read_files_from_HDFS
 
 
@@ -13,10 +13,10 @@ def calculate_top_entity_stats(year):
     listens = get_listens_from_dump(from_date, to_date)
     listens.createOrReplaceTempView(table)
 
-    df_name = "release_data_cache"
-    read_files_from_HDFS(RELEASE_METADATA_CACHE_DATAFRAME).createOrReplaceTempView(df_name)
-
+    df_name = "entity_data_cache"
     for entity in ["artists", "recordings", "releases"]:
+        cache_table_path = entity_cache_map.get(entity)
+        read_files_from_HDFS(cache_table_path).createOrReplaceTempView(df_name)
         stats = calculate_entity_stats(
             from_date, to_date, table, df_name, entity, "this_year", "year_in_music_top_stats"
         )


### PR DESCRIPTION
All of our inserts have statistics.year_in_music.data || EXCLUDED.data in the sql query in some form. This fails if existing data in table is NULL. Therefore, we COALESCE it with an empty jsonb object ('{}'::jsonb). If the query is processed by SQL().format then need to escape it as '{{}}'.

Also, fix some bugs in YIM stats.