### PR TITLE
Remove filter_artist_credit option from similarity datasets

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -362,7 +362,7 @@ def request_similar_users(max_num_users):
     send_request_to_spark_cluster('similarity.similar_users', max_num_users=max_num_users)
 
 
-@cli.command(name='request_similar_recordings')
+@cli.command(name="request_similar_recordings")
 @click.option("--days", type=int, help="The number of days of listens to use.", required=True)
 @click.option("--session", type=int, help="The maximum duration in seconds between two listens in a listening"
                                           " session.", required=True)
@@ -373,10 +373,8 @@ def request_similar_users(max_num_users):
 @click.option("--limit", type=int, help="The maximum number of similar recordings to generate per recording"
                                         " (the limit is instructive. upto 2x recordings may be returned than"
                                         " the limit).", required=True)
-@click.option("--filter-artist-credit", type=bool, help="Whether to filter tracks by same artists in a listening"
-                                                        " session", required=True)
 @click.option("--skip", type=int, help="the minimum difference threshold to mark track as skipped", required=True)
-def request_similar_recordings(days, session, contribution, threshold, limit, filter_artist_credit, skip):
+def request_similar_recordings(days, session, contribution, threshold, limit, skip):
     """ Send the cluster a request to generate similar recordings index. """
     send_request_to_spark_cluster(
         "similarity.recording",
@@ -385,7 +383,6 @@ def request_similar_recordings(days, session, contribution, threshold, limit, fi
         contribution=contribution,
         threshold=threshold,
         limit=limit,
-        filter_artist_credit=filter_artist_credit,
         skip=skip
     )
 
@@ -401,10 +398,8 @@ def request_similar_recordings(days, session, contribution, threshold, limit, fi
 @click.option("--limit", type=int, help="The maximum number of similar artists to generate per artist"
                                         " (the limit is instructive. upto 2x artists may be returned than"
                                         " the limit).", required=True)
-@click.option("--filter-artist-credit", type=bool, help="Whether to filter artists in session if they appear on the"
-                                                        " same artist credit", required=True)
 @click.option("--skip", type=int, help="the minimum difference threshold to mark track as skipped", required=True)
-def request_similar_artists(days, session, contribution, threshold, limit, filter_artist_credit, skip):
+def request_similar_artists(days, session, contribution, threshold, limit, skip):
     """ Send the cluster a request to generate similar artists index. """
     send_request_to_spark_cluster(
         "similarity.artist",
@@ -413,7 +408,6 @@ def request_similar_artists(days, session, contribution, threshold, limit, filte
         contribution=contribution,
         threshold=threshold,
         limit=limit,
-        filter_artist_credit=filter_artist_credit,
         skip=skip
     )
 

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -142,7 +142,6 @@
       "contribution",
       "threshold",
       "limit",
-      "filter_artist_credit",
       "skip"
     ]
   },
@@ -155,7 +154,6 @@
       "contribution",
       "threshold",
       "limit",
-      "filter_artist_credit",
       "skip"
     ]
   },

--- a/listenbrainz_spark/similarity/artist.py
+++ b/listenbrainz_spark/similarity/artist.py
@@ -16,7 +16,7 @@ DEFAULT_TRACK_LENGTH = 180
 FEATURED_ARTIST_WEIGHT = 0.25
 
 
-def build_sessioned_index(listen_table, metadata_table, artist_credit_table, session, max_contribution, threshold, limit, _filter, skip_threshold):
+def build_sessioned_index(listen_table, metadata_table, artist_credit_table, session, max_contribution, threshold, limit, skip_threshold):
     # TODO: Handle case of unmatched recordings breaking sessions!
     return f"""
             WITH listens AS (
@@ -104,7 +104,7 @@ def build_sessioned_index(listen_table, metadata_table, artist_credit_table, ses
     """
 
 
-def main(days, session, contribution, threshold, limit, filter_artist_credit, skip):
+def main(days, session, contribution, threshold, limit, skip):
     """ Generate similar artists based on user listening sessions.
 
     Args:
@@ -114,7 +114,6 @@ def main(days, session, contribution, threshold, limit, filter_artist_credit, sk
         threshold: the minimum similarity score for two recordings to be considered similar
         limit: the maximum number of similar recordings to request for a given recording
             (this limit is instructive only, upto 2x number of recordings may be returned)
-        filter_artist_credit: whether to filter out tracks by same artist from a listening session
         skip: the minimum threshold in seconds to mark a listen as skipped. we cannot just mark a negative difference
             as skip because there may be a difference in track length in MB and music services and also issues in
             timestamping listens.
@@ -135,10 +134,10 @@ def main(days, session, contribution, threshold, limit, filter_artist_credit, sk
     artist_credit_df.createOrReplaceTempView(artist_credit_table)
 
     skip_threshold = -skip
-    query = build_sessioned_index(table, metadata_table, artist_credit_table, session, contribution, threshold, limit, filter_artist_credit, skip_threshold)
+    query = build_sessioned_index(table, metadata_table, artist_credit_table, session, contribution, threshold, limit, skip_threshold)
     data = run_query(query).toLocalIterator()
 
-    algorithm = f"session_based_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_filter_{filter_artist_credit}_skip_{skip}"
+    algorithm = f"session_based_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_skip_{skip}"
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]

--- a/listenbrainz_spark/similarity/recording.py
+++ b/listenbrainz_spark/similarity/recording.py
@@ -14,9 +14,8 @@ RECORDINGS_PER_MESSAGE = 10000
 DEFAULT_TRACK_LENGTH = 180
 
 
-def build_sessioned_index(listen_table, metadata_table, session, max_contribution, threshold, limit, _filter, skip_threshold):
+def build_sessioned_index(listen_table, metadata_table, session, max_contribution, threshold, limit, skip_threshold):
     # TODO: Handle case of unmatched recordings breaking sessions!
-    filter_artist_credit = "AND NOT arrays_overlap(s1.artist_credit_mbids, s2.artist_credit_mbids)" if _filter else ""
     return f"""
             WITH listens AS (
                  SELECT user_id
@@ -60,7 +59,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
                   JOIN sessions_filtered s2
                  USING (user_id, session_id)
                  WHERE s1.recording_mbid != s2.recording_mbid
-                       {filter_artist_credit}
+                   AND NOT arrays_overlap(s1.artist_credit_mbids, s2.artist_credit_mbids)
             ), user_contribtion_mbids AS (
                 SELECT user_id
                      , lexical_mbid0 AS mbid0
@@ -93,7 +92,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
     """
 
 
-def main(days, session, contribution, threshold, limit, filter_artist_credit, skip):
+def main(days, session, contribution, threshold, limit, skip):
     """ Generate similar recordings based on user listening sessions.
 
     Args:
@@ -103,7 +102,6 @@ def main(days, session, contribution, threshold, limit, filter_artist_credit, sk
         threshold: the minimum similarity score for two recordings to be considered similar
         limit: the maximum number of similar recordings to request for a given recording
             (this limit is instructive only, upto 2x number of recordings may be returned)
-        filter_artist_credit: whether to filter out tracks by same artist from a listening session
         skip: the minimum threshold in seconds to mark a listen as skipped. we cannot just mark a negative difference
             as skip because there may be a difference in track length in MB and music services and also issues in
             timestamping listens.
@@ -120,10 +118,10 @@ def main(days, session, contribution, threshold, limit, filter_artist_credit, sk
     metadata_df.createOrReplaceTempView(metadata_table)
 
     skip_threshold = -skip
-    query = build_sessioned_index(table, metadata_table, session, contribution, threshold, limit, filter_artist_credit, skip_threshold)
+    query = build_sessioned_index(table, metadata_table, session, contribution, threshold, limit, skip_threshold)
     data = run_query(query).toLocalIterator()
 
-    algorithm = f"session_based_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_filter_{filter_artist_credit}_skip_{skip}"
+    algorithm = f"session_based_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_skip_{skip}"
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]

--- a/listenbrainz_spark/year_in_music/listening_time.py
+++ b/listenbrainz_spark/year_in_music/listening_time.py
@@ -1,5 +1,6 @@
 import listenbrainz_spark
 from listenbrainz_spark import config
+from listenbrainz_spark.path import RECORDING_LENGTH_DATAFRAME
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.year_in_music.utils import setup_listens_for_year
 
@@ -7,8 +8,8 @@ from listenbrainz_spark.year_in_music.utils import setup_listens_for_year
 def get_listening_time(year):
     """ Calculate the total listening time in seconds of the user for the given year. """
     setup_listens_for_year(year)
-    metadata_table = "mb_metadata_cache"
-    metadata_df = listenbrainz_spark.sql_context.read.json(config.HDFS_CLUSTER_URI + "/mb_metadata_cache.jsonl")
+    metadata_table = "recording_length"
+    metadata_df = listenbrainz_spark.sql_context.read.parquet(config.HDFS_CLUSTER_URI + RECORDING_LENGTH_DATAFRAME)
     metadata_df.createOrReplaceTempView(metadata_table)
 
     data = run_query(_get_total_listening_time()).collect()
@@ -20,14 +21,14 @@ def get_listening_time(year):
 
 
 def _get_total_listening_time():
-    # get recording length from mb_metadata_cache, if listen is unmapped default to 3 minutes.
+    # get recording length from recording table, if listen is unmapped default to 3 minutes.
     return """
           WITH listening_times AS (
                   SELECT user_id
-                       , sum(COALESCE(recording_data.length / 1000, BIGINT(180))) AS total_listening_time
+                       , sum(COALESCE(rl.length / 1000, BIGINT(180))) AS total_listening_time
                     FROM listens_of_year l
-               LEFT JOIN mb_metadata_cache rdd
-                      ON l.recording_mbid = rdd.recording_mbid
+               LEFT JOIN recording_length rl
+                      ON l.recording_mbid = rl.recording_mbid
                 GROUP BY user_id
           )
             SELECT to_json(


### PR DESCRIPTION
We always want to filter so need to keep this as configurable.