### PR TITLE
LB-1239: Update sphinxcontrib httpdomain dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==5.0.2
-sphinxcontrib-httpdomain==1.8.0
+sphinxcontrib-httpdomain==1.8.1
 sphinx_rtd_theme==0.5.1
 docutils==0.17.1
 sphinx-click==4.3.0


### PR DESCRIPTION
Since werkzeug 2.2 a missing method is causing autohttp to break the ReadTheDocs build ([example](https://readthedocs.org/projects/listenbrainz/builds/19825411/)).
Version 1.8.1 of httpdomain fixes the issue: https://github.com/sphinx-contrib/httpdomain/pull/61#issuecomment-1314117576