### PR TITLE
Fix test_cf_recording_recommendations_complete test

### DIFF
--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -394,8 +394,8 @@ class HandlersTestCase(DatabaseTestCase):
             mock_send_mail.assert_not_called()
 
             calls = [
-                call(mock.ANY, {'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'type': 'top'}),
-                call(mock.ANY, {'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'type': 'similar'}),
+                call(mock.ANY, {'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'echo': False, 'type': 'top'}),
+                call(mock.ANY, {'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'echo': False, 'type': 'similar'}),
             ]
             mock_gen_playlist.assert_has_calls(calls)
 


### PR DESCRIPTION
Changes introduced in #2415 are making the server test suite fail.
Simple addition to make the test pass.