### PR TITLE
LB-1251: Store spotify user id in external_service_oauth

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -124,6 +124,7 @@ CREATE TABLE spotify_auth (
 CREATE TABLE external_service_oauth (
     id                      SERIAL,  -- PK
     user_id                 INTEGER NOT NULL,  -- FK to "user".id
+    external_user_id        TEXT,
     service                 external_service_oauth_type NOT NULL,
     access_token            TEXT NOT NULL,
     refresh_token           TEXT,

--- a/admin/sql/updates/2023-03-23-add-external-user-id-column-to-external-services-oauth-table.sql
+++ b/admin/sql/updates/2023-03-23-add-external-user-id-column-to-external-services-oauth-table.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE external_service_oauth ADD COLUMN external_user_id TEXT;
+
+COMMIT;

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Optional, Union
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz import db, utils
@@ -6,7 +6,7 @@ import sqlalchemy
 
 
 def save_token(user_id: int, service: ExternalServiceType, access_token: str, refresh_token: str,
-               token_expires_ts: int, record_listens: bool, scopes: List[str], external_user_id: str = None):
+               token_expires_ts: int, record_listens: bool, scopes: List[str], external_user_id: Optional[str] = None):
     """ Add a row to the external_service_oauth table for specified user with corresponding tokens and information.
 
     Args:

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -6,7 +6,7 @@ import sqlalchemy
 
 
 def save_token(user_id: int, service: ExternalServiceType, access_token: str, refresh_token: str,
-               token_expires_ts: int, record_listens: bool, scopes: List[str]):
+               token_expires_ts: int, record_listens: bool, scopes: List[str], external_user_id: str = None):
     """ Add a row to the external_service_oauth table for specified user with corresponding tokens and information.
 
     Args:
@@ -17,6 +17,7 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
         token_expires_ts: the unix timestamp at which the user_token will expire
         record_listens: True if user wishes to import listens, False otherwise
         scopes: the oauth scopes
+        external_user_id: the user's id in the external linked service
     """
     # regardless of whether a row is inserted or updated, the end result of the query
     # should remain the same. if not so, weird things can happen as it is likely we
@@ -29,12 +30,13 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
     with db.engine.begin() as connection:
         result = connection.execute(sqlalchemy.text("""
             INSERT INTO external_service_oauth
-            (user_id, service, access_token, refresh_token, token_expires, scopes)
+            (user_id, external_user_id, service, access_token, refresh_token, token_expires, scopes)
             VALUES
-            (:user_id, :service, :access_token, :refresh_token, :token_expires, :scopes)
+            (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires, :scopes)
             ON CONFLICT (user_id, service)
             DO UPDATE SET
                 user_id = EXCLUDED.user_id,
+                external_user_id = EXCLUDED.external_user_id,
                 service = EXCLUDED.service,
                 access_token = EXCLUDED.access_token,
                 refresh_token = EXCLUDED.refresh_token,
@@ -44,6 +46,7 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
             RETURNING id
             """), {
                 "user_id": user_id,
+                "external_user_id": external_user_id,
                 "service": service.value,
                 "access_token": access_token,
                 "refresh_token": refresh_token,

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -148,6 +148,7 @@ def get_token(user_id: int, service: ExternalServiceType) -> Union[dict, None]:
                  , last_updated
                  , token_expires
                  , scopes
+                 , external_user_id
               FROM external_service_oauth
               JOIN "user"
                 ON "user".id = external_service_oauth.user_id

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -66,6 +66,7 @@ def get_user(user_id: int) -> Optional[dict]:
                  , "user".musicbrainz_id
                  , "user".musicbrainz_row_id
                  , external_service_oauth.service
+                 , external_user_id
                  , access_token
                  , refresh_token
                  , external_service_oauth.last_updated

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -21,7 +21,8 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             refresh_token='refresh_token',
             token_expires_ts=int(time.time()),
             record_listens=True,
-            scopes=['user-read-recently-played']
+            scopes=['user-read-recently-played'],
+            external_user_id='external_user_idid',
         )
 
     def test_create_oauth(self):
@@ -33,10 +34,13 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             refresh_token='refresh_token',
             token_expires_ts=int(time.time()),
             record_listens=True,
-            scopes=['user-read-recently-played']
+            scopes=['user-read-recently-played'],
+            external_user_id='external_user_idid'
         )
         user = db_oauth.get_token(user2['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual('token', user['access_token'])
+        self.assertEqual('external_user_idid', user['external_user_id'])
+
 
     def test_create_oauth_multiple(self):
         """ Test saving the token again for a given service and user_id
@@ -46,6 +50,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         time_before_update = datetime.now(timezone.utc)
         db_oauth.save_token(
             user_id=self.user['id'],
+            external_user_id='external_user_idid',
             service=ExternalServiceType.SPOTIFY,
             access_token='new_token',
             refresh_token='refresh_token',

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -3,6 +3,7 @@ import base64
 from typing import Sequence, Optional
 
 import requests
+import spotipy
 
 from flask import current_app
 from spotipy import SpotifyOAuth
@@ -93,9 +94,13 @@ class SpotifyService(ImporterService):
         scopes = token['scope'].split()
         active = set(scopes).issuperset(SPOTIFY_IMPORT_PERMISSIONS)
 
+        sp = spotipy.Spotify(auth=access_token)
+        details = sp.current_user()
+        external_user_id = details["id"]
+
         external_service_oauth.save_token(user_id=user_id, service=self.service, access_token=access_token,
                                           refresh_token=refresh_token, token_expires_ts=expires_at,
-                                          record_listens=active, scopes=scopes)
+                                          record_listens=active, scopes=scopes, external_user_id=external_user_id)
         return True
 
     def get_authorize_url(self, permissions: Sequence[str]):

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timezone
 from unittest import mock
+import spotipy
 
 import requests_mock
 
@@ -17,15 +18,21 @@ class SpotifyServiceTestCase(IntegrationTestCase):
         super(SpotifyServiceTestCase, self).setUp()
         self.user_id = db_user.create(312, 'spotify_user')
         self.service = SpotifyService()
-        self.service.add_new_user(self.user_id, {
-            'access_token': 'old-token',
-            'refresh_token': 'old-refresh-token',
-            'expires_in': 3600,
-            'scope': 'user-read-currently-playing user-read-recently-played'
-        })
+        
+        with mock.patch.object(spotipy.Spotify, 'current_user', return_value = {"id": "test_user_id"}):
+            self.service.add_new_user(self.user_id, {
+                'access_token': 'old-token',
+                'refresh_token': 'old-refresh-token',
+                'expires_in': 3600,
+                'scope': 'user-read-currently-playing user-read-recently-played'
+            })
+
         self.spotify_user = self.service.get_user(self.user_id)
 
-    def test_get_active_users(self):
+    @mock.patch.object(spotipy.Spotify, 'current_user')
+    def test_get_active_users(self, mock_current_user):
+        mock_current_user.return_value = {"id": "test_user_id"}
+
         user_id_1 = db_user.create(333, 'user-1')
         user_id_2 = db_user.create(666, 'user-2')
         user_id_3 = db_user.create(999, 'user-3')
@@ -127,8 +134,11 @@ class SpotifyServiceTestCase(IntegrationTestCase):
         self.assertEqual(user['refresh_token'], 'old-refresh-token')
         self.assertIsNotNone(user['last_updated'])
 
+    
+    @mock.patch.object(spotipy.Spotify, 'current_user')
     @mock.patch('time.time')
-    def test_add_new_user(self, mock_time):
+    def test_add_new_user(self, mock_time, mock_current_user):
+        mock_current_user.return_value = {"id": "test_user_id"}
         mock_time.return_value = 0
         self.service.remove_user(self.user_id)
         self.service.add_new_user(self.user_id, {

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -151,3 +151,4 @@ class SpotifyServiceTestCase(IntegrationTestCase):
         self.assertEqual(self.user_id, user['user_id'])
         self.assertEqual('access-token', user['access_token'])
         self.assertEqual('refresh-token', user['refresh_token'])
+        self.assertEqual("test_user_id", user["external_user_id"])

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -1,4 +1,5 @@
 import requests_mock
+import spotipy
 
 import listenbrainz.db.user as db_user
 import time
@@ -129,7 +130,9 @@ class ProfileViewsTestCase(IntegrationTestCase):
         self.assertIsNone(self.service.get_user(self.user['id']))
 
     @patch('listenbrainz.domain.spotify.SpotifyService.fetch_access_token')
-    def test_spotify_callback(self, mock_fetch_access_token):
+    @patch.object(spotipy.Spotify, 'current_user')
+    def test_spotify_callback(self, mock_current_user, mock_fetch_access_token):
+        mock_current_user.return_value = {"id": "test-id"}
         mock_fetch_access_token.return_value = {
             'access_token': 'token',
             'refresh_token': 'refresh',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
There is a need for spotify user ids to export playlists from troi to spotify. Currently, the system queries the spotify user id each time before doing so. This solution stores this data in the external service oauth tables itself when the user connects their account.

Related JIRA Ticket: LB-1251

This is the implementation of a the first part of the original ticket.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
This creates a new column in the `external_services_oauth` table, adds a part to call the Spotify API and get user id in the `add_new_user` function (`listenbrainz/domain/spotify.py`). This ensures that the user ids are added whenever a new user connects their account (as mentioned in the JIRA ticket). Also added an a new entry corresponding to the user id in `save_token` (`listenbrainz/db/external_service_oauth.py`) function to add the external service user id (Spotify in this case) to the row being added in the `external_service_oauth` table.


