### PR TITLE
bugfix: scrobbling on now_playing (type mismatch)

### DIFF
--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -12,7 +12,8 @@ from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError, ListenVa
 import xmltodict
 
 from listenbrainz.webserver.models import SubmitListenUserMetadata
-from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen
+from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
+
 from listenbrainz.db.lastfm_user import User
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.db.lastfm_token import Token
@@ -287,7 +288,8 @@ def record_listens(data):
         raise InvalidAPIUsage(LastFMError(code=6, message=err.message), 400, output_format)
 
     user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])
-    augmented_listens = insert_payload(validated_payload, user_metadata, listen_type=listen_type)
+    proper_listen_type = LISTEN_TYPE_PLAYING_NOW if listen_type == 'playing_now' else LISTEN_TYPE_SINGLE
+    augmented_listens = insert_payload(validated_payload, user_metadata, listen_type=proper_listen_type)
 
     # With corrections than the original submitted listen.
     doc, tag, text = Doc().tagtext()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

People are experiencing multiple scrobbles using `cmus-status-scrobbler` https://github.com/vjeranc/cmus-status-scrobbler/issues/2

`cmus-status-scrobbler` sends a `track.updateNowPlaying` event whenever the player resumes from a pause.

Listenbrainz server interprets that as a scrobble (`track.scrobble` is not sent).

# Solution

This looks like a type mismatch. `insert_payload` expects an integer enumeration for the `listen_type` but the code that sends the `listen_type` passes `"playing_now"` and `"listens"`.

# Action

This should be tested. I am unsure if there's a need for the `LISTEN_TYPE_IMPORT` type to be used.