### PR TITLE
LB-1240: External services list and Updated Docs

### DIFF
--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -154,3 +154,20 @@ def get_token(user_id: int, service: ExternalServiceType) -> Union[dict, None]:
                 'service': service.value
             })
         return result.mappings().first()
+
+
+def get_registered_services(user_id: int) -> Union[dict, None]:
+    """ Get a list services that are already registered by the user.
+
+    Args:
+        user_id: the ListenBrainz row ID of the user
+    """
+    with db.engine.begin() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT service 
+              FROM external_service_oauth
+             WHERE user_id = :user_id
+            """), {
+                'user_id': user_id
+            })
+        return result.mappings().first()

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -156,18 +156,27 @@ def get_token(user_id: int, service: ExternalServiceType) -> Union[dict, None]:
         return result.mappings().first()
 
 
-def get_registered_services(user_id: int) -> Union[dict, None]:
+def get_registered_services(user_id: int) -> List[str]:
     """ Get a list services that are already registered by the user.
 
     Args:
         user_id: the ListenBrainz row ID of the user
     """
     with db.engine.begin() as connection:
-        result = connection.execute(sqlalchemy.text("""
+        rows = connection.execute(sqlalchemy.text("""
             SELECT service 
               FROM external_service_oauth
              WHERE user_id = :user_id
             """), {
                 'user_id': user_id
             })
-        return result.mappings().first()
+        
+        if not rows:
+            return []
+    
+        result = []
+
+        for row in rows:
+            result.append(row.service)
+
+        return result

--- a/listenbrainz/domain/external_service.py
+++ b/listenbrainz/domain/external_service.py
@@ -39,9 +39,6 @@ class ExternalService(ABC):
     def get_user(self, user_id: int) -> Union[dict, None]:
         return external_service_oauth.get_token(user_id=user_id, service=self.service)
 
-    def get_registered_services(self, user_id: int) -> Union[dict, None]:
-        return external_service_oauth.get_registered_services(user_id=user_id)
-
     def user_oauth_token_has_expired(self, user: dict, within_minutes: int = 5) -> bool:
         """Check if a user's oauth token has expired (within a threshold)
 

--- a/listenbrainz/domain/external_service.py
+++ b/listenbrainz/domain/external_service.py
@@ -39,6 +39,9 @@ class ExternalService(ABC):
     def get_user(self, user_id: int) -> Union[dict, None]:
         return external_service_oauth.get_token(user_id=user_id, service=self.service)
 
+    def get_registered_services(self, user_id: int) -> Union[dict, None]:
+        return external_service_oauth.get_registered_services(user_id=user_id)
+
     def user_oauth_token_has_expired(self, user: dict, within_minutes: int = 5) -> bool:
         """Check if a user's oauth token has expired (within a threshold)
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -37,6 +37,8 @@ SEARCH_USER_LIMIT = 10
 @ratelimit()
 def search_user():
     """Search a ListenBrainz registered user.
+
+    :param search_term: Input on which search operation is to be performed.
     """
     search_term = request.args.get("search_term")
     if search_term:
@@ -639,17 +641,17 @@ def get_playlists_collaborated_on_for_user(playlist_user_name):
 def get_registered_services(user_name):
     """Fetch a list of registered services for the user. Empty if none registered.
 
-    :param user_name: Name of the user.
     :statuscode 404: User not found
     """
+
     user = db_user.get_by_mb_id(user_name)
     
     if not user:
         raise APINotFound("User %s not found" % user_name)
     
-    from listenbrainz.domain.external_service import ExternalService
+    from listenbrainz.db.external_service_oauth import get_registered_services
 
-    services = ExternalService().get_registered_services(user["id"])
+    services = get_registered_services(user["id"])
  
     return jsonify({"services": services})
 

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -178,8 +178,13 @@ def create_user_cb_review_event(user_name):
 
         {
             "metadata": {
-                "message": "<the message to post, required>",
-            }
+                "entity_name": "<entity name, required>",
+                "entity_id": "<entity id, required>",
+                "entity_type": "<entity type, required>",
+                "text": "<the message to post, required>",
+                "language": "<language code, required>",
+                "rating": <rating, int>,
+            },
         }
 
     :param user_name: The MusicBrainz ID of the user who is creating the review.


### PR DESCRIPTION
# Problems

Currently there exists no API endpoint that can give a user's registered services in ListenBrainz.
Ticket: [LB-1240](https://tickets.metabrainz.org/projects/LB/issues/LB-1240)

Documentation for [post a CritiqueBrainz review from feed](https://listenbrainz.readthedocs.io/en/latest/users/api/social.html#post--1-user-(user_name)-timeline-event-create-review) is outdated.

Documentation for [search a user](https://github.com/metabrainz/listenbrainz-server/blob/3527273f63420577bf715ebcf723b1286844c424/listenbrainz/webserver/views/api.py#L38) is missing.

# Solution

Added appropriate `GET /1/user/<user_name>/services` endpoint with a suitable method to access database.

Updated documentation of the concerned endpoints.

