### PR TITLE
LB-1240: Add an API to list external services user has connected

### DIFF
--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -154,3 +154,18 @@ def get_token(user_id: int, service: ExternalServiceType) -> Union[dict, None]:
                 'service': service.value
             })
         return result.mappings().first()
+
+
+def get_services(user_id: int) -> list[str]:
+    """ Get the list of connected services for a given user
+
+    Args:
+        user_id: the ListenBrainz row ID of the user
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT service
+              FROM external_service_oauth
+             WHERE user_id = :user_id
+            """), {'user_id': user_id})
+        return [r.service for r in result.all()]

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -91,3 +91,12 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         db_oauth.delete_token(self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=False)
         self.assertIsNone(db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY))
         self.assertIsNotNone(db_spotify.get_user_import_details(self.user['id']))
+
+    def test_get_services(self):
+        services = db_oauth.get_services(self.user["id"])
+        self.assertEqual(services, ["spotify"])
+
+        db_oauth.delete_token(self.user["id"], ExternalServiceType.SPOTIFY, True)
+        services = db_oauth.get_services(self.user["id"])
+        self.assertEqual(services, [])
+

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -653,6 +653,7 @@ def get_service_details(user_name):
     :param user_name: the MusicBrainz ID of the user whose similar users are being requested.
     :resheader Content-Type: *application/json*
     :statuscode 200: Yay, you have data!
+    :statuscode 401: Invalid authorization. See error message for details.
     :statuscode 403: Forbidden, you do not have permissions to view this user's information.
     :statuscode 404: The requested user was not found.
     """


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
   
 
    Mention and link a JIRA ticket if there is one that's relevant.

  
-->

The Android App needed a way to know whether the user has connected their CritiqueBrainz account with ListenBrainz.  Therefore, I added a new API endpoint to return the list of services a user has connected to their account.
 https://tickets.metabrainz.org/browse/LB-1240

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.

-->

  I added a new API endpoint to return the list of services a user has connected to their account.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
  
   
-->

    I am slightly confused about tests so I might need help with that.

