### PR TITLE
LB-1253:Retrieving the Spotify user ID from the external_service_oauth table

### DIFF
--- a/listenbrainz/troi/troi_bot.py
+++ b/listenbrainz/troi/troi_bot.py
@@ -113,7 +113,9 @@ def _get_spotify_details(user_id, service):
             return None
 
         sp = spotipy.Spotify(auth=token["access_token"])
-        spotify_user_id = sp.current_user()["id"]
+        # Retrieve the Spotify user ID from the external_service_oauth table
+        spotify_user_id = ExternalServiceOAuth.query.filter_by(user_id=user_id, service_name='spotify').first().external_user_id
+
         return {
             "is_public": True,
             "is_collaborative": False,


### PR DESCRIPTION
# Problem

Spotify API to retrieve user ID each time to generate and export a playlist from troi. Instead of this API call, we should, we retrieve the Spotify user ID from the external_service_oauth table like the access token.

Retrieve Spotify user ID from database for passing to troi bot.
Related JIRA ticket : [LB-1253](https://tickets.metabrainz.org/projects/LB/issues/LB-1253?filter=allissues)



# Solution

To retrieve the Spotify user ID from the external_service_oauth table instead of making an API call, you would need to modify the _get_spotify_details function to query the table for the user's Spotify ID. 
```
# Retrieve the Spotify user ID from the external_service_oauth table

        sp = spotipy.Spotify(auth=token["access_token"])
        spotify_user_id = ExternalServiceOAuth.query.filter_by(user_id=user_id, service_name='spotify').first().external_user_id

        return {
            "is_public": True,
            "is_collaborative": False,
            "user_id": spotify_user_id,
            "token": token["access_token"]
        }
```


