### PR TITLE
LB-1011: Don't load album covers if Save-Data HTTP header is on

### DIFF
--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -91,7 +91,6 @@ export type ListenCardProps = {
 export type ListenCardState = {
   isCurrentlyPlaying: boolean;
   thumbnailSrc?: string; // Full URL to the CoverArtArchive thumbnail
-  saveDataMode?: boolean;
 };
 
 export default class ListenCard extends React.Component<

--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -91,6 +91,7 @@ export type ListenCardProps = {
 export type ListenCardState = {
   isCurrentlyPlaying: boolean;
   thumbnailSrc?: string; // Full URL to the CoverArtArchive thumbnail
+  saveDataMode?: boolean;
 };
 
 export default class ListenCard extends React.Component<
@@ -106,20 +107,28 @@ export default class ListenCard extends React.Component<
 
     this.state = {
       isCurrentlyPlaying: false,
+      saveDataMode: false,
     };
   }
 
   async componentDidMount() {
     window.addEventListener("message", this.receiveBrainzPlayerMessage);
-    await this.getCoverArt();
+    const { userPreferences } = this.context;
+    if (userPreferences?.saveDate) {
+      this.setState({ saveDataMode: true });
+    } else {
+      await this.getCoverArt();
+    }
   }
 
   async componentDidUpdate(oldProps: ListenCardProps) {
     const { listen, customThumbnail } = this.props;
+    const { saveDataMode } = this.state;
     if (
       !customThumbnail &&
       Boolean(listen) &&
-      !isEqual(listen, oldProps.listen)
+      !isEqual(listen, oldProps.listen) &&
+      saveDataMode === true
     ) {
       await this.getCoverArt();
     }

--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -114,9 +114,7 @@ export default class ListenCard extends React.Component<
   async componentDidMount() {
     window.addEventListener("message", this.receiveBrainzPlayerMessage);
     const { userPreferences } = this.context;
-    if (userPreferences?.saveDate) {
-      this.setState({ saveDataMode: true });
-    } else {
+    if (userPreferences?.saveData !== true) {
       await this.getCoverArt();
     }
   }

--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -107,7 +107,6 @@ export default class ListenCard extends React.Component<
 
     this.state = {
       isCurrentlyPlaying: false,
-      saveDataMode: false,
     };
   }
 
@@ -121,12 +120,12 @@ export default class ListenCard extends React.Component<
 
   async componentDidUpdate(oldProps: ListenCardProps) {
     const { listen, customThumbnail } = this.props;
-    const { saveDataMode } = this.state;
+    const { userPreferences } = this.context;
     if (
       !customThumbnail &&
       Boolean(listen) &&
       !isEqual(listen, oldProps.listen) &&
-      saveDataMode !== true
+      userPreferences?.saveData !== true
     ) {
       await this.getCoverArt();
     }

--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -128,7 +128,7 @@ export default class ListenCard extends React.Component<
       !customThumbnail &&
       Boolean(listen) &&
       !isEqual(listen, oldProps.listen) &&
-      saveDataMode === true
+      saveDataMode !== true
     ) {
       await this.getCoverArt();
     }

--- a/frontend/js/src/utils/GlobalAppContext.tsx
+++ b/frontend/js/src/utils/GlobalAppContext.tsx
@@ -7,6 +7,7 @@ export type GlobalAppContextT = {
   spotifyAuth?: SpotifyUser;
   youtubeAuth?: YoutubeUser;
   critiquebrainzAuth?: CritiqueBrainzUser;
+  userPreferences?: UserPreferences;
 };
 
 const GlobalAppContext = createContext<GlobalAppContextT>({
@@ -15,6 +16,7 @@ const GlobalAppContext = createContext<GlobalAppContextT>({
   spotifyAuth: {},
   youtubeAuth: {},
   critiquebrainzAuth: {},
+  userPreferences: {},
 });
 
 export default GlobalAppContext;

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -684,5 +684,5 @@ declare type SearchUser = {
 };
 
 declare type UserPreferences = {
-  saveDate?: boolean
-}
+  saveData?: boolean;
+};

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -682,3 +682,7 @@ type UserFreshReleasesResponse = {
 declare type SearchUser = {
   user_name: string;
 };
+
+declare type UserPreferences = {
+  saveDate?: boolean
+}

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -473,6 +473,7 @@ const getPageProps = (): {
     user_preferences = { ...user_preferences, saveData: false };
 
     if ("connection" in navigator) {
+      // @ts-ignore
       if (navigator.connection?.saveData === true) {
         user_preferences.saveData = true;
       }

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -470,7 +470,7 @@ const getPageProps = (): {
 
     let { user_preferences } = globalReactProps;
 
-    user_preferences = { ...user_preferences, saveData: true };
+    user_preferences = { ...user_preferences, saveData: false };
 
     if ("connection" in navigator) {
       if (navigator.connection?.saveData === true) {

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -419,7 +419,7 @@ type GlobalAppProps = {
   spotify?: SpotifyUser;
   youtube?: YoutubeUser;
   critiquebrainz?: CritiqueBrainzUser;
-  userPreferences?: UserPreferences;
+  user_preferences?: UserPreferences;
 };
 type GlobalProps = GlobalAppProps & SentryProps;
 
@@ -466,12 +466,14 @@ const getPageProps = (): {
       critiquebrainz,
       sentry_traces_sample_rate,
       sentry_dsn,
-      userPreferences
+      user_preferences,
     } = globalReactProps;
+
+    console.log(globalReactProps);
 
     if ("connection" in navigator) {
       if (navigator.connection?.saveData === true) {
-        userPreferences!.saveDate = true;
+        user_preferences!.saveDate = true;
       }
     }
 
@@ -484,7 +486,7 @@ const getPageProps = (): {
       spotifyAuth: spotify,
       youtubeAuth: youtube,
       critiquebrainzAuth: critiquebrainz,
-      userPreferences: userPreferences
+      userPreferences: user_preferences,
     };
     sentryProps = {
       sentry_dsn,

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -419,6 +419,7 @@ type GlobalAppProps = {
   spotify?: SpotifyUser;
   youtube?: YoutubeUser;
   critiquebrainz?: CritiqueBrainzUser;
+  userPreferences?: UserPreferences;
 };
 type GlobalProps = GlobalAppProps & SentryProps;
 
@@ -465,7 +466,14 @@ const getPageProps = (): {
       critiquebrainz,
       sentry_traces_sample_rate,
       sentry_dsn,
+      userPreferences
     } = globalReactProps;
+
+    if ("connection" in navigator) {
+      if (navigator.connection?.saveData === true) {
+        userPreferences!.saveDate = true;
+      }
+    }
 
     const apiService = new APIServiceClass(
       api_url || `${window.location.origin}/1`
@@ -476,6 +484,7 @@ const getPageProps = (): {
       spotifyAuth: spotify,
       youtubeAuth: youtube,
       critiquebrainzAuth: critiquebrainz,
+      userPreferences: userPreferences
     };
     sentryProps = {
       sentry_dsn,

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -469,8 +469,6 @@ const getPageProps = (): {
       user_preferences,
     } = globalReactProps;
 
-    console.log(globalReactProps);
-
     if ("connection" in navigator) {
       if (navigator.connection?.saveData === true) {
         user_preferences!.saveDate = true;

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -466,12 +466,15 @@ const getPageProps = (): {
       critiquebrainz,
       sentry_traces_sample_rate,
       sentry_dsn,
-      user_preferences,
     } = globalReactProps;
+
+    let { user_preferences } = globalReactProps;
+
+    user_preferences = { ...user_preferences, saveData: true };
 
     if ("connection" in navigator) {
       if (navigator.connection?.saveData === true) {
-        user_preferences!.saveDate = true;
+        user_preferences.saveData = true;
       }
     }
 

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -69,6 +69,7 @@ def get_global_props():
         "youtube": get_current_youtube_user(),
         "critiquebrainz": get_current_critiquebrainz_user(),
         "sentry_traces_sample_rate": sentry_config.get("traces_sample_rate", 0.0),
+        "user_preferences": {},
     }
     return ujson.dumps(props)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,7 @@
         "jest-junit": "^12.0.0",
         "jest-location-mock": "^1.0.9",
         "less-loader": "^11.1.0",
+        "network-information-types": "^0.1.1",
         "postcss-less": "^6.0.0",
         "prettier": "^2.0.2",
         "stylelint": "^14.8.5",
@@ -14346,6 +14347,15 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/network-information-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/network-information-types/-/network-information-types-0.1.1.tgz",
+      "integrity": "sha512-mLXNafJYOkiJB6IlF727YWssTRpXitR+tKSLyA5VAdBi3SOvLf5gtizHgxf241YHPWocnAO/fAhVrB/68tPHDw==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">= 3.0.0"
+      }
     },
     "node_modules/ngraph.events": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "jest-junit": "^12.0.0",
     "jest-location-mock": "^1.0.9",
     "less-loader": "^11.1.0",
+    "network-information-types": "^0.1.1",
     "postcss-less": "^6.0.0",
     "prettier": "^2.0.2",
     "stylelint": "^14.8.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
     // Preserving old behavior after moving to TypeScript ^4.4
     // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
     "useUnknownInCatchVariables": false,
+    "types": [
+      "./node_modules/network-information-types"
+    ]
   },
   "exclude": [
     "node_modules", "**/dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,6 @@
     // Preserving old behavior after moving to TypeScript ^4.4
     // https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables
     "useUnknownInCatchVariables": false,
-    "types": [
-      "./node_modules/network-information-types"
-    ]
   },
   "exclude": [
     "node_modules", "**/dist"


### PR DESCRIPTION
# Problem

[LB-1011](https://tickets.metabrainz.org/browse/LB-1011):
If a user's browser has set the header "Save-Data: on", we should detect that and set a javascript property in global_props accordingly.

Then in the React pages, we can avoid loading and showing cover artwork on ListenCards.

# Solution

Check for the saveData header on the client side and add it to the global props object. This way we can detect if the user has save data mode on and we can not load album covers in the ListenCard component.


# Action

Updated the GlobalContextType and added the user preferences object to be able to store the user's save-data preference globally. The network-information-types are necessary to use the navigator object in Typescript. 


