### PR TITLE
LB-1177: Mobile navbar link broken for Year in Music

### DIFF
--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -42,7 +42,9 @@
             <li><a href="{{ url_for('explore.fresh_releases') }}">Fresh Releases</a></li>
             <li><a href="{{ url_for('explore.huesound') }}">Hue Sound</a></li>
             <li><a href="{{ url_for('explore.similar_users') }}">Top similar users</a></li>
-            <li><a href="{{ url_for('user.year_in_music', user_name=current_user.musicbrainz_id) }}">Your Year In Music</a></li>
+            {% if current_user.is_authenticated %}
+              <li><a href="{{ url_for('user.year_in_music', user_name=current_user.musicbrainz_id) }}">Your Year In Music</a></li>
+            {% endif %}
             <li><a href="{{ url_for('explore.cover_art_collage') }}">Cover Art Collage</a></li>
           </ul>
         </li>


### PR DESCRIPTION
# Problem
When no user is logged in, clicking the YIM 2021 navbar link on mobile directs the user to the broken link:
https://listenbrainz.org/user//year-in-music
Instead of:
[https://listenbrainz.org/user/<user>/year-in-music](https://listenbrainz.org/user//year-in-music)

Related JIRA Ticket: [LB-1177](https://tickets.metabrainz.org/browse/LB-1177)

# Solution
The jinja template for the navbar needs to ascertain whether a user is logged in, and hide the year in the music link if not.
- When a user is not logged in. Hiding the Year in Music
![Screenshot (206)](https://user-images.githubusercontent.com/95949460/229569311-bd99d4ee-2f6d-401d-9c04-a041ae168d23.png)

- When a user is logged in. Showing the Year in Music
![Screenshot (207)](https://user-images.githubusercontent.com/95949460/229569894-310acd4d-2478-4864-bf40-7e17b9d02ae5.png)




