### PR TITLE
Improve ListenCard cover art fallback

### DIFF
--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -97,6 +97,7 @@ export default class ListenCard extends React.Component<
   ListenCardState
 > {
   static addCoverArtThumbnailSrc: string = "/static/img/add-cover-art.svg";
+  static coverartPlaceholder = "/static/img/cover-art-placeholder.jpg";
   static contextType = GlobalAppContext;
   declare context: React.ContextType<typeof GlobalAppContext>;
 
@@ -129,11 +130,12 @@ export default class ListenCard extends React.Component<
   }
 
   async getCoverArt() {
-    const { spotifyAuth } = this.context;
+    const { spotifyAuth, APIService } = this.context;
     const { listen } = this.props;
     const albumArtSrc = await getAlbumArtFromListenMetadata(
       listen,
-      spotifyAuth
+      spotifyAuth,
+      APIService
     );
     if (albumArtSrc) {
       this.setState({ thumbnailSrc: albumArtSrc });
@@ -363,7 +365,7 @@ export default class ListenCard extends React.Component<
           </div>
         </a>
       );
-    } else {
+    } else if (!recordingMBID) {
       const openModal = () => {
         NiceModal.show(MBIDMappingModal, {
           listenToMap: listen,
@@ -386,6 +388,25 @@ export default class ListenCard extends React.Component<
             <FontAwesomeIcon icon={faLink} />
           </div>
         </div>
+      );
+    } else {
+      // Edge case: has no thumbnail, has a recording_mbid
+      // but no release_mbid for some reason
+      thumbnail = (
+        <a
+          href={`https://musicbrainz.org/recording/${recordingMBID}`}
+          title="Open in MusicBrainz"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="listen-thumbnail"
+        >
+          <div className="cover-art-fallback">
+            <img
+              src={ListenCard.coverartPlaceholder}
+              alt="Open in MusicBrainz"
+            />
+          </div>
+        </a>
       );
     }
 

--- a/frontend/js/src/metadata-viewer/types.d.ts
+++ b/frontend/js/src/metadata-viewer/types.d.ts
@@ -22,6 +22,34 @@ declare type MusicBrainzArtistCredit = {
   };
 };
 
+declare type MusicBrainzReleaseGroup = {
+  title: string;
+  id: string;
+  disambiguation: string;
+  "first-release-date": string;
+  "primary-type": string;
+  "primary-type-id": string;
+  "secondary-types": string[];
+  "secondary-type-ids": string[];
+};
+
+declare type MusicBrainzTrack = {
+  number: string;
+  length: number;
+  position: number;
+  title: string;
+  id: string;
+  recording: MusicBrainzRecording;
+};
+declare type MusicBrainzMedia = {
+  title: string;
+  position: number;
+  tracks: Array<MusicBrainzTrack>;
+  format: string;
+  "format-id": string;
+  "track-offset": number;
+  "track-count": number;
+};
 declare type MusicBrainzRelease = {
   title: string;
   id: string;
@@ -35,6 +63,13 @@ declare type MusicBrainzRelease = {
   quality: string;
   country: string;
 };
+declare type MusicBrainzReleaseWithMedia = MusicBrainzRelease & {
+  media: Array<MusicBrainzMedia>;
+};
+// With ?inc=release-groups
+declare type MusicBrainzReleaseWithReleaseGroup = MusicBrainzRelease & {
+  "release-group": MusicBrainzReleaseGroup;
+};
 
 declare type MusicBrainzRecording = {
   title: string;
@@ -44,7 +79,10 @@ declare type MusicBrainzRecording = {
   video: boolean;
   disambiguation: string;
   "artist-credit": Array<MusicBrainzArtistCredit>;
-  releases?: Array<MusicBrainzRelease>;
+};
+// With ?inc=releases
+declare type MusicBrainzRecordingWithReleases = MusicBrainzRecording & {
+  releases: Array<MusicBrainzRelease>;
 };
 
 declare type MusicBrainzRecordingRel = {

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1045,21 +1045,29 @@ export default class APIService {
   lookupMBRecording = async (
     recordingMBID: string,
     inc = "artists"
-  ): Promise<any> => {
+  ): Promise<MusicBrainzRecording> => {
     const url = `${this.MBBaseURI}/recording/${recordingMBID}?fmt=json&inc=${inc}`;
     const response = await fetch(encodeURI(url));
     await this.checkStatus(response);
     return response.json();
   };
 
-  lookupMBRelease = async (releaseMBID: string): Promise<any> => {
+  lookupMBRelease = async (
+    releaseMBID: string
+  ): Promise<MusicBrainzReleaseWithReleaseGroup> => {
     const url = `${this.MBBaseURI}/release/${releaseMBID}?fmt=json&inc=release-groups`;
     const response = await fetch(encodeURI(url));
     await this.checkStatus(response);
     return response.json();
   };
 
-  lookupMBReleaseFromTrack = async (trackMBID: string): Promise<any> => {
+  lookupMBReleaseFromTrack = async (
+    trackMBID: string
+  ): Promise<{
+    "release-offset": number;
+    "release-count": number;
+    releases: MusicBrainzReleaseWithMedia[];
+  }> => {
     const url = `${this.MBBaseURI}/release?track=${trackMBID}&fmt=json`;
     const response = await fetch(encodeURI(url));
     await this.checkStatus(response);

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -599,6 +599,8 @@ const getAlbumArtFromReleaseMBID = async (
 const getAlbumArtFromListenMetadata = async (
   listen: BaseListenFormat,
   spotifyUser?: SpotifyUser
+  spotifyUser?: SpotifyUser,
+  APIService?: APIServiceClass
 ): Promise<string | undefined> => {
   // if spotifyListen
   if (


### PR DESCRIPTION
I recently noticed we sometimes match a recording with the MBID mapper, but don't send a corresponding CAA ID or release MBID.

This creates the impression for the user that the recording is not mapped:
<img width="696" alt="image" src="https://user-images.githubusercontent.com/6179856/231526402-42086cac-4994-4fb1-a08f-30536a369348.png">

<details>
<summary>
  Example listen from the screenshot above (see in particular `mbid_mapping` missing `release_mbid`):
</summary>

```json
{
  "inserted_at": 1680876572,
  "listened_at": 1680876482,
  "recording_msid": "378e069e-181e-4ca8-870f-201ae8602ab7",
  "track_metadata": {
    "additional_info": {
      "recording_msid": "378e069e-181e-4ca8-870f-201ae8602ab7"
    },
    "artist_name": "ASTRAL HAND",
    "mbid_mapping": {
      "artist_mbids": [
        "c47c56d8-d3ea-4956-8127-9e707f076822"
      ],
      "artists": [
        {
          "artist_credit_name": "Astral Hand",
          "artist_mbid": "c47c56d8-d3ea-4956-8127-9e707f076822",
          "join_phrase": ""
        }
      ],
      "recording_mbid": "47062eb3-4b1c-4ac4-ae3a-3b05996eefb4"
    },
    "release_name": "Lords of Data",
    "track_name": "Not Alone"
  },
  "user_name": "mr_monkey"
}
```
</details>

In the situation where we have a mapped recording but no mapped release_mbid and couldn't find cover art, show a placeholder image and make it a link to the recording on MB (we usually link to the release when we have that mbid)

I also added two extra fallback mechanisms to try a bit harder to fetch some cover art:
1. When we have a mapped **release** MBID but no CAA IDs, we can try to get the cover art using the `mbid_mapping.release_mbid`
2. Failing that, if we have a mapped **recording** MBID but no release MBID, we can try our best and lookup MusicBrainz releases for that recording and try to get the cover art from the first release.


While I was in there I also improved Typescript types for the APIService methods that return MusicBrainz lookup entities (I almost pushed code that would break, fixed types to prevent it in the future). 