### PR TITLE
LB-1190: Missing video ID in YoutubePlayer metadata

### DIFF
--- a/frontend/js/src/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/brainzplayer/YoutubePlayer.tsx
@@ -143,7 +143,7 @@ export default class YoutubePlayer
     }
     onTrackInfoChange(
       title,
-      `https://www.youtube.com/watch?v=${videoId}`,
+      videoId ? `https://www.youtube.com/watch?v=${videoId}` : "",
       undefined,
       undefined,
       images
@@ -177,13 +177,19 @@ export default class YoutubePlayer
       const videoId = _get(player, "playerInfo.videoData.video_id", "");
       // The player info is sometimes missing a title initially.
       // We fallback to getting it with getVideoData method once the information is loaded in the player
-      if (!title) {
+      if (!title || !videoId) {
         setTimeout(this.updateVideoInfo.bind(this), 2000);
       } else {
         const images: MediaImage[] = YoutubePlayer.getThumbnailsFromVideoid(
           videoId
         );
-        onTrackInfoChange(title, videoId, undefined, undefined, images);
+        onTrackInfoChange(
+          title,
+          `https://www.youtube.com/watch?v=${videoId}`,
+          undefined,
+          undefined,
+          images
+        );
       }
     }
     if (state === YouTube.PlayerState.PAUSED) {

--- a/frontend/js/tests/brainzplayer/YoutubePlayer.test.tsx
+++ b/frontend/js/tests/brainzplayer/YoutubePlayer.test.tsx
@@ -116,7 +116,7 @@ describe("YoutubePlayer", () => {
       expect(instance.props.onTrackInfoChange).toHaveBeenCalledTimes(1);
       expect(instance.props.onTrackInfoChange).toHaveBeenCalledWith(
         "FNORD",
-        "IhaveSeenTheFnords",
+        "https://www.youtube.com/watch?v=IhaveSeenTheFnords",
         undefined,
         undefined,
         [


### PR DESCRIPTION
Sometimes we don't have required info (video ID) available when Youtube player starts playing. We retry manually after a set time.
However, currently an invalid youtube URL is set in the listen submitted by BrainzPlayer if the videoID is missing.
And separate from that issue, when we retry only the video ID is sent instead of the whole youtube URL in one case.

I still need to test this to make sure we don't have a regression or any unexpected weird Youtube bug.