### PR TITLE
LB-1250: user-submitted `{recording, artist}_mbid` does not match artist display in listens

### DIFF
--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -52,6 +52,7 @@ declare type MBIDMappingArtist = {
 };
 
 declare type MBIDMapping = {
+  recording_name?: string;
   recording_mbid: string;
   release_mbid: string;
   artist_mbids: Array<string>;

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -174,16 +174,33 @@ const getReleaseGroupMBID = (listen: Listen): string | undefined =>
   _.get(listen, "track_metadata.mbid_mapping.release_group_mbid");
 
 const getTrackName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
-  _.get(listen, "track_metadata.track_name", "") || _.get(listen, "title", "");
+  _.get(listen, "track_metadata.mbid_mapping.recording_name", "") ||
+  _.get(listen, "track_metadata.track_name", "") ||
+  _.get(listen, "title", "");
 
 const getTrackDurationInMs = (listen?: Listen | JSPFTrack): number =>
   _.get(listen, "track_metadata.additional_info.duration_ms", "") ||
   _.get(listen, "track_metadata.additional_info.duration", "") * 1000 ||
   _.get(listen, "duration", "");
 
-const getArtistName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
-  _.get(listen, "track_metadata.artist_name", "") ||
-  _.get(listen, "creator", "");
+const getArtistName = (
+  listen?: Listen | JSPFTrack | PinnedRecording
+): string => {
+  const artists: MBIDMappingArtist[] = _.get(
+    listen,
+    "track_metadata.mbid_mapping.artists",
+    []
+  );
+  if (artists?.length) {
+    return artists
+      .map((artist) => `${artist.artist_credit_name}${artist.join_phrase}`)
+      .join("");
+  }
+  return (
+    _.get(listen, "track_metadata.artist_name", "") ||
+    _.get(listen, "creator", "")
+  );
+};
 
 const getArtistLink = (listen: Listen) => {
   const artists = listen.track_metadata?.mbid_mapping?.artists;
@@ -196,6 +213,7 @@ const getArtistLink = (listen: Listen) => {
               href={`https://musicbrainz.org/artist/${artist.artist_mbid}`}
               target="_blank"
               rel="noopener noreferrer"
+              title={artist.artist_credit_name}
             >
               {artist.artist_credit_name}
             </a>

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -126,7 +126,7 @@ class Listen(object):
 
     @classmethod
     def from_timescale(cls, listened_at, track_name, user_id, created, data,
-                       recording_mbid=None, release_mbid=None, artist_mbids=None,
+                       recording_mbid=None, recording_name=None, release_mbid=None, artist_mbids=None,
                        ac_names=None, ac_join_phrases=None, user_name=None,
                        caa_id=None, caa_release_mbid=None):
         """Factory to make Listen() objects from a timescale dict"""
@@ -135,6 +135,9 @@ class Listen(object):
         data["track_metadata"]["track_name"] = track_name
         if recording_mbid is not None:
             data["track_metadata"]["mbid_mapping"] = {"recording_mbid": str(recording_mbid)}
+
+            if recording_name is not None:
+                data["track_metadata"]["mbid_mapping"]["recording_name"] = recording_name
 
             if release_mbid is not None:
                 data["track_metadata"]["mbid_mapping"]["release_mbid"] = str(release_mbid)

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -55,7 +55,15 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
                       , '{"artist": [], "recording": [], "release_group": []}'
                       , '{"mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd", "name": "Dummy"}'
                       , 'f'
-                       )
+                       ),
+                       ('2cfad207-3f55-4aec-8120-86cf66e34d59'
+                      , '{678d88b2-87b0-403b-b63d-5da7465aecc3}'::UUID[]
+                      , '93ac1812-d38d-4125-88e8-8440e3e89072'
+                      , '{"name": "Immigrant Song", "rels": [], "length": 145426}'
+                      , '{"name": "Led Zeppelin", "artists": [{"area": "United Kingdom", "name": "Led Zeppelin", "rels": {"lyrics": "https://genius.com/artists/Led-zeppelin", "youtube": "https://www.youtube.com/@ledzeppelin", "wikidata": "https://www.wikidata.org/wiki/Q2331", "streaming": "https://tidal.com/artist/67522", "free streaming": "https://www.deezer.com/artist/848", "social network": "https://www.facebook.com/ledzeppelin", "official homepage": "http://www.ledzeppelin.com/", "purchase for download": "https://www.7digital.com/artist/led-zeppelin"}, "type": "Group", "end_year": 1980, "begin_year": 1968, "join_phrase": ""}], "artist_credit_id": 388}'
+                      , '{"artist": [], "recording": [], "release_group": []}'
+                      , '{"mbid": "93ac1812-d38d-4125-88e8-8440e3e89072", "name": "Led Zeppelin III", "year": 1987, "caa_id": 1287533205, "caa_release_mbid": "7aadcfa2-df82-480e-8d2d-7ec4d0b41172", "album_artist_name": "Led Zeppelin", "release_group_mbid": "53f80f76-f8af-3558-bfd5-e7221e055c75"}'
+                      , 'f' )
         """
 
         join_query = """INSERT INTO mbid_mapping
@@ -148,9 +156,10 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self._insert_mapping_metadata("c7a41965-9f1e-456c-8b1d-27c0f0dde280")
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=1400000000, limit=1)
         self.assertEqual(len(listens), 1)
-        self.assertEqual(listens[0].data["mbid_mapping"]["artist_mbids"], ['8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11'])
-        self.assertEqual(listens[0].data["mbid_mapping"]["release_mbid"], '76df3287-6cda-33eb-8e9a-044b5e15ffdd')
-        self.assertEqual(listens[0].data["mbid_mapping"]["recording_mbid"], '2f3d422f-8890-41a1-9762-fbe16f107c31')
+        # mbid submitted by the user is preferred over the mapping created by LB
+        self.assertEqual(listens[0].data["mbid_mapping"]["artist_mbids"], ['678d88b2-87b0-403b-b63d-5da7465aecc3'])
+        self.assertEqual(listens[0].data["mbid_mapping"]["release_mbid"], '93ac1812-d38d-4125-88e8-8440e3e89072')
+        self.assertEqual(listens[0].data["mbid_mapping"]["recording_mbid"], '2cfad207-3f55-4aec-8120-86cf66e34d59')
 
     def test_get_listen_count_for_user(self):
         uid = random.randint(2000, 1 << 31)

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -225,6 +225,7 @@ class TimescaleListenStore:
                         , created
                         , data
                         , sl.recording_mbid
+                        , mbc.recording_data->>'name' AS recording_name
                         , mbc.release_mbid
                         , mbc.artist_mbids::TEXT[]
                         , (mbc.release_data->>'caa_id')::bigint AS caa_id
@@ -245,6 +246,7 @@ class TimescaleListenStore:
                         , created
                         , data
                         , sl.recording_mbid
+                        , recording_data->>'name'
                         , release_mbid
                         , artist_mbids
                         , artist_data->>'name'
@@ -318,6 +320,7 @@ class TimescaleListenStore:
                         created=result.created,
                         data=result.data,
                         recording_mbid=result.recording_mbid,
+                        recording_name=result.recording_name,
                         release_mbid=result.release_mbid,
                         artist_mbids=result.artist_mbids,
                         ac_names=result.ac_names,
@@ -394,6 +397,7 @@ class TimescaleListenStore:
                          , created
                          , data
                          , l.recording_mbid
+                         , mbc.recording_data->>'name' AS recording_name
                          , mbc.release_mbid
                          , mbc.artist_mbids::TEXT[]
                          , (mbc.release_data->>'caa_id')::bigint AS caa_id
@@ -411,6 +415,7 @@ class TimescaleListenStore:
                          , created
                          , data
                          , l.recording_mbid
+                         , mbc.recording_data->>'name'
                          , mbc.release_mbid
                          , mbc.artist_mbids
                          , mbc.release_data->>'caa_id'
@@ -434,6 +439,7 @@ class TimescaleListenStore:
                     created=result.created,
                     data=result.data,
                     recording_mbid=result.recording_mbid,
+                    recording_name=result.recording_name,
                     release_mbid=result.release_mbid,
                     artist_mbids=result.artist_mbids,
                     ac_names=result.ac_names,

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -208,8 +208,8 @@ class TimescaleListenStore:
                              , l.user_id
                              , l.created
                              , l.data
-                             -- prefer to use user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
-                             , COALESCE(user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
+                             -- prefer to use user submitted mbid, then user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
+                             , COALESCE((data->'track_metadata'->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
                           FROM listen l
                      LEFT JOIN mbid_mapping mm
                             ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = mm.recording_msid
@@ -377,8 +377,8 @@ class TimescaleListenStore:
                      WHERE {filters} 
               ), selected_listens AS (
                     SELECT l.*
-                           -- prefer to use user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
-                         , COALESCE(user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
+                        -- prefer to use user submitted mbid, then user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
+                         , COALESCE((data->'track_metadata'->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
                       FROM intermediate l
                  LEFT JOIN mbid_mapping mm
                         ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = mm.recording_msid


### PR DESCRIPTION
Prefer user-submitted recording mbids over mapped mbids for listen metadata. We already do this for spark dumps and as a result for statistics.

https://github.com/metabrainz/listenbrainz-server/blob/78e37b78ff9e1a246d24adb2a0a0108a1462b284/listenbrainz/listenstore/dump_listenstore.py#L351-L353

Fix the omission in this case as well.

For consistency on the frontend, try to use all data from MB. If the user submitted a recording_mbid, its title will be shown. Otherwise the mapped recording's. If no mapping was made then the user submitted track name will be used.