### PR TITLE
LB-1189: YoutubePlayer: Use getVideoIDFromListen utility

### DIFF
--- a/frontend/js/src/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/brainzplayer/YoutubePlayer.tsx
@@ -299,19 +299,8 @@ export default class YoutubePlayer
     if (!show) {
       return;
     }
-    let youtubeId = _get(listen, "track_metadata.additional_info.youtube_id");
-    const originURL = _get(listen, "track_metadata.additional_info.origin_url");
-    if (!youtubeId && _isString(originURL) && originURL.length) {
-      try {
-        const parsedURL = new URL(originURL);
-        const { hostname, searchParams } = parsedURL;
-        if (/youtube\.com/.test(hostname)) {
-          youtubeId = searchParams.get("v");
-        }
-      } catch {
-        // URL is not valid, do nothing
-      }
-    }
+    const youtubeId = YoutubePlayer.getVideoIDFromListen(listen);
+
     if (youtubeId) {
       this.playTrackById(youtubeId);
     } else {


### PR DESCRIPTION
As described in LB-1189, this listen can't currently be played in BrainzPlayer despite having a youtube ID in the metadata:
(Ignore the empty track and artist names, that's all [legit](https://musicbrainz.org/release/d00a4034-345c-42d8-9a78-1d20244b5674))

Make a note of the `origin_url` with a `youtu.be/…` short link.
```
{
  "track_metadata": {
    "artist_name": "‌",
    "additional_info": {
      "duration": 235,
      "origin_url": "https://youtu.be/XrHTI04i9yk",
      "recording_msid": "9270d65e-5df2-45a5-95df-9dd987836347",
      "submission_client": "Web Scrobbler",
      "music_service_name": "YouTube",
      "submission_client_version": "2.84.0"
    },
    "track_name": "‌",
    "mbid_mapping": {
      "recording_mbid": "b9f04c56-7397-4931-a9a6-41d1f32260ed",
      "artists": [
        {
          "artist_mbid": "152d8a7c-7159-49bf-92d2-ee4564e74d1e",
          "artist_credit_name": "‌",
          "join_phrase": ""
        }
      ],
      "artist_mbids": [
        "152d8a7c-7159-49bf-92d2-ee4564e74d1e"
      ]
    }
  },
}
```

The code we currently have in the `playListen` method of the YoutubePlayer component hasn't been refactored to use the `YoutubePlayer.getVideoIDFromListen` static method, and does not handle as many use-cases.
In this case, no support for `youtu.be` style short links prevents the video from being played.