### PR TITLE
Remove recordings with too long titles from mapping

### DIFF
--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -74,6 +74,9 @@ class CanonicalMusicBrainzData(BulkInsertTable):
                    ON acn.artist_credit = s.artist_credit
             LEFT JOIN musicbrainz.release_country rc
                    ON rc.release = rl.id
+               --- there is some bad data in MB for which the title is too large and exceeds the postgres indexing limits
+               --- therefore filter out such recordings before-hand, otherwise index creation may fail
+                WHERE length(concat(ac.name, r.name)) < 500      
              GROUP BY rpr.id, ac.id, s.artist_mbids, rl.gid, artist_credit_name, r.gid, r.name, release_name, year
              ORDER BY ac.id, rpr.id
         """)]


### PR DESCRIPTION
There is some bad data in MB for which the title is too large and exceeds the postgres indexing limits. Filter such recordings beforehand, otherwise index creation may fail. The length 500 was chosen empirically, there are only ~1000 recordings which have longer titles. Therefore, it seems like a good threshold.
