### PR TITLE
Store MusicBrainz access/refresh token in db

### DIFF
--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -10,7 +10,7 @@ CREATE TYPE user_timeline_event_type_enum AS ENUM('recording_recommendation', 'n
 
 CREATE TYPE hide_user_timeline_event_type_enum AS ENUM('recording_recommendation', 'recording_pin');
 
-CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm', 'librefm');
+CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm', 'librefm', 'musicbrainz');
 
 CREATE TYPE stats_range_type AS ENUM ('week', 'month', 'quarter', 'half_yearly', 'year', 'all_time',
     'this_week', 'this_month', 'this_year');

--- a/admin/sql/updates/2023-04-20-add-musicbrainz-as-external-service.sql
+++ b/admin/sql/updates/2023-04-20-add-musicbrainz-as-external-service.sql
@@ -1,0 +1,1 @@
+ALTER TYPE external_service_oauth_type ADD VALUE 'musicbrainz';

--- a/data/model/external_service.py
+++ b/data/model/external_service.py
@@ -4,5 +4,6 @@ from enum import Enum
 class ExternalServiceType(Enum):
     SPOTIFY = 'spotify'
     CRITIQUEBRAINZ = 'critiquebrainz'
+    MUSICBRAINZ = 'musicbrainz'
     LASTFM = 'lastfm'
     LIBREFM = 'librefm'

--- a/listenbrainz/domain/brainz_service.py
+++ b/listenbrainz/domain/brainz_service.py
@@ -1,0 +1,84 @@
+import time
+
+from requests_oauthlib import OAuth2Session
+from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+from listenbrainz.db import external_service_oauth
+
+from listenbrainz.domain.external_service import ExternalService, ExternalServiceInvalidGrantError
+
+
+class BaseBrainzService(ExternalService):
+
+    def __init__(self, service, client_id, client_secret, redirect_uri,
+                 authorize_url, token_url, scopes):
+        super(BaseBrainzService, self).__init__(service)
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.authorize_url = authorize_url
+        self.token_url = token_url
+        self.scopes = scopes
+
+    def add_new_user(self, user_id: int, token: dict) -> bool:
+        expires_at = int(time.time()) + token["expires_in"]
+        external_service_oauth.save_token(
+            user_id=user_id,
+            service=self.service,
+            access_token=token["access_token"],
+            refresh_token=token["refresh_token"],
+            token_expires_ts=expires_at,
+            record_listens=False,
+            scopes=self.scopes
+        )
+        return True
+
+    def get_authorize_url(self, scopes: list, state: str = None, **kwargs):
+        oauth = OAuth2Session(
+            client_id=self.client_id,
+            redirect_uri=self.redirect_uri,
+            scope=scopes,
+            state=state
+        )
+        authorization_url, _ = oauth.authorization_url(self.authorize_url, **kwargs)
+        return authorization_url
+
+    def fetch_access_token(self, code: str):
+        oauth = OAuth2Session(
+            client_id=self.client_id,
+            redirect_uri=self.redirect_uri
+        )
+        return oauth.fetch_token(
+            self.token_url,
+            client_secret=self.client_secret,
+            code=code,
+            include_client_id=True
+        )
+
+    def refresh_access_token(self, user_id: int, refresh_token: str):
+        oauth = OAuth2Session(
+            client_id=self.client_id,
+            redirect_uri=self.redirect_uri,
+            scope=self.scopes
+        )
+        try:
+            token = oauth.refresh_token(
+                self.token_url,
+                client_secret=self.client_secret,
+                client_id=self.client_id,
+                refresh_token=refresh_token,
+            )
+        except InvalidGrantError as e:
+            raise ExternalServiceInvalidGrantError("User revoked access") from e
+
+        expires_at = int(time.time()) + token["expires_in"]
+        external_service_oauth.update_token(
+            user_id=user_id,
+            service=self.service,
+            access_token=token["access_token"],
+            refresh_token=token["refresh_token"],
+            expires_at=expires_at
+        )
+        return self.get_user(user_id)
+
+    def get_user_connection_details(self, user_id: int):
+        pass

--- a/listenbrainz/domain/critiquebrainz.py
+++ b/listenbrainz/domain/critiquebrainz.py
@@ -1,19 +1,11 @@
-import time
-
-import json
-import requests
-from requests_oauthlib import OAuth2Session
-from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from typing import Iterable
+
+import requests
+from flask import current_app
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.db.model.review import CBReviewMetadata
-from listenbrainz.db import external_service_oauth
-
-from flask import current_app
-
-from listenbrainz.domain.external_service import ExternalService, ExternalServiceInvalidGrantError
-
+from listenbrainz.domain.brainz_service import BaseBrainzService
 
 CRITIQUEBRAINZ_SCOPES = ["review"]
 
@@ -25,76 +17,18 @@ CRITIQUEBRAINZ_REVIEW_FETCH_URL = "https://critiquebrainz.org/ws/1/reviews/"
 CRITIQUEBRAINZ_REVIEW_LICENSE = "CC BY-SA 3.0"
 
 
-class CritiqueBrainzService(ExternalService):
+class CritiqueBrainzService(BaseBrainzService):
 
     def __init__(self):
-        super(CritiqueBrainzService, self).__init__(ExternalServiceType.CRITIQUEBRAINZ)
-        self.client_id = current_app.config["CRITIQUEBRAINZ_CLIENT_ID"]
-        self.client_secret = current_app.config["CRITIQUEBRAINZ_CLIENT_SECRET"]
-        self.redirect_uri = current_app.config["CRITIQUEBRAINZ_REDIRECT_URI"]
-
-    def add_new_user(self, user_id: int, token: dict) -> bool:
-        expires_at = int(time.time()) + token['expires_in']
-        external_service_oauth.save_token(
-            user_id=user_id,
-            service=self.service,
-            access_token=token["access_token"],
-            refresh_token=token["refresh_token"],
-            token_expires_ts=expires_at,
-            record_listens=False,
+        super(CritiqueBrainzService, self).__init__(
+            ExternalServiceType.CRITIQUEBRAINZ,
+            client_id=current_app.config["CRITIQUEBRAINZ_CLIENT_ID"],
+            client_secret=current_app.config["CRITIQUEBRAINZ_CLIENT_SECRET"],
+            redirect_uri=current_app.config["CRITIQUEBRAINZ_REDIRECT_URI"],
+            authorize_url=OAUTH_AUTHORIZE_URL,
+            token_url=OAUTH_TOKEN_URL,
             scopes=CRITIQUEBRAINZ_SCOPES
         )
-        return True
-
-    def get_authorize_url(self, scopes: list):
-        oauth = OAuth2Session(
-            client_id=self.client_id,
-            redirect_uri=self.redirect_uri,
-            scope=scopes
-        )
-        authorization_url, _ = oauth.authorization_url(OAUTH_AUTHORIZE_URL)
-        return authorization_url
-
-    def fetch_access_token(self, code: str):
-        oauth = OAuth2Session(
-            client_id=self.client_id,
-            redirect_uri=self.redirect_uri
-        )
-        return oauth.fetch_token(
-            OAUTH_TOKEN_URL,
-            client_secret=self.client_secret,
-            code=code,
-            include_client_id=True
-        )
-
-    def refresh_access_token(self, user_id: int, refresh_token: str):
-        oauth = OAuth2Session(
-            client_id=self.client_id,
-            redirect_uri=self.redirect_uri,
-            scope=CRITIQUEBRAINZ_SCOPES
-        )
-        try:
-            token = oauth.refresh_token(
-                OAUTH_TOKEN_URL,
-                client_secret=self.client_secret,
-                client_id=self.client_id,
-                refresh_token=refresh_token,
-            )
-        except InvalidGrantError as e:
-            raise ExternalServiceInvalidGrantError("User revoked access") from e
-
-        expires_at = int(time.time()) + token['expires_in']
-        external_service_oauth.update_token(
-            user_id=user_id,
-            service=self.service,
-            access_token=token["access_token"],
-            refresh_token=token["refresh_token"],
-            expires_at=expires_at
-        )
-        return self.get_user(user_id)
-
-    def get_user_connection_details(self, user_id: int):
-        pass
 
     def _submit_review_to_CB(self, token: str, review: CBReviewMetadata):
         headers = {

--- a/listenbrainz/domain/musicbrainz.py
+++ b/listenbrainz/domain/musicbrainz.py
@@ -1,0 +1,28 @@
+import requests
+from flask import current_app, url_for
+
+from data.model.external_service import ExternalServiceType
+from listenbrainz.domain.brainz_service import BaseBrainzService
+
+MUSICBRAINZ_SCOPES = ["tag", "rating", "profile"]
+
+MUSICBRAINZ_USER_INFO_URL = "https://musicbrainz.org/oauth2/userinfo"
+
+
+class MusicBrainzService(BaseBrainzService):
+
+    def __init__(self):
+        super(MusicBrainzService, self).__init__(
+            ExternalServiceType.MUSICBRAINZ,
+            client_id=current_app.config["MUSICBRAINZ_CLIENT_ID"],
+            client_secret=current_app.config["MUSICBRAINZ_CLIENT_SECRET"],
+            redirect_uri=url_for('login.musicbrainz_post', _external=True),
+            authorize_url="https://musicbrainz.org/oauth2/authorize",
+            token_url="https://musicbrainz.org/oauth2/token",
+            scopes=MUSICBRAINZ_SCOPES
+        )
+
+    def get_user_info(self, token: str):
+        response = requests.post(MUSICBRAINZ_USER_INFO_URL, headers={"Authorization": f"Bearer {token}"})
+        response.raise_for_status()
+        return response.json()

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -126,8 +126,6 @@ def create_app(debug=None):
     # OAuth
     from listenbrainz.webserver.login import login_manager, provider
     login_manager.init_app(app)
-    provider.init(app.config['MUSICBRAINZ_CLIENT_ID'],
-                  app.config['MUSICBRAINZ_CLIENT_SECRET'])
 
     # Error handling
     from listenbrainz.webserver.errors import init_error_handlers

--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -1,16 +1,13 @@
-from markupsafe import Markup
-from rauth import OAuth2Service
-from flask import request, session, url_for, current_app
+from flask import request, session, current_app
 from brainzutils.musicbrainz_db import engine as mb_engine
 from brainzutils.musicbrainz_db import editor as mb_editor
-from listenbrainz.webserver.login import User
+
+from listenbrainz.domain.musicbrainz import MusicBrainzService, MUSICBRAINZ_SCOPES
 from listenbrainz.webserver.utils import generate_string
 from listenbrainz.webserver.timescale_connection import _ts as ts
 import listenbrainz.db.user as db_user
-import orjson
 
-_musicbrainz = None
-_session_key = None
+_session_key = "musicbrainz"
 
 
 class MusicBrainzAuthSessionError(Exception):
@@ -23,38 +20,15 @@ class MusicBrainzAuthNoEmailError(Exception):
     pass
 
 
-def init(client_id, client_secret, session_key='musicbrainz'):
-    global _musicbrainz, _session_key
-    _musicbrainz = OAuth2Service(
-        name='musicbrainz',
-        base_url="https://musicbrainz.org/",
-        authorize_url="https://musicbrainz.org/oauth2/authorize",
-        access_token_url="https://musicbrainz.org/oauth2/token",
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-    _session_key = session_key
-
-
-def musicbrainz_auth_session_decoder(message):
-    """Decode the json oauth response from MusicBrainz, returning {} if the response isn't valid json"""
-    try:
-        return orjson.loads(message)
-    except ValueError:
-        return {}
-
-
 def get_user():
     """Function should fetch user data from database, or, if necessary, create it, and return it."""
+    service = MusicBrainzService()
     try:
-        s = _musicbrainz.get_auth_session(data={
-            'code': _fetch_data('code'),
-            'grant_type': 'authorization_code',
-            'redirect_uri': url_for('login.musicbrainz_post', _external=True)
-        }, decoder=musicbrainz_auth_session_decoder)
-        data = s.get('oauth2/userinfo').json()
-        musicbrainz_id = data.get('sub')
-        musicbrainz_row_id = data.get('metabrainz_user_id')
+        code = _fetch_data("code")
+        token = service.fetch_access_token(code)
+        info = service.get_user_info(token["access_token"])
+        musicbrainz_id = info["sub"]
+        musicbrainz_row_id = info["metabrainz_user_id"]
     except KeyError:
         # get_auth_session raises a KeyError if it was unable to get the required data from `code`
         raise MusicBrainzAuthSessionError()
@@ -62,7 +36,7 @@ def get_user():
     user = db_user.get_by_mb_row_id(musicbrainz_row_id, musicbrainz_id)
     user_email = None
     if mb_engine:
-        user_email = mb_editor.get_editor_by_id(musicbrainz_row_id)['email']
+        user_email = mb_editor.get_editor_by_id(musicbrainz_row_id)["email"]
 
     if user is None:  # a new user is trying to sign up
         if current_app.config["REJECT_NEW_USERS_WITHOUT_EMAIL"] and user_email is None:
@@ -71,6 +45,8 @@ def get_user():
         db_user.create(musicbrainz_row_id, musicbrainz_id, email=user_email)
         user = db_user.get_by_mb_id(musicbrainz_id, fetch_email=True)
         ts.set_empty_values_for_user(user["id"])
+
+        service.add_new_user(user["id"], token)
     else:  # an existing user is trying to log in
         # Other option is to change the return type of get_by_mb_row_id to a dict
         # but its used so widely that we would modifying huge number of tests
@@ -86,13 +62,7 @@ def get_authentication_uri():
     """Prepare and return URL to authentication service login form."""
     csrf = generate_string(20)
     _persist_data(csrf=csrf)
-    params = {
-        'response_type': 'code',
-        'redirect_uri': url_for('login.musicbrainz_post', _external=True),
-        'scope': 'profile',
-        'state': csrf,
-    }
-    return _musicbrainz.get_authorize_url(**params)
+    return MusicBrainzService().get_authorize_url(MUSICBRAINZ_SCOPES, state=csrf, access_type="offline")
 
 
 def validate_post_login():


### PR DESCRIPTION
We need MusicBrainz access/refresh token in ListenBrainz database to submit tags to MusicBrainz.

Note: This only works for new users. Even just logging out users won't work. The access to ListenBrainz application needs to be removed from MB as well in order to make this work. Alternatively, we can add refresh tokens to MB oauth tables manually for existing users and then copy them over to LB.