### PR TITLE
Prevent redundant requests to CAA from taste page

### DIFF
--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -98,7 +98,7 @@ def _update_mbid_items(models: dict[str, list[ModelT]], metadatas: dict, remaini
                 "track_name": metadata["title"],
                 "artist_name": metadata["artist"],
                 "release_name": metadata["release"],
-                "additional_info": {
+                "mbid_mapping": {
                     "recording_mbid": metadata["recording_mbid"],
                     "release_mbid": metadata["release_mbid"],
                     "artist_mbids": metadata["artist_mbids"],
@@ -107,11 +107,11 @@ def _update_mbid_items(models: dict[str, list[ModelT]], metadatas: dict, remaini
             }
 
             if metadata["caa_id"]:
-                item.track_metadata["additional_info"]["caa_id"] = metadata["caa_id"]
-                item.track_metadata["additional_info"]["caa_release_mbid"] = metadata["caa_release_mbid"]
+                item.track_metadata["mbid_mapping"]["caa_id"] = metadata["caa_id"]
+                item.track_metadata["mbid_mapping"]["caa_release_mbid"] = metadata["caa_release_mbid"]
 
             if item.recording_msid:
-                item.track_metadata["additional_info"]["recording_msid"] = item.recording_msid
+                item.track_metadata["additional_info"] = {"recording_msid": item.recording_msid}
 
 
 def _update_msid_items(models: dict[str, list[ModelT]], metadatas: dict[str, dict]):

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -3,8 +3,7 @@ from datetime import datetime
 
 from listenbrainz import db
 from listenbrainz.db.model.pinned_recording import PinnedRecording, WritablePinnedRecording
-from typing import List
-
+from typing import List, Iterable
 
 PINNED_REC_GET_COLUMNS = [
     "user_id",
@@ -186,7 +185,7 @@ def get_pins_for_user_following(user_id: int, count: int, offset: int) -> List[P
         return [PinnedRecording(**row) for row in result.mappings()]
 
 
-def get_pins_for_feed(user_ids: List[int], min_ts: int, max_ts: int, count: int) -> List[PinnedRecording]:
+def get_pins_for_feed(user_ids: Iterable[int], min_ts: int, max_ts: int, count: int) -> List[PinnedRecording]:
     """ Gets a list of PinnedRecordings for specified users in descending order of their created date.
 
     Args:

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -240,8 +240,8 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(result[0].score, self.sample_feedback_with_metadata[0]["score"])
         self.assertEqual(result[0].track_metadata["artist_name"], "Portishead")
         self.assertEqual(result[0].track_metadata["track_name"], "Strangers")
-        self.assertEqual(result[0].track_metadata["additional_info"]["recording_mbid"], "2f3d422f-8890-41a1-9762-fbe16f107c31")
-        self.assertEqual(result[0].track_metadata["additional_info"]["release_mbid"], "76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        self.assertEqual(result[0].track_metadata["mbid_mapping"]["recording_mbid"], "2f3d422f-8890-41a1-9762-fbe16f107c31")
+        self.assertEqual(result[0].track_metadata["mbid_mapping"]["release_mbid"], "76df3287-6cda-33eb-8e9a-044b5e15ffdd")
 
     def test_get_feedback_count_for_user(self):
         count = self.insert_test_data(self.user["id"])

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -198,11 +198,11 @@ class MappingTestCase(TimescaleTestCase):
                 continue
 
             self.assertEqual(metadata["release_name"], recording["release"])
-            self.assertEqual(metadata["additional_info"]["recording_mbid"], recording["recording_mbid"])
             self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
-            self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
-            self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
-            self.assertEqual(metadata["additional_info"]["artists"], recording["artists"])
+            self.assertEqual(metadata["mbid_mapping"]["recording_mbid"], recording["recording_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["release_mbid"], recording["release_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["artist_mbids"], recording["artist_mbids"])
+            self.assertEqual(metadata["mbid_mapping"]["artists"], recording["artists"])
 
     def test_fetch_track_metadata_for_items_with_same_mbid(self):
         recording = self.insert_recordings()[0]
@@ -216,9 +216,9 @@ class MappingTestCase(TimescaleTestCase):
             self.assertEqual(metadata["track_name"], recording["title"])
             self.assertEqual(metadata["artist_name"], recording["artist"])
             self.assertEqual(metadata["release_name"], recording["release"])
-            self.assertEqual(metadata["additional_info"]["recording_mbid"], recording["recording_mbid"])
             self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
-            self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
-            self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
-            self.assertEqual(metadata["additional_info"]["artists"], recording["artists"])
+            self.assertEqual(metadata["mbid_mapping"]["recording_mbid"], recording["recording_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["release_mbid"], recording["release_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["artist_mbids"], recording["artist_mbids"])
+            self.assertEqual(metadata["mbid_mapping"]["artists"], recording["artists"])
 

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -176,6 +176,9 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             "artist_name": "Portishead",
             "release_name": "Dummy",
             "additional_info": {
+                "recording_msid": msids[0]
+            },
+            "mbid_mapping": {
                 "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31",
                 "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
                 "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"],
@@ -185,8 +188,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                         "join_phrase": "",
                         "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
                     }
-                ],
-                "recording_msid": msids[0]
+                ]
             }
         })
 

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -296,7 +296,7 @@ def get_current_pin_for_user(user_name):
                 "recording_mbid": null,
                 "recording_msid": "fd7d9162-a284-4a10-906c-faae4f1e166b"
                 "track_metadata": {
-                "artist_name": "Rick Astley",
+                    "artist_name": "Rick Astley",
                     "track_name": "Never Gonna Give You Up"
                 }
             },

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -306,7 +306,9 @@ class UserViewsTestCase(IntegrationTestCase):
             "artist_name": "Danny Elfman",
             "release_name": "Danny Elfman & Tim Burton 25th Anniversary Music Box",
             "additional_info": {
-                "recording_msid": "b7ffd2af-418f-4be2-bdd1-22f8b48613da",
+                "recording_msid": "b7ffd2af-418f-4be2-bdd1-22f8b48613da"
+            },
+            "mbid_mapping": {
                 "recording_mbid": "1fe669c9-5a2b-4dcb-9e95-77480d1e732e",
                 "release_mbid": "607cc05a-e462-4f39-91b5-e9322544e0a6",
                 "artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],


### PR DESCRIPTION
While working on an unrelated task I noticed a barrage of API requests being made to CAA on taste page.

![image](https://user-images.githubusercontent.com/27751938/233619717-9a9c2319-7737-4d93-9d00-9669d458dc66.png)

The MsidMbidModel is used to add track metadata to feedback and pinned recordings. It sets the mapping metadata in track_metadata.additional_info. However, some fields like caa_id and caa_release_mbid belong in mbid_mapping because the frontend doesn't check additional_info field for these. 

Also, if a release_mbid is present in additional_info, it will be treated as user submitted mbid by the frontend. The caa_id/caa_release_mbid fields will be ignored and a redundant API call will be made to CAA with the "user-submitted" release mbid. Therefore, move all fields to mbid_mapping instead. Logically also mbid_mapping makes more sense than additional_info.