### PR TITLE
Use mapping data in recommendation events

### DIFF
--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -192,11 +192,7 @@ export default class ListenCard extends React.Component<
     const { APIService, currentUser } = this.context;
 
     if (currentUser?.auth_token) {
-      const metadata: UserTrackRecommendationMetadata = {
-        artist_name: getArtistName(listen),
-        track_name: getTrackName(listen),
-        release_name: get(listen, "track_metadata.release_name"),
-      };
+      const metadata: UserTrackRecommendationMetadata = {};
 
       const recording_mbid = getRecordingMBID(listen);
       if (recording_mbid) {
@@ -218,7 +214,7 @@ export default class ListenCard extends React.Component<
           newAlert(
             "success",
             `You recommended a track to your followers!`,
-            `${metadata.artist_name} - ${metadata.track_name}`
+            `${getArtistName(listen)} - ${getTrackName(listen)}`
           );
         }
       } catch (error) {

--- a/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
+++ b/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
@@ -115,15 +115,20 @@ export default NiceModal.create(
         event.preventDefault();
         if (currentUser?.auth_token) {
           const metadata: UserTrackPersonalRecommendationMetadata = {
-            artist_name: getArtistName(listenToPersonallyRecommend),
-            track_name: getTrackName(listenToPersonallyRecommend),
-            release_name: listenToPersonallyRecommend!.track_metadata
-              .release_name,
-            recording_mbid: getRecordingMBID(listenToPersonallyRecommend),
-            recording_msid: getRecordingMSID(listenToPersonallyRecommend),
             users,
             blurb_content: blurbContent,
           };
+
+          const recording_mbid = getRecordingMBID(listenToPersonallyRecommend);
+          if (recording_mbid) {
+            metadata.recording_mbid = recording_mbid;
+          }
+
+          const recording_msid = getRecordingMSID(listenToPersonallyRecommend);
+          if (recording_msid) {
+            metadata.recording_msid = recording_msid;
+          }
+
           try {
             const status = await APIService.submitPersonalRecommendation(
               currentUser.auth_token,
@@ -136,7 +141,9 @@ export default NiceModal.create(
                 `You recommended this track to ${users.length} user${
                   users.length > 1 ? "s" : ""
                 }`,
-                `${metadata.artist_name} - ${metadata.track_name}`
+                `${getArtistName(listenToPersonallyRecommend)} - ${getTrackName(
+                  listenToPersonallyRecommend
+                )}`
               );
               closeModal();
             }

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -554,9 +554,6 @@ declare type PinnedRecording = {
 
 /** For recommending a track from the front-end */
 declare type UserTrackRecommendationMetadata = {
-  artist_name: string;
-  track_name: string;
-  release_name?: string;
   recording_mbid?: string;
   recording_msid?: string;
 };
@@ -565,6 +562,7 @@ declare type UserTrackRecommendationMetadata = {
 declare type UserTrackPersonalRecommendationMetadata = UserTrackRecommendationMetadata & {
   blurb_content: string;
   users: Array<string>;
+  track_metadata?: TrackMetadata;
 };
 
 declare type PinEventMetadata = Listen & {

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -771,16 +771,8 @@ export function personalRecommendationEventToListen(
 ): BaseListenFormat {
   return {
     listened_at: -1,
-    track_metadata: {
-      track_name: eventMetadata.track_name,
-      artist_name: eventMetadata.artist_name,
-      release_name: eventMetadata.release_name ?? "",
-      additional_info: {
-        recording_mbid: eventMetadata.recording_mbid,
-        recording_msid: eventMetadata.recording_msid,
-      },
-    },
-  };
+    track_metadata: eventMetadata.track_metadata,
+  } as BaseListenFormat;
 }
 
 export function getReviewEventContent(

--- a/frontend/js/tests/listens/ListenCard.test.tsx
+++ b/frontend/js/tests/listens/ListenCard.test.tsx
@@ -229,8 +229,6 @@ describe("ListenCard", () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith("test", "baz", {
-        artist_name: instance.props.listen.track_metadata.artist_name,
-        track_name: instance.props.listen.track_metadata.track_name,
         recording_msid:
           instance.props.listen.track_metadata.additional_info?.recording_msid,
         recording_mbid:

--- a/frontend/js/tests/personal-recommendations/PersonalRecommendationsModal.test.tsx
+++ b/frontend/js/tests/personal-recommendations/PersonalRecommendationsModal.test.tsx
@@ -125,9 +125,6 @@ describe("PersonalRecommendationModal", () => {
         {
           recording_mbid: "recording_mbid",
           recording_msid: "recording_msid",
-          artist_name: "TWICE",
-          track_name: "Feel Special",
-          release_name: undefined,
           blurb_content: "hii",
           users: ["fnord"],
         }

--- a/frontend/js/tests/utils/APIService.test.ts
+++ b/frontend/js/tests/utils/APIService.test.ts
@@ -826,8 +826,6 @@ describe("recommendTrackToFollowers", () => {
 
   it("calls fetch with correct parameters", async () => {
     const metadata: UserTrackRecommendationMetadata = {
-      artist_name: "Hans Zimmer",
-      track_name: "Flight",
       recording_msid: "recording_msid",
     };
     await apiService.recommendTrackToFollowers(
@@ -850,8 +848,6 @@ describe("recommendTrackToFollowers", () => {
 
   it("calls checkStatus once", async () => {
     const metadata: UserTrackRecommendationMetadata = {
-      artist_name: "Hans Zimmer",
-      track_name: "Flight",
       recording_msid: "recording_msid",
     };
     await apiService.recommendTrackToFollowers(
@@ -864,8 +860,6 @@ describe("recommendTrackToFollowers", () => {
 
   it("returns the response code if successful", async () => {
     const metadata: UserTrackRecommendationMetadata = {
-      artist_name: "Hans Zimmer",
-      track_name: "Flight",
       recording_msid: "recording_msid",
     };
     await expect(

--- a/listenbrainz/db/model/user_timeline_event.py
+++ b/listenbrainz/db/model/user_timeline_event.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Union, Optional, List
 
-from data.model.listen import APIListen
+from data.model.listen import APIListen, TrackMetadata
 from listenbrainz.db.model.review import CBReviewTimelineMetadata
 from listenbrainz.db.msid_mbid_mapping import MsidMbidModel
 
@@ -38,12 +38,10 @@ class UserTimelineEventType(Enum):
 
 
 class RecordingRecommendationMetadata(MsidMbidModel):
-    artist_name: constr(min_length=1)
-    track_name: constr(min_length=1)
-    release_name: Optional[str]
+    pass
 
 
-class PersonalRecordingRecommendationMetadata(RecordingRecommendationMetadata):
+class PersonalRecordingRecommendationMetadata(MsidMbidModel):
     users: conlist(str, min_items=1)
     blurb_content: Optional[str]
 
@@ -92,16 +90,12 @@ class APICBReviewEvent(BaseModel):
 
 
 class APIPersonalRecommendationEvent(BaseModel):
-    artist_name: constr(min_length=1)
-    track_name: constr(min_length=1)
-    release_name: Optional[str]
-    recording_mbid: Optional[str]
-    recording_msid: constr(min_length=1)
     users: List[str]
     blurb_content: Optional[str]
+    track_metadata: TrackMetadata
 
 
-APIEventMetadata = Union[APIListen, APIFollowEvent, APINotificationEvent, APIPinEvent, APICBReviewEvent, APIPersonalRecommendationEvent]
+APIEventMetadata = Union[APIPersonalRecommendationEvent, APIListen, APIFollowEvent, APINotificationEvent, APIPinEvent, APICBReviewEvent]
 
 
 class APITimelineEvent(BaseModel):

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -98,7 +98,7 @@ def _update_mbid_items(models: dict[str, list[ModelT]], metadatas: dict, remaini
                 "track_name": metadata["title"],
                 "artist_name": metadata["artist"],
                 "release_name": metadata["release"],
-                "additional_info": {
+                "mbid_mapping": {
                     "recording_mbid": metadata["recording_mbid"],
                     "release_mbid": metadata["release_mbid"],
                     "artist_mbids": metadata["artist_mbids"],
@@ -107,11 +107,11 @@ def _update_mbid_items(models: dict[str, list[ModelT]], metadatas: dict, remaini
             }
 
             if metadata["caa_id"]:
-                item.track_metadata["additional_info"]["caa_id"] = metadata["caa_id"]
-                item.track_metadata["additional_info"]["caa_release_mbid"] = metadata["caa_release_mbid"]
+                item.track_metadata["mbid_mapping"]["caa_id"] = metadata["caa_id"]
+                item.track_metadata["mbid_mapping"]["caa_release_mbid"] = metadata["caa_release_mbid"]
 
             if item.recording_msid:
-                item.track_metadata["additional_info"]["recording_msid"] = item.recording_msid
+                item.track_metadata["additional_info"] = {"recording_msid": item.recording_msid}
 
 
 def _update_msid_items(models: dict[str, list[ModelT]], metadatas: dict[str, dict]):

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -131,3 +131,6 @@ def _update_msid_items(models: dict[str, list[ModelT]], metadatas: dict[str, dic
                     "recording_msid": msid
                 }
             }
+
+            if metadata.get("release"):
+                item.track_metadata["release_name"] = metadata["release"]

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -3,8 +3,7 @@ from datetime import datetime
 
 from listenbrainz import db
 from listenbrainz.db.model.pinned_recording import PinnedRecording, WritablePinnedRecording
-from typing import List
-
+from typing import List, Iterable
 
 PINNED_REC_GET_COLUMNS = [
     "user_id",
@@ -186,7 +185,7 @@ def get_pins_for_user_following(user_id: int, count: int, offset: int) -> List[P
         return [PinnedRecording(**row) for row in result.mappings()]
 
 
-def get_pins_for_feed(user_ids: List[int], min_ts: int, max_ts: int, count: int) -> List[PinnedRecording]:
+def get_pins_for_feed(user_ids: Iterable[int], min_ts: int, max_ts: int, count: int) -> List[PinnedRecording]:
     """ Gets a list of PinnedRecordings for specified users in descending order of their created date.
 
     Args:

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -240,8 +240,8 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(result[0].score, self.sample_feedback_with_metadata[0]["score"])
         self.assertEqual(result[0].track_metadata["artist_name"], "Portishead")
         self.assertEqual(result[0].track_metadata["track_name"], "Strangers")
-        self.assertEqual(result[0].track_metadata["additional_info"]["recording_mbid"], "2f3d422f-8890-41a1-9762-fbe16f107c31")
-        self.assertEqual(result[0].track_metadata["additional_info"]["release_mbid"], "76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        self.assertEqual(result[0].track_metadata["mbid_mapping"]["recording_mbid"], "2f3d422f-8890-41a1-9762-fbe16f107c31")
+        self.assertEqual(result[0].track_metadata["mbid_mapping"]["release_mbid"], "76df3287-6cda-33eb-8e9a-044b5e15ffdd")
 
     def test_get_feedback_count_for_user(self):
         count = self.insert_test_data(self.user["id"])

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -198,11 +198,11 @@ class MappingTestCase(TimescaleTestCase):
                 continue
 
             self.assertEqual(metadata["release_name"], recording["release"])
-            self.assertEqual(metadata["additional_info"]["recording_mbid"], recording["recording_mbid"])
             self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
-            self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
-            self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
-            self.assertEqual(metadata["additional_info"]["artists"], recording["artists"])
+            self.assertEqual(metadata["mbid_mapping"]["recording_mbid"], recording["recording_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["release_mbid"], recording["release_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["artist_mbids"], recording["artist_mbids"])
+            self.assertEqual(metadata["mbid_mapping"]["artists"], recording["artists"])
 
     def test_fetch_track_metadata_for_items_with_same_mbid(self):
         recording = self.insert_recordings()[0]
@@ -216,9 +216,9 @@ class MappingTestCase(TimescaleTestCase):
             self.assertEqual(metadata["track_name"], recording["title"])
             self.assertEqual(metadata["artist_name"], recording["artist"])
             self.assertEqual(metadata["release_name"], recording["release"])
-            self.assertEqual(metadata["additional_info"]["recording_mbid"], recording["recording_mbid"])
             self.assertEqual(metadata["additional_info"]["recording_msid"], recording["recording_msid"])
-            self.assertEqual(metadata["additional_info"]["release_mbid"], recording["release_mbid"])
-            self.assertEqual(metadata["additional_info"]["artist_mbids"], recording["artist_mbids"])
-            self.assertEqual(metadata["additional_info"]["artists"], recording["artists"])
+            self.assertEqual(metadata["mbid_mapping"]["recording_mbid"], recording["recording_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["release_mbid"], recording["release_mbid"])
+            self.assertEqual(metadata["mbid_mapping"]["artist_mbids"], recording["artist_mbids"])
+            self.assertEqual(metadata["mbid_mapping"]["artists"], recording["artists"])
 

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -163,6 +163,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(received[0]["track_metadata"], {
             "track_name": "Wicked Game",
             "artist_name": "Tom Ellis",
+            "release_name": "Lucifer",
             "additional_info": {
                 "recording_msid": msids[1]
             }

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -176,6 +176,9 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             "artist_name": "Portishead",
             "release_name": "Dummy",
             "additional_info": {
+                "recording_msid": msids[0]
+            },
+            "mbid_mapping": {
                 "recording_mbid": "2f3d422f-8890-41a1-9762-fbe16f107c31",
                 "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
                 "artist_mbids": ["8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"],
@@ -185,8 +188,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                         "join_phrase": "",
                         "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
                     }
-                ],
-                "recording_msid": msids[0]
+                ]
             }
         })
 

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -32,7 +32,7 @@ from listenbrainz.db.model.user_timeline_event import (
 )
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
-from typing import List, Tuple
+from typing import List, Tuple, Iterable
 
 from listenbrainz.db.model.review import CBReviewTimelineMetadata
 
@@ -125,16 +125,13 @@ def create_personal_recommendation_event(user_id: int, metadata:
                         :user_id,
                         'personal_recording_recommendation',
                         jsonb_build_object(
-                            'track_name', :track_name,
-                            'artist_name', :artist_name,
-                            'release_name', :release_name,
                             'recording_mbid', :recording_mbid,
                             'recording_msid', :recording_msid,
                             'users', (
                                 SELECT jsonb_agg("user".id) as users
                                   FROM unnest(:users) as arr
-                                  INNER JOIN "user"
-                                  ON "user".musicbrainz_id = arr
+                            INNER JOIN "user"
+                                    ON "user".musicbrainz_id = arr
                             ),
                             'blurb_content', :blurb_content
                         )
@@ -142,9 +139,6 @@ def create_personal_recommendation_event(user_id: int, metadata:
                 RETURNING id, user_id, event_type, metadata, created
                 """), {
                     'user_id': user_id,
-                    'track_name': metadata.track_name,
-                    'artist_name': metadata.artist_name,
-                    'release_name': metadata.release_name,
                     'recording_mbid': metadata.recording_mbid,
                     'recording_msid': metadata.recording_msid,
                     'users': metadata.users,
@@ -176,7 +170,7 @@ def get_user_timeline_events(user_id: int, event_type: UserTimelineEventType, co
             'count': count,
         })
 
-        return [UserTimelineEvent(**row) for row in result.mappings()]
+        return [UserTimelineEvent(**row,) for row in result.mappings()]
 
 
 def get_user_track_recommendation_events(user_id: int, count: int = 50) -> List[UserTimelineEvent]:
@@ -191,7 +185,7 @@ def get_user_track_recommendation_events(user_id: int, count: int = 50) -> List[
     )
 
 
-def get_recording_recommendation_events_for_feed(user_ids: Tuple[int], min_ts: float, max_ts: float, count: int) \
+def get_recording_recommendation_events_for_feed(user_ids: Iterable[int], min_ts: float, max_ts: float, count: int) \
         -> List[UserTimelineEvent]:
     """ Gets a list of recording_recommendation events for specified users.
 
@@ -215,7 +209,13 @@ def get_recording_recommendation_events_for_feed(user_ids: Tuple[int], min_ts: f
             "event_type": UserTimelineEventType.RECORDING_RECOMMENDATION.value,
         })
 
-        return [UserTimelineEvent(**row) for row in result.mappings()]
+        return [UserTimelineEvent(
+            id=row.id,
+            user_id=row.user_id,
+            event_type=row.event_type,
+            metadata=RecordingRecommendationMetadata(**row.metadata),
+            created=row.created
+        ) for row in result]
 
 
 def get_personal_recommendation_events_for_feed(user_id: int, min_ts: int, max_ts: int, count: int) -> List[UserTimelineEvent]:
@@ -231,16 +231,14 @@ def get_personal_recommendation_events_for_feed(user_id: int, min_ts: int, max_t
                  ,
                  (
                     SELECT jsonb_build_object(
-                        'track_name', user_timeline_event.metadata -> 'track_name',
-                        'artist_name', user_timeline_event.metadata -> 'artist_name',
-                        'release_name', user_timeline_event.metadata -> 'release_name',
                         'recording_mbid', user_timeline_event.metadata -> 'recording_mbid',
                         'recording_msid', user_timeline_event.metadata -> 'recording_msid',
                         'users', jsonb_agg("user".musicbrainz_id),
                         'blurb_content', user_timeline_event.metadata -> 'blurb_content'
                     ) AS metadata
-                    FROM jsonb_array_elements_text(user_timeline_event.metadata -> 'users') AS arr
-                   INNER JOIN "user" ON arr.value::int = "user".id
+                      FROM jsonb_array_elements_text(user_timeline_event.metadata -> 'users') AS arr
+                INNER JOIN "user" 
+                        ON arr.value::int = "user".id
                  )
                  , user_timeline_event.created
                  , "user".musicbrainz_id as user_name
@@ -262,7 +260,14 @@ def get_personal_recommendation_events_for_feed(user_id: int, min_ts: int, max_t
             "event_type": UserTimelineEventType.PERSONAL_RECORDING_RECOMMENDATION.value,
         })
 
-        return [UserTimelineEvent(**row) for row in result.mappings()]
+        return [UserTimelineEvent(
+            id=row.id,
+            user_id=row.user_id,
+            user_name=row.user_name,
+            event_type=row.event_type,
+            metadata=PersonalRecordingRecommendationMetadata(**row.metadata),
+            created=row.created
+        ) for row in result]
 
 
 def get_cb_review_events(user_ids: List[int], min_ts: int, max_ts: int, count: int) -> List[UserTimelineEvent]:

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -63,11 +63,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.app.config["TESTING"] = False
 
     def test_recommendation_writes_an_event_to_the_database(self):
-        metadata = {
-            'artist_name': 'Kanye West',
-            'track_name': 'Fade',
-            'recording_msid': str(uuid.uuid4()),
-        }
+        metadata = {'recording_msid': str(uuid.uuid4())}
         r = self.client.post(
             url_for('user_timeline_event_api_bp.create_user_recording_recommendation_event', user_name=self.user['musicbrainz_id']),
             data=json.dumps({'metadata': metadata}),
@@ -80,16 +76,11 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
             count=1,
         )
         self.assertEqual(1, len(events))
-        self.assertEqual('Kanye West', events[0].metadata.artist_name)
-        self.assertEqual('Fade', events[0].metadata.track_name)
+        self.assertEqual(metadata["recording_msid"], events[0].metadata.recording_msid)
 
     def test_recommendation_mbid_only(self):
         """ Test recommendation with mbid only works """
-        metadata = {
-            'artist_name': 'Kanye West',
-            'track_name': 'Fade',
-            'recording_mbid': str(uuid.uuid4()),
-        }
+        metadata = {'recording_mbid': str(uuid.uuid4())}
         r = self.client.post(
             url_for('user_timeline_event_api_bp.create_user_recording_recommendation_event', user_name=self.user['musicbrainz_id']),
             data=json.dumps({'metadata': metadata}),
@@ -102,8 +93,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
             count=1,
         )
         self.assertEqual(1, len(events))
-        self.assertEqual('Kanye West', events[0].metadata.artist_name)
-        self.assertEqual('Fade', events[0].metadata.track_name)
         self.assertEqual(metadata['recording_mbid'], events[0].metadata.recording_mbid)
 
     def test_recommendation_checks_auth_token_for_authorization(self):
@@ -840,9 +829,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "Seedhe Maut",
-            "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
@@ -865,14 +851,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         self.assertEqual(1, len(events))
 
-        received = events[0].metadata.dict()
-        self.assertEqual(metadata["track_name"], received["track_name"])
-        self.assertEqual(metadata["artist_name"], received["artist_name"])
-        self.assertEqual(metadata["release_name"], received["release_name"])
-        self.assertEqual(metadata["recording_mbid"], received["recording_mbid"])
-        self.assertEqual(metadata["recording_msid"], received["recording_msid"])
-        self.assertEqual(metadata["blurb_content"], received["blurb_content"])
-        self.assertCountEqual(metadata["users"], received["users"])
+        received = events[0].metadata.dict(exclude_none=True)
+        self.assertEqual(metadata, received)
 
     def test_personal_recommendation_checks_auth_token(self):
         user_one = db_user.get_or_create(2, "riksucks")
@@ -919,9 +899,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "Seedhe Maut",
-            "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
@@ -944,9 +921,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "Seedhe Maut",
-            "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
@@ -970,9 +944,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
 
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "Seedhe Maut",
-            "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
@@ -996,9 +967,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
 
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "seedhe Maut",
-            "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": ["peter k"],
@@ -1022,9 +990,6 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
 
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "Seedhe Maut",
-            "release_name": "न",
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
@@ -1049,14 +1014,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         self.assertEqual(1, len(events))
 
-        received = events[0].metadata.dict()
-        self.assertEqual(metadata["track_name"], received["track_name"])
-        self.assertEqual(metadata["artist_name"], received["artist_name"])
-        self.assertEqual(metadata["release_name"], received["release_name"])
-        self.assertEqual(metadata["recording_mbid"], received["recording_mbid"])
-        self.assertEqual(metadata["recording_msid"], received["recording_msid"])
-        self.assertEqual(metadata["blurb_content"], received["blurb_content"])
-        self.assertCountEqual(metadata["users"], received["users"])
+        received = events[0].metadata.dict(exclude_none=True)
+        self.assertDictEqual(metadata, received)
 
     def test_personal_recommendation_mbid_only(self):
         """ Test that we can recommend a recording with only mbid """
@@ -1067,10 +1026,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
         metadata = {
-            "track_name": "Natkhat",
-            "artist_name": "Seedhe Maut",
-            "release_name": "न",
-            "recording_mbid": str(uuid.uuid4()),
+            "recording_mbid": "34c208ee-2de7-4d38-b47e-907074866dd3",
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],
             "blurb_content": "Try out these new people in Indian Hip-Hop!"
         }
@@ -1091,11 +1047,5 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         self.assertEqual(1, len(events))
 
-        received = events[0].metadata.dict()
-        self.assertEqual(metadata["track_name"], received["track_name"])
-        self.assertEqual(metadata["artist_name"], received["artist_name"])
-        self.assertEqual(metadata["release_name"], received["release_name"])
-        self.assertEqual(metadata["recording_mbid"], received["recording_mbid"])
-        self.assertEqual(None, received["recording_msid"])
-        self.assertEqual(metadata["blurb_content"], received["blurb_content"])
-        self.assertCountEqual(metadata["users"], received["users"])
+        received = events[0].metadata.dict(exclude_none=True)
+        self.assertDictEqual(received, metadata)

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -296,7 +296,7 @@ def get_current_pin_for_user(user_name):
                 "recording_mbid": null,
                 "recording_msid": "fd7d9162-a284-4a10-906c-faae4f1e166b"
                 "track_metadata": {
-                "artist_name": "Rick Astley",
+                    "artist_name": "Rick Astley",
                     "track_name": "Never Gonna Give You Up"
                 }
             },

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -306,7 +306,9 @@ class UserViewsTestCase(IntegrationTestCase):
             "artist_name": "Danny Elfman",
             "release_name": "Danny Elfman & Tim Burton 25th Anniversary Music Box",
             "additional_info": {
-                "recording_msid": "b7ffd2af-418f-4be2-bdd1-22f8b48613da",
+                "recording_msid": "b7ffd2af-418f-4be2-bdd1-22f8b48613da"
+            },
+            "mbid_mapping": {
                 "recording_mbid": "1fe669c9-5a2b-4dcb-9e95-77480d1e732e",
                 "release_mbid": "607cc05a-e462-4f39-91b5-e9322544e0a6",
                 "artist_mbids": ["5b24fbab-c58f-4c37-a59d-ab232e2d98c4"],

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -15,11 +15,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-import logging
 
 import time
-from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Tuple, Dict, Iterable
 
 import pydantic
@@ -30,7 +28,7 @@ from flask import Blueprint, jsonify, request, current_app
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 import listenbrainz.db.user_timeline_event as db_user_timeline_event
-from data.model.listen import APIListen, TrackMetadata, AdditionalInfo
+from data.model.listen import APIListen
 from listenbrainz.db.model.user_timeline_event import RecordingRecommendationMetadata, APITimelineEvent, UserTimelineEventType, \
     APIFollowEvent, NotificationMetadata, APINotificationEvent, APIPinEvent, APICBReviewEvent, \
     CBReviewTimelineMetadata, PersonalRecordingRecommendationMetadata, APIPersonalRecommendationEvent
@@ -43,7 +41,7 @@ from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.decorators import crossdomain, api_listenstore_needed
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APIUnauthorized, APINotFound, \
     APIForbidden
-from listenbrainz.webserver.views.api_tools import validate_auth_header, _filter_description_html, \
+from listenbrainz.webserver.views.api_tools import validate_auth_header, \
     _validate_get_endpoint_params
 
 MAX_LISTEN_EVENTS_PER_USER = 2  # the maximum number of listens we want to return in the feed per user
@@ -59,17 +57,15 @@ user_timeline_event_api_bp = Blueprint('user_timeline_event_api_bp', __name__)
 def create_user_recording_recommendation_event(user_name):
     """ Make the user recommend a recording to their followers.
 
-    The request should post the following data about the recording being recommended:
+    The request should post the following data about the recording being recommended (either one of recording_msid or
+    recording_mbid is sufficient):
 
     .. code-block:: json
 
         {
             "metadata": {
-                "artist_name": "<The name of the artist, required>",
-                "track_name": "<The name of the track, required>",
-                "recording_msid": "<The MessyBrainz ID of the recording, required>",
-                "release_name": "<The name of the release, optional>",
-                "recording_mbid": "<The MusicBrainz ID of the recording, optional>"
+                "recording_msid": "<The MessyBrainz ID of the recording, optional>",
+                "recording_mbid": "<The MusicBrainz ID of the recording>"
             }
         }
 
@@ -510,19 +506,16 @@ def unhide_user_timeline_event(user_name):
 @ratelimit()
 def create_personal_recommendation_event(user_name):
     '''
-    Make the user recommend a recording to their followers.
-    The request should post the following data about the recording being
-    recommended, and also the list of followers getting recommended:
+    Make the user recommend a recording to their followers. The request should post
+    the following data about the recording being recommended (either one of recording_msid
+    or recording_mbid is sufficient), and also the list of followers getting recommended:
 
     .. code-block:: json
 
         {
             "metadata": {
-                "artist_name": "<The name of the artist, required>",
-                "track_name": "<The name of the track, required>",
-                "recording_msid": "<The MessyBrainz ID of the recording, required>",
-                "release_name": "<The name of the release, optional>",
-                "recording_mbid": "<The MusicBrainz ID of the recording, optional>",
+                "recording_msid": "<The MessyBrainz ID of the recording, optional>",
+                "recording_mbid": "<The MusicBrainz ID of the recording>",
                 "users": [<usernames of the persons you want to recommend to, required>]
                 "blurb_content": "<String containing personalized recommendation>"
             }
@@ -531,8 +524,7 @@ def create_personal_recommendation_event(user_name):
     :reqheader Authorization: Token <user token>
     :reqheader Content-Type: *application/json*
     :statuscode 200: Successful query, recording has been recommended!
-    :statuscode 400: Bad request, check ``response['error']`` for more
-    details.
+    :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized, you do not have permissions to recommend
     personal recordings on the behalf of this user
     :statuscode 404: User not found
@@ -566,7 +558,10 @@ def create_personal_recommendation_event(user_name):
     except DatabaseException:
         raise APIInternalServerError("Something went wrong, please try again.")
 
-    return jsonify({"status": "ok"})
+    event_data = event.dict()
+    event_data['created'] = event_data['created'].timestamp()
+    event_data['event_type'] = event_data['event_type'].value
+    return jsonify(event_data)
 
 
 def get_listen_events(
@@ -678,21 +673,14 @@ def get_recording_recommendation_events(
         max_ts=max_ts,
         count=count,
     )
+    events_metadata_db = fetch_track_metadata_for_items([e.metadata for e in recording_recommendation_events_db])
 
     events = []
     for event in recording_recommendation_events_db:
         try:
             listen = APIListen(
                 user_name=id_username_map[event.user_id],
-                track_metadata=TrackMetadata(
-                    artist_name=event.metadata.artist_name,
-                    track_name=event.metadata.track_name,
-                    release_name=event.metadata.release_name,
-                    additional_info=AdditionalInfo(
-                        recording_msid=event.metadata.recording_msid,
-                        recording_mbid=event.metadata.recording_mbid,
-                    )
-                ),
+                track_metadata=event.metadata.track_metadata,
             )
 
             events.append(APITimelineEvent(
@@ -814,16 +802,13 @@ def get_personal_recording_recommendation_events(
         max_ts=max_ts,
         count=count,
     )
+    events_metadata_db = fetch_track_metadata_for_items([e.metadata for e in personal_recording_recommendation_events_db])
 
     events = []
     for event in personal_recording_recommendation_events_db:
         try:
             personal_recommendation = APIPersonalRecommendationEvent(
-                artist_name=event.metadata.artist_name,
-                track_name=event.metadata.track_name,
-                release_name=event.metadata.release_name,
-                recording_mbid=event.metadata.recording_mbid,
-                recording_msid=event.metadata.recording_msid,
+                track_metadata=event.metadata.track_metadata,
                 users=event.metadata.users,
                 blurb_content=event.metadata.blurb_content
             )


### PR DESCRIPTION
Instead of having the user to submit artist/track/release etc. fields for a recommendation, only accept a msid and mbid (atleast one required). While retrieving the events, add metadata using mapping tables. This has the benefit that we can have cover art and all other metadata for free. Also, ensures a more consistent experience across the website.

There is also a bugfix for when recommendation created using only mbids without msids fails to load.

Before:
![image](https://user-images.githubusercontent.com/27751938/233724181-0b6b652b-a2ec-4bdc-8f54-f3ad6b720d4f.png)

After:
![image](https://user-images.githubusercontent.com/27751938/233724086-5def858a-2c08-4bd2-8fc0-7704740f1912.png)
