### PR TITLE
LB-1259: Deleting a playlist doesn't refresh the playlist page

### DIFF
--- a/frontend/js/src/playlists/PlaylistsList.tsx
+++ b/frontend/js/src/playlists/PlaylistsList.tsx
@@ -44,10 +44,22 @@ export default class PlaylistsList extends React.Component<
     };
   }
 
+  static getDerivedStateFromProps(
+    nextProps: React.PropsWithChildren<PlaylistsListProps>,
+    prevState: PlaylistsListState
+  ) {
+    if (nextProps.playlists !== prevState.playlists) {
+      return {
+        playlists: nextProps.playlists,
+      };
+    }
+    return prevState;
+  }
+
   async componentDidUpdate(
     prevProps: React.PropsWithChildren<PlaylistsListProps>
   ): Promise<void> {
-    const { user, activeSection, newAlert } = this.props;
+    const { user, activeSection, newAlert, playlists } = this.props;
     const { currentUser } = this.context;
     if (prevProps.activeSection !== activeSection) {
       await this.fetchPlaylists(0);
@@ -178,6 +190,7 @@ export default class PlaylistsList extends React.Component<
                 onSuccessfulCopy={this.onCopiedPlaylist}
                 newAlert={newAlert}
                 selectPlaylistForEdit={selectPlaylistForEdit}
+                key={playlist.identifier}
               />
             );
           })}

--- a/frontend/js/src/playlists/PlaylistsList.tsx
+++ b/frontend/js/src/playlists/PlaylistsList.tsx
@@ -53,7 +53,7 @@ export default class PlaylistsList extends React.Component<
         playlists: nextProps.playlists,
       };
     }
-    return prevState;
+    return null;
   }
 
   async componentDidUpdate(

--- a/frontend/js/src/playlists/PlaylistsList.tsx
+++ b/frontend/js/src/playlists/PlaylistsList.tsx
@@ -59,7 +59,7 @@ export default class PlaylistsList extends React.Component<
   async componentDidUpdate(
     prevProps: React.PropsWithChildren<PlaylistsListProps>
   ): Promise<void> {
-    const { user, activeSection, newAlert, playlists } = this.props;
+    const { user, activeSection, newAlert } = this.props;
     const { currentUser } = this.context;
     if (prevProps.activeSection !== activeSection) {
       await this.fetchPlaylists(0);


### PR DESCRIPTION
# Problem

[LB-1259](https://tickets.metabrainz.org/browse/LB-1259):
While creating, editing, or deleting a new playlist, the Playlists page does not re-render to display the changed state. This occurs due to the props not being loaded by the _PlaylistList.tsx_ file.

# Solution

Load the latest props dynamically in the  _PlaylistList.tsx_ file to display the modified state.

# Action

Implemented the getDerivedStateFromProps function in the _PlaylistList.tsx_ file to fetch the latest props from the parent component. Also added a unique prop to each Playlist being rendered.

