### PR TITLE
LB-1263: release-group cover art fallback for user submitted release_mbids

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -575,47 +575,75 @@ const generateAlbumArtThumbnailLink = (
   return `https://archive.org/download/mbid-${releaseMBID}/mbid-${releaseMBID}-${caaId}_thumb250.jpg`;
 };
 
+const getThumbnailFromCAAResponse = (
+  body: CoverArtArchiveResponse
+): string | undefined => {
+  if (!body.images?.length) {
+    return undefined;
+  }
+  const { release } = body;
+  const releaseMBID = release.replace("https://musicbrainz.org/release/", "");
+
+  const frontImage = body.images.find((image) => image.front);
+
+  if (frontImage?.id) {
+    // CAA links are http redirects instead of https, causing LB-1067 (mixed content warning).
+    // We also don't need or want the redirect from CAA, instead we can reconstruct
+    // the link to the underlying archive.org resource directly
+    // Also see https://github.com/metabrainz/listenbrainz-server/commit/9e40ad440d0b280b6c53d13e804f911657469c8b
+    const { id } = frontImage;
+    return generateAlbumArtThumbnailLink(id, releaseMBID);
+  }
+
+  // No front image? Fallback to whatever the first image is
+  const { thumbnails, image } = body.images[0];
+  return thumbnails[250] ?? thumbnails.small ?? image;
+};
+
 const getAlbumArtFromReleaseMBID = async (
-  userSubmittedReleaseMBID: string
+  userSubmittedReleaseMBID: string,
+  useReleaseGroupFallback: boolean = false,
+  APIService?: APIServiceClass
 ): Promise<string | undefined> => {
   try {
+    const retryParams = {
+      retries: 4,
+      retryOn: [429],
+      retryDelay(attempt: number) {
+        // Exponential backoff at random interval between maxRetryTime and minRetryTime,
+        // adding minRetryTime for every attempt. `attempt` starts at 0
+        const maxRetryTime = 2500;
+        const minRetryTime = 1800;
+        const clampedRandomTime =
+          Math.random() * (maxRetryTime - minRetryTime) + minRetryTime;
+        // Make it exponential
+        return Math.floor(clampedRandomTime) * 2 ** attempt;
+      },
+    };
+
     const CAAResponse = await fetchWithRetry(
       `https://coverartarchive.org/release/${userSubmittedReleaseMBID}`,
-      {
-        retries: 4,
-        retryOn: [429],
-        retryDelay(attempt: number) {
-          // Exponential backoff at random interval between maxRetryTime and minRetryTime,
-          // adding minRetryTime for every attempt. `attempt` starts at 0
-          const maxRetryTime = 2500;
-          const minRetryTime = 1800;
-          const clampedRandomTime =
-            Math.random() * (maxRetryTime - minRetryTime) + minRetryTime;
-          // Make it exponential
-          return Math.floor(clampedRandomTime) * 2 ** attempt;
-        },
-      }
+      retryParams
     );
     if (CAAResponse.ok) {
       const body: CoverArtArchiveResponse = await CAAResponse.json();
-      if (!body.images?.length) {
-        return undefined;
+      return getThumbnailFromCAAResponse(body);
+    }
+
+    if (CAAResponse.status === 404 && useReleaseGroupFallback && APIService) {
+      const releaseGroupResponse = await APIService.lookupMBRelease(
+        userSubmittedReleaseMBID
+      );
+      const releaseGroupMBID = releaseGroupResponse["release-group"].id;
+
+      const CAAReleaseGroupResponse = await fetchWithRetry(
+        `https://coverartarchive.org/release-group/${releaseGroupMBID}`,
+        retryParams
+      );
+      if (CAAReleaseGroupResponse.ok) {
+        const body: CoverArtArchiveResponse = await CAAReleaseGroupResponse.json();
+        return getThumbnailFromCAAResponse(body);
       }
-
-      const frontImage = body.images.find((image) => image.front);
-
-      if (frontImage?.id) {
-        // CAA links are http redirects instead of https, causing LB-1067 (mixed content warning).
-        // We also don't need or want the redirect from CAA, instead we can reconstruct
-        // the link to the underlying archive.org resource directly
-        // Also see https://github.com/metabrainz/listenbrainz-server/commit/9e40ad440d0b280b6c53d13e804f911657469c8b
-        const { id } = frontImage;
-        return generateAlbumArtThumbnailLink(id, userSubmittedReleaseMBID);
-      }
-
-      // No front image? Fallback to whatever the first image is
-      const { thumbnails, image } = body.images[0];
-      return thumbnails[250] ?? thumbnails.small ?? image;
     }
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -652,18 +680,22 @@ const getAlbumArtFromListenMetadata = async (
   // to query CAA for user submitted mbids.
   const userSubmittedReleaseMBID =
     listen.track_metadata?.additional_info?.release_mbid;
+  const caaId = listen.track_metadata?.mbid_mapping?.caa_id;
+  const caaReleaseMbid = listen.track_metadata?.mbid_mapping?.caa_release_mbid;
   if (userSubmittedReleaseMBID) {
+    // try getting the cover art using user submitted release mbid. if user submitted release mbid
+    // does not have a cover art and the mapper matched to a different release, try to fallback to
+    // release group cover art of the user submitted release mbid next
     const userSubmittedReleaseAlbumArt = await getAlbumArtFromReleaseMBID(
-      userSubmittedReleaseMBID
+      userSubmittedReleaseMBID,
+      Boolean(caaReleaseMbid) && userSubmittedReleaseMBID !== caaReleaseMbid,
+      APIService
     );
-    // if user submitted release mbid does not have a cover art, we will try to fallback to release group cover art next
     if (userSubmittedReleaseAlbumArt) {
       return userSubmittedReleaseAlbumArt;
     }
   }
   // user submitted release mbids not found, check if there is a match from mbid mapper.
-  const caaId = listen.track_metadata?.mbid_mapping?.caa_id;
-  const caaReleaseMbid = listen.track_metadata?.mbid_mapping?.caa_release_mbid;
   if (caaId && caaReleaseMbid) {
     return generateAlbumArtThumbnailLink(caaId, caaReleaseMbid);
   }


### PR DESCRIPTION
Currently, we use the cover art from the user submitted release mbid if available. Otherwise, we fallback to using MBID mapper specified cover art. Add another case of fallback - try using cover art from the release group of the release mbid submitted by the user before going for the mapper's cover art.