### PR TITLE
LB-1252: Create a script to retrieve spotify user ids for existing users

### DIFF
--- a/listenbrainz/domain/spotify_fill_user_id.py
+++ b/listenbrainz/domain/spotify_fill_user_id.py
@@ -1,0 +1,80 @@
+from flask import current_app
+from psycopg2.extras import execute_values
+from spotipy import Spotify
+from sqlalchemy import text
+
+from listenbrainz import db
+from listenbrainz.domain.spotify import SpotifyService
+
+
+def get_users_to_update() -> list[dict]:
+    """ Retrieve users who have a connected spotify account but we don't have the spotify user id for them. """
+    current_app.logger.info("Fetching users to retrieve spotify user ids for")
+    query = """
+        SELECT user_id
+             , musicbrainz_id
+             , access_token
+             , refresh_token
+             , token_expires
+          FROM external_service_oauth
+          JOIN "user"
+            ON "user".id = external_service_oauth.user_id
+         WHERE service = 'spotify'
+           AND external_user_id IS NULL
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(text(query))
+        rows = result.mappings().all()
+    current_app.logger.info(f"Fetched {len(rows)} users to update")
+    return rows
+
+
+def update_users_spotify_ids(users: dict[str, str]):
+    """ Update the users in the database by inserting the spotify user ids retrieved earlier. """
+    current_app.logger.info("Updating spotify user ids for users")
+    query = """
+        UPDATE external_service_oauth eso
+           SET external_user_id = t.spotify_id
+          FROM (VALUES %s) AS t(user_id, spotify_id)
+         WHERE eso.user_id = t.user_id
+    """
+    conn = db.engine.raw_connection()
+    try:
+        with conn.cursor() as curs:
+            execute_values(curs, query, users.items(), template=None)
+        conn.commit()
+    finally:
+        conn.close()
+    current_app.logger.info("Completed updating spotify user ids for users")
+
+
+def retrieve_spotify_user_id(service: SpotifyService, user: dict) -> str:
+    """ Check the access token for a given user is still valid and then use it to retrieve the user's spotify id. """
+    if service.user_oauth_token_has_expired(user):
+        user = service.refresh_access_token(user["user_id"], user["refresh_token"])
+    sp = Spotify(auth=user["access_token"])
+    spotify_user_id = sp.current_user()["id"]
+    return spotify_user_id
+
+
+def retrieve_spotify_user_ids(users: list[dict]) -> dict[str, str]:
+    """ Retrieve spotify user ids for all users. """
+    current_app.logger.info("Retrieving spotify user ids")
+    service = SpotifyService()
+    updates = {}
+    for user in users:
+        try:
+            spotify_id = retrieve_spotify_user_id(service, user)
+            updates[user["user_id"]] = spotify_id
+            current_app.logger.info(f"Retrieved spotify id successfully for user: {user['musicbrainz_id']}")
+        except Exception:
+            current_app.logger.error(f"Error while retrieving spotify id for user: {user['musicbrainz_id']}", exc_info=True)
+    current_app.logger.info("Finished retrieving spotify user ids")
+    return updates
+
+
+def main():
+    """ Script to retrieve spotify user ids of existing users and store those in database. """
+    users = get_users_to_update()
+    updates = retrieve_spotify_user_ids(users)
+    update_users_spotify_ids(updates)

--- a/listenbrainz/domain/spotify_fill_user_id.py
+++ b/listenbrainz/domain/spotify_fill_user_id.py
@@ -11,16 +11,19 @@ def get_users_to_update() -> list[dict]:
     """ Retrieve users who have a connected spotify account but we don't have the spotify user id for them. """
     current_app.logger.info("Fetching users to retrieve spotify user ids for")
     query = """
-        SELECT user_id
+        SELECT eso.user_id
              , musicbrainz_id
              , access_token
              , refresh_token
              , token_expires
-          FROM external_service_oauth
+          FROM external_service_oauth eso
           JOIN "user"
-            ON "user".id = external_service_oauth.user_id
-         WHERE service = 'spotify'
+            ON "user".id = eso.user_id
+     LEFT JOIN listens_importer li
+            ON "user".id = li.user_id
+         WHERE eso.service = 'spotify'
            AND external_user_id IS NULL
+           AND error_message IS NULL
     """
     with db.engine.connect() as connection:
         result = connection.execute(text(query))

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -15,6 +15,7 @@ from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data a
     delete_listens as ts_delete_listens, \
     delete_listens_and_update_user_listen_data as ts_delete_listens_and_update_user_listen_data, \
     refresh_top_manual_mappings as ts_refresh_top_manual_mappings
+from listenbrainz.domain import spotify_fill_user_id
 from listenbrainz.messybrainz import transfer_to_timescale, update_msids_from_mapping
 from listenbrainz.spotify_metadata_cache.seeder import submit_new_releases_to_cache
 from listenbrainz.troi.troi_bot import run_daily_jams_troi_bot
@@ -283,6 +284,16 @@ def listen_add_userid():
     app = create_app()
     with app.app_context():
         timescale_fill_userid.fill_userid()
+
+
+@cli.command()
+def spotify_add_userid():
+    """
+        Fill in the spotify user id using the connected user's oauth token.
+    """
+    app = create_app()
+    with app.app_context():
+        spotify_fill_user_id.main()
 
 
 @cli.command()


### PR DESCRIPTION
# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
A mechanism for retrieving the Spotify user id of new users has been implemented in #2423. Following this, the next task is to retrieve Spotify user ids for existing users, by adding a script and a new click command to invoke it. The script should query Spotify APIs for all the connected users, fetch their user ids and insert it in the database.

Related JIRA ticket: [LB-1252](https://tickets.metabrainz.org/browse/LB-1252)

# Solution
Added a script to get the Spotify user ids for users existing in the database. Added a click command to invoke the same.
