### PR TITLE
LB-1253: Retrieve Spotify user id from database for passing to troi bot

### DIFF
--- a/listenbrainz/troi/troi_bot.py
+++ b/listenbrainz/troi/troi_bot.py
@@ -119,12 +119,10 @@ def _get_spotify_details(user_id, service):
         if not token:
             return None
 
-        sp = spotipy.Spotify(auth=token["access_token"])
-        spotify_user_id = sp.current_user()["id"]
         return {
             "is_public": True,
             "is_collaborative": False,
-            "user_id": spotify_user_id,
+            "user_id": token["external_user_id"],
             "token": token["access_token"]
         }
     except Exception:


### PR DESCRIPTION
# Problem
Currently we call to Spotify API to retrieve user id each time to generate and export a playlist from troi. Instead of this API call, we should we retrieve the Spotify user id from the external_service_oauth table like the access token.

Related JIRA ticket: [LB-1253](https://tickets.metabrainz.org/browse/LB-1253)

# Solution
Remove the portion making the API call from `troi_bot.py` and add a part to retrieve `external_user_id` from external_service_oauth table.