### PR TITLE
Fix URL on stats details previous page button

### DIFF
--- a/frontend/js/src/stats/UserEntityChart.tsx
+++ b/frontend/js/src/stats/UserEntityChart.tsx
@@ -636,7 +636,7 @@ export default class UserEntityChart extends React.Component<
                         }`}
                       >
                         <a
-                          href=""
+                          href={this.buildURLParams(prevPage, range, entity)}
                           role="button"
                           onClick={(e) => {
                             this.handleClickEvent(e, () => {

--- a/frontend/js/tests/stats/__snapshots__/UserEntityChart.test.tsx.snap
+++ b/frontend/js/tests/stats/__snapshots__/UserEntityChart.test.tsx.snap
@@ -5664,7 +5664,7 @@ exports[`Sitewide Stats UserEntityChart Page renders correctly for artists 1`] =
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >
@@ -16070,7 +16070,7 @@ exports[`Sitewide Stats UserEntityChart Page renders correctly for recording 1`]
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >
@@ -23070,7 +23070,7 @@ exports[`Sitewide Stats UserEntityChart Page renders correctly for release group
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >
@@ -30037,7 +30037,7 @@ exports[`Sitewide Stats UserEntityChart Page renders correctly for releases 1`] 
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >
@@ -37909,7 +37909,7 @@ exports[`User Stats UserEntityChart Page renders correctly for artists 1`] = `
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >
@@ -48321,7 +48321,7 @@ exports[`User Stats UserEntityChart Page renders correctly for recording 1`] = `
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >
@@ -55327,7 +55327,7 @@ exports[`User Stats UserEntityChart Page renders correctly for release groups 1`
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >
@@ -62300,7 +62300,7 @@ exports[`User Stats UserEntityChart Page renders correctly for releases 1`] = `
                 className="previous disabled"
               >
                 <a
-                  href=""
+                  href="?page=0&range=&entity="
                   onClick={[Function]}
                   role="button"
                 >


### PR DESCRIPTION
# Problem

The missing link on the previous page button will cause the button to reload the page instead of going to the previous one if JavaScript isn't enabled.

Originally reported by o3 in [the MetaBrainz Community](https://community.metabrainz.org/t/listenbrainz-redesign-beta-release/631498/66?u=maxr1998).

# Solution

Copied the link template from the next button and adapted it accordingly.

# Action

Not applicable.