### PR TITLE
Refresh similarity datasets weekly

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -62,13 +62,15 @@ CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, 
 CREATE UNIQUE INDEX similar_recordings_reverse_uniq_idx ON similarity.recording (mbid1, mbid0);
 CREATE INDEX similar_recordings_algorithm_idx ON similarity.recording USING gin (metadata);
 
--- NOTE: If the indexes for the recording_prod table changes, update the code in listenbrainz/db/similarity.py !
-CREATE UNIQUE INDEX similar_recordings_prod_uniq_idx ON similarity.recording_prod (mbid0, mbid1);
-CREATE UNIQUE INDEX similar_recordings_prod_reverse_uniq_idx ON similarity.recording_prod (mbid1, mbid0);
-
 CREATE UNIQUE INDEX similar_artists_uniq_idx ON similarity.artist_credit_mbids (mbid0, mbid1);
 CREATE UNIQUE INDEX similar_artist_credit_mbids_reverse_uniq_idx ON similarity.artist_credit_mbids (mbid1, mbid0);
 CREATE INDEX similar_artist_credit_mbids_algorithm_idx ON similarity.artist_credit_mbids USING gin (metadata);
+
+-- NOTE: If the indexes for the recording_prod/artist_credit_mbids_prod table changes, update the code in listenbrainz/db/similarity.py !
+CREATE UNIQUE INDEX similar_recordings_prod_uniq_idx ON similarity.recording_prod (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_recordings_prod_reverse_uniq_idx ON similarity.recording_prod (mbid1, mbid0);
+CREATE UNIQUE INDEX similar_artist_credit_mbids_prod_uniq_idx ON similarity.recording_prod (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_artist_credit_mbids_prod_reverse_uniq_idx ON similarity.recording_prod (mbid1, mbid0);
 
 CREATE INDEX mbid_manual_mapping_top_idx ON mbid_manual_mapping_top (recording_msid) INCLUDE (recording_mbid);
 

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -58,19 +58,20 @@ CREATE UNIQUE INDEX spotify_cache_track_spotify_id_idx ON spotify_cache.track (s
 CREATE INDEX spotify_cache_rel_album_artist_track_id_idx ON spotify_cache.rel_album_artist (album_id);
 CREATE INDEX spotify_cache_rel_track_artist_track_id_idx ON spotify_cache.rel_track_artist (track_id);
 
-CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
-CREATE UNIQUE INDEX similar_recordings_reverse_uniq_idx ON similarity.recording (mbid1, mbid0);
-CREATE INDEX similar_recordings_algorithm_idx ON similarity.recording USING gin (metadata);
+CREATE UNIQUE INDEX similar_recordings_dev_uniq_idx ON similarity.recording_dev (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_recordings_dev_reverse_uniq_idx ON similarity.recording_dev (mbid1, mbid0);
+CREATE INDEX similar_recordings_algorithm_dev_idx ON similarity.recording_dev USING gin (metadata);
 
-CREATE UNIQUE INDEX similar_artists_uniq_idx ON similarity.artist_credit_mbids (mbid0, mbid1);
-CREATE UNIQUE INDEX similar_artist_credit_mbids_reverse_uniq_idx ON similarity.artist_credit_mbids (mbid1, mbid0);
-CREATE INDEX similar_artist_credit_mbids_algorithm_idx ON similarity.artist_credit_mbids USING gin (metadata);
+CREATE UNIQUE INDEX similar_artist_credit_mbids_dev_uniq_idx ON similarity.artist_credit_mbids_dev (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_artist_credit_mbids_dev_reverse_uniq_idx ON similarity.artist_credit_mbids_dev (mbid1, mbid0);
+CREATE INDEX similar_artist_credit_mbids_algorithm_dev_idx ON similarity.artist_credit_mbids_dev USING gin (metadata);
 
 -- NOTE: If the indexes for the recording_prod/artist_credit_mbids_prod table changes, update the code in listenbrainz/db/similarity.py !
-CREATE UNIQUE INDEX similar_recordings_prod_uniq_idx ON similarity.recording_prod (mbid0, mbid1);
-CREATE UNIQUE INDEX similar_recordings_prod_reverse_uniq_idx ON similarity.recording_prod (mbid1, mbid0);
-CREATE UNIQUE INDEX similar_artist_credit_mbids_prod_uniq_idx ON similarity.recording_prod (mbid0, mbid1);
-CREATE UNIQUE INDEX similar_artist_credit_mbids_prod_reverse_uniq_idx ON similarity.recording_prod (mbid1, mbid0);
+CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_recordings_reverse_uniq_idx ON similarity.recording (mbid1, mbid0);
+
+CREATE UNIQUE INDEX similar_artist_credit_mbids_uniq_idx ON similarity.artist_credit_mbids (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_artist_credit_mbids_reverse_uniq_idx ON similarity.artist_credit_mbids (mbid1, mbid0);
 
 CREATE INDEX mbid_manual_mapping_top_idx ON mbid_manual_mapping_top (recording_msid) INCLUDE (recording_mbid);
 

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -62,6 +62,10 @@ CREATE UNIQUE INDEX similar_recordings_uniq_idx ON similarity.recording (mbid0, 
 CREATE UNIQUE INDEX similar_recordings_reverse_uniq_idx ON similarity.recording (mbid1, mbid0);
 CREATE INDEX similar_recordings_algorithm_idx ON similarity.recording USING gin (metadata);
 
+-- NOTE: If the indexes for the recording_prod table changes, update the code in listenbrainz/db/similarity.py !
+CREATE UNIQUE INDEX similar_recordings_prod_uniq_idx ON similarity.recording_prod (mbid0, mbid1);
+CREATE UNIQUE INDEX similar_recordings_prod_reverse_uniq_idx ON similarity.recording_prod (mbid1, mbid0);
+
 CREATE UNIQUE INDEX similar_artists_uniq_idx ON similarity.artist_credit_mbids (mbid0, mbid1);
 CREATE UNIQUE INDEX similar_artist_credit_mbids_reverse_uniq_idx ON similarity.artist_credit_mbids (mbid1, mbid0);
 CREATE INDEX similar_artist_credit_mbids_algorithm_idx ON similarity.artist_credit_mbids USING gin (metadata);

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -202,6 +202,12 @@ CREATE TABLE similarity.recording (
     metadata JSONB NOT NULL
 );
 
+CREATE TABLE similarity.recording_prod (
+    mbid0 UUID NOT NULL,
+    mbid1 UUID NOT NULL,
+    score INT NOT NULL
+);
+
 CREATE TABLE similarity.artist_credit_mbids (
     mbid0 UUID NOT NULL,
     mbid1 UUID NOT NULL,

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -196,26 +196,26 @@ CREATE TABLE background_worker_state (
 COMMENT ON TABLE background_worker_state IS 'This table is used to store miscellaneous data by various background processes or the ListenBrainz webserver. Use it when storing the data is redis is not reliable enough.';
 
 
-CREATE TABLE similarity.recording (
+CREATE TABLE similarity.recording_dev (
     mbid0 UUID NOT NULL,
     mbid1 UUID NOT NULL,
     metadata JSONB NOT NULL
 );
 
-CREATE TABLE similarity.recording_prod (
+CREATE TABLE similarity.recording (
     mbid0 UUID NOT NULL,
     mbid1 UUID NOT NULL,
     score INT NOT NULL
 );
 
-CREATE TABLE similarity.artist_credit_mbids (
+CREATE TABLE similarity.artist_credit_mbids_dev (
     mbid0 UUID NOT NULL,
     mbid1 UUID NOT NULL,
     metadata JSONB NOT NULL
 );
 
 
-CREATE TABLE similarity.artist_credit_mbids_prod (
+CREATE TABLE similarity.artist_credit_mbids (
     mbid0 UUID NOT NULL,
     mbid1 UUID NOT NULL,
     score INT NOT NULL

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -214,4 +214,11 @@ CREATE TABLE similarity.artist_credit_mbids (
     metadata JSONB NOT NULL
 );
 
+
+CREATE TABLE similarity.artist_credit_mbids_prod (
+    mbid0 UUID NOT NULL,
+    mbid1 UUID NOT NULL,
+    score INT NOT NULL
+);
+
 COMMIT;

--- a/admin/timescale/updates/2023-05-06-rename-similarity-tables.sql
+++ b/admin/timescale/updates/2023-05-06-rename-similarity-tables.sql
@@ -1,0 +1,12 @@
+BEGIN;
+ALTER TABLE similarity.recording RENAME TO recording_dev;
+ALTER TABLE similarity.artist_credit_mbids RENAME TO artist_credit_mbids_dev;
+
+ALTER INDEX similarity.similar_recordings_reverse_uniq_idx RENAME TO similar_recordings_dev_reverse_uniq_idx;
+ALTER INDEX similarity.similar_recordings_uniq_idx RENAME TO similar_recordings_dev_uniq_idx;
+ALTER INDEX similarity.similar_recordings_algorithm_idx RENAME TO similar_recordings_dev_algorithm_idx;
+
+ALTER INDEX similarity.similar_artist_credit_mbids_reverse_uniq_idx RENAME TO similar_artist_credit_mbids_dev_reverse_uniq_idx;
+ALTER INDEX similarity.similar_artist_credit_mbids_uniq_idx RENAME TO similar_artist_credit_mbids_dev_uniq_idx;
+ALTER INDEX similarity.similar_artist_credit_mbids_algorithm_idx RENAME TO similar_artist_credit_mbids_dev_algorithm_idx;
+COMMIT;

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -52,3 +52,6 @@ MAILTO=""
 
 # run weekly cron job to remove expired do not recommends
 0 8 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py clear-expired-do-not-recommends >> /logs/do_not_recommend.log 2>&1
+
+# run weekly cron job to update similarity datasets
+0 9 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_similarity_datasets >> /logs/similarity_datasets.log 2>&1

--- a/listenbrainz/db/similarity.py
+++ b/listenbrainz/db/similarity.py
@@ -100,8 +100,8 @@ def start_prod_table(name, algorithm):
             curs.execute(query)
 
             query = SQL("""
-                COMMENT ON TABLE {table} IS 'This dataset is created using the algorithm {algorithm}'
-            """).format(table=table, algorithm=Literal(algorithm))
+                COMMENT ON TABLE {table} IS {comment}
+            """).format(table=table, comment=Literal(f"This dataset is created using the algorithm {algorithm}"))
             curs.execute(query)
 
         conn.commit()

--- a/listenbrainz/db/similarity.py
+++ b/listenbrainz/db/similarity.py
@@ -112,13 +112,7 @@ def start_prod_table(name, algorithm):
 def insert_prod_table(name, data, algorithm):
     """ Insert similar recordings for the production dataset. """
     table = Identifier("similarity", f"{name}_prod_tmp")
-    query = SQL("""
-        INSERT INTO {table} AS sr (mbid0, mbid1, score)
-             VALUES %s
-        ON CONFLICT (mbid0, mbid1)
-          DO UPDATE
-                SET score = EXCLUDED.score
-    """).format(table=table)
+    query = SQL("INSERT INTO {table} (mbid0, mbid1, score) VALUES %s").format(table=table)
     values = [(x["mbid0"], x["mbid1"], x["score"]) for x in data]
 
     conn = timescale.engine.raw_connection()

--- a/listenbrainz/db/similarity.py
+++ b/listenbrainz/db/similarity.py
@@ -99,11 +99,6 @@ def start_prod_table(name, algorithm):
             """).format(table=table)
             curs.execute(query)
 
-            query = SQL("""
-                COMMENT ON TABLE {table} IS {comment}
-            """).format(table=table, comment=Literal(f"This dataset is created using the algorithm {algorithm}"))
-            curs.execute(query)
-
         conn.commit()
     finally:
         conn.close()
@@ -159,6 +154,12 @@ def end_prod_table(name, algorithm):
              """).format(incoming_table=incoming_table, prod_table=Identifier(f"{name}_prod"))
             curs.execute(query)
             query = SQL("""DROP TABLE {old_table}""").format(old_table=Identifier("similarity", f"{name}_prod_old"))
+            curs.execute(query)
+
+            query = SQL("COMMENT ON TABLE {table} IS {comment}").format(
+                table=Identifier("similarity", f"{name}_prod"),
+                comment=Literal(f"This dataset is created using the algorithm {algorithm}")
+            )
             curs.execute(query)
 
         conn.commit()

--- a/listenbrainz/db/similarity.py
+++ b/listenbrainz/db/similarity.py
@@ -1,3 +1,4 @@
+import time
 from uuid import UUID
 
 from psycopg2.extras import execute_values, DictCursor
@@ -70,3 +71,82 @@ def get(curs, table, mbids, algorithm, count):
         score_index[similar_mbid] = row["score"]
         mbids.append(similar_mbid)
     return mbids, score_index, similar_mbid_index
+
+
+def start_prod_table(name, algorithm):
+    """ Create the production table to store recording similarity data.
+
+    When we start receiving the production table, we create a temporary table to store the data. Once
+    the dataset has been received completely, we switch the temporary table with the production tables.
+    We do not store the production dataset in the development tables because production dataset is generated
+    daily, and we do not want leftovers from earlier runs to mixup the latst runs' results.
+
+    Args:
+        name: 'recording' or 'artist' dataset
+        algorithm: the algorithm used to create the dataset
+    """
+    table = Identifier("similarity", f"{name}_prod_tmp")
+    conn = timescale.engine.raw_connection()
+    try:
+        with conn.cursor() as curs:
+            query = SQL("""
+                DROP TABLE IF EXISTS {table}
+            """).format(table=table)
+            curs.execute(query)
+
+            query = SQL("""
+                CREATE TABLE {table} (mbid0 UUID NOT NULL, mbid1 NOT NULL, score INT NOT NULL)
+            """).format(table=table)
+            curs.execute(query)
+
+            query = SQL("""
+                COMMENT ON TABLE {table} IS 'This dataset is created using the algorithm {algorithm}'
+            """).format(table=table, algorithm=Literal(algorithm))
+            curs.execute(query)
+
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def end_prod_table(name, algorithm):
+    """ Switch the temporary production table in production.
+
+    Args:
+        name: 'recording' or 'artist' dataset
+        algorithm: the algorithm used to create the dataset
+    """
+    incoming_table = Identifier("similarity", f"{name}_prod_tmp")
+
+    # add a random suffix to the index name to avoid issues while renaming
+    suffix = int(time.time())
+
+    conn = timescale.engine.raw_connection()
+    try:
+        with conn.cursor() as curs:
+            query = SQL("""
+                CREATE UNIQUE INDEX similar_recordings_prod_uniq_idx_{suffix} ON {table} (mbid0, mbid1)
+             """).format(table=incoming_table, suffix=Literal(suffix))
+            curs.execute(query)
+
+            query = SQL("""
+                CREATE UNIQUE INDEX similar_recordings_prod_reverse_uniq_idx_{suffix} ON {table} (mbid1, mbid0)
+             """).format(table=incoming_table, suffix=Literal(suffix))
+            curs.execute(query)
+
+            # rotate tables
+            query = SQL("""
+                ALTER TABLE {prod_table} RENAME TO {outgoing_table}
+             """).format(prod_table=Identifier("similarity", f"{name}_prod"), outgoing_table=Identifier(f"{name}_prod_old"))
+            curs.execute(query)
+            query = SQL("""
+                ALTER TABLE {incoming_table} RENAME TO {prod_table}
+             """).format(incoming_table=incoming_table, prod_table=Identifier(f"{name}_prod"))
+            curs.execute(query)
+            query = SQL("""DROP TABLE {old_table}""").format(old_table=Identifier("similarity", f"{name}_prod_old"))
+            curs.execute(query)
+
+        conn.commit()
+    finally:
+        conn.close()
+

--- a/listenbrainz/db/similarity.py
+++ b/listenbrainz/db/similarity.py
@@ -109,6 +109,27 @@ def start_prod_table(name, algorithm):
         conn.close()
 
 
+def insert_prod_table(name, data, algorithm):
+    """ Insert similar recordings for the production dataset. """
+    table = Identifier("similarity", f"{name}_prod_tmp")
+    query = SQL("""
+        INSERT INTO {table} AS sr (mbid0, mbid1, score)
+             VALUES %s
+        ON CONFLICT (mbid0, mbid1)
+          DO UPDATE
+                SET score = EXCLUDED.score
+    """).format(table=table)
+    values = [(x["mbid0"], x["mbid1"], x["score"]) for x in data]
+
+    conn = timescale.engine.raw_connection()
+    try:
+        with conn.cursor() as curs:
+            execute_values(curs, query, values)
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def end_prod_table(name, algorithm):
     """ Switch the temporary production table in production.
 

--- a/listenbrainz/db/similarity.py
+++ b/listenbrainz/db/similarity.py
@@ -95,7 +95,7 @@ def start_prod_table(name, algorithm):
             curs.execute(query)
 
             query = SQL("""
-                CREATE TABLE {table} (mbid0 UUID NOT NULL, mbid1 NOT NULL, score INT NOT NULL)
+                CREATE TABLE {table} (mbid0 UUID NOT NULL, mbid1 UUID NOT NULL, score INT NOT NULL)
             """).format(table=table)
             curs.execute(query)
 

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -428,8 +428,17 @@ def handle_yim_tracks_of_the_year_end(message):
     yim_patch_runner(message["year"])
 
 
+def handle_similar_recordings_start(message):
+    similarity.start_prod_table("recording", message["algorithm"])
+
+
+def handle_similar_recordings_end(message):
+    similarity.end_prod_table("recording", message["algorithm"])
+
+
 def handle_similar_recordings(message):
-    similarity.insert("recording", message["data"], message["algorithm"])
+    table = "recording_prod_tmp" if message.get("is_production_dataset") else "recording"
+    similarity.insert(table, message["data"], message["algorithm"])
 
 
 def handle_similar_artists(message):

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -443,5 +443,16 @@ def handle_similar_recordings(message):
         similarity.insert("recording", message["data"], message["algorithm"])
 
 
+def handle_similar_artists_start(message):
+    similarity.start_prod_table("artist_credit_mbids", message["algorithm"])
+
+
+def handle_similar_artists_end(message):
+    similarity.end_prod_table("artist_credit_mbids", message["algorithm"])
+
+
 def handle_similar_artists(message):
-    similarity.insert("artist_credit_mbids", message["data"], message["algorithm"])
+    if message.get("is_production_dataset"):
+        similarity.insert_prod_table("artist_credit_mbids", message["data"], message["algorithm"])
+    else:
+        similarity.insert("artist_credit_mbids", message["data"], message["algorithm"])

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -437,8 +437,10 @@ def handle_similar_recordings_end(message):
 
 
 def handle_similar_recordings(message):
-    table = "recording_prod_tmp" if message.get("is_production_dataset") else "recording"
-    similarity.insert(table, message["data"], message["algorithm"])
+    if message.get("is_production_dataset"):
+        similarity.insert_prod_table("recording", message["data"], message["algorithm"])
+    else:
+        similarity.insert("recording", message["data"], message["algorithm"])
 
 
 def handle_similar_artists(message):

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -434,7 +434,9 @@ def request_similar_recordings(days, session, contribution, threshold, limit, sk
                                         " (the limit is instructive. upto 2x artists may be returned than"
                                         " the limit).", required=True)
 @click.option("--skip", type=int, help="the minimum difference threshold to mark track as skipped", required=True)
-def request_similar_artists(days, session, contribution, threshold, limit, skip):
+@click.option("--production", is_flag=True, help="whether the dataset is being created as a production dataset."
+                                                 " affects how the resulting dataset is stored in LB.", required=True)
+def request_similar_artists(days, session, contribution, threshold, limit, skip, production):
     """ Send the cluster a request to generate similar artists index. """
     send_request_to_spark_cluster(
         "similarity.artist",
@@ -443,7 +445,8 @@ def request_similar_artists(days, session, contribution, threshold, limit, skip)
         contribution=contribution,
         threshold=threshold,
         limit=limit,
-        skip=skip
+        skip=skip,
+        is_production_dataset=production
     )
 
 
@@ -532,3 +535,12 @@ def cron_request_recommendations(ctx):
     ctx.invoke(request_candidate_sets)
     ctx.invoke(request_recording_discovery)
     ctx.invoke(request_recommendations)
+
+
+@cli.command(name='cron_request_similarity_datasets')
+@click.pass_context
+def cron_request_similarity_datasets(ctx):
+    ctx.request_similar_recordings(days=7500, session=300, contribution=5, threshold=10,
+                                   limit=100, skip=30, production=True)
+    ctx.request_similar_artists(days=7500, session=300, contribution=5, threshold=10,
+                                limit=100, skip=30, production=True)

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -406,7 +406,9 @@ def request_similar_users(max_num_users):
                                         " (the limit is instructive. upto 2x recordings may be returned than"
                                         " the limit).", required=True)
 @click.option("--skip", type=int, help="the minimum difference threshold to mark track as skipped", required=True)
-def request_similar_recordings(days, session, contribution, threshold, limit, skip):
+@click.option("--production", is_flag=True, help="whether the dataset is being created as a production dataset."
+                                                 " affects how the resulting dataset is stored in LB.", required=True)
+def request_similar_recordings(days, session, contribution, threshold, limit, skip, production):
     """ Send the cluster a request to generate similar recordings index. """
     send_request_to_spark_cluster(
         "similarity.recording",
@@ -415,7 +417,8 @@ def request_similar_recordings(days, session, contribution, threshold, limit, sk
         contribution=contribution,
         threshold=threshold,
         limit=limit,
-        skip=skip
+        skip=skip,
+        is_production_dataset=production
     )
 
 

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -540,7 +540,7 @@ def cron_request_recommendations(ctx):
 @cli.command(name='cron_request_similarity_datasets')
 @click.pass_context
 def cron_request_similarity_datasets(ctx):
-    ctx.request_similar_recordings(days=7500, session=300, contribution=5, threshold=10,
-                                   limit=100, skip=30, production=True)
-    ctx.request_similar_artists(days=7500, session=300, contribution=5, threshold=10,
-                                limit=100, skip=30, production=True)
+    ctx.invoke(request_similar_recordings, days=7500, session=300, contribution=5,
+               threshold=10, limit=100, skip=30, production=True)
+    ctx.invoke(request_similar_artists, days=7500, session=300, contribution=5,
+               threshold=10, limit=100, skip=30, production=True)

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -147,7 +147,8 @@
       "contribution",
       "threshold",
       "limit",
-      "skip"
+      "skip",
+      "is_production_dataset"
     ]
   },
   "similarity.artist": {

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -160,7 +160,8 @@
       "contribution",
       "threshold",
       "limit",
-      "skip"
+      "skip",
+      "is_production_dataset"
     ]
   },
   "year_in_music.similar_users": {

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -38,7 +38,8 @@ from listenbrainz.spark.handlers import (handle_candidate_sets,
                                          handle_yim_tracks_of_the_year_start,
                                          handle_yim_tracks_of_the_year_data,
                                          handle_yim_tracks_of_the_year_end,
-                                         handle_yim_artist_map)
+                                         handle_yim_artist_map, handle_similar_recordings_start,
+                                         handle_similar_recordings_end)
 from listenbrainz.utils import get_fallback_connection_name
 from listenbrainz.webserver import create_app
 
@@ -64,6 +65,8 @@ response_handler_map = {
     'cf_recommendations_recording_mail': cf_recording_recommendations_complete,
     'similar_users': handle_similar_users,
     'similar_recordings': handle_similar_recordings,
+    'similar_recordings_start': handle_similar_recordings_start,
+    'similar_recordings_end': handle_similar_recordings_end,
     'similar_artists': handle_similar_artists,
     'year_in_music_top_stats': handle_yim_top_stats,
     'year_in_music_listens_per_day': handle_yim_listens_per_day,

--- a/listenbrainz_spark/similarity/artist.py
+++ b/listenbrainz_spark/similarity/artist.py
@@ -104,7 +104,7 @@ def build_sessioned_index(listen_table, metadata_table, artist_credit_table, ses
     """
 
 
-def main(days, session, contribution, threshold, limit, skip):
+def main(days, session, contribution, threshold, limit, skip, is_production_dataset):
     """ Generate similar artists based on user listening sessions.
 
     Args:
@@ -117,6 +117,7 @@ def main(days, session, contribution, threshold, limit, skip):
         skip: the minimum threshold in seconds to mark a listen as skipped. we cannot just mark a negative difference
             as skip because there may be a difference in track length in MB and music services and also issues in
             timestamping listens.
+        is_production_dataset: only determines how the dataset is stored in ListenBrainz database.
     """
     to_date = datetime.combine(date.today(), time.min)
     from_date = to_date + timedelta(days=-days)
@@ -139,10 +140,23 @@ def main(days, session, contribution, threshold, limit, skip):
 
     algorithm = f"session_based_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_skip_{skip}"
 
+    if is_production_dataset:
+        yield {
+            "type": "similar_recordings_start",
+            "algorithm": algorithm
+        }
+
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]
         yield {
-            "type": "similar_artists",
+            "type": "similar_recordings",
             "algorithm": algorithm,
-            "data": items
+            "data": items,
+            "is_production_dataset": is_production_dataset
+        }
+
+    if is_production_dataset:
+        yield {
+            "type": "similar_recordings_end",
+            "algorithm": algorithm
         }

--- a/listenbrainz_spark/similarity/artist.py
+++ b/listenbrainz_spark/similarity/artist.py
@@ -34,6 +34,7 @@ def build_sessioned_index(listen_table, metadata_table, artist_credit_table, ses
                   JOIN {artist_credit_table} ac
                  USING (artist_credit_id)
                  WHERE l.recording_mbid IS NOT NULL
+                   AND l.recording_mbid != ''
                 WINDOW w AS (PARTITION BY l.user_id, listened_at, l.recording_mbid ORDER BY ac.position)
             ), ordered AS (
                 SELECT user_id

--- a/listenbrainz_spark/similarity/recording.py
+++ b/listenbrainz_spark/similarity/recording.py
@@ -136,7 +136,7 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
             "type": "similar_recordings",
             "algorithm": algorithm,
             "data": items,
-            "production": is_production_dataset
+            "is_production_dataset": is_production_dataset
         }
 
     if is_production_dataset:

--- a/listenbrainz_spark/similarity/recording.py
+++ b/listenbrainz_spark/similarity/recording.py
@@ -92,7 +92,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
     """
 
 
-def main(days, session, contribution, threshold, limit, skip):
+def main(days, session, contribution, threshold, limit, skip, is_production_dataset):
     """ Generate similar recordings based on user listening sessions.
 
     Args:
@@ -105,6 +105,7 @@ def main(days, session, contribution, threshold, limit, skip):
         skip: the minimum threshold in seconds to mark a listen as skipped. we cannot just mark a negative difference
             as skip because there may be a difference in track length in MB and music services and also issues in
             timestamping listens.
+        is_production_dataset: only determines how the dataset is stored in ListenBrainz database.
     """
     to_date = datetime.combine(date.today(), time.min)
     from_date = to_date + timedelta(days=-days)
@@ -123,10 +124,23 @@ def main(days, session, contribution, threshold, limit, skip):
 
     algorithm = f"session_based_days_{days}_session_{session}_contribution_{contribution}_threshold_{threshold}_limit_{limit}_skip_{skip}"
 
+    if is_production_dataset:
+        yield {
+            "type": "similar_recordings_start",
+            "algorithm": algorithm
+        }
+
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]
         yield {
             "type": "similar_recordings",
             "algorithm": algorithm,
-            "data": items
+            "data": items,
+            "production": is_production_dataset
+        }
+
+    if is_production_dataset:
+        yield {
+            "type": "similar_recordings_end",
+            "algorithm": algorithm
         }

--- a/listenbrainz_spark/similarity/recording.py
+++ b/listenbrainz_spark/similarity/recording.py
@@ -27,6 +27,7 @@ def build_sessioned_index(listen_table, metadata_table, session, max_contributio
               LEFT JOIN {metadata_table} r
                   USING (recording_mbid)
                   WHERE l.recording_mbid IS NOT NULL
+                    AND l.recording_mbid != ''
             ), ordered AS (
                 SELECT user_id
                      , listened_at


### PR DESCRIPTION
When we start receiving the production table, we create a temporary table to store the data. Once the dataset has been received completely, we switch the temporary table with the production tables.  We do not store the production dataset in the development tables because production dataset is generated periodically, and we do not want leftovers from earlier runs to mixup the latst runs' results.

We cannot use BulkInsertTable because it is defined in mbid_mapping directory not in listenbrainz. Also, it would need certain changes to support data coming through RMQ.