### PR TITLE
LB-1262: Create POST endpoint for get-feedback-for-recordings

### DIFF
--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -588,8 +588,17 @@ export default class APIService {
       throw new SyntaxError("Username missing");
     }
 
-    const url = `${this.APIBaseURI}/feedback/user/${userName}/get-feedback-for-recordings?recording_msids=${recording_msids}&recording_mbids=${recording_mbids}`;
-    const response = await fetch(url);
+    const url = `${this.APIBaseURI}/feedback/user/${userName}/get-feedback-for-recordings`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json;charset=UTF-8",
+      },
+      body: JSON.stringify({
+        recording_mbids,
+        recording_msids,
+      }),
+    });
     await this.checkStatus(response);
     return response.json();
   };
@@ -601,8 +610,16 @@ export default class APIService {
     if (!userName) {
       throw new SyntaxError("Username missing");
     }
-    const url = `${this.APIBaseURI}/feedback/user/${userName}/get-feedback-for-recordings?recording_mbids=${recording_mbids}`;
-    const response = await fetch(url);
+    const url = `${this.APIBaseURI}/feedback/user/${userName}/get-feedback-for-recordings`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json;charset=UTF-8",
+      },
+      body: JSON.stringify({
+        recording_mbids,
+      }),
+    });
     await this.checkStatus(response);
     return response.json();
   };
@@ -692,9 +709,8 @@ export default class APIService {
       };
     }
 
-    const url = `${this.APIBaseURI}/user/${userName}/playlists${
-      createdFor ? "/createdfor" : ""
-    }${collaborator ? "/collaborator" : ""}?offset=${offset}&count=${count}`;
+    const url = `${this.APIBaseURI}/user/${userName}/playlists${createdFor ? "/createdfor" : ""
+      }${collaborator ? "/collaborator" : ""}?offset=${offset}&count=${count}`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -196,7 +196,7 @@ def _get_feedback_for_recording(recording_type, recording):
     })
 
 
-@feedback_api_bp.route("/user/<user_name>/get-feedback-for-recordings", methods=["GET"])
+@feedback_api_bp.route("/user/<user_name>/get-feedback-for-recordings", methods=["GET", "POST"])
 @crossdomain
 @ratelimit()
 def get_feedback_for_recordings_for_user(user_name):
@@ -225,13 +225,21 @@ def get_feedback_for_recordings_for_user(user_name):
     :statuscode 200: Yay, you have data!
     :resheader Content-Type: *application/json*
     """
-
-    msids_unparsed = request.args.get("recording_msids")
-    if msids_unparsed is None:
-        msids_unparsed = request.args.get("recordings")
-    mbids_unparsed = request.args.get("recording_mbids")
+    msids_unparsed = None
+    mbids_unparsed = None
 
     recording_msids, recording_mbids = [], []
+    if request.method == "GET":
+        msids_unparsed = request.args.get("recording_msids")
+        if msids_unparsed is None:
+            msids_unparsed = request.args.get("recordings")
+        mbids_unparsed = request.args.get("recording_mbids")
+    elif request.method == "POST":
+        msids_unparsed = request.json.get(recording_msids)
+        if msids_unparsed is None:
+            msids_unparsed = request.json.get("recordings")
+        mbids_unparsed = request.json.get("recording_mbids")
+        
     if msids_unparsed:
         recording_msids = parse_param_list(msids_unparsed)
     if mbids_unparsed:


### PR DESCRIPTION
[LB-1262]:(https://tickets.metabrainz.org/browse/LB-1262)

# Problem

Currently, the endpoint /user/<user_name>/get-feedback-for-recordings accepts GET requests and a list of recording MBIDs in the URL.

This is creating some issues for example for playlists with over 80 tracks.

# Solution

Add a method to accept POST requests as well as the corresponding body containing the list of recording MBIDs.



# Action

Added a POST method for /user/<user_name>/get-feedback-for-recordings and updated the frontend API service to make a POST instead of a GET request.
