### PR TITLE
Switch listen tables in production

### DIFF
--- a/admin/timescale/create_functions.sql
+++ b/admin/timescale/create_functions.sql
@@ -1,8 +1,0 @@
-BEGIN;
-
-CREATE OR REPLACE FUNCTION unix_now() 
-                   RETURNS BIGINT LANGUAGE SQL STABLE AS $$ 
-                    SELECT extract(epoch from now())::BIGINT $$;
-SELECT set_integer_now_func('listen', 'unix_now');
-
-COMMIT;

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -2,13 +2,11 @@ BEGIN;
 
 CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id);
 CREATE INDEX created_ndx_listen ON listen (created);
+CREATE UNIQUE INDEX listened_at_user_id_recording_msid_ndx_listen ON listen (listened_at DESC, user_id, recording_msid);
 
-CREATE UNIQUE INDEX listened_at_track_name_user_id_ndx_listen ON listen (listened_at DESC, track_name, user_id);
-CREATE UNIQUE INDEX listened_at_user_id_recording_msid_ndx_listen ON listen_new (listened_at DESC, user_id, recording_msid);
+CREATE INDEX recording_msid_ndx_listen on listen (recording_msid);
 
-CREATE INDEX recording_msid_ndx_listen on listen ((data->'track_metadata'->'additional_info'->>'recording_msid'));
-
-CREATE UNIQUE INDEX user_id_ndx_listen_user_metadata_new ON listen_user_metadata_new (user_id);
+CREATE UNIQUE INDEX user_id_ndx_listen_user_metadata ON listen_user_metadata (user_id);
 
 -- View indexes are created in listenbrainz/db/timescale.py
 

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -23,8 +23,7 @@ CREATE TABLE listen_user_metadata (
     created             TIMESTAMP WITH TIME ZONE    NOT NULL  -- the created timestamp when data for this user was updated last
 );
 
--- 86400 seconds * 5 = 432000 seconds = 5 days
-SELECT create_hypertable('listen', 'listened_at', chunk_time_interval => 432000);
+SELECT create_hypertable('listen', 'listened_at', chunk_time_interval => INTERVAL '30 days');
 
 -- Playlists
 

--- a/admin/timescale/reset_tables.sql
+++ b/admin/timescale/reset_tables.sql
@@ -1,7 +1,6 @@
 BEGIN;
 
 DELETE FROM listen                      CASCADE;
-DELETE FROM listen_new                  CASCADE;
 DELETE FROM listen_delete_metadata      CASCADE;
 DELETE FROM listen_user_metadata        CASCADE;
 DELETE FROM mbid_mapping                CASCADE;

--- a/admin/timescale/updates/2023-05-05-listens-table-switch.sql
+++ b/admin/timescale/updates/2023-05-05-listens-table-switch.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+ALTER TABLE listen RENAME TO listen_old;
+ALTER INDEX listened_at_track_name_user_id_ndx_listen RENAME TO listened_at_track_name_user_id_ndx_listen_old;
+ALTER INDEX created_user_name_ndx_listen RENAME TO created_user_name_ndx_listen_old;
+ALTER INDEX listen_listened_at_idx RENAME TO listen_listened_at_idx_old;
+ALTER INDEX listened_at_user_id_ndx_listen RENAME TO listened_at_user_id_ndx_listen_old;
+
+ALTER TABLE listen_new RENAME TO listen;
+CREATE INDEX listened_at_user_id_ndx_listen ON listen (listened_at DESC, user_id);
+CREATE INDEX created_ndx_listen ON listen (created);
+CREATE UNIQUE INDEX listened_at_user_id_recording_msid_ndx_listen ON listen (listened_at DESC, user_id, recording_msid);
+CREATE INDEX recording_msid_ndx_listen on listen (recording_msid);
+
+ALTER TABLE listen_delete_metadata RENAME TO listen_delete_metadata_old;
+ALTER TABLE listen_delete_metadata_new RENAME TO listen_delete_metadata;
+
+ALTER TABLE listen_user_metadata RENAME TO listen_user_metadata_old;
+ALTER INDEX user_id_ndx_user_metadata RENAME TO user_id_ndx_user_metadata_old;
+
+ALTER TABLE listen_user_metadata_new RENAME TO listen_user_metadata;
+CREATE UNIQUE INDEX user_id_ndx_listen_user_metadata ON listen_user_metadata (user_id);
+
+COMMIT;

--- a/listenbrainz/labs_api/labs/api/user_listen_sessions.py
+++ b/listenbrainz/labs_api/labs/api/user_listen_sessions.py
@@ -68,7 +68,7 @@ class UserListensSessionQuery(Query):
                           , (l.data->'track_metadata'->'additional_info'->>'duration_ms')::INT / 1000
                           , {DEFAULT_TRACK_LENGTH}
                         ) AS duration
-                   FROM listen_new l
+                   FROM listen l
               LEFT JOIN mbid_mapping mm
                      ON (l.data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = recording_msid
               LEFT JOIN mbid_mapping_metadata mmm

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -45,7 +45,7 @@ class DumpListenStore:
         """
 
         query = """SELECT extract(epoch from listened_at) as listened_at, user_id, created, recording_msid::TEXT, data
-                      FROM listen_new
+                      FROM listen
                      WHERE listened_at >= :start_time
                        AND listened_at <= :end_time
                   ORDER BY listened_at ASC"""
@@ -63,7 +63,7 @@ class DumpListenStore:
         """
 
         query = """SELECT extract(epoch from listened_at) as listened_at, user_id, created, recording_msid::TEXT, data
-                      FROM listen_new
+                      FROM listen
                      WHERE created > :start_ts
                        AND created <= :end_ts
                   ORDER BY created ASC"""
@@ -344,7 +344,7 @@ class DumpListenStore:
                           , data->'additional_info'->>'recording_mbid' AS l_recording_mbid
                           -- prefer to use user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
                           , COALESCE(user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS m_recording_mbid
-                       FROM listen_new l
+                       FROM listen l
                   LEFT JOIN mbid_mapping mm
                          ON l.recording_msid = mm.recording_msid
                   LEFT JOIN mbid_manual_mapping user_mm

--- a/listenbrainz/listenstore/tests/test_dumplistenstore.py
+++ b/listenbrainz/listenstore/tests/test_dumplistenstore.py
@@ -48,7 +48,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         for listen in listens:
             submit.append((*listen.to_timescale(), listen.inserted_timestamp))
 
-        query = """INSERT INTO listen_new (listened_at, user_id, recording_msid, data, created)
+        query = """INSERT INTO listen (listened_at, user_id, recording_msid, data, created)
                         VALUES %s
                    ON CONFLICT (listened_at, user_id, recording_msid)
                     DO NOTHING

--- a/listenbrainz/listenstore/tests/test_timescale_utils.py
+++ b/listenbrainz/listenstore/tests/test_timescale_utils.py
@@ -40,7 +40,7 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
             result = connection.execute(
                 text("""
                     SELECT count, min_listened_at, max_listened_at
-                      FROM listen_user_metadata_new
+                      FROM listen_user_metadata
                      WHERE user_id = :user_id
                 """), {"user_id": user["id"]})
             row = result.fetchone()
@@ -69,7 +69,7 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(metadata_2["max_listened_at"], datetime.utcfromtimestamp(1400000200))
         self.assertEqual(metadata_2["count"], 5)
 
-        # to test the case when the update script has not run since delete, so metadata in listen_user_metadata_new does
+        # to test the case when the update script has not run since delete, so metadata in listen_user_metadata does
         # account for this listen and deleting should not affect it either.
         self._create_test_data(user_1, "timescale_listenstore_test_listens_2.json")
         self.logstore.delete_listen(datetime.utcfromtimestamp(1400000500), user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -277,7 +277,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def _get_pending_deletes(self):
         with timescale.engine.connect() as connection:
-            result = connection.execute(text("SELECT * FROM listen_delete_metadata_new"))
+            result = connection.execute(text("SELECT * FROM listen_delete_metadata"))
             return [{
                 "user_id": row.user_id,
                 "recording_msid": row.recording_msid,
@@ -289,7 +289,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
             result = connection.execute(
                 text("""
                     SELECT count, min_listened_at, max_listened_at
-                      FROM listen_user_metadata_new
+                      FROM listen_user_metadata
                      WHERE user_id = :user_id
                 """), {"user_id": user_id})
             return result.fetchone()._asdict()

--- a/listenbrainz/listenstore/timescale_listens_migrate.py
+++ b/listenbrainz/listenstore/timescale_listens_migrate.py
@@ -18,7 +18,7 @@ MAX_CREATED_WHEN_ENABLED_ON_TEST = datetime(2023, 4, 27, tzinfo=timezone.utc)
 def process_created(created: datetime):
     print("Fixing-up using created - this may take a while.")
     query = """
-        INSERT INTO listen_new (listened_at, created, user_id, recording_msid, data)
+        INSERT INTO listen (listened_at, created, user_id, recording_msid, data)
              SELECT to_timestamp(listened_at)
                   , created
                   , user_id
@@ -47,7 +47,7 @@ def process_chunk(chunk_start):
     print(f"Processing chunk: {chunk_start_dt.isoformat()} - {chunk_end_dt.isoformat()}")
 
     query = """
-        INSERT INTO listen_new (listened_at, created, user_id, recording_msid, data)
+        INSERT INTO listen (listened_at, created, user_id, recording_msid, data)
              SELECT to_timestamp(listened_at)
                   , created
                   , user_id
@@ -78,7 +78,7 @@ def migrate_listens():
     query2 = """
         SELECT COALESCE(EXTRACT('epoch' from max(listened_at)), 0) AS already_done_ts
              , max(created) AS already_max_created
-          FROM listen_new
+          FROM listen
     """
     with timescale.engine.connect() as connection:
         result = connection.execute(text(query1), {"least_accepted_ts": LISTEN_MINIMUM_TS})

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -24,33 +24,33 @@ def delete_listens():
     #
     # 1) Delete Mismatch
     #
-    # The listen_delete_metadata_new table holds the rows to be deleted FROM listen_new. We fetch the rows from it and delete
-    # corresponding listens FROM listen_new table. After that, we update counts and timestamps in listen_user_metadata_new table
-    # as necessary. Between the time rows are deleted FROM listen_new table and the time we get to clear up the
-    # listen_delete_metadata_new table, new rows may have been inserted in the latter. So, we would have deleted rows from
-    # listen_delete_metadata_new table without deleting the actual listens.
+    # The listen_delete_metadata table holds the rows to be deleted FROM listen. We fetch the rows from it and delete
+    # corresponding listens FROM listen table. After that, we update counts and timestamps in listen_user_metadata table
+    # as necessary. Between the time rows are deleted FROM listen table and the time we get to clear up the
+    # listen_delete_metadata table, new rows may have been inserted in the latter. So, we would have deleted rows from
+    # listen_delete_metadata table without deleting the actual listens.
     #
     # This issue exists because our transaction isolation level is READ COMMITTED. This issue can be prevented by using
     # the REPEATABLE READ isolation level but that comes with its own issues. To alleviate this issue, the id
-    # column has been added to the listen_delete_metadata_new table. Before the start of the transaction, we record the
-    # maximum id in the table. This id is used to select the rows from listen_delete_metadata_new table and the same rows
+    # column has been added to the listen_delete_metadata table. Before the start of the transaction, we record the
+    # maximum id in the table. This id is used to select the rows from listen_delete_metadata table and the same rows
     # are then later deleted.
     #
     # 2) "Fake/Double" Delete
     #
     # The DELETE listen endpoint does not verify whether a listen already exists in the listen table. It also does not
-    # check whether that row for that delete already exists in listen_delete_metadata_new table. This can actually be a
+    # check whether that row for that delete already exists in listen_delete_metadata table. This can actually be a
     # quite common situation, for example: the user clicking delete for the same listen twice. If we count the number of
-    # deleted listens to subtract using listen_delete_metadata_new table, the count may become inaccurate.
+    # deleted listens to subtract using listen_delete_metadata table, the count may become inaccurate.
     #
-    # Therefore, we use the RETURNING clause with the DELETE FROM listen_new statement to return the user_id and created
+    # Therefore, we use the RETURNING clause with the DELETE FROM listen statement to return the user_id and created
     # of the actual deletes and then calculate the deleted listen count from it and subtract it from existing count to
     # get the updated count.
     #
     # However, PG's CTEs have a limitation that they unrelated WITH'ed queries may be executed in any order and if there
     # are multiple updates to a row in a CTE, only 1 query's update will be visible afterwards. So the queries to update
     # timestamps cannot be put in the WITH of update counts query. Further, this means that we cannot utilise the
-    # RETURNING clause to return listened_at for these queries and need to read the listen_delete_metadata_new table.
+    # RETURNING clause to return listened_at for these queries and need to read the listen_delete_metadata table.
     # (**There is an alternative if needed: create a temporary table out of the RETURNING clause data.**)
     # But but wait... For updating min/max listened_at timestamp, we scan the listen table so even if there are double
     # entries or fake entries for delete, it doesn't matter. The new min/max timestamps are going to come from the
@@ -58,17 +58,17 @@ def delete_listens():
     #
     # 3) Interaction with regular metadata update cron job
     #
-    # A periodic cron job run updates the metadata in the listen_user_metadata_new table. Specifically, the count,
+    # A periodic cron job run updates the metadata in the listen_user_metadata table. Specifically, the count,
     # min_listened_at and max_listened_at values for a user have been calculated only on the basis of listens created
-    # prior to the created value of that user's listen_user_metadata_new row. But many users will have listens created
+    # prior to the created value of that user's listen_user_metadata row. But many users will have listens created
     # since the last cron job run, some of these may end up in deletes as well.
     #
-    # Listens which have a created value later than the created value in the listen_user_metadata_new table haven't yet
-    # been counted in the listen_user_metadata_new table. So when deleted the count of these listens should not be
-    # subtracted from listen_user_metadata_new. The FILTER clause with count(*) is responsible for that.
+    # Listens which have a created value later than the created value in the listen_user_metadata table haven't yet
+    # been counted in the listen_user_metadata table. So when deleted the count of these listens should not be
+    # subtracted from listen_user_metadata. The FILTER clause with count(*) is responsible for that.
     #
     # Similarly, a listen with listened_at greater than max_listened_at can be created later than the created value
-    # in the listen_user_metadata_new table. If this listen is deleted and the listen with max_listened_at is also deleted,
+    # in the listen_user_metadata table. If this listen is deleted and the listen with max_listened_at is also deleted,
     # max(listened_at) of deleted listens != max_listened_at of listened_user_metadata. So, we will have missed to
     # update listen timestamps in this case. To avoid this, we need to check max_listened_at is in the list of
     # listened_at of delete listens. The same situation can happen with min_listened_at.
@@ -76,7 +76,7 @@ def delete_listens():
     # 4) Redundant work in updating min/max listened_at
     #
     # To update min/max listened_at fields, it doesn't really matter whether the listens were created prior or after
-    # the created value in the listen_user_metadata_new table. It is a matter of choosing the best performance
+    # the created value in the listen_user_metadata table. It is a matter of choosing the best performance
     # characteristics. When updating the these fields we use the existing min/max listened_at values to reduce the
     # search space.
     #
@@ -95,13 +95,13 @@ def delete_listens():
 
     # select the maximum id in the table till now, we are only to process
     # deletes with row id earlier than this.
-    select_max_id = "SELECT max(id) AS max_id FROM listen_delete_metadata_new"
+    select_max_id = "SELECT max(id) AS max_id FROM listen_delete_metadata"
 
     # count deleted listens, checked created and update listen counts
     delete_listens_and_update_listen_counts = """
         WITH deleted_listens AS (
-            DELETE FROM listen_new l
-             USING listen_delete_metadata_new ldm
+            DELETE FROM listen l
+             USING listen_delete_metadata ldm
              WHERE ldm.id <= :max_id
                AND l.user_id = ldm.user_id
                AND l.listened_at = ldm.listened_at
@@ -111,11 +111,11 @@ def delete_listens():
             SELECT user_id
                  , count(*) AS deleted_count
               FROM deleted_listens dl
-              JOIN listen_user_metadata_new lm
+              JOIN listen_user_metadata lm
              USING (user_id)
           GROUP BY user_id
         ) 
-            UPDATE listen_user_metadata_new lm
+            UPDATE listen_user_metadata lm
                SET count = count - deleted_count
               FROM update_counts uc
              WHERE lm.user_id = uc.user_id
@@ -126,8 +126,8 @@ def delete_listens():
     update_listen_min_ts = """
         WITH update_ts AS (
             SELECT user_id, min_listened_at, lm.created
-              FROM listen_delete_metadata_new dl
-              JOIN listen_user_metadata_new lm
+              FROM listen_delete_metadata dl
+              JOIN listen_user_metadata lm
              USING (user_id)
              WHERE dl.id <= :max_id
           GROUP BY user_id, min_listened_at, lm.created
@@ -141,7 +141,7 @@ def delete_listens():
               -- for each user calculate the new minimum timestamp
               JOIN LATERAL (
                     SELECT min(listened_at) AS min_listened_ts
-                      FROM listen_new l
+                      FROM listen l
                         -- new minimum will be greater than the last one
                      WHERE l.listened_at >= u.min_listened_at
                        AND l.user_id = u.user_id
@@ -149,7 +149,7 @@ def delete_listens():
                    ) AS new_ts
                 ON TRUE
         )
-            UPDATE listen_user_metadata_new lm
+            UPDATE listen_user_metadata lm
                SET min_listened_at = new_listened_at
               FROM calculate_new_ts mt
              WHERE lm.user_id = mt.user_id
@@ -160,8 +160,8 @@ def delete_listens():
     update_listen_max_ts = """
         WITH update_ts AS (
             SELECT user_id, max_listened_at, lm.created
-              FROM listen_delete_metadata_new dl
-              JOIN listen_user_metadata_new lm
+              FROM listen_delete_metadata dl
+              JOIN listen_user_metadata lm
              USING (user_id)
              WHERE dl.id <= :max_id
           GROUP BY user_id, max_listened_at, lm.created
@@ -175,7 +175,7 @@ def delete_listens():
                 -- for each user calculate the new maximum timestamp
               JOIN LATERAL (
                     SELECT max(listened_at) AS max_listened_ts
-                      FROM listen_new l
+                      FROM listen l
                         -- new maximum will be lesser than the last one
                      WHERE l.listened_at <= u.max_listened_at
                        AND l.user_id = u.user_id
@@ -183,12 +183,12 @@ def delete_listens():
                    ) AS new_ts
                 ON TRUE
         )
-            UPDATE listen_user_metadata_new lm
+            UPDATE listen_user_metadata lm
                SET max_listened_at = new_listened_at
               FROM calculate_new_ts mt
              WHERE lm.user_id = mt.user_id
     """
-    delete_user_metadata = "DELETE FROM listen_delete_metadata_new WHERE id <= :max_id"
+    delete_user_metadata = "DELETE FROM listen_delete_metadata WHERE id <= :max_id"
 
     with timescale.engine.begin() as connection:
         result = connection.execute(text(select_max_id))
@@ -199,7 +199,7 @@ def delete_listens():
             return
 
         max_id = row.max_id
-        logger.info("Found max id in listen_delete_metadata_new table: %s", max_id)
+        logger.info("Found max id in listen_delete_metadata table: %s", max_id)
 
         logger.info("Deleting Listens and updating affected listens counts")
         connection.execute(text(delete_listens_and_update_listen_counts), {"max_id": max_id})
@@ -217,21 +217,21 @@ def delete_listens():
 
 
 def update_user_listen_data():
-    """ Scan listens created since last run and update metadata in listen_user_metadata_new accordingly """
+    """ Scan listens created since last run and update metadata in listen_user_metadata accordingly """
     query = """
         WITH new AS (
             SELECT user_id
                  , count(*) as count
                  , min(listened_at) AS min_listened_at
                  , max(listened_at) AS max_listened_at
-              FROM listen_new l
-              JOIN listen_user_metadata_new lm
+              FROM listen l
+              JOIN listen_user_metadata lm
              USING (user_id)
              WHERE l.created > lm.created
                AND l.created <= :until
           GROUP BY user_id
         )
-        UPDATE listen_user_metadata_new old
+        UPDATE listen_user_metadata old
            SET count = old.count + new.count
              , min_listened_at = least(old.min_listened_at, new.min_listened_at)
              , max_listened_at = greatest(old.max_listened_at, new.max_listened_at)
@@ -256,7 +256,7 @@ def delete_listens_and_update_user_listen_data():
 
 
 def add_missing_to_listen_users_metadata():
-    """ Fetch users from LB and add an entry those users which are missing from listen_user_metadata_new """
+    """ Fetch users from LB and add an entry those users which are missing from listen_user_metadata """
     # Select a list of users
     user_list = []
     query = 'SELECT id FROM "user"'
@@ -274,7 +274,7 @@ def add_missing_to_listen_users_metadata():
                 len(user_list))
 
     query = """
-        INSERT INTO listen_user_metadata_new (user_id, count, min_listened_at, max_listened_at, created)
+        INSERT INTO listen_user_metadata (user_id, count, min_listened_at, max_listened_at, created)
              VALUES %s
         ON CONFLICT (user_id)
          DO NOTHING
@@ -306,7 +306,7 @@ def recalculate_all_user_data():
     logger.info("Fetched %d users. Resetting created timestamps for all users.", len(user_list))
 
     query = """
-        INSERT INTO listen_user_metadata_new (user_id, count, min_listened_at, max_listened_at, created)
+        INSERT INTO listen_user_metadata (user_id, count, min_listened_at, max_listened_at, created)
              VALUES %s
         ON CONFLICT (user_id)
           DO UPDATE

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -163,10 +163,6 @@ def init_ts_db(force, create_db):
         print('TS: Creating views...')
         ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_views.sql'))
 
-        print('TS: Creating Functions...')
-        ts.run_sql_script(os.path.join(
-            TIMESCALE_SQL_DIR, 'create_functions.sql'))
-
         print('TS: Creating indexes...')
         ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_indexes.sql'))
 


### PR DESCRIPTION
For the purpose of testing, we had two sets of listen tables, one with the existing schema and another with the new schema. Now that we are satisfied with the testing of the new schema, switch the tables in prod. Rename the existing tables by adding an old suffix and remove the new suffix from the new tables.