### PR TITLE
Finish migrating listens table

### DIFF
--- a/listenbrainz/listenstore/redis_listenstore.py
+++ b/listenbrainz/listenstore/redis_listenstore.py
@@ -10,11 +10,11 @@ from listenbrainz.listen import Listen, NowPlayingListen
 
 class RedisListenStore:
 
-    RECENT_LISTENS_KEY = "new-rl-"
+    RECENT_LISTENS_KEY = "rl-"
     RECENT_LISTENS_MAX = 100
-    PLAYING_NOW_KEY = "new-pn."
+    PLAYING_NOW_KEY = "pn."
     LISTEN_COUNT_PER_DAY_EXPIRY_TIME = 3 * 24 * 60 * 60  # 3 days in seconds
-    LISTEN_COUNT_PER_DAY_KEY = "new-lc-day-"
+    LISTEN_COUNT_PER_DAY_KEY = "lc-day-"
 
     def __init__(self, logger):
         self.log = logger
@@ -62,7 +62,6 @@ class RedisListenStore:
         recent = {}
         for listen in unique:
             recent[orjson.dumps(listen.to_json())] = float(listen.ts_since_epoch)
-        print(recent)
 
         # Don't take this very seriously -- if it fails, really no big deal. Let is go.
         if recent:

--- a/listenbrainz/listenstore/tests/test_timescale_utils.py
+++ b/listenbrainz/listenstore/tests/test_timescale_utils.py
@@ -77,9 +77,9 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
         # test min_listened_at is updated if that listen is deleted for a user
         self.logstore.delete_listen(datetime.utcfromtimestamp(1400000000), user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
         # test max_listened_at is updated if that listen is deleted for a user
-        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000200), user_1["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
+        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000200), user_1["id"], "db072fa7-0c7f-4f55-b90f-a88da531b219")
         # test normal listen delete updates correctly
-        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000100), user_2["id"], "4269ddbc-9241-46da-935d-4fa9e0f7f371")
+        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000100), user_2["id"], "08ade1eb-800e-4ad8-8184-32941664ac02")
 
         delete_listens()
 

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -213,7 +213,7 @@ class TimescaleListenStore:
                              , l.recording_msid
                              , l.data
                              -- prefer to use user submitted mbid, then user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
-                             , COALESCE((data->'track_metadata'->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
+                             , COALESCE((data->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
                           FROM listen l
                      LEFT JOIN mbid_mapping mm
                             ON l.recording_msid = mm.recording_msid
@@ -385,7 +385,7 @@ class TimescaleListenStore:
               ), selected_listens AS (
                     SELECT l.*
                         -- prefer to use user submitted mbid, then user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
-                         , COALESCE((data->'track_metadata'->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
+                         , COALESCE((data->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
                       FROM intermediate l
                  LEFT JOIN mbid_mapping mm
                         ON l.recording_msid = mm.recording_msid

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -20,9 +20,9 @@ from listenbrainz.listenstore import LISTENS_DUMP_SCHEMA_VERSION, LISTEN_MINIMUM
 from listenbrainz.listenstore import ORDER_ASC, ORDER_TEXT, ORDER_DESC, DEFAULT_LISTENS_PER_FETCH
 
 # Append the user name for both of these keys
-REDIS_USER_LISTEN_COUNT = "new-lc."
-REDIS_USER_TIMESTAMPS = "new-ts."
-REDIS_TOTAL_LISTEN_COUNT = "new-lc-total"
+REDIS_USER_LISTEN_COUNT = "lc."
+REDIS_USER_TIMESTAMPS = "ts."
+REDIS_TOTAL_LISTEN_COUNT = "lc-total"
 # cache listen counts for 5 minutes only, so that listen counts are always up-to-date in 5 minutes.
 REDIS_USER_LISTEN_COUNT_EXPIRY = 300
 

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -27,7 +27,6 @@ REDIS_TOTAL_LISTEN_COUNT = "lc-total"
 REDIS_USER_LISTEN_COUNT_EXPIRY = 300
 
 DUMP_CHUNK_SIZE = 100000
-DATA_START_YEAR = 2005
 DATA_START_YEAR_IN_SECONDS = 1104537600
 
 # How many listens to fetch on the first attempt. If we don't fetch enough, increase it by WINDOW_SIZE_MULTIPLIER

--- a/listenbrainz/mbid_mapping_writer/job_queue.py
+++ b/listenbrainz/mbid_mapping_writer/job_queue.py
@@ -156,10 +156,10 @@ class MappingJobQueue(threading.Thread):
            Listens are added to the queue with a low priority."""
 
         # Find listens that have no entry in the mapping yet.
-        legacy_query = """SELECT data->'track_metadata'->'additional_info'->>'recording_msid'::TEXT AS recording_msid
+        legacy_query = """SELECT data->'additional_info'->>'recording_msid'::TEXT AS recording_msid
                             FROM listen
                        LEFT JOIN mbid_mapping m
-                              ON data->'track_metadata'->'additional_info'->>'recording_msid' = m.recording_msid::text
+                              ON data->'additional_info'->>'recording_msid' = m.recording_msid::text
                            WHERE m.recording_mbid IS NULL
                              AND listened_at <= :max_ts
                              AND listened_at > :min_ts"""

--- a/listenbrainz/mbid_mapping_writer/job_queue.py
+++ b/listenbrainz/mbid_mapping_writer/job_queue.py
@@ -12,10 +12,11 @@ from flask import current_app
 import sqlalchemy
 from listenbrainz.listen import Listen
 from listenbrainz.db import timescale
+from listenbrainz.listenstore import LISTEN_MINIMUM_DATE
 from listenbrainz.mbid_mapping_writer.matcher import process_listens
 from listenbrainz.mbid_mapping_writer.mbid_mapper import MATCH_TYPES
 from listenbrainz.utils import init_cache
-from listenbrainz.listenstore.timescale_listenstore import DATA_START_YEAR_IN_SECONDS
+from listenbrainz.listenstore.timescale_listenstore import DATA_START_YEAR_IN_SECONDS, EPOCH
 from listenbrainz import messybrainz as msb_db
 from brainzutils import metrics, cache
 
@@ -32,7 +33,7 @@ NEW_LISTEN = 0
 UNMATCHED_LISTENS_COMPLETED_TIMEOUT = 86400  # in s
 
 # This is the point where the legacy listens should be processed from
-LEGACY_LISTENS_LOAD_WINDOW = 86400 * 3   # load 3 days of data per go
+LEGACY_LISTENS_LOAD_WINDOW = datetime.timedelta(days=3)
 LEGACY_LISTENS_INDEX_DATE_CACHE_KEY = "mbid.legacy_index_date"
 
 # How many listens should be re-checked every mapping pass?
@@ -66,7 +67,7 @@ class MappingJobQueue(threading.Thread):
         self.unmatched_listens_complete_time = 0
         self.legacy_load_thread = None
         self.legacy_next_run = 0
-        self.legacy_listens_index_date = 0
+        self.legacy_listens_index_date = EPOCH
         self.num_legacy_listens_loaded = 0
         self.last_processed = 0
 
@@ -173,24 +174,25 @@ class MappingJobQueue(threading.Thread):
         if not self.legacy_listens_index_date:
             dt = cache.get(LEGACY_LISTENS_INDEX_DATE_CACHE_KEY, decode=False) or b""
             try:
-                self.legacy_listens_index_date = int(
-                    datetime.datetime.strptime(str(dt, "utf-8"), "%Y-%m-%d").timestamp())
-                self.app.logger.info("Loaded date index from cache: %d %s" % (
+                self.legacy_listens_index_date = datetime.datetime.strptime(str(dt, "utf-8"), "%Y-%m-%d")
+                self.app.logger.info("Loaded date index from cache: %s %s" % (
                     self.legacy_listens_index_date, str(dt)))
             except ValueError:
-                self.legacy_listens_index_date = int(
-                    datetime.datetime.now().timestamp())
+                self.legacy_listens_index_date = datetime.datetime.now()
                 self.app.logger.info("Use date index now()")
 
         # Check to see if we're done
-        if self.legacy_listens_index_date < DATA_START_YEAR_IN_SECONDS - LEGACY_LISTENS_LOAD_WINDOW:
-            self.app.logger.info(
-                "Finished looking up all legacy listens! Wooo!")
+        if self.legacy_listens_index_date < LISTEN_MINIMUM_DATE - LEGACY_LISTENS_LOAD_WINDOW:
+            self.app.logger.info("Finished looking up all legacy listens! Wooo!")
             self.legacy_next_run = monotonic() + UNMATCHED_LISTENS_COMPLETED_TIMEOUT
-            self.legacy_listens_index_date = int(datetime.datetime.now().timestamp())
+            self.legacy_listens_index_date = datetime.datetime.now()
             self.num_legacy_listens_loaded = 0
-            dt = datetime.datetime.fromtimestamp(self.legacy_listens_index_date)
-            cache.set(LEGACY_LISTENS_INDEX_DATE_CACHE_KEY, dt.strftime("%Y-%m-%d"), expirein=0, encode=False)
+            cache.set(
+                LEGACY_LISTENS_INDEX_DATE_CACHE_KEY,
+                self.legacy_listens_index_date.strftime("%Y-%m-%d"),
+                expirein=0,
+                encode=False
+            )
 
             return
 
@@ -201,16 +203,21 @@ class MappingJobQueue(threading.Thread):
             return
         else:
             # If none, check for old legacy listens
-            count = self.fetch_and_queue_listens(legacy_query, {"max_ts": self.legacy_listens_index_date,
-                                                                "min_ts": self.legacy_listens_index_date - LEGACY_LISTENS_LOAD_WINDOW},
-                                                 LEGACY_LISTEN)
-            self.app.logger.info("Loaded %s more legacy listens for %s" % (count, datetime.datetime.fromtimestamp(
-                self.legacy_listens_index_date).strftime("%Y-%m-%d")))
+            count = self.fetch_and_queue_listens(legacy_query, {
+                "max_ts": self.legacy_listens_index_date,
+                "min_ts": self.legacy_listens_index_date - LEGACY_LISTENS_LOAD_WINDOW
+            }, LEGACY_LISTEN)
+            self.app.logger.info("Loaded %s more legacy listens for %s" %
+                                 (count, self.legacy_listens_index_date.strftime("%Y-%m-%d")))
 
         # update cache entry and count
         self.legacy_listens_index_date -= LEGACY_LISTENS_LOAD_WINDOW
-        dt = datetime.datetime.fromtimestamp(self.legacy_listens_index_date)
-        cache.set(LEGACY_LISTENS_INDEX_DATE_CACHE_KEY, dt.strftime("%Y-%m-%d"), expirein=0, encode=False)
+        cache.set(
+            LEGACY_LISTENS_INDEX_DATE_CACHE_KEY,
+            self.legacy_listens_index_date.strftime("%Y-%m-%d"),
+            expirein=0,
+            encode=False
+        )
         self.num_legacy_listens_loaded = count
 
     def update_metrics(self, stats):
@@ -267,7 +274,7 @@ class MappingJobQueue(threading.Thread):
                         no_match_rate=stats["no_match"] - stats["last_no_match"],
                         listens_per_sec=listens_per_sec,
                         listens_matched_p=stats["listens_matched"] / (stats["listen_count"] or .000001) * 100.0,
-                        legacy_index_date=datetime.date.fromtimestamp(self.legacy_listens_index_date).strftime("%Y-%m-%d"))
+                        legacy_index_date=self.legacy_listens_index_date.strftime("%Y-%m-%d"))
 
             stats["last_exact_match"] = stats["exact_match"]
             stats["last_high_quality"] = stats["high_quality"]

--- a/listenbrainz/testdata/timescale_listenstore_test_listens.json
+++ b/listenbrainz/testdata/timescale_listenstore_test_listens.json
@@ -5,7 +5,7 @@
             "track_metadata": {
                 "track_name": "Immigrant Song 0",
                 "additional_info": {
-                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
+                    "recording_mbid": "103e7457-e64b-43f1-a2df-94ba0286cd59"
                 },
                 "artist_name": "Led Zeppelin"
             },
@@ -27,34 +27,34 @@
             "track_metadata": {
                 "track_name": "Immigrant Song 100",
                 "additional_info": {
-                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
+                    "recording_mbid": "74676f79-c8ab-4d06-8d0a-67e06ddc5f4e"
                 },
                 "artist_name": "Led Zeppelin"
             },
             "listened_at": "1400000100",
-            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+            "recording_msid": "08ade1eb-800e-4ad8-8184-32941664ac02"
         },
         {
             "track_metadata": {
                 "track_name": "Immigrant Song 150",
                 "additional_info": {
-                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
+                    "recording_mbid": "c656b799-6b23-4a72-b1e4-384d6c8baf06"
                 },
                 "artist_name": "Led Zeppelin"
             },
             "listened_at": "1400000150",
-            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+            "recording_msid": "5da3e48f-dcde-43b1-9bec-bdd95ff1dfce"
         },
         {
             "track_metadata": {
                 "track_name": "Immigrant Song 200",
                 "additional_info": {
-                    "recording_mbid": "2cfad207-3f55-4aec-8120-86cf66e34d59"
+                    "recording_mbid": "afd5316a-e9f4-42c0-8933-8892678f4e07"
                 },
                 "artist_name": "Led Zeppelin"
             },
             "listened_at": "1400000200",
-            "recording_msid": "4269ddbc-9241-46da-935d-4fa9e0f7f371"
+            "recording_msid": "db072fa7-0c7f-4f55-b90f-a88da531b219"
         }
     ]
 }

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -1015,7 +1015,10 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(1, len(events))
 
         received = events[0].metadata.dict(exclude_none=True)
-        self.assertDictEqual(metadata, received)
+        self.assertEqual(metadata["blurb_content"], received["blurb_content"])
+        self.assertEqual(metadata["recording_msid"], received["recording_msid"])
+        self.assertEqual(metadata["recording_mbid"], received["recording_mbid"])
+        self.assertCountEqual(metadata["users"], received["users"])
 
     def test_personal_recommendation_mbid_only(self):
         """ Test that we can recommend a recording with only mbid """

--- a/mbid_mapping/reports/top_discoveries.py
+++ b/mbid_mapping/reports/top_discoveries.py
@@ -85,15 +85,15 @@ def fetch_top_discoveries_for_users(lb_conn, mb_conn, year):
             # a track was listened to. This data directly is not useful for anything directly, but from this 
             # a few types of playlists can be generated.
             query = """SELECT user_name
-                            , track_name
-                            , data->'track_metadata'->>'artist_name' AS artist_name
+                            , data->>'track_name' AS track_name
+                            , data->>'artist_name' AS artist_name
                             , array_agg(extract(year from to_timestamp(listened_at))::INT ORDER BY
                                         extract(year from to_timestamp(listened_at))::INT) AS years
                             , m.recording_mbid
                             , mm.artist_mbids
-                         FROM listen
+                         FROM listen l
               FULL OUTER JOIN mbid_mapping m
-                           ON (data->'track_metadata'->'additional_info'->>'recording_msid')::uuid = m.recording_msid
+                           ON l.recording_msid = m.recording_msid
               FULL OUTER JOIN mbid_mapping_metadata mm
                               ON mm.recording_mbid = m.recording_mbid
                         WHERE user_name in %s

--- a/mbid_mapping/reports/tracks_of_the_year.py
+++ b/mbid_mapping/reports/tracks_of_the_year.py
@@ -83,7 +83,7 @@ def fetch_tracks_listened_to(lb_conn, mb_conn, start_ts, end_ts):
                             , count(*) AS listen_count
                          FROM listen l
                          JOIN mbid_mapping m
-                           ON data->'track_metadata'->'additional_info'->>'recording_msid' = m.recording_msid::TEXT
+                           ON l.recording_msid = m.recording_msid
                          JOIN mbid_mapping_metadata md
                            ON m.recording_mbid = md.recording_mbid
                         WHERE listened_at >= %s


### PR DESCRIPTION
1. Remove new- prefix redis cache keys. Was only needed for listens table migration.
2. Use datetime instead of timestamp in mbid_mapper. The listened_at column in listen table is of TIMESTAMPTZ type instead of BIGINT now. So use datetime objects instead of epoch timestamps where needed.
3. Fix reference to track_metadata in data JSONB. track_metadata used to be a key of data JSON column in listen table
earlier but in the new schema data column itself is track_metadata. Therefore, remove erroneous references to ->'track_metadata'.