### PR TITLE
Multisearch component: use MB API to lookup recording by MBID

### DIFF
--- a/frontend/js/src/mbid-mapping/MBIDMappingModal.tsx
+++ b/frontend/js/src/mbid-mapping/MBIDMappingModal.tsx
@@ -144,7 +144,8 @@ export default NiceModal.create(
             <div className="modal-body">
               <p>
                 Sometimes ListenBrainz is unable to automatically link your
-                Listen with a MusicBrainz recording (song). Paste a{" "}
+                Listen with a MusicBrainz recording (song). Search by track and
+                artist name or paste a{" "}
                 <a href="https://musicbrainz.org/doc/About">MusicBrainz</a>{" "}
                 recording URL{" "}
                 <FontAwesomeIcon
@@ -156,7 +157,10 @@ export default NiceModal.create(
                 below to link this Listen, as well as your other Listens with
                 the same metadata.
               </p>
-
+              <small className="help-block">
+                Recordings added to MusicBrainz within the last 4 hours may
+                temporarily look incomplete.
+              </small>
               <ListenCard
                 listen={listenToMap}
                 showTimestamp={false}


### PR DESCRIPTION
In #2461 lucifer suggested using the LB API endpoint to fetch metadata for a recording by MBID.
However this turns out not to be ideal despite the additional metadata this endpoint gives us.

ListenBrainz mapping lags behind MusicBrainz, and considering this search component is (also) used to link unmapped listens to MB, we will sometimes be in the situation where a user copies a recording MBID/MB URL and pastes it in the multisearch component, only to have no result (since the recording hasn't been mapped, it's likely the MB recording was created recently)
It's better UX to use the MB API to lookup the recording instead of relying on the mapper.
Reverts commit 010f2f2331418f393fe96558f4736b1a43eb6bc8
