### PR TITLE
Don't load UserPageHeading component

### DIFF
--- a/listenbrainz/webserver/templates/user/base.html
+++ b/listenbrainz/webserver/templates/user/base.html
@@ -35,7 +35,6 @@
 
 {% block scripts %}
   {{ super() }}
-  <script src="{{ get_static_path('userPageHeading.js') }}" type="text/javascript"></script>
   
   <!-- This dragscroll library will need to be replaced with a React hook once we move to a SPA -->
   <script src="{{ url_for('static', filename='js/lib/dragscroll.js') }}"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,6 @@ module.exports = function (env, argv) {
       import: path.resolve(jsDir, "src/lastfm/LastFMImporter.tsx"),
       userEntityChart: path.resolve(jsDir, "src/stats/UserEntityChart.tsx"),
       userReports: path.resolve(jsDir, "src/stats/UserReports.tsx"),
-      userPageHeading: path.resolve(jsDir, "src/user/UserPageHeading.tsx"),
       userTaste: path.resolve(jsDir, "src/user/UserTaste.tsx"),
       userFeed: path.resolve(jsDir, "src/user-feed/UserFeed.tsx"),
       playlist: path.resolve(jsDir, "src/playlists/Playlist.tsx"),


### PR DESCRIPTION
While redesigning the website, I didn't realize we shouldn't be loading this UserPageHeading component anymore. Currently this creates an error when on the user dashboard because the div we target to load that react component in doesn't exist anymore.
We also consequently don't need to export a separate javascript file for this component

I'm keeping the component itself as-is because we might choose to use it in the user dashboard (for instance there is a report user button that is currently missing.
