### PR TITLE
Make BrainzPlayer toast notifications unique

### DIFF
--- a/frontend/js/src/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/brainzplayer/BrainzPlayer.tsx
@@ -58,9 +58,9 @@ export type DataSourceProps = {
   ) => void;
   onTrackEnd: () => void;
   onTrackNotFound: () => void;
-  handleError: (error: BrainzPlayerError, title?: string) => void;
-  handleWarning: (message: string | JSX.Element, title?: string) => void;
-  handleSuccess: (message: string | JSX.Element, title?: string) => void;
+  handleError: (error: BrainzPlayerError, title: string) => void;
+  handleWarning: (message: string | JSX.Element, title: string) => void;
+  handleSuccess: (message: string | JSX.Element, title: string) => void;
   onInvalidateDataSource: (
     dataSource?: DataSourceTypes,
     message?: string | JSX.Element
@@ -317,7 +317,7 @@ export default class BrainzPlayer extends React.Component<
     this.playListen(nextListen);
   };
 
-  handleError = (error: BrainzPlayerError, title?: string): void => {
+  handleError = (error: BrainzPlayerError, title: string): void => {
     if (!error) {
       return;
     }
@@ -326,23 +326,27 @@ export default class BrainzPlayer extends React.Component<
       : `${!_isNil(error.status) ? `Error ${error.status}:` : ""} ${
           error.message || error.statusText
         }`;
-    toast.error(
-      <ToastMsg title={title || "Playback error"} message={message} />
-    );
+    toast.error(<ToastMsg title={title} message={message} />, {
+      toastId: title,
+    });
   };
 
-  handleWarning = (message: string | JSX.Element, title?: string): void => {
-    toast.warn(
-      <ToastMsg title={title || "Playback error"} message={message} />
-    );
+  handleWarning = (message: string | JSX.Element, title: string): void => {
+    toast.warn(<ToastMsg title={title} message={message} />, {
+      toastId: title,
+    });
   };
 
-  handleSuccess = (message: string | JSX.Element, title?: string): void => {
-    toast.success(<ToastMsg title={title || "Success"} message={message} />);
+  handleSuccess = (message: string | JSX.Element, title: string): void => {
+    toast.success(<ToastMsg title={title} message={message} />, {
+      toastId: title,
+    });
   };
 
-  handleInfoMessage = (message: string | JSX.Element, title?: string): void => {
-    toast.info(<ToastMsg title={title || ""} message={message} />);
+  handleInfoMessage = (message: string | JSX.Element, title: string): void => {
+    toast.info(<ToastMsg title={title} message={message} />, {
+      toastId: title,
+    });
   };
 
   invalidateDataSource = (
@@ -433,7 +437,7 @@ export default class BrainzPlayer extends React.Component<
       }
       await dataSource.togglePlay();
     } catch (error) {
-      this.handleError(error);
+      this.handleError(error, "Could not play");
     }
   };
 
@@ -596,7 +600,10 @@ export default class BrainzPlayer extends React.Component<
             {album && ` — ${album}`}
           </>
         );
-        this.handleInfoMessage(message);
+        this.handleInfoMessage(
+          message,
+          `Playing ${title}${artist && ` — ${artist}`}`
+        );
       }
     });
 

--- a/frontend/js/src/brainzplayer/BrainzPlayerUI.tsx
+++ b/frontend/js/src/brainzplayer/BrainzPlayerUI.tsx
@@ -141,7 +141,8 @@ function BrainzPlayerUI(props: React.PropsWithChildren<BrainzPlayerUIProps>) {
           <ToastMsg
             title="Error while submitting feedback"
             message={error?.message ?? error.toString()}
-          />
+          />,
+          { toastId: "submit-feedback-error" }
         );
       }
     }

--- a/frontend/js/src/brainzplayer/SpotifyPlayer.tsx
+++ b/frontend/js/src/brainzplayer/SpotifyPlayer.tsx
@@ -176,8 +176,12 @@ export default class SpotifyPlayer
       onTrackNotFound,
     } = this.props;
     if (!trackName && !artistName && !releaseName) {
-      handleWarning("Not enough info to search on Spotify");
+      handleWarning(
+        "We are missing a track title, artist or album name to search on Spotify",
+        "Not enough info to search on Spotify"
+      );
       onTrackNotFound();
+      return;
     }
 
     try {
@@ -194,7 +198,10 @@ export default class SpotifyPlayer
       onTrackNotFound();
     } catch (errorObject) {
       if (!has(errorObject, "status")) {
-        handleError(errorObject.message ?? errorObject);
+        handleError(
+          errorObject.message ?? errorObject,
+          "Error searching on Spotify"
+        );
       }
       if (errorObject.status === 401) {
         // Handle token error and try again if fixed
@@ -273,9 +280,9 @@ export default class SpotifyPlayer
         return;
       }
       // catch-all
-      handleError(errorObject?.message ?? response);
+      handleError(errorObject?.message ?? response, "Spotify error");
     } catch (error) {
-      handleError(error.message);
+      handleError(error.message, "Error playing on Spotify");
     }
   };
 
@@ -309,7 +316,7 @@ export default class SpotifyPlayer
   togglePlay = (): void => {
     const { handleError } = this.props;
     this.spotifyPlayer.togglePlay().catch((error: Response) => {
-      handleError(error);
+      handleError(error, "Spotify playback error");
     });
   };
 
@@ -459,7 +466,7 @@ export default class SpotifyPlayer
         }
       })
       .catch((error: Error) => {
-        handleError(error);
+        handleError(error, "Error connecting to Spotify");
       });
   };
 

--- a/frontend/js/src/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/brainzplayer/YoutubePlayer.tsx
@@ -217,7 +217,7 @@ export default class YoutubePlayer
       </p>
     );
     const { onTrackNotFound, handleWarning } = this.props;
-    handleWarning(errorMessage);
+    handleWarning(errorMessage, "Youtube account error");
     onTrackNotFound();
   };
 
@@ -247,7 +247,10 @@ export default class YoutubePlayer
       return;
     }
     if (!trackName && !artistName && !releaseName) {
-      handleWarning("Not enough info to search on Youtube");
+      handleWarning(
+        "We are missing a track title, artist or album name to search on Youtube",
+        "Not enough info to search on Youtube"
+      );
       onTrackNotFound();
       return;
     }


### PR DESCRIPTION
If we get repeated errors, the new toast library implemented in #2425 will create a new toast for each call of the toast function.
We had previously ensure that duplicate notifications we shown only once, with a number counter to show that it got called multiple times (see #1345)

To prevent duplicates, we need to pass an id, and the new react-toastify library will know not to create a duplicate notification.
We do lose the count of duplicate calls, but I doubt it was useful for users anyway.



This is what happens otherwise:
<img width="636" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/662c9fe0-818f-4d26-a80e-dc30f645189b">
