### PR TITLE
LB-1272: Support http and https in getThumbnailFromCAAResponse util

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -582,11 +582,12 @@ const getThumbnailFromCAAResponse = (
     return undefined;
   }
   const { release } = body;
-  const releaseMBID = release.replace("https://musicbrainz.org/release/", "");
+  const regexp = /musicbrainz.org\/release\/(?<mbid>[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})/g;
+  const releaseMBID = regexp.exec(release)?.groups?.mbid;
 
   const frontImage = body.images.find((image) => image.front);
 
-  if (frontImage?.id) {
+  if (frontImage?.id && releaseMBID) {
     // CAA links are http redirects instead of https, causing LB-1067 (mixed content warning).
     // We also don't need or want the redirect from CAA, instead we can reconstruct
     // the link to the underlying archive.org resource directly


### PR DESCRIPTION
Previously only supports https and fails pretty miserably in case the CAA response JSON contains a release link with http instead:
See the `release` has an http link: https://ia902803.us.archive.org/13/items/mbid-c128ffe8-5808-3af9-af74-5bcda1c96b16/index.json
This in turns means our string replace with `https://` fails to replace anything but carries on, generating a malformed thumbnail source that looks like this (notice the repeating `http://musicbrainz.org/release/` in two places that expect only a UUID):
https://archive.org/download/mbid-http://musicbrainz.org/release/c128ffe8-5808-3af9-af74-5bcda1c96b16/mbid-http://musicbrainz.org/release/c128ffe8-5808-3af9-af74-5bcda1c96b16-1827905959_thumb250.jpg
Result for the user:
<img width="272" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/07d22970-b844-4228-a633-ef166dbf1306">



Using a regexp solves the issue and adds an extra safety, ensuring we only carry on if we found and actual UUID.
