### PR TITLE
LB-1274: Small usability improvements of the MBID mapping modal

### DIFF
--- a/frontend/js/src/mbid-mapping/MBIDMappingModal.tsx
+++ b/frontend/js/src/mbid-mapping/MBIDMappingModal.tsx
@@ -133,7 +133,6 @@ export default NiceModal.create(
           className={`modal fade ${visible ? "in" : ""}`}
           style={visible ? { display: "block" } : {}}
           id="MapToMusicBrainzRecordingModal"
-          tabIndex={-1}
           role="dialog"
           aria-labelledby="MBIDMappingModalLabel"
         >

--- a/frontend/js/src/mbid-mapping/MBIDMappingModal.tsx
+++ b/frontend/js/src/mbid-mapping/MBIDMappingModal.tsx
@@ -54,6 +54,16 @@ export default NiceModal.create(
       setTimeout(remove, 500);
     }, [hide, remove]);
 
+    React.useEffect(() => {
+      const closeOnEscape = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          closeModal();
+        }
+      };
+      window.addEventListener("keydown", closeOnEscape);
+      return () => window.removeEventListener("keydown", closeOnEscape);
+    }, [closeModal]);
+
     const handleError = React.useCallback(
       (error: string | Error, title?: string): void => {
         if (!error) {

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-autofocus */
 import React, {
   useCallback,
   useContext,
@@ -157,6 +158,7 @@ export default function SearchTrackOrMBID({
       <div className="input-group track-search">
         <input
           type="search"
+          autoFocus
           value={inputValue}
           className="form-control"
           id="recording-mbid"

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable jsx-a11y/no-autofocus */
 import React, {
   useCallback,
   useContext,
   useEffect,
   useMemo,
   useState,
+  useRef,
 } from "react";
 import { throttle, throttle as _throttle } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -27,12 +27,22 @@ export default function SearchTrackOrMBID({
 }: SearchTrackOrMBIDProps) {
   const { APIService } = useContext(GlobalAppContext);
   const { lookupMBRecording } = APIService;
+  const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState("");
   const [searchResults, setSearchResults] = useState<Array<ACRMSearchResult>>(
     []
   );
 
-  const handleError = React.useCallback(
+  useEffect(() => {
+    // autoFocus property on the input element does not work
+    // We need to wait for the modal animated transition to finish
+    // and trigger the focus manually.
+    setTimeout(() => {
+      inputRef?.current?.focus();
+    }, 600);
+  }, []);
+
+  const handleError = useCallback(
     (error: string | Error, title?: string): void => {
       if (!error) {
         return;
@@ -158,7 +168,6 @@ export default function SearchTrackOrMBID({
       <div className="input-group track-search">
         <input
           type="search"
-          autoFocus
           value={inputValue}
           className="form-control"
           id="recording-mbid"
@@ -168,6 +177,7 @@ export default function SearchTrackOrMBID({
           }}
           placeholder="Track name or MusicBrainz URL/MBID"
           required
+          ref={inputRef}
         />
         <span className="input-group-btn">
           <button className="btn btn-default" type="button" onClick={reset}>


### PR DESCRIPTION
As requested in LB-1274 , this PR adds autofocus on the track search input as well as reestablishing Escape key to close the modal (we strayed away from Bootstrap modal JS's `data-toggle="modal"` for this modal in #2480 )