### PR TITLE
LB-1268: Placeholder for cover art not occupying full size in `Listening Now` unlike normal cover arts

### DIFF
--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -285,11 +285,7 @@
           max-width: @cover-art-thumbnail-size / 2;
           aspect-ratio: unset;
           border-radius: unset;
-        }
-      }
-      .add-cover-art {
-        .img {
-          max-height: 25px;
+          height: auto;
         }
       }
       img {

--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -276,7 +276,6 @@
       .cover-art-fallback {
         background-color: @gray-lighter;
         min-width: @cover-art-thumbnail-size;
-        height: inherit;
         display: flex;
         align-items: center;
         color: #cbcbcb;
@@ -286,6 +285,11 @@
           max-width: @cover-art-thumbnail-size / 2;
           aspect-ratio: unset;
           border-radius: unset;
+        }
+      }
+      .add-cover-art {
+        .img {
+          max-height: 25px;
         }
       }
       img {


### PR DESCRIPTION
# Problem

Placeholder for cover art not occupying full size in `Listening Now` unlike regular cover arts. This occurs because the picture icon is actually an img HTML element while the other icons are SVG (FontAwesome)

# Action

Added CSS to make the img occupy full size.

