### PR TITLE
LB-1291: Link to Update Intervals doc page

### DIFF
--- a/listenbrainz/webserver/templates/index/current-status.html
+++ b/listenbrainz/webserver/templates/index/current-status.html
@@ -47,6 +47,10 @@
         <a href="https://stats.metabrainz.org/d/000000059/rabbitmq?orgId=1&refresh=1m&var-queue_vhost=%2Flistenbrainz">
         RabbitMQ ListenBrainz view</a> shows how many listens we are currently processing, and the number of incoming listens currently queued for processing.
       </p>
+      
+      <p>
+        Something isn't updating? Stay calm and check the <a href="https://listenbrainz.readthedocs.io/en/latest/general/data-update-intervals.html">Expected Data Update Intervals</a> doc.
+      </p>
 
       <h3>load average</h3>
 


### PR DESCRIPTION
# Problem

We have a great new ‘expected data update intervals’ doc, but people might not see it.

# Solution

Added a link to the doc from the LB About > Status page


