### PR TITLE
LB-1256 Fix uses of APIUnauthorized error

### DIFF
--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -164,7 +164,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
             data=json.dumps({'metadata': metadata}),
             headers={'Authorization': 'Token {}'.format(self.user['auth_token'])},
         )
-        self.assert401(r)
+        self.assert403(r)
         data = json.loads(r.data)
         self.assertEqual("You don't have permissions to post to this user's timeline.", data['error'])
 
@@ -932,7 +932,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
             data=json.dumps({"metadata": metadata}),
             headers={'Authorization': 'Token {}'.format(user_one['auth_token'])},
         )
-        self.assert401(r)
+        self.assert403(r)
         data = json.loads(r.data)
         self.assertEqual("You don't have permissions to post to this user's timeline.", data['error'])
 

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -76,12 +76,13 @@ def create_user_recording_recommendation_event(user_name):
     :statuscode 200: Successful query, recording has been recommended!
     :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized, you do not have permissions to recommend recordings on the behalf of this user
+    :statuscode 403: Forbidden, you are not an approved user.
     :statuscode 404: User not found
     :resheader Content-Type: *application/json*
     """
     user = validate_auth_header()
     if user_name != user['musicbrainz_id']:
-        raise APIUnauthorized("You don't have permissions to post to this user's timeline.")
+        raise APIForbidden("You don't have permissions to post to this user's timeline.")
 
     try:
         data = orjson.loads(request.get_data())
@@ -188,7 +189,7 @@ def create_user_cb_review_event(user_name):
     """
     user = validate_auth_header()
     if user_name != user["musicbrainz_id"]:
-        raise APIUnauthorized("You don't have permissions to post to this user's timeline.")
+        raise APIForbidden("You don't have permissions to post to this user's timeline.")
 
     try:
         data = orjson.loads(request.get_data())
@@ -240,13 +241,14 @@ def user_feed(user_name: str):
     :statuscode 200: Successful query, you have feed events!
     :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized, you do not have permission to view this user's feed.
+    :statuscode 403: Forbidden, you do not have permission to view this user's feed.
     :statuscode 404: User not found
     :resheader Content-Type: *application/json*
     """
 
     user = validate_auth_header()
     if user_name != user['musicbrainz_id']:
-        raise APIUnauthorized("You don't have permissions to view this user's timeline.")
+        raise APIForbidden("You don't have permissions to view this user's timeline.")
 
     min_ts, max_ts, count = _validate_get_endpoint_params()
     if min_ts is None and max_ts is None:
@@ -367,13 +369,14 @@ def delete_feed_events(user_name):
     :statuscode 200: Successful deletion
     :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized
+    :statuscode 403: Forbidden, you do not have permission to delete from this user's feed.
     :statuscode 404: User not found
     :statuscode 500: API Internal Server Error
     :resheader Content-Type: *application/json*
     '''
     user = validate_auth_header()
     if user_name != user['musicbrainz_id']:
-        raise APIUnauthorized("You don't have permissions to delete from this user's timeline.")
+        raise APIForbidden("You don't have permissions to delete from this user's timeline.")
 
     try:
         event = orjson.loads(request.get_data())
@@ -425,6 +428,7 @@ def hide_user_timeline_event(user_name):
     :statuscode 200: Event hidden successfully
     :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized
+    :statuscode 403: Forbidden, you don't have permissions to hide events from this user's timeline.
     :statuscode 404: User not found
     :statuscode 500: API Internal Server Error
     :resheader Content-Type: *application/json*
@@ -432,7 +436,7 @@ def hide_user_timeline_event(user_name):
 
     user = validate_auth_header()
     if user_name != user['musicbrainz_id']:
-        raise APIUnauthorized("You don't have permissions to hide events from this user's timeline.")
+        raise APIForbidden("You don't have permissions to hide events from this user's timeline.")
 
     try:
         data = orjson.loads(request.get_data())
@@ -480,6 +484,7 @@ def unhide_user_timeline_event(user_name):
     :statuscode 200: Event unhidden successfully
     :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized
+    :statuscode 403: Forbidden
     :statuscode 404: User not found
     :statuscode 500: API Internal Server Error
     :resheader Content-Type: *application/json*
@@ -487,7 +492,7 @@ def unhide_user_timeline_event(user_name):
     
     user = validate_auth_header()
     if user_name != user['musicbrainz_id']:
-        raise APIUnauthorized("You don't have permissions to delete events from this user's timeline.")
+        raise APIForbidden("You don't have permissions to delete events from this user's timeline.")
 
     try:
         data = orjson.loads(request.get_data())
@@ -527,6 +532,7 @@ def create_personal_recommendation_event(user_name):
     :statuscode 400: Bad request, check ``response['error']`` for more details.
     :statuscode 401: Unauthorized, you do not have permissions to recommend
     personal recordings on the behalf of this user
+    :statuscode 403: Forbidden, you do not have permissions to recommend
     :statuscode 404: User not found
     :resheader Content-Type: *application/json*
     '''
@@ -534,7 +540,7 @@ def create_personal_recommendation_event(user_name):
     user = validate_auth_header()
 
     if user_name != user['musicbrainz_id']:
-        raise APIUnauthorized("You don't have permissions to post to this user's timeline.")
+        raise APIForbidden("You don't have permissions to post to this user's timeline.")
 
     try:
         data = orjson.loads(request.get_data())


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
At some places in the api endpoints, we return 401 Unauthorized error instead of 403 Forbidden for wrong auth token.
For instance, see https://github.com/metabrainz/listenbrainz-server/blob/b28e14f2843f221cd5cbe555c9eabdc50c1a6e36/listenbrainz/webserver/views/user_timeline_event_api.py#L252-L253 .

https://tickets.metabrainz.org/browse/LB-1256


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
 401 should be returned for missing or invalid token. If the token is valid but not authorized to access a resource, 403 should be returned. Therefore, the above case should be updated to return a 403 error instead.
So I made changes to 403 at couple of places and added docs.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


