### PR TITLE
Fix Spotify playlist export message

### DIFF
--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -509,7 +509,7 @@ export default class PlaylistPage extends React.Component<
       auth_token,
       playlistId
     );
-    const { external_url } = await result.json();
+    const { external_url } = result;
     newAlert(
       "success",
       "Playlist exported to Spotify",


### PR DESCRIPTION
Currently exporting a playlist to Spotify does work, but the resulting confirmation message breaks the page.
We were trying to get json from the response, which already returns json.
A very simple change indeed.