### PR TITLE
Add new script to fix "none" strings in recording_mbids

### DIFF
--- a/admin/timescale/updates/2023-06-130-fix-none-in-recording-mbid.sql
+++ b/admin/timescale/updates/2023-06-130-fix-none-in-recording-mbid.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+   UPDATE listen l                                                                                                                 
+      SET data = jsonb_set(l.data, '{additional_info,recording_mbid}', coalesce(to_jsonb(null::int), 'null'))
+    WHERE data->'additional_info'->>'recording_mbid' = 'None' 
+
+commit;


### PR DESCRIPTION
In debugging the export problem, I found that my listens export failed because we have some data->additional_info->recording_mbid that contains the string "None". Ooops. This additional script finds those and removes the recording_mbid key from the data.

After fixing one of my own listens, the export now fails on another listens. Not sure if this will fix the problem entirely, but it is one step forward.