### PR TITLE
Fix users_df selection in generating recommendations

### DIFF
--- a/listenbrainz_spark/recommendations/recording/recommend.py
+++ b/listenbrainz_spark/recommendations/recording/recommend.py
@@ -196,7 +196,7 @@ def get_user_name_and_user_id(all_users_df, users):
             .where(all_users_df.user_id.isin(users)) \
             .distinct()
 
-    if _is_empty_dataframe(all_users_df):
+    if _is_empty_dataframe(users_df):
         raise EmptyDataframeExcpetion('No active users found!')
 
     return users_df


### PR DESCRIPTION
Currently, the users_df is being read from candidate sets df but a failed attempt to generate candidate sets could make it outdated. Also, we actually write the users_df separately in the create dataframes step so simply read that.