### PR TITLE
Lay foundations for generating and storing apple music tokens

### DIFF
--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -10,7 +10,7 @@ CREATE TYPE user_timeline_event_type_enum AS ENUM('recording_recommendation', 'n
 
 CREATE TYPE hide_user_timeline_event_type_enum AS ENUM('recording_recommendation', 'recording_pin');
 
-CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm', 'librefm', 'musicbrainz');
+CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm', 'librefm', 'musicbrainz', 'apple');
 
 CREATE TYPE stats_range_type AS ENUM ('week', 'month', 'quarter', 'half_yearly', 'year', 'all_time',
     'this_week', 'this_month', 'this_year');

--- a/admin/sql/updates/2023-07-06-add-apple-as-external-service.sql
+++ b/admin/sql/updates/2023-07-06-add-apple-as-external-service.sql
@@ -1,0 +1,1 @@
+ALTER TYPE external_service_oauth_type ADD VALUE 'apple';

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -236,6 +236,12 @@ SPOTIFY_CLIENT_ID = '''{{template "KEY" "spotify/client_id"}}'''
 SPOTIFY_CLIENT_SECRET = '''{{template "KEY" "spotify/client_secret"}}'''
 SPOTIFY_CALLBACK_URL = '''{{template "KEY" "spotify/redirect_uri"}}'''
 
+# APPLE MUSIC
+APPLE_MUSIC_TEAM_ID = '''{{template "KEY" "apple/team_id"}}'''
+APPLE_MUSIC_KID = '''{{template "KEY" "apple/kid"}}'''
+APPLE_MUSIC_KEY = '''{{template "KEY" "apple/key"}}'''
+APPLE_MUSIC_CALLBACK_URL = '''{{template "KEY" "apple/redirect_uri"}}'''
+
 # CRITIQUEBRAINZ
 CRITIQUEBRAINZ_CLIENT_ID = '''{{template "KEY" "critiquebrainz/client_id"}}'''
 CRITIQUEBRAINZ_CLIENT_SECRET = '''{{template "KEY" "critiquebrainz/client_secret"}}'''

--- a/data/model/external_service.py
+++ b/data/model/external_service.py
@@ -7,3 +7,4 @@ class ExternalServiceType(Enum):
     MUSICBRAINZ = 'musicbrainz'
     LASTFM = 'lastfm'
     LIBREFM = 'librefm'
+    APPLE = 'apple'

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -161,6 +161,12 @@ CRITIQUEBRAINZ_CLIENT_ID = 'needs a non empty default value for tests, change th
 CRITIQUEBRAINZ_CLIENT_SECRET = 'needs a non empty default value for tests, change this'
 CRITIQUEBRAINZ_REDIRECT_URI = 'http://localhost:8100/profile/music-services/critiquebrainz/callback/'
 
+# APPLE MUSIC
+APPLE_MUSIC_TEAM_ID = 'needs a non empty default value for tests, change this'
+APPLE_MUSIC_KID = 'needs a non empty default value for tests, change this'
+APPLE_MUSIC_KEY = 'needs a non empty default value for tests, change this'
+APPLE_MUSIC_REDIRECT_URI = 'http://localhost:8100/profile/music-services/critiquebrainz/callback/'
+
 # YOUTUBE
 YOUTUBE_API_KEY = 'change me'
 

--- a/listenbrainz/domain/apple.py
+++ b/listenbrainz/domain/apple.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timedelta
+
+import jwt
+from flask import current_app
+
+DEVELOPER_TOKEN_VALIDITY = timedelta(days=180)
+
+
+def generate_developer_token():
+    """ Generate an Apple Music JWT token for use with Apple Music API """
+    key = current_app.config["APPLE_MUSIC_KEY"]
+    kid = current_app.config["APPLE_MUSIC_KID"]
+    team_id = current_app.config["APPLE_MUSIC_TEAM_ID"]
+
+    iat = datetime.now()
+    exp = iat + DEVELOPER_TOKEN_VALIDITY
+    token = jwt.encode(
+        {
+            "iss": team_id,
+            "iat": int(iat.timestamp()),
+            "exp": int(exp.timestamp())
+        },
+        key,
+        "ES256",
+        headers={"kid": kid}
+    )
+    return token

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ countryinfo==0.1.2
 urllib3==1.26.9
 orjson==3.8.7
 dnspython==2.2.1
+pyjwt==2.7.0


### PR DESCRIPTION
We need to generate and store developer tokens for integrating apple music in BrainzPlayer. Apple developer tokens are JWTs, add a method to generate these. Also, add apple as a service to services enum.