### PR TITLE
Generate weekly playlists once a week

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -8,8 +8,8 @@ MAILTO=""
 # Generating troi daily playlists runs hourly
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py run-daily-jams >> /logs/troi.log 2>&1
 # Batch generate weekly playlists
-4 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_troi_playlists --slug weekly-jams >> /logs/troi_spark.log
-5 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_troi_playlists --slug weekly-exploration >> /logs/troi_spark.log
+4 * * * 0,1 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_troi_playlists --slug weekly-jams >> /logs/troi_spark.log
+5 * * * 0,1 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_troi_playlists --slug weekly-exploration >> /logs/troi_spark.log
 
 ## Trigger an incremental dump everyday, near noon, far away from whole dump times, again do not block for the lock.
 0 0 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental >> /logs/dumps.log 2>&1

--- a/listenbrainz/troi/weekly_playlists.py
+++ b/listenbrainz/troi/weekly_playlists.py
@@ -18,10 +18,13 @@ from listenbrainz.troi.utils import get_existing_playlist_urls, SPOTIFY_EXPORT_P
 
 
 def get_users_for_weekly_playlists(create_all):
-    """ Retrieve the users who had midnight in their timezone less than 59 minutes ago and generate
-        the weekly playlists for them.
+    """ Retrieve the users who had their midnight in their timezone less than 59 minutes ago and
+        where its monday currently and generate the weekly playlists for them.
     """
-    timezone_filter = "WHERE EXTRACT('hour' from NOW() AT TIME ZONE COALESCE(us.timezone_name, 'GMT')) = 0"
+    timezone_filter = """
+        WHERE EXTRACT(HOUR from NOW() AT TIME ZONE COALESCE(us.timezone_name, 'GMT')) = 0
+          AND EXTRACT(DOW from NOW() AT TIME ZONE COALESCE(us.timezone_name, 'GMT')) = 1
+    """
     query = """
         SELECT "user".id as user_id
              , to_char(NOW() AT TIME ZONE COALESCE(us.timezone_name, 'GMT'), 'YYYY-MM-DD Dy') AS jam_date


### PR DESCRIPTION
The cron job is run every hour on Sunday and Monday so that we cover all timezones from UTC-11 to UTC+13. The cronjob invokes the troi playlist generator which then checks the users who just had the monday morning in their timezone. The playlists are then generated for only for these users. Over various runs, all timezones are covered.