### PR TITLE
Refactor spark handlers

### DIFF
--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -2,7 +2,8 @@ from listenbrainz.spark.spark_dataset import DatabaseDataset
 
 
 class PopularityDataset(DatabaseDataset):
-    """ Dataset class for top artists, recordings and releases from MLHD data """
+    """ Dataset class for artists, recordings and releases with popularity info (listen count and unique listener count)
+     from MLHD data """
 
     def __init__(self, entity):
         super().__init__(f"mlhd_popularity_{entity}", entity, "popularity")
@@ -25,7 +26,8 @@ class PopularityDataset(DatabaseDataset):
 
 
 class PopularityTopDataset(DatabaseDataset):
-    """ Dataset class for top recordings and releases per artist from MLHD data """
+    """ Dataset class for all recordings and releases with popularity info (total listen count and unique listener
+     count) for each artist in MLHD data. """
     def __init__(self, entity):
         super().__init__(f"mlhd_popularity_top_{entity}", f"top_{entity}", "popularity")
         self.entity = entity

--- a/listenbrainz/db/tags.py
+++ b/listenbrainz/db/tags.py
@@ -33,7 +33,7 @@ class _TagsDataset(DatabaseDataset):
 
         template = SQL("(%s, %s, %s, %s, {source})").format(source=Literal(message["source"]))
         values = []
-        for rec in message["recordings"]:
+        for rec in message["data"]:
             tags = [(rec["recording_mbid"], tag["tag"], tag["tag_count"], tag["_percent"]) for tag in rec["tags"]]
             values.extend(tags)
 

--- a/listenbrainz/db/tags.py
+++ b/listenbrainz/db/tags.py
@@ -6,6 +6,7 @@ from listenbrainz.spark.spark_dataset import DatabaseDataset
 
 
 class _TagsDataset(DatabaseDataset):
+    """ Dataset for recording/release-group/artist tags used for LB Tag radio. """
 
     def __init__(self):
         super().__init__("tags_dataset", "lb_tag_radio", schema="tags")

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -15,7 +15,7 @@ import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 from data.model.user_cf_recommendations_recording_message import UserRecommendationsJson
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
-from listenbrainz.db import year_in_music, couchdb, tags, popularity
+from listenbrainz.db import year_in_music, couchdb
 from listenbrainz.db.fresh_releases import insert_fresh_releases
 from listenbrainz.db import similarity
 from listenbrainz.db.similar_users import import_user_similarities
@@ -25,42 +25,6 @@ from listenbrainz.troi.year_in_music import yim_patch_runner
 
 TIME_TO_CONSIDER_STATS_AS_OLD = 20  # minutes
 TIME_TO_CONSIDER_RECOMMENDATIONS_AS_OLD = 7  # days
-
-
-def handle_couchdb_data_start(message):
-    match = couchdb.DATABASE_NAME_PATTERN.match(message["database"])
-    if not match:
-        return
-    try:
-        couchdb.create_database(match[1] + "_" + match[2] + "_" + match[3])
-        if match[1] == "artists":
-            couchdb.create_database("artistmap" + "_" + match[2] + "_" + match[3])
-    except HTTPError as e:
-        current_app.logger.error(f"{e}. Response: %s", e.response.json(), exc_info=True)
-
-
-def handle_couchdb_data_end(message):
-    # database names are of the format, prefix_YYYYMMDD. calculate and pass the prefix to the
-    # method to delete all database of the type except the latest one.
-    match = couchdb.DATABASE_NAME_PATTERN.match(message["database"])
-    # if the database name does not match pattern, abort to avoid deleting any data inadvertently
-    if not match:
-        return
-    try:
-        _, retained = couchdb.delete_database(match[1] + "_" + match[2])
-        if retained:
-            current_app.logger.info(f"Databases: {retained} matched but weren't deleted because"
-                                    f" _LOCK file existed")
-
-        # when new artist stats received, also invalidate old artist map stats
-        if match[1] == "artists":
-            _, retained = couchdb.delete_database("artistmap" + "_" + match[2])
-            if retained:
-                current_app.logger.info(f"Databases: {retained} matched but weren't deleted because"
-                                        f" _LOCK file existed")
-
-    except HTTPError as e:
-        current_app.logger.error(f"{e}. Response: %s", e.response.json(), exc_info=True)
 
 
 def _handle_stats(message, stats_type, key):
@@ -426,34 +390,12 @@ def handle_yim_tracks_of_the_year_end(message):
     yim_patch_runner(message["year"])
 
 
-def handle_similar_recordings_start(message):
-    similarity.start_prod_table("recording", message["algorithm"])
-
-
-def handle_similar_recordings_end(message):
-    similarity.end_prod_table("recording", message["algorithm"])
-
-
 def handle_similar_recordings(message):
-    if message.get("is_production_dataset"):
-        similarity.insert_prod_table("recording", message["data"], message["algorithm"])
-    else:
-        similarity.insert("recording", message["data"], message["algorithm"])
-
-
-def handle_similar_artists_start(message):
-    similarity.start_prod_table("artist_credit_mbids", message["algorithm"])
-
-
-def handle_similar_artists_end(message):
-    similarity.end_prod_table("artist_credit_mbids", message["algorithm"])
+    similarity.insert("recording", message["data"], message["algorithm"])
 
 
 def handle_similar_artists(message):
-    if message.get("is_production_dataset"):
-        similarity.insert_prod_table("artist_credit_mbids", message["data"], message["algorithm"])
-    else:
-        similarity.insert("artist_credit_mbids", message["data"], message["algorithm"])
+    similarity.insert("artist_credit_mbids", message["data"], message["algorithm"])
 
 
 def handle_troi_playlists(message):
@@ -462,35 +404,3 @@ def handle_troi_playlists(message):
 
 def handle_troi_playlists_end(message):
     batch_process_playlists_end(message["slug"])
-
-
-def handle_lb_tag_radio_start(message):
-    tags.start_table()
-
-
-def handle_lb_tag_radio_insert(message):
-    tags.insert(message["source"], message["data"])
-
-
-def handle_lb_tag_radio_end(message):
-    tags.end_table()
-
-
-def handle_popularity_recording(message):
-    popularity.insert_recording(message["data"])
-
-
-def handle_popularity_artist(message):
-    popularity.insert_artist(message["data"])
-
-
-def handle_popularity_release(message):
-    popularity.insert_release(message["data"])
-
-
-def handle_popularity_top_recording(message):
-    popularity.insert_top_recording(message["data"])
-
-
-def handle_popularity_top_release(message):
-    popularity.insert_top_release(message["data"])

--- a/listenbrainz/spark/spark_dataset.py
+++ b/listenbrainz/spark/spark_dataset.py
@@ -121,7 +121,7 @@ class DatabaseDataset(SparkDataset, ABC):
         Each item in the list should be a CREATE INDEX statement with a {suffix} and {table} marker that will be later
         formatted by the caller.
         """
-        raise NotImplementedError()
+        return []
 
     @abc.abstractmethod
     def get_inserts(self, message):

--- a/listenbrainz/spark/spark_dataset.py
+++ b/listenbrainz/spark/spark_dataset.py
@@ -100,7 +100,7 @@ class DatabaseDataset(SparkDataset, ABC):
         if suffix is None:
             table_name = self.base_table_name
         else:
-            table_name = f"{self.base_table_name}_tmp"
+            table_name = f"{self.base_table_name}_{suffix}"
 
         if self.schema is None or exclude_schema:
             return Identifier(table_name)
@@ -192,8 +192,10 @@ class DatabaseDataset(SparkDataset, ABC):
     def handle_insert(self, message):
         query, template, values = self.get_inserts(message)
         tmp_table = self._get_table_name("tmp")
-        query = SQL(query).format(tmp_table)
-        template = SQL(template)
+        query = SQL(query).format(table=tmp_table)
+
+        if isinstance(template, str):
+            template = SQL(template)
 
         conn = timescale.engine.raw_connection()
         try:

--- a/listenbrainz/spark/spark_dataset.py
+++ b/listenbrainz/spark/spark_dataset.py
@@ -1,0 +1,204 @@
+import abc
+import time
+from abc import ABC
+from urllib.error import HTTPError
+
+from flask import current_app
+from psycopg2.extras import execute_values
+from psycopg2.sql import Identifier, SQL, Literal
+
+from listenbrainz.db import couchdb, timescale
+
+
+class SparkDataset(ABC):
+
+    def __init__(self, name):
+        self.name = name
+
+    @abc.abstractmethod
+    def handle_start(self, message):
+        pass
+
+    @abc.abstractmethod
+    def handle_insert(self, message):
+        pass
+
+    @abc.abstractmethod
+    def handle_end(self, message):
+        pass
+
+    def get_handlers(self):
+        return {
+            f"{self.name}_start": self.handle_start,
+            self.name: self.handle_insert,
+            f"{self.name}_end": self.handle_end
+        }
+
+
+class _CouchDbDataset(SparkDataset):
+
+    def __init__(self):
+        super().__init__(name="couchdb_data")
+
+    def handle_start(self, message):
+        match = couchdb.DATABASE_NAME_PATTERN.match(message["database"])
+        if not match:
+            return
+        try:
+            couchdb.create_database(match[1] + "_" + match[2] + "_" + match[3])
+            if match[1] == "artists":
+                couchdb.create_database("artistmap" + "_" + match[2] + "_" + match[3])
+        except HTTPError as e:
+            current_app.logger.error(f"{e}. Response: %s", e.response.json(), exc_info=True)
+
+    def handle_insert(self, message):
+        raise NotImplementedError()
+
+    def handle_end(self, message):
+        # database names are of the format, prefix_YYYYMMDD. calculate and pass the prefix to the
+        # method to delete all database of the type except the latest one.
+        match = couchdb.DATABASE_NAME_PATTERN.match(message["database"])
+        # if the database name does not match pattern, abort to avoid deleting any data inadvertently
+        if not match:
+            return
+        try:
+            _, retained = couchdb.delete_database(match[1] + "_" + match[2])
+            if retained:
+                current_app.logger.info(f"Databases: {retained} matched but weren't deleted because"
+                                        f" _LOCK file existed")
+
+            # when new artist stats received, also invalidate old artist map stats
+            if match[1] == "artists":
+                _, retained = couchdb.delete_database("artistmap" + "_" + match[2])
+                if retained:
+                    current_app.logger.info(f"Databases: {retained} matched but weren't deleted because"
+                                            f" _LOCK file existed")
+
+        except HTTPError as e:
+            current_app.logger.error(f"{e}. Response: %s", e.response.json(), exc_info=True)
+
+
+CouchDbDataset = _CouchDbDataset()
+
+
+class DatabaseDataset(SparkDataset, ABC):
+    """ A base class that makes it simple to setup swap tables workflow for datasets generated
+    in spark and stored in timescale db.
+
+    When we start receiving the dataset, we create a temporary table to store the data. Once
+    the dataset has been received completely, we switch the temporary table with the production tables.
+    We do not use something like INSERT ON CONFLICT DO NOTHING to avoid mixups the last runs' results
+    (like tags being deleted since then).
+    """
+
+    def __init__(self, name, table_name, schema=None):
+        super().__init__(name)
+        self.base_table_name = table_name
+        self.schema = schema
+
+    def _get_table_name(self, suffix=None, exclude_schema=False):
+        if suffix is None:
+            table_name = self.base_table_name
+        else:
+            table_name = f"{self.base_table_name}_tmp"
+
+        if self.schema is None or exclude_schema:
+            return Identifier(table_name)
+        else:
+            return Identifier(self.schema, table_name)
+
+    @abc.abstractmethod
+    def get_table(self):
+        """ Return the table query to create the table for storing this dataset.
+
+            Note that the table name will be substituted later and should be specified as {table} in the query.
+        """
+        raise NotImplementedError()
+
+    def get_indices(self):
+        """ Return a list of indices to create on the dataset table.
+
+        Each item in the list should be a CREATE INDEX statement with a {suffix} and {table} marker that will be later
+        formatted by the caller.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_inserts(self, message):
+        """ Return the query and the template along with the rows to be inserted into the database using them.
+
+        Note that insert query should have a {table} marker to subsitute the name in it later and must have a
+        VALUES %s clause.
+        """
+        raise NotImplementedError()
+
+    def run_post_processing(self, cursor, message):
+        """ Called after the rotate table swap is complete so that the user can execute any post processing steps. """
+        pass
+
+    def create_table(self, cursor):
+        tmp_table = self._get_table_name("tmp")
+        query = SQL("DROP TABLE IF EXISTS {table}").format(table=tmp_table)
+        cursor.execute(query)
+
+        query = SQL(self.get_table()).format(table=tmp_table)
+        cursor.execute(query)
+
+    def create_indices(self, cursor):
+        tmp_table = self._get_table_name("tmp")
+        # add a random suffix to the index name to avoid issues while renaming
+        suffix = int(time.time())
+
+        for index in self.get_indices():
+            query = SQL(index).format(table=tmp_table, suffix=Literal(suffix))
+            cursor.execute(query)
+
+    def rotate_tables(self, cursor):
+        query = SQL("ALTER TABLE IF EXISTS {prod_table} RENAME TO {outgoing_table}").format(
+            prod_table=self._get_table_name(),
+            outgoing_table=self._get_table_name(suffix="old", exclude_schema=True)
+        )
+        cursor.execute(query)
+
+        query = SQL("ALTER TABLE IF EXISTS {incoming_table} RENAME TO {prod_table} ").format(
+            incoming_table=self._get_table_name("tmp"),
+            prod_table=self._get_table_name(exclude_schema=True)
+        )
+        cursor.execute(query)
+
+        query = SQL("DROP TABLE IF EXISTS {old_table}").format(old_table=self._get_table_name(suffix="old"))
+        cursor.execute(query)
+
+    def handle_start(self, message):
+        conn = timescale.engine.raw_connection()
+        try:
+            with conn.cursor() as curs:
+                self.create_table(curs)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def handle_end(self, message):
+        conn = timescale.engine.raw_connection()
+        try:
+            with conn.cursor() as curs:
+                self.create_indices(curs)
+                self.rotate_tables(curs)
+                self.run_post_processing(curs, message)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def handle_insert(self, message):
+        query, template, values = self.get_inserts(message)
+        tmp_table = self._get_table_name("tmp")
+        query = SQL(query).format(tmp_table)
+        template = SQL(template)
+
+        conn = timescale.engine.raw_connection()
+        try:
+            with conn.cursor() as curs:
+                execute_values(curs, query, values, template)
+            conn.commit()
+        finally:
+            conn.close()

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -6,98 +6,46 @@ import orjson
 from kombu import Connection, Message, Consumer, Exchange, Queue
 from kombu.mixins import ConsumerMixin
 
-from listenbrainz.spark.handlers import (handle_candidate_sets,
-                                         handle_dataframes,
-                                         handle_dump_imported, handle_model,
-                                         handle_recommendations,
-                                         handle_user_daily_activity,
-                                         handle_user_entity,
-                                         handle_couchdb_data_start,
-                                         handle_couchdb_data_end,
-                                         handle_user_listening_activity,
-                                         handle_sitewide_entity,
-                                         notify_artist_relation_import,
-                                         notify_mapping_import,
-                                         handle_missing_musicbrainz_data,
-                                         cf_recording_recommendations_complete,
-                                         handle_sitewide_listening_activity,
-                                         handle_similar_users,
-                                         handle_yim_new_releases_of_top_artists,
-                                         handle_yim_similar_users,
-                                         handle_yim_day_of_week,
-                                         handle_yim_most_listened_year,
-                                         handle_yim_top_stats,
-                                         handle_yim_listens_per_day,
-                                         handle_yim_listen_counts,
-                                         handle_fresh_releases,
-                                         handle_similar_recordings,
-                                         handle_similar_artists,
-                                         handle_entity_listener,
-                                         handle_yim_listening_time,
-                                         handle_new_artists_discovered_count,
-                                         handle_yim_tracks_of_the_year_start,
-                                         handle_yim_tracks_of_the_year_data,
-                                         handle_yim_tracks_of_the_year_end,
-                                         handle_yim_artist_map, handle_similar_recordings_start,
-                                         handle_similar_recordings_end, handle_troi_playlists,
-                                         handle_troi_playlists_end, handle_lb_tag_radio_insert, handle_lb_tag_radio_start,
-                                         handle_lb_tag_radio_end, handle_popularity_recording,
-                                         handle_popularity_release, handle_popularity_artist,
-                                         handle_popularity_top_recording, handle_popularity_top_release)
+from listenbrainz.db.popularity import RecordingPopularityDataset, ReleasePopularityDataset, \
+    TopRecordingPopularityDataset, ArtistPopularityDataset, TopReleasePopularityDataset
+from listenbrainz.db.similarity import SimilarRecordingsDataset, SimilarArtistsDataset
+from listenbrainz.db.tags import TagsDataset
+from listenbrainz.spark.handlers import (
+    handle_candidate_sets,
+    handle_dataframes,
+    handle_dump_imported,
+    handle_model,
+    handle_recommendations,
+    handle_user_daily_activity,
+    handle_user_entity,
+    handle_user_listening_activity,
+    handle_sitewide_entity,
+    notify_artist_relation_import,
+    notify_mapping_import,
+    handle_missing_musicbrainz_data,
+    cf_recording_recommendations_complete,
+    handle_sitewide_listening_activity,
+    handle_similar_users,
+    handle_yim_new_releases_of_top_artists,
+    handle_yim_similar_users,
+    handle_yim_day_of_week,
+    handle_yim_most_listened_year,
+    handle_yim_top_stats,
+    handle_yim_listens_per_day,
+    handle_yim_listen_counts,
+    handle_fresh_releases,
+    handle_entity_listener,
+    handle_yim_listening_time,
+    handle_new_artists_discovered_count,
+    handle_yim_tracks_of_the_year_start,
+    handle_yim_tracks_of_the_year_data,
+    handle_yim_tracks_of_the_year_end,
+    handle_yim_artist_map,
+    handle_troi_playlists,
+    handle_troi_playlists_end)
+from listenbrainz.spark.spark_dataset import CouchDbDataset
 from listenbrainz.utils import get_fallback_connection_name
 from listenbrainz.webserver import create_app
-
-response_handler_map = {
-    'couchdb_data_start': handle_couchdb_data_start,
-    'couchdb_data_end': handle_couchdb_data_end,
-    'user_entity': handle_user_entity,
-    'entity_listener': handle_entity_listener,
-    'user_listening_activity': handle_user_listening_activity,
-    'user_daily_activity': handle_user_daily_activity,
-    'sitewide_entity': handle_sitewide_entity,
-    'sitewide_listening_activity': handle_sitewide_listening_activity,
-    'fresh_releases': handle_fresh_releases,
-    'import_full_dump': handle_dump_imported,
-    'import_incremental_dump': handle_dump_imported,
-    'cf_recommendations_recording_dataframes': handle_dataframes,
-    'cf_recommendations_recording_model': handle_model,
-    'cf_recommendations_recording_candidate_sets': handle_candidate_sets,
-    'cf_recommendations_recording_recommendations': handle_recommendations,
-    'import_mapping': notify_mapping_import,
-    'import_artist_relation': notify_artist_relation_import,
-    'missing_musicbrainz_data': handle_missing_musicbrainz_data,
-    'cf_recommendations_recording_mail': cf_recording_recommendations_complete,
-    'similar_users': handle_similar_users,
-    'similar_recordings': handle_similar_recordings,
-    'similar_recordings_start': handle_similar_recordings_start,
-    'similar_recordings_end': handle_similar_recordings_end,
-    'similar_artists': handle_similar_artists,
-    'mlhd_popularity_recording': handle_popularity_recording,
-    'mlhd_popularity_artist': handle_popularity_artist,
-    'mlhd_popularity_release': handle_popularity_release,
-    'mlhd_popularity_top_recording': handle_popularity_top_recording,
-    'mlhd_popularity_top_release': handle_popularity_top_release,
-    'year_in_music_top_stats': handle_yim_top_stats,
-    'year_in_music_listens_per_day': handle_yim_listens_per_day,
-    'year_in_music_listen_count': handle_yim_listen_counts,
-    'year_in_music_similar_users': handle_yim_similar_users,
-    'year_in_music_new_releases_of_top_artists': handle_yim_new_releases_of_top_artists,
-    'year_in_music_day_of_week': handle_yim_day_of_week,
-    'year_in_music_most_listened_year': handle_yim_most_listened_year,
-    'year_in_music_listening_time': handle_yim_listening_time,
-    'year_in_music_artist_map': handle_yim_artist_map,
-    'year_in_music_new_artists_discovered_count': handle_new_artists_discovered_count,
-    'year_in_music_tracks_of_the_year_start': handle_yim_tracks_of_the_year_start,
-    'year_in_music_tracks_of_the_year_data': handle_yim_tracks_of_the_year_data,
-    'year_in_music_tracks_of_the_year_end': handle_yim_tracks_of_the_year_end,
-    'troi_playlists': handle_troi_playlists,
-    'troi_playlists_end': handle_troi_playlists_end,
-    'tags_dataset': handle_lb_tag_radio_insert,
-    'tags_dataset_start': handle_lb_tag_radio_start,
-    'tags_dataset_end': handle_lb_tag_radio_end,
-}
-
-RABBITMQ_HEARTBEAT_TIME = 60 * 60  # 1 hour, in seconds
 
 
 class SparkReader(ConsumerMixin):
@@ -108,6 +56,58 @@ class SparkReader(ConsumerMixin):
         self.spark_result_exchange = Exchange(app.config["SPARK_RESULT_EXCHANGE"], "fanout", durable=False)
         self.spark_result_queue = Queue(app.config["SPARK_RESULT_QUEUE"], exchange=self.spark_result_exchange,
                                         durable=True)
+        self.response_handlers = {}
+
+    def register_handlers(self):
+        datasets = [
+            CouchDbDataset,
+            SimilarRecordingsDataset,
+            SimilarArtistsDataset,
+            TagsDataset,
+            RecordingPopularityDataset,
+            ReleasePopularityDataset,
+            ArtistPopularityDataset,
+            TopRecordingPopularityDataset,
+            TopReleasePopularityDataset,
+        ]
+        for dataset in datasets:
+            self.response_handlers.update(dataset.get_handlers())
+
+        self.response_handlers.update({
+            'user_entity': handle_user_entity,
+            'entity_listener': handle_entity_listener,
+            'user_listening_activity': handle_user_listening_activity,
+            'user_daily_activity': handle_user_daily_activity,
+            'sitewide_entity': handle_sitewide_entity,
+            'sitewide_listening_activity': handle_sitewide_listening_activity,
+            'fresh_releases': handle_fresh_releases,
+            'import_full_dump': handle_dump_imported,
+            'import_incremental_dump': handle_dump_imported,
+            'cf_recommendations_recording_dataframes': handle_dataframes,
+            'cf_recommendations_recording_model': handle_model,
+            'cf_recommendations_recording_candidate_sets': handle_candidate_sets,
+            'cf_recommendations_recording_recommendations': handle_recommendations,
+            'import_mapping': notify_mapping_import,
+            'import_artist_relation': notify_artist_relation_import,
+            'missing_musicbrainz_data': handle_missing_musicbrainz_data,
+            'cf_recommendations_recording_mail': cf_recording_recommendations_complete,
+            'similar_users': handle_similar_users,
+            'year_in_music_top_stats': handle_yim_top_stats,
+            'year_in_music_listens_per_day': handle_yim_listens_per_day,
+            'year_in_music_listen_count': handle_yim_listen_counts,
+            'year_in_music_similar_users': handle_yim_similar_users,
+            'year_in_music_new_releases_of_top_artists': handle_yim_new_releases_of_top_artists,
+            'year_in_music_day_of_week': handle_yim_day_of_week,
+            'year_in_music_most_listened_year': handle_yim_most_listened_year,
+            'year_in_music_listening_time': handle_yim_listening_time,
+            'year_in_music_artist_map': handle_yim_artist_map,
+            'year_in_music_new_artists_discovered_count': handle_new_artists_discovered_count,
+            'year_in_music_tracks_of_the_year_start': handle_yim_tracks_of_the_year_start,
+            'year_in_music_tracks_of_the_year_data': handle_yim_tracks_of_the_year_data,
+            'year_in_music_tracks_of_the_year_end': handle_yim_tracks_of_the_year_end,
+            'troi_playlists': handle_troi_playlists,
+            'troi_playlists_end': handle_troi_playlists_end,
+        })
 
     def process_response(self, response):
         try:
@@ -118,7 +118,7 @@ class SparkReader(ConsumerMixin):
             return
         self.app.logger.info("Received message for %s", response_type)
         try:
-            response_handler = response_handler_map[response_type]
+            response_handler = self.response_handlers[response_type]
         except Exception:
             self.app.logger.error("Unknown response type: %s, doing nothing.", response_type, exc_info=True)
             return
@@ -156,6 +156,7 @@ class SparkReader(ConsumerMixin):
     def start(self):
         """ initiates RabbitMQ connection and starts consuming from the queue
         """
+        self.register_handlers()
         with self.app.app_context():
             while True:
                 try:

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -23,7 +23,8 @@ from listenbrainz.spark.handlers import (
     notify_artist_relation_import,
     notify_mapping_import,
     handle_missing_musicbrainz_data,
-    cf_recording_recommendations_complete, handle_couchdb_data_start)
+    cf_recording_recommendations_complete)
+from listenbrainz.spark.spark_dataset import CouchDbDataset
 from listenbrainz.webserver import create_app
 
 
@@ -72,7 +73,7 @@ class HandlersTestCase(DatabaseTestCase):
             ],
             'database': 'artists_all_time_20220718'
         }
-        handle_couchdb_data_start({"database": "artists_all_time_20220718"})
+        CouchDbDataset.handle_start({"database": "artists_all_time_20220718"})
         handle_user_entity(data)
 
         received = db_stats.get(self.user1['id'], 'artists', 'all_time', EntityRecord)
@@ -158,7 +159,7 @@ class HandlersTestCase(DatabaseTestCase):
             ],
             'database': 'listening_activity_all_time_20220718'
         }
-        handle_couchdb_data_start({"database": "listening_activity_all_time_20220718"})
+        CouchDbDataset.handle_start({"database": "listening_activity_all_time_20220718"})
         handle_user_listening_activity(data)
 
         received = db_stats.get(self.user1['id'], 'listening_activity', 'all_time', ListeningActivityRecord)
@@ -240,7 +241,7 @@ class HandlersTestCase(DatabaseTestCase):
             ],
             'database': 'daily_activity_all_time_20220718'
         }
-        handle_couchdb_data_start({"database": "daily_activity_all_time_20220718"})
+        CouchDbDataset.handle_start({"database": "daily_activity_all_time_20220718"})
         handle_user_daily_activity(data)
 
         received = db_stats.get(self.user1['id'], 'daily_activity', 'all_time', DailyActivityRecord)
@@ -300,7 +301,7 @@ class HandlersTestCase(DatabaseTestCase):
             ],
             'count': 1
         }
-        handle_couchdb_data_start({"database": "artists_all_time_20220818"})
+        CouchDbDataset.handle_start({"database": "artists_all_time_20220818"})
         handle_sitewide_entity(data)
         stats = db_stats.get(
             db_stats.SITEWIDE_STATS_USER_ID,

--- a/listenbrainz_spark/mlhd/popularity.py
+++ b/listenbrainz_spark/mlhd/popularity.py
@@ -91,5 +91,7 @@ def main():
     }
 
     for name, query in queries.items():
+        yield {"type": f"{name}_start"}
         for message in generate_popularity_stats(name, query):
             yield message
+        yield {"type": f"{name}_end"}


### PR DESCRIPTION
A lot of our spark generated datasets follow the write to temporary table, post process and do atomic rename swap model. To make code reuse simpler, create a base class for such datasets.

Note that the popularity datasets didn't have the swap implemented so far and with the changes mentioned before it becomes very simple to add.

I didn't reuse the BulkTable class from mbid_mapping to keep things simpler. That class deals with both MB and LB connections and it would also be non-trivial to share it among both containers in the current setup.