### PR TITLE
Handle standalone recordings in spotify id lookups

### DIFF
--- a/listenbrainz/labs_api/labs/api/spotify/spotify_mbid_lookup.py
+++ b/listenbrainz/labs_api/labs/api/spotify/spotify_mbid_lookup.py
@@ -73,7 +73,7 @@ class SpotifyIdFromMBIDQuery(Query):
             redirected_mbid = redirect_index.get(mbid, mbid)
             canonical_mbid = canonical_index.get(redirected_mbid, redirected_mbid)
 
-            mbid_metadata = metadata[canonical_mbid]
+            mbid_metadata = metadata.get(canonical_mbid, {})
             # regardless of whether we redirected the mbid, add the original mbid in the response returned to user
             mbid_metadata["recording_mbid"] = mbid
             ordered_metadata.append(mbid_metadata)

--- a/listenbrainz/labs_api/labs/api/spotify/utils.py
+++ b/listenbrainz/labs_api/labs/api/spotify/utils.py
@@ -87,9 +87,11 @@ def combined_without_album_detuned(item) -> str:
 def lookup_using_metadata(params: list[dict]):
     """ Given a list of dicts each having artist name, release name and track name, attempt to find spotify track
     id for each. """
-    metadata = {}
+    all_metadata, metadata = {}, {}
     for idx, item in enumerate(params):
-        metadata[idx] = item
+        all_metadata[idx] = item
+        if "artist_name" in item and "track_name" in item:
+            metadata[idx] = item
 
     # first attempt matching on artist, track and release followed by trying various detunings for unmatched recordings
     _, remaining_items = perform_lookup(LookupType.ALL, metadata, combined_all)
@@ -98,8 +100,9 @@ def lookup_using_metadata(params: list[dict]):
     _, remaining_items = perform_lookup(LookupType.WITHOUT_ALBUM, remaining_items, combined_without_album_detuned)
 
     # to the still unmatched recordings, add null value so that each item has in the response has spotify_track_id key
-    for item in remaining_items.values():
-        item["spotify_track_ids"] = []
+    for item in all_metadata.values():
+        if "spotify_track_ids" not in item:
+            item["spotify_track_ids"] = []
 
-    return list(metadata.values())
+    return list(all_metadata.values())
 


### PR DESCRIPTION
Sometimes, we encounter standalone recording mbids in LB playlists. We do not have data available for these in the mapping datasets therefore add the necessary empty fields for this to avoid 500 errors in various places.