### PR TITLE
Fix incorrect sidebar width

### DIFF
--- a/frontend/css/new-navbar.less
+++ b/frontend/css/new-navbar.less
@@ -19,7 +19,7 @@ body {
   display: flex;
   > nav[role="navigation"] {
     #side-nav {
-      min-width: @sidenav-width;
+      width: @sidenav-width;
       // using important here to override Botostrap 3 collapse plugin setting height
       height: 100vh !important;
       display: flex;
@@ -74,6 +74,8 @@ body {
         .username {
           font-weight: 700;
           margin-bottom: 0.3em;
+          // prevent long usernames from breaking the layout
+          word-break: break-all;
         }
         line-height: 1.5em;
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

The CSS generally expects the sidebar to have a known width of 190px (`@navbar-width`), but the actual sidebar ends up at around 210px, which causes the cover art/ListenBrainz logo in the player bar to be clipped.

![image](https://github.com/metabrainz/listenbrainz-server/assets/3387265/82f53b5b-fdec-4e71-b134-e5fa14477aef)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The sidebar width was specified using `min-width`, but as far as I can tell the sidebar is not actually supposed to grow. The browser applies a default width of 170px to the input element of the search bar, which in turn causes the sidebar to grow beyond the expected 190px.

This can be prevented by just setting the width directly using `width` instead.

Additionally, I added word breaking to the username, which should prevent long usernames from messing with the layout.
