### PR TITLE
LB-1327: Listening now: Deduplicate tags after fetching user's tags

### DIFF
--- a/frontend/js/src/tags/TagsComponent.tsx
+++ b/frontend/js/src/tags/TagsComponent.tsx
@@ -1,4 +1,4 @@
-import { isUndefined, noop } from "lodash";
+import { isUndefined, noop, uniqBy } from "lodash";
 import * as React from "react";
 import { useCallback, useState, useEffect } from "react";
 import {
@@ -116,8 +116,8 @@ export default function AddTagSelect(props: {
       const responseJSON = await response.json();
       const userTags = responseJSON["user-tags"];
       if (userTags?.length) {
-        setSelected((prevSelected) =>
-          userTags
+        setSelected((prevSelected) => {
+          const tagsArray: TagOptionType[] = userTags
             .map(
               (tag: { name: string }): TagOptionType => ({
                 value: tag.name,
@@ -129,8 +129,9 @@ export default function AddTagSelect(props: {
                 originalTag: { tag: tag.name, count: 1 },
               })
             )
-            .concat(prevSelected)
-        );
+            .concat(prevSelected);
+          return uniqBy(tagsArray, "value");
+        });
       }
     }
   }, [entityType, entityMBID, musicbrainzAuthToken, MBBaseURI]);


### PR DESCRIPTION
chaban reported in LB-1327 that there is an issue with duplicated tags in the Listening Now page when a user votes for a tag.

Looking at the code, it looks like we just set the array without deduplicating it, which would indeed look odd at best.
Adding some deduplication after fetching the user's tags should do the trick.

Before: 
<img width="556" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/f28bc0d0-21d0-4541-9d24-b67fd02cf3c1">

After:
<img width="561" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/c10e5647-0e7f-4eb5-b862-34629d48c9e0">
