### PR TITLE
Fix unstable sort order in python test

### DIFF
--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -852,7 +852,10 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(1, len(events))
 
         received = events[0].metadata.dict(exclude_none=True)
-        self.assertEqual(metadata, received)
+        self.assertEqual(metadata.recording_mbid, received.recording_mbid)
+        self.assertEqual(metadata.recording_msid, received.recording_msid)
+        self.assertEqual(set(metadata.users), set(received.users))
+        self.assertEqual(metadata.blurb_content, received.blurb_content)
 
     def test_personal_recommendation_checks_auth_token(self):
         user_one = db_user.get_or_create(2, "riksucks")


### PR DESCRIPTION
One test keeps having random failures due to the assertion of a list with unstable sort order.
Using `set(…)` to ensure the list elements are equal regardless of sort order.

Recent example of failing test: https://github.com/Aerozol/listenbrainz-server/actions/runs/6008353397/job/16295861342#step:6:1965