### PR TITLE
Add longplay link

### DIFF
--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -11,7 +11,7 @@
   <ul>
     <li><em><a href="https://www.videolan.org/vlc/">VLC</a></em>, cross-platform multimedia player: <a href="https://github.com/amCap1712/vlc-listenbrainz-plugin"><code>VLC Listenbrainz plugin</code></a></li>
     <li><em><a href="https://www.musicpd.org/">mpd</a></em>, cross-platform server-side application for playing music: <a href="https://codeberg.org/elomatreb/listenbrainz-mpd"><code>listenbrainz-mpd</code></a>, <a href="https://github.com/kori/wylt"><code>wylt</code></a></li>
-    <li><em><a href="https://www.strawberrymusicplayer.org/">Strawberry</a></em>, a cross-platform music player which supports ListenBrainz natively</li>
+    <li><em><a href="https://www.strawberrymusicplayer.org/">Strawberry</a></em>, a cross-platform music player</li>
     <li><em><a href="https://www.foobar2000.org/">Foobar2000</a></em>, full-fledged audio player for Windows: <a href="https://github.com/phw/foo_listenbrainz2"><code>foo_listenbrainz2</code></a></li>
     <li><em><a href="https://getmusicbee.com/">MusicBee</a></em>, a music manager and player for Windows: <a href="https://github.com/karaluh/ScrobblerBrainz"><code>ScrobblerBrainz plugin</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>

--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -17,6 +17,7 @@
     <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
     <li><em><a href="https://cmus.github.io/">cmus</a></em>, a console-based music player for Unix-like operating systems: <a href="https://github.com/vjeranc/cmus-status-scrobbler"><code>cmus-status-scrobbler</code></a></li>
+    <li><em><a href="https://longplay.app/">Longplay</a></em>, a album-based music player for iOS</li>
   </ul>
   
   <h4>Standalone programs/streaming servers</h4>

--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -17,7 +17,7 @@
     <li><em><a href="https://wiki.gnome.org/Apps/Rhythmbox/">Rhythmbox</a></em>, a music playing application for GNOME: <a href="https://github.com/phw/rhythmbox-plugin-listenbrainz"><code>rhythmbox-plugin-listenbrainz</code></a></li>
     <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
     <li><em><a href="https://cmus.github.io/">cmus</a></em>, a console-based music player for Unix-like operating systems: <a href="https://github.com/vjeranc/cmus-status-scrobbler"><code>cmus-status-scrobbler</code></a></li>
-    <li><em><a href="https://longplay.app/">Longplay</a></em>, a album-based music player for iOS</li>
+    <li><em><a href="https://longplay.app/">Longplay</a></em>, an album-based music player for iOS</li>
   </ul>
   
   <h4>Standalone programs/streaming servers</h4>


### PR DESCRIPTION
According to the Longplay developer ListenBrainz support has now been added in 2.0 - adding ‘Longplay’ to the Music Players list.

https://longplay.rocks/changelog/
(not mentioned in the changelog)