### PR TITLE
Fix unsafe access to possibly undefined artist_identifiers in playlist track metadata

### DIFF
--- a/frontend/js/src/playlists/utils.tsx
+++ b/frontend/js/src/playlists/utils.tsx
@@ -88,7 +88,7 @@ export function JSPFTrackToListen(track: JSPFTrack): Listen {
 
   listen.track_metadata.mbid_mapping = {
     artist_mbids:
-      customFields?.artist_identifiers.map(getArtistMBIDFromURI) ?? [],
+      customFields?.artist_identifiers?.map(getArtistMBIDFromURI) ?? [],
     artists: [],
     recording_mbid: recordingMBID,
     release_mbid: caa_release_mbid,

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -220,7 +220,7 @@ declare type SoundCloudTrack = {
   user: {
     id: string;
     username: string;
-  }
+  };
 };
 
 // Expect either a string or an Error or an html Response object
@@ -507,10 +507,9 @@ declare type JSPFPlaylistExtension = {
 
 declare type JSPFTrackExtension = {
   added_by: string;
-  artist_identifiers: string[]; // Full MusicBrainz artist URIs
   added_at: string; // ISO date string
+  artist_identifiers?: string[]; // Full MusicBrainz artist URIs
   release_identifier?: string; // Full MusicBrainz release URI
-
   additional_metadata?: { [key: string]: any };
 };
 


### PR DESCRIPTION
Apparently this object can be undefined, which wasn't planned for initially.

Currently, some playlists just crash the page entirely, as reported by @Aerozol (https://chatlogs.metabrainz.org/libera/metabrainz/2023-09-05/?msg=5220128&page=2)


+some very minor formatting