### PR TITLE
Stats art creator improvements

### DIFF
--- a/frontend/css/stats-art-creator.less
+++ b/frontend/css/stats-art-creator.less
@@ -37,6 +37,7 @@
 
   .settings-navbar {
     margin-left: auto;
+    max-width: 320px;
   }
 
   /*Color Picker*/

--- a/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
+++ b/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
@@ -122,13 +122,13 @@ const DEFAULT_IMAGE_SIZE = 750;
 
 // const fontOptions = Object.values(FontNameEnum).filter((v) => isNaN(Number(v)));
 
+const defaultStyleOnLoad = TemplateEnum["designer-top-5"] as TextTemplateOption;
+
 function ArtCreator() {
   const { currentUser } = React.useContext(GlobalAppContext);
   // Add images for the gallery, don't compose them on the fly
   const [userName, setUserName] = useState(currentUser?.name);
-  const [style, setStyle] = useState<TemplateOption>(
-    TemplateEnum["designer-top-5"]
-  );
+  const [style, setStyle] = useState<TemplateOption>(defaultStyleOnLoad);
   const [timeRange, setTimeRange] = useState<keyof typeof TimeRangeOptions>(
     "this_month"
   );
@@ -136,9 +136,15 @@ function ArtCreator() {
   const [gridLayout, setGridLayout] = useState(0);
   const [previewUrl, setPreviewUrl] = useState("");
   // const [font, setFont] = useState<keyof typeof FontNameEnum>("Roboto");
-  const [textColor, setTextColor] = useState<string>("#321529");
-  const [firstBgColor, setFirstBgColor] = useState<string>("");
-  const [secondBgColor, setSecondBgColor] = useState<string>("");
+  const [textColor, setTextColor] = useState<string>(
+    defaultStyleOnLoad.defaultColors[0]
+  );
+  const [firstBgColor, setFirstBgColor] = useState<string>(
+    defaultStyleOnLoad.defaultColors[1]
+  );
+  const [secondBgColor, setSecondBgColor] = useState<string>(
+    defaultStyleOnLoad.defaultColors[2]
+  );
   const previewSVGRef = React.useRef<SVGSVGElement>(null);
 
   const updateStyleButtonCallback = useCallback(

--- a/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
+++ b/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
@@ -295,6 +295,9 @@ function ArtCreator() {
     );
   }, [setPreviewUrl]);
   React.useEffect(() => {
+    if (!userName) {
+      return;
+    }
     debouncedSetPreviewUrl(style, userName, timeRange, gridSize, gridLayout);
   }, [
     userName,

--- a/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
+++ b/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
@@ -90,7 +90,7 @@ export const TemplateEnum: TemplateEnumType = {
   },
   [TemplateNameEnum.gridStatsSpecial]: {
     name: TemplateNameEnum.gridStatsSpecial,
-    displayName: "Album grid with special layout",
+    displayName: "Album grid alt",
     image: "/static/img/explore/stats-art/template-grid-stats-2.png",
     type: "grid",
     defaultGridSize: 5,

--- a/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
+++ b/frontend/js/src/explore/stats-art-designer/ArtCreator.tsx
@@ -125,7 +125,7 @@ const DEFAULT_IMAGE_SIZE = 750;
 const defaultStyleOnLoad = TemplateEnum["designer-top-5"] as TextTemplateOption;
 
 function ArtCreator() {
-  const { currentUser } = React.useContext(GlobalAppContext);
+  const { currentUser, APIService } = React.useContext(GlobalAppContext);
   // Add images for the gallery, don't compose them on the fly
   const [userName, setUserName] = useState(currentUser?.name);
   const [style, setStyle] = useState<TemplateOption>(defaultStyleOnLoad);
@@ -323,11 +323,11 @@ function ArtCreator() {
       ) => {
         if (styleArg.type === "grid") {
           setPreviewUrl(
-            `https://api.listenbrainz.org/1/art/grid-stats/${userNameArg}/${timeRangeArg}/${gridSizeArg}/${gridLayoutArg}/${DEFAULT_IMAGE_SIZE}`
+            `${APIService.APIBaseURI}/art/grid-stats/${userNameArg}/${timeRangeArg}/${gridSizeArg}/${gridLayoutArg}/${DEFAULT_IMAGE_SIZE}`
           );
         } else {
           setPreviewUrl(
-            `https://api.listenbrainz.org/1/art/${styleArg.name}/${userNameArg}/${timeRangeArg}/${DEFAULT_IMAGE_SIZE}`
+            `${APIService.APIBaseURI}/art/${styleArg.name}/${userNameArg}/${timeRangeArg}/${DEFAULT_IMAGE_SIZE}`
           );
         }
       },

--- a/frontend/js/src/explore/stats-art-designer/components/IconTray.tsx
+++ b/frontend/js/src/explore/stats-art-designer/components/IconTray.tsx
@@ -13,10 +13,18 @@ type IconTrayProps = {
   onClickDownload: React.MouseEventHandler;
   onClickCopy: React.MouseEventHandler;
   onClickCopyCode: React.MouseEventHandler;
+  onClickCopyURL: React.MouseEventHandler;
 };
 
 function IconTray(props: IconTrayProps) {
-  const { previewUrl, onClickDownload, onClickCopy, onClickCopyCode } = props;
+  const {
+    previewUrl,
+    onClickDownload,
+    onClickCopy,
+    onClickCopyCode,
+    onClickCopyURL,
+  } = props;
+  const browserHasClipboardAPI = "clipboard" in navigator;
   return (
     <div className="flex-center" id="share-button-bar">
       {/* <div className="profile">
@@ -38,20 +46,24 @@ function IconTray(props: IconTrayProps) {
         >
           <FontAwesomeIcon icon={faDownload} fixedWidth />
         </button>
-        <button
-          type="button"
-          className="btn btn-icon btn-info"
-          onClick={onClickCopy}
-        >
-          <FontAwesomeIcon icon={faCopy} fixedWidth />
-        </button>
-        <button
-          type="button"
-          className="btn btn-icon btn-info"
-          onClick={onClickCopyCode}
-        >
-          <FontAwesomeIcon icon={faCode} fixedWidth />
-        </button>
+        {browserHasClipboardAPI && (
+          <button
+            type="button"
+            className="btn btn-icon btn-info"
+            onClick={onClickCopy}
+          >
+            <FontAwesomeIcon icon={faCopy} fixedWidth />
+          </button>
+        )}
+        {browserHasClipboardAPI && (
+          <button
+            type="button"
+            className="btn btn-icon btn-info"
+            onClick={onClickCopyCode}
+          >
+            <FontAwesomeIcon icon={faCode} fixedWidth />
+          </button>
+        )}
         <div className="input-group link-container">
           <input
             type="text"
@@ -59,17 +71,17 @@ function IconTray(props: IconTrayProps) {
             disabled
             className="form-control"
           />
-          <span className="input-group-btn">
-            <button
-              type="button"
-              onClick={async () => {
-                await navigator.clipboard.writeText(previewUrl);
-              }}
-              className="btn btn-info btn-sm"
-            >
-              <FontAwesomeIcon icon={faLink} fixedWidth />
-            </button>
-          </span>
+          {browserHasClipboardAPI && (
+            <span className="input-group-btn">
+              <button
+                type="button"
+                onClick={onClickCopyURL}
+                className="btn btn-info btn-sm"
+              >
+                <FontAwesomeIcon icon={faLink} fixedWidth />
+              </button>
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/js/src/explore/stats-art-designer/utils.tsx
+++ b/frontend/js/src/explore/stats-art-designer/utils.tsx
@@ -1,4 +1,4 @@
-import { Canvg, presets } from "canvg";
+import { Canvg, RenderingContext2D, presets } from "canvg";
 
 export async function svgToBlob(
   width: number,
@@ -6,18 +6,48 @@ export async function svgToBlob(
   svgString: string,
   encodeType: string = "image/png"
 ): Promise<Blob> {
-  const canvas = new OffscreenCanvas(width, height);
+  let canvas: OffscreenCanvas | HTMLCanvasElement;
+  if ("OffscreenCanvas" in window) {
+    // Not supported everywhere: https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas#browser_compatibility
+    canvas = new OffscreenCanvas(width, height);
+  } else {
+    canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+  }
 
   const ctx = canvas.getContext("2d");
   if (!ctx) {
     throw new Error("No canvas context");
   }
-  const v = await Canvg.from(ctx, svgString, presets.offscreen());
+  const v = await Canvg.fromString(
+    ctx as RenderingContext2D,
+    svgString,
+    presets.offscreen()
+  );
 
   // Render only first frame, ignoring animations and mouse.
   await v.render();
 
-  const blob = await canvas.convertToBlob({ type: encodeType });
+  let blob;
+  if ("OffscreenCanvas" in window) {
+    blob = await (canvas as OffscreenCanvas).convertToBlob({
+      type: encodeType,
+    });
+  } else {
+    blob = await new Promise<Blob | null>((done, err) => {
+      try {
+        (canvas as HTMLCanvasElement).toBlob(done, encodeType);
+      } catch (error) {
+        err(error);
+      }
+    });
+    if (blob === null) {
+      throw new Error(
+        "No image to copy. This is most likely due to a canvas rendering issue in your browser"
+      );
+    }
+  }
   return blob;
 }
 export async function toPng(

--- a/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
@@ -1,6 +1,7 @@
 <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="{{ width }}" height="{{ height }}">
+     width="{{ width }}" height="{{ height }}"
+     viewBox="0 0 {{ width }} {{ height }}">
     <image x="89"
            y="318"
            width="195"


### PR DESCRIPTION
Just merged the previous PR, and kellnerd and I found some issues and small improvements straight away…

- default BG colors selected on load (defaults to the first text template)
- sidebar width should be constrained
- should not show an error on load if user is not logged in
- some issues with the Clipboard API, which is not implemented equally on all browsers. Tried to make it more robust, and hide the copy buttons / provide helpful error message if we're out of options
- use api base URI from global props to resolve CORS issues with images coming from other domains