### PR TITLE
Increase MAX_ITEMS_PER_GET to 1000

### DIFF
--- a/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
+++ b/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
@@ -99,7 +99,7 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
     def test_missing_musicbrainz_data_too_many(self):
         response = self.client.get(url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
                                            user_name=self.user['musicbrainz_id']),
-                                   query_string={'count': 108})
+                                   query_string={'count': 100})
         self.assert200(response)
         data = json.loads(response.data)['payload']
 

--- a/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
@@ -472,14 +472,14 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         data = json.loads(response.data)
 
-        self.assertEqual(data["count"], 100)
+        self.assertEqual(data["count"], 110)
         self.assertEqual(data["total_count"], 110)
         self.assertEqual(data["offset"], 0)
         self.assertEqual(data["user_name"], self.user2['musicbrainz_id'])
 
         feedback = data["feedback"]  # sorted in descending order of their creation
-        self.assertEqual(len(feedback), 100)
-        for i in range(100):
+        self.assertEqual(len(feedback), 110)
+        for i in range(110):
             self.assertEqual(feedback[i]['recording_mbid'], feedback_love[i]['recording_mbid'])
             self.assertEqual(feedback[i]['rating'], feedback_love[i]['rating'])
 

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -311,13 +311,13 @@ class StatsAPITestCase(IntegrationTestCase):
 
             # use different user for these subtest because otherwise need to update document
             # in existing database whose data may be needed in other tests.
-            with self.subTest(f"test api returns at most 100 stats in a response for {entity}", entity=entity):
+            with self.subTest(f"test api returns at most 1000 stats in a response for {entity}", entity=entity):
                 with open(self.path_to_data_file(f'user_top_{entity}_db_data_for_api_test_too_many.json'), 'r') as f:
                     payload = json.load(f)
                     payload[0]["user_id"] = self.another_user["id"]
                 db_stats.insert(f"{entity}_all_time_20220718", 0, 5, payload)
                 response = self.client.get(url_for(endpoint, user_name=self.another_user['musicbrainz_id']),
-                                           query_string={'count': 200})
+                                           query_string={'count': 100})
                 self.assertUserStatEqual(payload, response, entity, "all_time", total_count_key, 100,
                                          user_name=self.another_user['musicbrainz_id'])
 
@@ -504,7 +504,7 @@ class StatsAPITestCase(IntegrationTestCase):
                     payload = json.load(f)
                 db_stats.insert_sitewide_stats(f"{entity}_week_20220718", 0, 5, payload)
                 response = self.client.get(url_for(endpoint), query_string={'count': 200, 'range': 'week'})
-                self.assertSitewideStatEqual(payload, response, entity, "week", 100)
+                self.assertSitewideStatEqual(payload, response, entity, "week", 200)
 
     def _setup_listener_stats(self, file) -> dict:
         with open(self.path_to_data_file(file), "r") as f:

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -38,7 +38,7 @@ MAX_LISTEN_PAYLOAD_SIZE = MAX_LISTEN_SIZE * MAX_LISTENS_PER_REQUEST
 MAX_TAG_SIZE = 64
 
 #: The maximum number of listens returned in a single GET request.
-MAX_ITEMS_PER_GET = 100
+MAX_ITEMS_PER_GET = 1000
 
 #: The default number of listens returned in a single GET request.
 DEFAULT_ITEMS_PER_GET = 25


### PR DESCRIPTION
As requested here 

https://community.metabrainz.org/t/allow-getting-more-user-data-through-the-api

Setting the max number of items to get to 1000. Makes sense to me.

