### PR TITLE
LB-1347: Allow "Export to JSPF" option when user is not logged in on the LB radio page.

### DIFF
--- a/frontend/js/src/explore/lb-radio/Playlist.tsx
+++ b/frontend/js/src/explore/lb-radio/Playlist.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 
-import * as React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
-import { faCog, faFileExport } from "@fortawesome/free-solid-svg-icons";
 import { faSpotify } from "@fortawesome/free-brands-svg-icons";
-import GlobalAppContext from "../../utils/GlobalAppContext";
+import { faCog, faFileExport } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import * as React from "react";
 import PlaylistItemCard from "../../playlists/PlaylistItemCard";
+import GlobalAppContext from "../../utils/GlobalAppContext";
 
 type LBRadioFeedbackProps = {
   feedback: string[];
@@ -41,7 +41,6 @@ export function LBRadioFeedback(props: LBRadioFeedbackProps) {
 export function Playlist(props: PlaylistProps) {
   const { playlist, onSavePlaylist, onSaveToSpotify, onExportJSPF } = props;
   const { spotifyAuth, currentUser } = React.useContext(GlobalAppContext);
-  const enableOptions = Boolean(currentUser?.auth_token);
   const showSpotifyExportButton = spotifyAuth?.permission?.includes(
     "playlist-modify-public"
   );
@@ -54,59 +53,58 @@ export function Playlist(props: PlaylistProps) {
   return (
     <div>
       <div id="playlist-title">
-        {enableOptions && (
-          <span className="dropdown pull-right">
-            <button
-              className="btn btn-info dropdown-toggle"
-              type="button"
-              id="options-dropdown"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="true"
-            >
-              <FontAwesomeIcon icon={faCog as IconProp} title="Options" />
-              &nbsp;Options
-            </button>
-            <ul
-              className="dropdown-menu dropdown-menu-right"
-              aria-labelledby="options-dropdown"
-            >
-              <li>
-                <a onClick={onSavePlaylist} role="button" href="#">
-                  Save
-                </a>
-              </li>
-              {showSpotifyExportButton && (
-                <>
-                  <li role="separator" className="divider" />
-                  <li>
-                    <a
-                      onClick={onSaveToSpotify}
-                      id="exportPlaylistToSpotify"
-                      role="button"
-                      href="#"
-                    >
-                      <FontAwesomeIcon icon={faSpotify as IconProp} /> Export to
-                      Spotify
-                    </a>
-                  </li>
-                </>
-              )}
-              <li role="separator" className="divider" />
-              <li>
-                <a
-                  onClick={onExportJSPF}
-                  id="exportPlaylistToJSPF"
-                  role="button"
-                  href="#"
-                >
-                  <FontAwesomeIcon icon={faFileExport as IconProp} /> Export as
-                  JSPF
-                </a>
-              </li>
-            </ul>
-          </span>
-        )}
+        <span className="dropdown pull-right">
+          <button
+            className="btn btn-info dropdown-toggle"
+            type="button"
+            id="options-dropdown"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="true"
+          >
+            <FontAwesomeIcon icon={faCog as IconProp} title="Options" />
+            &nbsp;Options
+          </button>
+          <ul
+            className="dropdown-menu dropdown-menu-right"
+            aria-labelledby="options-dropdown"
+          >
+            <li>
+              <a onClick={onSavePlaylist} role="button" href="#">
+                Save
+              </a>
+            </li>
+            {showSpotifyExportButton && (
+              <>
+                <li role="separator" className="divider" />
+                <li>
+                  <a
+                    onClick={onSaveToSpotify}
+                    id="exportPlaylistToSpotify"
+                    role="button"
+                    href="#"
+                  >
+                    <FontAwesomeIcon icon={faSpotify as IconProp} /> Export to
+                    Spotify
+                  </a>
+                </li>
+              </>
+            )}
+            <li role="separator" className="divider" />
+            <li>
+              <a
+                onClick={onExportJSPF}
+                id="exportPlaylistToJSPF"
+                role="button"
+                href="#"
+              >
+                <FontAwesomeIcon icon={faFileExport as IconProp} /> Export as
+                JSPF
+              </a>
+            </li>
+          </ul>
+        </span>
+
         <div id="title">{playlist?.title}</div>
         <div id="description">{playlist?.annotation}</div>
       </div>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
Currently on the LB radio page the entire options button is not rendered when the user is not logged in, preventing them from exporting the playlist to JSPF.
<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution
Removed user authorization check for displaying option menu.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


