### PR TITLE
Fixes for running apple metadata cache

### DIFF
--- a/listenbrainz/metadata_cache/apple/runner.py
+++ b/listenbrainz/metadata_cache/apple/runner.py
@@ -1,0 +1,11 @@
+from listenbrainz.metadata_cache.apple.handler import AppleCrawlerHandler
+from listenbrainz.metadata_cache.consumer import ServiceMetadataCache
+from listenbrainz.webserver import create_app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    with app.app_context():
+        handler = AppleCrawlerHandler(app)
+        smc = ServiceMetadataCache(app, handler)
+        smc.start()

--- a/listenbrainz/metadata_cache/consumer.py
+++ b/listenbrainz/metadata_cache/consumer.py
@@ -34,7 +34,8 @@ class ServiceMetadataCache(ConsumerMixin):
         self.service_queue = Queue(
             self.handler.external_service_queue,
             exchange=self.external_services_exchange,
-            durable=True
+            durable=True,
+            routing_key=self.handler.external_service_queue
         )
 
     def get_consumers(self, _, channel):
@@ -80,7 +81,7 @@ class ServiceMetadataCache(ConsumerMixin):
                 self.crawler = Crawler(self.app, self.handler)
                 self.crawler.start()
 
-                self.app.logger.info("Starting Spotify Metadata Cache ...")
+                self.app.logger.info(f"Starting {self.crawler.name} Metadata Cache ...")
                 self.init_rabbitmq_connection()
                 self.run()
             except KeyboardInterrupt:
@@ -88,7 +89,7 @@ class ServiceMetadataCache(ConsumerMixin):
                 self.app.logger.error("Keyboard interrupt!")
                 break
             except Exception:
-                self.app.logger.error("Error in Spotify Metadata Cache: ", exc_info=True)
+                self.app.logger.error(f"Error in {self.crawler.name} Metadata Cache: ", exc_info=True)
                 time.sleep(3)
         # the while True loop above makes this line unreachable but adding it anyway
         # so that we remember that every started thread should also be joined.

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,4 +55,4 @@ countryinfo==0.1.2
 urllib3==1.26.9
 orjson==3.8.7
 dnspython==2.2.1
-pyjwt==2.7.0
+pyjwt[crypto]==2.7.0


### PR DESCRIPTION
- Add missing crypto dependency and runner file. 
- Fix storefront logic in cache seeder. 
- Add routing key when registering consumer.
