### PR TITLE
Update add-data.html

### DIFF
--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -18,6 +18,9 @@
     <li><em><a href="https://wiki.gnome.org/Apps/Lollypop">Lollypop</a></em>, a modern music player for GNOME</li>
     <li><em><a href="https://cmus.github.io/">cmus</a></em>, a console-based music player for Unix-like operating systems: <a href="https://github.com/vjeranc/cmus-status-scrobbler"><code>cmus-status-scrobbler</code></a></li>
     <li><em><a href="https://longplay.app/">Longplay</a></em>, an album-based music player for iOS</li>
+    <li><em><a href="https://powerampapp.com/">Poweramp</a></em>, a music player for Android: <a href="https://github.com/StratusFearMe21/listenbrainz-poweramp"><code>plugin</code></a></li>
+    <li><em><a href="https://tauonmusicbox.rocks/">Tauon Music Box</a></em>, a music player for Linux, Arch Linux, and Windows</li>
+    <li><em><a href="https://quodlibet.readthedocs.io/">Quod Libet</a></em>, a cross-platform audio player</li>
   </ul>
   
   <h4>Standalone programs/streaming servers</h4>


### PR DESCRIPTION
Adding new LB-supporting players to the list:
**PowerAmp** (and the plugin required)
**Tauon Music Box** (has support for ListenBrainz and Picard is its default tag editor!)
**Quod Libet** (https://quodlibet.readthedocs.io/en/latest/changelog.html - “Move listenbrainz plugin to the right location” lol)