### PR TITLE
docs: list gonic as a listenbrainz compatible music server

### DIFF
--- a/listenbrainz/webserver/templates/index/add-data.html
+++ b/listenbrainz/webserver/templates/index/add-data.html
@@ -27,13 +27,14 @@
   <ul>
     <li><em><a href="https://github.com/InputUsername/rescrobbled">Rescrobbled</a></em>, a universal Linux scrobbler for MPRIS enabled players</li>
     <li><em><a href="https://github.com/mariusor/mpris-scrobbler">mpris-scrobbler</a></em>, a minimalistic unix scrobbler for MPRIS enabled players</li>
-    <li><em><a href="https://github.com/FoxxMD/multi-scrobbler">Multi-scrobbler</a></em>, a powerful javascript server application for all platforms, with support for many sources.</li>
-    <li><em><a href="https://www.smashbits.nl/smashtunes/">SmashTunes</a></em>, a Mac menu bar utility for displaying the current track. Submits Apple Music and Spotify listens.</li>
+    <li><em><a href="https://github.com/FoxxMD/multi-scrobbler">Multi-scrobbler</a></em>, a powerful javascript server application for all platforms, with support for many sources</li>
+    <li><em><a href="https://www.smashbits.nl/smashtunes/">SmashTunes</a></em>, a Mac menu bar utility for displaying the current track. Submits Apple Music and Spotify listens</li>
     <li><em><a href="https://github.com/golgote/applescript-listenbrainz">applescript-listenbrainz</a></em>, an applescript service to submit Apple Music listens</li>
     <li><em><a href="https://github.com/simonxciv/eavesdrop.fm">Eavesdrop.FM</a></em>, submits Plex music listening data to ListenBrainz</li>
     <li><em><a href="https://github.com/vvdleun/audiostreamerscrobbler">AudioStreamerScrobbler</a></em>, submit listens from hardware audiostreamers (Bluesound/BluOS, MusicCast, HEOS)</li>
     <li><em><a href="https://docs.funkwhale.audio/users/builtinplugins.html#listenbrainz-plugin">Funkwhale</a></em>, a decentralized music sharing and listening platform with built-in support for ListenBrainz</li>
     <li><em><a href="https://jellyfin.org/">Jellyfin</a></em>, a free software media streaming system: <a href="https://github.com/lyarenei/jellyfin-plugin-listenbrainz"><code>jellyfin-plugin-listenbrainz</code></a></li>
+    <li><em><a href="https://github.com/sentriz/gonic">gonic</a></em>, a free software Subsonic-compatible music server, has built-in support for ListenBrainz</li>
   </ul>
   
   <h4>Browser extensions</h4>


### PR DESCRIPTION
not really a problem/solution/action situation as asked by the template, but instead just updating the docs to add [gonic](github.com/sentriz/gonic) as an option here 


![image](https://github.com/metabrainz/listenbrainz-server/assets/6832539/a09b571d-6e93-447c-8dc8-b76feded3e6b)

https://listenbrainz.org/add-data/

thanks!

