### PR TITLE
Fix API docs link 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ completely open-source and publish our data as open data.
 
 You can use ListenBrainz to track your music listening habits and
 share your taste with others using our visualizations. We also have an
-[API](https://listenbrainz.readthedocs.io/en/production/dev/api/)
+[API](https://listenbrainz.readthedocs.io/en/latest/users/api/index.html)
 if you want to do more with our data.
 
 ListenBrainz is operated by the [MetaBrainz Foundation](https://metabrainz.org)

--- a/listenbrainz/webserver/templates/index/index.html
+++ b/listenbrainz/webserver/templates/index/index.html
@@ -15,7 +15,7 @@
         share your taste with others using our visualizations.
         <br>
         We also have an
-        <a href="https://listenbrainz.readthedocs.io/en/production/dev/api/">API</a>
+        <a href="https://listenbrainz.readthedocs.io/en/latest/users/api/index.html">API</a>
         if you want to do more with our data.
       </p>
       <p>


### PR DESCRIPTION
# Problem

The current API docs link is a 404.

# Solution

Replace it with the link from https://listenbrainz.readthedocs.io/en/latest/index.html.
