### PR TITLE
LB-1332: Display user top navigation on playlist page

### DIFF
--- a/listenbrainz/webserver/templates/playlists/playlist.html
+++ b/listenbrainz/webserver/templates/playlists/playlist.html
@@ -1,10 +1,7 @@
-{% extends 'base-react.html' %}
-
-{% block content %}
-
-  {{ super() }}
-
-{% endblock %}
+{% extends 'user/base.html' %}
+{%- block title -%}
+   Playlist - ListenBrainz
+{%- endblock-%}
 
 {% block scripts %}
   {{ super() }}

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -7,6 +7,7 @@ from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 from listenbrainz.webserver.views.playlist_api import serialize_jspf, fetch_playlist_recording_metadata
 import listenbrainz.db.playlist as db_playlist
+import listenbrainz.db.user as db_user
 
 playlist_bp = Blueprint("playlist", __name__)
 
@@ -34,7 +35,10 @@ def load_playlist(playlist_mbid: str):
         "playlist": serialize_jspf(playlist),
     }
 
+    playlist_creator = db_user.get(playlist.creator_id)
+
     return render_template(
         "playlists/playlist.html",
-        props=orjson.dumps(props).decode("utf-8")
+        props=orjson.dumps(props).decode("utf-8"),
+        user=playlist_creator
     )


### PR DESCRIPTION
Currently, the playlist page does not show any navbar at the top of the page, a departure from our other pages that is confusing and doesn't look great.

As discussed in  LB-1332 we decided to show the navbar associated with the playlist's owner, to facilitate useful navigation.
The rationale was: "I assume most of the time people will be navigating from that persons playlist page anyway, or from their YIM or similar, so I think this makes sense. Even if they're randomly linked from the internet it invites them to explore the playlist creator's other pages."

Before:
<img width="1280" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/47f361e8-bc87-4f49-98a9-284f1c84089c">


After:
<img width="1280" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/4a2510c9-635e-4701-8255-f52692af2619">
 P.S: ^ here I am not logged in