### PR TITLE
Max-width for sidenav

### DIFF
--- a/frontend/css/new-navbar.less
+++ b/frontend/css/new-navbar.less
@@ -19,7 +19,7 @@ body {
   display: flex;
   > nav[role="navigation"] {
     max-width: @sidenav-width;
-    
+
     #side-nav {
       min-width: @sidenav-width;
       // using important here to override Botostrap 3 collapse plugin setting height

--- a/frontend/css/new-navbar.less
+++ b/frontend/css/new-navbar.less
@@ -18,6 +18,8 @@
 body {
   display: flex;
   > nav[role="navigation"] {
+    max-width: @sidenav-width;
+    
     #side-nav {
       min-width: @sidenav-width;
       // using important here to override Botostrap 3 collapse plugin setting height
@@ -168,6 +170,7 @@ body {
   @media (max-width: @offscreen-sidenav-breakpoint) {
     display: initial;
     > nav[role="navigation"] {
+      max-width: unset;
       #side-nav {
         transition: transform 0.3s ease-in-out;
         position: fixed;


### PR DESCRIPTION
Otherwise we have issues on Firefox where the width exceeds the expected 190px (which other parts of the website expect such as BrainzPlayer)
