### PR TITLE
Docs: Clarify that listened_at should be set to start of playback

### DIFF
--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -156,7 +156,8 @@ A minimal payload must include
 ``artist_name`` and ``track_name`` elements must be simple strings.
 
 The payload should also include the ``listened_at`` element, which must be an integer
-representing the Unix time when the track was listened to. The minimum accepted
+representing the Unix time when the track was listened to. This should be set to
+playback start time of the submitted track. The minimum accepted
 value for this field is :data:`~listenbrainz.webserver.views.api_tools.LISTEN_MINIMUM_TS`.
 playing_now requests should not have a ``listened_at`` field
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

The API docs at https://listenbrainz.readthedocs.io/en/latest/users/json.html are unclear about to which time the value of `listened_at` should be set to. Different tools use different times. Common is either the time when playback started, but in some cases tools set the time when the listen was marked for submission (so usually after half the track or 4 minutes of listening).

In the discussion at https://community.metabrainz.org/t/listened-at-parameter-for-submissions-specification-unclear/659142 it was explained, that playback start time is preferred.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Update the API documentation to make clear `listened_at` *should* be time of playback start. This is intentionally formulated as should and not must. For technical reasons clients might not be able to submit the playback start time and instead will have to use the time when the listen gets marked for submission.