### PR TITLE
Update troi to the latest release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.7.1
 spotipy>=2.22.1
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@a1e12968af93d2f296a42a8094ebff83f3ed33f3
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@6b02541946f3e7b308ba20b04de8817463c1e504
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2023-10-30.0
 PyYAML==6.0
 eventlet == 0.33.1
 # eventlet fails to patch dnspython >= 2.3 https://github.com/eventlet/eventlet/issues/781


### PR DESCRIPTION
Update troi to the v-2023-10-30.0 release to include album data into listen submission from LB Radio tracks.