### PR TITLE
Fix user similarity

### DIFF
--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -1,5 +1,10 @@
 FROM metabrainz/listenbrainz-spark-base:latest
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+                       libcurl4-openssl-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY docker/spark-cluster-config/test/core-site.xml $HADOOP_HOME/etc/hadoop/core-site.xml
 COPY docker/spark-cluster-config/test/hdfs-site.xml $HADOOP_HOME/etc/hadoop/hdfs-site.xml
 COPY docker/spark-cluster-config/test/spark-env.sh $SPARK_HOME/conf/spark-env.sh

--- a/frontend/js/src/stats/SimilarityScore.tsx
+++ b/frontend/js/src/stats/SimilarityScore.tsx
@@ -21,10 +21,9 @@ const getclassName = (similarityScore: number): string => {
 function SimilarityScore(props: SimilarityScoreProps) {
   const { user, type, similarityScore } = props;
 
-  // We transform the similarity score from a scale 0-1 to 0-10
-  const adjustedSimilarityScore = Number((similarityScore * 10).toFixed(1));
+  // We transform the similarity score from a scale 0-1 to 0-100
+  const percentage = Number((similarityScore * 100).toFixed());
   const className = getclassName(similarityScore);
-  const percentage = adjustedSimilarityScore * 10;
 
   return (
     <div
@@ -49,11 +48,11 @@ function SimilarityScore(props: SimilarityScoreProps) {
       </div>
       {type === "regular" ? (
         <p className="text-muted">
-          Your compatibility with {user?.name} is {adjustedSimilarityScore}
-          /10
+          Your compatibility with {user?.name} is {percentage}
+          % 
         </p>
       ) : (
-        <p className="small text-muted">{adjustedSimilarityScore}/10</p>
+        <p className="small text-muted">{percentage}%</p>
       )}
     </div>
   );

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -164,9 +164,9 @@ class UserTestCase(DatabaseTestCase):
         user_id_22 = db_user.create(22, "twenty_two")
         user_id_23 = db_user.create(23, "twenty_three")
 
-        similar_users_21 = {str(user_id_22): [0.4, .01], str(user_id_23): [0.7, 0.001]}
-        similar_users_22 = {str(user_id_21): [0.4, .01]}
-        similar_users_23 = {str(user_id_21): [0.7, .02]}
+        similar_users_21 = {str(user_id_22): 0.4, str(user_id_23): 0.7}
+        similar_users_22 = {str(user_id_21): 0.4}
+        similar_users_23 = {str(user_id_21): 0.7}
 
         similar_users = {
             str(user_id_21): similar_users_21,
@@ -230,9 +230,9 @@ class UserTestCase(DatabaseTestCase):
                 {
                     "user_id": searcher_id,
                     "similar_users": json.dumps({
-                        str(user_id_c): [0.42, 0.20],
-                        str(user_id_l): [0.61, 0.25],
-                        str(user_id_r): [0.87, 0.43]
+                        str(user_id_c): 0.42,
+                        str(user_id_l): 0.61,
+                        str(user_id_r): 0.87
                     })
                 }
             )

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -462,7 +462,7 @@ def get_similar_users(user_id: int) -> Optional[list[dict]]:
         result = connection.execute(sqlalchemy.text("""
             SELECT musicbrainz_id
                  , id
-                 , value->0 AS similarity -- first element of array is local similarity, second is global_similarity
+                 , value AS similarity
               FROM recommendation.similar_user r 
               JOIN jsonb_each(r.similar_users) j
                 ON TRUE

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -664,7 +664,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
         conn = db.engine.raw_connection()
         with conn.cursor() as curs:
-            data = {self.user2['id']: (.123, 0.01)}
+            data = {self.user2['id']: .123}
             curs.execute("""INSERT INTO recommendation.similar_user VALUES (%s, %s)""",
                          (self.user['id'], json.dumps(data)))
         conn.commit()

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -59,9 +59,9 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.insert(user, following_user['id'], 'follow')
         return following_user
 
-    def create_similar_user(self, similar_to_user: int, mb_row_id: int, similarity: float, global_similarity: float, name: str) -> dict:
+    def create_similar_user(self, similar_to_user: int, mb_row_id: int, similarity: float, name: str) -> dict:
         similar_user = db_user.get_or_create(mb_row_id, name)
-        self.similar_user_data[similar_user['id']] = (similarity, global_similarity)
+        self.similar_user_data[similar_user['id']] = similarity
         with db.engine.begin() as connection:
             connection.execute(text("""
                 INSERT INTO recommendation.similar_user (user_id, similar_users)
@@ -150,8 +150,8 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             payload = json.load(f)
 
         self.similar_user_data = dict()
-        similar_user_1 = self.create_similar_user(self.main_user['id'], 104, 0.1, 0.1, 'similar_1')
-        similar_user_2 = self.create_similar_user(self.main_user['id'], 105, 0.2, 0.2, 'similar_2')
+        similar_user_1 = self.create_similar_user(self.main_user['id'], 104, 0.1, 'similar_1')
+        similar_user_2 = self.create_similar_user(self.main_user['id'], 105, 0.2, 'similar_2')
 
         ts = int(time.time())
         # Send 3 listens for the following_user_1

--- a/listenbrainz_spark/mlhd/popularity.py
+++ b/listenbrainz_spark/mlhd/popularity.py
@@ -141,13 +141,13 @@ def main():
     read_files_from_HDFS(RELEASE_METADATA_CACHE_DATAFRAME).createOrReplaceTempView(rel_cache_table)
 
     queries = {
-        # "mlhd_popularity_top_recording": get_popularity_per_artist_query("recording", mlhd_table, listens_table),
-        # "mlhd_popularity_recording": get_popularity_query("recording", mlhd_table, listens_table),
-        # "mlhd_popularity_release": get_popularity_query("release", mlhd_table, listens_table),
-        # "mlhd_popularity_release_group": get_release_group_popularity_query(mlhd_table, listens_table, rel_cache_table),
+        "mlhd_popularity_top_recording": get_popularity_per_artist_query("recording", mlhd_table, listens_table),
+        "mlhd_popularity_recording": get_popularity_query("recording", mlhd_table, listens_table),
+        "mlhd_popularity_release": get_popularity_query("release", mlhd_table, listens_table),
+        "mlhd_popularity_release_group": get_release_group_popularity_query(mlhd_table, listens_table, rel_cache_table),
         "mlhd_popularity_top_release_group": get_release_group_popularity_per_artist_query(mlhd_table, listens_table, rel_cache_table),
-        # "mlhd_popularity_artist": get_popularity_per_artist_query("artist", mlhd_table, listens_table),
-        # "mlhd_popularity_top_release": get_popularity_per_artist_query("release", mlhd_table, listens_table)
+        "mlhd_popularity_artist": get_popularity_per_artist_query("artist", mlhd_table, listens_table),
+        "mlhd_popularity_top_release": get_popularity_per_artist_query("release", mlhd_table, listens_table)
     }
 
     for name, query in queries.items():


### PR DESCRIPTION
Right now user similarity leaves a lot to be desired:

   https://community.metabrainz.org/t/how-is-user-similarity-score-calculated/662453

That thread made me realize that we're being stupid about scaling the user similarity and that it actually already works fine as percentage, we just need to scale it a bit. More trickly, it changes the format of the similar user data -- we will need to consider this carefully when we merge this. Perhaps keeping it backwards compatible for now might be good; thoughts? @amCap1712 

THIS CODE HAS NOT BEEN TESTED. DO NOT MERGE.