### PR TITLE
LB-1386: Fix play various artists album on LB

### DIFF
--- a/listenbrainz/webserver/views/player.py
+++ b/listenbrainz/webserver/views/player.py
@@ -164,7 +164,7 @@ def load_release(release_mbid):
                 for recording in medium.get("track-list", []):
                     rec = WritablePlaylistRecording(
                         title=recording["name"],
-                        artist_credit=release["artist-credit-phrase"],
+                        artist_credit=recording["artist-credit-phrase"],
                         artist_mbids=[a["artist"]["mbid"] for a in recording["artist-credit"]],
                         release_name=release["name"],
                         release_mbid=release["mbid"],


### PR DESCRIPTION
This thread raised an issue with Various artist albums on "play this on LB":

https://community.metabrainz.org/t/play-on-listenbrainz-for-various-artist-compilations-issue/663146

Quick fix: Use the recording artist for tracks, not the release artist