### PR TITLE
LB-1300: Fix 'following' field in get_following_docstring

### DIFF
--- a/listenbrainz/webserver/views/social_api.py
+++ b/listenbrainz/webserver/views/social_api.py
@@ -53,7 +53,7 @@ def get_following(user_name: str):
     .. code-block:: json
 
         {
-            "followers": ["rob", "mr_monkey", "..."],
+            "following": ["rob", "mr_monkey", "..."],
             "user": "shivam-kapila"
         }
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

The JSON example in the API documentation for the `get_following` function was incorrect. It used the term 'followers' instead of 'following', which could lead to confusion for users trying to understand the API.

# Solution

I corrected the JSON example in the docstring of the `get_following` function to use the correct term 'following'. This should now accurately represent the structure of the returned JSON object and make it clearer for users.

# Action

Please review the changes made to the docstring of the `get_following` function. No other action is required.

