### PR TITLE
LB-1382: Place private dumps into wholly seperate file system paths

### DIFF
--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -5,6 +5,7 @@
 
 DUMP_THREADS="{{template "KEY" "dump_threads"}}"
 DUMP_BASE_DIR="{{template "KEY" "base_dir"}}"
+PRIVATE_DUMP_BASE_DIR="{{template "KEY" "private_base_dir"}}"
 
 # Where to back things up to, who should own the backup files, and what mode
 # those files should have.
@@ -14,6 +15,8 @@ BACKUP_USER="{{template "KEY" "user"}}"
 BACKUP_GROUP="{{template "KEY" "group"}}"
 BACKUP_DIR_MODE=700
 BACKUP_FILE_MODE=600
+
+PRIVATE_BACKUP_DIR="{{template "KEY" "private_backup_dir"}}"
 
 # Same but for the files that need to copied to the FTP server,
 # for public consumption

--- a/admin/config.sh.sample
+++ b/admin/config.sh.sample
@@ -2,6 +2,7 @@
 
 DUMP_THREADS=4
 DUMP_BASE_DIR='/mnt/dumps'
+PRIVATE_DUMP_BASE_DIR='/private/dumps'
 
 # Where to back things up to, who should own the backup files, and what mode
 # those files should have.
@@ -11,6 +12,8 @@ BACKUP_USER=root
 BACKUP_GROUP=root
 BACKUP_DIR_MODE=700
 BACKUP_FILE_MODE=600
+
+PRIVATE_BACKUP_DIR=/private/backup
 
 # Same but for the files that need to copied to the FTP server,
 # for public consumption

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -48,6 +48,7 @@ class DumpTestCase(DatabaseTestCase):
     def setUp(self):
         super().setUp()
         self.tempdir = tempfile.mkdtemp()
+        self.tempdir_private = tempfile.mkdtemp()
         self.app = create_app()
 
     def tearDown(self):
@@ -125,7 +126,7 @@ class DumpTestCase(DatabaseTestCase):
             self.assertEqual(user_count, 1)
 
             # do a db dump and reset the db
-            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir)
+            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir, self.tempdir_private)
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)
@@ -163,7 +164,7 @@ class DumpTestCase(DatabaseTestCase):
             db_feedback.insert(feedback)
 
             # do a db dump and reset the db
-            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir)
+            private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir, self.tempdir_private)
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)


### PR DESCRIPTION
To avoid accidental leaking of private data, make the separation between public and private dumps more explicit. Often such errors occur when running scripts by hand, so adding a few more safeguards to the dumps running code too.
