### PR TITLE
LB-1357: Add support for importing local listen dumps into Spark

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,6 @@
 
 # Javascript packages
 /node_modules/
+
+# ListenBrainz local dump directory
+/listenbrainz-export

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -33,6 +33,20 @@ PARQUET_APPROX_COMPRESSION_RATIO = .57
 PARQUET_TARGET_SIZE = 134217728 / PARQUET_APPROX_COMPRESSION_RATIO  # 128MB / compression ratio
 
 
+SPARK_LISTENS_SCHEMA = pa.schema([
+    pa.field("listened_at", pa.timestamp("ms"), False),
+    pa.field("user_id", pa.int64(), False),
+    pa.field("recording_msid", pa.string(), False),
+    pa.field("artist_name", pa.string(), False),
+    pa.field("artist_credit_id", pa.int64(), True),
+    pa.field("release_name", pa.string(), True),
+    pa.field("release_mbid", pa.string(), True),
+    pa.field("recording_name", pa.string(), False),
+    pa.field("recording_mbid", pa.string(), True),
+    pa.field('artist_credit_mbids', pa.list_(pa.string()), True),
+])
+
+
 class DumpListenStore:
 
     def __init__(self, app):
@@ -441,7 +455,7 @@ class DumpListenStore:
 
                 # Create a pandas dataframe, then write that to a parquet files
                 df = pd.DataFrame(data, dtype=object)
-                table = pa.Table.from_pandas(df, preserve_index=False)
+                table = pa.Table.from_pandas(df, schema=SPARK_LISTENS_SCHEMA, preserve_index=False)
                 pq.write_table(table, filename)
                 file_size = os.path.getsize(filename)
                 tar_file.add(filename, arcname=os.path.join(archive_dir, "%d.parquet" % parquet_file_id))

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -253,25 +253,27 @@ def request_yim_top_genres(year: int):
 @cli.command(name="request_import_full")
 @click.option("--id", "id_", type=int, required=False,
               help="Optional. ID of the full dump to import, defaults to latest dump available on FTP server")
-def request_import_new_full_dump(id_: int):
+@click.option("--use-local", "local", is_flag=True, help="Use local dump instead of FTP")
+def request_import_new_full_dump(id_: int, local: bool):
     """ Send the cluster a request to import a new full data dump
     """
     if id_:
-        send_request_to_spark_cluster('import.dump.full_id', dump_id=id_)
+        send_request_to_spark_cluster('import.dump.full_id', dump_id=id_, local=local)
     else:
-        send_request_to_spark_cluster('import.dump.full_newest')
+        send_request_to_spark_cluster('import.dump.full_newest', local=local)
 
 
 @cli.command(name="request_import_incremental")
 @click.option("--id", "id_", type=int, required=False,
               help="Optional. ID of the incremental dump to import, defaults to latest dump available on FTP server")
-def request_import_new_incremental_dump(id_: int):
+@click.option("--use-local", "local", is_flag=True, help="Use local dump instead of FTP")
+def request_import_new_incremental_dump(id_: int, local: bool):
     """ Send the cluster a request to import a new incremental data dump
     """
     if id_:
-        send_request_to_spark_cluster('import.dump.incremental_id', dump_id=id_)
+        send_request_to_spark_cluster('import.dump.incremental_id', dump_id=id_, local=local)
     else:
-        send_request_to_spark_cluster('import.dump.incremental_newest')
+        send_request_to_spark_cluster('import.dump.incremental_newest', local=local)
 
 
 @cli.command(name="request_dataframes")

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -57,22 +57,22 @@
   "import.dump.full_newest": {
     "name": "import.dump.full_newest",
     "description": "Import the newest available full dump into the spark cluster",
-    "params": []
+    "params": ["local"]
   },
   "import.dump.full_id": {
     "name": "import.dump.full_id",
     "description": "Import full dump with the specified ID into the spark cluster",
-    "params": ["dump_id"]
+    "params": ["dump_id", "local"]
   },
   "import.dump.incremental_newest": {
     "name": "import.dump.incremental_newest",
     "description": "Import the newest available incremental dump into the spark cluster",
-    "params": []
+    "params": ["local"]
   },
   "import.dump.incremental_id": {
     "name": "import.dump.incremental_id",
     "description": "Import incremental dump with the specified ID into the spark cluster",
-    "params": ["dump_id"]
+    "params": ["dump_id", "local"]
   },
   "import.dump.mlhd": {
     "name": "import.dump.mlhd",

--- a/listenbrainz_spark/dump/__init__.py
+++ b/listenbrainz_spark/dump/__init__.py
@@ -1,0 +1,98 @@
+import hashlib
+from enum import Enum
+from typing import NamedTuple
+from abc import ABC, abstractmethod
+
+from listenbrainz_spark.exceptions import DumpNotFoundException
+
+
+class DumpType(Enum):
+    INCREMENTAL = 'incremental'
+    FULL = 'full'
+
+
+class ListensDump(NamedTuple):
+    dump_id: int
+    dump_date: str
+    dump_tod: str
+    dump_type: DumpType
+
+    @staticmethod
+    def from_dir_name(dir_name: str) -> 'ListensDump':
+        # Remove / if any from the end of dir name before splitting so the dump_type is correct
+        parts = dir_name.replace('/', '').split('-')
+        return ListensDump(dump_id=int(parts[2]),
+                           dump_date=parts[3],
+                           dump_tod=parts[4],
+                           dump_type=DumpType.INCREMENTAL if parts[5] == 'incremental' else DumpType.FULL)
+
+    def get_dump_file(self):
+        return f'listenbrainz-spark-dump-{self.dump_id}-{self.dump_date}' \
+               f'-{self.dump_tod}-{self.dump_type.value}.tar'
+
+
+class ListenbrainzDumpLoader(ABC):
+
+    @abstractmethod
+    def list_dump_directories(self, dump_type: DumpType):
+        pass
+
+    def get_latest_dump_id(self, dump_type: DumpType):
+        listens_dumps = [ListensDump.from_dir_name(name) for name in self.list_dump_directories(dump_type)]
+        listens_dumps.sort(key=lambda x: x.dump_id)
+        return listens_dumps[-1].dump_id
+
+    def get_dump_name_to_download(self, dump, dump_id, dump_id_pos):
+        """ Get name of the dump to be downloaded.
+
+            Args:
+                dump (list): Contents of the directory from which dump will be downloaded.
+                dump_id (int): Unique identifier of dump to be downloaded.
+                dump_id_pos (int): Unique identifier position in dump name.
+
+            Returns:
+                req_dump (str): Name of the dump to be downloaded.
+        """
+        if dump_id:
+            req_dump = None
+            for dump_name in dump:
+                if int(dump_name.split('-')[dump_id_pos]) == dump_id:
+                    req_dump = dump_name
+                    break
+            if req_dump is None:
+                err_msg = "Could not find dump with ID: {}. Aborting...".format(dump_id)
+                raise DumpNotFoundException(err_msg)
+        else:
+            req_dump = dump[-1]
+        return req_dump
+
+    def get_listens_dump_file_name(self, dump_name):
+        """ Get the name of Spark listens dump name archive.
+
+            Returns:
+                str : Spark listens dump archive name.
+        """
+        return ListensDump.from_dir_name(dump_name).get_dump_file()
+
+    @abstractmethod
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+        pass
+
+    def _calc_sha256(self, filepath: str) -> str:
+        """ Takes in path of a file and calculates the SHA256 checksum for it
+        """
+        calculated_sha = hashlib.sha256()
+        with open(filepath, "rb") as f:
+            # Read and update hash string value in blocks of 4K
+            for byte_block in iter(lambda: f.read(4096), b""):
+                calculated_sha.update(byte_block)
+
+        return calculated_sha.hexdigest()
+
+    def _read_sha_file(self, filepath: str) -> str:
+        """ Reads the SHA file and returns the string stripped of any whitespace and extra characters
+        """
+        with open(filepath, "r") as f:
+            sha = f.read().lstrip().split(" ", 1)[0].strip()
+
+        return sha

--- a/listenbrainz_spark/dump/__init__.py
+++ b/listenbrainz_spark/dump/__init__.py
@@ -75,7 +75,7 @@ class ListenbrainzDumpLoader(ABC):
         return ListensDump.from_dir_name(dump_name).get_dump_file()
 
     @abstractmethod
-    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL) -> (str, str, int):
         pass
 
     def _calc_sha256(self, filepath: str) -> str:

--- a/listenbrainz_spark/dump/local.py
+++ b/listenbrainz_spark/dump/local.py
@@ -1,0 +1,21 @@
+import os
+
+from listenbrainz_spark.dump import ListenbrainzDumpLoader, DumpType
+
+
+class ListenbrainzLocalDumpLoader(ListenbrainzDumpLoader):
+
+    def list_dump_directories(self, dump_type: DumpType):
+        files = os.listdir('listenbrainz-export')
+        return list(filter(lambda x: x.startswith(f'listenbrainz-dump-'), files))
+
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+        dump_directories = self.list_dump_directories(dump_type)
+
+        listens_dump_list = sorted(dump_directories, key=lambda x: int(x.split('-')[2]))
+        req_listens_dump = self.get_dump_name_to_download(listens_dump_list, listens_dump_id, 2)
+        listens_file_name = self.get_listens_dump_file_name(req_listens_dump)
+        dest_path = os.path.join('listenbrainz-export', req_listens_dump, listens_file_name)
+        dump_id = int(req_listens_dump.split('-')[2])
+
+        return dest_path, listens_file_name, dump_id

--- a/listenbrainz_spark/dump/local.py
+++ b/listenbrainz_spark/dump/local.py
@@ -9,7 +9,7 @@ class ListenbrainzLocalDumpLoader(ListenbrainzDumpLoader):
         files = os.listdir('listenbrainz-export')
         return list(filter(lambda x: x.startswith(f'listenbrainz-dump-'), files))
 
-    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL) -> (str, str, int):
         dump_directories = self.list_dump_directories(dump_type)
 
         listens_dump_list = sorted(dump_directories, key=lambda x: int(x.split('-')[2]))

--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -1,6 +1,7 @@
 import ftplib
 import logging
 import os
+from abc import ABC
 
 from listenbrainz_spark import config
 from listenbrainz_spark.dump import DumpType, ListenbrainzDumpLoader
@@ -9,7 +10,7 @@ from listenbrainz_spark.exceptions import DumpInvalidException
 logger = logging.getLogger(__name__)
 
 
-class ListenBrainzFTPDownloader(ListenbrainzDumpLoader):
+class ListenBrainzFTPDownloader(ListenbrainzDumpLoader, ABC):
 
     def __init__(self):
         self.connect()

--- a/listenbrainz_spark/ftp/__init__.py
+++ b/listenbrainz_spark/ftp/__init__.py
@@ -1,43 +1,15 @@
-import os
 import ftplib
-import hashlib
 import logging
-from enum import Enum
-from typing import NamedTuple
+import os
 
 from listenbrainz_spark import config
+from listenbrainz_spark.dump import DumpType, ListenbrainzDumpLoader
 from listenbrainz_spark.exceptions import DumpInvalidException
-
 
 logger = logging.getLogger(__name__)
 
 
-class DumpType(Enum):
-    INCREMENTAL = 'incremental'
-    FULL = 'full'
-
-
-class ListensDump(NamedTuple):
-    dump_id: int
-    dump_date: str
-    dump_tod: str
-    dump_type: DumpType
-
-    @staticmethod
-    def from_ftp_dir(dir_name: str) -> 'ListensDump':
-        # Remove / if any from the end of dir name before splitting so the dump_type is correct
-        parts = dir_name.replace('/', '').split('-')
-        return ListensDump(dump_id=int(parts[2]),
-                           dump_date=parts[3],
-                           dump_tod=parts[4],
-                           dump_type=DumpType.INCREMENTAL if parts[5] == 'incremental' else DumpType.FULL)
-
-    def get_dump_file(self):
-        return f'listenbrainz-spark-dump-{self.dump_id}-{self.dump_date}' \
-               f'-{self.dump_tod}-{self.dump_type.value}.tar'
-
-
-class ListenBrainzFTPDownloader:
+class ListenBrainzFTPDownloader(ListenbrainzDumpLoader):
 
     def __init__(self):
         self.connect()
@@ -70,6 +42,15 @@ class ListenBrainzFTPDownloader:
             cmd += ' ' + path
         self.connection.retrlines(cmd, callback=callback)
         return files
+
+    def list_dump_directories(self, dump_type: DumpType):
+        if dump_type == DumpType.INCREMENTAL:
+            dump_dir = os.path.join(config.FTP_LISTENS_DIR, 'incremental/')
+        else:
+            dump_dir = os.path.join(config.FTP_LISTENS_DIR, 'fullexport/')
+
+        self.connection.cwd(dump_dir)
+        return self.list_dir()
 
     def download_file_binary(self, src, dest):
         """ Download file `src` from the FTP server to `dest`
@@ -119,22 +100,3 @@ class ListenBrainzFTPDownloader:
 
         self.connection.cwd('/')
         return dest_path
-
-    def _calc_sha256(self, filepath: str) -> str:
-        """ Takes in path of a file and calculates the SHA256 checksum for it
-        """
-        calculated_sha = hashlib.sha256()
-        with open(filepath, "rb") as f:
-            # Read and update hash string value in blocks of 4K
-            for byte_block in iter(lambda: f.read(4096), b""):
-                calculated_sha.update(byte_block)
-
-        return calculated_sha.hexdigest()
-
-    def _read_sha_file(self, filepath: str) -> str:
-        """ Reads the SHA file and returns the string stripped of any whitespace and extra characters
-        """
-        with open(filepath, "r") as f:
-            sha = f.read().lstrip().split(" ", 1)[0].strip()
-
-        return sha

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
 
-    def download_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+    def download_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL) -> (str, str, int):
         """ Download listens to dir passed as an argument.
 
             Args:
@@ -50,7 +50,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         self.connection.close()
         return dest_path, listens_file_name, dump_id
 
-    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL) -> (str, str, int):
         return self.download_listens(directory, listens_dump_id, dump_type)
 
     def download_artist_relation(self, directory, artist_relation_dump_id=None):

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -63,29 +63,6 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         """
         return ListensDump.from_ftp_dir(dump_name).get_dump_file()
 
-    def get_available_dumps(self, dump, mapping_name_prefix):
-        """ Get list of available mapping dumps.
-
-            Args:
-                dump: list of dumps in the current working directory.
-                mapping_name_prefix (str): prefix of mapping dump name.
-
-            Returns:
-                mapping: list of mapping dump names in the current working directory.
-        """
-        mapping = list()
-        for mapping_name in dump:
-            mapping_pattern = '{}-\\d+-\\d+(.tar.bz2)$'.format(mapping_name_prefix)
-
-            if re.match(mapping_pattern, mapping_name):
-                mapping.append(mapping_name)
-
-        if len(mapping) == 0:
-            err_msg = '{} type mapping not found'.format(mapping_name_prefix)
-            raise DumpNotFoundException(err_msg)
-
-        return mapping
-
     def download_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
         """ Download listens to dir passed as an argument.
 

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -1,11 +1,12 @@
+import logging
 import os
 import tempfile
 import time
-import logging
 
 from listenbrainz_spark import config
-from listenbrainz_spark.ftp import ListenBrainzFTPDownloader, DumpType, ListensDump
+from listenbrainz_spark.dump import DumpType, ListensDump
 from listenbrainz_spark.exceptions import DumpNotFoundException
+from listenbrainz_spark.ftp import ListenBrainzFTPDownloader
 
 # mbid_msid_mapping_with_matchable is used.
 # refer to: http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/labs/mappings/
@@ -19,38 +20,6 @@ logger = logging.getLogger(__name__)
 
 class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
 
-    def get_dump_name_to_download(self, dump, dump_id, dump_id_pos):
-        """ Get name of the dump to be downloaded.
-
-            Args:
-                dump (list): Contents of the directory from which dump will be downloaded.
-                dump_id (int): Unique indentifier of dump to be downloaded .
-                dump_id_pos (int): Unique identifier position in dump name.
-
-            Returns:
-                req_dump (str): Name of the dump to be downloaded.
-        """
-        if dump_id:
-            req_dump = None
-            for dump_name in dump:
-                if int(dump_name.split('-')[dump_id_pos]) == dump_id:
-                    req_dump = dump_name
-                    break
-            if req_dump is None:
-                err_msg = "Could not find dump with ID: {}. Aborting...".format(dump_id)
-                raise DumpNotFoundException(err_msg)
-        else:
-            req_dump = dump[-1]
-        return req_dump
-
-    def get_listens_dump_file_name(self, dump_name):
-        """ Get the name of Spark listens dump name archive.
-
-            Returns:
-                str : Spark listens dump archive name.
-        """
-        return ListensDump.from_ftp_dir(dump_name).get_dump_file()
-
     def download_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
         """ Download listens to dir passed as an argument.
 
@@ -63,25 +32,26 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
             Returns:
                 dest_path (str): Local path where listens have been downloaded.
                 listens_file_name (str): name of downloaded listens dump.
-                dump_id (int): Unique indentifier of downloaded listens dump.
+                dump_id (int): Unique identifier of downloaded listens dump.
         """
-        if dump_type == DumpType.INCREMENTAL:
-            ftp_cwd = os.path.join(config.FTP_LISTENS_DIR, 'incremental/')
-        else:
-            ftp_cwd = os.path.join(config.FTP_LISTENS_DIR, 'fullexport/')
-        self.connection.cwd(ftp_cwd)
-        listens_dump_list = sorted(self.list_dir(), key=lambda x: int(x.split('-')[2]))
+        dump_directories = self.list_dump_directories(dump_type)
+
+        listens_dump_list = sorted(dump_directories, key=lambda x: int(x.split('-')[2]))
         req_listens_dump = self.get_dump_name_to_download(listens_dump_list, listens_dump_id, 2)
-        dump_id = req_listens_dump.split('-')[2]
+        listens_file_name = self.get_listens_dump_file_name(req_listens_dump)
+        dump_id = int(req_listens_dump.split('-')[2])
 
         self.connection.cwd(req_listens_dump)
-        listens_file_name = self.get_listens_dump_file_name(req_listens_dump)
 
         t0 = time.monotonic()
         logger.info('Downloading {} from FTP...'.format(listens_file_name))
         dest_path = self.download_dump(listens_file_name, directory)
         logger.info('Done. Total time: {:.2f} sec'.format(time.monotonic() - t0))
-        return dest_path, listens_file_name, int(dump_id)
+        self.connection.close()
+        return dest_path, listens_file_name, dump_id
+
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+        return self.download_listens(directory, listens_dump_id, dump_type)
 
     def download_artist_relation(self, directory, artist_relation_dump_id=None):
         """ Download artist relation to dir passed as an argument.
@@ -118,21 +88,10 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
                 dump_name = f.readline().strip()
         self.connection.cwd(dump_name)
 
-        logger.info(f"Downloading release.tar.gz of dump {dump_name} from FTP...")
-        t0 = time.monotonic()
         filename = "release.tar.xz"
+        logger.info(f"Downloading {filename} of dump {dump_name} from FTP...")
+        t0 = time.monotonic()
         dest = os.path.join(directory, filename)
         self.download_file_binary(filename, dest)
         logger.info(f"Done. Total time: {time.monotonic() - t0:.2f} sec")
         return dest
-
-    def get_latest_dump_id(self, dump_type: DumpType):
-        if dump_type == DumpType.INCREMENTAL:
-            ftp_cwd = os.path.join(config.FTP_LISTENS_DIR, 'incremental/')
-        else:
-            ftp_cwd = os.path.join(config.FTP_LISTENS_DIR, 'fullexport/')
-        self.connection.cwd(ftp_cwd)
-
-        listens_dumps = [ListensDump.from_ftp_dir(name) for name in self.list_dir()]
-        listens_dumps.sort(key=lambda x: x.dump_id)
-        return listens_dumps[-1].dump_id

--- a/listenbrainz_spark/ftp/download.py
+++ b/listenbrainz_spark/ftp/download.py
@@ -1,5 +1,4 @@
 import os
-import re
 import tempfile
 import time
 import logging
@@ -43,17 +42,6 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         else:
             req_dump = dump[-1]
         return req_dump
-
-    def get_dump_archive_name(self, dump_name):
-        """ Get the name of the Spark dump archive from the dump directory name.
-
-            Args:
-                dump_name (str): FTP dump directory name.
-
-            Returns:
-                '' : Spark dump archive name.
-        """
-        return dump_name + '.tar.bz2'
 
     def get_listens_dump_file_name(self, dump_name):
         """ Get the name of Spark listens dump name archive.
@@ -112,7 +100,7 @@ class ListenbrainzDataDownloader(ListenBrainzFTPDownloader):
         req_dump = self.get_dump_name_to_download(dump, artist_relation_dump_id, ARTIST_RELATION_DUMP_ID_POS)
 
         self.connection.cwd(req_dump)
-        artist_relation_file_name = self.get_dump_archive_name(req_dump)
+        artist_relation_file_name = req_dump + '.tar.bz2'
 
         t0 = time.monotonic()
         logger.info('Downloading {} from FTP...'.format(artist_relation_file_name))

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -35,33 +35,6 @@ class FTPDownloaderTestCase(unittest.TestCase):
         filename = ListenbrainzDataDownloader().get_listens_dump_file_name('listenbrainz-dump-17-20190101-000001-incremental/')
         self.assertEqual('listenbrainz-spark-dump-17-20190101-000001-incremental.tar', filename)
 
-    @patch('ftplib.FTP')
-    def test_get_available_dumps(self, mock_ftp):
-        dump = [
-            'msid-mbid-mapping-with-matchable-20200603-203731.tar.bz2',
-            'msid-mbid-mapping-with-text-20180603-202000.tar.bz2',
-            'msid-mbid-mapping-with-matchable-20200603-202732.tar.bz2',
-            'msid-mbid-mapping-with-matchable-xxxx-20200603-202732.tar.bz2'
-            'msid-mbid-mapping-with-matchable-20100603-202732.tar.bz2.md5',
-        ]
-
-        mapping = ListenbrainzDataDownloader().get_available_dumps(dump, 'msid-mbid-mapping-with-matchable')
-
-        expected_mapping = [
-            'msid-mbid-mapping-with-matchable-20200603-203731.tar.bz2',
-            'msid-mbid-mapping-with-matchable-20200603-202732.tar.bz2',
-        ]
-
-        self.assertEqual(mapping, expected_mapping)
-
-        dump = [
-            'msid-mbid-mapping-with-text-20180603-202000.tar.bz2',
-            'msid-mbid-mapping-with-matchable-20100603-202732.tar.bz2.md5',
-        ]
-
-        with self.assertRaises(DumpNotFoundException):
-            ListenbrainzDataDownloader().get_available_dumps(dump, 'msid-mbid-mapping-with-matchable')
-
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_dump')
     @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.get_listens_dump_file_name')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir')

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -92,7 +92,7 @@ class FTPDownloaderTestCase(unittest.TestCase):
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir')
     @patch('ftplib.FTP')
     def test_download_listens_incremental_dump_by_id(self, mock_ftp, mock_list_dir, mock_get_f_name, mock_download_dump):
-        mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000/', 'listenbrainz-dump-45-20190201-000000']
+        mock_list_dir.return_value = ['listenbrainz-dump-123-20190101-000000', 'listenbrainz-dump-45-20190201-000000']
         mock_get_f_name.return_value = 'listenbrainz-spark-dump-45-20190201-000000-incremental.tar'
         dest_path, filename, dump_id = ListenbrainzDataDownloader().download_listens('fakedir', listens_dump_id=45,
                                                                                      dump_type=DumpType.INCREMENTAL)
@@ -108,26 +108,24 @@ class FTPDownloaderTestCase(unittest.TestCase):
         self.assertEqual(dest_path, mock_download_dump.return_value)
         self.assertEqual(dump_id, 45)
 
-    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.get_dump_archive_name')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_dump')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.list_dir')
     @patch('ftplib.FTP')
-    def test_download_artist_relation(self, mock_ftp_cons, mock_list_dir, mock_download_dump, mock_dump_archive):
+    def test_download_artist_relation(self, mock_ftp_cons, mock_list_dir, mock_download_dump):
         directory = '/fakedir'
         mock_list_dir.return_value = [
-            'artist-credit-artist-credit-relations-01-20191230-134806/',
-            'artist-credit-artist-credit-relations-02-20191230-134806/',
+            'artist-credit-artist-credit-relations-01-20191230-134806',
+            'artist-credit-artist-credit-relations-02-20191230-134806',
         ]
-        mock_dump_archive.return_value = 'artist-credit-artist-credit-relations-02-20191230-134806.tar.bz2'
+        expected_filename = 'artist-credit-artist-credit-relations-02-20191230-134806.tar.bz2'
         dest_path, filename = ListenbrainzDataDownloader().download_artist_relation(directory)
 
         mock_list_dir.assert_called_once()
         mock_ftp_cons.return_value.cwd.assert_has_calls([
             call(config.FTP_ARTIST_RELATION_DIR),
-            call('artist-credit-artist-credit-relations-02-20191230-134806/')
+            call('artist-credit-artist-credit-relations-02-20191230-134806')
         ])
 
-        self.assertEqual('artist-credit-artist-credit-relations-02-20191230-134806.tar.bz2', filename)
-        mock_dump_archive.assert_called_once_with('artist-credit-artist-credit-relations-02-20191230-134806/')
-        mock_download_dump.assert_called_once_with(mock_dump_archive.return_value, directory)
+        self.assertEqual(expected_filename, filename)
+        mock_download_dump.assert_called_once_with(expected_filename, directory)
         self.assertEqual(dest_path, mock_download_dump.return_value)

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -2,8 +2,8 @@ import unittest
 from unittest.mock import patch, call
 
 from listenbrainz_spark import config
+from listenbrainz_spark.dump import DumpType
 from listenbrainz_spark.exceptions import DumpNotFoundException
-from listenbrainz_spark.ftp import DumpType
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
 
 

--- a/listenbrainz_spark/ftp/tests/test_download.py
+++ b/listenbrainz_spark/ftp/tests/test_download.py
@@ -22,12 +22,6 @@ class FTPDownloaderTestCase(unittest.TestCase):
             ListenbrainzDataDownloader().get_dump_name_to_download(dump, 3, 1)
 
     @patch('ftplib.FTP')
-    def test_get_dump_archive_name(self, mock_ftp_cons):
-        dump_name = 'listenbrainz-01-00000'
-        filename = ListenbrainzDataDownloader().get_dump_archive_name(dump_name)
-        self.assertEqual(dump_name + '.tar.bz2', filename)
-
-    @patch('ftplib.FTP')
     def test_get_listens_dump_file_name(self, mock_ftp_cons):
         filename = ListenbrainzDataDownloader().get_listens_dump_file_name('listenbrainz-dump-17-20190101-000001-full/')
         self.assertEqual('listenbrainz-spark-dump-17-20190101-000001-full.tar', filename)

--- a/listenbrainz_spark/ftp/tests/test_init.py
+++ b/listenbrainz_spark/ftp/tests/test_init.py
@@ -75,7 +75,7 @@ class FTPTestCase(SparkNewTestCase):
         filename = 'fakefile.txt'
         directory = 'fakedir'
 
-        self.assertRaises(DumpInvalidException,TestableListenBrainzFTPDownloader().download_dump, filename, directory)
+        self.assertRaises(DumpInvalidException, TestableListenBrainzFTPDownloader().download_dump, filename, directory)
 
     @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_file_binary')

--- a/listenbrainz_spark/ftp/tests/test_init.py
+++ b/listenbrainz_spark/ftp/tests/test_init.py
@@ -4,20 +4,26 @@ from unittest.mock import patch, mock_open, call, MagicMock
 
 import listenbrainz_spark
 from listenbrainz_spark import config
+from listenbrainz_spark.dump import DumpType
 from listenbrainz_spark.exceptions import DumpInvalidException
 from listenbrainz_spark.tests import SparkNewTestCase
+
+
+class TestableListenBrainzFTPDownloader(listenbrainz_spark.ftp.ListenBrainzFTPDownloader):
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL):
+        return '', '', 1
 
 
 class FTPTestCase(SparkNewTestCase):
 
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.connect')
     def test_init(self, mock_connect):
-        listenbrainz_spark.ftp.ListenBrainzFTPDownloader()
+        TestableListenBrainzFTPDownloader()
         mock_connect.assert_called_once()
 
     @patch('ftplib.FTP')
     def test_connect(self, mock_ftp_cons):
-        listenbrainz_spark.ftp.ListenBrainzFTPDownloader().connect()
+        TestableListenBrainzFTPDownloader().connect()
         mock_ftp_cons.assert_called_with(config.FTP_SERVER_URI)
         mock_ftp = mock_ftp_cons.return_value
         self.assertTrue(mock_ftp.login.called)
@@ -25,7 +31,7 @@ class FTPTestCase(SparkNewTestCase):
     @patch('ftplib.FTP')
     def test_list(self, mock_ftp_cons):
         mock_ftp = mock_ftp_cons.return_value
-        dirs = listenbrainz_spark.ftp.ListenBrainzFTPDownloader().list_dir()
+        dirs = TestableListenBrainzFTPDownloader().list_dir()
         self.assertTrue(mock_ftp.retrlines.called)
         self.assertEqual(dirs, [])
 
@@ -33,7 +39,7 @@ class FTPTestCase(SparkNewTestCase):
     def test_download_file_binary(self, mock_ftp_cons):
         mock_ftp = mock_ftp_cons.return_value
         with patch('listenbrainz_spark.ftp.open', mock_open(), create=True) as mock_file:
-            listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_file_binary('fake/src', 'fake/dest')
+            TestableListenBrainzFTPDownloader().download_file_binary('fake/src', 'fake/dest')
         mock_file.assert_called_once_with('fake/dest', 'wb')
         mock_ftp.retrbinary.assert_called_once_with('RETR {}'.format('fake/src'), mock_file().write)
 
@@ -52,7 +58,7 @@ class FTPTestCase(SparkNewTestCase):
         calls = [call(sha_filename, sha_dest_path), call(filename, 'fakedir/' + filename)]
 
         with patch('listenbrainz_spark.ftp.open', mock_open(read_data='test'), create=True) as mock_file:
-            dest_path = listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump(filename, directory)
+            dest_path = TestableListenBrainzFTPDownloader().download_dump(filename, directory)
 
         self.assertEqual(os.path.join(directory, filename), dest_path)
         mock_list_dir.assert_called_once()
@@ -69,8 +75,7 @@ class FTPTestCase(SparkNewTestCase):
         filename = 'fakefile.txt'
         directory = 'fakedir'
 
-        self.assertRaises(DumpInvalidException,
-                          listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump, filename, directory)
+        self.assertRaises(DumpInvalidException,TestableListenBrainzFTPDownloader().download_dump, filename, directory)
 
     @patch('ftplib.FTP')
     @patch('listenbrainz_spark.ftp.ListenBrainzFTPDownloader.download_file_binary')
@@ -84,13 +89,13 @@ class FTPTestCase(SparkNewTestCase):
         filename = 'fakefile.txt'
         directory = 'fakedir'
 
-        with patch('listenbrainz_spark.ftp.open', mock_open(read_data='test'), create=True) as mock_file:
+        with patch('listenbrainz_spark.dump.open', mock_open(read_data='test'), create=True) as mock_file:
             self.assertRaises(DumpInvalidException,
-                              listenbrainz_spark.ftp.ListenBrainzFTPDownloader().download_dump, filename, directory)
+                              TestableListenBrainzFTPDownloader().download_dump, filename, directory)
 
     @patch('ftplib.FTP')
     def test_read_sha_file_(self, mock_ftp_cons):
         mock_ftp = mock_ftp_cons.return_value
-        with patch('listenbrainz_spark.ftp.open', mock_open(read_data='  test\n filename  \n'), create=True) as mock_file:
-            result = listenbrainz_spark.ftp.ListenBrainzFTPDownloader()._read_sha_file("/sha_file.sha256")
+        with patch('listenbrainz_spark.dump.open', mock_open(read_data='  test\n filename  \n'), create=True) as mock_file:
+            result = TestableListenBrainzFTPDownloader()._read_sha_file("/sha_file.sha256")
             self.assertEqual('test', result)

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # of the params in request_queries.json.
 
 
-def import_full_dump_to_hdfs(dump_id: int = None) -> str:
+def import_full_dump_to_hdfs(dump_id: int = None, local: bool = False) -> str:
     """ Import the full dump with the given dump_id if specified otherwise the
      latest full dump.
 
@@ -28,6 +28,7 @@ def import_full_dump_to_hdfs(dump_id: int = None) -> str:
         Deletes all the existing listens and uploads listens from new dump.
     Args:
         dump_id: id of the full dump to be imported
+        local: if True, import the dump from local file system instead of FTP
     Returns:
         the name of the imported dump
     """
@@ -44,7 +45,7 @@ def import_full_dump_to_hdfs(dump_id: int = None) -> str:
     return dump_name
 
 
-def import_incremental_dump_to_hdfs(dump_id: int = None) -> str:
+def import_incremental_dump_to_hdfs(dump_id: int = None, local: bool = False) -> str:
     """ Import the incremental dump with the given dump_id if specified otherwise the
      latest incremental dump.
 
@@ -53,6 +54,7 @@ def import_incremental_dump_to_hdfs(dump_id: int = None) -> str:
         listens directory.
     Args:
         dump_id: id of the incremental dump to be imported
+        local: if True, import the dump from local file system instead of FTP
     Returns:
         the name of the imported dump
     """
@@ -71,11 +73,11 @@ def import_incremental_dump_to_hdfs(dump_id: int = None) -> str:
     return dump_name
 
 
-def import_newest_full_dump_handler():
+def import_newest_full_dump_handler(local: bool):
     errors = []
     dumps = []
     try:
-        dumps.append(import_full_dump_to_hdfs(dump_id=None))
+        dumps.append(import_full_dump_to_hdfs(dump_id=None, local=local))
     except Exception as e:
         logger.error("Error while importing full dump: ", exc_info=True)
         errors.append(str(e))
@@ -87,11 +89,11 @@ def import_newest_full_dump_handler():
     }]
 
 
-def import_full_dump_by_id_handler(dump_id: int):
+def import_full_dump_by_id_handler(dump_id: int, local: bool):
     errors = []
     dumps = []
     try:
-        dumps.append(import_full_dump_to_hdfs(dump_id=dump_id))
+        dumps.append(import_full_dump_to_hdfs(dump_id=dump_id, local=local))
     except Exception as e:
         logger.error("Error while importing full dump: ", exc_info=True)
         errors.append(str(e))
@@ -103,13 +105,13 @@ def import_full_dump_by_id_handler(dump_id: int):
     }]
 
 
-def import_newest_incremental_dump_handler():
+def import_newest_incremental_dump_handler(local: bool):
     errors = []
     imported_dumps = []
     latest_full_dump = utils.get_latest_full_dump()
     if latest_full_dump is None:
         # If no prior full dump is present, just import the latest incremental dump
-        imported_dumps.append(import_incremental_dump_to_hdfs(dump_id=None))
+        imported_dumps.append(import_incremental_dump_to_hdfs(dump_id=None, local=local))
 
         error_msg = "No previous full dump found, importing latest incremental dump"
         errors.append(error_msg)
@@ -123,7 +125,7 @@ def import_newest_incremental_dump_handler():
         for dump_id in range(start_id, end_id, 1):
             if not utils.search_dump(dump_id, DumpType.INCREMENTAL, imported_at):
                 try:
-                    imported_dumps.append(import_incremental_dump_to_hdfs(dump_id))
+                    imported_dumps.append(import_incremental_dump_to_hdfs(dump_id=dump_id, local=local))
                 except Exception as e:
                     # Skip current dump if any error occurs during import
                     error_msg = f"Error while importing incremental dump with ID {dump_id}: {e}"
@@ -139,11 +141,11 @@ def import_newest_incremental_dump_handler():
     }]
 
 
-def import_incremental_dump_by_id_handler(dump_id: int):
+def import_incremental_dump_by_id_handler(dump_id: int, local: bool):
     errors = []
     dumps = []
     try:
-        dumps.append(import_incremental_dump_to_hdfs(dump_id=dump_id))
+        dumps.append(import_incremental_dump_to_hdfs(dump_id=dump_id, local=local))
     except Exception as e:
         logger.error("Error while importing incremental dump: ", exc_info=True)
         errors.append(str(e))

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -12,7 +12,7 @@ from listenbrainz_spark.tests import SparkNewTestCase
 from listenbrainz_spark.utils import (read_files_from_HDFS)
 
 
-def mock_import_dump_to_hdfs(dump_id: int):
+def mock_import_dump_to_hdfs(dump_id: int, local: bool):
     """ Mock function returning dump name all dump ids less than 210, else raising DumpNotFoundException """
     if dump_id < 210:
         return f"listenbrainz-spark-dump-{dump_id}-incremental.tar"
@@ -20,9 +20,9 @@ def mock_import_dump_to_hdfs(dump_id: int):
         raise DumpNotFoundException("Dump Not Found")
 
 
-def mock_import_dump_to_hdfs_error(dump_id: int):
+def mock_import_dump_to_hdfs_error(dump_id: int, local: bool):
     """ Mock function returning dump name all dump ids less than 210, else raise DumpInvalidException"""
-    if (dump_id < 210) or (dump_id > 210 and dump_id < 213):
+    if (dump_id < 210) or (210 < dump_id < 213):
         return f"listenbrainz-spark-dump-{dump_id}-incremental.tar"
     elif dump_id == 210:
         raise DumpInvalidException("Invalid Dump")
@@ -45,7 +45,7 @@ class DumpImporterJobTestCase(SparkNewTestCase):
             delete_dir(self.path_, recursive=True)
 
     @patch('ftplib.FTP')
-    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_listens')
+    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.load_listens')
     @patch('listenbrainz_spark.hdfs.upload.ListenbrainzDataUploader.upload_new_listens_full_dump')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
     def test_import_full_dump_handler(self, mock_datetime, mock_upload, mock_download, _):
@@ -53,7 +53,7 @@ class DumpImporterJobTestCase(SparkNewTestCase):
         mock_download.return_value = (mock_src, 'listenbrainz-spark-dump-202-20200915-180002-full.tar', 202)
         mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
 
-        messages = import_dump.import_newest_full_dump_handler()
+        messages = import_dump.import_newest_full_dump_handler(local=False)
         mock_download.assert_called_once_with(directory=mock.ANY, dump_type=DumpType.FULL, listens_dump_id=None)
         mock_upload.assert_called_once_with(mock_src)
 
@@ -69,7 +69,7 @@ class DumpImporterJobTestCase(SparkNewTestCase):
         self.assertListEqual(['listenbrainz-spark-dump-202-20200915-180002-full.tar'], messages[0]['imported_dump'])
 
     @patch('ftplib.FTP')
-    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_listens')
+    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.load_listens')
     @patch('listenbrainz_spark.hdfs.upload.ListenbrainzDataUploader.upload_new_listens_full_dump')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
     def test_import_full_dump_by_id_handler(self, mock_datetime, mock_upload, mock_download, _):
@@ -77,8 +77,8 @@ class DumpImporterJobTestCase(SparkNewTestCase):
         mock_download.return_value = (mock_src, 'listenbrainz-spark-dump-202-20200915-180002-full.tar', 202)
         mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
 
-        messages = import_dump.import_full_dump_by_id_handler(202)
-        mock_download.assert_called_once_with(directory=mock.ANY, dump_type=DumpType.FULL,  listens_dump_id=202)
+        messages = import_dump.import_full_dump_by_id_handler(202, local=False)
+        mock_download.assert_called_once_with(directory=mock.ANY, dump_type=DumpType.FULL, listens_dump_id=202)
         mock_upload.assert_called_once_with(mock_src)
 
         # Check if appropriate entry has been made in the table
@@ -97,8 +97,7 @@ class DumpImporterJobTestCase(SparkNewTestCase):
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.import_incremental_dump_to_hdfs', side_effect=mock_import_dump_to_hdfs)
     @patch('listenbrainz_spark.request_consumer.jobs.utils.search_dump', side_effect=mock_search_dump)
     @patch('listenbrainz_spark.request_consumer.jobs.utils.get_latest_full_dump')
-    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.request_consumer')
-    def test_import_newest_incremental_dump_handler(self, _, mock_latest_full_dump, __, mock_import_dump, ___, ____):
+    def test_import_newest_incremental_dump_handler(self, mock_latest_full_dump, _, mock_import_dump, __, ___):
         """ Test to make sure required incremental dumps are imported. """
         mock_latest_full_dump.return_value = {
             "dump_id": 202,
@@ -108,10 +107,10 @@ class DumpImporterJobTestCase(SparkNewTestCase):
         mock_import_calls = []
         expected_import_list = []
         for dump_id in range(204, 210, 3):
-            mock_import_calls.append(call(dump_id))
+            mock_import_calls.append(call(dump_id=dump_id, local=False))
             expected_import_list.append(f"listenbrainz-spark-dump-{dump_id}-incremental.tar")
 
-        messages = import_dump.import_newest_incremental_dump_handler()
+        messages = import_dump.import_newest_incremental_dump_handler(local=False)
 
         mock_import_dump.assert_has_calls(mock_import_calls)
         self.assertListEqual(expected_import_list, messages[0]['imported_dump'])
@@ -121,9 +120,7 @@ class DumpImporterJobTestCase(SparkNewTestCase):
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.import_incremental_dump_to_hdfs', side_effect=mock_import_dump_to_hdfs_error)
     @patch('listenbrainz_spark.request_consumer.jobs.utils.search_dump', side_effect=mock_search_dump)
     @patch('listenbrainz_spark.request_consumer.jobs.utils.get_latest_full_dump')
-    @patch('listenbrainz_spark.request_consumer.jobs.import_dump.request_consumer')
-    def test_import_newest_incremental_dump_handler_error(self, _, mock_latest_full_dump, __,
-                                                          mock_import_dump, mock_latest_dump_id, ___):
+    def test_import_newest_incremental_dump_handler_error(self, mock_latest_full_dump, _, mock_import_dump, __, ___):
         """ Test to make sure import continues if there is a fatal error. """
         mock_latest_full_dump.return_value = {
             "dump_id": 202,
@@ -133,10 +130,10 @@ class DumpImporterJobTestCase(SparkNewTestCase):
         mock_import_calls = []
         expected_import_list = []
         for dump_id in range(204, 210, 3):
-            mock_import_calls.append(call(dump_id))
+            mock_import_calls.append(call(dump_id=dump_id, local=False))
             expected_import_list.append(f"listenbrainz-spark-dump-{dump_id}-incremental.tar")
 
-        messages = import_dump.import_newest_incremental_dump_handler()
+        messages = import_dump.import_newest_incremental_dump_handler(local=False)
 
         mock_import_dump.assert_has_calls(mock_import_calls)
         # Only three calls should be made
@@ -145,19 +142,19 @@ class DumpImporterJobTestCase(SparkNewTestCase):
 
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.import_incremental_dump_to_hdfs')
     @patch('listenbrainz_spark.request_consumer.jobs.utils.get_latest_full_dump', return_value=None)
-    def test_import_newest_incremental_dump_handler_no_full_dump(self, mock_latest_full_dump, mock_import_dump):
+    def test_import_newest_incremental_dump_handler_no_full_dump(self, _, mock_import_dump):
         """ Test to make sure only latest incremental dump is imported if no full dump is found """
         mock_import_dump.return_value = 'listenbrainz-spark-dump-202-20200915-180002-incremental.tar'
 
-        messages = import_dump.import_newest_incremental_dump_handler()
+        messages = import_dump.import_newest_incremental_dump_handler(local=False)
 
-        mock_import_dump.assert_called_once_with(dump_id=None)
+        mock_import_dump.assert_called_once_with(dump_id=None, local=False)
         self.assertEqual(len(messages), 1)
         self.assertListEqual(['listenbrainz-spark-dump-202-20200915-180002-incremental.tar'],
                              messages[0]['imported_dump'])
 
     @patch('ftplib.FTP')
-    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.download_listens')
+    @patch('listenbrainz_spark.ftp.download.ListenbrainzDataDownloader.load_listens')
     @patch('listenbrainz_spark.hdfs.upload.ListenbrainzDataUploader.upload_new_listens_incremental_dump')
     @patch('listenbrainz_spark.request_consumer.jobs.import_dump.datetime')
     def test_import_incremental_dump_by_id_handler(self, mock_datetime, mock_upload, mock_download, _):
@@ -165,9 +162,8 @@ class DumpImporterJobTestCase(SparkNewTestCase):
         mock_download.return_value = (mock_src, 'listenbrainz-spark-dump-202-20200915-180002-incremental.tar', 202)
         mock_datetime.utcnow.return_value = datetime(2020, 8, 18)
 
-        messages = import_dump.import_incremental_dump_by_id_handler(202)
-        mock_download.assert_called_once_with(directory=mock.ANY, dump_type=DumpType.INCREMENTAL,
-                                              listens_dump_id=202)
+        messages = import_dump.import_incremental_dump_by_id_handler(202, local=False)
+        mock_download.assert_called_once_with(directory=mock.ANY, listens_dump_id=202, dump_type=DumpType.INCREMENTAL)
         mock_upload.assert_called_once_with(mock_src)
 
         # Check if appropriate entry has been made in the table

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_import_dump.py
@@ -1,17 +1,16 @@
 from datetime import datetime
+from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
-from unittest import mock
-
-from listenbrainz_spark.ftp import DumpType
-from listenbrainz_spark.request_consumer.jobs import import_dump
+from listenbrainz_spark.dump import DumpType
 from listenbrainz_spark.exceptions import (DumpInvalidException,
                                            DumpNotFoundException)
+from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists)
 from listenbrainz_spark.path import IMPORT_METADATA
+from listenbrainz_spark.request_consumer.jobs import import_dump
 from listenbrainz_spark.tests import SparkNewTestCase
 from listenbrainz_spark.utils import (read_files_from_HDFS)
 
-from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists)
 
 def mock_import_dump_to_hdfs(dump_id: int):
     """ Mock function returning dump name all dump ids less than 210, else raising DumpNotFoundException """

--- a/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/tests/test_utils.py
@@ -1,16 +1,16 @@
 import json
 from datetime import datetime
 
+from pyspark.sql import Row
+
 import listenbrainz_spark.request_consumer.jobs.utils as import_utils
-from listenbrainz_spark.ftp import DumpType
+from listenbrainz_spark.dump import DumpType
+from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists, rename)
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.tests import SparkNewTestCase
 from listenbrainz_spark.utils import (create_dataframe,
-                                   read_files_from_HDFS, save_parquet)
-from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists, rename)
-
-from pyspark.sql import Row
+                                      read_files_from_HDFS, save_parquet)
 
 
 class ImporterUtilsTestCase(SparkNewTestCase):

--- a/listenbrainz_spark/request_consumer/jobs/utils.py
+++ b/listenbrainz_spark/request_consumer/jobs/utils.py
@@ -3,16 +3,16 @@ import logging
 from datetime import datetime
 from typing import Optional
 
+from pyspark.sql import Row
+from pyspark.sql.functions import col
+
+from listenbrainz_spark.dump import DumpType
 from listenbrainz_spark.exceptions import PathNotFoundException
-from listenbrainz_spark.ftp import DumpType
+from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists, rename)
 from listenbrainz_spark.path import IMPORT_METADATA
 from listenbrainz_spark.schema import import_metadata_schema
 from listenbrainz_spark.utils import (create_dataframe, read_files_from_HDFS,
                                       save_parquet)
-from listenbrainz_spark.hdfs.utils import (delete_dir, path_exists, rename)
-from pyspark.sql import Row
-from pyspark.sql.functions import col
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
See LB-1357.

### Motivation

Currently, there are two Spark management commands to download either a full or an incremental listen dump from the Metabrainz FTP server and import it into spark.

At the same time, the dump manager within the ListenBrainz server supports creating dumps through the `create_full` or `create_incremental` commands. These dumps are stored inside a `listenbrainz-export` folder that's also mounted into the spark container(s) at `/rec/listenbrainz-export`.
If you want to import those dumps into Spark, e.g. for working on stats computation with your own, known data, you'd have to make them available through an FTP server and let the importer download them first, even if they are available locally.

### Solution

An additional `--use-local` flag on the import Spark commands searches for dumps in the export directory, picks the latest (or specified through ID) dump and imports it without having to copy the archive first.

This was implemented by further generalizing the `ListenBrainzFTPDownloader` to provide functions to list files and pick a specific dump archive. The FTP subclass downloads the archive to a temporary folder and returns its path (like now), the local version directly returns the archive path.