### PR TITLE
Deduplicate MSIDs

### DIFF
--- a/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
+++ b/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
@@ -48,7 +48,7 @@ with gather_data as (
          from gather_data ctnt
  join lateral unnest(msids[2:]) AS duplicate_msid
            on true
-        where array_length(msids) > 1
+        where array_length(msids, 1) > 1
   on conflict (duplicate_msid)
    do nothing;
 

--- a/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
+++ b/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
@@ -43,13 +43,12 @@ with gather_data as (
          from gather_data gd
   on conflict (gid)
    do nothing
-    returning gd.msids[2:], msb.gid AS original_msid
 ) insert into messybrainz.submissions_redirect (duplicate_msid, original_msid)
        select duplicate_msid
-            , original_msid
-         from copy_to_new_table ctnt
- join lateral unnest(duplicate_msids) AS duplicate_msid
-          on true
+            , msids[1]
+         from gather_data ctnt
+ join lateral unnest(msids[2:]) AS duplicate_msid
+           on true
   on conflict (duplicate_msid)
    do nothing;
 

--- a/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
+++ b/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
@@ -1,0 +1,56 @@
+begin;
+
+CREATE TABLE messybrainz.submissions_unique (
+    id              INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL PRIMARY KEY,
+    gid             UUID NOT NULL UNIQUE,
+    recording       TEXT NOT NULL,
+    artist_credit   TEXT NOT NULL,
+    release         TEXT,
+    track_number    TEXT,
+    duration        INTEGER,
+    submitted       TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE messybrainz.submissions_redirect (
+    duplicate_msid UUID NOT NULL UNIQUE,
+    original_msid UUID NOT NULL REFERENCES messybrainz.submissions_unique (gid)
+);
+
+with gather_data as (
+       select recording
+            , artist_credit
+            , release
+            , track_number
+            , duration
+            , (array_agg(submitted order by submitted))[1] AS original_submitted
+            , array_agg(gid order by submitted, gid) AS msids
+         from messybrainz.submissions
+     group by recording
+            , artist_credit
+            , release
+            , track_number
+            , duration
+       having count(*) > 1
+), copy_to_new_table as (
+  insert into messybrainz.submissions_unique as msb (gid, recording, artist_credit, release, track_number, duration, submitted)
+       select msids[1]
+            , recording
+            , artist_credit
+            , release
+            , track_number
+            , duration
+            , original_submitted
+         from gather_data gd
+  on conflict (gid)
+   do nothing
+    returning gd.msids[2:], msb.gid AS original_msid
+) insert into messybrainz.submissions_redirect (duplicate_msid, original_msid)
+       select duplicate_msid
+            , original_msid
+         from copy_to_new_table ctnt
+ join lateral unnest(duplicate_msids) AS duplicate_msid
+          on true
+  on conflict (duplicate_msid)
+   do nothing;
+
+commit;

--- a/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
+++ b/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
@@ -48,7 +48,7 @@ with gather_data as (
          from gather_data ctnt
  join lateral unnest(msids[2:]) AS duplicate_msid
            on true
-        where length(msids) > 1
+        where array_length(msids) > 1
   on conflict (duplicate_msid)
    do nothing;
 

--- a/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
+++ b/admin/timescale/updates/2023-11-11-msb-deduplicate-1.sql
@@ -30,7 +30,6 @@ with gather_data as (
             , release
             , track_number
             , duration
-       having count(*) > 1
 ), copy_to_new_table as (
   insert into messybrainz.submissions_unique as msb (gid, recording, artist_credit, release, track_number, duration, submitted)
        select msids[1]
@@ -49,6 +48,7 @@ with gather_data as (
          from gather_data ctnt
  join lateral unnest(msids[2:]) AS duplicate_msid
            on true
+        where length(msids) > 1
   on conflict (duplicate_msid)
    do nothing;
 

--- a/admin/timescale/updates/2023-11-11-msb-deduplicate-2.sql
+++ b/admin/timescale/updates/2023-11-11-msb-deduplicate-2.sql
@@ -1,0 +1,27 @@
+begin;
+
+insert into messybrainz.submissions_unique (gid, recording, artist_credit, release, track_number, duration, submitted)
+     select gid
+          , recording
+          , artist_credit
+          , release
+          , track_number
+          , duration
+          , submitted
+       from messybrainz.submissions
+      where submitted > make_date(2023, 11, 15)
+on conflict (gid)
+ do nothing;
+
+-- run query from first deduplicate script here with appropriate timestamp added
+
+alter table messybrainz.submissions rename to submissions_old;
+alter table messybrainz.submissions_unique rename to submissions;
+
+CREATE INDEX messybrainz_submissions_recording_ndx ON messybrainz.submissions (lower(recording));
+CREATE INDEX messybrainz_submissions_artist_credit_ndx ON messybrainz.submissions (lower(artist_credit));
+CREATE INDEX messybrainz_submissions_release_ndx ON messybrainz.submissions (lower(release));
+CREATE INDEX messybrainz_submissions_track_number_ndx ON messybrainz.submissions (lower(track_number));
+CREATE INDEX messybrainz_submissions_duration_ndx ON messybrainz.submissions (duration);
+
+commit;


### PR DESCRIPTION
Duplicate MSIDs exist because:

1. we made the conditions for a new MSID to be created more stringent.
2. during the recent LB database incident, the table was lost and had to be recovered from other sources in the process of which duplicates were created.

To fixup the issue:

1. Run the 2023-11-11-msb-deduplicate-1.sql script. This will separate the MSIDs into two tables, unique submissions and redirects. The redirects table will be used to fixup MSIDs in all of ListenBrainz one by one.

2. Stop timescale writer.

3. Run the 2023-11-11-msb-deduplicate-2.sql script. This will fixup the MSIDs that have been inserted since the first script ran. Since new duplicates cannot be created, we can use a simple insert. Then the script renames and switches the tables atomically.

4. Restart timescale writer.