### PR TITLE
API: Add oldest listen timestamp to /user/<username>/listens API response

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -88,8 +88,9 @@ class APITestCase(ListenAPIIntegrationTestCase):
         # make sure that artist msid, release msid and recording msid are present in data
         self.assertTrue(is_valid_uuid(data['listens'][0]['recording_msid']))
 
-        # check for latest listen timestamp
+        # check for latest and oldest  listen timestamp
         self.assertEqual(data['latest_listen_ts'], ts)
+        self.assertEqual(data['oldest_listen_ts'], ts)
 
         # request with min_ts should work
         response = self.client.get(
@@ -102,6 +103,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert200(response)
         self.assertListEqual(response.json['payload']['listens'], [])
         self.assertEqual(response.json['payload']['latest_listen_ts'], ts)
+        self.assertEqual(response.json['payload']['oldest_listen_ts'], ts)
 
         # test request with both max_ts and min_ts is working
         url = url_for('api_v1.get_listens',

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -161,7 +161,7 @@ def get_listens(user_name):
     if min_ts and max_ts and min_ts >= max_ts:
         raise APIBadRequest("min_ts should be less than max_ts")
 
-    listens, _, max_ts_per_user = timescale_connection._ts.fetch_listens(
+    listens, min_ts_per_user, max_ts_per_user = timescale_connection._ts.fetch_listens(
         user,
         limit=count,
         from_ts=datetime.utcfromtimestamp(min_ts) if min_ts else None,
@@ -176,6 +176,7 @@ def get_listens(user_name):
         'count': len(listen_data),
         'listens': listen_data,
         'latest_listen_ts': int(max_ts_per_user.timestamp()),
+        'oldest_listen_ts': int(min_ts_per_user.timestamp()),
     }})
 
 


### PR DESCRIPTION
@phw [requested in IRC](https://chatlogs.metabrainz.org/libera/metabrainz/2023-11-15/?msg=5249710&page=1) that we add a way to retrieve the oldest listen timestamp using the API.

Currently, the `/user/<username>/listens` API endpoint returns `latest_listen_ts` and we simply discard the information about the oldest timestamp. I suppose we never thought it was useful information to have in that response?

I've modified the code to use the discarded timestamp and return it as part of the API response as `oldest_listen_ts` (as we do in other places in the code, although none publicly-facing).
Are we happy with the name?


If there are other considerations that I missed please let me know.