### PR TITLE
Ensure all events selected for feed lie within min_ts and max_ts bounds

### DIFF
--- a/listenbrainz/db/tests/test_user_timeline_event.py
+++ b/listenbrainz/db/tests/test_user_timeline_event.py
@@ -36,11 +36,6 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
     def setUp(self):
         super(UserTimelineEventDatabaseTestCase, self).setUp()
         self.user = db_user.get_or_create(1, 'friendly neighborhood spider-man')
-        events = db_user_timeline_event.get_user_track_recommendation_events(
-            user_id=self.user['id'],
-            count=1,
-        )
-        self.assertListEqual([], events)
 
     def test_it_adds_rows_to_the_database(self):
         recording_msid = str(uuid.uuid4())
@@ -49,8 +44,10 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
             event_type=UserTimelineEventType.RECORDING_RECOMMENDATION,
             metadata=RecordingRecommendationMetadata(recording_msid=recording_msid)
         )
-        events = db_user_timeline_event.get_user_track_recommendation_events(
-            user_id=self.user['id'],
+        events = db_user_timeline_event.get_recording_recommendation_events_for_feed(
+            user_ids=[self.user['id']],
+            min_ts=0,
+            max_ts=time.time(),
             count=1,
         )
         self.assertEqual(1, len(events))
@@ -117,8 +114,11 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 recording_msid=str(uuid.uuid4()),
             )
         )
-        events = db_user_timeline_event.get_user_track_recommendation_events(
-            user_id=new_user['id'],
+        events = db_user_timeline_event.get_recording_recommendation_events_for_feed(
+            user_ids=[new_user['id']],
+            min_ts=0,
+            max_ts=int(time.time()) + 1000,
+            count=10
         )
         self.assertEqual(1, len(events))
         self.assertEqual(new_user['id'], events[0].user_id)
@@ -255,7 +255,9 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
             user_id=self.user["id"],
         )
         event_rec = db_user_timeline_event.get_user_notification_events(
-            user_id=self.user["id"],
+            user_ids=[self.user["id"]],
+            min_ts=0,
+            max_ts=int(time.time()),
             count=1,
         )
         self.assertEqual(0, len(event_rec))
@@ -266,7 +268,9 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
             user_id=new_user["id"],
         )
         event_not = db_user_timeline_event.get_user_notification_events(
-            user_id=new_user["id"],
+            user_ids=[self.user["id"]],
+            min_ts=0,
+            max_ts=int(time.time()),
             count=1,
         )
         self.assertEqual(0, len(event_not))

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -17,7 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from datetime import datetime
-from typing import List, Tuple
+from typing import List, Tuple, Iterable
 
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
@@ -136,14 +136,13 @@ def get_following_for_user(user: int) -> List[dict]:
                 ON "user".id = user_1
              WHERE user_0 = :user
                AND relationship_type = 'follow'
-
         """), {
             "user": user,
         })
         return result.mappings().all()
 
 
-def get_follow_events(user_ids: Tuple[int], min_ts: float, max_ts: float, count: int) -> List[dict]:
+def get_follow_events(user_ids: Iterable[int], min_ts: float, max_ts: float, count: int) -> List[dict]:
     """ Gets a list of follow events for specified users.
 
     Args:

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -12,8 +12,7 @@ from listenbrainz import webserver
 from listenbrainz.db import listens_importer
 from listenbrainz.db.missing_musicbrainz_data import get_user_missing_musicbrainz_data
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
-from listenbrainz.db.playlist import get_playlists_for_user, get_playlists_created_for_user, \
-    get_playlists_collaborated_on, get_recommendation_playlists_for_user
+from listenbrainz.db.playlist import get_playlists_for_user, get_recommendation_playlists_for_user
 from listenbrainz.db.pinned_recording import get_current_pin_for_user, get_pin_count_for_user, get_pin_history_for_user
 from listenbrainz.db.feedback import get_feedback_count_for_user, get_feedback_for_user
 from listenbrainz.db import year_in_music as db_year_in_music


### PR DESCRIPTION
The feed was showing duplicate events on navigating because the endpoints didn't consider the max_ts and min_ts timestamps.