### PR TITLE
Fix websockets setup for development

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -204,6 +204,7 @@ API_URL = '''{{template "KEY" "api_url"}}'''
 LASTFM_PROXY_URL = '''{{template "KEY" "lastfm_proxy_url"}}'''
 SERVER_ROOT_URL = '''{{template "KEY" "server_root_url"}}'''
 LISTENBRAINZ_LABS_API_URL = 'https://labs.api.listenbrainz.org'
+WEBSOCKETS_SERVER_URL = SERVER_ROOT_URL
 
 # Sentry config
 LOG_SENTRY = {

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -108,7 +108,10 @@ export default class PlaylistPage extends React.Component<
   };
 
   createWebsocketsConnection = (): void => {
-    this.socket = io(`${window.location.origin}`, { path: "/socket.io/" });
+    const { websocketsUrl } = this.context;
+    this.socket = io(websocketsUrl || window.location.origin, {
+      path: "/socket.io/",
+    });
   };
 
   addWebsocketsHandlers = (): void => {

--- a/frontend/js/src/user/Listens.tsx
+++ b/frontend/js/src/user/Listens.tsx
@@ -196,7 +196,10 @@ export default class Listens extends React.Component<
     // if modifying the uri or path, lookup socket.io namespace vs paths.
     // tl;dr io("https://listenbrainz.org/socket.io/") and
     // io("https://listenbrainz.org", { path: "/socket.io" }); are not equivalent
-    this.socket = io(`${window.location.origin}`, { path: "/socket.io/" });
+    const { websocketsUrl } = this.context;
+    this.socket = io(websocketsUrl || window.location.origin, {
+      path: "/socket.io/",
+    });
   };
 
   addWebsocketsHandlers = (): void => {

--- a/frontend/js/src/utils/GlobalAppContext.tsx
+++ b/frontend/js/src/utils/GlobalAppContext.tsx
@@ -4,6 +4,7 @@ import RecordingFeedbackManager from "./RecordingFeedbackManager";
 
 export type GlobalAppContextT = {
   APIService: APIService;
+  websocketsUrl: string;
   currentUser: ListenBrainzUser;
   spotifyAuth?: SpotifyUser;
   youtubeAuth?: YoutubeUser;
@@ -18,6 +19,7 @@ const apiService = new APIService(`${window.location.origin}/1`);
 
 const GlobalAppContext = createContext<GlobalAppContextT>({
   APIService: apiService,
+  websocketsUrl: "",
   currentUser: {} as ListenBrainzUser,
   spotifyAuth: {},
   youtubeAuth: {},

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -461,6 +461,7 @@ type SentryProps = {
 };
 type GlobalAppProps = {
   api_url: string;
+  websockets_url: string;
   current_user: ListenBrainzUser;
   spotify?: SpotifyUser;
   youtube?: YoutubeUser;
@@ -507,6 +508,7 @@ const getPageProps = (): {
     const {
       current_user,
       api_url,
+      websockets_url,
       spotify,
       youtube,
       soundcloud,
@@ -532,6 +534,7 @@ const getPageProps = (): {
     );
     globalAppContext = {
       APIService: apiService,
+      websocketsUrl: websockets_url,
       currentUser: current_user,
       spotifyAuth: spotify,
       youtubeAuth: youtube,

--- a/frontend/js/tests/brainzplayer/BrainzPlayer.test.tsx
+++ b/frontend/js/tests/brainzplayer/BrainzPlayer.test.tsx
@@ -43,6 +43,7 @@ const soundcloudPermissions = {
 const GlobalContextMock: { context: GlobalAppContextT } = {
   context: {
     APIService: new APIService("base-uri"),
+    websocketsUrl: "",
     spotifyAuth: {
       access_token: "heyo",
       permission: [

--- a/frontend/js/tests/follow/FollowButton.test.tsx
+++ b/frontend/js/tests/follow/FollowButton.test.tsx
@@ -40,6 +40,7 @@ const loggedInUser = {
 
 const globalContext: GlobalAppContextT = {
   APIService: new APIService("foo"),
+  websocketsUrl: "",
   youtubeAuth: {},
   spotifyAuth: {},
   currentUser: loggedInUser,

--- a/frontend/js/tests/follow/FollowerFollowingModal.test.tsx
+++ b/frontend/js/tests/follow/FollowerFollowingModal.test.tsx
@@ -39,6 +39,7 @@ const props = {
 
 const globalContext: GlobalAppContextT = {
   APIService: new APIService("foo"),
+  websocketsUrl: "",
   youtubeAuth: {},
   spotifyAuth: {},
   currentUser: {} as ListenBrainzUser,

--- a/frontend/js/tests/follow/SimilarUsersModal.test.tsx
+++ b/frontend/js/tests/follow/SimilarUsersModal.test.tsx
@@ -16,6 +16,7 @@ const props = {
 };
 const globalContext: GlobalAppContextT = {
   APIService: new APIService("foo"),
+  websocketsUrl: "",
   youtubeAuth: {},
   spotifyAuth: {},
   currentUser: {} as ListenBrainzUser,

--- a/frontend/js/tests/follow/UserSocialNetwork.test.tsx
+++ b/frontend/js/tests/follow/UserSocialNetwork.test.tsx
@@ -45,6 +45,7 @@ const props = {
 
 const globalContext: GlobalAppContextT = {
   APIService: new APIService("foo"),
+  websocketsUrl: "",
   youtubeAuth: {},
   spotifyAuth: {},
   currentUser: loggedInUser,

--- a/frontend/js/tests/fresh-releases/FreshReleases.test.tsx
+++ b/frontend/js/tests/fresh-releases/FreshReleases.test.tsx
@@ -38,6 +38,7 @@ const { youtube, spotify, user } = freshReleasesProps;
 const mountOptions: { context: GlobalAppContextT } = {
   context: {
     APIService: new APIService("foo"),
+    websocketsUrl: "",
     youtubeAuth: youtube as YoutubeUser,
     spotifyAuth: spotify as SpotifyUser,
     currentUser: user,

--- a/frontend/js/tests/huesound/ColorPlay.test.tsx
+++ b/frontend/js/tests/huesound/ColorPlay.test.tsx
@@ -25,6 +25,7 @@ const props = {
 const mountOptions: { context: GlobalAppContextT } = {
   context: {
     APIService: new APIService("foo"),
+    websocketsUrl: "",
     youtubeAuth: colorPlayProps.youtube as YoutubeUser,
     spotifyAuth: colorPlayProps.spotify as SpotifyUser,
     currentUser: colorPlayProps.user,

--- a/frontend/js/tests/listens/ListenCard.test.tsx
+++ b/frontend/js/tests/listens/ListenCard.test.tsx
@@ -49,6 +49,7 @@ const props: ListenCardProps = {
 
 const globalProps: GlobalAppContextT = {
   APIService: new APIServiceClass(""),
+  websocketsUrl: "",
   currentUser: { auth_token: "baz", name: "test" },
   spotifyAuth: {},
   youtubeAuth: {},

--- a/frontend/js/tests/listens/ListenCountCard.test.tsx
+++ b/frontend/js/tests/listens/ListenCountCard.test.tsx
@@ -20,6 +20,7 @@ const loggedInUser = {
 
 const globalContext: GlobalAppContextT = {
   APIService: new APIService("foo"),
+  websocketsUrl: "",
   currentUser: loggedInUser,
   recordingFeedbackManager: new RecordingFeedbackManager(
     new APIService("foo"),

--- a/frontend/js/tests/listens/RecommendationFeedbackComponent.test.tsx
+++ b/frontend/js/tests/listens/RecommendationFeedbackComponent.test.tsx
@@ -52,6 +52,7 @@ const props: RecommendationFeedbackComponentProps = {
 
 const globalProps: GlobalAppContextT = {
   APIService: new APIServiceClass(""),
+  websocketsUrl: "",
   currentUser: { auth_token: "baz", name: "test" },
   spotifyAuth: {},
   youtubeAuth: {},

--- a/frontend/js/tests/missing-mb-data/MissingMBData.test.tsx
+++ b/frontend/js/tests/missing-mb-data/MissingMBData.test.tsx
@@ -26,6 +26,7 @@ const props = {
 const mountOptions: { context: GlobalAppContextT } = {
   context: {
     APIService: new APIService("foo"),
+    websocketsUrl: "",
     youtubeAuth: youtube as YoutubeUser,
     spotifyAuth: spotify as SpotifyUser,
     currentUser: user,

--- a/frontend/js/tests/personal-recommendations/PersonalRecommendationsModal.test.tsx
+++ b/frontend/js/tests/personal-recommendations/PersonalRecommendationsModal.test.tsx
@@ -34,6 +34,7 @@ const user = {
 const testAPIService = new APIServiceClass("");
 const globalProps: GlobalAppContextT = {
   APIService: testAPIService,
+  websocketsUrl: "",
   currentUser: user,
   spotifyAuth: {},
   youtubeAuth: {},

--- a/frontend/js/tests/pins/PinRecordingModal.test.tsx
+++ b/frontend/js/tests/pins/PinRecordingModal.test.tsx
@@ -52,6 +52,7 @@ const user = {
 const APIService = new APIServiceClass("");
 const globalProps: GlobalAppContextT = {
   APIService,
+  websocketsUrl: "",
   currentUser: user,
   spotifyAuth: {},
   youtubeAuth: {},

--- a/frontend/js/tests/pins/PinnedRecordingCard.test.tsx
+++ b/frontend/js/tests/pins/PinnedRecordingCard.test.tsx
@@ -28,6 +28,7 @@ const user = {
 
 const globalProps: GlobalAppContextT = {
   APIService: new APIServiceClass(""),
+  websocketsUrl: "",
   currentUser: user,
   spotifyAuth: {},
   youtubeAuth: {},

--- a/frontend/js/tests/pins/UserPins.test.tsx
+++ b/frontend/js/tests/pins/UserPins.test.tsx
@@ -53,6 +53,7 @@ const APIPinsPageTwo = {
 const mountOptions: { context: GlobalAppContextT } = {
   context: {
     APIService: new APIService("foo"),
+    websocketsUrl: "",
     youtubeAuth: pinsPageProps.youtube as YoutubeUser,
     spotifyAuth: pinsPageProps.spotify as SpotifyUser,
     currentUser: pinsPageProps.user,

--- a/frontend/js/tests/playlists/Playlist.test.tsx
+++ b/frontend/js/tests/playlists/Playlist.test.tsx
@@ -31,6 +31,7 @@ const props = {
 
 const GlobalContextMock: GlobalAppContextT = {
   APIService: new APIService("foo"),
+  websocketsUrl: "",
   youtubeAuth: {
     api_key: "fake-api-key",
   },

--- a/frontend/js/tests/recent/RecentListens.test.tsx
+++ b/frontend/js/tests/recent/RecentListens.test.tsx
@@ -62,6 +62,7 @@ const props = {
 const mountOptions: { context: GlobalAppContextT } = {
   context: {
     APIService: new APIServiceClass("foo"),
+    websocketsUrl: "",
     youtubeAuth: youtube as YoutubeUser,
     spotifyAuth: spotify as SpotifyUser,
     currentUser: { id: 1, name: "iliekcomputers", auth_token: "fnord" },

--- a/frontend/js/tests/recommendations/Recommendations.test.tsx
+++ b/frontend/js/tests/recommendations/Recommendations.test.tsx
@@ -43,6 +43,7 @@ const props = {
 const mountOptions: { context: GlobalAppContextT } = {
   context: {
     APIService: new APIService("foo"),
+    websocketsUrl: "",
     youtubeAuth: youtube as YoutubeUser,
     spotifyAuth: spotify as SpotifyUser,
     currentUser: user,

--- a/frontend/js/tests/test-utils/rtl-test-utils.tsx
+++ b/frontend/js/tests/test-utils/rtl-test-utils.tsx
@@ -19,6 +19,7 @@ jest.requireActual("react-toastify");
 const testAPIService = new APIService("");
 const defaultGlobalContext: GlobalAppContextT = {
   APIService: testAPIService,
+  websocketsUrl: "",
   currentUser: {
     id: 1,
     name: "FNORD",

--- a/frontend/js/tests/user-feed/UserFeed.test.tsx
+++ b/frontend/js/tests/user-feed/UserFeed.test.tsx
@@ -45,6 +45,7 @@ const props = {
 
 const GlobalContextMock: GlobalAppContextT = {
   APIService: new APIService("base-uri"),
+  websocketsUrl: "",
   spotifyAuth: timelineProps.spotify as SpotifyUser,
   youtubeAuth: timelineProps.youtube as YoutubeUser,
   currentUser: timelineProps.currentUser,

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -140,6 +140,7 @@ API_URL = 'https://api.listenbrainz.org'
 LASTFM_PROXY_URL = 'http://localhost:8101/'
 SERVER_ROOT_URL = 'http://localhost:8100'
 LISTENBRAINZ_LABS_API_URL = 'https://labs.api.listenbrainz.org'
+WEBSOCKETS_SERVER_URL = 'http://localhost:8102'
 
 # Flask Debug redirect
 # Set to True if you want Flask-Debug to intercept redirects

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -62,6 +62,7 @@ def get_global_props():
 
     props = {
         "api_url": current_app.config["API_URL"],
+        "websockets_url": current_app.config["WEBSOCKETS_SERVER_URL"],
         "sentry_dsn": sentry_config.get("dsn"),
         "current_user": current_user_data,
         "spotify": get_current_spotify_user(),


### PR DESCRIPTION
Websockets don't work in development because the code expected it to run on the same host and port as the LB webserver. To configure the url for websockets in development and production properly, add a separate configuration variable.

**TODO: Test on test.lb before merging.**