### PR TITLE
Fix CBReviewModal randomly failing frontend test suite

### DIFF
--- a/frontend/js/src/add-listen/AddListenModal.tsx
+++ b/frontend/js/src/add-listen/AddListenModal.tsx
@@ -52,7 +52,7 @@ export default NiceModal.create(() => {
 
   const closeModal = useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 500);
+    setTimeout(modal.remove, 3000);
   }, [modal]);
 
   const handleError = useCallback(

--- a/frontend/js/src/cb-review/CBReviewModal.tsx
+++ b/frontend/js/src/cb-review/CBReviewModal.tsx
@@ -43,7 +43,7 @@ export default NiceModal.create(({ listen }: CBReviewModalProps) => {
 
   const closeModal = React.useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 500);
+    setTimeout(modal.remove, 3000);
   }, [modal]);
 
   const { APIService, currentUser, critiquebrainzAuth } = React.useContext(
@@ -539,7 +539,11 @@ export default NiceModal.create(({ listen }: CBReviewModalProps) => {
           </label>
         </div>
         {!reviewValid && (
-          <div id="text-too-short-alert" className="alert alert-danger">
+          <div
+            id="text-too-short-alert"
+            className="alert alert-danger"
+            role="alert"
+          >
             Your review needs to be longer than {minTextLength} characters.
           </div>
         )}

--- a/frontend/js/src/listens/AddToPlaylist.tsx
+++ b/frontend/js/src/listens/AddToPlaylist.tsx
@@ -31,7 +31,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
 
   const closeModal = React.useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 500);
+    setTimeout(modal.remove, 3000);
   }, [modal]);
 
   const { listen } = props;

--- a/frontend/js/src/listens/ListenPayloadModal.tsx
+++ b/frontend/js/src/listens/ListenPayloadModal.tsx
@@ -28,7 +28,7 @@ export default NiceModal.create(({ listen }: ListenPayloadModalProps) => {
 
   const closeModal = () => {
     modal.hide();
-    setTimeout(modal.remove, 500);
+    setTimeout(modal.remove, 3000);
   };
   const stringifiedJSON = JSON.stringify(listen, null, 2);
 

--- a/frontend/js/src/notifications/Notifications.tsx
+++ b/frontend/js/src/notifications/Notifications.tsx
@@ -7,7 +7,7 @@ export type ToastMsgProps = {
 
 export function ToastMsg({ title, message }: ToastMsgProps) {
   return (
-    <div>
+    <div aria-roledescription="alert" role="alert">
       <b>{title}</b>
       <p>{message}</p>
     </div>

--- a/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
+++ b/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
@@ -103,7 +103,7 @@ export default NiceModal.create(
 
     const closeModal = () => {
       modal.hide();
-      setTimeout(modal.remove, 500);
+      setTimeout(modal.remove, 3000);
     };
 
     const submitPersonalRecommendation = React.useCallback(

--- a/frontend/js/src/pins/PinRecordingModal.tsx
+++ b/frontend/js/src/pins/PinRecordingModal.tsx
@@ -63,7 +63,7 @@ export default NiceModal.create(
 
     const closeModal = () => {
       modal.hide();
-      setTimeout(modal.remove, 500);
+      setTimeout(modal.remove, 3000);
     };
 
     const submitPinRecording = React.useCallback(

--- a/frontend/js/src/playlists/CreateOrEditPlaylistModal.tsx
+++ b/frontend/js/src/playlists/CreateOrEditPlaylistModal.tsx
@@ -22,7 +22,7 @@ export default NiceModal.create((props: CreateOrEditPlaylistModalProps) => {
   const modal = useModal();
   const closeModal = React.useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 500);
+    setTimeout(modal.remove, 3000);
   }, [modal]);
 
   const { currentUser, APIService } = React.useContext(GlobalAppContext);

--- a/frontend/js/src/playlists/DeletePlaylistConfirmationModal.tsx
+++ b/frontend/js/src/playlists/DeletePlaylistConfirmationModal.tsx
@@ -14,7 +14,7 @@ export default NiceModal.create(
     const modal = useModal();
     const closeModal = React.useCallback(() => {
       modal.hide();
-      setTimeout(modal.remove, 500);
+      setTimeout(modal.remove, 3000);
     }, [modal]);
 
     const { playlist } = props;


### PR DESCRIPTION
Some of the tests in the CBReviewModal test suite are repeatedly and randomly failing for some reason, causing us to repeatedly rerunning the test suite and praying it passes this time, and I couldn't figure out why.
Here is one example of this failing test suite, although there are PLENTY more: https://github.com/metabrainz/listenbrainz-server/actions/runs/6922403742/job/18976667482#step:6:952

After working on it again and spending a day digging deeper, I finally figured out it has to do with the modal cleanup we run when we close the modal.
It basically pulls the rug under the running tests by removing the modal from the DOM after a timeout.

I didn't realize it before because we do not call this cleanup method manually in the tests, rather it is run automatically after a successful review submission.
The very simple solution is to increase the delay before removing the modal content from DOM.

This PR also changes that same delay for all our modal components that were using the same code.