### PR TITLE
Use unique testing env var for running tests

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -37,6 +37,7 @@ services:
     environment:
       PYTHONDONTWRITEBYTECODE: 1
       SQLALCHEMY_WARN_20: 1
+      PYTHON_TESTS_RUNNING: 1
     depends_on:
       - redis
       - lb_db

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -22,7 +22,6 @@ https://listenbrainz.readthedocs.io/en/production/dev/listenbrainz-dumps.html
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-
 import os
 import shutil
 import subprocess
@@ -103,13 +102,7 @@ PUBLIC_TABLES_DUMP = {
         'listen_count',
         'last_updated',
     ),
-    'recording_feedback': (
-        'id',
-        'user_id',
-        'recording_msid',
-        'score',
-        'created'
-    ),
+    'recording_feedback': ('id', 'user_id', 'recording_msid', 'score', 'created'),
 }
 
 PUBLIC_TABLES_TIMESCALE_DUMP = {
@@ -153,14 +146,14 @@ PUBLIC_TABLES_IMPORT = PUBLIC_TABLES_DUMP.copy()
 # When importing fields with COPY we need to use the names of the fields, rather
 # than the placeholders that we set for the export
 PUBLIC_TABLES_IMPORT['user'] = (
-        'id',
-        'created',
-        'musicbrainz_id',
-        'musicbrainz_row_id',
-        'auth_token',
-        'last_login',
-        'latest_import',
-    )
+    'id',
+    'created',
+    'musicbrainz_id',
+    'musicbrainz_row_id',
+    'auth_token',
+    'last_login',
+    'latest_import',
+)
 
 # this dict contains the tables dumped in the private dump as keys
 # and a tuple of columns that should be dumped as values
@@ -176,25 +169,10 @@ PRIVATE_TABLES = {
         'gdpr_agreed',
         'email',
     ),
-    'external_service_oauth': (
-        'id',
-        'user_id',
-        'service',
-        'access_token',
-        'refresh_token',
-        'token_expires',
-        'last_updated',
-        'scopes'
-    ),
-    'listens_importer': (
-        'id',
-        'external_service_oauth_id',
-        'user_id',
-        'service',
-        'last_updated',
-        'latest_listened_at',
-        'error_message'
-    ),
+    'external_service_oauth':
+    ('id', 'user_id', 'service', 'access_token', 'refresh_token', 'token_expires', 'last_updated', 'scopes'),
+    'listens_importer':
+    ('id', 'external_service_oauth_id', 'user_id', 'service', 'last_updated', 'latest_listened_at', 'error_message'),
     'api_compat.token': (
         'id',
         'user_id',
@@ -225,18 +203,8 @@ PRIVATE_TABLES_TIMESCALE = {
         'created_for_id',
         'additional_metadata',
     ),
-    'playlist.playlist_recording': (
-        'id',
-        'playlist_id',
-        'position',
-        'mbid',
-        'added_by_id',
-        'created'
-    ),
-    'playlist.playlist_collaborator': (
-        'playlist_id',
-        'collaborator_id'
-    )
+    'playlist.playlist_recording': ('id', 'playlist_id', 'position', 'mbid', 'added_by_id', 'created'),
+    'playlist.playlist_collaborator': ('playlist_id', 'collaborator_id')
 }
 
 
@@ -277,7 +245,8 @@ def dump_postgres_db(location, dump_time=datetime.today(), threads=DUMP_DEFAULT_
     return private_dump, public_dump
 
 
-def dump_timescale_db(location: str, dump_time: datetime = datetime.today(),
+def dump_timescale_db(location: str,
+                      dump_time: datetime = datetime.today(),
                       threads: int = DUMP_DEFAULT_THREAD_COUNT) -> Optional[Tuple[str, str]]:
     """ Create timescale database (excluding listens) dump in the specified location
 
@@ -299,8 +268,7 @@ def dump_timescale_db(location: str, dump_time: datetime = datetime.today(),
         current_app.logger.info('Removing created files and giving up...')
         shutil.rmtree(location)
         return
-    current_app.logger.info(
-        'Dump of private timescale data created at %s!', private_timescale_dump)
+    current_app.logger.info('Dump of private timescale data created at %s!', private_timescale_dump)
 
     current_app.logger.info('Creating dump of timescale public data...')
     try:
@@ -358,8 +326,13 @@ def dump_statistics(location: str):
             couchdb.dump_database(stat, fp)
 
 
-def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], dump_type: str, tables: Optional[dict],
-                 schema_version: int, dump_time: datetime, threads=DUMP_DEFAULT_THREAD_COUNT):
+def _create_dump(location: str,
+                 db_engine: Optional[sqlalchemy.engine.Engine],
+                 dump_type: str,
+                 tables: Optional[dict],
+                 schema_version: int,
+                 dump_time: datetime,
+                 threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Creates a dump of the provided tables at the location passed
 
         Arguments:
@@ -376,13 +349,8 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], d
             the path to the archive file created
     """
 
-    archive_name = 'listenbrainz-{dump_type}-dump-{time}'.format(
-        dump_type=dump_type,
-        time=dump_time.strftime('%Y%m%d-%H%M%S')
-    )
-    archive_path = os.path.join(location, '{archive_name}.tar.xz'.format(
-        archive_name=archive_name,
-    ))
+    archive_name = 'listenbrainz-{dump_type}-dump-{time}'.format(dump_type=dump_type, time=dump_time.strftime('%Y%m%d-%H%M%S'))
+    archive_path = os.path.join(location, '{archive_name}.tar.xz'.format(archive_name=archive_name, ))
 
     with open(archive_path, 'w') as archive:
 
@@ -397,15 +365,12 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], d
                 schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
                 with open(schema_seq_path, "w") as f:
                     f.write(str(schema_version))
-                tar.add(schema_seq_path,
-                        arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
+                tar.add(schema_seq_path, arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
                 timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
                 with open(timestamp_path, "w") as f:
                     f.write(dump_time.isoformat(" "))
-                tar.add(timestamp_path,
-                        arcname=os.path.join(archive_name, "TIMESTAMP"))
-                tar.add(DUMP_LICENSE_FILE_PATH,
-                        arcname=os.path.join(archive_name, "COPYING"))
+                tar.add(timestamp_path, arcname=os.path.join(archive_name, "TIMESTAMP"))
+                tar.add(DUMP_LICENSE_FILE_PATH, arcname=os.path.join(archive_name, "COPYING"))
             except Exception:
                 current_app.logger.error('Exception while adding dump metadata: ', exc_info=True)
                 raise
@@ -444,8 +409,7 @@ def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], d
                 # This is so that when imported into a db with FK constraints added, we import dependent
                 # tables first
                 for table in tables:
-                    tar.add(os.path.join(archive_tables_dir, table),
-                            arcname=os.path.join(archive_name, 'lbdump', table))
+                    tar.add(os.path.join(archive_tables_dir, table), arcname=os.path.join(archive_name, 'lbdump', table))
 
             shutil.rmtree(temp_dir)
 
@@ -462,6 +426,11 @@ def create_private_dump(location: str, dump_time: datetime, threads=DUMP_DEFAULT
             api_compat.token,
             api_compat.session
     """
+
+    if "PYTHON_TESTS_RUNNING" in os.environ:
+        db_connect = db.create_test_database_connect_strings()
+        db.init_db_connection(db_connect["DB_CONNECT"])
+
     return _create_dump(
         location=location,
         db_engine=db.engine,
@@ -476,6 +445,10 @@ def create_private_dump(location: str, dump_time: datetime, threads=DUMP_DEFAULT
 def create_private_timescale_dump(location: str, dump_time: datetime, threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Create timescale database dump for private data in db.
     """
+    if "PYTHON_TESTS_RUNNING" in os.environ:
+        ts_connect = timescale.create_test_database_connect_strings()
+        timescale.init_db_connection(ts_connect["DB_CONNECT"])
+
     return _create_dump(
         location=location,
         db_engine=timescale.engine,
@@ -496,6 +469,10 @@ def create_public_dump(location: str, dump_time: datetime, threads=DUMP_DEFAULT_
             statistics.release
             statistics.recording
     """
+    if "PYTHON_TESTS_RUNNING" in os.environ:
+        db_connect = db.create_test_database_connect_strings()
+        db.init_db_connection(db_connect["DB_CONNECT"])
+
     return _create_dump(
         location=location,
         db_engine=db.engine,
@@ -511,6 +488,10 @@ def create_public_timescale_dump(location: str, dump_time: datetime, threads=DUM
     """ Create postgres database dump for public info in the timescale database.
         This includes the MBID mapping table
     """
+    if "PYTHON_TESTS_RUNNING" in os.environ:
+        ts_connect = ts.create_test_timescale_connect_strings()
+        ts.init_db_connection(ts_connect["DB_CONNECT"])
+
     return _create_dump(
         location=location,
         db_engine=timescale.engine,
@@ -525,6 +506,11 @@ def create_public_timescale_dump(location: str, dump_time: datetime, threads=DUM
 def create_feedback_dump(location: str, dump_time: datetime, threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Create a spark format dump of user listen and user recommendation feedback.
     """
+
+    if "PYTHON_TESTS_RUNNING" in os.environ:
+        db_connect = db.create_test_database_connect_strings()
+        db.init_db_connection(db_connect["DB_CONNECT"])
+
     return _create_dump(
         location=location,
         db_engine=db.engine,
@@ -556,7 +542,8 @@ def dump_user_feedback(connection, location):
     with connection.begin() as transaction:
 
         # First dump the user feedback
-        result = connection.execute(sqlalchemy.text("""
+        result = connection.execute(
+            sqlalchemy.text("""
             SELECT musicbrainz_id, recording_msid, score, r.created,
                    EXTRACT(YEAR FROM r.created) AS year,
                    EXTRACT(MONTH FROM r.created) AS month,
@@ -573,8 +560,8 @@ def dump_user_feedback(connection, location):
             row = result.fetchone()
             today = (row[4], row[5], row[6]) if row else ()
             if (not row or today != last_day) and len(todays_items) > 0:
-                full_path = os.path.join(location, "feedback", "listens", "%02d" % int(last_day[0]),
-                                         "%02d" % int(last_day[1]), "%02d" % int(last_day[2]))
+                full_path = os.path.join(location, "feedback", "listens", "%02d" % int(last_day[0]), "%02d" % int(last_day[1]),
+                                         "%02d" % int(last_day[2]))
                 os.makedirs(full_path)
                 with open(os.path.join(full_path, "data.json"), "wb") as f:
                     for item in todays_items:
@@ -585,14 +572,17 @@ def dump_user_feedback(connection, location):
             if not row:
                 break
 
-            todays_items.append({'user_name': row[0],
-                                 'recording_msid': str(row[1]),
-                                 'feedback': row[2],
-                                 'created': row[3].isoformat()})
+            todays_items.append({
+                'user_name': row[0],
+                'recording_msid': str(row[1]),
+                'feedback': row[2],
+                'created': row[3].isoformat()
+            })
             last_day = today
 
         # Now dump the recommendation feedback
-        result = connection.execute(sqlalchemy.text("""
+        result = connection.execute(
+            sqlalchemy.text("""
             SELECT musicbrainz_id, recording_mbid, rating, r.created,
                    EXTRACT(YEAR FROM r.created) AS year,
                    EXTRACT(MONTH FROM r.created) AS month,
@@ -620,10 +610,12 @@ def dump_user_feedback(connection, location):
             if not row:
                 break
 
-            todays_items.append({'user_name': row[0],
-                                 'mb_recording_mbid': str(row[1]),
-                                 'feedback': row[2],
-                                 'created': row[3].isoformat()})
+            todays_items.append({
+                'user_name': row[0],
+                'mb_recording_mbid': str(row[1]),
+                'feedback': row[2],
+                'created': row[3].isoformat()
+            })
             last_day = today
         transaction.rollback()
 
@@ -656,13 +648,14 @@ def add_dump_entry(timestamp):
     """
 
     with db.engine.begin() as connection:
-        result = connection.execute(sqlalchemy.text("""
+        result = connection.execute(
+            sqlalchemy.text("""
                 INSERT INTO data_dump (created)
                      VALUES (TO_TIMESTAMP(:ts))
                   RETURNING id
             """), {
-            'ts': timestamp,
-        })
+                'ts': timestamp,
+            })
         return result.fetchone().id
 
 
@@ -671,7 +664,8 @@ def get_dump_entries():
     """
 
     with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
+        result = connection.execute(
+            sqlalchemy.text("""
                 SELECT id, created
                   FROM data_dump
               ORDER BY created DESC
@@ -682,13 +676,14 @@ def get_dump_entries():
 
 def get_dump_entry(dump_id):
     with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
+        result = connection.execute(
+            sqlalchemy.text("""
             SELECT id, created
               FROM data_dump
              WHERE id = :dump_id
         """), {
-            'dump_id': dump_id,
-        })
+                'dump_id': dump_id,
+            })
         if result.rowcount > 0:
             return result.mappings().first()
         return None
@@ -709,6 +704,12 @@ def import_postgres_dump(private_dump_archive_path=None,
             threads: the number of threads to use while decompressing the archives, defaults to
                      db.DUMP_DEFAULT_THREAD_COUNT
     """
+
+    if "PYTHON_TESTS_RUNNING" in os.environ:
+        db_connect = db.create_test_database_connect_strings()
+        db.init_db_connection(db_connect["DB_CONNECT"])
+        ts_connect = timescale.create_test_timescale_connect_strings()
+        timescale.init_db_connection(ts_connect["DB_CONNECT"])
 
     if private_dump_archive_path:
         current_app.logger.info('Importing private dump %s...', private_dump_archive_path)
@@ -779,8 +780,7 @@ def _escape_table_columns(table: str, columns: list[str | Composable]) \
     return escaped_table_name, joined_fields
 
 
-def _import_dump(archive_path, db_engine: sqlalchemy.engine.Engine,
-                 tables, schema_version: int, threads=DUMP_DEFAULT_THREAD_COUNT):
+def _import_dump(archive_path, db_engine: sqlalchemy.engine.Engine, tables, schema_version: int, threads=DUMP_DEFAULT_THREAD_COUNT):
     """ Import dump present in passed archive path into postgres db.
 
         Arguments:
@@ -808,8 +808,7 @@ def _import_dump(archive_path, db_engine: sqlalchemy.engine.Engine,
                     schema_seq = int(tar.extractfile(member).read().strip())
                     if schema_seq != schema_version:
                         raise SchemaMismatchException('Incorrect schema version! Expected: %d, got: %d.'
-                                                      'Please, get the latest version of the dump.'
-                                                      % (schema_version, schema_seq))
+                                                      'Please, get the latest version of the dump.' % (schema_version, schema_seq))
                     else:
                         current_app.logger.info('Schema version verified.')
 
@@ -839,7 +838,8 @@ def _update_sequence(db_engine: sqlalchemy.engine.Engine, seq_name, table_name):
         table_name (str): the name of the table from which the maximum value is to be retrieved
     """
     with db_engine.connect() as connection:
-        connection.execute(sqlalchemy.text("""
+        connection.execute(
+            sqlalchemy.text("""
             SELECT setval('{seq_name}', max(id))
               FROM {table_name}
         """.format(seq_name=seq_name, table_name=table_name)))
@@ -997,13 +997,11 @@ def check_ftp_dump_ages():
     app = create_app()
     with app.app_context():
         if not current_app.config['TESTING'] and msg:
-            send_mail(
-                subject="ListenBrainz outdated dumps!",
-                text=render_template('emails/data_dump_outdated.txt', msg=msg),
-                recipients=['listenbrainz-exceptions@metabrainz.org'],
-                from_name='ListenBrainz',
-                from_addr='noreply@' + current_app.config['MAIL_FROM_DOMAIN']
-            )
+            send_mail(subject="ListenBrainz outdated dumps!",
+                      text=render_template('emails/data_dump_outdated.txt', msg=msg),
+                      recipients=['listenbrainz-exceptions@metabrainz.org'],
+                      from_name='ListenBrainz',
+                      from_addr='noreply@' + current_app.config['MAIL_FROM_DOMAIN'])
         elif msg:
             print(msg)
 

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -48,8 +48,15 @@ NUMBER_OF_CANONICAL_DUMPS_TO_KEEP = 2
 
 cli = click.Group()
 
+# Scratchpad
+#    if "PYTHON_TESTS_RUNNING" in os.environ:
+#        db_connect = db.create_test_database_connect_strings()
+#        db.init_db_connection(db_connect["DB_CONNECT"])
+#        ts_connect = timescale.create_test_timescale_connect_strings()
+#        timescale.init_db_connection(ts_connect["DB_CONNECT"])
 
 def send_dump_creation_notification(dump_name, dump_type):
+
     if not current_app.config['TESTING']:
         dump_link = 'http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/{}/{}'.format(
             dump_type, dump_name)

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -25,6 +25,8 @@ class DatabaseTestCase(unittest.TestCase):
         self.reset_db()
 
     def reset_db(self):
+        db_connect = create_test_database_connect_strings()
+        db.init_db_connection(db_connect["DB_CONNECT"])
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'reset_tables.sql'))
 
     @classmethod
@@ -62,4 +64,6 @@ class TimescaleTestCase(unittest.TestCase):
         self.reset_timescale_db()
 
     def reset_timescale_db(self):
+        ts_connect = create_test_timescale_connect_strings()
+        ts.init_db_connection(ts_connect["DB_CONNECT"])
         ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'reset_tables.sql'))

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -50,6 +50,10 @@ class DumpTestCase(DatabaseTestCase):
         self.tempdir = tempfile.mkdtemp()
         self.app = create_app()
 
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+
     def tearDown(self):
         super().tearDown()
         shutil.rmtree(self.tempdir)

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -36,6 +36,7 @@ from listenbrainz.db import dump_manager
 from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.db.model.recommendation_feedback import RecommendationFeedbackSubmit
 from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.db import timescale
 from listenbrainz.listenstore.tests.util import generate_data
 from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app, timescale_connection
@@ -49,6 +50,13 @@ class DumpManagerTestCase(DatabaseTestCase):
         self.tempdir = tempfile.mkdtemp()
         self.runner = CliRunner()
         self.listenstore = timescale_connection._ts
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+            ts_connect = timescale.create_test_timescale_connect_strings()
+            timescale.init_db_connection(ts_connect["DB_CONNECT"])
+
         self.user_id = db_user.create(1, 'iliekcomputers')
         self.user_name = db_user.get(self.user_id)['musicbrainz_id']
 

--- a/listenbrainz/listenstore/tests/test_dumplistenstore.py
+++ b/listenbrainz/listenstore/tests/test_dumplistenstore.py
@@ -26,9 +26,17 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         self.app = create_app()
         self.logstore = TimescaleListenStore(self.app.logger)
         self.dumpstore = DumpListenStore(self.app)
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+            ts_connect = timescale.create_test_timescale_connect_strings()
+            timescale.init_db_connection(ts_connect["DB_CONNECT"])
+
         self.testuser = db_user.get_or_create(1, "test")
         self.testuser_name = self.testuser["musicbrainz_id"]
         self.testuser_id = self.testuser["id"]
+
 
     def tearDown(self):
         self.logstore = None

--- a/listenbrainz/listenstore/tests/test_timescale_utils.py
+++ b/listenbrainz/listenstore/tests/test_timescale_utils.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from datetime import datetime
 
@@ -23,6 +24,12 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
         self.log = logging.getLogger(__name__)
         self.app = create_app()
         self.logstore = TimescaleListenStore(self.log)
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+            ts_connect = timescale.create_test_timescale_connect_strings()
+            timescale.init_db_connection(ts_connect["DB_CONNECT"])
 
     def tearDown(self):
         self.logstore = None

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import random
 from datetime import datetime, timedelta
@@ -26,6 +27,12 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.app = create_app()
         self.log = logging.getLogger(__name__)
         self.logstore = TimescaleListenStore(self.log)
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+            ts_connect = timescale.create_test_timescale_connect_strings()
+            timescale.init_db_connection(ts_connect["DB_CONNECT"])
 
         self.testuser = db_user.get_or_create(1, "test")
         self.testuser_id = self.testuser["id"]

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -56,7 +56,6 @@ def init_db(force, create_db):
     """
     from listenbrainz import config
     if "PYTHON_TESTS_RUNNING" in os.environ:
-        print("PYTHON TESTING DETECTED!")
         db_connect = db.create_test_database_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT_ADMIN"])
     else:
@@ -99,7 +98,6 @@ def init_db(force, create_db):
     application = webserver.create_app()
     with application.app_context():
         if "PYTHON_TESTS_RUNNING" in os.environ:
-            print("PYTHON TESTING DETECTED!")
             db_connect = db.create_test_database_connect_strings()
             db.init_db_connection(db_connect["DB_CONNECT"])
         else:
@@ -196,7 +194,6 @@ def init_ts_db(force, create_db):
     application = webserver.create_app()
     with application.app_context():
         if "PYTHON_TESTS_RUNNING" in os.environ:
-            print("PYTHON TESTING DETECTED!")
             ts_connect = ts.create_test_timescale_connect_strings()
             ts.init_db_connection(ts_connect["DB_CONNECT"])
         else:

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -60,6 +60,7 @@ def init_db(force, create_db):
         db_connect = db.create_test_database_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT_ADMIN"])
     else:
+        db_connect = {"DB_NAME": "listenbrainz", "DB_USER": "listenbrainz"}
         db.init_db_connection(config.POSTGRES_ADMIN_URI)
     if force:
         res = db.run_sql_query_without_transaction(
@@ -100,9 +101,10 @@ def init_db(force, create_db):
         if "PYTHON_TESTS_RUNNING" in os.environ:
             print("PYTHON TESTING DETECTED!")
             db_connect = db.create_test_database_connect_strings()
-            db.init_db_connection(db_connect["DB_CONNECT_ADMIN_LB"])
+            db.init_db_connection(db_connect["DB_CONNECT"])
         else:
-            db.init_db_connection(config.POSTGRES_ADMIN_URI)
+            db_connect = {"DB_NAME": "listenbrainz", "DB_USER": "listenbrainz"}
+            db.init_db_connection(config.SQLALCHEMY_DATABASE_URI)
 
         print('PG: Creating schema...')
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_schema.sql'))
@@ -113,12 +115,6 @@ def init_db(force, create_db):
         print('PG: Creating tables...')
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_tables.sql'))
 
-        print('PG: Grant privs...')
-        res = db.run_sql_query_without_transaction(
-            [f"GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {db_connect['DB_NAME']}"])
-        if not res:
-            raise Exception('Failed to set table priviledges! Exit code: %i' % res)
-
         print('PG: Creating primary and foreign keys...')
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_primary_keys.sql'))
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_foreign_keys.sql'))
@@ -126,6 +122,8 @@ def init_db(force, create_db):
         print('PG: Creating indexes...')
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_indexes.sql'))
 
+        if not res:
+            raise Exception('Failed to set table priviledges! Exit code: %i' % res)
         print("Done!")
 
 
@@ -145,6 +143,7 @@ def init_ts_db(force, create_db):
         ts_connect = ts.create_test_timescale_connect_strings()
         ts.init_db_connection(ts_connect["DB_CONNECT_ADMIN"])
     else:
+        ts_connect = {"DB_NAME": "listenbrainz_ts", "DB_USER": "listenbrainz_ts"}
         ts.init_db_connection(config.TIMESCALE_ADMIN_URI)
     if force:
         res = ts.run_sql_query_without_transaction(
@@ -199,9 +198,10 @@ def init_ts_db(force, create_db):
         if "PYTHON_TESTS_RUNNING" in os.environ:
             print("PYTHON TESTING DETECTED!")
             ts_connect = ts.create_test_timescale_connect_strings()
-            ts.init_db_connection(ts_connect["DB_CONNECT_ADMIN_LB"])
+            ts.init_db_connection(ts_connect["DB_CONNECT"])
         else:
-            ts.init_db_connection(config.TIMESCALE_ADMIN_URI)
+            ts_connect = {"DB_NAME": "listenbrainz_ts", "DB_USER": "listenbrainz_ts"}
+            ts.init_db_connection(config.SQLALCHEMY_TIMESCALE_URI)
 
         print('TS: Creating Schemas...')
         ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'create_schemas.sql'))

--- a/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
+++ b/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
@@ -1,3 +1,4 @@
+import os
 import json
 from datetime import datetime
 
@@ -16,6 +17,10 @@ class MsidUpdaterTestCase(IntegrationTestCase):
     def setUp(self):
         IntegrationTestCase.setUp(self)
         self.user = db_user.get_or_create(1111, "msid-updater-user")
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            ts_connect = timescale.create_test_timescale_connect_strings()
+            timescale.init_db_connection(ts_connect["DB_CONNECT"])
 
     def create_dummy_data(self):
         mapping = [

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from unittest import mock
 from unittest.mock import call
@@ -32,7 +33,12 @@ class HandlersTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(HandlersTestCase, self).setUp()
+
         self.app = create_app()
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+
         self.user1 = db_user.get_or_create(1, 'iliekcomputers')
         self.user2 = db_user.get_or_create(2, 'lucifer')
 

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -21,6 +21,11 @@ class ConvertListensTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(ConvertListensTestCase, self).setUp()
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+
         self.user = db_user.get_or_create(1, 'testuserpleaseignore')
 
         self.DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -103,6 +108,9 @@ class ConvertListensTestCase(DatabaseTestCase):
         app = listenbrainz.webserver.create_app()
         app.config['SERVER_NAME'] = "test"
         with app.app_context():
+            if "PYTHON_TESTS_RUNNING" in os.environ:
+                db_connect = db_user.db.create_test_database_connect_strings()
+                db_user.db.init_db_connection(db_connect["DB_CONNECT"])
             spotify_read_listens.notify_error(musicbrainz_id="two", error='some random error')
         mock_send_mail.assert_called_once()
         self.assertListEqual(mock_send_mail.call_args[1]['recipients'], ['one@two.one'])
@@ -115,6 +123,9 @@ class ConvertListensTestCase(DatabaseTestCase):
         app = listenbrainz.webserver.create_app()
         app.config['TESTING'] = False
         with app.app_context():
+            if "PYTHON_TESTS_RUNNING" in os.environ:
+                db_connect = db_user.db.create_test_database_connect_strings()
+                db_user.db.init_db_connection(db_connect["DB_CONNECT"])
             spotify_read_listens.process_all_spotify_users()
             mock_notify_error.assert_called_once_with(self.user['musicbrainz_id'], 'api borked')
             mock_update.assert_called_once()
@@ -124,6 +135,9 @@ class ConvertListensTestCase(DatabaseTestCase):
         mock_spotipy.return_value.current_user_playing_track.return_value = None
 
         with listenbrainz.webserver.create_app().app_context():
+            if "PYTHON_TESTS_RUNNING" in os.environ:
+                db_connect = db_user.db.create_test_database_connect_strings()
+                db_user.db.init_db_connection(db_connect["DB_CONNECT"])
             SpotifyService().update_latest_listen_ts(self.user['id'],
                                                      int(datetime(2014, 5, 13, 16, 53, 20).timestamp()))
             spotify_read_listens.process_all_spotify_users()
@@ -137,6 +151,9 @@ class ConvertListensTestCase(DatabaseTestCase):
         mock_current_user_recently_played.return_value = None
 
         with listenbrainz.webserver.create_app().app_context():
+            if "PYTHON_TESTS_RUNNING" in os.environ:
+                db_connect = db_user.db.create_test_database_connect_strings()
+                db_user.db.init_db_connection(db_connect["DB_CONNECT"])
             spotify_read_listens.process_all_spotify_users()
             mock_current_user_playing_track.assert_called_once()
             mock_current_user_recently_played.assert_called_once_with(limit=50, after=0)

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -1,3 +1,4 @@
+import os
 import json
 import time
 from unittest.mock import patch
@@ -18,6 +19,11 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(APITestCase, self).setUp()
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+
         self.followed_user = db_user.get_or_create(3, 'followed_user')
         self.follow_user_url = url_for("social_api_v1.follow_user", user_name=self.followed_user["musicbrainz_id"])
         self.follow_user_headers = {'Authorization': 'Token {}'.format(self.user['auth_token'])}

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+import os
 import json
 import logging
 import time
@@ -25,6 +26,7 @@ import xmltodict
 from flask import url_for
 
 import listenbrainz.db.user as db_user
+from listenbrainz.db import timescale
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.db.lastfm_token import Token
 from listenbrainz.db.lastfm_user import User
@@ -37,6 +39,13 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(APICompatTestCase, self).setUp()
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+            ts_connect = timescale.create_test_timescale_connect_strings()
+            timescale.init_db_connection(ts_connect["DB_CONNECT"])
+
         self.lb_user = db_user.get_or_create(1, 'apicompattestuser')
         self.lfm_user = User(
             self.lb_user['id'],

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -18,7 +18,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-
+import os
 import logging
 import time
 from datetime import datetime
@@ -27,6 +27,7 @@ from flask import url_for
 from werkzeug.exceptions import BadRequest
 
 import listenbrainz.db.user as db_user
+from listenbrainz.db import timescale
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
 from listenbrainz.tests.integration import APICompatIntegrationTestCase
@@ -39,6 +40,13 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
     def setUp(self):
         super(APICompatDeprecatedTestCase, self).setUp()
+
+        if "PYTHON_TESTS_RUNNING" in os.environ:
+            db_connect = db_user.db.create_test_database_connect_strings()
+            db_user.db.init_db_connection(db_connect["DB_CONNECT"])
+            ts_connect = timescale.create_test_timescale_connect_strings()
+            timescale.init_db_connection(ts_connect["DB_CONNECT"])
+
         self.user = db_user.get_or_create(1, 'apicompatoldtestuser')
 
         self.log = logging.getLogger(__name__)

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+import os
 from sqlalchemy import text
 
 from listenbrainz import messybrainz

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest import mock
 
 import requests_mock

--- a/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
+++ b/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
@@ -1,4 +1,5 @@
 import json
+import os
 from flask import url_for, current_app
 from redis import Redis
 

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -1,4 +1,5 @@
 import time
+import os
 from unittest import mock
 from uuid import UUID
 

--- a/listenbrainz/tests/integration/test_profile_views.py
+++ b/listenbrainz/tests/integration/test_profile_views.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 
 from brainzutils import cache

--- a/listenbrainz/tests/integration/test_spotify_read_listens.py
+++ b/listenbrainz/tests/integration/test_spotify_read_listens.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 
 from flask import url_for

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 from datetime import datetime
 from random import randint

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -98,7 +98,7 @@ def create_app(debug=None):
 
     # If we're running tests, overwrite the given DB configuration from the config and disregard the
     # configuration, since that configuration could possibly point a different (production) DB.
-    if app.config['TESTING']:
+    if 'PYTHON_TESTS_RUNNING' in app.config:
         db_connect = create_test_database_connect_strings()
         ts_connect = create_test_timescale_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -22,7 +22,6 @@ class ServerTestCase(unittest.TestCase):
     @classmethod
     def create_app(cls):
         app = create_web_app(debug=False)
-        app.config['TESTING'] = True
         return app
 
     def temporary_login(self, user_login_id):
@@ -239,5 +238,4 @@ class APICompatServerTestCase(ServerTestCase):
     @classmethod
     def create_app(cls):
         app = create_api_compat_app()
-        app.config['TESTING'] = True
         return app


### PR DESCRIPTION
The previous fix for preventing tests from being run in production wasn't fool-proof either, since the user can control the TESTING variable. The test now create a different env var and check for its presence and then create a empty test DB from the strings generated from the app, ignoring settings in config.py.

This PR includes fixes from #2637, so we can close that PR now.