### PR TITLE
Use unique testing env var try 2

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -37,6 +37,7 @@ services:
     environment:
       PYTHONDONTWRITEBYTECODE: 1
       SQLALCHEMY_WARN_20: 1
+      PYTHON_TESTS_RUNNING: 1
     depends_on:
       - redis
       - lb_db

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -50,6 +50,8 @@ services:
       - redis
       - lb_db
       - rabbitmq
+    environment:
+      PYTHON_TESTS_RUNNING: 1
 
   frontend_tester:
     build:

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -55,10 +55,12 @@ def init_db(force, create_db):
         3. Indexes are created.
     """
     from listenbrainz import config
-    if config.TESTING:
+    if "PYTHON_TESTS_RUNNING" in os.environ:
         db_connect = db.create_test_database_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT_ADMIN"])
+        config.PYTHON_TESTS_RUNNING = True
     else:
+        db_connect = {"DB_NAME": "listenbrainz", "DB_USER": "listenbrainz"}
         db.init_db_connection(config.POSTGRES_ADMIN_URI)
     if force:
         res = db.run_sql_query_without_transaction(
@@ -69,7 +71,7 @@ def init_db(force, create_db):
     if create_db or force:
         print('PG: Creating user and a database...')
 
-        if config.TESTING:
+        if "PYTHON_TESTS_RUNNING" in os.environ:
             res = db.run_sql_query_without_transaction([
                 f"CREATE USER {db_connect['DB_USER']} NOCREATEDB NOSUPERUSER",
                 f"ALTER USER {db_connect['DB_USER']} WITH PASSWORD 'listenbrainz'",
@@ -80,7 +82,7 @@ def init_db(force, create_db):
         if not res:
             raise Exception('Failed to create new database and user! Exit code: %i' % res)
 
-        if config.TESTING:
+        if "PYTHON_TESTS_RUNNING" in os.environ:
             db.init_db_connection(db_connect["DB_CONNECT_ADMIN_LB"])
         else:
             db.init_db_connection(config.POSTGRES_ADMIN_LB_URI)
@@ -131,10 +133,12 @@ def init_ts_db(force, create_db):
         3. Views are created
     """
     from listenbrainz import config
-    if config.TESTING:
+    if "PYTHON_TESTS_RUNNING" in os.environ:
         ts_connect = ts.create_test_timescale_connect_strings()
         ts.init_db_connection(ts_connect["DB_CONNECT_ADMIN"])
+        config.PYTHON_TESTS_RUNNING = True
     else:
+        ts_connect = {"DB_NAME": "listenbrainz_ts", "DB_USER": "listenbrainz_ts"}
         ts.init_db_connection(config.TIMESCALE_ADMIN_URI)
     if force:
         res = ts.run_sql_query_without_transaction(
@@ -147,7 +151,7 @@ def init_ts_db(force, create_db):
         retries = 0
         while True:
             try:
-                if config.TESTING:
+                if "PYTHON_TESTS_RUNNING" in os.environ:
                     res = ts.run_sql_query_without_transaction([
                         f"CREATE USER {ts_connect['DB_USER']} NOCREATEDB NOSUPERUSER",
                         f"ALTER USER {ts_connect['DB_USER']} WITH PASSWORD 'listenbrainz_ts'",
@@ -167,7 +171,7 @@ def init_ts_db(force, create_db):
         if not res:
             raise Exception('Failed to create new database and user! Exit code: %i' % res)
 
-        if config.TESTING:
+        if "PYTHON_TESTS_RUNNING" in os.environ:
             ts.init_db_connection(ts_connect["DB_CONNECT_ADMIN_LB"])
         else:
             ts.init_db_connection(config.TIMESCALE_ADMIN_LB_URI)
@@ -179,7 +183,7 @@ def init_ts_db(force, create_db):
         if not res:
             raise Exception('Failed to create ts extension! Exit code: %i' % res)
 
-    if config.TESTING:
+    if "PYTHON_TESTS_RUNNING" in os.environ:
         ts.init_db_connection(ts_connect["DB_CONNECT"])
     else:
         ts.init_db_connection(config.SQLALCHEMY_TIMESCALE_URI)

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -83,6 +83,7 @@ def init_db(force, create_db):
             raise Exception('Failed to create new database and user! Exit code: %i' % res)
 
         if "PYTHON_TESTS_RUNNING" in os.environ:
+            print( "TESTS RUNNING:")
             db.init_db_connection(db_connect["DB_CONNECT_ADMIN_LB"])
         else:
             db.init_db_connection(config.POSTGRES_ADMIN_LB_URI)

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -83,7 +83,6 @@ def init_db(force, create_db):
             raise Exception('Failed to create new database and user! Exit code: %i' % res)
 
         if "PYTHON_TESTS_RUNNING" in os.environ:
-            print( "TESTS RUNNING:")
             db.init_db_connection(db_connect["DB_CONNECT_ADMIN_LB"])
         else:
             db.init_db_connection(config.POSTGRES_ADMIN_LB_URI)

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -98,7 +98,7 @@ def create_app(debug=None):
 
     # If we're running tests, overwrite the given DB configuration from the config and disregard the
     # configuration, since that configuration could possibly point a different (production) DB.
-    if app.config['TESTING']:
+    if 'PYTHON_TESTS_RUNNING' in app.config:
         db_connect = create_test_database_connect_strings()
         ts_connect = create_test_timescale_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -103,7 +103,9 @@ def create_app(debug=None):
         ts_connect = create_test_timescale_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])
         ts.init_db_connection(ts_connect["DB_CONNECT"])
+        print("RUNNING IN TESTS: %s" % db_connect["DB_CONNECT"])
     else:
+        print("NOT RUNNING IN TESTS")
         db.init_db_connection(app.config['SQLALCHEMY_DATABASE_URI'])
         ts.init_db_connection(app.config['SQLALCHEMY_TIMESCALE_URI'])
 

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -98,7 +98,7 @@ def create_app(debug=None):
 
     # If we're running tests, overwrite the given DB configuration from the config and disregard the
     # configuration, since that configuration could possibly point a different (production) DB.
-    if 'PYTHON_TESTS_RUNNING' in app.config:
+    if "PYTHON_TESTS_RUNNING" in os.environ:
         db_connect = create_test_database_connect_strings()
         ts_connect = create_test_timescale_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -103,9 +103,7 @@ def create_app(debug=None):
         ts_connect = create_test_timescale_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])
         ts.init_db_connection(ts_connect["DB_CONNECT"])
-        print("RUNNING IN TESTS: %s" % db_connect["DB_CONNECT"])
     else:
-        print("NOT RUNNING IN TESTS")
         db.init_db_connection(app.config['SQLALCHEMY_DATABASE_URI'])
         ts.init_db_connection(app.config['SQLALCHEMY_TIMESCALE_URI'])
 

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -239,5 +239,5 @@ class APICompatServerTestCase(ServerTestCase):
     @classmethod
     def create_app(cls):
         app = create_api_compat_app()
-        app.config['TESTING'] = True
+        app.config['PYTHON_TESTS_RUNNING'] = True
         return app

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -22,7 +22,7 @@ class ServerTestCase(unittest.TestCase):
     @classmethod
     def create_app(cls):
         app = create_web_app(debug=False)
-        app.config['TESTING'] = True
+        app.config['PYTHON_TESTS_RUNNING'] = True
         return app
 
     def temporary_login(self, user_login_id):

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -22,7 +22,6 @@ class ServerTestCase(unittest.TestCase):
     @classmethod
     def create_app(cls):
         app = create_web_app(debug=False)
-        app.config['PYTHON_TESTS_RUNNING'] = True
         return app
 
     def temporary_login(self, user_login_id):

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -22,6 +22,7 @@ class ServerTestCase(unittest.TestCase):
     @classmethod
     def create_app(cls):
         app = create_web_app(debug=False)
+        app.config['TESTING'] = True
         return app
 
     def temporary_login(self, user_login_id):

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -238,5 +238,5 @@ class APICompatServerTestCase(ServerTestCase):
     @classmethod
     def create_app(cls):
         app = create_api_compat_app()
-        app.config['PYTHON_TESTS_RUNNING'] = True
+        app.config['TESTING'] = True
         return app


### PR DESCRIPTION
The previous fix for preventing tests from being run in production wasn't fool-proof either, since the user can control the TESTING variable. The test now create a different env var and check for its presence and then create a empty test DB from the strings generated from the app, ignoring settings in config.py.

This PR includes fixes from https://github.com/metabrainz/listenbrainz-server/pull/2637, so we can close that PR now.