### PR TITLE
LB-1329 (I): Cover art mouseovers don't display in some pages/elements

### DIFF
--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -37,6 +37,7 @@ import {
   getRecordingMSID,
   getReleaseGroupMBID,
   getReleaseMBID,
+  getReleaseName,
   getTrackDurationInMs,
   getTrackLink,
   getTrackName,
@@ -327,21 +328,29 @@ export default class ListenCard extends React.Component<
     if (customThumbnail) {
       thumbnail = customThumbnail;
     } else if (thumbnailSrc) {
+      let thumbnailLink;
+      let thumbnailTitle;
+      if (releaseMBID) {
+        thumbnailLink = `https://musicbrainz.org/release/${releaseMBID}`;
+        thumbnailTitle = getReleaseName(listen);
+      } else if (releaseGroupMBID) {
+        thumbnailLink = `https://musicbrainz.org/release-group/${releaseGroupMBID}`;
+        thumbnailTitle = get(listen, "track_metadata.mbid_mapping.release_group_name");
+      } else {
+        thumbnailLink = spotifyURL || youtubeURL || soundcloudURL;
+        thumbnailTitle = "Cover art";
+      }
       thumbnail = (
         <div className="listen-thumbnail">
           <a
-            href={
-              releaseMBID
-                ? `https://musicbrainz.org/release/${releaseMBID}`
-                : (spotifyURL || youtubeURL || soundcloudURL) ?? ""
-            }
-            title={listen.track_metadata?.release_name ?? "Cover art"}
+            href={thumbnailLink}
+            title={thumbnailTitle}
             target="_blank"
             rel="noopener noreferrer"
           >
             <CoverArtWithFallback
               imgSrc={thumbnailSrc}
-              altText={listen.track_metadata?.release_name}
+              altText={thumbnailTitle}
             />
           </a>
         </div>

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -214,6 +214,10 @@ const getReleaseGroupMBID = (listen: Listen): string | undefined =>
   _.get(listen, "track_metadata.additional_info.release_group_mbid") ??
   _.get(listen, "track_metadata.mbid_mapping.release_group_mbid");
 
+const getReleaseName = (listen: Listen): string =>
+  _.get(listen, "track_metadata.mbid_mapping.release_name", "") ||
+  _.get(listen, "track_metadata.release_name", "");
+
 const getTrackName = (listen?: Listen | JSPFTrack | PinnedRecording): string =>
   _.get(listen, "track_metadata.mbid_mapping.recording_name", "") ||
   _.get(listen, "track_metadata.track_name", "") ||
@@ -919,6 +923,7 @@ export {
   getArtistMBIDs,
   getArtistName,
   getTrackName,
+  getReleaseName,
   getTrackDurationInMs,
   pinnedRecordingToListen,
   getAlbumArtFromReleaseMBID,

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -321,6 +321,8 @@ def fetch_playlist_recording_metadata(playlist: Playlist):
         if "[artist_credit_mbids]" in row and row["[artist_credit_mbids]"] is not None:
             rec.artist_mbids = [UUID(mbid) for mbid in row["[artist_credit_mbids]"]]
         rec.title = row.get("recording_name", "")
+        rec.release_name = row.get("release_name", "")
+        rec.duration_ms = row.get("length", "")
 
         caa_id = row.get("caa_id")
         caa_release_mbid = row.get("caa_release_mbid")


### PR DESCRIPTION
Improve the logic for choosing the thumbnail link and title for mouseovers in certain cases. This fixes the two top albums pages.

For playlist pages, we forgot to send the release name/album field in the playlist data. Add that.