### PR TITLE
LB-1371: "Playing now" does not show cover art on page load

### DIFF
--- a/frontend/js/src/listens/ListenCard.tsx
+++ b/frontend/js/src/listens/ListenCard.tsx
@@ -335,7 +335,10 @@ export default class ListenCard extends React.Component<
         thumbnailTitle = getReleaseName(listen);
       } else if (releaseGroupMBID) {
         thumbnailLink = `https://musicbrainz.org/release-group/${releaseGroupMBID}`;
-        thumbnailTitle = get(listen, "track_metadata.mbid_mapping.release_group_name");
+        thumbnailTitle = get(
+          listen,
+          "track_metadata.mbid_mapping.release_group_name"
+        );
       } else {
         thumbnailLink = spotifyURL || youtubeURL || soundcloudURL;
         thumbnailTitle = "Cover art";

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -303,6 +303,19 @@ const getTrackLink = (listen: Listen): JSX.Element | string => {
   return trackName;
 };
 
+const getListenCardKey = (listen: Listen): string =>
+  `${listen.listened_at}-${listen.user_name}-${getRecordingMSID(
+    listen
+  )}-${getTrackName(listen)}-${getArtistName(listen)}-${getReleaseName(
+    listen
+  )}-${
+    listen.track_metadata?.mbid_mapping?.release_group_name
+  }-${getRecordingMBID(listen)}-${getArtistMBIDs(listen)?.join(
+    ","
+  )}-${getReleaseMBID(listen)}-${getReleaseGroupMBID(listen)}-${
+    listen.track_metadata?.mbid_mapping?.caa_id
+  }-${listen.track_metadata?.mbid_mapping?.caa_release_mbid}`;
+
 const formatWSMessageToListen = (wsMsg: any): Listen | null => {
   const json = wsMsg;
   try {
@@ -925,6 +938,7 @@ export {
   getTrackName,
   getReleaseName,
   getTrackDurationInMs,
+  getListenCardKey,
   pinnedRecordingToListen,
   getAlbumArtFromReleaseMBID,
   getAlbumArtFromListenMetadata,


### PR DESCRIPTION
When the mbid_mapping info in the listen changes, we want the state of the listen to be updated with the new props. The easiest way to make this happen is add all the properties that matter to key on ListenCard. There are over 40 usages of
ListenCard in the project, each with different properties in the key. At some point, we will likely want to unify all of these (or maybe not, unsure). I have created a utility function to use for keys elsewhere as well if needed.

ListenCard does not deepcopy the listen passed to it in props, therefore modifying the playing now listen object elsewhere also changed the object stored inside ListenCard's state even before React can propagate updates. therefore, deep copy
the object.