### PR TITLE
Fix test_fetch_top_similar_users

### DIFF
--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -32,4 +32,4 @@ class SimilarUserTestCase(DatabaseTestCase):
         assert len(similar_users) == 1
         assert similar_users[0][0] == "jerry"
         assert similar_users[0][1] == "tom"
-        assert similar_users[0][2] == "0.420"
+        assert similar_users[0][2] == "0.020"


### PR DESCRIPTION
Following the recent PR #2615 modifying the user similarity, we went from storing in the similarity table two similarity values to a single one. This test was not updated to reflect that and is currently failing in master.
