### PR TITLE
Fix fresh releases page

### DIFF
--- a/frontend/js/src/explore/fresh-releases/ReleaseCardsGrid.tsx
+++ b/frontend/js/src/explore/fresh-releases/ReleaseCardsGrid.tsx
@@ -54,7 +54,7 @@ export default function ReleaseCardsGrid(props: ReleaseCardReleaseProps) {
     release_order: string
   ): string => {
     if (release_order === "release_date") {
-      return formatReleaseDate(releaseKey);
+      return releaseKey;
     }
     if (
       release_order === "artist_credit_name" ||


### PR DESCRIPTION
Currently, the fresh releases page errors with: `RangeError: date value is not finite in DateTimeFormat.formatToParts()` . This was happening because formatReleaseDate was being called on an already formatted date. First call is at:

 https://github.com/metabrainz/listenbrainz-server/blob/206b1528cd6761cdab564f3ac69ad98f59b4b25e/frontend/js/src/explore/fresh-releases/ReleaseCardsGrid.tsx#L18

Removed the second call to fix.