### PR TITLE
Improve handling of scarce stats in cover art api

### DIFF
--- a/frontend/js/src/user/Listens.tsx
+++ b/frontend/js/src/user/Listens.tsx
@@ -15,7 +15,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Integrations } from "@sentry/tracing";
-import {cloneDeep, get, isEmpty, isEqual, isNil} from "lodash";
+import { cloneDeep, get, isEmpty, isEqual, isNil } from "lodash";
 import DateTimePicker from "react-datetime-picker/dist/entry.nostyle";
 import { toast } from "react-toastify";
 import { Socket, io } from "socket.io-client";

--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -107,19 +107,19 @@ class CoverArtGenerator:
         except ValueError:
             return None
 
-        return (r, g, b)
+        return r, g, b
 
     def validate_parameters(self):
         """ Validate the parameters for the cover art designs. """
 
         if self.dimension not in list(range(MIN_DIMENSION, MAX_DIMENSION + 1)):
-            return "dimmension must be between {MIN_DIMENSION} and {MAX_DIMENSION}, inclusive."
+            return "dimension must be between {MIN_DIMENSION} and {MAX_DIMENSION}, inclusive."
 
         bg_color = self.parse_color_code(self.background)
         if self.background not in ("transparent", "white", "black") and bg_color is None:
             return f"background must be one of transparent, white, black or a color code #rrggbb, not {self.background}"
 
-        if self.image_size < MIN_IMAGE_SIZE or self.image_size > MAX_IMAGE_SIZE:
+        if self.image_size < MIN_IMAGE_SIZE or self.image_size > MAX_IMAGE_SIZE or self.image_size is None:
             return f"image size must be between {MIN_IMAGE_SIZE} and {MAX_IMAGE_SIZE}, inclusive."
 
         if not isinstance(self.skip_missing, bool):
@@ -157,11 +157,11 @@ class CoverArtGenerator:
         """ Given a cell 'address' return its bounding box. An address is a list of comma separeated
             grid cells, which taken collectively present a bounding box for a cover art image."""
 
-        tiles = address.split(",")
         try:
+            tiles = address.split(",")
             for i in range(len(tiles)):
                 tiles[i] = int(tiles[i].strip())
-        except ValueError:
+        except (ValueError, TypeError):
             return None, None, None, None
 
         for tile in tiles:

--- a/listenbrainz/domain/lastfm.py
+++ b/listenbrainz/domain/lastfm.py
@@ -36,6 +36,8 @@ def bulk_insert_loved_tracks(user_id: int, feedback: list[tuple[int, str]]):
 def load_recordings_from_tracks(track_mbids: list) -> dict[str, str]:
     """ Fetch recording mbids corresponding to track mbids. Last.FM uses tracks mbids in loved tracks endpoint
      but we use recording mbids in feedback table so need convert between the two. """
+    if not track_mbids:
+        return {}
     query = """
         SELECT track.gid::text AS track_mbid
              , recording.gid::text AS recording_mbid

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
@@ -35,167 +35,26 @@
    <text id="date"><tspan id="tspan18" y="36" x="773">{{ metadata["date"] }}</tspan></text>
   </g>
   <g font-size="23px">
-   <text
-     id="artist-1">
-     <tspan
-       x="130"
-       y="230"
-       id="artist-1-number">1</tspan>
-       <tspan
-       x="175"
-       y="230"
-       id="artist-1-album">{{ releases[0].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="253"
-       class="artist-name"
-       id="artist-1-name">{{ releases[0].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-2">
-     <tspan
-       x="130"
-       y="280"
-       id="artist-2-number">2</tspan>
-       <tspan
-       x="175"
-       y="280"
-       id="artist-2-album">{{ releases[1].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="303"
-       class="artist-name"
-       id="artist-2-name">{{ releases[1].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-3">
-     <tspan
-       x="130"
-       y="330"
-       id="artist-3-number">3</tspan>
-       <tspan
-       x="175"
-       y="330"
-       id="artist-3-album">{{ releases[2].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="353"
-       class="artist-name"
-       id="artist-3-name">{{ releases[2].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-4">
-     <tspan
-       x="130"
-       y="380"
-       id="artist-4-number">4</tspan>
-       <tspan
-       x="175"
-       y="380"
-       id="artist-4-album">{{ releases[3].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="403"
-       class="artist-name"
-       id="artist-4-name">{{ releases[3].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-5">
-     <tspan
-       x="130"
-       y="430"
-       id="artist-5-number">5</tspan>
-       <tspan
-       x="175"
-       y="430"
-       id="artist-5-album">{{ releases[4].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="453"
-       class="artist-name"
-       id="artist-5-name">{{ releases[4].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-6">
-     <tspan
-       x="130"
-       y="480"
-       id="artist-6-number">6</tspan>
-       <tspan
-       x="175"
-       y="480"
-       id="artist-6-album">{{ releases[5].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="503"
-       class="artist-name"
-       id="artist-6-name">{{ releases[5].artist_name|upper|e }}</tspan>
-   </text>
-
-   <text
-     id="artist-7">
-     <tspan
-       x="130"
-       y="530"
-       id="artist-7-number">7</tspan>
-       <tspan
-       x="175"
-       y="530"
-       id="artist-7-album">{{ releases[6].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="553"
-       class="artist-name"
-       id="artist-7-name">{{ releases[6].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-8">
-     <tspan
-       x="130"
-       y="580"
-       id="artist-8-number">8</tspan>
-       <tspan
-       x="175"
-       y="580"
-       id="artist-8-album">{{ releases[7].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="603"
-       class="artist-name"
-       id="artist-8-name">{{ releases[7].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-9">
-     <tspan
-       x="130"
-       y="630"
-       id="artist-9-number">9</tspan>
-       <tspan
-       x="175"
-       y="630"
-       id="artist-9-album">{{ releases[8].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="653"
-       class="artist-name"
-       id="artist-9-name">{{ releases[8].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-10">
-     <tspan
-       x="130"
-       y="680"
-       id="artist-10-number">X</tspan>
-       <tspan
-       x="175"
-       y="680"
-       id="artist-10-album">{{ releases[9].release_name|upper|e }}</tspan>
-     <tspan
-       x="175"
-       y="703"
-       class="artist-name"
-       id="artist-10-name">{{ releases[9].artist_name|upper|e }}</tspan>
-   </text>  
+   {% set y_artists_start = 230 %}
+   {% set y_albums_start = 253 %}
+   {% set gap = 50 %}
+   {% for release in releases[:10] %}
+    <text id="artist-{{ loop.index }}">
+     <tspan x="130" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-number">
+      {% if loop.index == 10 %}
+        X
+      {% else %}
+        {{ loop.index }}
+      {% endif %}
+     </tspan>
+     <tspan x="175" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-album">
+      {{ release.release_name|upper|e }}
+     </tspan>
+     <tspan x="175" y="{{ y_albums_start + loop.index0 * gap }}" class="artist-name" id="artist-{{ loop.index }}-name">
+      {{ release.artist_name|upper|e }}
+     </tspan>
+    </text>
+   {% endfor %}
   </g>
  </g>
 </svg>

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
@@ -31,231 +31,38 @@
    <text id="number_of_releases"><tspan id="tspan14" y="894" x="769">{{ metadata["num_releases"] }} RELEASES</tspan></text>
    <text id="date"><tspan id="tspan18" y="36" x="773">{{ metadata["date"] }}</tspan></text>
   </g>
+  {% set y_artists_start = 100 %}
+  {% set y_albums_start = 135 %}
+  {% set y_lines_start = 87 %}
+  {% set gap = 80 %}
   <g font-size="35px">
-   <text
-     id="artist-1">
-     <tspan
-       x="-7"
-       y="100"
-       id="artist-1-number">1</tspan>
-       <tspan
-       x="40"
-       y="100"
-       id="artist-1-album">{{ releases[0].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="135"
-       class="artist-name"
-       id="artist-1-name">{{ releases[0].artist_name|upper|e }}</tspan>
+   {% for release in releases[:10] %}
+     <text id="artist-{{ loop.index }}">
+     <tspan x="-7" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-number">
+       {% if loop.index == 10 %}
+         X
+       {% else %}
+         {{ loop.index }}
+       {% endif %}
+     </tspan>
+     <tspan x="40" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-album">
+       {{ release.release_name|upper|e }}
+     </tspan>
+     <tspan x="40" y="{{ y_albums_start + loop.index0 * gap }}" class="artist-name" id="artist-{{ loop.index }}-name">
+       {{ release.artist_name|upper|e }}
+     </tspan>
    </text>
-   <text
-     id="artist-2">
-     <tspan
-       x="-7"
-       y="180"
-       id="artist-2-number">2</tspan>
-       <tspan
-       x="40"
-       y="180"
-       id="artist-2-album">{{ releases[1].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="215"
-       class="artist-name"
-       id="artist-2-name">{{ releases[1].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-3">
-     <tspan
-       x="-7"
-       y="255"
-       id="artist-3-number">3</tspan>
-       <tspan
-       x="40"
-       y="255"
-       id="artist-3-album">{{ releases[2].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="290"
-       class="artist-name"
-       id="artist-3-name">{{ releases[2].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-4">
-     <tspan
-       x="-7"
-       y="335"
-       id="artist-4-number">4</tspan>
-       <tspan
-       x="40"
-       y="335"
-       id="artist-4-album">{{ releases[3].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="370"
-       class="artist-name"
-       id="artist-4-name">{{ releases[3].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-5">
-     <tspan
-       x="-7"
-       y="415"
-       id="artist-5-number">5</tspan>
-       <tspan
-       x="40"
-       y="415"
-       id="artist-5-album">{{ releases[4].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="450"
-       class="artist-name"
-       id="artist-5-name">{{ releases[4].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-6">
-     <tspan
-       x="-7"
-       y="495"
-       id="artist-6-number">6</tspan>
-       <tspan
-       x="40"
-       y="495"
-       id="artist-6-album">{{ releases[5].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="530"
-       class="artist-name"
-       id="artist-6-name">{{ releases[5].artist_name|upper|e }}</tspan>
-   </text>
-
-   <text
-     id="artist-7">
-     <tspan
-       x="-7"
-       y="575"
-       id="artist-7-number">7</tspan>
-       <tspan
-       x="40"
-       y="575"
-       id="artist-7-album">{{ releases[6].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="610"
-       class="artist-name"
-       id="artist-7-name">{{ releases[6].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-8">
-     <tspan
-       x="-7"
-       y="655"
-       id="artist-8-number">8</tspan>
-       <tspan
-       x="40"
-       y="655"
-       id="artist-8-album">{{ releases[7].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="690"
-       class="artist-name"
-       id="artist-8-name">{{ releases[7].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-9">
-     <tspan
-       x="-7"
-       y="735"
-       id="artist-9-number">9</tspan>
-       <tspan
-       x="40"
-       y="735"
-       id="artist-9-album">{{ releases[8].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="770"
-       class="artist-name"
-       id="artist-9-name">{{ releases[8].artist_name|upper|e }}</tspan>
-   </text>
-   <text
-     id="artist-10">
-     <tspan
-       x="-7"
-       y="815"
-       id="artist-10-number">X</tspan>
-       <tspan
-       x="40"
-       y="815"
-       id="artist-10-album">{{ releases[9].release_name|upper|e }}</tspan>
-     <tspan
-       x="40"
-       y="850"
-       class="artist-name"
-       id="artist-10-name">{{ releases[9].artist_name|upper|e }} </tspan>
-   </text>
-  
+   {% endfor %}
   </g>
   <g id="lines" stroke="#FAFF5B">
-    <line
+    {% for _ in releases[:10] %}
+      <line
        x1="0"
-       y1="87"
+       y1="{{ y_lines_start + loop.index0 * gap }}"
        x2="925"
-       y2="87"
-       id="line-1" />
-    <line
-       x1="0"
-       y1="168"
-       x2="925"
-       y2="168"
-       id="line-2" />
-    <line
-       x1="0"
-       y1="243"
-       x2="925"
-       y2="243"
-       id="line-3" />
-    <line
-       x1="0"
-       y1="322"
-       x2="925"
-       y2="322"
-       id="line-4" />
-    <line
-       x1="0"
-       y1="402"
-       x2="925"
-       y2="402"
-       id="line-5" />
-    <line
-       x1="0"
-       y1="482"
-       x2="925"
-       y2="482"
-       id="line-6" />
-    <line
-       x1="0"
-       y1="562"
-       x2="925"
-       y2="562"
-       id="line-7" />
-    <line
-       x1="0"
-       y1="642"
-       x2="925"
-       y2="642"
-       id="line-8" />
-    <line
-       x1="0"
-       y1="722"
-       x2="925"
-       y2="722"
-       id="line-9" />
-    <line
-       x1="0"
-       y1="802"
-       x2="925"
-       y2="802"
-       id="line-10" />
+       y2="{{ y_lines_start + loop.index0 * gap }}"
+       id="line-{{ loop.index }}" />
+    {% endfor %}
   </g> 
  </g>
 </svg>

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
@@ -29,11 +29,15 @@
    <text id="date"><tspan id="tspan18" y="36" x="773">{{ metadata["date"] }}</tspan></text>
   </g>
   <g font-size="186px">
-   <text id="artist_1"><tspan id="tspan22" y="211" x="-20">{{ artists[0].artist_name|upper|e }}</tspan></text>
-   <text id="artist_2"><tspan id="tspan26" y="375" x="-20">{{ artists[1].artist_name|upper|e }}</tspan></text>
-   <text id="artist_3"><tspan id="tspan30" y="534" x="-20">{{ artists[2].artist_name|upper|e }}</tspan></text>
-   <text id="artist_4"><tspan id="tspan34" y="692" x="-20">{{ artists[3].artist_name|upper|e }}</tspan></text>
-   <text id="artist_5"><tspan id="tspan38" y="849" x="-20">{{ artists[4].artist_name|upper|e }}</tspan></text>
+   {% set y_start = 211 %}
+   {% set gap = 160 %}
+   {% for idx in artists[:5] %}
+   <text id="artist_{{ loop.index }}">
+    <tspan id="tspan2{{ loop.index }}" y="{{ y_start + loop.index0 * gap }}" x="-20">
+     {{ artists[loop.index0].artist_name|upper|e }}
+    </tspan>
+   </text>
+   {% endfor %}
   </g>
  </g>
 </svg>

--- a/listenbrainz/webserver/templates/art/svg-templates/yim-2022-artists.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/yim-2022-artists.svg
@@ -34,16 +34,13 @@
             <text class="branding" x="844" y="43">2022</text>
         </g>
         <g>
-            <text class="artist-name" y="155" x="-20">{{ artists[0].artist_name|upper|e }}</text>
-            <text class="artist-name" y="230" x="-20">{{ artists[1].artist_name|upper|e }}</text>
-            <text class="artist-name" y="305" x="-20">{{ artists[2].artist_name|upper|e }}</text>
-            <text class="artist-name" y="380" x="-20">{{ artists[3].artist_name|upper|e }}</text>
-            <text class="artist-name" y="455" x="-20">{{ artists[4].artist_name|upper|e }}</text>
-            <text class="artist-name" y="530" x="-20">{{ artists[5].artist_name|upper|e }}</text>
-            <text class="artist-name" y="605" x="-20">{{ artists[6].artist_name|upper|e }}</text>
-            <text class="artist-name" y="680" x="-20">{{ artists[7].artist_name|upper|e }}</text>
-            <text class="artist-name" y="755" x="-20">{{ artists[8].artist_name|upper|e }}</text>
-            <text class="artist-name" y="830" x="-20">{{ artists[9].artist_name|upper|e }}</text>
+            {% set y_start = 155 %}
+            {% set gap = 75 %}
+            {% for artist in artists[:10] %}
+                <text class="artist-name" y="{{ y_start + loop.index0 * gap }}" x="-20">
+                    {{ artist.artist_name|upper|e }}
+                </text>
+            {% endfor %}
         </g>
     </g>
 </svg>

--- a/listenbrainz/webserver/templates/art/svg-templates/yim-2022-tracks.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/yim-2022-tracks.svg
@@ -51,56 +51,23 @@
             </text>
         </g>
         <g>
+            {% set y_start = 240 %}
+            {% set gap = 45 %}
+            {% for track in tracks[:10] %}
             <text>
-                <tspan class="track-name" x="100" y="240">1</tspan>
-                <tspan class="track-name" x="125" y="240">{{ tracks[0].track_name|upper|e }}</tspan>
+                <tspan class="track-name" x="100" y="{{ y_start + loop.index0 * gap }}">
+                    {% if loop.index == 10 %}
+                        X
+                    {% else %}
+                        {{ loop.index }}
+                    {% endif %}
+                </tspan>
+                <tspan class="track-name" x="125" y="{{ y_start + loop.index0 * gap }}">
+                    {{ track.track_name|upper|e }}
+                </tspan>
                 <tspan class="artist-name" x="125" dy="20">{{ tracks[0].artist_name|upper|e }}</tspan>
             </text>
-            <text>
-                <tspan class="track-name" x="100" y="285">2</tspan>
-                <tspan class="track-name" x="125" y="285">{{ tracks[1].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[1].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="330">3</tspan>
-                <tspan class="track-name" x="125" y="330">{{ tracks[2].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[2].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="375">4</tspan>
-                <tspan class="track-name" x="125" y="375">{{ tracks[3].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[3].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="420">5</tspan>
-                <tspan class="track-name" x="125" y="420">{{ tracks[4].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[4].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="465">6</tspan>
-                <tspan class="track-name" x="125" y="465">{{ tracks[5].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[5].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="510">7</tspan>
-                <tspan class="track-name" x="125" y="510">{{ tracks[6].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[6].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="555">8</tspan>
-                <tspan class="track-name" x="125" y="555">{{ tracks[7].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[7].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="600">9</tspan>
-                <tspan class="track-name" x="125" y="600">{{ tracks[8].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[8].artist_name|upper|e }}</tspan>
-            </text>
-            <text>
-                <tspan class="track-name" x="100" y="645">X</tspan>
-                <tspan class="track-name" x="125" y="645">{{ tracks[9].track_name|upper|e }}</tspan>
-                <tspan class="artist-name" x="125" dy="20">{{ tracks[9].artist_name|upper|e }}</tspan>
-            </text>
+            {% endfor %}
         </g>
     </g>
 </svg>


### PR DESCRIPTION
Some of the cover art templates require 5 or 10 artists/albums/images to render the full svg template. Currently, when stats are present but less than the minimum required the number the server 500s because the code assumes enough data will always be available.

To fix this, use two measures:

1. For the templates using cover art images repeat existing urls until the minimum required number is reached.
2. For the templates using text only display items as much as there are in the data.

A small unrelated fix for lastfm loved tracks import and a formatting fix for frontend too.