### PR TITLE
Fetch Top Release Groups for Artist

### DIFF
--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -182,7 +182,7 @@ def get_top_release_groups_for_artist(artist_mbid: str, count=None):
 
     release_groups_data.sort(key=lambda x: release_group_mbids.index(x["release_group_mbid"]))
 
-    release_mbids = [str(r["release"]['caa_release_mbid']) for r in release_groups_data \
+    release_mbids = [str(r["release"]['caa_release_mbid']) for r in release_groups_data
                      if r["release"] is not None and r["release"]['caa_release_mbid'] is not None]
 
     releases_color = color.fetch_color_for_releases(release_mbids)
@@ -191,7 +191,7 @@ def get_top_release_groups_for_artist(artist_mbid: str, count=None):
         release_group.update({
             "total_listen_count": pop["total_listen_count"],
             "total_user_count": pop["total_user_count"],
-            "release_color": releases_color.get(str(release_group["release"]["caa_release_mbid"] \
+            "release_color": releases_color.get(str(release_group["release"]["caa_release_mbid"]
                                                     if release_group["release"] is not None else None), {})
         })
 

--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -3,9 +3,10 @@ from psycopg2.extras import DictCursor, execute_values
 from psycopg2.sql import SQL, Identifier
 from sqlalchemy import text
 
-from listenbrainz.db import timescale
+from listenbrainz.db import timescale, color
 from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
 from listenbrainz.spark.spark_dataset import DatabaseDataset
+from listenbrainz.webserver.views.metadata_api import fetch_release_group_metadata
 
 import psycopg2
 
@@ -147,6 +148,8 @@ def get_top_recordings_for_artist(artist_mbid, count=None):
             mb_conn.cursor(cursor_factory=DictCursor) as mb_curs, \
             ts_conn.cursor(cursor_factory=DictCursor) as ts_curs:
         recordings_data = load_recordings_from_mbids_with_redirects(mb_curs, ts_curs, recording_mbids)
+        release_mbids = [str(r["release_mbid"]) for r in recordings_data if r["release_mbid"] is not None]
+        releases_color = color.fetch_color_for_releases(release_mbids)
 
         for recording, data in zip(recordings, recordings_data):
             data.pop("artist_credit_id", None)
@@ -156,7 +159,40 @@ def get_top_recordings_for_artist(artist_mbid, count=None):
                 "artist_name": data.pop("artist_credit_name"),
                 "artist_mbids": data.pop("[artist_credit_mbids]"),
                 "total_listen_count": recording["total_listen_count"],
-                "total_user_count": recording["total_user_count"]
+                "total_user_count": recording["total_user_count"],
+                "release_color": releases_color.get(str(data["release_mbid"]), {})
             })
 
         return recordings_data
+
+
+def get_top_release_groups_for_artist(artist_mbid: str, count=None):
+    """ Get the top releases for a given artist mbid """
+    release_groups = get_top_entity_for_artist("release_group", artist_mbid, count)
+    release_group_mbids = [str(r["release_group_mbid"]) for r in release_groups]
+
+    release_groups_data = []
+    for i in range(0, len(release_group_mbids), 50):
+        fetchedData = fetch_release_group_metadata(release_group_mbids[i:i + 50], incs=["artist", "release", "tag"])
+
+        release_group_data_list = []
+        for release_group_mbid, release_group_data in fetchedData.items():
+            release_group_data["release_group_mbid"] = release_group_mbid
+            release_group_data_list.append(release_group_data)
+                        
+        release_groups_data.extend(release_group_data_list)
+    
+    release_groups_data.sort(key=lambda x: release_group_mbids.index(x["release_group_mbid"]))
+
+    release_mbids = [str(r["release"]['caa_release_mbid']) for r in release_groups_data if r["release"] is not None and r["release"]['caa_release_mbid'] is not None]
+
+    releases_color = color.fetch_color_for_releases(release_mbids)
+    
+    for release_group, pop in zip(release_groups_data, release_groups):
+        release_group.update({
+            "total_listen_count": pop["total_listen_count"],
+            "total_user_count": pop["total_user_count"],
+            "release_color": releases_color.get(str(release_group["release"]["caa_release_mbid"] if release_group["release"] is not None else None), {})
+        })
+
+    return release_groups_data

--- a/listenbrainz/webserver/views/popularity_api.py
+++ b/listenbrainz/webserver/views/popularity_api.py
@@ -1,10 +1,7 @@
-import psycopg2
 from brainzutils.ratelimit import ratelimit
 from flask import Blueprint, request, current_app
-from psycopg2.extras import DictCursor
 
 from listenbrainz.db import popularity
-from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
@@ -31,6 +28,11 @@ def top_recordings():
             "length": 373133,
             "recording_mbid": "13dd61c7-ce73-4e97-9f0c-9f0e53144411",
             "recording_name": "Closer",
+            "release_color": {
+                "blue": 104,
+                "green": 104,
+                "red": 84
+            },
             "release_mbid": "ba8701ba-dc7c-4bca-9c83-846ee8c3d576",
             "release_name": "The Downward Spiral",
             "total_listen_count": 1380798,
@@ -53,3 +55,62 @@ def top_recordings():
     except Exception:
         current_app.logger.error("Error while fetching metadata for recordings: ", exc_info=True)
         raise APIInternalServerError("Failed to fetch metadata for recordings. Please try again.")
+
+@popularity_api_bp.get("/top-release-groups-for-artist")
+@crossdomain
+@ratelimit()
+def top_release_groups():
+    """ Get the top release groups by listen count for a given artist. The response is of the following format:
+
+    .. code:: json
+
+        [
+          {
+            "artist": {
+              "artist_credit_id": 368737,
+              "artists": [],
+              "name": "Pritam"
+            },
+            "release": {
+              "caa_id": 14996821464,
+              "caa_release_mbid": "488ef20e-7a2b-4daf-8bee-4f54fe26c7ab",
+              "date": "2016-10-26",
+              "name": "Ae Dil Hai Mushkil",
+              "rels": [],
+              "type": "Album"
+            },
+            "release_color": {
+              "blue": 64,
+              "green": 69,
+              "red": 113
+            },
+            "release_group": {
+              "caa_id": 14996821464,
+              "caa_release_mbid": "488ef20e-7a2b-4daf-8bee-4f54fe26c7ab",
+              "date": "2016-10-26",
+              "name": "Ae Dil Hai Mushkil",
+              "rels": [],
+              "type": "Album"
+            },
+            "release_group_mbid": "d0991cc9-2277-4f5e-bd4d-2fa44507f623",
+            "tag": {},
+            "total_listen_count": 1432,
+            "total_user_count": 82
+          },
+        ]
+
+    :param artist_mbid: the mbid of the artist to get top release groups for
+    :type artist_mbid: ``str``
+    :statuscode 200: you have data!
+    :statuscode 400: invalid artist_mbid argument
+    """
+    artist_mbid = request.args.get("artist_mbid")
+    if not is_valid_uuid(artist_mbid):
+        raise APIBadRequest(f"artist_mbid: '{artist_mbid}' is not a valid uuid")
+
+    try:
+        releases = popularity.get_top_release_groups_for_artist(artist_mbid)
+        return releases
+    except Exception:
+        current_app.logger.error("Error while fetching metadata for release groups: ", exc_info=True)
+        raise APIInternalServerError("Failed to fetch metadata for release groups. Please try again.")

--- a/listenbrainz/webserver/views/popularity_api.py
+++ b/listenbrainz/webserver/views/popularity_api.py
@@ -56,6 +56,7 @@ def top_recordings():
         current_app.logger.error("Error while fetching metadata for recordings: ", exc_info=True)
         raise APIInternalServerError("Failed to fetch metadata for recordings. Please try again.")
 
+
 @popularity_api_bp.get("/top-release-groups-for-artist")
 @crossdomain
 @ratelimit()


### PR DESCRIPTION
This PR adds an endpoint to fetch top release groups for an artist. Also it now also includes `release_colors` in the response.