### PR TITLE
 Use UNLOGGED tables when creating mapping tables in MB

### DIFF
--- a/mbid_mapping/mapping/bulk_table.py
+++ b/mbid_mapping/mapping/bulk_table.py
@@ -159,9 +159,14 @@ class BulkInsertTable:
         """
             This function creates the temp table, given the provided specification.
         """
+        if self.lb_conn is not None:
+            conn = self.lb_conn
+            unlogged = False
+        else:
+            conn = self.mb_conn
+            unlogged = True
 
         # drop/create finished table
-        conn = self.lb_conn if self.lb_conn is not None else self.mb_conn
         try:
             with conn.cursor() as curs:
                 if "." in self.table_name:
@@ -187,7 +192,7 @@ class BulkInsertTable:
                 columns = ", ".join(columns)
 
                 curs.execute(f"DROP TABLE IF EXISTS {self.temp_table_name}")
-                curs.execute(f"CREATE TABLE {self.temp_table_name} ({columns})")
+                curs.execute(f"CREATE {'UNLOGGED' if unlogged else ''} TABLE {self.temp_table_name} ({columns})")
                 conn.commit()
 
         except (psycopg2.errors.OperationalError, psycopg2.errors.UndefinedTable) as err:

--- a/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_metadata_cache.py
@@ -734,7 +734,7 @@ def create_mb_metadata_cache(use_lb_conn: bool):
     psycopg2.extras.register_uuid()
 
     if use_lb_conn:
-        mb_uri = config.MB_DATABASE_STANDBY_URI or config.MBID_MAPPING_DATABASE_URI
+        mb_uri = config.MB_DATABASE_MASTER_URI or config.MBID_MAPPING_DATABASE_URI
     else:
         mb_uri = config.MBID_MAPPING_DATABASE_URI
 
@@ -759,7 +759,7 @@ def incremental_update_mb_metadata_cache(use_lb_conn: bool):
     psycopg2.extras.register_uuid()
 
     if use_lb_conn:
-        mb_uri = config.MB_DATABASE_STANDBY_URI or config.MBID_MAPPING_DATABASE_URI
+        mb_uri = config.MB_DATABASE_MASTER_URI or config.MBID_MAPPING_DATABASE_URI
     else:
         mb_uri = config.MBID_MAPPING_DATABASE_URI
 


### PR DESCRIPTION
Creating mapping tables takes a lot of time and writes a lot of data which in turn creates a lot of WAL. These tables are needed only in MB db temporarily, hence its fine to change these tables to UNLOGGED when using MB connection.

Note that unlogged tables are not replicated, therefore all queries must be run against the primary database.