### PR TITLE
Improvements to mapping.mb_metadata_cache

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -94,6 +94,7 @@ ALTER TABLE mbid_mapping_metadata
 -- there. this definition is only for tests and local development. remember to keep both in sync.
 CREATE TABLE mapping.mb_metadata_cache (
     dirty               BOOLEAN DEFAULT FALSE,
+    last_updated        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     recording_mbid      UUID NOT NULL,
     artist_mbids        UUID[] NOT NULL,
     release_mbid        UUID,

--- a/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_metadata_cache.py
@@ -233,6 +233,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                     ON l.link_type = lt.id
                                   {values_join}
                                  WHERE lt.gid IN ({ARTIST_LINK_GIDS_SQL})
+                                   AND NOT l.ended
                               GROUP BY a.gid
                    ), recording_rels AS (
                                 SELECT r.gid
@@ -252,6 +253,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                                     ON la.attribute_type = lat.id
                                   {values_join}
                                  WHERE lt.gid IN ({RECORDING_LINK_GIDS_SQL})
+                                   AND NOT l.ended
                                GROUP BY r.gid
                    ), artist_data AS (
                             SELECT r.gid

--- a/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_metadata_cache.py
@@ -59,6 +59,11 @@ class MusicBrainzMetadataCache(BulkInsertTable):
 
     def __init__(self, mb_conn, lb_conn=None, batch_size=None):
         super().__init__("mapping.mb_metadata_cache", mb_conn, lb_conn, batch_size)
+        # cache the last updated to avoid calling it millions of times for the entire cache,
+        # not initializing it here because there can be a huge time gap between initialization
+        # and the actual query to fetch and insert the items in the cache. the pre_insert_queries_db_setup
+        # is called just before the insert queries are run.
+        self.last_updated = None
 
     def get_create_table_columns(self):
         # this table is created in local development and tables using admin/timescale/create_tables.sql
@@ -86,6 +91,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
 
     def pre_insert_queries_db_setup(self, curs):
         self.config_postgres_join_limit(curs)
+        self.last_updated = datetime.now()
 
     def get_post_process_queries(self):
         return ["""
@@ -100,7 +106,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 ("mb_metadata_cache_idx_dirty",          "dirty",                   False)]
 
     def process_row(self, row):
-        return [("false", datetime.now(), *self.create_json_data(row))]
+        return [("false", self.last_updated, *self.create_json_data(row))]
 
     def process_row_complete(self):
         return []

--- a/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_metadata_cache.py
@@ -64,6 +64,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
         # this table is created in local development and tables using admin/timescale/create_tables.sql
         # remember to keep both in sync.
         return [("dirty ",                     "BOOLEAN DEFAULT FALSE"),
+                ("last_updated",               "TIMESTAMPTZ NOT NULL DEFAULT NOW()"),
                 ("recording_mbid ",            "UUID NOT NULL"),
                 ("artist_mbids ",              "UUID[] NOT NULL"),
                 ("release_mbid ",              "UUID"),
@@ -99,7 +100,7 @@ class MusicBrainzMetadataCache(BulkInsertTable):
                 ("mb_metadata_cache_idx_dirty",          "dirty",                   False)]
 
     def process_row(self, row):
-        return [("false", *self.create_json_data(row))]
+        return [("false", datetime.now(), *self.create_json_data(row))]
 
     def process_row_complete(self):
         return []


### PR DESCRIPTION
1. Add a last_updated column to help in debugging.
2. Do not include ended links in the cache.