### PR TITLE
LB-947: Change entity pills on charts page from button to anchor

### DIFF
--- a/frontend/js/src/components/Pill.tsx
+++ b/frontend/js/src/components/Pill.tsx
@@ -3,25 +3,33 @@ import * as React from "react";
 type PillProps = {
   active?: boolean;
   type?: "primary" | "secondary";
+  href?: string;
   style?: React.CSSProperties;
   className?: string;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
   [key: string]: any;
 };
 
 export default function Pill(props: React.PropsWithChildren<PillProps>) {
-  const { active, children, type, style: propStyle, ...buttonProps } = props;
+  const {
+    active,
+    children,
+    type,
+    href,
+    style: propStyle,
+    ...linkProps
+  } = props;
 
   return (
-    <button
-      type="button"
+    <a
       style={propStyle}
-      {...buttonProps}
+      href={href || "#"}
+      {...linkProps}
       className={`pill ${type === "secondary" ? "secondary" : ""} ${
         active ? "active" : ""
       }`}
     >
       {children}
-    </button>
+    </a>
   );
 }

--- a/frontend/js/src/stats/UserEntityChart.tsx
+++ b/frontend/js/src/stats/UserEntityChart.tsx
@@ -116,6 +116,11 @@ export default class UserEntityChart extends React.Component<
     this.syncStateWithURL();
   };
 
+  entityHref = (newEntity: Entity): string => {
+    const { range } = this.state;
+    return this.buildURLParams(1, range, newEntity);
+  };
+
   getInitData = async (
     range: UserStatsAPIRange,
     entity: Entity
@@ -239,7 +244,7 @@ export default class UserEntityChart extends React.Component<
             count: elem.listen_count,
             caaID: elem.caa_id,
             caaReleaseMBID: elem.caa_release_mbid,
-            artists: elem.artists
+            artists: elem.artists,
           };
         })
         .reverse();
@@ -259,7 +264,7 @@ export default class UserEntityChart extends React.Component<
             count: elem.listen_count,
             caaID: elem.caa_id,
             caaReleaseMBID: elem.caa_release_mbid,
-            artists: elem.artists
+            artists: elem.artists,
           };
         })
         .reverse();
@@ -277,7 +282,7 @@ export default class UserEntityChart extends React.Component<
             count: elem.listen_count,
             caaID: elem.caa_id,
             caaReleaseMBID: elem.caa_release_mbid,
-            artists: elem.artists
+            artists: elem.artists,
           };
         })
         .reverse();
@@ -495,21 +500,42 @@ export default class UserEntityChart extends React.Component<
                 <Pill
                   active={entity === "artist"}
                   type="secondary"
-                  onClick={() => this.changeEntity("artist")}
+                  href={this.entityHref("artist")}
+                  onClick={(e) => {
+                    // LB-925 ctrl-click and cmd-click shouldn't navigate in this tab
+                    if (!e.ctrlKey) {
+                      e.preventDefault();
+                      this.changeEntity("artist");
+                    }
+                  }}
                 >
                   Artists
                 </Pill>
                 <Pill
                   active={entity === "release-group"}
                   type="secondary"
-                  onClick={() => this.changeEntity("release-group")}
+                  href={this.entityHref("release-group")}
+                  onClick={(e) => {
+                    // LB-925 ctrl-click and cmd-click shouldn't navigate in this tab
+                    if (!e.ctrlKey) {
+                      e.preventDefault();
+                      this.changeEntity("release-group");
+                    }
+                  }}
                 >
                   Albums
                 </Pill>
                 <Pill
                   active={entity === "recording"}
                   type="secondary"
-                  onClick={() => this.changeEntity("recording")}
+                  href={this.entityHref("recording")}
+                  onClick={(e) => {
+                    // LB-925 ctrl-click and cmd-click shouldn't navigate in this tab
+                    if (!e.ctrlKey) {
+                      e.preventDefault();
+                      this.changeEntity("recording");
+                    }
+                  }}
                 >
                   Tracks
                 </Pill>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

https://tickets.metabrainz.org/browse/LB-947

Dipping my toes in, looking to contribute something to a project I've been loving lately!



# Solution

I switched the element from a `<button>` to an `<a>`, and also added href properties to their usage in `UserEntityChart`. It defaults to `#` as a hash to preserve the pointer cursor, and for accessibility reasons. Changed validated locally - URL appears in status bar and open-in-new-tab (both middle click and right click -> open in new tab) seems to work fine. I integrated the proposed fix in LB-925, so ctrl/cmd+click also work.

Open question: should it only be an `<a>` if the href property is set? Semantically, `<button>` makes sense in several of the other places `Pill` is used. Not sure how much it matters though.


