### PR TITLE
 Store yim playlists in json data too 

### DIFF
--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -5,6 +5,15 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, validator, NonNegativeInt, constr
 from data.model.validators import check_valid_uuid
 
+
+PLAYLIST_TRACK_URI_PREFIX = "https://musicbrainz.org/recording/"
+PLAYLIST_ARTIST_URI_PREFIX = "https://musicbrainz.org/artist/"
+PLAYLIST_RELEASE_URI_PREFIX = "https://musicbrainz.org/release/"
+PLAYLIST_URI_PREFIX = "https://listenbrainz.org/playlist/"
+PLAYLIST_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#playlist"
+PLAYLIST_TRACK_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#track"
+
+
 class PlaylistRecording(BaseModel):
     """A recording that is part of a playlist"""
     # Internal id of the playlist
@@ -111,6 +120,65 @@ class Playlist(BaseModel):
         if user_id == self.creator_id or user_id in self.collaborator_ids:
             return True
         return False
+
+    def serialize_jspf(self):
+        """ Given a playlist, return a properly formated dict that can be passed to jsonify. """
+
+        pl = {
+            "creator": self.creator,
+            "title": self.name,
+            "identifier": PLAYLIST_URI_PREFIX + str(self.mbid),
+            "date": self.created.astimezone(datetime.timezone.utc).isoformat()
+        }
+        if self.description:
+            pl["annotation"] = self.description
+
+        extension = {"public": self.public, "creator": self.creator}
+        if self.last_updated:
+            extension["last_modified_at"] = self.last_updated.astimezone(datetime.timezone.utc).isoformat()
+        if self.copied_from_id is not None:
+            if self.copied_from_mbid is None:
+                extension['copied_from_deleted'] = True
+            else:
+                extension['copied_from_mbid'] = PLAYLIST_URI_PREFIX + str(self.copied_from_mbid)
+        if self.created_for_id:
+            extension['created_for'] = self.created_for
+        if self.collaborators:
+            extension['collaborators'] = self.collaborators
+        if self.additional_metadata:
+            extension['additional_metadata'] = self.additional_metadata
+
+        pl["extension"] = {PLAYLIST_EXTENSION_URI: extension}
+
+        tracks = []
+        for rec in self.recordings:
+            tr = {"identifier": PLAYLIST_TRACK_URI_PREFIX + str(rec.mbid)}
+            if rec.artist_credit:
+                tr["creator"] = rec.artist_credit
+
+            if rec.release_name:
+                tr["album"] = rec.release_name
+
+            if rec.title:
+                tr["title"] = rec.title
+
+            extension = {"added_by": rec.added_by,
+                         "added_at": rec.created.astimezone(datetime.timezone.utc).isoformat()}
+            if rec.artist_mbids:
+                extension["artist_identifiers"] = [PLAYLIST_ARTIST_URI_PREFIX + str(mbid) for mbid in rec.artist_mbids]
+
+            if rec.release_mbid:
+                extension["release_identifier"] = PLAYLIST_RELEASE_URI_PREFIX + str(rec.release_mbid)
+
+            if rec.additional_metadata:
+                extension["additional_metadata"] = rec.additional_metadata
+
+            tr["extension"] = {PLAYLIST_TRACK_EXTENSION_URI: extension}
+            tracks.append(tr)
+
+        pl["track"] = tracks
+
+        return {"playlist": pl}
 
 
 class WritablePlaylist(Playlist):

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -1,6 +1,7 @@
 import collections
 import datetime
 from typing import List, Optional
+from uuid import UUID
 
 import sqlalchemy
 import orjson
@@ -11,6 +12,8 @@ from sqlalchemy import text
 from listenbrainz.db.model import playlist as model_playlist
 from listenbrainz.db import timescale as ts
 from listenbrainz.db import user as db_user
+from listenbrainz.db.model.playlist import Playlist
+from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
 from listenbrainz.db.user import get_users_by_id
 from troi.patches.periodic_jams import WEEKLY_JAMS_DESCRIPTION, WEEKLY_EXPLORATION_DESCRIPTION
 
@@ -764,3 +767,35 @@ def move_recordings(playlist: model_playlist.Playlist, position_from: int, posit
     removed = playlist.recordings[position_from:position_from+count]
     delete_recordings_from_playlist(playlist, position_from, count)
     add_recordings_to_playlist(playlist, removed, position_to)
+
+
+def get_playlist_recordings_metadata(mb_curs, ts_curs, playlist: Playlist) -> Playlist:
+    """ Retrieve metadata for all recordings in a playlist from the database. """
+    mbids = [str(item.mbid) for item in playlist.recordings]
+    if not mbids:
+        return playlist
+
+    rows = load_recordings_from_mbids_with_redirects(mb_curs, ts_curs, mbids)
+
+    for rec, row in zip(playlist.recordings, rows):
+        rec.artist_credit = row.get("artist_credit_name", "")
+        if "[artist_credit_mbids]" in row and row["[artist_credit_mbids]"] is not None:
+            rec.artist_mbids = [UUID(mbid) for mbid in row["[artist_credit_mbids]"]]
+        rec.title = row.get("recording_name", "")
+        rec.release_name = row.get("release_name", "")
+        rec.duration_ms = row.get("length", "")
+
+        caa_id = row.get("caa_id")
+        caa_release_mbid = row.get("caa_release_mbid")
+        additional_metadata = {}
+        if caa_id and caa_release_mbid:
+            additional_metadata["caa_id"] = caa_id
+            additional_metadata["caa_release_mbid"] = caa_release_mbid
+
+        if row.get("artists"):
+            additional_metadata["artists"] = row["artists"]
+
+        if additional_metadata:
+            rec.additional_metadata = additional_metadata
+
+    return playlist

--- a/listenbrainz/troi/year_in_music.py
+++ b/listenbrainz/troi/year_in_music.py
@@ -83,9 +83,12 @@ def insert_playlists_in_yim(slug, year, playlists, user_details):
                 ]
             )
             get_playlist_recordings_metadata(mb_curs, ts_curs, playlist_obj)
-            playlist_jsons.append({"user_id": playlist["user_id"], "data": playlist_obj.serialize_jspf()})
+            playlist_jsons.append({
+                "user_id": playlist["user_id"],
+                "data": playlist_obj.serialize_jspf()["playlist"]
+            })
 
-    handle_multi_large_insert(slug, year, playlist_jsons)
+    handle_multi_large_insert(f"playlist-{slug}-for-year", year, playlist_jsons)
 
 
 def process_yim_playlists(slug, year, playlists):

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -26,7 +26,6 @@ from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400
     is_valid_uuid, MAX_LISTEN_PAYLOAD_SIZE, MAX_LISTENS_PER_REQUEST, MAX_LISTEN_SIZE, LISTEN_TYPE_SINGLE, \
     LISTEN_TYPE_IMPORT, _validate_get_endpoint_params, LISTEN_TYPE_PLAYING_NOW, validate_auth_header, \
     get_non_negative_param
-from listenbrainz.webserver.views.playlist_api import serialize_jspf
 
 api_bp = Blueprint('api_v1', __name__)
 
@@ -530,7 +529,7 @@ def serialize_playlists(playlists, playlist_count, count, offset):
 
     items = []
     for playlist in playlists:
-        items.append(serialize_jspf(playlist))
+        items.append(playlist.serialize_jspf())
 
     return {"playlists": items,
             "playlist_count": playlist_count,

--- a/listenbrainz/webserver/views/player.py
+++ b/listenbrainz/webserver/views/player.py
@@ -10,7 +10,6 @@ from brainzutils.musicbrainz_db import engine as mb_engine
 from brainzutils.musicbrainz_db.release import get_release_by_mbid
 
 from listenbrainz.db.cover_art import get_caa_ids_for_release_mbids
-from listenbrainz.webserver.views.playlist_api import serialize_jspf
 from listenbrainz.db.model.playlist import WritablePlaylistRecording, WritablePlaylist
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 from listenbrainz.webserver.views.playlist_api import fetch_playlist_recording_metadata
@@ -121,7 +120,7 @@ def load_instant():
 
     return render_template(
         "player/player-page.html",
-        props=orjson.dumps({"playlist": serialize_jspf(playlist)}).decode("utf-8")
+        props=orjson.dumps({"playlist": playlist.serialize_jspf()}).decode("utf-8")
     )
 
 
@@ -178,5 +177,5 @@ def load_release(release_mbid):
 
     return render_template(
         "player/player-page.html",
-        props=orjson.dumps({"playlist": serialize_jspf(playlist) if playlist is not None else {}}).decode("utf-8")
+        props=orjson.dumps({"playlist": playlist.serialize_jspf() if playlist is not None else {}}).decode("utf-8")
     )

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -5,7 +5,7 @@ from flask import Blueprint, render_template, current_app
 from flask_login import current_user
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
-from listenbrainz.webserver.views.playlist_api import serialize_jspf, fetch_playlist_recording_metadata
+from listenbrainz.webserver.views.playlist_api import fetch_playlist_recording_metadata
 import listenbrainz.db.playlist as db_playlist
 import listenbrainz.db.user as db_user
 
@@ -32,7 +32,7 @@ def load_playlist(playlist_mbid: str):
 
     props = {
         "labs_api_url": current_app.config["LISTENBRAINZ_LABS_API_URL"],
-        "playlist": serialize_jspf(playlist),
+        "playlist": playlist.serialize_jspf(),
     }
 
     playlist_creator = db_user.get(playlist.creator_id)

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -10,7 +10,6 @@ from psycopg2.extras import DictCursor
 import listenbrainz.db.playlist as db_playlist
 import listenbrainz.db.user as db_user
 from listenbrainz.domain.spotify import SpotifyService, SPOTIFY_PLAYLIST_PERMISSIONS
-from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
 from listenbrainz.troi.export import export_to_spotify
 
 from listenbrainz.webserver.utils import parse_boolean_arg
@@ -19,17 +18,12 @@ from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError,
 from brainzutils.ratelimit import ratelimit
 from listenbrainz.webserver.views.api_tools import log_raise_400, is_valid_uuid, validate_auth_header, \
     _filter_description_html
-from listenbrainz.db.model.playlist import Playlist, WritablePlaylist, WritablePlaylistRecording
+from listenbrainz.db.model.playlist import Playlist, WritablePlaylist, WritablePlaylistRecording, \
+    PLAYLIST_EXTENSION_URI, PLAYLIST_TRACK_URI_PREFIX, PLAYLIST_URI_PREFIX, PLAYLIST_TRACK_EXTENSION_URI, \
+    PLAYLIST_ARTIST_URI_PREFIX, PLAYLIST_RELEASE_URI_PREFIX
 
 playlist_api_bp = Blueprint('playlist_api_v1', __name__)
 
-PLAYLIST_TRACK_URI_PREFIX = "https://musicbrainz.org/recording/"
-PLAYLIST_ARTIST_URI_PREFIX = "https://musicbrainz.org/artist/"
-PLAYLIST_RELEASE_URI_PREFIX = "https://musicbrainz.org/release/"
-PLAYLIST_URI_PREFIX = "https://listenbrainz.org/playlist/"
-PLAYLIST_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#playlist"
-PLAYLIST_TRACK_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#track"
-RECORDING_LOOKUP_SERVER_URL = "https://labs.api.listenbrainz.org/recording-mbid-lookup/json"
 MAX_RECORDINGS_PER_ADD = 100
 
 
@@ -90,67 +84,6 @@ def validate_playlist(jspf):
 
         if not is_valid_uuid(recording_mbid):
             log_raise_400("JSPF playlist track %d does not contain a valid track identifier field." % i)
-
-
-def serialize_jspf(playlist: Playlist):
-    """
-        Given a playlist, return a properly formated dict that can be passed to jsonify.
-    """
-
-    pl = {
-        "creator": playlist.creator,
-        "title": playlist.name,
-        "identifier": PLAYLIST_URI_PREFIX + str(playlist.mbid),
-        "date": playlist.created.astimezone(datetime.timezone.utc).isoformat()
-    }
-    if playlist.description:
-        pl["annotation"] = playlist.description
-
-    extension = {"public": playlist.public, "creator": playlist.creator}
-    if playlist.last_updated:
-        extension["last_modified_at"] = playlist.last_updated.astimezone(datetime.timezone.utc).isoformat()
-    if playlist.copied_from_id is not None:
-        if playlist.copied_from_mbid is None:
-            extension['copied_from_deleted'] = True
-        else:
-            extension['copied_from_mbid'] = PLAYLIST_URI_PREFIX + str(playlist.copied_from_mbid)
-    if playlist.created_for_id:
-        extension['created_for'] = playlist.created_for
-    if playlist.collaborators:
-        extension['collaborators'] = playlist.collaborators
-    if playlist.additional_metadata:
-        extension['additional_metadata'] = playlist.additional_metadata
-
-    pl["extension"] = {PLAYLIST_EXTENSION_URI: extension}
-
-    tracks = []
-    for rec in playlist.recordings:
-        tr = {"identifier": PLAYLIST_TRACK_URI_PREFIX + str(rec.mbid)}
-        if rec.artist_credit:
-            tr["creator"] = rec.artist_credit
-
-        if rec.release_name:
-            tr["album"] = rec.release_name
-
-        if rec.title:
-            tr["title"] = rec.title
-
-        extension = {"added_by": rec.added_by, "added_at": rec.created.astimezone(datetime.timezone.utc).isoformat()}
-        if rec.artist_mbids:
-            extension["artist_identifiers"] = [PLAYLIST_ARTIST_URI_PREFIX + str(mbid) for mbid in rec.artist_mbids]
-
-        if rec.release_mbid:
-            extension["release_identifier"] = PLAYLIST_RELEASE_URI_PREFIX + str(rec.release_mbid)
-
-        if rec.additional_metadata:
-            extension["additional_metadata"] = rec.additional_metadata
-
-        tr["extension"] = {PLAYLIST_TRACK_EXTENSION_URI: extension}
-        tracks.append(tr)
-
-    pl["track"] = tracks
-
-    return {"playlist": pl}
 
 
 def serialize_xspf(playlist: Playlist):
@@ -311,31 +244,10 @@ def fetch_playlist_recording_metadata(playlist: Playlist):
                 psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as ts_conn, \
                 mb_conn.cursor(cursor_factory=DictCursor) as mb_curs, \
                 ts_conn.cursor(cursor_factory=DictCursor) as ts_curs:
-            rows = load_recordings_from_mbids_with_redirects(mb_curs, ts_curs, mbids)
+            db_playlist.get_playlist_recordings_metadata(mb_curs, ts_curs, playlist)
     except Exception:
         current_app.logger.error("Error while fetching metadata for a playlist: ", exc_info=True)
         raise APIInternalServerError("Failed to fetch metadata for a playlist. Please try again.")
-
-    for rec, row in zip(playlist.recordings, rows):
-        rec.artist_credit = row.get("artist_credit_name", "")
-        if "[artist_credit_mbids]" in row and row["[artist_credit_mbids]"] is not None:
-            rec.artist_mbids = [UUID(mbid) for mbid in row["[artist_credit_mbids]"]]
-        rec.title = row.get("recording_name", "")
-        rec.release_name = row.get("release_name", "")
-        rec.duration_ms = row.get("length", "")
-
-        caa_id = row.get("caa_id")
-        caa_release_mbid = row.get("caa_release_mbid")
-        additional_metadata = {}
-        if caa_id and caa_release_mbid:
-            additional_metadata["caa_id"] = caa_id
-            additional_metadata["caa_release_mbid"] = caa_release_mbid
-
-        if row.get("artists"):
-            additional_metadata["artists"] = row["artists"]
-
-        if additional_metadata:
-            rec.additional_metadata = additional_metadata
 
 
 @playlist_api_bp.route("/create", methods=["POST", "OPTIONS"])
@@ -568,7 +480,7 @@ def get_playlist(playlist_mbid):
     if fetch_metadata:
         fetch_playlist_recording_metadata(playlist)
 
-    return jsonify(serialize_jspf(playlist))
+    return jsonify(playlist.serialize_jspf())
 
 
 @playlist_api_bp.route("/<playlist_mbid>/xspf", methods=["GET", "OPTIONS"])

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -23,7 +23,6 @@ from listenbrainz.webserver.login import User, api_login_required
 from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.views.api import DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL
 from werkzeug.exceptions import NotFound, BadRequest
-from listenbrainz.webserver.views.playlist_api import serialize_jspf
 
 LISTENS_PER_PAGE = 25
 DEFAULT_NUMBER_OF_FEEDBACK_ITEMS_PER_CALL = 25
@@ -235,7 +234,7 @@ def playlists(user_name: str):
                                                             count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL,
                                                             offset=0)
     for playlist in user_playlists:
-        playlists.append(serialize_jspf(playlist))
+        playlists.append(playlist.serialize_jspf())
 
     props = {
         "playlists": playlists,
@@ -281,7 +280,7 @@ def recommendation_playlists(user_name: str):
     user_playlists = get_recommendation_playlists_for_user(
         user.id)
     for playlist in user_playlists:
-        playlists.append(serialize_jspf(playlist))
+        playlists.append(playlist.serialize_jspf())
 
     props = {
         "playlists": playlists,


### PR DESCRIPTION
Refactor serialize_jspf and fetch_playlist_recordings_metadata. Move these functions to playlist model and database layer respectively to avoid circular import.

Store yim playlists in data too so that frontend doesn't need to make extra api calls.