### PR TITLE
Improve check for selecting users for spotify playlist export

### DIFF
--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -24,8 +24,8 @@ def get_active_users_to_process() -> List[dict]:
                 ON "user".id = external_service_oauth.user_id
               JOIN listens_importer
                 ON listens_importer.external_service_oauth_id = external_service_oauth.id
-              WHERE external_service_oauth.service = 'spotify'
-                AND error_message IS NULL
+             WHERE external_service_oauth.service = 'spotify'
+               AND error_message IS NULL
           ORDER BY latest_listened_at DESC NULLS LAST
         """))
         return [row for row in result.mappings()]

--- a/listenbrainz/troi/tests/test_spark.py
+++ b/listenbrainz/troi/tests/test_spark.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+
+from data.model.external_service import ExternalServiceType
+from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
+from listenbrainz.db import user as db_user
+from listenbrainz.db import user_setting as db_user_setting
+from listenbrainz.db import external_service_oauth as db_external_service_oauth
+from listenbrainz.troi.spark import get_user_details
+
+
+class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
+
+    def setUp(self):
+        DatabaseTestCase.setUp(self)
+        TimescaleTestCase.setUp(self)
+
+    def test_get_user_details(self):
+        self.maxDiff = None
+
+        self.user1 = db_user.get_or_create(100, "user1")
+        self.user2 = db_user.get_or_create(200, "user2")
+        self.user3 = db_user.get_or_create(300, "user3")
+        
+        db_user_setting.update_troi_prefs(self.user1["id"], True)
+        db_user_setting.update_troi_prefs(self.user2["id"], False)
+        
+        db_external_service_oauth.save_token(
+            self.user1["id"], 
+            ExternalServiceType.SPOTIFY,
+            "access_token",
+            "refresh_token", 
+            int(datetime.now().timestamp()),
+            True,
+            ["streaming", "user-read-email", "user-read-private", "playlist-modify-public", "playlist-modify-private"],
+            "spotify_user_id"
+        )
+        db_external_service_oauth.save_token(
+            self.user1["id"],
+            ExternalServiceType.MUSICBRAINZ,
+            "access_token",
+            "refresh_token",
+            int(datetime.now().timestamp()),
+            True,
+            [],
+            "musicbrainz_user_id"
+        )
+        db_external_service_oauth.save_token(
+            self.user1["id"],
+            ExternalServiceType.LASTFM,
+            "access_token",
+            "refresh_token",
+            int(datetime.now().timestamp()),
+            False,
+            [],
+            "lastfm_user_id"
+        )
+        db_external_service_oauth.save_token(
+            self.user2["id"],
+            ExternalServiceType.SPOTIFY,
+            "access_token",
+            "refresh_token",
+            int(datetime.now().timestamp()),
+            True,
+            ["streaming", "user-read-email", "user-read-private", "playlist-modify-public", "playlist-modify-private"],
+            "spotify_user_id"
+        )
+
+        user_ids = [self.user1["id"], self.user2["id"], self.user3["id"]]
+
+        user_details = get_user_details("test-slug", user_ids)
+        self.assertEqual(len(user_details), 3)
+        self.assertDictEqual(user_details, {
+            self.user1["id"]: {
+                "username": self.user1["musicbrainz_id"],
+                "export_to_spotify": True,
+                "existing_url": None
+            },
+            self.user2["id"]: {
+                "username": self.user2["musicbrainz_id"],
+                "export_to_spotify": False,
+                "existing_url": None
+            },
+            self.user3["id"]: {
+                "username": self.user3["musicbrainz_id"],
+                "export_to_spotify": False,
+                "existing_url": None
+            }
+        })


### PR DESCRIPTION
Some users have configured exporting playlists to spotify automatically but have not connected their spotify accounts. Detect and do not try to export playlists for them.