### PR TITLE
Fix canonical release redirect

### DIFF
--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -103,7 +103,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             mapping.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             can_rec_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
-            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=mb_conn)
+            can_rel.swap_into_production(no_swap_transaction=True, swap_conn=lb_conn)
             mb_conn.commit()
             lb_conn.commit()
             lb_conn.close()

--- a/mbid_mapping/mapping/canonical_release_redirect.py
+++ b/mbid_mapping/mapping/canonical_release_redirect.py
@@ -24,37 +24,41 @@ class CanonicalReleaseRedirect(BulkInsertTable):
                 ("release_group_mbid",       "UUID NOT NULL"),]
 
     def get_insert_queries(self):
-        return []
+        return [("MB", """
+            WITH canonical_release AS (
+                SELECT release.gid rel_mbid
+                    , rg.gid rg_mbid
+                    , cmdr.id
+                    , rank() over (partition by rg.id order by cmdr.id)
+                FROM musicbrainz.release
+                JOIN musicbrainz.release_group rg
+                  ON release.release_group = rg.id
+                JOIN mapping.canonical_release_tmp cmdr
+                  ON cmdr.release = release.id
+            ), first_release AS (
+              SELECT *
+                FROM canonical_release
+               WHERE rank = 1
+            ), release_rg AS (
+              SELECT release.gid release_mbid
+                   , rg.gid release_group_mbid
+                FROM musicbrainz.release
+                JOIN musicbrainz.release_group rg
+                  ON release.release_group = rg.id
+           )
+              SELECT release_rg.release_mbid
+                   , first_release.rel_mbid AS canonical_release_mbid
+                   , release_rg.release_group_mbid
+                FROM release_rg
+                JOIN first_release
+                  ON first_release.rg_mbid = release_rg.release_group_mbid
+        """)]
 
     def get_post_process_queries(self):
-        return ["""INSERT INTO mapping.canonical_release_redirect_tmp (release_mbid, canonical_release_mbid, release_group_mbid)
-                    WITH canonical_release AS (
-                        SELECT release.gid rel_mbid
-                            , rg.gid rg_mbid
-                            , cmdr.id
-                            , rank() over (partition by rg.id order by cmdr.id)
-                        FROM musicbrainz.release
-                        JOIN musicbrainz.release_group rg
-                          ON release.release_group = rg.id
-                        JOIN mapping.canonical_release_tmp cmdr
-                          ON cmdr.release = release.id),
-                        first_release AS (select * from canonical_release where rank = 1),
-                        release_rg AS (
-                           SELECT release.gid release_mbid
-                                , rg.gid release_group_mbid
-                            FROM musicbrainz.release
-                            JOIN musicbrainz.release_group rg
-                                ON release.release_group = rg.id
-                    )
-                   SELECT release_rg.release_mbid
-                        , first_release.rel_mbid canonical_rel_mbid
-                        , release_rg.release_group_mbid
-                    FROM release_rg
-                    JOIN first_release
-                        ON first_release.rg_mbid = release_rg.release_group_mbid"""]
+        return []
 
     def get_index_names(self):
         return [("release_mbid_ndx_canonical_release_redirect", "release_mbid", True)]
 
     def process_row(self, row):
-        return []
+        return [(row["release_mbid"], row["canonical_release_mbid"], row["release_group_mbid"])]


### PR DESCRIPTION
Currently, the table can only be built in MB. Fix that so that tables can be built in either table.