### PR TITLE
LB-1412: Fix release groups aggregate for artists without any release groups

### DIFF
--- a/mbid_mapping/mapping/mb_artist_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_artist_metadata_cache.py
@@ -242,7 +242,10 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                             rgd.caa_id,
                                             rgd.caa_release_mbid
                                         ) ORDER BY rgd.date
-                                   ) AS release_groups
+                                   )
+                                    -- if the artist has no release groups, left join will cause a NULL row to be
+                                    -- added to the array, filter ensures that it is removed
+                                    FILTER (WHERE rgd.release_group_mbid IS NOT NULL) AS release_groups
                               FROM musicbrainz.artist a
                          LEFT JOIN musicbrainz.artist_type at
                                 ON a.type = at.id


### PR DESCRIPTION
If the artist has no release groups, the left join to release_group_data will cause a NULL row to be added to the array, filter ensures that it is removed.