### PR TITLE
Fix broken readthedocs links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,7 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'canonical_url': "https://listenbrainz.readthedocs.io/en/production/",
+    'canonical_url': "https://listenbrainz.readthedocs.io/en/latest/",
     'collapse_navigation': False,
     'display_version': False,
     'navigation_depth': 3,

--- a/frontend/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/frontend/js/src/metadata-viewer/MetadataViewer.tsx
@@ -243,7 +243,7 @@ export default function MetadataViewer(props: MetadataViewerProps) {
               <br />
               We work hard to make this data available to you as soon as we
               receive it, but until your music service sends us a{" "}
-              <a href="https://listenbrainz.readthedocs.io/en/production/dev/json/?highlight=playing%20now#submission-json">
+              <a href="https://listenbrainz.readthedocs.io/en/latest/users/json.html?highlight=playing%20now#submission-json">
                 <i>playing-now</i> event
               </a>
               , we cannot display anything here.

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -1,7 +1,7 @@
 """ This module contains data dump creation and import functions.
 
 Read more about the data dumps in our documentation here:
-https://listenbrainz.readthedocs.io/en/production/dev/listenbrainz-dumps.html
+https://listenbrainz.readthedocs.io/en/latest/users/listenbrainz-dumps.html
 """
 
 # listenbrainz-server - Server for the ListenBrainz project

--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -1,7 +1,7 @@
 """ This module contains data dump creation and import functions.
 
 Read more about the data dumps in our documentation here:
-https://listenbrainz.readthedocs.io/en/production/dev/listenbrainz-dumps.html
+https://listenbrainz.readthedocs.io/en/latest/users/listenbrainz-dumps.html
 """
 
 # listenbrainz-server - Server for the ListenBrainz project

--- a/listenbrainz/webserver/templates/index/data.html
+++ b/listenbrainz/webserver/templates/index/data.html
@@ -17,7 +17,7 @@
       <b>fullexport:</b> Dumps of the full ListenBrainz database, updated every two weeks on or about the 1st and the 15th of each month.<br>
       <b>incremental:</b> Daily incremental dumps based on the most recent fullexport dump.<br>
       <b>spark:</b> A version of the fullexport dump suitable for importing directly into
-          <a href="https://listenbrainz.readthedocs.io/en/production/dev/spark-devel-env/">our spark infrastructure</a>.
+          <a href="https://listenbrainz.readthedocs.io/en/latest/developers/spark-devel-env.html">our spark infrastructure</a>.
   </p>
 
 

--- a/listenbrainz/webserver/templates/index/index.html
+++ b/listenbrainz/webserver/templates/index/index.html
@@ -52,7 +52,7 @@
       </p>
       <p>
         We also make this incredibly useful data available to anyone who cares to play with it. You
-        can use our API or our regular public <a href="https://listenbrainz.readthedocs.io/en/production/dev/listenbrainz-dumps/">data dumps</a>.
+        can use our API or our regular public <a href="https://listenbrainz.readthedocs.io/en/latest/users/listenbrainz-dumps.html">data dumps</a>.
         All non-commercial use of this data is free, but commercial users are asked to <a href="https://metabrainz.org/supporters/account-type">support</a>
         us in order to help fund the project.
       </p>

--- a/listenbrainz_spark/README.md
+++ b/listenbrainz_spark/README.md
@@ -1,4 +1,4 @@
 # ListenBrainz Spark
 
 In order to understand how ListenBrainz works and communicates
-with Spark, read the [architecture document](https://listenbrainz.readthedocs.io/en/production/dev/spark-architecture).
+with Spark, read the [architecture document](https://listenbrainz.readthedocs.io/en/latest/developers/spark-architecture.html).

--- a/listenbrainz_spark/recommendations/README.md
+++ b/listenbrainz_spark/recommendations/README.md
@@ -8,7 +8,7 @@ The component uses collaborative filtering to recommend recordings to users base
 
 **Note**:  
 - The listening history and supporting data used by ListenBrainz is heavy for the local environment. Releasing small test datasets to make the development experience smoother is on our roadmap.
-- Spark sends the generated recommendations to ListenBrainz webserver containers as Rabbit MQ messages. Therefore before generating the recommendations, the `spark_reader` container should be running. For details, see the [Spark Architecture](https://listenbrainz.readthedocs.io/en/production/dev/spark-architecture/) document.
+- Spark sends the generated recommendations to ListenBrainz webserver containers as Rabbit MQ messages. Therefore before generating the recommendations, the `spark_reader` container should be running. For details, see the [Spark Architecture](https://listenbrainz.readthedocs.io/en/latest/developers/spark-architecture.html) document.
 
 
 ## Production environment


### PR DESCRIPTION
I noticed the "data dumps" link on the homepage was broken in the same way as https://github.com/metabrainz/listenbrainz-server/pull/2594.

Then I searched for other instances of "en/latest/dev" and found even more broken links. I guess something changed with your readthedocs setup at some point (?).