### PR TITLE
LB-1407 (I): Listening stats don't add up

### DIFF
--- a/data/model/entity_listener_stat.py
+++ b/data/model/entity_listener_stat.py
@@ -18,6 +18,7 @@ class UserIdListener(BaseModel):
 class BaseListenerRecord(BaseModel):
     """ Common base class for entity listener stats """
     total_listen_count: NonNegativeInt
+    total_user_count: NonNegativeInt
     listeners: List[UserIdListener]
 
 

--- a/frontend/js/src/entity-pages/AlbumPage.tsx
+++ b/frontend/js/src/entity-pages/AlbumPage.tsx
@@ -62,6 +62,7 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
   const {
     total_listen_count: listenCount,
     listeners: topListeners,
+    total_user_count: userCount,
   } = listening_stats;
 
   const [metadata, setMetadata] = React.useState(initialReleaseGroupMetadata);
@@ -376,7 +377,7 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
             <div className="separator" />
             <div className="text-center">
               <div className="number">
-                {bigNumberFormatter.format(topListeners.length)}
+                {bigNumberFormatter.format(userCount)}
               </div>
               <div className="text-muted small">
                 <FontAwesomeIcon icon={faUserAstronaut} /> listeners

--- a/frontend/js/src/entity-pages/ArtistPage.tsx
+++ b/frontend/js/src/entity-pages/ArtistPage.tsx
@@ -52,6 +52,7 @@ export default function ArtistPage(props: ArtistPageProps): JSX.Element {
   const {
     total_listen_count: listenCount,
     listeners: topListeners,
+    total_user_count: userCount
   } = listeningStats;
 
   const [artist, setArtist] = React.useState(initialArtist);
@@ -354,7 +355,7 @@ export default function ArtistPage(props: ArtistPageProps): JSX.Element {
             <div className="separator" />
             <div className="text-center">
               <div className="number">
-                {bigNumberFormatter.format(topListeners.length)}
+                {bigNumberFormatter.format(userCount)}
               </div>
               <div className="text-muted small">
                 <FontAwesomeIcon icon={faUserAstronaut} /> listeners

--- a/frontend/js/src/entity-pages/utils.tsx
+++ b/frontend/js/src/entity-pages/utils.tsx
@@ -57,6 +57,7 @@ export type PopularRecording = {
 
 export type ListeningStats = {
   total_listen_count: number;
+  total_user_count: number;
   listeners: Array<{
     user_name: string;
     listen_count: number;

--- a/listenbrainz_spark/stats/listener/artist.py
+++ b/listenbrainz_spark/stats/listener/artist.py
@@ -49,6 +49,7 @@ def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -
         ), entity_count as (
             SELECT artist_mbid
                  , SUM(listen_count) as total_listen_count
+                 , COUNT(DISTINCT user_id) as total_user_count
               FROM intermediate_table
           GROUP BY artist_mbid      
         ), ranked_stats as (
@@ -79,6 +80,7 @@ def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -
                  , artist_name
                  , listeners
                  , total_listen_count
+                 , total_user_count
               FROM grouped_stats
               JOIN entity_count
              USING (artist_mbid)

--- a/listenbrainz_spark/stats/listener/artist.py
+++ b/listenbrainz_spark/stats/listener/artist.py
@@ -56,7 +56,7 @@ def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -
                  , artist_name
                  , user_id 
                  , listen_count
-                 , row_number() OVER (PARTITION BY user_id ORDER BY listen_count DESC) AS rank
+                 , row_number() OVER (PARTITION BY artist_mbid ORDER BY listen_count DESC) AS rank
               FROM intermediate_table
         ), grouped_stats AS (
             SELECT artist_mbid

--- a/listenbrainz_spark/stats/listener/release_group.py
+++ b/listenbrainz_spark/stats/listener/release_group.py
@@ -62,8 +62,9 @@ def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -
         ), entity_count as (
             SELECT release_group_mbid
                  , SUM(listen_count) as total_listen_count
+                 , COUNT(DISTINCT user_id) as total_user_count
               FROM intermediate_table
-          GROUP BY release_group_mbid      
+          GROUP BY release_group_mbid
         ), ranked_stats as (
             SELECT release_group_mbid
                  , release_group_name
@@ -108,6 +109,7 @@ def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -
                  , caa_release_mbid
                  , listeners
                  , total_listen_count
+                 , total_user_count
               FROM grouped_stats
               JOIN entity_count
              USING (release_group_mbid)

--- a/listenbrainz_spark/stats/listener/release_group.py
+++ b/listenbrainz_spark/stats/listener/release_group.py
@@ -73,7 +73,7 @@ def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -
                  , caa_release_mbid
                  , user_id 
                  , listen_count
-                 , row_number() OVER (PARTITION BY user_id ORDER BY listen_count DESC) AS rank
+                 , row_number() OVER (PARTITION BY release_group_mbid ORDER BY listen_count DESC) AS rank
               FROM intermediate_table
         ), grouped_stats AS (
             SELECT release_group_mbid

--- a/listenbrainz_spark/testdata/user_top_artist_listeners_output.json
+++ b/listenbrainz_spark/testdata/user_top_artist_listeners_output.json
@@ -6,202 +6,376 @@
     "to_ts": 1628511763,
     "data": [
       {
-        "artist_mbid": "056e4f3e-d505-4dad-8ec1-d04f521cbb56",
-        "artist_name": "Daft Punk",
-        "total_listen_count": 1,
+        "total_listen_count": 4,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 1,
-            "listen_count": 1
+            "listen_count": 4
           }
-        ]
+        ],
+        "artist_mbid": "c44ff36b-651f-4c20-98ee-519cf4ed07e7",
+        "artist_name": "Aether"
       },
       {
-        "artist_mbid": "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8",
-        "artist_name": "Massive Attack",
-        "total_listen_count": 6,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 6
-          }
-        ]
-      },
-      {
-        "artist_mbid": "122d63fc-8671-43e4-9752-34e846d62a9c",
-        "artist_name": "Katy Perry",
         "total_listen_count": 5,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
             "listen_count": 5
           }
-        ]
+        ],
+        "artist_mbid": "122d63fc-8671-43e4-9752-34e846d62a9c",
+        "artist_name": "Katy Perry"
       },
       {
-        "artist_mbid": "298f4089-1948-44b5-b5e8-d5381f42362f",
-        "artist_name": "X Ambassadors",
-        "total_listen_count": 2,
-        "listeners": [
-          {
-            "user_id": 2,
-            "listen_count": 2
-          }
-        ]
-      },
-      {
-        "artist_mbid": "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e",
-        "artist_name": "Jon Bellion",
         "total_listen_count": 3,
+        "total_user_count": 1,
         "listeners": [
           {
-            "user_id": 2,
+            "user_id": 1,
             "listen_count": 3
           }
-        ]
-      },
-      {
+        ],
         "artist_mbid": "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f",
-        "artist_name": "Vangelis",
-        "total_listen_count": 3,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 3
-          }
-        ]
+        "artist_name": "Vangelis"
       },
       {
+        "total_listen_count": 2,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 2
+          }
+        ],
         "artist_mbid": "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0",
-        "artist_name": "Olivia Rodrigo",
-        "total_listen_count": 2,
-        "listeners": [
-          {
-            "user_id": 2,
-            "listen_count": 2
-          }
-        ]
+        "artist_name": "Olivia Rodrigo"
       },
       {
-        "artist_mbid": "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f",
-        "artist_name": "Tracey Thorn",
-        "total_listen_count": 1,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 1
-          }
-        ]
-      },
-      {
-        "artist_mbid": "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f",
-        "artist_name": "Dua Lipa",
-        "total_listen_count": 2,
-        "listeners": [
-          {
-            "user_id": 2,
-            "listen_count": 2
-          }
-        ]
-      },
-      {
-        "artist_mbid": "859d0860-d480-4efd-970c-c05d5f1776b8",
-        "artist_name": "Beyonc\u00e9",
         "total_listen_count": 3,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
             "listen_count": 3
           }
-        ]
+        ],
+        "artist_mbid": "cf15719f-51f9-4db8-a15d-5eed9664ce69",
+        "artist_name": "Lupe Fiasco"
       },
       {
-        "artist_mbid": "8b2350de-b682-4fe7-ad8f-4508d7b6c697",
-        "artist_name": "Brazilian Girls",
         "total_listen_count": 3,
+        "total_user_count": 1,
         "listeners": [
           {
-            "user_id": 1,
+            "user_id": 2,
             "listen_count": 3
           }
-        ]
+        ],
+        "artist_mbid": "f116b984-45ae-49d0-9445-efc5a61458a1",
+        "artist_name": "Guy Sebastian"
       },
       {
-        "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-        "artist_name": "Portishead",
         "total_listen_count": 6,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 1,
             "listen_count": 6
           }
-        ]
+        ],
+        "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+        "artist_name": "Portishead"
       },
       {
-        "artist_mbid": "93cfee41-b1a6-4604-a01c-91243e6926e6",
-        "artist_name": "Annaca Espach",
+        "total_listen_count": 3,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 3
+          }
+        ],
+        "artist_mbid": "859d0860-d480-4efd-970c-c05d5f1776b8",
+        "artist_name": "Beyonc\u00e9"
+      },
+      {
         "total_listen_count": 2,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
             "listen_count": 2
           }
-        ]
+        ],
+        "artist_mbid": "298f4089-1948-44b5-b5e8-d5381f42362f",
+        "artist_name": "X Ambassadors"
       },
       {
+        "total_listen_count": 6,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 6
+          }
+        ],
+        "artist_mbid": "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8",
+        "artist_name": "Massive Attack"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "6dbd7f8b-20ac-4287-8dd3-b4cae5c5f82f",
+        "artist_name": "Tracey Thorn"
+      },
+      {
+        "total_listen_count": 4,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 4
+          }
+        ],
         "artist_mbid": "b014d579-b549-4b21-b90d-5264e0433988",
-        "artist_name": "Romare",
-        "total_listen_count": 4,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 4
-          }
-        ]
+        "artist_name": "Romare"
       },
       {
-        "artist_mbid": "c44ff36b-651f-4c20-98ee-519cf4ed07e7",
-        "artist_name": "Aether",
-        "total_listen_count": 4,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 4
-          }
-        ]
-      },
-      {
-        "artist_mbid": "cf15719f-51f9-4db8-a15d-5eed9664ce69",
-        "artist_name": "Lupe Fiasco",
-        "total_listen_count": 3,
+        "total_listen_count": 2,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
-            "listen_count": 3
+            "listen_count": 2
           }
-        ]
+        ],
+        "artist_mbid": "93cfee41-b1a6-4604-a01c-91243e6926e6",
+        "artist_name": "Annaca Espach"
       },
       {
-        "artist_mbid": "e9787dd2-5857-4b51-8e59-a190a54820fc",
-        "artist_name": "The Polish Ambassador",
         "total_listen_count": 2,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 1,
             "listen_count": 2
           }
-        ]
+        ],
+        "artist_mbid": "e9787dd2-5857-4b51-8e59-a190a54820fc",
+        "artist_name": "The Polish Ambassador"
       },
       {
-        "artist_mbid": "f116b984-45ae-49d0-9445-efc5a61458a1",
-        "artist_name": "Guy Sebastian",
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "603ba565-3967-4be1-931e-9cb945394e86",
+        "artist_name": "*NSYNC"
+      },
+      {
+        "total_listen_count": 2,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 2
+          }
+        ],
+        "artist_mbid": "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f",
+        "artist_name": "Dua Lipa"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "7eb1ce54-a355-41f9-8d68-e018b096d427",
+        "artist_name": "Harry Styles"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "4f29ecd7-21a5-4c03-b9ba-d0cfe9488f8c",
+        "artist_name": "Wyclef Jean"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "bf24ca37-25f4-4e34-9aec-460b94364cfc",
+        "artist_name": "Shakira"
+      },
+      {
         "total_listen_count": 3,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
             "listen_count": 3
           }
-        ]
+        ],
+        "artist_mbid": "2bd8101a-11c3-42d5-a9bd-6a3b26445f7e",
+        "artist_name": "Jon Bellion"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "056e4f3e-d505-4dad-8ec1-d04f521cbb56",
+        "artist_name": "Daft Punk"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "3252542b-98a7-48ba-9861-7a612b16c227",
+        "artist_name": "Kiasmos"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "904cc1c8-021e-45ac-bbe9-95c01a1f8099",
+        "artist_name": "Jah Wobble"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "3f9b5837-ed1c-413e-bfef-ca4f892dcc59",
+        "artist_name": "Marconi Union"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "6fe91ae9-8ddb-47b0-a2d7-252833ce5500",
+        "artist_name": "The Egg"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "53d2a4d1-556e-4701-a8ac-5fcb74a8e393",
+        "artist_name": "All India Radio"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "9806e551-9a63-4a9d-be1b-5297b2ac0e76",
+        "artist_name": "Sounds From the Ground"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "1a40f886-0877-4bab-9ab1-761147dadb89",
+        "artist_name": "Ott"
+      },
+      {
+        "total_listen_count": 3,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 3
+          }
+        ],
+        "artist_mbid": "8b2350de-b682-4fe7-ad8f-4508d7b6c697",
+        "artist_name": "Brazilian Girls"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "a8b39181-6939-451e-9641-2db231b73706",
+        "artist_name": "Abakus"
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "artist_mbid": "f1106b17-dcbb-45f6-b938-199ccfab50cc",
+        "artist_name": "New Order"
       }
     ],
     "database": "artists_listeners_all_time",

--- a/listenbrainz_spark/testdata/user_top_release_group_listeners_output.json
+++ b/listenbrainz_spark/testdata/user_top_release_group_listeners_output.json
@@ -6,41 +6,8 @@
     "to_ts": 1628511763,
     "data": [
       {
-        "total_listen_count": 6,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 6
-          }
-        ],
-        "release_group_mbid": "163339ab-813b-3d29-bba8-e1d5acf63cab",
-        "release_group_name": "Third",
-        "artist_name": "Portishead",
-        "caa_id": 8201679314,
-        "caa_release_mbid": "f5bfccaf-1816-427a-b03d-b41c8ac155c5",
-        "artist_mbids": [
-          "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
-        ]
-      },
-      {
-        "total_listen_count": 5,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 5
-          }
-        ],
-        "release_group_mbid": "ded46e46-788d-3c1f-b21b-9f5e9c37b1bc",
-        "release_group_name": "Protection",
-        "artist_name": "Massive Attack",
-        "caa_id": 19647449808,
-        "caa_release_mbid": "50d1ca93-f6ef-4692-b18d-3e3cc29aba1e",
-        "artist_mbids": [
-          "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
-        ]
-      },
-      {
         "total_listen_count": 4,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 1,
@@ -58,6 +25,7 @@
       },
       {
         "total_listen_count": 4,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 1,
@@ -74,73 +42,8 @@
         ]
       },
       {
-        "total_listen_count": 4,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 4
-          }
-        ],
-        "release_group_mbid": "b609c28e-5b7c-4b19-8d43-8d3c7323f7d0",
-        "release_group_name": "Projections",
-        "artist_name": "Romare",
-        "caa_id": 9018227739,
-        "caa_release_mbid": "95b93c79-f4b0-4f3e-b726-7d3dd51c1054",
-        "artist_mbids": [
-          "b014d579-b549-4b21-b90d-5264e0433988"
-        ]
-      },
-      {
-        "total_listen_count": 3,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 3
-          }
-        ],
-        "release_group_mbid": "df9e8d11-9d68-3e49-b348-8454cfbaa692",
-        "release_group_name": "Brazilian Girls",
-        "artist_name": "Brazilian Girls",
-        "caa_id": 11778363663,
-        "caa_release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd",
-        "artist_mbids": [
-          "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
-        ]
-      },
-      {
-        "total_listen_count": 2,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 2
-          }
-        ],
-        "release_group_mbid": "51d9f264-ea9c-46a2-8545-e22cd4b085ed",
-        "release_group_name": "Ecozoic",
-        "artist_name": "The Polish Ambassador",
-        "caa_id": 34328682227,
-        "caa_release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf",
-        "artist_mbids": [
-          "e9787dd2-5857-4b51-8e59-a190a54820fc"
-        ]
-      },
-      {
-        "total_listen_count": 1,
-        "listeners": [
-          {
-            "user_id": 1,
-            "listen_count": 1
-          }
-        ],
-        "release_group_mbid": "6e58a533-6847-4ac1-8d0a-8d09abe5278d",
-        "release_group_name": "Francesco",
-        "artist_name": "Vangelis",
-        "artist_mbids": [
-          "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
-        ]
-      },
-      {
         "total_listen_count": 5,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
@@ -157,7 +60,78 @@
         ]
       },
       {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "6e58a533-6847-4ac1-8d0a-8d09abe5278d",
+        "release_group_name": "Francesco",
+        "artist_name": "Vangelis",
+        "artist_mbids": [
+          "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+        ]
+      },
+      {
+        "total_listen_count": 2,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 2
+          }
+        ],
+        "release_group_mbid": "2ae2e504-7116-4b4f-b632-9748bb18ccd2",
+        "release_group_name": "SOUR",
+        "artist_name": "Olivia Rodrigo",
+        "caa_id": 32201040812,
+        "caa_release_mbid": "6dd75bce-0194-4737-810c-d389689b4759",
+        "artist_mbids": [
+          "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "030996fb-4388-34a5-8dfa-ddbdb71a2ac4",
+        "release_group_name": "Infinite Euphoria",
+        "artist_name": "Ferry Corsten",
+        "caa_id": 8448022908,
+        "caa_release_mbid": "0efa1563-cbc7-4249-b6ec-fab766c38c81",
+        "artist_mbids": [
+          "47347cb8-ac34-4916-84b6-d85d4e5e5384"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "4243c89d-d31b-301f-bfd4-76fefd75d03c",
+        "release_group_name": "See You Later",
+        "artist_name": "Vangelis",
+        "caa_id": 15902858347,
+        "caa_release_mbid": "71771d40-0236-4cde-b71d-b0eee0270d6c",
+        "artist_mbids": [
+          "57fca0e2-f9ad-4ae6-af9d-6a6f50cbcd5f"
+        ]
+      },
+      {
         "total_listen_count": 3,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
@@ -174,7 +148,26 @@
         ]
       },
       {
+        "total_listen_count": 6,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 6
+          }
+        ],
+        "release_group_mbid": "163339ab-813b-3d29-bba8-e1d5acf63cab",
+        "release_group_name": "Third",
+        "artist_name": "Portishead",
+        "caa_id": 8201679314,
+        "caa_release_mbid": "f5bfccaf-1816-427a-b03d-b41c8ac155c5",
+        "artist_mbids": [
+          "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+        ]
+      },
+      {
         "total_listen_count": 3,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
@@ -192,7 +185,190 @@
         ]
       },
       {
+        "total_listen_count": 2,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 2
+          }
+        ],
+        "release_group_mbid": "68834e04-745e-4dba-a15f-4e2ac62f1ccc",
+        "release_group_name": "VHS",
+        "artist_name": "X Ambassadors",
+        "caa_id": 23591912180,
+        "caa_release_mbid": "d852d98b-0851-492f-aa4d-3f32ad01482a",
+        "artist_mbids": [
+          "298f4089-1948-44b5-b5e8-d5381f42362f"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "f1ceb805-8bf6-3a18-9c07-f29f407abba0",
+        "release_group_name": "The Best of Everything but the Girl",
+        "artist_name": "Everything but the Girl",
+        "caa_id": 10340680649,
+        "caa_release_mbid": "91231e74-2674-411e-968f-b188bb67b711",
+        "artist_mbids": [
+          "959cf5bf-ee29-4af6-a85a-0b480181d988"
+        ]
+      },
+      {
+        "total_listen_count": 5,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 5
+          }
+        ],
+        "release_group_mbid": "ded46e46-788d-3c1f-b21b-9f5e9c37b1bc",
+        "release_group_name": "Protection",
+        "artist_name": "Massive Attack",
+        "caa_id": 19647449808,
+        "caa_release_mbid": "50d1ca93-f6ef-4692-b18d-3e3cc29aba1e",
+        "artist_mbids": [
+          "10adbe5e-a2c0-4bf3-8249-2b4cbf6e6ca8"
+        ]
+      },
+      {
+        "total_listen_count": 4,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 4
+          }
+        ],
+        "release_group_mbid": "b609c28e-5b7c-4b19-8d43-8d3c7323f7d0",
+        "release_group_name": "Projections",
+        "artist_name": "Romare",
+        "caa_id": 9018227739,
+        "caa_release_mbid": "95b93c79-f4b0-4f3e-b726-7d3dd51c1054",
+        "artist_mbids": [
+          "b014d579-b549-4b21-b90d-5264e0433988"
+        ]
+      },
+      {
+        "total_listen_count": 2,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 2
+          }
+        ],
+        "release_group_mbid": "6996c6a9-0eeb-48d2-857d-1a122ba887f9",
+        "release_group_name": "Wicked Game",
+        "artist_name": "Ursine Vulpine feat. Annaca",
+        "caa_id": 15528924240,
+        "caa_release_mbid": "1355c8b7-f563-4ddc-8b00-620f4a63d081",
+        "artist_mbids": [
+          "43736f76-419a-42a0-816a-830876647ba5",
+          "93cfee41-b1a6-4604-a01c-91243e6926e6"
+        ]
+      },
+      {
+        "total_listen_count": 2,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 2
+          }
+        ],
+        "release_group_mbid": "51d9f264-ea9c-46a2-8545-e22cd4b085ed",
+        "release_group_name": "Ecozoic",
+        "artist_name": "The Polish Ambassador",
+        "caa_id": 34328682227,
+        "caa_release_mbid": "7a2598fb-f6f0-4e4c-947b-317858ee5acf",
+        "artist_mbids": [
+          "e9787dd2-5857-4b51-8e59-a190a54820fc"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "a648d0c2-1438-33d0-87d2-5fbab3c0990a",
+        "release_group_name": "No Strings Attached",
+        "artist_name": "*NSYNC",
+        "caa_id": 13042053778,
+        "caa_release_mbid": "dec22fe3-01f1-43f3-bd91-11b93c35c1e0",
+        "artist_mbids": [
+          "603ba565-3967-4be1-931e-9cb945394e86"
+        ]
+      },
+      {
+        "total_listen_count": 2,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 2
+          }
+        ],
+        "release_group_mbid": "aa366795-92d7-4d67-91fa-6741f82a4858",
+        "release_group_name": "Future Nostalgia",
+        "artist_name": "Dua Lipa",
+        "caa_id": 25806517352,
+        "caa_release_mbid": "315bbc48-dea9-463c-bfa9-a6ccab78b990",
+        "artist_mbids": [
+          "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f",
+          "6f1a58bf-9b1b-49cf-a44a-6cefad7ae04f"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "b9990da8-7953-4e64-aea5-065ca9cd3cb7",
+        "release_group_name": "Fine Line",
+        "artist_name": "Harry Styles",
+        "caa_id": 24909263406,
+        "caa_release_mbid": "61210065-4118-43f9-866f-4038cfae5df4",
+        "artist_mbids": [
+          "7eb1ce54-a355-41f9-8d68-e018b096d427"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 2,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "daa154b8-34e9-350d-9e1a-e8626f946804",
+        "release_group_name": "Oral Fixation, Vol. 2",
+        "artist_name": "Shakira",
+        "caa_id": 1129595405,
+        "caa_release_mbid": "0e247e68-9134-3a6b-ba6a-1e2ce5fad35c",
+        "artist_mbids": [
+          "bf24ca37-25f4-4e34-9aec-460b94364cfc"
+        ]
+      },
+      {
         "total_listen_count": 3,
+        "total_user_count": 1,
         "listeners": [
           {
             "user_id": 2,
@@ -209,20 +385,184 @@
         ]
       },
       {
-        "total_listen_count": 2,
+        "total_listen_count": 1,
+        "total_user_count": 1,
         "listeners": [
           {
-            "user_id": 2,
-            "listen_count": 2
+            "user_id": 1,
+            "listen_count": 1
           }
         ],
-        "release_group_mbid": "2ae2e504-7116-4b4f-b632-9748bb18ccd2",
-        "release_group_name": "SOUR",
-        "artist_name": "Olivia Rodrigo",
-        "caa_id": 32201040812,
-        "caa_release_mbid": "6dd75bce-0194-4737-810c-d389689b4759",
+        "release_group_mbid": "111e4cc8-e7b6-437a-af02-a42c757e4e17",
+        "release_group_name": "Give Life Back to Music",
+        "artist_name": "Daft Punk",
+        "caa_id": 28936814610,
+        "caa_release_mbid": "74fcd7f4-a2c8-4526-b350-558b157942bf",
         "artist_mbids": [
-          "6925db17-f35e-42f3-a4eb-84ee6bf5d4b0"
+          "056e4f3e-d505-4dad-8ec1-d04f521cbb56"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "8f3d55a7-efea-419b-add8-2a5469c2e014",
+        "release_group_name": "Kiasmos",
+        "artist_name": "Kiasmos",
+        "caa_id": 22036362973,
+        "caa_release_mbid": "73e4a3e9-bb1d-4243-9c1b-f285fc842248",
+        "artist_mbids": [
+          "3252542b-98a7-48ba-9861-7a612b16c227"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "7e8d5285-826c-4b8a-b33b-3a8f3230d6c5",
+        "release_group_name": "Anomic",
+        "artist_name": "Jah Wobble & Marconi Union",
+        "caa_id": 27448523314,
+        "caa_release_mbid": "39967fee-e436-4f87-b36e-299aae4dc670",
+        "artist_mbids": [
+          "904cc1c8-021e-45ac-bbe9-95c01a1f8099",
+          "3f9b5837-ed1c-413e-bfef-ca4f892dcc59"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "e3decf7e-d480-3abc-9ff9-e00b86338eeb",
+        "release_group_name": "/Forwards",
+        "artist_name": "The Egg",
+        "caa_id": 11988727956,
+        "caa_release_mbid": "00cc6a5a-1051-4b7e-8344-4ec33099eb98",
+        "artist_mbids": [
+          "6fe91ae9-8ddb-47b0-a2d7-252833ce5500"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "02034451-9359-37c5-ab04-b07ff52f298f",
+        "release_group_name": "Echo Other",
+        "artist_name": "All India Radio",
+        "caa_id": 11008525379,
+        "caa_release_mbid": "48d4b42e-ab47-411c-8c8f-3b519832bd87",
+        "artist_mbids": [
+          "53d2a4d1-556e-4701-a8ac-5fcb74a8e393"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "99725626-809b-4a49-bf8b-9ee93546c557",
+        "release_group_name": "Mosaic",
+        "artist_name": "Sounds From the Ground",
+        "caa_id": 14187025380,
+        "caa_release_mbid": "2f7634f3-3bb5-4f2c-9821-d150e8415fb8",
+        "artist_mbids": [
+          "9806e551-9a63-4a9d-be1b-5297b2ac0e76"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "fd7749a8-a579-3059-8dc4-97a99d25e062",
+        "release_group_name": "Blumenkraft",
+        "artist_name": "Ott",
+        "caa_id": 6477557415,
+        "caa_release_mbid": "99e39642-cae5-4061-9800-751108bc650b",
+        "artist_mbids": [
+          "1a40f886-0877-4bab-9ab1-761147dadb89"
+        ]
+      },
+      {
+        "total_listen_count": 3,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 3
+          }
+        ],
+        "release_group_mbid": "df9e8d11-9d68-3e49-b348-8454cfbaa692",
+        "release_group_name": "Brazilian Girls",
+        "artist_name": "Brazilian Girls",
+        "caa_id": 11778363663,
+        "caa_release_mbid": "75735819-6bca-42bf-a807-5d456f277dbd",
+        "artist_mbids": [
+          "8b2350de-b682-4fe7-ad8f-4508d7b6c697"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "7300a439-8e91-402b-a3b8-09b4cd352fe9",
+        "release_group_name": "Silent Geometry",
+        "artist_name": "Abakus",
+        "caa_id": 3984827641,
+        "caa_release_mbid": "6122ca09-a4ca-4d13-96c5-2b1ea502e7f5",
+        "artist_mbids": [
+          "a8b39181-6939-451e-9641-2db231b73706"
+        ]
+      },
+      {
+        "total_listen_count": 1,
+        "total_user_count": 1,
+        "listeners": [
+          {
+            "user_id": 1,
+            "listen_count": 1
+          }
+        ],
+        "release_group_mbid": "a0902fc4-e3d9-3b2b-bc94-cd4d0e59db29",
+        "release_group_name": "Technique",
+        "artist_name": "New Order",
+        "caa_id": 2546509254,
+        "caa_release_mbid": "01681b1d-3068-3689-b879-efefde1f7b3b",
+        "artist_mbids": [
+          "f1106b17-dcbb-45f6-b938-199ccfab50cc"
         ]
       }
     ],


### PR DESCRIPTION
Instead of partitioning on user ids, need to partition on entity mbid because we want top listeners per entity. Also, add the correct total listeners count.