### PR TITLE
LB-1411: Add mediums to release group metadata cache

### DIFF
--- a/frontend/js/src/entity-pages/AlbumPage.tsx
+++ b/frontend/js/src/entity-pages/AlbumPage.tsx
@@ -11,7 +11,7 @@ import {
   faPlayCircle,
   faUserAstronaut,
 } from "@fortawesome/free-solid-svg-icons";
-import { chain, isEmpty, isUndefined, merge } from "lodash";
+import { chain, flatMap, isEmpty, isUndefined, merge } from "lodash";
 import tinycolor from "tinycolor2";
 import {
   getRelIconLink,
@@ -43,8 +43,14 @@ type AlbumRecording = {
   total_listen_count: number;
   total_user_count: number;
 };
+
 export type AlbumPageProps = {
-  recordings?: Array<AlbumRecording>;
+  mediums?: Array<{
+    name: string;
+    position: number;
+    format: string;
+    tracks?: Array<AlbumRecording>;
+  }>;
   release_group_mbid: string;
   release_group_metadata: ReleaseGroupMetadataLookup;
   type: string;
@@ -58,7 +64,7 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
   const {
     release_group_metadata: initialReleaseGroupMetadata,
     release_group_mbid,
-    recordings,
+    mediums,
     caa_id,
     caa_release_mbid,
     type,
@@ -81,7 +87,8 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
   } = metadata as ReleaseGroupMetadataLookup;
   const releaseGroupTags = tag?.release_group;
 
-  const [trackList, setTrackList] = React.useState(recordings);
+  // JSPF Tracks fetched using the recording mbids above
+  const [popularTracks, setPopularTracks] = React.useState<JSPFTrack[]>([]);
   const [loading, setLoading] = React.useState(false);
 
   /** Album art and album color related */
@@ -153,19 +160,24 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
   const artistName = artist?.name ?? "";
 
   const listensFromAlbumRecordings =
-    trackList?.map(
-      (track): Listen =>
-        popularRecordingToListen(
-          merge(track, {
-            artist_name: artistName,
-            artist_mbids: artist?.artists?.map((ar) => ar.artist_mbid) ?? [],
-            caa_id: Number(caa_id) || undefined,
-            caa_release_mbid,
-            recording_name: track.name,
-            release_mbid: caa_release_mbid ?? "",
-            release_name: album.name,
-          })
-        )
+    flatMap(
+      mediums,
+      (medium) =>
+        medium?.tracks?.map(
+          (track): Listen =>
+            popularRecordingToListen(
+              merge(track, {
+                artist_name: artistName,
+                artist_mbids:
+                  artist?.artists?.map((ar) => ar.artist_mbid) ?? [],
+                caa_id: Number(caa_id) || undefined,
+                caa_release_mbid,
+                recording_name: track.name,
+                release_mbid: caa_release_mbid ?? "",
+                release_name: album.name,
+              })
+            )
+        ) ?? []
     ) ?? [];
 
   const filteredTags = chain(releaseGroupTags)
@@ -177,6 +189,7 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
   const bigNumberFormatter = Intl.NumberFormat(undefined, {
     notation: "compact",
   });
+  const showMediumTitle = (mediums?.length ?? 0) > 1;
 
   return (
     <div
@@ -325,33 +338,51 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
               )}
             </h3>
           </div>
-          {trackList?.map((recording, index) => {
-            let listenCountComponent;
-            if (recording && Number.isFinite(recording.total_listen_count)) {
-              listenCountComponent = (
-                <span className="badge badge-info">
-                  {bigNumberFormatter.format(recording.total_listen_count)}
-                  &nbsp;
-                  <FontAwesomeIcon icon={faHeadphones} />
-                </span>
-              );
-            }
-            const listenFromRecording = listensFromAlbumRecordings[index];
-            let thumbnailReplacement;
-            if (Number.isFinite(recording.position)) {
-              thumbnailReplacement = (
-                <div className="track-position">{recording.position}.</div>
-              );
-            }
+          {mediums?.map((medium) => {
             return (
-              <ListenCard
-                key={recording.name}
-                customThumbnail={thumbnailReplacement}
-                listen={listenFromRecording}
-                showTimestamp={false}
-                showUsername={false}
-                additionalActions={listenCountComponent}
-              />
+              <>
+                {showMediumTitle && (
+                  <h4 className="header-with-line">
+                    {medium.format} {medium.position}: {medium.name}
+                  </h4>
+                )}
+                {medium?.tracks?.map((recording, index) => {
+                  let listenCountComponent;
+                  if (
+                    recording &&
+                    Number.isFinite(recording.total_listen_count)
+                  ) {
+                    listenCountComponent = (
+                      <span className="badge badge-info">
+                        {bigNumberFormatter.format(
+                          recording.total_listen_count
+                        )}
+                        &nbsp;
+                        <FontAwesomeIcon icon={faHeadphones} />
+                      </span>
+                    );
+                  }
+                  const listenFromRecording = listensFromAlbumRecordings[index];
+                  let thumbnailReplacement;
+                  if (Number.isFinite(recording.position)) {
+                    thumbnailReplacement = (
+                      <div className="track-position">
+                        {recording.position}.
+                      </div>
+                    );
+                  }
+                  return (
+                    <ListenCard
+                      key={recording.name}
+                      customThumbnail={thumbnailReplacement}
+                      listen={listenFromRecording}
+                      showTimestamp={false}
+                      showUsername={false}
+                      additionalActions={listenCountComponent}
+                    />
+                  );
+                })}
+              </>
             );
           })}
         </div>
@@ -460,7 +491,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
   const {
-    recordings,
+    mediums,
     release_group_mbid,
     caa_id,
     caa_release_mbid,
@@ -485,7 +516,7 @@ document.addEventListener("DOMContentLoaded", () => {
             release_group_metadata={
               release_group_metadata as ReleaseGroupMetadataLookup
             }
-            recordings={recordings}
+            mediums={mediums}
             release_group_mbid={release_group_mbid}
             caa_id={caa_id}
             caa_release_mbid={caa_release_mbid}

--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -135,7 +135,7 @@ def get_counts(entity, mbids):
             "total_listen_count": total_listen_count,
             "total_user_count": total_user_count
         })
-    return entity_data
+    return entity_data, index
 
 
 def get_top_recordings_for_artist(artist_mbid, count=None):

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -135,7 +135,7 @@ def artist_entity(artist_mbid):
 
     release_group_data = artist_data[0].release_group_data
     release_group_mbids = [rg["mbid"] for rg in release_group_data]
-    popularity_data = popularity.get_counts("release_group", release_group_mbids)
+    popularity_data, _ = popularity.get_counts("release_group", release_group_mbids)
 
     release_groups = []
     for release_group, pop in zip(release_group_data, popularity_data):
@@ -189,16 +189,19 @@ def album_entity(release_group_mbid):
         raise NotFound(f"Release group mbid {release_group_mbid} not found in the metadata cache")
     release_group = metadata[release_group_mbid]
 
-    recording_data = release_group.pop("recording").get("recordings", [])
-    recording_mbids = [rec["recording_mbid"] for rec in recording_data]
-    popularity_data = popularity.get_counts("recording", recording_mbids)
+    mediums = release_group.pop("recording").get("mediums", [])
+    recording_mbids = []
+    for medium in mediums:
+        for track in medium["tracks"]:
+            recording_mbids.append(track["recording_mbid"])
+    popularity_data, popularity_index = popularity.get_counts("recording", recording_mbids)
 
-    recordings = []
-    for rec, pop in zip(recording_data, popularity_data):
-        recording = dict(rec)
-        recording["total_listen_count"] = pop["total_listen_count"]
-        recording["total_user_count"] = pop["total_user_count"]
-        recordings.append(recording)
+    for medium in mediums:
+        for track in medium["tracks"]:
+            track["total_listen_count"], track["total_user_count"] = popularity_index.get(
+                track["recording_mbid"],
+                (None, None)
+            )
 
     listening_stats = get_entity_listener("release_groups", release_group_mbid, "all_time")
     if listening_stats is None:
@@ -210,7 +213,7 @@ def album_entity(release_group_mbid):
     props = {
         "release_group_mbid": release_group_mbid,
         "release_group_metadata": release_group,
-        "recordings": recordings,
+        "mediums": mediums,
         "caa_id": release_group["release_group"]["caa_id"],
         "caa_release_mbid": release_group["release_group"]["caa_release_mbid"],
         "type": release_group["release_group"].get("type"),

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -66,6 +66,8 @@ def fetch_release_group_metadata(release_group_mbids, incs):
             data["release"] = entry.release_group_data
 
         if "recording" in incs:
+            if "recordings" in entry.recording_data:
+                del entry.recording_data["recordings"]
             data["recording"] = entry.recording_data
 
         result[str(entry.release_group_mbid)] = data


### PR DESCRIPTION
Store mediums in release group metadata cache so that tracklists for releases with multiple discs are displayed properly.
