### PR TITLE
Album page: fix listen formatting for BrainzPlayer

### DIFF
--- a/frontend/js/src/entity-pages/utils.tsx
+++ b/frontend/js/src/entity-pages/utils.tsx
@@ -44,8 +44,9 @@ export type ReleaseGroup = {
 export type PopularRecording = {
   artist_mbids: string[];
   artist_name: string;
-  caa_id: number;
-  caa_release_mbid: string;
+  caa_id?: number;
+  caa_release_mbid?: string;
+  position?: number;
   length: number;
   recording_mbid: string;
   recording_name: string;
@@ -147,6 +148,7 @@ export function popularRecordingToListen(recording: PopularRecording): Listen {
         recording_mbid: recording.recording_mbid,
         duration_ms: recording.length,
         release_mbid: recording.release_mbid,
+        tracknumber: recording.position ?? null,
       },
       mbid_mapping: {
         caa_id: recording.caa_id,


### PR DESCRIPTION
Currently, with #2639 not yet merged, the album page can only play a single listen at a time and then stops once at the end of the track.
This is because of how I implemented the translation from the tracks we get in props into the Listen format BrainzPlayer expects and relies on to figure out which track is playing.

I reused the utility function I already refactored when working on the Artist page, but Ideally we would send the same track format to both pages to avoid this game.