### PR TITLE
Add Field Recording secondary type to mapping sort

### DIFF
--- a/mbid_mapping/mapping/custom_sorts.py
+++ b/mbid_mapping/mapping/custom_sorts.py
@@ -1,5 +1,4 @@
 import psycopg2
-from psycopg2.errors import OperationalError, UndefinedTable
 
 RELEASE_GROUP_SECONDARY_TYPES = [
     (2, "Soundtrack"),
@@ -11,6 +10,7 @@ RELEASE_GROUP_SECONDARY_TYPES = [
     (4, "Interview"),
     (10, "Demo"),
     (6, "Live"),
+    (12, "Field recording"),
     (1, "Compilation"),
     (8, "DJ-mix")
 ]


### PR DESCRIPTION
This secondary release group type was recently added to MusicBrainz, hence the secondary types list which has not been updated in almost a year didn't include it.