### PR TITLE
Entity pages: Fix listening stats

### DIFF
--- a/frontend/js/src/entity-pages/AlbumPage.tsx
+++ b/frontend/js/src/entity-pages/AlbumPage.tsx
@@ -11,7 +11,7 @@ import {
   faPlayCircle,
   faUserAstronaut,
 } from "@fortawesome/free-solid-svg-icons";
-import { chain, isEmpty, merge } from "lodash";
+import { chain, isEmpty, isUndefined, merge } from "lodash";
 import tinycolor from "tinycolor2";
 import {
   getRelIconLink,
@@ -359,7 +359,9 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
           <div className="listening-stats card flex-center">
             <div className="text-center">
               <div className="number">
-                {bigNumberFormatter.format(listenCount)}
+                {isUndefined(listenCount) || !Number.isFinite(listenCount)
+                  ? "-"
+                  : bigNumberFormatter.format(listenCount)}
               </div>
               <div className="text-muted small">
                 <FontAwesomeIcon icon={faHeadphones} /> plays
@@ -368,7 +370,9 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
             <div className="separator" />
             <div className="text-center">
               <div className="number">
-                {bigNumberFormatter.format(userCount)}
+                {isUndefined(userCount) || !Number.isFinite(userCount)
+                  ? "-"
+                  : bigNumberFormatter.format(userCount)}
               </div>
               <div className="text-muted small">
                 <FontAwesomeIcon icon={faUserAstronaut} /> listeners

--- a/frontend/js/src/entity-pages/ArtistPage.tsx
+++ b/frontend/js/src/entity-pages/ArtistPage.tsx
@@ -11,7 +11,7 @@ import {
   faPlayCircle,
   faUserAstronaut,
 } from "@fortawesome/free-solid-svg-icons";
-import { chain, isEmpty, partition, sortBy } from "lodash";
+import { chain, isEmpty, isUndefined, partition, sortBy } from "lodash";
 import { sanitize } from "dompurify";
 import withAlertNotifications from "../notifications/AlertNotificationsHOC";
 import GlobalAppContext from "../utils/GlobalAppContext";
@@ -52,7 +52,7 @@ export default function ArtistPage(props: ArtistPageProps): JSX.Element {
   const {
     total_listen_count: listenCount,
     listeners: topListeners,
-    total_user_count: userCount
+    total_user_count: userCount,
   } = listeningStats;
 
   const [artist, setArtist] = React.useState(initialArtist);
@@ -346,7 +346,9 @@ export default function ArtistPage(props: ArtistPageProps): JSX.Element {
           <div className="listening-stats card flex-center">
             <div className="text-center">
               <div className="number">
-                {bigNumberFormatter.format(listenCount)}
+                {isUndefined(listenCount) || !Number.isFinite(listenCount)
+                  ? "-"
+                  : bigNumberFormatter.format(listenCount)}
               </div>
               <div className="text-muted small">
                 <FontAwesomeIcon icon={faHeadphones} /> plays
@@ -355,7 +357,9 @@ export default function ArtistPage(props: ArtistPageProps): JSX.Element {
             <div className="separator" />
             <div className="text-center">
               <div className="number">
-                {bigNumberFormatter.format(userCount)}
+                {isUndefined(userCount) || !Number.isFinite(userCount)
+                  ? "-"
+                  : bigNumberFormatter.format(userCount)}
               </div>
               <div className="text-muted small">
                 <FontAwesomeIcon icon={faUserAstronaut} /> listeners

--- a/frontend/js/src/entity-pages/utils.tsx
+++ b/frontend/js/src/entity-pages/utils.tsx
@@ -57,8 +57,8 @@ export type PopularRecording = {
 };
 
 export type ListeningStats = {
-  total_listen_count: number;
-  total_user_count: number;
+  total_listen_count?: number;
+  total_user_count?: number;
   listeners: Array<{
     user_name: string;
     listen_count: number;


### PR DESCRIPTION
Listening stats values can apparently be undefined, which wasn't planned for, and this results in a NaN when we try to format them:

<img width="471" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/56e179bd-237e-42a2-8f56-868cb00cc457">

Adding a check to ensure they are a number.