### PR TITLE
Fix get_user_details for YIM playlists

### DIFF
--- a/listenbrainz/troi/tests/test_spark.py
+++ b/listenbrainz/troi/tests/test_spark.py
@@ -16,11 +16,12 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
 
     def test_get_user_details(self):
         self.maxDiff = None
-
         self.user1 = db_user.get_or_create(100, "user1")
         self.user2 = db_user.get_or_create(200, "user2")
         self.user3 = db_user.get_or_create(300, "user3")
-        
+        self.user4 = db_user.get_or_create(400, "user4")
+        self.user5 = db_user.get_or_create(500, "user5")
+
         db_user_setting.update_troi_prefs(self.user1["id"], True)
         db_user_setting.update_troi_prefs(self.user2["id"], False)
         
@@ -54,6 +55,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
             [],
             "lastfm_user_id"
         )
+
         db_external_service_oauth.save_token(
             self.user2["id"],
             ExternalServiceType.SPOTIFY,
@@ -62,13 +64,35 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
             int(datetime.now().timestamp()),
             True,
             ["streaming", "user-read-email", "user-read-private", "playlist-modify-public", "playlist-modify-private"],
-            "spotify_user_id"
+            "spotify_user_id2"
         )
 
-        user_ids = [self.user1["id"], self.user2["id"], self.user3["id"]]
+        db_external_service_oauth.save_token(
+            self.user4["id"],
+            ExternalServiceType.SPOTIFY,
+            "access_token",
+            "refresh_token",
+            int(datetime.now().timestamp()),
+            True,
+            ["streaming", "user-read-email", "user-read-private"],
+            "spotify_user_id3"
+        )
+
+        db_external_service_oauth.save_token(
+            self.user5["id"],
+            ExternalServiceType.LASTFM,
+            "access_token",
+            "refresh_token",
+            int(datetime.now().timestamp()),
+            False,
+            [],
+            "lastfm_user_id2"
+        )
+
+        user_ids = [self.user1["id"], self.user2["id"], self.user3["id"], self.user4["id"], self.user5["id"]]
 
         user_details = get_user_details("test-slug", user_ids)
-        self.assertEqual(len(user_details), 3)
+        self.assertEqual(len(user_details), 5)
         self.assertDictEqual(user_details, {
             self.user1["id"]: {
                 "username": self.user1["musicbrainz_id"],
@@ -82,6 +106,16 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
             },
             self.user3["id"]: {
                 "username": self.user3["musicbrainz_id"],
+                "export_to_spotify": False,
+                "existing_url": None
+            },
+            self.user4["id"]: {
+                "username": self.user4["musicbrainz_id"],
+                "export_to_spotify": False,
+                "existing_url": None
+            },
+            self.user5["id"]: {
+                "username": self.user5["musicbrainz_id"],
                 "export_to_spotify": False,
                 "existing_url": None
             }


### PR DESCRIPTION
The existing query excluded users who had performed a last.fm import or linked MB but didn't connect spotify. Fixed it and added a test as well.