### PR TITLE
YIM Frontend Fixes - Batch 2

### DIFF
--- a/frontend/css/year-in-music.less
+++ b/frontend/css/year-in-music.less
@@ -108,7 +108,7 @@
       height: auto;
       > div {
         min-height: 300px;
-        max-height: 500px;
+        max-height: 700px;
       }
     }
   }

--- a/frontend/js/src/explore/year-in-music/2023/YearInMusic.tsx
+++ b/frontend/js/src/explore/year-in-music/2023/YearInMusic.tsx
@@ -425,7 +425,7 @@ export default class YearInMusic extends React.Component<
       // Ensure there are no holes between years
       const filledYears = range(
         Number(mostListenedYears[0]),
-        Number(mostListenedYears[mostListenedYears.length - 1])
+        Number(mostListenedYears[mostListenedYears.length - 1]) + 1
       );
       mostListenedYearDataForGraph = filledYears.map((year: number) => ({
         year,


### PR DESCRIPTION
1. **fix: most listened years not showing listens for the latest year.**

    range is exclusive of the end value, so need to add + 1.

2. **fix: artist map gets misaligned/skewed**

    On normal desktop screens, the resolution is around 1440px. And the overall container width is allowed to go upto 1400px. The aspect ratio of the artist map is 2:1 seems to be 2:1. The current max-width breaks the aspect ratio when the width exceeds 1000px which it does on most laptops. So increase the max-height from 500px to 700px so that
we can always maintain the aspect ratio.