### PR TITLE
Upgrade Flask-SocketIO

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Login == 0.6.3
 Flask-WTF == 1.2.1
 Flask-SQLAlchemy == 3.1.1
 Flask-UUID == 0.2
-Flask-SocketIO==5.2.0
+Flask-SocketIO==5.3.6
 bleach==5.0.0
 click == 8.1.3
 jsonschema == 4.6.0


### PR DESCRIPTION
Latest versions of Flask have removed some fields that older versions of the flask-socketio library relied on.