### PR TITLE
Fix websockets again

### DIFF
--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -40,7 +40,9 @@ TIMESCALE_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.
               "'DEBUG' value in the config file.")
 def run_websockets(host, port, debug=True):
     from listenbrainz.websockets.websockets import run_websockets
-    run_websockets(host=host, port=port, debug=debug)
+    application = webserver.create_app()
+    with application.app_context():
+        run_websockets(application, host=host, port=port, debug=debug)
 
 
 @cli.command(name="init_db")

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -60,15 +60,14 @@ class ListensDispatcher(ConsumerMixin):
         )
 
     def start(self):
-        with self.app.app_context():
-            while True:
-                try:
-                    self.app.logger.info("Starting player writer...")
-                    self.init_rabbitmq_connection()
-                    self.run()
-                except KeyboardInterrupt:
-                    self.app.logger.error("Keyboard interrupt!")
-                    break
-                except Exception:
-                    self.app.logger.error("Error in PlayerWriter:", exc_info=True)
-                    time.sleep(3)
+        while True:
+            try:
+                self.app.logger.info("Starting player writer...")
+                self.init_rabbitmq_connection()
+                self.run()
+            except KeyboardInterrupt:
+                self.app.logger.error("Keyboard interrupt!")
+                break
+            except Exception:
+                self.app.logger.error("Error in PlayerWriter:", exc_info=True)
+                time.sleep(3)

--- a/listenbrainz/websockets/websockets.py
+++ b/listenbrainz/websockets/websockets.py
@@ -1,23 +1,15 @@
 import eventlet
-from threading import Thread
 
-from brainzutils import sentry
 from flask_login import current_user
 from flask_socketio import SocketIO, join_room, emit, disconnect
 from werkzeug.exceptions import BadRequest
 
-from listenbrainz.webserver import create_app
 from listenbrainz.db import playlist as db_playlist
 from listenbrainz.websockets.listens_dispatcher import ListensDispatcher
 
-eventlet.monkey_patch()
+eventlet.monkey_patch(all=False, socket=True)
 
-app = create_app()
-sentry_config = app.config.get('LOG_SENTRY')
-if sentry_config:
-    sentry.init_sentry(**sentry_config)
-
-socketio = SocketIO(app, cors_allowed_origins='*', logger=True, engineio_logger=True)
+socketio = SocketIO(cors_allowed_origins='*', logger=True, engineio_logger=True)
 
 
 @socketio.on('json')
@@ -50,7 +42,8 @@ def joined(data):
         disconnect()
 
 
-def run_websockets(host='0.0.0.0', port=7082, debug=True):
+def run_websockets(app, host='0.0.0.0', port=7082, debug=True):
+    socketio.init_app(app)
     dispatcher = ListensDispatcher(app, socketio)
-    Thread(target=dispatcher.start).start()
+    socketio.start_background_task(dispatcher.start)
     socketio.run(app, debug=debug, host=host, port=port)


### PR DESCRIPTION
Websockets are breaking down in production because the connections to rabbitmq disconnect randomly. I could not find anything obvious explaining the issue but some experimenting with eventlet options and using socketio methods instead of stdlib threads for running the background tasks seems to fix the issue for now.