### PR TITLE
Fix type / date separator in AlbumPage

### DIFF
--- a/frontend/js/src/entity-pages/AlbumPage.tsx
+++ b/frontend/js/src/entity-pages/AlbumPage.tsx
@@ -229,7 +229,8 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
               })}
             </div>
             <small className="help-block">
-              {type ? `${type} - ` : ""}
+              {type}
+              {type && album?.date ? " - " : ""}
               {album?.date}
             </small>
           </div>


### PR DESCRIPTION
Only show the separator if both the type and the date are truthy values, to avoid displaying e.g: "Single —"
