### PR TITLE
Remove whitespace in SVG title elements

### DIFF
--- a/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
@@ -13,7 +13,7 @@
     >
         {% if image.title and image.artist %}
         <title>
-          {{ image.title|escape ~ " - " ~ image.artist|escape }}
+          {{- image.title|escape ~ " - " ~ image.artist|escape -}}
         </title>
         {% endif %}
     </image>

--- a/listenbrainz/webserver/templates/art/svg-templates/macros.j2
+++ b/listenbrainz/webserver/templates/art/svg-templates/macros.j2
@@ -26,7 +26,7 @@
         href="{{ image.url }}">
         {% if image.title and image.artist %}
         <title>
-          {{ image.title|escape ~ " - " ~ image.artist|escape }}
+          {{- image.title|escape ~ " - " ~ image.artist|escape -}}
         </title>
         {% endif %}
     </image>

--- a/listenbrainz/webserver/templates/art/svg-templates/yim-2023-albums.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/yim-2023-albums.svg
@@ -76,7 +76,7 @@
                         href="{{ image.url }}">
                     {% if image.title and image.artist %}
                         <title>
-                          {{ image.title|escape ~ " - " ~ image.artist|escape }}
+                          {{- image.title|escape ~ " - " ~ image.artist|escape -}}
                         </title>
                     {% endif %}
                 </image>

--- a/listenbrainz/webserver/templates/art/svg-templates/yim-2023-playlist-arrows.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/yim-2023-playlist-arrows.svg
@@ -102,7 +102,7 @@
                     href="{{ image.url }}">
                 {% if image.title and image.artist %}
                 <title>
-                    {{ image.title|escape ~ " - " ~ image.artist|escape }}
+                    {{- image.title|escape ~ " - " ~ image.artist|escape -}}
                 </title>
                 {% endif %}
             </image>

--- a/listenbrainz/webserver/templates/art/svg-templates/yim-2023-playlist-hug.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/yim-2023-playlist-hug.svg
@@ -105,7 +105,7 @@
                     href="{{ image.url }}">
                     {% if image.title and image.artist %}
                         <title>
-                            {{ image.title|escape ~ " - " ~ image.artist|escape }}
+                            {{- image.title|escape ~ " - " ~ image.artist|escape -}}
                         </title>
                     {% endif %}
                 </image>


### PR DESCRIPTION
# Problem

While whitespace seems to have no effect in Chromium-based browsers, Firefox includes it in its tooltip rendering, which looks weird:

![screenshot](https://github.com/metabrainz/listenbrainz-server/assets/52860029/6e8c0195-a7cc-4e7c-a057-549ea4de0ea1)

# Solution

Slurp leading and trailing whitespace with the appropriate template tags. I found these after having a brief look at the Jinja docs, so let me know if you prefer a different solution (such as inlining the template tag).

# Action

I haven't set up a development server to test this, so a sanity check would be appreciated.
