### PR TITLE
Create separate MB service type for each LB deployment

### DIFF
--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -10,7 +10,7 @@ CREATE TYPE user_timeline_event_type_enum AS ENUM('recording_recommendation', 'n
 
 CREATE TYPE hide_user_timeline_event_type_enum AS ENUM('recording_recommendation', 'recording_pin');
 
-CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm', 'librefm', 'musicbrainz', 'soundcloud', 'apple');
+CREATE TYPE external_service_oauth_type AS ENUM ('spotify', 'youtube', 'critiquebrainz', 'lastfm', 'librefm', 'musicbrainz', 'soundcloud', 'apple', 'musicbrainz-prod', 'musicbrainz-beta', 'musicbrainz-test');
 
 CREATE TYPE stats_range_type AS ENUM ('week', 'month', 'quarter', 'half_yearly', 'year', 'all_time',
     'this_week', 'this_month', 'this_year');

--- a/admin/sql/updates/2024-01-15-add-deployments-as-external-service.sql
+++ b/admin/sql/updates/2024-01-15-add-deployments-as-external-service.sql
@@ -1,0 +1,3 @@
+ALTER TYPE external_service_oauth_type ADD VALUE 'musicbrainz-prod';
+ALTER TYPE external_service_oauth_type ADD VALUE 'musicbrainz-beta';
+ALTER TYPE external_service_oauth_type ADD VALUE 'musicbrainz-test';

--- a/data/model/external_service.py
+++ b/data/model/external_service.py
@@ -9,3 +9,7 @@ class ExternalServiceType(Enum):
     LIBREFM = 'librefm'
     SOUNDCLOUD = 'soundcloud'
     APPLE = 'apple'
+    # these are not MB deployments but LB deployments
+    MUSICBRAINZ_PROD = 'musicbrainz-prod'
+    MUSICBRAINZ_BETA = 'musicbrainz-beta'
+    MUSICBRAINZ_TEST = 'musicbrainz-test'

--- a/listenbrainz/domain/musicbrainz.py
+++ b/listenbrainz/domain/musicbrainz.py
@@ -10,8 +10,16 @@ MUSICBRAINZ_SCOPES = ["tag", "rating", "profile"]
 class MusicBrainzService(BaseBrainzService):
 
     def __init__(self):
+        # these are not MB deployments but LB deployments
+        from listenbrainz.webserver import deploy_env
+        if deploy_env == "test":
+            service = ExternalServiceType.MUSICBRAINZ_TEST
+        elif deploy_env == "beta":
+            service = ExternalServiceType.MUSICBRAINZ_BETA
+        else:
+            service = ExternalServiceType.MUSICBRAINZ_PROD
         super(MusicBrainzService, self).__init__(
-            ExternalServiceType.MUSICBRAINZ,
+            service=service,
             client_id=current_app.config["MUSICBRAINZ_CLIENT_ID"],
             client_secret=current_app.config["MUSICBRAINZ_CLIENT_SECRET"],
             redirect_uri=url_for('login.musicbrainz_post', _external=True),

--- a/listenbrainz/webserver/views/profile.py
+++ b/listenbrainz/webserver/views/profile.py
@@ -21,7 +21,7 @@ from listenbrainz.domain.spotify import SpotifyService, SPOTIFY_LISTEN_PERMISSIO
 from listenbrainz.webserver import flash
 from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.decorators import web_listenstore_needed
-from listenbrainz.webserver.errors import APIServiceUnavailable, APINotFound
+from listenbrainz.webserver.errors import APIServiceUnavailable, APINotFound, APIForbidden
 from listenbrainz.webserver.login import api_login_required
 from listenbrainz.webserver.views.user import delete_user, delete_listens_history
 
@@ -392,7 +392,7 @@ def refresh_service_token(service_name: str):
         try:
             user = service.refresh_access_token(current_user.id, user["refresh_token"])
         except ExternalServiceInvalidGrantError:
-            raise APINotFound("User has revoked authorization to %s" % service_name.capitalize())
+            raise APIForbidden("User has revoked authorization to %s" % service_name.capitalize())
         except Exception:
             current_app.logger.error("Unable to refresh %s token:", exc_info=True)
             raise APIServiceUnavailable("Cannot refresh %s token right now" % service_name.capitalize())

--- a/listenbrainz/webserver/views/test/test_profile.py
+++ b/listenbrainz/webserver/views/test/test_profile.py
@@ -206,7 +206,7 @@ class ProfileViewsTestCase(IntegrationTestCase):
 
         response = self.client.post(url_for('profile.refresh_service_token', service_name='spotify'))
 
-        self.assertEqual(response.json, {'code': 404, 'error': 'User has revoked authorization to Spotify'})
+        self.assertEqual(response.json, {'code': 403, 'error': 'User has revoked authorization to Spotify'})
 
     @patch('listenbrainz.listenstore.timescale_listenstore.TimescaleListenStore.fetch_listens')
     def test_export_streaming(self, mock_fetch_listens):


### PR DESCRIPTION
LB has 3 deployments and each deployment is a different MB OAuth application. As of now, we store all the access tokens and refresh tokens in one 'musicbrainz' service entry which creates problems. Logging in on test/beta/prod overrides the tokens generated on other deployments which essentially means refreshing tokens will fail. Further, MB doesn't return refresh tokens on each login so once broken the tokens will forever remain broken.

To fix, create 3 separate musicbrainz service types, one matching each LB deployment.
