### PR TITLE
Tags component improvements

### DIFF
--- a/frontend/js/src/entity-pages/AlbumPage.tsx
+++ b/frontend/js/src/entity-pages/AlbumPage.tsx
@@ -189,7 +189,6 @@ export default function AlbumPage(props: AlbumPageProps): JSX.Element {
   );
 
   const filteredTags = chain(releaseGroupTags)
-    .filter("genre_mbid")
     .sortBy("count")
     .value()
     .reverse();

--- a/frontend/js/src/entity-pages/ArtistPage.tsx
+++ b/frontend/js/src/entity-pages/ArtistPage.tsx
@@ -128,7 +128,6 @@ export default function ArtistPage(props: ArtistPageProps): JSX.Element {
     popularRecordings.map(popularRecordingToListen) ?? [];
 
   const filteredTags = chain(artist.tag?.artist)
-    .filter("genre_mbid")
     .sortBy("count")
     .value()
     .reverse();

--- a/frontend/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/frontend/js/src/metadata-viewer/MetadataViewer.tsx
@@ -44,16 +44,12 @@ function getNowPlayingRecordingMBID(
 }
 
 function filterAndSortTags(tags?: EntityTag[]): EntityTag[] | undefined {
-  return tags
-    ?.filter((tag) => {
-      return tag.genre_mbid;
-    })
-    .sort((a, b) => {
-      if (a.genre_mbid && !b.genre_mbid) {
-        return 1;
-      }
-      return b.count - a.count;
-    });
+  return tags?.sort((a, b) => {
+    if (a.genre_mbid && !b.genre_mbid) {
+      return 1;
+    }
+    return b.count - a.count;
+  });
 }
 
 export default function MetadataViewer(props: MetadataViewerProps) {

--- a/frontend/js/src/tags/TagsComponent.tsx
+++ b/frontend/js/src/tags/TagsComponent.tsx
@@ -251,6 +251,16 @@ export default function AddTagSelect(props: {
             ...styles,
             flexWrap: "nowrap",
             overflowX: "auto",
+            "::-webkit-scrollbar": {
+              height: "5px",
+              backgroundColor: "#f5f5f5",
+            },
+            "::-webkit-scrollbar-track": {
+              backgroundColor: "#f5f5f5",
+            },
+            ":hover::-webkit-scrollbar-thumb": {
+              backgroundColor: "#ccc",
+            },
           }),
           indicatorsContainer: (styles) => ({
             ...styles,

--- a/frontend/js/src/tags/TagsComponent.tsx
+++ b/frontend/js/src/tags/TagsComponent.tsx
@@ -247,6 +247,23 @@ export default function AddTagSelect(props: {
             ...baseStyles,
             border: "0px",
           }),
+          valueContainer: (styles) => ({
+            ...styles,
+            flexWrap: "nowrap",
+            overflowX: "auto",
+          }),
+          indicatorsContainer: (styles) => ({
+            ...styles,
+            position: "relative",
+            ":before": {
+              content: "''",
+              width: "3em",
+              position: "absolute",
+              height: "100%",
+              left: "-3em",
+              background: "linear-gradient(-90deg, white 10%, transparent)",
+            },
+          }),
         }}
       />
     </div>


### PR DESCRIPTION
Users have been asking to see non-genre tags in the entity pages.
We initially filtered them out because the tags component wasn't suited for showing a lot of tags comfortably.

This PR addresses this issue by showing all the tags in one line (prevent wrapping of the component) with a scroll indicator to hint at more content.

<img width="542" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/7f837bed-b2d6-44b5-8e81-e980734c2f32">
