### PR TITLE
LB-1420: Use smaller cover art on listening now page

### DIFF
--- a/frontend/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/frontend/js/src/metadata-viewer/MetadataViewer.tsx
@@ -169,9 +169,9 @@ export default function MetadataViewer(props: MetadataViewerProps) {
 
   let coverArtSrc = "/static/img/cover-art-placeholder.jpg";
 
-  // try fetching cover art using user submitted release mbid first
+  // try fetching cover art using user-submitted release mbid first
   if (userSubmittedReleaseMBID) {
-    coverArtSrc = `https://coverartarchive.org/release/${userSubmittedReleaseMBID}/front`;
+    coverArtSrc = `https://coverartarchive.org/release/${userSubmittedReleaseMBID}/front-500`;
   } else if (CAAReleaseMBID && CAAID) {
     // if user didn't submit a release mbid but mapper has a match, try using that
     // Bypass the Cover Art Archive redirect since we have the info to directly fetch from archive.org


### PR DESCRIPTION
In case the user provides a release MBID, we are currently fetching the front image (original size) instead of a 500px version like we do below when no MBID is provided.
This is wasteful of users' resources and is only due to my lack of knowledge of the cover art archive's API.
