### PR TITLE
Display recording credit `type` if no instrument is available

### DIFF
--- a/frontend/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/frontend/js/src/metadata-viewer/MetadataViewer.tsx
@@ -186,6 +186,9 @@ export default function MetadataViewer(props: MetadataViewerProps) {
       const copy = { ...cur };
       if (copy.type === "vocal") {
         copy.instrument = "vocals";
+      } else if (!copy.instrument) {
+        // Fall back to credit type if no instrument is available
+        copy.instrument = copy.type;
       }
       if (existingArtist) {
         existingArtist.instrument += `, ${copy.instrument}`;

--- a/frontend/js/src/metadata-viewer/MetadataViewer.tsx
+++ b/frontend/js/src/metadata-viewer/MetadataViewer.tsx
@@ -184,11 +184,16 @@ export default function MetadataViewer(props: MetadataViewerProps) {
         (el) => el.artist_mbid === cur.artist_mbid
       );
       const copy = { ...cur };
-      if (copy.type === "vocal") {
-        copy.instrument = "vocals";
-      } else if (!copy.instrument) {
-        // Fall back to credit type if no instrument is available
-        copy.instrument = copy.type;
+      // Fall back to credit type if no instrument/vocal attribute is available
+      if (!copy.instrument) {
+        // Prefer plural form for unspecified vocal or instrument type
+        if (copy.type === "vocal") {
+          copy.instrument = "vocals";
+        } else if (copy.type === "instrument") {
+          copy.instrument = "instruments";
+        } else {
+          copy.instrument = copy.type;
+        }
       }
       if (existingArtist) {
         existingArtist.instrument += `, ${copy.instrument}`;


### PR DESCRIPTION
Small display enhancement for the metadata viewer.

# Problem

If an artist neither played an instrument nor performed vocals on the recording, their name is shown without any additional information.
It is more useful to show that someone was e.g. a conductor.

# Solution

Fallback to the credit type (e.g. "conductor", "performer", "instrument", "vocal") instead of displaying no instrument.

# Action

There is already a special case to display "vocal" as "vocals", so it might make sense to do the same for "instrument". What do you think?

I also noticed that what you are calling `instrument` here, is really the link attribute type and might also contain the type of the vocals, such as "lead vocals" IIRC.
If that's the case, we could expose this as well and only do s/vocal/vocals/ if `instrument` has no value.
Giving the `instrument` a better name to reflect that would be a breaking API change, though.

P.S. Again this is untested code, as I still have not set up a dev server. My IDE thinks that the types are correct at least.