### PR TITLE
Remove mb_metadata_cache's dependency on canonical_musicbrainz_data

### DIFF
--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -57,7 +57,6 @@ PUBLIC_TABLES_MAPPING = {
             'recording_name',
             'combined_lookup',
             'score',
-            'year',
         ),
     },
     'mapping.canonical_recording_redirect': {

--- a/listenbrainz/labs_api/labs/api/base_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/api/base_mbid_mapping.py
@@ -13,7 +13,7 @@ class BaseMBIDMappingQuery(Query):
     def outputs(self):
         return ['index', 'artist_credit_arg', 'recording_arg',
                 'artist_credit_name', 'artist_mbids', 'release_name', 'recording_name',
-                'release_mbid', 'recording_mbid', 'artist_credit_id', 'year']
+                'release_mbid', 'recording_mbid', 'artist_credit_id']
 
     def get_debug_log_lines(self):
         return self.mapper.read_log()

--- a/listenbrainz/labs_api/labs/tests/test_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/tests/test_mbid_mapping.py
@@ -39,8 +39,7 @@ typesense_response_0 = [
                 "recording_mbid": "398a5f12-80ba-4d29-8b6b-bfe2176341a6",
                 "recording_name": "Gloria",
                 "release_mbid": "7abd5878-4ea3-4b33-a5d2-7721317013d7",
-                "release_name": "October",
-                "year": 1981
+                "release_name": "October"
             },
         }
         ]
@@ -57,8 +56,7 @@ typesense_response_0 = [
                     "recording_mbid": "e97f805a-ab48-4c52-855e-07049142113d",
                     "recording_name": "Strangers",
                     "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
-                    "release_name": "Dummy",
-                    "year": 1995
+                    "release_name": "Dummy"
                 }
             }
         ]
@@ -77,8 +75,7 @@ typesense_response_0 = [
                 "recording_mbid": "145f5c43-0ac2-4886-8b09-63d0e92ded5d",
                 "recording_name": "Glory Box",
                 "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
-                "release_name": "Dummy",
-                "year": 1996
+                "release_name": "Dummy"
             }
         }
         ]
@@ -98,8 +95,7 @@ typesense_response_1 = [
                     "recording_mbid": "e97f805a-ab48-4c52-855e-07049142113d",
                     "recording_name": "Strangers",
                     "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
-                    "release_name": "Dummy",
-                    "year": 1996
+                    "release_name": "Dummy"
                 }
             }
         ]
@@ -118,8 +114,7 @@ json_response_0 = [
         "recording_mbid": "398a5f12-80ba-4d29-8b6b-bfe2176341a6",
         "recording_name": "Gloria",
         "release_mbid": "7abd5878-4ea3-4b33-a5d2-7721317013d7",
-        "release_name": "October",
-        "year": 1981
+        "release_name": "October"
     },
     {
         "artist_credit_arg": "portishead",
@@ -132,8 +127,7 @@ json_response_0 = [
         "recording_mbid": "e97f805a-ab48-4c52-855e-07049142113d",
         "recording_name": "Strangers",
         "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
-        "release_name": "Dummy",
-        "year": 1995
+        "release_name": "Dummy"
     },
     {
         "artist_credit_arg": "portishead",
@@ -146,8 +140,7 @@ json_response_0 = [
         "recording_mbid": "145f5c43-0ac2-4886-8b09-63d0e92ded5d",
         "recording_name": "Glory Box",
         "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
-        "release_name": "Dummy",
-        "year": 1996
+        "release_name": "Dummy"
     }
 ]
 
@@ -163,10 +156,10 @@ json_response_1 = [
         "recording_mbid": "e97f805a-ab48-4c52-855e-07049142113d",
         "recording_name": "Strangers",
         "release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
-        "release_name": "Dummy",
-        "year": 1996
+        "release_name": "Dummy"
     }
 ]
+
 
 class MainTestCase(flask_testing.TestCase):
 
@@ -189,7 +182,7 @@ class MainTestCase(flask_testing.TestCase):
             q.inputs(), ['[artist_credit_name]', '[recording_name]'])
         self.assertEqual(q.outputs(), ['index', 'artist_credit_arg', 'recording_arg',
                                        'artist_credit_name', 'artist_mbids', 'release_name', 'recording_name',
-                                       'release_mbid', 'recording_mbid', 'artist_credit_id', 'year'])
+                                       'release_mbid', 'recording_mbid', 'artist_credit_id'])
 
     @patch('typesense.documents.Documents.search')
     def test_fetch(self, search):

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -312,7 +312,6 @@ class MBIDMapper:
             'release_mbid': hit['document']['release_mbid'],
             'recording_name': hit['document']['recording_name'],
             'recording_mbid': hit['document']['recording_mbid'],
-            'year': hit['document']['year'],
             'match_type': match_type
         }
 

--- a/listenbrainz/mbid_mapping_writer/mbid_mapper_metadata_api.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper_metadata_api.py
@@ -280,7 +280,6 @@ class MBIDMapperMetadataAPI:
             'release_mbid': hit['document']['release_mbid'],
             'recording_name': hit['document']['recording_name'],
             'recording_mbid': hit['document']['recording_mbid'],
-            'year': hit['document']['year'],
             'match_type': match_type
         }
 

--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -169,7 +169,6 @@ def cron_build_mb_metadata_cache():
     """ Build the mb metadata cache and tables it depends on in production in appropriate databases.
      After building the cache, cleanup mbid_mapping table.
     """
-    create_canonical_musicbrainz_data(False)
     create_mb_metadata_cache(True)
     cleanup_mbid_mapping_table()
 

--- a/mbid_mapping/mapping/canonical_musicbrainz_data_base.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data_base.py
@@ -14,17 +14,18 @@ class CanonicalMusicBrainzDataBase(BulkInsertTable):
     """
 
     def get_create_table_columns(self):
-        return [("id",                 "SERIAL"),
-                ("artist_credit_id",   "INT NOT NULL"),
-                ("artist_mbids",       "UUID[] NOT NULL"),
-                ("artist_credit_name", "TEXT NOT NULL"),
-                ("release_mbid",       "UUID NOT NULL"),
-                ("release_name",       "TEXT NOT NULL"),
-                ("recording_mbid",     "UUID NOT NULL"),
-                ("recording_name",     "TEXT NOT NULL"),
-                ("combined_lookup",    "TEXT NOT NULL"),
-                ("score",              "INTEGER NOT NULL"),
-                ("year",               "INTEGER")]
+        return [
+            ("id",                 "SERIAL"),
+            ("artist_credit_id",   "INT NOT NULL"),
+            ("artist_mbids",       "UUID[] NOT NULL"),
+            ("artist_credit_name", "TEXT NOT NULL"),
+            ("release_mbid",       "UUID NOT NULL"),
+            ("release_name",       "TEXT NOT NULL"),
+            ("recording_mbid",     "UUID NOT NULL"),
+            ("recording_name",     "TEXT NOT NULL"),
+            ("combined_lookup",    "TEXT NOT NULL"),
+            ("score",              "INTEGER NOT NULL")
+        ]
 
     def get_insert_queries(self):
         return ["""
@@ -36,7 +37,6 @@ class CanonicalMusicBrainzDataBase(BulkInsertTable):
                     , rl.name AS release_name
                     , rl.gid AS release_mbid
                     , rpr.id AS score
-                    , date_year AS year
                  FROM musicbrainz.recording r
                  JOIN musicbrainz.artist_credit ac
                    ON r.artist_credit = ac.id
@@ -64,7 +64,7 @@ class CanonicalMusicBrainzDataBase(BulkInsertTable):
                -- postgres indexing limits. therefore filter out such recordings before-hand, otherwise index creation
                -- may fail
                 WHERE length(concat(ac.name, r.name, rl.name)) < 500 
-             GROUP BY rpr.id, ac.id, s.artist_mbids, rl.gid, artist_credit_name, r.gid, r.name, release_name, year
+             GROUP BY rpr.id, ac.id, s.artist_mbids, rl.gid, artist_credit_name, r.gid, r.name, release_name
              ORDER BY ac.id, rpr.id
         """]
 
@@ -83,7 +83,6 @@ class CanonicalMusicBrainzDataBase(BulkInsertTable):
                 row["recording_mbid"],
                 row["recording_name"],
                 combined_lookup,
-                row["score"],
-                row["year"]
+                row["score"]
             )]
         }

--- a/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_metadata_cache.py
@@ -338,11 +338,14 @@ class MusicBrainzMetadataCache(MusicBrainzEntityMetadataCache):
                                  , crrr.release_mbid::TEXT
                                  , rgca.caa_id
                                  , rgca.caa_release_mbid
+                                 , rfdr.year
                               FROM musicbrainz.recording r
                               JOIN mapping.canonical_recording_release_redirect crrr
                                 ON r.gid = crrr.recording_mbid
                               JOIN musicbrainz.release rel
                                 ON crrr.release_mbid = rel.gid
+                         LEFT JOIN musicbrainz.release_first_release_date rfdr
+                                ON rfdr.release = rel.id     
                               JOIN musicbrainz.artist_credit rac
                                 ON rac.id = rel.artist_credit  
                               JOIN musicbrainz.release_group rg
@@ -367,7 +370,7 @@ class MusicBrainzMetadataCache(MusicBrainzEntityMetadataCache):
                                  , rd.album_artist_name
                                  , rd.caa_id
                                  , rd.caa_release_mbid
-                                 , year
+                                 , rd.year
                               FROM musicbrainz.recording r
                               JOIN musicbrainz.artist_credit ac
                                 ON r.artist_credit = ac.id
@@ -383,8 +386,6 @@ class MusicBrainzMetadataCache(MusicBrainzEntityMetadataCache):
                                 ON rts.recording_mbid = r.gid
                          LEFT JOIN release_data rd
                                 ON rd.recording_mbid = r.gid
-                         LEFT JOIN mapping.canonical_musicbrainz_data cmb
-                                ON cmb.recording_mbid = r.gid
                               {values_join}
                           GROUP BY r.gid
                                  , r.name
@@ -402,7 +403,8 @@ class MusicBrainzMetadataCache(MusicBrainzEntityMetadataCache):
                                  , rd.album_artist_name
                                  , rd.caa_id
                                  , rd.caa_release_mbid
-                                 , year"""
+                                 , rd.year
+                                 """
         return query
 
     def query_last_updated_items(self, timestamp):

--- a/mbid_mapping/mapping/typesense_index.py
+++ b/mbid_mapping/mapping/typesense_index.py
@@ -99,7 +99,6 @@ def build(client, collection_name, table, combiner):
                      , artist_credit_name
                      , artist_mbids
                      , score
-                     , year
                   FROM {table}
             """
 


### PR DESCRIPTION
mb_metadata_cache requires only year field from canonical_musicbrainz_data but for this reason we need to build the table in both LB and MB database which is expensive. It is better to read the year from release_first_release_date table.