### PR TITLE
 Fix location canonical_recording_release_redirect and canonical_release_redirect

### DIFF
--- a/listenbrainz/db/mapping_dump.py
+++ b/listenbrainz/db/mapping_dump.py
@@ -69,7 +69,7 @@ PUBLIC_TABLES_MAPPING = {
         )
     },
     'mapping.canonical_release_redirect': {
-        'engine': 'mb',
+        'engine': 'lb_if_set',
         'filename': 'canonical_release_redirect.csv',
         'columns': (
             'release_mbid',

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -84,7 +84,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         # Setup all the needed objects
         can = CanonicalRecordingRedirect(mb_conn, lb_conn, unlogged=unlogged)
         can_rec_rel = CanonicalRecordingReleaseRedirect(mb_conn, lb_conn, unlogged=unlogged)
-        can_rel = CanonicalReleaseRedirect(mb_conn, unlogged=unlogged)
+        can_rel = CanonicalReleaseRedirect(mb_conn, lb_conn, unlogged=unlogged)
         releases = CanonicalRelease(mb_conn, unlogged=False)
         mapping = CanonicalMusicBrainzData(mb_conn, lb_conn, unlogged=unlogged)
         mapping.add_additional_bulk_table(can)

--- a/mbid_mapping/mapping/canonical_recording_release_redirect.py
+++ b/mbid_mapping/mapping/canonical_recording_release_redirect.py
@@ -19,20 +19,22 @@ class CanonicalRecordingReleaseRedirect(BulkInsertTable):
                 ("release_mbid",             "UUID NOT NULL")]
 
     def get_insert_queries(self):
-        return []
+        return [
+            """SELECT recording_mbid
+                    , canonical_release_mbid AS release_mbid
+                 FROM mapping.canonical_recording_redirect_tmp
+            """,
+            """SELECT recording_mbid
+                    , release_mbid
+                 FROM mapping.canonical_musicbrainz_data_tmp
+            """
+        ]
 
     def get_post_process_queries(self):
-        return ["""INSERT INTO mapping.canonical_recording_release_redirect_tmp (recording_mbid, release_mbid)
-                        SELECT recording_mbid
-                             , canonical_release_mbid AS release_mbid
-                          FROM mapping.canonical_recording_redirect_tmp""",
-                """INSERT INTO mapping.canonical_recording_release_redirect_tmp (recording_mbid, release_mbid)
-                                 SELECT recording_mbid
-                                      , release_mbid
-                                   FROM mapping.canonical_musicbrainz_data_tmp"""]
+        return []
 
     def get_index_names(self):
         return [("recording_mbid_ndx_canonical_recording_release_redirect", "recording_mbid", True)]
 
     def process_row(self, row):
-        return []
+        return [(row["recording_mbid"], row["release_mbid"])]


### PR DESCRIPTION
1. To avoid generating unnecessary WAL on mb prod.
2. This table is needed in MB as it is joined to in the queries to generate mb_metadata_cache.