### PR TITLE
TagComponent: Fix vertical alignment

### DIFF
--- a/frontend/css/tags.less
+++ b/frontend/css/tags.less
@@ -15,8 +15,8 @@
   }
   > * {
     height: 100%;
-    display: inline-block;
     padding: 3px 7px;
+    vertical-align: middle;
     &:first-child {
       border-top-left-radius: @tagBorderRadius;
       border-bottom-left-radius: @tagBorderRadius;


### PR DESCRIPTION
# Problem

The tag vote buttons were shifted downwards by a few pixels with the previous styling:

![before](https://github.com/metabrainz/listenbrainz-server/assets/52860029/9b6d6c8d-e9e3-40f3-9804-a4b7b1c216bf)

# Solution

069f1330acfcb78671d208480441a3deaf62c9f3 recently removed the vertical alignment setting, presumably to fix the alignment of the new tag count, but removing the inline-block property is the better solution.
Tag label and count are now aligned to the middle instead of the baseline:

![after](https://github.com/metabrainz/listenbrainz-server/assets/52860029/aff65e67-b265-4425-84d1-e654e9f1d229)

# Action

The changes have only been tested by manipulating the live CSS with the Firefox developer tools, but I assume that I have found the right place in the Less source files.