### PR TITLE
Show artist-recording and artist-release_group rels even if marked ended

### DIFF
--- a/listenbrainz_spark/stats/listener/release_group.py
+++ b/listenbrainz_spark/stats/listener/release_group.py
@@ -1,10 +1,10 @@
 from typing import Iterator, List
 
-from data.model.entity_listener_stat import ArtistListenerRecord
+from data.model.entity_listener_stat import ReleaseGroupListenerRecord
 from listenbrainz_spark.stats import run_query
 
 
-def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -> Iterator[ArtistListenerRecord]:
+def get_listeners(table: str, cache_tables: List[str], number_of_results: int) -> Iterator[ReleaseGroupListenerRecord]:
     """ Get information about top listeners of a release group.
 
         Args:

--- a/mbid_mapping/mapping/mb_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_metadata_cache.py
@@ -191,6 +191,7 @@ class MusicBrainzMetadataCache(MusicBrainzEntityMetadataCache):
                                     ON l.link_type = lt.id
                                   {values_join}
                                  WHERE lt.gid IN ({ARTIST_LINK_GIDS_SQL})
+                                 -- do not show outdated urls to users
                                    AND NOT l.ended
                               GROUP BY a.gid
                    ), recording_rels AS (
@@ -211,7 +212,7 @@ class MusicBrainzMetadataCache(MusicBrainzEntityMetadataCache):
                                     ON la.attribute_type = lat.id
                                   {values_join}
                                  WHERE lt.gid IN ({RECORDING_LINK_GIDS_SQL})
-                                   AND NOT l.ended
+                                 -- performer rels are ended by definition (the artist is no longer performing) but they should still be shown to the user
                                GROUP BY r.gid
                    ), artist_data AS (
                             SELECT r.gid

--- a/mbid_mapping/mapping/mb_release_group_cache.py
+++ b/mbid_mapping/mapping/mb_release_group_cache.py
@@ -212,6 +212,7 @@ class MusicBrainzReleaseGroupCache(MusicBrainzEntityMetadataCache):
                                     ON l.link_type = lt.id
                                   {values_join}
                                  WHERE lt.gid IN ({ARTIST_LINK_GIDS_SQL})
+                                 -- do not show outdated urls to users
                                    AND NOT l.ended
                               GROUP BY a.gid
                    ), release_group_rels AS (
@@ -232,7 +233,7 @@ class MusicBrainzReleaseGroupCache(MusicBrainzEntityMetadataCache):
                                     ON la.attribute_type = lat.id
                                   {values_join}
                                  WHERE lt.gid IN ({RELEASE_GROUP_LINK_GIDS_SQL})
-                                   AND NOT l.ended
+                                 -- the release group rels we use make sense to be shown to the user even if they have been marked as ended
                                GROUP BY rg.gid
                    ), artist_data AS (
                             SELECT rg.gid


### PR DESCRIPTION
Relationships like performer relations are ended by definition because an artist performed something on a particular date. Other recording and release group rels also make sense to be shown to users always. However, ended url rels are only for historical purposes and do not need to be shown to users.