### PR TITLE
LB-1471: Multiple CB reviews display over each other

### DIFF
--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -198,6 +198,7 @@
 
 .review {
   position: relative;
+  margin: 2em 0;
   .text {
     max-height: 10em;
     overflow: hidden;


### PR DESCRIPTION
# Problem

Bug fixed: LB-1471 : Multiple CritiqueBrainz reviews are displayed over each other in album pages.

https://tickets.metabrainz.org/browse/LB-1471



# Solution

A minor change in the entity-pages.less file In the path /listenbrainz/listenbrainz-server/frontend/css/entity-pages.less fixed the issue


# Action

No further action required


