### PR TITLE
chore: Update workflow actions/checkout to v4

### DIFF
--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -28,7 +28,7 @@ jobs:
       if: github.event.pull_request.draft == false
 
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/push-dev-image.yml
+++ b/.github/workflows/push-dev-image.yml
@@ -22,12 +22,12 @@ jobs:
 
       steps:
       # Run only if we are deploying a branch or tag from this repo
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # empty strings evaluate to 0
         if: ${{ github.event.inputs.pr == 0}}
         
       # Run only if we are deploying a PR (may be in a forked repo)
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ github.event.inputs.pr != 0}}
         with:
           ref: ${{ format('refs/pull/{0}/head', github.event.inputs.pr) }}

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Create configuration file
       run: cp listenbrainz/config.py.sample listenbrainz/config.py


### PR DESCRIPTION
Saw this warning in the push-dev-image action:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
