### PR TITLE
LB-1485: Album page overflows

### DIFF
--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -115,6 +115,7 @@
     .tracks {
       flex: 3 400px;
       min-height: 150px;
+      min-width: 0;
       .artist-page& {
         max-height: 520px;
         overflow-y: hidden;

--- a/frontend/js/src/common/listens/ListenCard.tsx
+++ b/frontend/js/src/common/listens/ListenCard.tsx
@@ -476,7 +476,7 @@ export default class ListenCard extends React.Component<
                 )}
               </div>
               <div
-                className="small text-muted ellipsis-2-lines"
+                className="small text-muted ellipsis"
                 title={artistName}
               >
                 {getArtistLink(listen)}

--- a/frontend/js/src/common/listens/ListenCard.tsx
+++ b/frontend/js/src/common/listens/ListenCard.tsx
@@ -475,7 +475,10 @@ export default class ListenCard extends React.Component<
                   </div>
                 )}
               </div>
-              <div className="small text-muted ellipsis" title={artistName}>
+              <div
+                className="small text-muted ellipsis-2-lines"
+                title={artistName}
+              >
                 {getArtistLink(listen)}
               </div>
             </div>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
Fix LB-1485: Album page overflows

https://tickets.metabrainz.org/projects/LB/issues/LB-1485

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

A minor change in the `ListenCard.tsx` clamping the artist-name to 2 lines has fixed the issue.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

No further action required.
