### PR TITLE
LB-1289: Fix XSPF playlist exporter bug and Enable XML support

### DIFF
--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -233,14 +233,19 @@ class PlaylistAPITestCase(IntegrationTestCase):
                     }
                 }
             }
-        
-        response = self.client.post(
+        response_post = self.client.post(
             url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
-        print(response)
-        self.assert200(response)
+        self.assert200(response_post)
+        playlist_mbid = response_post.json["playlist_mbid"]
+        print(playlist_mbid)
+        r = self.client.get(
+            url_for("playlist_api_v1.get_playlist_xspf", playlist_mbid=playlist_mbid),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(r)
 
     def test_playlist_json_with_missing_keys(self):
         """ Test for checking that submitting JSON with missing keys returns 400 """

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -240,7 +240,6 @@ class PlaylistAPITestCase(IntegrationTestCase):
         )
         self.assert200(response_post)
         playlist_mbid = response_post.json["playlist_mbid"]
-        print(playlist_mbid)
         r = self.client.get(
             url_for("playlist_api_v1.get_playlist_xspf", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -212,6 +212,36 @@ class PlaylistAPITestCase(IntegrationTestCase):
         # Make sure the return playlist id is valid
         UUID(response.json["playlist_mbid"])
 
+    def test_playlist_xspf_additional_metadata(self):
+        """ Test for checking that additional meta data field is properly constructed and not causing a crash """
+
+        playlist = {
+            "playlist": {
+                "title": "you're a person",
+                "extension": {
+                    PLAYLIST_EXTENSION_URI: {
+                        "public": True,
+                    }
+                },
+                "additional_metadata": {
+                    "note": "a great playlist",
+                    "details": {
+                         "mood": "varied",
+                         "genre": "eclectic",
+                         "favorite_track": "Random Song"
+                        }
+                    }
+                }
+            }
+        
+        response = self.client.post(
+            url_for("playlist_api_v1.create_playlist"),
+            json=playlist,
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        print(response)
+        self.assert200(response)
+
     def test_playlist_json_with_missing_keys(self):
         """ Test for checking that submitting JSON with missing keys returns 400 """
 

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -527,8 +527,11 @@ def get_playlist_xspf(playlist_mbid):
 
     if fetch_metadata:
         fetch_playlist_recording_metadata(playlist)
-
-    return serialize_xspf(playlist)
+    
+    xspf_data = serialize_xspf(playlist)
+    serialized_xspf_response = make_response(xspf_data)
+    serialized_xspf_response.content_type = 'text/xml'
+    return serialized_xspf_response
 
 
 @playlist_api_bp.route("/<playlist_mbid>/item/add/<int:offset>", methods=["POST", "OPTIONS"])

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -2,7 +2,7 @@ import datetime
 from uuid import UUID
 
 import psycopg2
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, jsonify, request, make_response
 from xml.etree import ElementTree as ET
 import requests
 from psycopg2.extras import DictCursor

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -143,11 +143,19 @@ def serialize_xspf(playlist: Playlist):
             playlist_extension_collaborator = ET.SubElement(playlist_extension_collaborators, "collaborator")
             playlist_extension_collaborator.text = collaborator
 
-    if playlist.additional_metadata:
-        playlist_extension_additional_metadata = ET.SubElement(playlist_extension, "additional_metadata")
-        for meta_key, meta_value in playlist.additional_metadata:
-            additional_metadata_item = ET.SubElement(playlist_extension_additional_metadata, "item", key=meta_key)
-            additional_metadata_item.text = meta_value
+        if playlist.additional_metadata:
+            playlist_extension_additional_metadata = ET.SubElement(playlist_extension, "additional_metadata")
+            for key, value in playlist.additional_metadata.items():
+                if isinstance(value, dict):
+                    # Handle dictionary-type metadata
+                    dict_metadata_item = ET.SubElement(playlist_extension_additional_metadata, key)
+                    for nested_key, nested_value in value.items():
+                        nested_item = ET.SubElement(dict_metadata_item, nested_key)
+                        nested_item.text = str(nested_value)
+                else:
+                    # Handle simple scalar values
+                    simple_item = ET.SubElement(playlist_extension_additional_metadata, key)
+                    simple_item.text = str(value)
 
     track_list = ET.SubElement(playlist_root, "trackList")
     for rec in playlist.recordings:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -143,19 +143,19 @@ def serialize_xspf(playlist: Playlist):
             playlist_extension_collaborator = ET.SubElement(playlist_extension_collaborators, "collaborator")
             playlist_extension_collaborator.text = collaborator
 
-        if playlist.additional_metadata:
-            playlist_extension_additional_metadata = ET.SubElement(playlist_extension, "additional_metadata")
-            for key, value in playlist.additional_metadata.items():
-                if isinstance(value, dict):
-                    # Handle dictionary-type metadata
-                    dict_metadata_item = ET.SubElement(playlist_extension_additional_metadata, key)
-                    for nested_key, nested_value in value.items():
-                        nested_item = ET.SubElement(dict_metadata_item, nested_key)
-                        nested_item.text = str(nested_value)
-                else:
-                    # Handle simple scalar values
-                    simple_item = ET.SubElement(playlist_extension_additional_metadata, key)
-                    simple_item.text = str(value)
+    if playlist.additional_metadata:
+        playlist_extension_additional_metadata = ET.SubElement(playlist_extension, "additional_metadata")
+        for key, value in playlist.additional_metadata.items():
+            if isinstance(value, dict):
+                # Handle dictionary-type metadata
+                dict_metadata_item = ET.SubElement(playlist_extension_additional_metadata, key)
+                for nested_key, nested_value in value.items():
+                    nested_item = ET.SubElement(dict_metadata_item, nested_key)
+                    nested_item.text = str(nested_value)
+            else:
+                # Handle simple scalar values
+                simple_item = ET.SubElement(playlist_extension_additional_metadata, key)
+                simple_item.text = str(value)
 
     track_list = ET.SubElement(playlist_root, "trackList")
     for rec in playlist.recordings:


### PR DESCRIPTION
# Problems

- The `serialize_xspf` method in `listenbrainz/webserver/views/playlist_api.py` has a bug which causes the `additional_metadata` field to be improperly constructed which leads to a crash.
- The response wasn't correctly formatted. 

# Solution
The following changes have been made:
- Fixed `serialize_xspf` to handle `additional_metadata` correctly. 
- Changed the response's content type in `get_playlist_xspf` to xml

