### PR TITLE
LB-1470:Fix Reviews always display 5/5 stars

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -982,7 +982,7 @@ export function getReviewEventContent(
             readonly
             onClick={() => {}}
             className="rating-stars"
-            ratingValue={eventMetadata.rating} // CB stores ratings in 0 - 5 scale but the component requires 0 - 100 UPDATE: component requires 0-5 scale too
+            ratingValue={eventMetadata.rating}
             transition
             size={20}
             iconsCount={5}

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -982,7 +982,7 @@ export function getReviewEventContent(
             readonly
             onClick={() => {}}
             className="rating-stars"
-            ratingValue={eventMetadata.rating * 20} // CB stores ratings in 0 - 5 scale but the component requires 0 - 100
+            ratingValue={eventMetadata.rating} // CB stores ratings in 0 - 5 scale but the component requires 0 - 100 UPDATE: component requires 0-5 scale too
             transition
             size={20}
             iconsCount={5}


### PR DESCRIPTION


# Problem

The rating on ListenBrainz artist/release page shows 5 stars on rating, no matter what the rating on CritiqueBrainz.

https://tickets.metabrainz.org/browse/LB-1347?jql=project%20%3D%20LB%20AND%20status%20%3D%20Open%20ORDER%20BY%20assignee%20ASC

# Solution

The problem is the { Rating } component is accepting incorrect value. For example, for 3 star rating, it shows 60 instead of 3. It is because it was mistaken that the component accepts value on scale 0 - 100. I changed the scale to 0-5.


