### PR TITLE
Check to make sure that the provided list isn't empty

### DIFF
--- a/listenbrainz/db/color.py
+++ b/listenbrainz/db/color.py
@@ -139,6 +139,9 @@ def fetch_color_for_releases(release_mbids: List[str]) -> Dict[str, Dict[str, in
           Returns a dict with the keys red, green and blue or None if no color is found.
     """
 
+    if not release_mbids:
+        return {}
+
     query = """SELECT release_mbid,
                       red,
                       green,


### PR DESCRIPTION
This PR should fix this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1455, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 869, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 867, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 852, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/listenbrainz/listenbrainz/webserver/decorators.py", line 57, in decorator
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/code/listenbrainz/listenbrainz/webserver/views/entity_pages.py", line 118, in artist_entity
    popular_recordings = popularity.get_top_recordings_for_artist(artist_mbid, 10)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/listenbrainz/listenbrainz/db/popularity.py", line 150, in get_top_recordings_for_artist
    releases_color = color.fetch_color_for_releases(release_mbids)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/listenbrainz/listenbrainz/db/color.py", line 152, in fetch_color_for_releases
    curs.execute(query, (tuple(release_mbids),))
  File "/usr/local/lib/python3.11/site-packages/psycopg2/extras.py", line 146, in execute
    return super().execute(query, vars)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.SyntaxError: syntax error at or near ")"
LINE 6:                 WHERE release_mbid in ()

```