### PR TITLE
Retain existing MB refresh token when user logs in and logs out

### DIFF
--- a/data/model/external_service.py
+++ b/data/model/external_service.py
@@ -4,6 +4,7 @@ from enum import Enum
 class ExternalServiceType(Enum):
     SPOTIFY = 'spotify'
     CRITIQUEBRAINZ = 'critiquebrainz'
+    # this type only exists for historical purposes and matching urls in the profile endpoint
     MUSICBRAINZ = 'musicbrainz'
     LASTFM = 'lastfm'
     LIBREFM = 'librefm'

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -110,28 +110,26 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         user = db_user.get_or_create(3, 'musicbrainz')
         db_oauth.save_token(
             user_id=user['id'],
-            service=ExternalServiceType.MUSICBRAINZ,
+            service=ExternalServiceType.MUSICBRAINZ_PROD,
             access_token='token',
             refresh_token='refresh_token',
             token_expires_ts=int(time.time()),
             record_listens=False,
             scopes=['profile', 'rating']
         )
-        oauth_user = db_oauth.get_token(user['id'], ExternalServiceType.MUSICBRAINZ)
+        oauth_user = db_oauth.get_token(user['id'], ExternalServiceType.MUSICBRAINZ_PROD)
         self.assertEqual('token', oauth_user['access_token'])
         self.assertEqual('refresh_token', oauth_user['refresh_token'])
 
         # for subsequent logins, refresh token returned by MusicBrainz will be None.
-        db_oauth.save_token(
+        db_oauth.update_token(
             user_id=user['id'],
-            service=ExternalServiceType.MUSICBRAINZ,
+            service=ExternalServiceType.MUSICBRAINZ_PROD,
             access_token='new_token',
             refresh_token=None,
-            token_expires_ts=int(time.time()),
-            record_listens=False,
-            scopes=['profile', 'rating']
+            expires_at=int(time.time())
         )
-        oauth_user = db_oauth.get_token(user['id'], ExternalServiceType.MUSICBRAINZ)
+        oauth_user = db_oauth.get_token(user['id'], ExternalServiceType.MUSICBRAINZ_PROD)
         self.assertEqual('new_token', oauth_user['access_token'])
 
         # test that the refresh token isn't deleted on subsequent updates

--- a/listenbrainz/domain/brainz_service.py
+++ b/listenbrainz/domain/brainz_service.py
@@ -32,6 +32,17 @@ class BaseBrainzService(ExternalService):
         )
         return True
 
+    def update_user(self, user_id: int, token: dict) -> bool:
+        expires_at = int(time.time()) + token["expires_in"]
+        external_service_oauth.update_token(
+            user_id=user_id,
+            service=self.service,
+            access_token=token["access_token"],
+            refresh_token=token.get("refresh_token"),
+            expires_at=expires_at
+        )
+        return True
+
     def get_authorize_url(self, scopes: list, state: str = None, **kwargs):
         oauth = OAuth2Session(
             client_id=self.client_id,

--- a/listenbrainz/troi/tests/test_spark.py
+++ b/listenbrainz/troi/tests/test_spark.py
@@ -37,7 +37,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
         )
         db_external_service_oauth.save_token(
             self.user1["id"],
-            ExternalServiceType.MUSICBRAINZ,
+            ExternalServiceType.MUSICBRAINZ_PROD,
             "access_token",
             "refresh_token",
             int(datetime.now().timestamp()),

--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -45,6 +45,8 @@ def get_user():
         db_user.create(musicbrainz_row_id, musicbrainz_id, email=user_email)
         user = db_user.get_by_mb_id(musicbrainz_id, fetch_email=True)
         ts.set_empty_values_for_user(user["id"])
+        # add new oauth token for the user
+        service.add_new_user(user["id"], token)
     else:  # an existing user is trying to log in
         # Other option is to change the return type of get_by_mb_row_id to a dict
         # but its used so widely that we would modify huge number of tests
@@ -52,9 +54,8 @@ def get_user():
         user["email"] = user_email
         # every time a user logs in, update the email in LB.
         db_user.update_user_details(user["id"], musicbrainz_id, user_email)
-
-    # update oauth token for the user
-    service.add_new_user(user["id"], token)
+        # update oauth token for the user
+        service.update_user(user["id"], token)
 
     return user
 


### PR DESCRIPTION
There was a special case to preserve refresh tokens for MusicBrainz service for this case but when I created 3 deployments to fix another auth related bug, that special case broke. I have now fixed it and replaced it with a more general fix so hopefully it won't break again.