### PR TITLE
Fix flask hot reload in development

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 # IMPORTANT NOTE: Volume paths mounted on containers are relative to the
 # directory that this file is in (`docker/`) and so probably need to start with
 # `../` to refer to a directory in the main code checkout
@@ -53,8 +51,7 @@ services:
         GIT_COMMIT_SHA: HEAD
     environment:
       FLASK_APP: listenbrainz.webserver:create_web_app()
-      FLASK_ENV: development
-    command: flask run -h 0.0.0.0 -p 80
+    command: flask run -h 0.0.0.0 -p 80 --debug
     image: web
     volumes:
       - web_home:/root
@@ -71,8 +68,7 @@ services:
     image: web
     environment:
       FLASK_APP: listenbrainz.webserver:create_api_compat_app()
-      FLASK_ENV: development
-    command: flask run -h 0.0.0.0 -p 8101
+    command: flask run -h 0.0.0.0 -p 8101 --debug
     ports:
       - "8101:8101"
     volumes:


### PR DESCRIPTION
The latest versions of flask require the --debug flag to be passed on command line to enable hot reload of code.