### PR TITLE
LB-1452: "Missing data" link on Add data page gives 404 error when not logged in

### DIFF
--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -198,7 +198,6 @@
 
 .review {
   position: relative;
-  margin: 2em 0;
   .text {
     max-height: 10em;
     overflow: hidden;

--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -198,6 +198,7 @@
 
 .review {
   position: relative;
+  margin: 2em 0;
   .text {
     max-height: 10em;
     overflow: hidden;

--- a/listenbrainz/webserver/templates/user/settings.html
+++ b/listenbrainz/webserver/templates/user/settings.html
@@ -28,7 +28,13 @@
 				<li {{ 'class=active' if active_settings_section == 'connect-services'}}><a href="{{ url_for('profile.music_services_details') }}">Connect services</a></li>
 				<li {{ 'class=active' if active_settings_section == 'import'}}><a href="{{ url_for('profile.import_data') }}">Import listens</a></li>
 				<li {{ 'class=active' if active_settings_section == 'add-listens'}}><a href="{{ url_for('index.add_data_info') }}">Add listens</a></li>
-				<li {{ 'class=active' if active_settings_section == 'missing-musicbrainz-data'}}><a href="{{ url_for('user.missing_mb_data', user_name=current_user.musicbrainz_id) }}">Missing data</a></li>
+				<li {{ 'class=active' if active_settings_section == 'missing-musicbrainz-data'}}>
+					{% if current_user.musicbrainz_id %}
+						<a href="{{ url_for('user.missing_mb_data', user_name=current_user.musicbrainz_id) }}">Missing data</a>
+					{% else %}
+					<span title="Login to visit this page">Missing data</span>
+					{% endif %}
+				</li>
 			</ul>
 			<p>
 				Account


### PR DESCRIPTION
# Problem

When you visit the ListenBrainz page without logging in, then follow the navigation sequence "About" → "Submitting data", which opens https://listenbrainz.org/add-data/, clicking on the "Missing data" link brings you to a 404 error page with the URL https://listenbrainz.org/user//missing-data/

It looks like the username was intended to be substituted into this URL, but that's not possible when the user is not logged in.

   https://tickets.metabrainz.org/projects/LB/issues/LB-1452?filter=allopenissues

# Solution

Adding conditional rendering to the 'Missing data' button based on the availability of user data solved the issue.

# Action

No further action required


