### PR TITLE
Improve legacy listens recheck in mbid mapper

### DIFF
--- a/listenbrainz/mbid_mapping_writer/matcher.py
+++ b/listenbrainz/mbid_mapping_writer/matcher.py
@@ -84,7 +84,7 @@ def process_listens(app, listens, priority):
     if priority == NEW_LISTEN:
         listens_to_check = filter_incoming_listens(msids, stats, app, debug)
     else:
-        listens_to_check = msids
+        listens_to_check = list(msids.values())
 
     if len(listens_to_check) == 0:
         return stats


### PR DESCRIPTION
There was a bug introduced in the last PR to fix legacy listens check, fixing that. And also adding more proactive rechecking by legacy listen thread for unmapped listens.