### PR TITLE
Make uwsgi.ini for web containers configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,7 +178,7 @@ COPY ./docker/services/apple_metadata_cache/apple_metadata_cache.finish /etc/ser
 RUN touch /etc/service/apple_metadata_cache/down
 
 # uwsgi (website)
-COPY ./docker/services/uwsgi/uwsgi.ini /etc/uwsgi/uwsgi.ini
+COPY ./docker/services/uwsgi/uwsgi.ini.ctmpl /etc/uwsgi/uwsgi.ini.ctmpl
 COPY ./docker/services/uwsgi/consul-template-uwsgi.conf /etc/consul-template-uwsgi.conf
 COPY ./docker/services/uwsgi/uwsgi.service /etc/service/uwsgi/run
 COPY ./docker/services/uwsgi/uwsgi.finish /etc/service/uwsgi/finish

--- a/docker/services/uwsgi/consul-template-uwsgi.conf
+++ b/docker/services/uwsgi/consul-template-uwsgi.conf
@@ -1,4 +1,9 @@
 template {
+    source = "/etc/uwsgi/uwsgi.ini.ctmpl"
+    destination = "/etc/uwsgi/uwsgi.ini"
+}
+
+template {
     source = "/code/listenbrainz/consul_config.py.ctmpl"
     destination = "/code/listenbrainz/listenbrainz/config.py"
 }

--- a/docker/services/uwsgi/uwsgi.ini.ctmpl
+++ b/docker/services/uwsgi/uwsgi.ini.ctmpl
@@ -1,3 +1,6 @@
+{{- define "KEY" -}}
+    {{ key (printf "docker-server-configs/LB/uwsgi.%s.json/%s" (env "DEPLOY_ENV") .) }}
+{{- end -}}
 [uwsgi]
 uid = www-data
 gid = www-data
@@ -7,7 +10,7 @@ module = listenbrainz.server
 callable = application
 chdir = /code/listenbrainz
 enable-threads = true
-processes = 500
+processes = {{template "KEY" "processes"}}
 listen = 1024
 log-x-forwarded-for=true
 disable-logging = true


### PR DESCRIPTION
We want a different number of processes for prod/beta/test environments so need to make uwsgi.ini populated by consul.