### PR TITLE
LB-1489: Fix content type of errors in `get_playlist_xspf` Endpoint

### DIFF
--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -286,14 +286,14 @@ class APITestCase(ListenAPIIntegrationTestCase):
         }
 
         response_post = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         playlist_mbid = response_post.json["playlist_mbid"]
 
         r = self.client.get(
-            url_for('playlist_api_v1.get_playlist_xspf', playlist_mbid=playlist_mbid),
+            self.custom_url_for('playlist_api_v1.get_playlist_xspf', playlist_mbid=playlist_mbid),
             headers={'Authorization': 'Token testtokenplsignore'}
         )
         self.assertEqual(r.status_code, 401)

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -257,12 +257,9 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assert400(response)
         self.assertEqual(response.json['code'], 400)
     
-    @mock.patch('listenbrainz.webserver.views.playlist_api.get_playlist_xspf')
-    def test_playlist_api_xml_error(self, mock_get_playlist_xspf):
-        # Mocking the condition where PlaylistAPIXMLError is raised
-        mock_get_playlist_xspf.side_effect = PlaylistAPIXMLError("Provided playlist ID is invalid.", 400)
+    def test_playlist_api_xml_error(self):
 
-        # Making a request that would trigger the mocked error
+        # Making a request that would trigger the error
         response = self.client.get('/1/playlist/-6924291-8b14-726253c14f12/xspf')
         self.assertEqual(response.status_code, 400)
 

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -278,8 +278,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
         second_xml_str = ''.join(expected_xml.split())
         self.assertEqual(first_xml_str, second_xml_str)
 
-    @mock.patch('listenbrainz.webserver.views.playlist_api.get_playlist_xspf')
-    def test_playlist_api_xml_auth_error(self, mock_get_playlist_xspf):
+    def test_playlist_api_xml_auth_error(self):
         # Testing for 401: Authorization Error
         playlist = {
             "playlist": {
@@ -291,7 +290,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
                 }
             }
         }
-        mock_get_playlist_xspf.side_effect = PlaylistAPIXMLError("Invalid authorization to access playlist.", 401)
+
         response_post = self.client.post(
             url_for("playlist_api_v1.create_playlist"),
             json=playlist,
@@ -308,9 +307,9 @@ class APITestCase(ListenAPIIntegrationTestCase):
         expected_error_xml = """
 <?xml version="1.0" encoding="utf-8"?>
 <playlist_error>
-<error code="401">Invalid authorization to access playlist.</error>
+<error code="401">Invalid authorization token.</error>
 </playlist_error>
-""".strip()
+""".strip().replace('\n', '').replace('    ', '')
         
         first_xml_str_auth = ''.join(r.data.decode('utf-8').split())
         second_xml_str_auth = ''.join(expected_error_xml.split())

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -1,8 +1,6 @@
 import json
 import time
-from unittest import mock
 from unittest.mock import patch
-from xml.etree import ElementTree as ET
 
 import pytest
 
@@ -13,7 +11,6 @@ from listenbrainz import db
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 import listenbrainz.db.external_service_oauth as db_oauth
-from listenbrainz.webserver.errors import PlaylistAPIXMLError
 from listenbrainz.webserver.views.playlist_api import PLAYLIST_EXTENSION_URI
 
 

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -278,8 +278,9 @@ class APITestCase(ListenAPIIntegrationTestCase):
         second_xml_str = ''.join(expected_xml.split())
         self.assertEqual(first_xml_str, second_xml_str)
 
+    @mock.patch('listenbrainz.webserver.views.playlist_api.get_playlist_xspf')
+    def test_playlist_api_xml_auth_error(self, mock_get_playlist_xspf):
         # Testing for 401: Authorization Error
-
         playlist = {
             "playlist": {
                 "title": "you're a person",

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -241,6 +241,27 @@ class InvalidAPIUsage(Exception):
                 text(self.api_error.message)
         return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
 
+class PlaylistAPIXMLError(Exception):
+    """
+    Custom error class for Playlist API to render errors in XML format.
+    """
+
+    def __init__(self, message, status_code=404):
+        Exception.__init__(self)
+        self.message = message
+        self.status_code = status_code
+
+    def render_error(self):
+        data = self.to_xml()
+        content_type = "application/xml; charset=utf-8"
+        return Response(data, status=self.status_code, mimetype=content_type)
+
+    def to_xml(self):
+        doc, tag, text = Doc().tagtext()
+        with tag('playlist_error'):
+            with tag('error', code=str(self.status_code)):
+                text(self.message)
+        return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
 
 class ListenValidationError(Exception):
     """ Error class for raising when the submitted payload does not pass validation.

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -241,6 +241,7 @@ class InvalidAPIUsage(Exception):
                 text(self.api_error.message)
         return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
 
+
 class PlaylistAPIXMLError(Exception):
     """
     Custom error class for Playlist API to render errors in XML format.

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -255,14 +255,14 @@ class PlaylistAPIXMLError(Exception):
     def render_error(self):
         data = self.to_xml()
         content_type = "application/xml; charset=utf-8"
-        return Response(data, status=self.status_code, mimetype=content_type)
+        raise Response(data, status=self.status_code, mimetype=content_type)
 
     def to_xml(self):
         doc, tag, text = Doc().tagtext()
         with tag('playlist_error'):
             with tag('error', code=str(self.status_code)):
                 text(self.message)
-        return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
+        raise '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
 
 class ListenValidationError(Exception):
     """ Error class for raising when the submitted payload does not pass validation.

--- a/listenbrainz/webserver/errors.py
+++ b/listenbrainz/webserver/errors.py
@@ -207,7 +207,10 @@ def init_error_handlers(app):
     @app.errorhandler(InvalidAPIUsage)
     def handle_api_compat_error(error):
         return error.render_error()
-
+    
+    @app.errorhandler(PlaylistAPIXMLError)
+    def handle_playlist_api_xml_error(error):
+        return error.render_error()
 
 class InvalidAPIUsage(Exception):
     """ General error class for the API_compat to render errors in multiple formats """
@@ -242,6 +245,8 @@ class InvalidAPIUsage(Exception):
         return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
 
 
+
+
 class PlaylistAPIXMLError(Exception):
     """
     Custom error class for Playlist API to render errors in XML format.
@@ -255,14 +260,14 @@ class PlaylistAPIXMLError(Exception):
     def render_error(self):
         data = self.to_xml()
         content_type = "application/xml; charset=utf-8"
-        raise Response(data, status=self.status_code, mimetype=content_type)
+        return Response(data, status=self.status_code, mimetype=content_type)
 
     def to_xml(self):
         doc, tag, text = Doc().tagtext()
         with tag('playlist_error'):
             with tag('error', code=str(self.status_code)):
                 text(self.message)
-        raise '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
+        return '<?xml version="1.0" encoding="utf-8"?>\n' + yattag.indent(doc.getvalue())
 
 class ListenValidationError(Exception):
     """ Error class for raising when the submitted payload does not pass validation.

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -15,7 +15,7 @@ from listenbrainz.webserver import db_conn, ts_conn
 
 from listenbrainz.webserver.utils import parse_boolean_arg
 from listenbrainz.webserver.decorators import crossdomain, api_listenstore_needed
-from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIForbidden, APIError, PlaylistAPIXMLError
+from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIForbidden, APIError, PlaylistAPIXMLError, APIUnauthorized
 from brainzutils.ratelimit import ratelimit
 from listenbrainz.webserver.views.api_tools import log_raise_400, is_valid_uuid, validate_auth_header, \
     _filter_description_html
@@ -519,7 +519,7 @@ def get_playlist_xspf(playlist_mbid):
 
     try:
         user = validate_auth_header(optional=True)
-    except Exception as e:
+    except APIUnauthorized as e:
         raise PlaylistAPIXMLError(str(e), status_code=401)
 
     user_id = user['id'] if user else None

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -513,8 +513,9 @@ def get_playlist_xspf(playlist_mbid):
         if not is_valid_uuid(playlist_mbid):
             raise PlaylistAPIXMLError("Provided playlist ID is invalid.", status_code=400)
 
-    fetch_metadata = parse_boolean_arg("fetch_metadata", True)
-    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, True)
+        fetch_metadata = parse_boolean_arg("fetch_metadata", True)
+
+        playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, True)
 
         if playlist is None:
             raise PlaylistAPIXMLError("Cannot find playlist: %s" % playlist_mbid, status_code=404)

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -523,7 +523,7 @@ def get_playlist_xspf(playlist_mbid):
         user_id = user["id"]
 
     if not playlist.is_visible_by(user_id):
-        return PlaylistAPIXMLError("Invalid authorization to access playlist: %s" % playlist_mbid, status_code=401).render_error()
+        return PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401).render_error()
 
     if fetch_metadata:
         fetch_playlist_recording_metadata(playlist)

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -517,10 +517,12 @@ def get_playlist_xspf(playlist_mbid):
     if playlist is None:
         return PlaylistAPIXMLError("Cannot find playlist: %s" % playlist_mbid, status_code=404).render_error()
 
-    user = validate_auth_header(optional=True)
-    user_id = None
-    if user:
-        user_id = user["id"]
+    try:
+        user = validate_auth_header(optional=True)
+    except Exception as e:
+        return PlaylistAPIXMLError(str(e), status_code=401).render_error()
+
+    user_id = user['id'] if user else None
 
     if not playlist.is_visible_by(user_id):
         return PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401).render_error()

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -510,22 +510,22 @@ def get_playlist_xspf(playlist_mbid):
     """
 
     if not is_valid_uuid(playlist_mbid):
-        return PlaylistAPIXMLError("Provided playlist ID is invalid.", status_code=400).render_error()
+        raise PlaylistAPIXMLError("Provided playlist ID is invalid.", status_code=400).render_error()
 
     fetch_metadata = parse_boolean_arg("fetch_metadata", True)
     playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, True)
     if playlist is None:
-        return PlaylistAPIXMLError("Cannot find playlist: %s" % playlist_mbid, status_code=404).render_error()
+        raise PlaylistAPIXMLError("Cannot find playlist: %s" % playlist_mbid, status_code=404).render_error()
 
     try:
         user = validate_auth_header(optional=True)
     except Exception as e:
-        return PlaylistAPIXMLError(str(e), status_code=401).render_error()
+        raise PlaylistAPIXMLError(str(e), status_code=401).render_error()
 
     user_id = user['id'] if user else None
 
     if not playlist.is_visible_by(user_id):
-        return PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401).render_error()
+        raise PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401).render_error()
 
     if fetch_metadata:
         fetch_playlist_recording_metadata(playlist)

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -510,22 +510,22 @@ def get_playlist_xspf(playlist_mbid):
     """
 
     if not is_valid_uuid(playlist_mbid):
-        raise PlaylistAPIXMLError("Provided playlist ID is invalid.", status_code=400).render_error()
+        raise PlaylistAPIXMLError("Provided playlist ID is invalid.", status_code=400)
 
     fetch_metadata = parse_boolean_arg("fetch_metadata", True)
     playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, True)
     if playlist is None:
-        raise PlaylistAPIXMLError("Cannot find playlist: %s" % playlist_mbid, status_code=404).render_error()
+        raise PlaylistAPIXMLError("Cannot find playlist: %s" % playlist_mbid, status_code=404)
 
     try:
         user = validate_auth_header(optional=True)
     except Exception as e:
-        raise PlaylistAPIXMLError(str(e), status_code=401).render_error()
+        raise PlaylistAPIXMLError(str(e), status_code=401)
 
     user_id = user['id'] if user else None
 
     if not playlist.is_visible_by(user_id):
-        raise PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401).render_error()
+        raise PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401)
 
     if fetch_metadata:
         fetch_playlist_recording_metadata(playlist)


### PR DESCRIPTION
# Problem
The `/1/<playlist_mbid>/xspf` endpoint in the ListenBrainz API was returning error messages in JSON format, which is inconsistent with its standard XML response format.
# Solution
It looks like this now. (used to be a json before)
<img width="494" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/73362292/77822ee3-c704-4cbc-abb3-75c9f590949a">

This change introduces a new exception class, `PlaylistAPIXMLError` ensuring error messages are formatted in XML. The `get_playlist_xspf` function has been updated to utilize the new class. 

