### PR TITLE
Do not push test_request_context in API tests

### DIFF
--- a/listenbrainz/domain/tests/test_critiquebrainz.py
+++ b/listenbrainz/domain/tests/test_critiquebrainz.py
@@ -6,10 +6,10 @@ import listenbrainz.db.user as db_user
 from listenbrainz.domain.critiquebrainz import CritiqueBrainzService, OAUTH_TOKEN_URL
 from listenbrainz.domain.external_service import ExternalServiceInvalidGrantError
 
-from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.tests.integration import NonAPIIntegrationTestCase
 
 
-class CritiqueBrainzTestCase(IntegrationTestCase):
+class CritiqueBrainzTestCase(NonAPIIntegrationTestCase):
 
     def setUp(self):
         super(CritiqueBrainzTestCase, self).setUp()

--- a/listenbrainz/domain/tests/test_external_service.py
+++ b/listenbrainz/domain/tests/test_external_service.py
@@ -3,10 +3,10 @@ import datetime
 from freezegun import freeze_time
 
 from listenbrainz.domain.spotify import SpotifyService
-from listenbrainz.webserver.testing import ServerTestCase
+from listenbrainz.tests.integration import NonAPIIntegrationTestCase
 
 
-class ExternalServiceTestCase(ServerTestCase):
+class ExternalServiceTestCase(NonAPIIntegrationTestCase):
 
     @freeze_time("2021-05-12 03:21:34", tz_offset=0)
     def test_user_oauth_token_has_expired(self):

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -9,10 +9,10 @@ import listenbrainz.db.user as db_user
 from listenbrainz.domain.external_service import ExternalServiceAPIError, ExternalServiceInvalidGrantError
 from listenbrainz.domain.spotify import SpotifyService, OAUTH_TOKEN_URL
 
-from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.tests.integration import NonAPIIntegrationTestCase
 
 
-class SpotifyServiceTestCase(IntegrationTestCase):
+class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
 
     def setUp(self):
         super(SpotifyServiceTestCase, self).setUp()

--- a/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
+++ b/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
@@ -175,7 +175,8 @@ class MsidUpdaterTestCase(IntegrationTestCase):
 
     def test_msid_updater(self):
         self.create_dummy_data()
-        update_msids_from_mapping.run_all_updates()
+        with self.app.app_context():
+            update_msids_from_mapping.run_all_updates()
 
         expected_feedback = [
             {

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -22,7 +22,6 @@ import logging
 import time
 
 import xmltodict
-from flask import url_for
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.lastfm_session import Session
@@ -59,12 +58,12 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'api_key': self.lfm_user.api_key,
             'format': 'json',
         }
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
         token = r.json['token']
 
         r = self.client.post(
-            url_for('api_compat.api_auth_approve'),
+            self.custom_url_for('api_compat.api_auth_approve'),
             data=f"token={token}",
             headers={'Content-Type': 'application/x-www-form-urlencoded'}
         )
@@ -76,7 +75,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'token': token,
             'format': 'json'
         }
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
         sk = r.json['session']['key']
 
@@ -91,7 +90,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'duration[0]': 300,
             'timestamp[0]': int(time.time()),
         }
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
 
         expected = {
@@ -128,8 +127,9 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         time.sleep(0.5)
         recalculate_all_user_data()
 
-        url = url_for('api_v1.get_listens', user_name=self.lb_user['musicbrainz_id'])
-        response = self.wait_for_query_to_have_items(url, num_items=1, query_string={'from_ts': data["timestamp[0]"] - 1})
+        url = self.custom_url_for('api_v1.get_listens', user_name=self.lb_user['musicbrainz_id'])
+        response = self.wait_for_query_to_have_items(url, num_items=1,
+                                                     query_string={'from_ts': data["timestamp[0]"] - 1})
         listens = json.loads(response.data)['payload']['listens']
         self.assertEqual(len(listens), 1)
 
@@ -153,7 +153,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'timestamp[0]': int(time.time()),
         }
 
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
 
         response = xmltodict.parse(r.data)
@@ -168,7 +168,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'api_key': self.lfm_user.api_key,
         }
 
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
 
         response = xmltodict.parse(r.data)
@@ -188,7 +188,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'api_key': self.lfm_user.api_key,
             'token': token.token,
         }
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
         self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
@@ -209,7 +209,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'api_key': self.lfm_user.api_key,
             'token': '',
         }
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
         self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
@@ -233,7 +233,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'sk': session.sid
         }
 
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
         self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
@@ -262,7 +262,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'timestamp[0]': timestamp,
         }
 
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
         self.assertEqual(r.headers["Content-type"], "application/xml; charset=utf-8")
 
@@ -274,7 +274,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         time.sleep(0.5)
         recalculate_all_user_data()
 
-        url = url_for('api_v1.get_listens', user_name=self.lb_user['musicbrainz_id'])
+        url = self.custom_url_for('api_v1.get_listens', user_name=self.lb_user['musicbrainz_id'])
         response = self.wait_for_query_to_have_items(url, num_items=1, query_string={'from_ts': timestamp - 1})
         listens = json.loads(response.data)['payload']['listens']
         self.assertEqual(len(listens), 1)
@@ -297,7 +297,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'timestamp[0]': timestamp,
         }
 
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert400(r)
         self.assertEqual(r.json["error"], "\u0000Kishore Kumar contains a unicode null")
 
@@ -323,10 +323,10 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'artist[1]': 'Fifth Harmony',
             'track[1]': 'Deliver',
             'duration[1]': 200,
-            'timestamp[1]': timestamp+300,
+            'timestamp[1]': timestamp + 300,
         }
 
-        r = self.client.post(url_for('api_compat.api_methods'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat.api_methods'), data=data)
         self.assert200(r)
 
         response = xmltodict.parse(r.data)
@@ -337,7 +337,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         time.sleep(0.5)
         recalculate_all_user_data()
 
-        url = url_for('api_v1.get_listens', user_name=self.lb_user['musicbrainz_id'])
+        url = self.custom_url_for('api_v1.get_listens', user_name=self.lb_user['musicbrainz_id'])
         response = self.wait_for_query_to_have_items(url, num_items=1, query_string={'from_ts': timestamp - 1})
         listens = json.loads(response.data)['payload']['listens']
         self.assertEqual(len(listens), 2)
@@ -363,7 +363,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             'listened_at': timestamp,
             'track_metadata': {
                 'artist_name': 'Kishore Kumar',
-                'track_name':  'Saamne Ye Kaun Aya',
+                'track_name': 'Saamne Ye Kaun Aya',
                 'release_name': 'Jawani Diwani',
                 'additional_info': {
                     'track_length': 300

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -23,7 +23,6 @@ import logging
 import time
 from datetime import datetime
 
-from flask import url_for
 from werkzeug.exceptions import BadRequest
 
 import listenbrainz.db.user as db_user
@@ -135,7 +134,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
             'i[0]': int(time.time()),
         }
 
-        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat_old.submit_listens'), data=data)
         self.assert200(r)
         self.assertEqual(r.data.decode('utf-8'), 'OK\n')
 
@@ -159,7 +158,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
             'i[0]': int(time.time()),
         }
 
-        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat_old.submit_listens'), data=data)
         self.assert401(r)
         self.assertEqual(r.data.decode('utf-8'), 'BADSESSION\n')
 
@@ -185,27 +184,27 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
             'i[0]': int(time.time()),
         }
 
-        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat_old.submit_listens'), data=data)
         self.assert400(r)
         self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')
 
         # add artist and remove track name
         data['a[0]'] = 'Kishore Kumar'
         del data['t[0]']
-        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat_old.submit_listens'), data=data)
         self.assert400(r)
         self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')
 
         # add track name and remove timestamp
         data['t[0]'] = 'Saamne Ye Kaun Aya'
         del data['i[0]']
-        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat_old.submit_listens'), data=data)
         self.assert400(r)
         self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')
 
         # re-add a timestamp in ns
         data['i[0]'] = int(time.time()) * 10**9
-        r = self.client.post(url_for('api_compat_old.submit_listens'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat_old.submit_listens'), data=data)
         self.assert400(r)
         self.assertEqual(r.data.decode('utf-8').split()[0], 'FAILED')
 
@@ -227,7 +226,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
             'b': 'Jawani Diwani',
         }
 
-        r = self.client.post(url_for('api_compat_old.submit_now_playing'), data=data)
+        r = self.client.post(self.custom_url_for('api_compat_old.submit_now_playing'), data=data)
         self.assert200(r)
         self.assertEqual(r.data.decode('utf-8'), 'OK\n')
 

--- a/listenbrainz/tests/integration/test_do_not_recommend_api.py
+++ b/listenbrainz/tests/integration/test_do_not_recommend_api.py
@@ -1,23 +1,9 @@
 from datetime import datetime, timedelta
 
-from brainzutils import cache
-from brainzutils.ratelimit import set_rate_limits
-from flask import url_for
-from typing import List
-from unittest.mock import patch
-
 import listenbrainz.db.user as db_user
-import listenbrainz.db.pinned_recording as db_pinned_rec
-import listenbrainz.db.user_relationship as db_user_relationship
 from listenbrainz.db import do_not_recommend
 
 from listenbrainz.tests.integration import IntegrationTestCase
-from listenbrainz.db.model.pinned_recording import (
-    PinnedRecording,
-    WritablePinnedRecording,
-    MAX_BLURB_CONTENT_LENGTH,
-)
-import json
 
 
 class DoNotRecommendAPITestCase(IntegrationTestCase):
@@ -71,13 +57,15 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
 
     def test_get_do_not_recommends(self):
         self.insert_test_data()
-        url = url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"])
+        url = self.custom_url_for("do_not_recommend_api_v1.get_do_not_recommends",
+                                  user_name=self.user["musicbrainz_id"])
         response = self.client.get(url)
         self._check_response(response, self.items)
 
     def test_delete_do_not_recommend(self):
         self.insert_test_data()
-        url = url_for("do_not_recommend_api_v1.delete_do_not_recommend", user_name=self.user["musicbrainz_id"])
+        url = self.custom_url_for("do_not_recommend_api_v1.delete_do_not_recommend",
+                                  user_name=self.user["musicbrainz_id"])
         response = self.client.post(
             url,
             json={"entity": self.items[3]["entity"], "entity_mbid": self.items[3]["entity_mbid"]},
@@ -85,11 +73,12 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
         )
         self.assert200(response)
 
-        response = self.client.get(url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"]))
+        response = self.client.get(
+            self.custom_url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"]))
         self._check_response(response, self.items[:3])
 
     def test_add_do_not_recommend(self):
-        url = url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
+        url = self.custom_url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
         response = self.client.post(
             url,
             json=self.items[0],
@@ -106,29 +95,34 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
         self.assert200(response)
         new_item["until"] = None
 
-        response = self.client.get(url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"]))
+        response = self.client.get(
+            self.custom_url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"]))
         self._check_response(response, [self.items[0], new_item])
 
     def test_invalid_username(self):
         user_name = " -- invalid username -- "
-        response = self.client.get(url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=user_name))
+        response = self.client.get(
+            self.custom_url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=user_name))
         self.assert404(response)
         self.assertEqual(response.json["code"], 404)
 
     def test_unauthorized(self):
-        response = self.client.post(url_for("do_not_recommend_api_v1.delete_do_not_recommend", user_name=self.user["musicbrainz_id"]))
+        response = self.client.post(self.custom_url_for("do_not_recommend_api_v1.delete_do_not_recommend",
+                                                        user_name=self.user["musicbrainz_id"]))
         self.assert401(response)
         self.assertEqual(response.json["code"], 401)
 
-        response = self.client.post(url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"]))
+        response = self.client.post(
+            self.custom_url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"]))
         self.assert401(response)
         self.assertEqual(response.json["code"], 401)
 
     def test_invalid_entity(self):
         invalid_entity_error = "Value 'label' for entity key is invalid"
         urls = [
-            url_for("do_not_recommend_api_v1.delete_do_not_recommend", user_name=self.user["musicbrainz_id"]),
-            url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
+            self.custom_url_for("do_not_recommend_api_v1.delete_do_not_recommend",
+                                user_name=self.user["musicbrainz_id"]),
+            self.custom_url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
         ]
         for url in urls:
             response = self.client.post(
@@ -143,8 +137,9 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
     def test_invalid_entity_mbid(self):
         invalid_entity_mbid_error = "Value 'foobar' for entity_mbid key is not a valid uuid"
         urls = [
-            url_for("do_not_recommend_api_v1.delete_do_not_recommend", user_name=self.user["musicbrainz_id"]),
-            url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
+            self.custom_url_for("do_not_recommend_api_v1.delete_do_not_recommend",
+                                user_name=self.user["musicbrainz_id"]),
+            self.custom_url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
         ]
         for url in urls:
             response = self.client.post(
@@ -157,7 +152,7 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
             self.assertTrue(response.json["error"].startswith(invalid_entity_mbid_error))
 
     def test_invalid_until(self):
-        url = url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
+        url = self.custom_url_for("do_not_recommend_api_v1.add_do_not_recommend", user_name=self.user["musicbrainz_id"])
 
         response = self.client.post(
             url,
@@ -186,10 +181,12 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
     def test_count_offset_get(self):
         self.insert_test_data()
         response = self.client.get(
-            url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"], count=2)
+            self.custom_url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"],
+                                count=2)
         )
         self._check_response(response, self.items[:2], total_count=4)
         response = self.client.get(
-            url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"], offset=2)
+            self.custom_url_for("do_not_recommend_api_v1.get_do_not_recommends", user_name=self.user["musicbrainz_id"],
+                                offset=2)
         )
         self._check_response(response, self.items[2:], total_count=4, offset=2)

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -22,14 +22,12 @@ from listenbrainz import db
 from listenbrainz.db import timescale
 from listenbrainz.db.model.user_timeline_event import RecordingRecommendationMetadata
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
-from flask import url_for, current_app
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 import listenbrainz.db.user_timeline_event as db_user_timeline_event
 import time
 import json
-import uuid
 from listenbrainz.webserver.views.user_timeline_event_api import DEFAULT_LISTEN_EVENT_WINDOW_NEW
 
 
@@ -116,7 +114,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         time.sleep(2)
 
         response = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
         )
         self.assert200(response)
@@ -188,7 +186,8 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         time.sleep(2)
 
         response = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed_listens_similar', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed_listens_similar',
+                                user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
         )
         self.assert200(response)
@@ -249,7 +248,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             self.assertEqual(response.json['status'], 'ok')
 
         from datetime import timedelta
-        listenWindowMillisec = int(DEFAULT_LISTEN_EVENT_WINDOW_NEW/timedelta(seconds=1))
+        listenWindowMillisec = int(DEFAULT_LISTEN_EVENT_WINDOW_NEW / timedelta(seconds=1))
 
         # Sending a listen with time difference slightly lesser than DEFAULT_LISTEN_EVENT_WINDOW_NEW
         payload['payload'][0]['listened_at'] = ts - listenWindowMillisec + 1000
@@ -268,7 +267,8 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         time.sleep(2)
 
         response = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed_listens_following', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed_listens_following',
+                                user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
         )
         self.assert200(response)
@@ -327,7 +327,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # max_ts = 2, should have sent back 2 listens
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'max_ts': ts + 2}
         )
@@ -339,7 +339,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # max_ts = 4, should have sent back 4 listens
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'max_ts': ts + 4}
         )
@@ -349,7 +349,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # min_ts = 1, should have sent back 4 listens
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'min_ts': ts + 1}
         )
@@ -359,7 +359,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # min_ts = 2, should have sent back 2 listens
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'min_ts': ts + 2}
         )
@@ -369,7 +369,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # min_ts = 1, max_ts = 3, should have sent back 2 listens
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'min_ts': ts + 1, 'max_ts': ts + 3}
         )
@@ -379,7 +379,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # should honor count
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'count': 1}
         )
@@ -393,7 +393,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # this should show up in the events
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'max_ts': int(time.time()) + 1}
         )
@@ -440,7 +440,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # this should show up in the events
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
             query_string={'max_ts': int(time.time()) + 1}
         )
@@ -484,7 +484,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
     def test_it_returns_empty_list_if_user_does_not_follow_anyone(self):
         new_user = db_user.get_or_create(111, 'totally_new_user_with_no_friends')
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=new_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=new_user['musicbrainz_id']),
             headers={'Authorization': f"Token {new_user['auth_token']}"},
         )
         self.assert200(r)
@@ -517,7 +517,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         time.sleep(1)
 
         r = self.client.get(
-            url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
+            self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.main_user['musicbrainz_id']),
             headers={'Authorization': f"Token {self.main_user['auth_token']}"},
         )
         self.assert200(r)

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -4,7 +4,6 @@ from unittest import mock
 import requests_mock
 
 from brainzutils import cache
-from flask import url_for, current_app
 
 import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.user as db_user
@@ -82,7 +81,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "score": 1
         }
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -95,7 +94,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "score": -1
         }
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -109,7 +108,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "score": -1
         }
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -126,7 +125,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
         # request with no authorization header
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             content_type="application/json"
         )
@@ -135,7 +134,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
         # request with invalid authorization header
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token testtokenplsignore"},
             content_type="application/json"
@@ -152,7 +151,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(incomplete_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -169,7 +168,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(incomplete_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -183,7 +182,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         empty_feedback = {}
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(empty_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -203,7 +202,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -223,7 +222,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "score": 1
         }
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -237,7 +236,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "score": 1
         }
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -251,7 +250,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "score": 5
         }
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -266,7 +265,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -287,7 +286,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -308,7 +307,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(updated_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -336,7 +335,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -357,7 +356,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(updated_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -385,7 +384,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -406,7 +405,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(updated_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -431,7 +430,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -452,7 +451,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("feedback_api_v1.recording_feedback"),
+            self.custom_url_for("feedback_api_v1.recording_feedback"),
             data=json.dumps(updated_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -468,7 +467,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         """ Test to make sure valid response is received """
         inserted_rows = self.insert_test_data(self.user["id"])
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user", user_name=self.user["musicbrainz_id"]))
+        response = self.client.get(
+            self.custom_url_for("feedback_api_v1.get_feedback_for_user", user_name=self.user["musicbrainz_id"]))
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -489,7 +489,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_user_invalid_user(self):
         """ Test to make sure that the API sends 404 if user does not exist. """
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user", user_name="nouser"))
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user", user_name="nouser"))
         self.assert404(response)
         self.assertEqual(response.json["error"], "Cannot find user: nouser")
 
@@ -498,13 +498,14 @@ class FeedbackAPITestCase(IntegrationTestCase):
         inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
 
         # pass score = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"score": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"score": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
         self.assertEqual(data["count"], 2)
-        self.assertEqual(data["total_count"], 2) # Only count feedback for this score = 1
+        self.assertEqual(data["total_count"], 2)  # Only count feedback for this score = 1
         self.assertEqual(data["offset"], 0)
 
         feedback = data["feedback"]  # sorted in descending order of their creation
@@ -521,13 +522,14 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[1]["score"], 1)
 
         # pass score = -1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"score": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"score": -1})
         self.assert200(response)
         data = json.loads(response.data)
 
         self.assertEqual(data["count"], 2)
-        self.assertEqual(data["total_count"], 2) # Only count feedback for score = -1
+        self.assertEqual(data["total_count"], 2)  # Only count feedback for score = -1
         self.assertEqual(data["offset"], 0)
 
         feedback = data["feedback"]  # sorted in descending order of their creation
@@ -548,14 +550,16 @@ class FeedbackAPITestCase(IntegrationTestCase):
         inserted_rows = self.insert_test_data(self.user["id"])
 
         # pass non-int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"score": "invalid_score"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"score": "invalid_score"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Invalid score argument: invalid_score")
 
         # pass invalid int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"score": 10})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"score": 10})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Score can have a value of 1 or -1.")
 
@@ -564,8 +568,9 @@ class FeedbackAPITestCase(IntegrationTestCase):
         inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"count": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"count": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -586,14 +591,16 @@ class FeedbackAPITestCase(IntegrationTestCase):
         inserted_rows = self.insert_test_data(self.user["id"])
 
         # pass non-int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"count": "invalid_count"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"count": "invalid_count"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
         # pass negative int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"count": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"count": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
@@ -602,8 +609,9 @@ class FeedbackAPITestCase(IntegrationTestCase):
         inserted_rows = self.insert_test_data(self.user["id"])
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"offset": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"offset": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -623,14 +631,16 @@ class FeedbackAPITestCase(IntegrationTestCase):
         inserted_rows = self.insert_test_data(self.user["id"])
 
         # pass non-int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"offset": "invalid_offset"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"offset": "invalid_offset"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
         # pass negative int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"offset": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"offset": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
@@ -641,8 +651,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1))
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1))
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -668,8 +678,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
         rec_mbid = inserted_rows[2]["recording_mbid"]
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid))
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid))
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -692,13 +702,15 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_recording_invalid_recording_msid(self):
         """ Test to make sure that the API sends 404 if recording_msid is invalid. """
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid", recording_msid="invalid_recording_msid"))
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid="invalid_recording_msid"))
         self.assert400(response)
         self.assertEqual(response.json["error"], "invalid_recording_msid msid format invalid.")
 
     def test_get_feedback_for_recording_mbid_invalid_recording_msid(self):
         """ Test to make sure that the API sends 404 if recording_mbid is invalid. """
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid", recording_mbid="invalid_recording_mbid"))
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid="invalid_recording_mbid"))
         self.assert400(response)
         self.assertEqual(response.json["error"], "invalid_recording_mbid mbid format invalid.")
 
@@ -710,8 +722,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass score = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"score": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1), query_string={"score": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -731,8 +743,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[0]["score"], inserted_rows[0]["score"])
 
         # pass score = -1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"score": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1), query_string={"score": -1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -751,8 +763,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_mbid_1 = inserted_rows[2]["recording_mbid"]
 
         # pass score = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"score": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1), query_string={"score": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -772,8 +784,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[1]["score"], inserted_rows[2]["score"])
 
         # pass score = -1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"score": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1), query_string={"score": -1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -792,14 +804,15 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass non-int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"score": "invalid_score"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1),
+                                   query_string={"score": "invalid_score"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Invalid score argument: invalid_score")
 
         # pass invalid int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"score": 10})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1), query_string={"score": 10})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Score can have a value of 1 or -1.")
 
@@ -811,14 +824,15 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_mbid_1 = inserted_rows[2]["recording_mbid"]
 
         # pass non-int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"score": "invalid_score"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1),
+                                   query_string={"score": "invalid_score"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Invalid score argument: invalid_score")
 
         # pass invalid int value to score
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"score": 10})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1), query_string={"score": 10})
         self.assert400(response)
         self.assertEqual(response.json["error"], "Score can have a value of 1 or -1.")
 
@@ -830,8 +844,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"count": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1), query_string={"count": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -854,8 +868,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_mbid_1 = inserted_rows[3]["recording_mbid"]
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"count": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1), query_string={"count": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -878,14 +892,15 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass non-int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"count": "invalid_count"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1),
+                                   query_string={"count": "invalid_count"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
         # pass negative int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"count": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1), query_string={"count": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
@@ -896,14 +911,15 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_mbid_1 = inserted_rows[2]["recording_mbid"]
 
         # pass non-int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"count": "invalid_count"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1),
+                                   query_string={"count": "invalid_count"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
         # pass negative int value to count
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"count": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1), query_string={"count": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'count' should be a non-negative integer")
 
@@ -915,8 +931,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"offset": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1), query_string={"offset": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -939,8 +955,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_mbid_1 = inserted_rows[3]["recording_mbid"]
 
         # pass count = 1
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"offset": 1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1), query_string={"offset": 1})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -963,14 +979,15 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_msid_1 = inserted_rows[0]["recording_msid"]
 
         # pass non-int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"offset": "invalid_offset"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1),
+                                   query_string={"offset": "invalid_offset"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
         # pass negative int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_msid",
-                                           recording_msid=rec_msid_1), query_string={"offset": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_msid",
+                                                       recording_msid=rec_msid_1), query_string={"offset": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
@@ -981,14 +998,15 @@ class FeedbackAPITestCase(IntegrationTestCase):
         rec_mbid_1 = inserted_rows[3]["recording_mbid"]
 
         # pass non-int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"offset": "invalid_offset"})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1),
+                                   query_string={"offset": "invalid_offset"})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
         # pass negative int value to offset
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recording_mbid",
-                                           recording_mbid=rec_mbid_1), query_string={"offset": -1})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recording_mbid",
+                                                       recording_mbid=rec_mbid_1), query_string={"offset": -1})
         self.assert400(response)
         self.assertEqual(response.json["error"], "'offset' should be a non-negative integer")
 
@@ -1003,8 +1021,9 @@ class FeedbackAPITestCase(IntegrationTestCase):
         non_existing_rec_msid = "b83fd3c3-449c-49be-a874-31d7cf26d946"
         recordings = recordings + "," + non_existing_rec_msid
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]), query_string={param: recordings})
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={param: recordings})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -1046,8 +1065,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
         non_existing_rec_mbid = "6a221fda-2200-11ec-ac7d-dfa16a57158f"
         recording_mbids = recording_mbids + "," + non_existing_rec_mbid
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]),
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
                                    query_string={"recording_msids": recordings, "recording_mbids": recording_mbids})
         self.assert200(response)
         data = json.loads(response.data)
@@ -1109,31 +1128,32 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_recordings_for_user_invalid_user(self):
         """ Test to make sure that the API sends 404 if user does not exist. """
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_user", user_name="nouser"))
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_user", user_name="nouser"))
         self.assert404(response)
         self.assertEqual(response.json["error"], "Cannot find user: nouser")
 
     def test_get_feedback_for_recordings_for_user_no_recordings(self):
         """ Test to make sure that the API sends 400 if param recordings is not passed or is empty. """
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]))  # missing recordings param
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user[
+                                                           "musicbrainz_id"]))  # missing recordings param
         self.assert400(response)
         self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]),
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
                                    query_string={"recordings": ""})  # empty string
         self.assert400(response)
         self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]),
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
                                    query_string={"recording_msids": ""})  # empty string
         self.assert400(response)
         self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]),
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
                                    query_string={"recording_mbidss": ""})  # empty string
         self.assert400(response)
         self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
@@ -1151,18 +1171,20 @@ class FeedbackAPITestCase(IntegrationTestCase):
         invalid_rec_msid = "invalid_recording_msid"
 
         recordings += invalid_rec_msid
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]),
-                                   query_string={"recording_msids": recordings})  # recording_msids has invalid recording_msid
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={
+                                       "recording_msids": recordings})  # recording_msids has invalid recording_msid
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
-        response = self.client.get(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user["musicbrainz_id"]),
-                                   query_string={"recording_mbids": recordings})  # recording_mbids has invalid recording_msid
+        response = self.client.get(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={
+                                       "recording_mbids": recordings})  # recording_mbids has invalid recording_msid
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
-        
+
     def test_get_feedback_for_recordings_for_post_method_for_user_valid_mbids(self):
         inserted_rows = self.insert_test_data_with_mbid(self.user["id"])
 
@@ -1174,16 +1196,17 @@ class FeedbackAPITestCase(IntegrationTestCase):
         recordings.append(non_existing_rec_msid)
 
         # recording_msids for which feedback records are inserted
-        recording_mbids = [inserted_rows[2]["recording_mbid"],  inserted_rows[3]["recording_mbid"]]
+        recording_mbids = [inserted_rows[2]["recording_mbid"], inserted_rows[3]["recording_mbid"]]
 
         # recording_mbid for which feedback record doesn't exist
         non_existing_rec_mbid = "6a221fda-2200-11ec-ac7d-dfa16a57158f"
         recording_mbids.append(non_existing_rec_mbid)
 
-        response = self.client.post(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                            user_name=self.user["musicbrainz_id"]),
-                                            data=json.dumps({"recording_msids": recordings, "recording_mbids": recording_mbids}),
-                                            content_type="application/json")
+        response = self.client.post(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                        user_name=self.user["musicbrainz_id"]),
+                                    data=json.dumps(
+                                        {"recording_msids": recordings, "recording_mbids": recording_mbids}),
+                                    content_type="application/json")
 
         self.assert200(response)
         data = json.loads(response.data)
@@ -1245,20 +1268,20 @@ class FeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_recordings_for_user_for_post_method_no_recordings(self):
         """ Test to make sure that the API sends 400 if body data recording_msids or recording_mbids is not passed or is empty. """
-        response = self.client.post(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                            user_name=self.user["musicbrainz_id"]),
-                                            data=json.dumps({"recording_msids": []}), # empty list
-                                            content_type="application/json")  
+        response = self.client.post(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                        user_name=self.user["musicbrainz_id"]),
+                                    data=json.dumps({"recording_msids": []}),  # empty list
+                                    content_type="application/json")
         self.assert400(response)
         self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
 
-        response = self.client.post(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                            user_name=self.user["musicbrainz_id"]),
-                                            data=json.dumps({"recording_mbids": []}), # empty list
-                                            content_type="application/json") 
+        response = self.client.post(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                        user_name=self.user["musicbrainz_id"]),
+                                    data=json.dumps({"recording_mbids": []}),  # empty list
+                                    content_type="application/json")
         self.assert400(response)
         self.assertEqual(response.json["error"], "No valid recording msid or recording mbid found.")
-    
+
     def test_get_feedback_for_recordings_for_post_method_for_user_invalid_recording(self):
         """ Test to make sure that the API sends 400 if body data recording_msids has invalid recording_msid. """
         inserted_rows = self.insert_test_data(self.user["id"])
@@ -1272,13 +1295,12 @@ class FeedbackAPITestCase(IntegrationTestCase):
         invalid_rec_msid = "invalid_recording_msid"
 
         recordings.append(invalid_rec_msid)
-        response = self.client.post(url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
-                                            user_name=self.user["musicbrainz_id"]),
-                                            data=json.dumps({"recording_msids": recordings}),
-                                            content_type="application/json")          
+        response = self.client.post(self.custom_url_for("feedback_api_v1.get_feedback_for_recordings_for_user",
+                                                        user_name=self.user["musicbrainz_id"]),
+                                    data=json.dumps({"recording_msids": recordings}),
+                                    content_type="application/json")
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
-
 
     def _insert_feedback_with_metadata(self, user_id):
         recordings = [
@@ -1321,7 +1343,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         inserted_rows = self._insert_feedback_with_metadata(self.user["id"])
 
         # Fetch loved page
-        r = self.client.get(url_for('user.taste', user_name=self.user['musicbrainz_id']))
+        r = self.client.get(self.custom_url_for('user.taste', user_name=self.user['musicbrainz_id']))
         self.assert200(r)
         props = json.loads(self.get_context_variable('props'))
 
@@ -1336,7 +1358,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertNotEqual(feedback[0]["created"], "")
 
         # Fetch hated page
-        r = self.client.get(url_for('user.taste', user_name=self.user['musicbrainz_id'], score=-1))
+        r = self.client.get(self.custom_url_for('user.taste', user_name=self.user['musicbrainz_id'], score=-1))
         self.assert200(r)
         props = json.loads(self.get_context_variable('props'))
 
@@ -1357,7 +1379,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
             page_1 = json.load(f)
         with open(self.path_to_data_file("lastfm_loved_tracks_2.json")) as f:
             page_2 = json.load(f)
-        mock_requests.get(current_app.config["LASTFM_API_URL"], [
+        mock_requests.get("https://ws.audioscrobbler.com/2.0/", [
             {"json": page_1, "status_code": 200},
             {"json": page_1, "status_code": 200},
             {"json": page_2, "status_code": 200}
@@ -1369,7 +1391,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         }
 
         r = self.client.post(
-            url_for("feedback_api_v1.import_feedback"),
+            self.custom_url_for("feedback_api_v1.import_feedback"),
             data=json.dumps({"service": "lastfm", "user_name": "lucifer"}),
             headers={"Authorization": f'Token {self.user["auth_token"]}'},
             content_type="application/json"
@@ -1382,7 +1404,8 @@ class FeedbackAPITestCase(IntegrationTestCase):
             "invalid_mbid": 1,
             "mbid_not_found": 2
         })
-        r = self.client.get(url_for("feedback_api_v1.get_feedback_for_user", user_name=self.user["musicbrainz_id"]))
+        r = self.client.get(
+            self.custom_url_for("feedback_api_v1.get_feedback_for_user", user_name=self.user["musicbrainz_id"]))
         data = r.json
         self.assertEqual(data["count"], 3)
         self.assertEqual(data["total_count"], 3)

--- a/listenbrainz/tests/integration/test_fresh_release_api.py
+++ b/listenbrainz/tests/integration/test_fresh_release_api.py
@@ -1,7 +1,5 @@
 import json
 
-from flask import url_for
-
 from listenbrainz.tests.integration import IntegrationTestCase
 from listenbrainz.db import user as db_user
 from listenbrainz.db import fresh_releases as db_fresh
@@ -25,7 +23,9 @@ class FreshReleasesTestCase(IntegrationTestCase):
         }])
 
     def test_fetch_fresh_releases(self):
-        r = self.client.get(url_for("fresh_releases_v1.get_releases", user_name=self.user["musicbrainz_id"]))
+        r = self.client.get(
+            self.custom_url_for("fresh_releases_v1.get_releases", user_name=self.user["musicbrainz_id"])
+        )
         self.assert200(r)
 
         self.assertEqual(r.json, {"payload": {

--- a/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
+++ b/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
@@ -1,6 +1,4 @@
 import json
-from flask import url_for, current_app
-from redis import Redis
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.missing_musicbrainz_data as db_missing_musicbrainz_data
@@ -20,30 +18,25 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
 
         db_missing_musicbrainz_data.insert_user_missing_musicbrainz_data(
             user_id=self.user['id'],
-            missing_musicbrainz_data=UserMissingMusicBrainzDataJson(**{'missing_musicbrainz_data': missing_musicbrainz_data}),
+            missing_musicbrainz_data=UserMissingMusicBrainzDataJson(missing_musicbrainz_data=missing_musicbrainz_data),
             source='cf'
         )
 
         self.data = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(user_id=self.user['id'], source='cf')
 
-    def tearDown(self):
-        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
-        r.flushall()
-        super(MissingMusicBrainzDataViewsTestCase, self).tearDown()
-
     def test_invalid_user(self):
-        response = self.client.get(url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
-                                           user_name='invalid_user'))
+        response = self.client.get(self.custom_url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
+                                                       user_name='invalid_user'))
         self.assert404(response)
 
     def test_user_musicbrainz_data_not_calculated(self):
-        response = self.client.get(url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
-                                           user_name=self.user2['musicbrainz_id']))
+        response = self.client.get(self.custom_url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
+                                                       user_name=self.user2['musicbrainz_id']))
         self.assertEqual(response.status_code, 204)
 
     def test_missing_musicbrainz_data_without_count(self):
-        response = self.client.get(url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
-                                           user_name=self.user['musicbrainz_id']))
+        response = self.client.get(self.custom_url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
+                                                       user_name=self.user['musicbrainz_id']))
         self.assert200(response)
         data = json.loads(response.data)['payload']
 
@@ -69,8 +62,8 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
         self.assertEqual(expected_data, received_data)
 
     def test_missing_musicbrainz_data_with_count(self):
-        response = self.client.get(url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
-                                           user_name=self.user['musicbrainz_id']),
+        response = self.client.get(self.custom_url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
+                                                       user_name=self.user['musicbrainz_id']),
                                    query_string={'count': 10})
         self.assert200(response)
         data = json.loads(response.data)['payload']
@@ -97,8 +90,8 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
         self.assertEqual(expected_data, received_data)
 
     def test_missing_musicbrainz_data_too_many(self):
-        response = self.client.get(url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
-                                           user_name=self.user['musicbrainz_id']),
+        response = self.client.get(self.custom_url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
+                                                       user_name=self.user['musicbrainz_id']),
                                    query_string={'count': 100})
         self.assert200(response)
         data = json.loads(response.data)['payload']
@@ -125,8 +118,8 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
         self.assertEqual(expected_data, received_data)
 
     def test_missing_musicbrainz_data_with_offset(self):
-        response = self.client.get(url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
-                                           user_name=self.user['musicbrainz_id']),
+        response = self.client.get(self.custom_url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',
+                                                       user_name=self.user['musicbrainz_id']),
                                    query_string={'offset': 10})
 
         self.assert200(response)

--- a/listenbrainz/tests/integration/test_pinned_recording_api.py
+++ b/listenbrainz/tests/integration/test_pinned_recording_api.py
@@ -1,6 +1,5 @@
 from brainzutils import cache
 from brainzutils.ratelimit import set_rate_limits
-from flask import url_for
 from typing import List
 from unittest.mock import patch
 
@@ -107,7 +106,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_pin(self):
         """Tests that pin endpoint returns 200 when successful"""
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(self.pinned_rec_samples[0]),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
@@ -120,7 +119,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_pin_unauthorized(self):
         """Tests that pin endpoint returns 401 when auth token is invalid"""
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(self.pinned_rec_samples[0]),
             headers={"Authorization": "Token {}".format("-- This is an invalid auth token --")},
             content_type="application/json",
@@ -137,7 +136,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
             "blurb_content": "Amazing first recording",
         }
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(invalid_pin_1),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
@@ -155,7 +154,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(invalid_pin_1),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
@@ -175,7 +174,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(invalid_pin_1),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
@@ -194,7 +193,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(invalid_pin_1),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
@@ -207,14 +206,14 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         """Tests that unpin endpoint returns 200 when successful"""
         # pin track before unpinning
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(self.pinned_rec_samples[0]),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
         )
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.unpin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.unpin_recording_for_user"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
         )
@@ -225,7 +224,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_unpin_no_pin_found(self):
         """Tests that unpin endpoint returns 404 when no pinned is found to unpin"""
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.unpin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.unpin_recording_for_user"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
         )
@@ -236,7 +235,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_unpin_unauthorized(self):
         """Tests that unpin endpoint returns 401 when auth token is invalid"""
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.unpin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.unpin_recording_for_user"),
             headers={"Authorization": "Token {}".format("-- This is an invalid auth token --")},
             content_type="application/json",
         )
@@ -248,7 +247,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         """Tests that unpin endpoint returns 200 when successful"""
         # pin track before deleting
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(self.pinned_rec_samples[0]),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
@@ -257,7 +256,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         pin_to_delete = db_pinned_rec.get_current_pin_for_user(self.user["id"])
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=pin_to_delete.row_id),
+            self.custom_url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=pin_to_delete.row_id),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
         )
 
@@ -268,7 +267,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         """Tests that delete endpoint returns 401 when auth token is invalid"""
         # pin track for user1
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(self.pinned_rec_samples[0]),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
@@ -278,7 +277,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         pin_to_delete = db_pinned_rec.get_current_pin_for_user(self.user["id"])
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=pin_to_delete.row_id),
+            self.custom_url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=pin_to_delete.row_id),
             headers={"Authorization": "Token {}".format("-- This is an invalid auth token --")},
         )
         self.assert401(response)
@@ -287,26 +286,28 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_delete_no_row_id_found(self):
         """Tests that delete endpoint returns 404 when no pin with row_id is found to delete"""
         self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(self.pinned_rec_samples[0]),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json",
         )
 
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=98764),
+            self.custom_url_for("pinned_rec_api_bp_v1.delete_pin_for_user", row_id=98764),
             headers={"Authorization": "Token {}".format(self.followed_user_1["auth_token"])},
         )
 
         self.assert404(response)
         self.assertEqual(response.json["code"], 404)
 
-    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items', fetch_track_metadata_for_pins)
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items',
+           fetch_track_metadata_for_pins)
     def test_get_pins_for_user(self):
         """Test that valid response is received with 200 code"""
 
         count = self.insert_test_data(self.user["id"], 2)  # pin 2 recordings
-        response = self.client.get(url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"]))
+        response = self.client.get(
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"]))
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -328,17 +329,20 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assertEqual(pins[1]["recording_mbid"], self.pinned_rec_samples[0]["recording_mbid"])
         self.assertEqual(pins[1]["blurb_content"], self.pinned_rec_samples[0]["blurb_content"])
 
-    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items', fetch_track_metadata_for_pins)
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items',
+           fetch_track_metadata_for_pins)
     def test_get_current_pin_for_user(self):
         """Test that valid response is received with 200 code"""
-        response = self.client.get(url_for("pinned_rec_api_bp_v1.get_current_pin_for_user", user_name=self.user["musicbrainz_id"]))
+        response = self.client.get(
+            self.custom_url_for("pinned_rec_api_bp_v1.get_current_pin_for_user", user_name=self.user["musicbrainz_id"]))
         self.assert200(response)
         data = json.loads(response.data)
         self.assertEqual(data["pinned_recording"], None)
         self.assertEqual(data["user_name"], self.user["musicbrainz_id"])
 
         self.insert_test_data(self.user["id"], 2)  # pin 2 recordings
-        response = self.client.get(url_for("pinned_rec_api_bp_v1.get_current_pin_for_user", user_name=self.user["musicbrainz_id"]))
+        response = self.client.get(
+            self.custom_url_for("pinned_rec_api_bp_v1.get_current_pin_for_user", user_name=self.user["musicbrainz_id"]))
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -350,18 +354,21 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_get_pins_for_user_invalid_username(self):
         """Tests that endpoint returns 404 when no user with given user_name is found"""
         self.insert_test_data(self.user["id"])  # pin 4 recordings for user
-        response = self.client.get(url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=" -- invalid username -- "))
+        response = self.client.get(
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=" -- invalid username -- "))
 
         self.assert404(response)
         self.assertEqual(response.json["code"], 404)
 
-    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items', fetch_track_metadata_for_pins)
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items',
+           fetch_track_metadata_for_pins)
     def test_get_pins_for_user_count_param(self):
         """Tests that valid response is received honoring count parameter"""
         limit = 2
         pinned_count = self.insert_test_data(self.user["id"])  # pin 4 recordings
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], count=limit)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                                count=limit)
         )
         data = json.loads(response.data)
         pins = data["pinned_recordings"]
@@ -376,7 +383,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         # double check with different limit
         limit = 3
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], count=limit)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                                count=limit)
         )
         data = json.loads(response.data)
 
@@ -388,25 +396,29 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # test with string
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], count="-- invalid count --")
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                                count="-- invalid count --")
         )
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
         # test with negative integer
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], count=-1)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                                count=-1)
         )
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
-    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items', fetch_track_metadata_for_pins)
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items',
+           fetch_track_metadata_for_pins)
     def test_get_pins_for_user_offset_param(self):
         """Tests that valid response is received honoring offset parameter"""
         offset = 2
         pinned_count = self.insert_test_data(self.user["id"])  # pin 4 recordings
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], offset=offset)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                                offset=offset)
         )
         data = json.loads(response.data)
         pins = data["pinned_recordings"]
@@ -421,7 +433,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         # double check with different limit
         offset = 3
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], offset=offset)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                                offset=offset)
         )
         data = json.loads(response.data)
 
@@ -433,8 +446,9 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # test with string
         response = self.client.get(
-            url_for(
-                "pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], offset="-- invalid offset --"
+            self.custom_url_for(
+                "pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                offset="-- invalid offset --"
             )
         )
         self.assert400(response)
@@ -442,12 +456,14 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # test with negative integer
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"], offset=-1)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user", user_name=self.user["musicbrainz_id"],
+                                offset=-1)
         )
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
-    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items', fetch_track_metadata_for_pins)
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items',
+           fetch_track_metadata_for_pins)
     def test_get_pins_for_user_following(self):
         """Test that valid response is received with 200 code"""
         # user follows followed_user_1 and followed_user_2
@@ -458,7 +474,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         pin2 = self.pin_single_sample(self.followed_user_2["id"], 1)  # pin recording for followed_user_2
 
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user_following", user_name=self.user["musicbrainz_id"])
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user_following",
+                                user_name=self.user["musicbrainz_id"])
         )
         self.assert200(response)
         data = json.loads(response.data)
@@ -483,12 +500,14 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_get_pins_for_user_following_invalid_username(self):
         """Tests that endpoint returns 404 when no user with given user_name is found"""
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user_following", user_name=" -- invalid username -- ")
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user_following",
+                                user_name=" -- invalid username -- ")
         )
         self.assert404(response)
         self.assertEqual(response.json["code"], 404)
 
-    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items', fetch_track_metadata_for_pins)
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items',
+           fetch_track_metadata_for_pins)
     def test_get_pins_for_user_count_param_2(self):
         """Tests that valid response is received honoring count parameter"""
         # user follows followed_user_1 and followed_user_2
@@ -500,7 +519,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         limit = 1
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user_following", user_name=self.user["musicbrainz_id"], count=limit)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user_following",
+                                user_name=self.user["musicbrainz_id"], count=limit)
         )
         data = json.loads(response.data)
         pins = data["pinned_recordings"]
@@ -509,7 +529,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assertEqual(data["count"], 2 - limit)
 
         # check that only the latest pin was included in returned json
-        self.assertEqual(pins[0]["recording_msid"], included_pin.recording_msid)  # included_pin was pinned most recently
+        self.assertEqual(pins[0]["recording_msid"],
+                         included_pin.recording_msid)  # included_pin was pinned most recently
         self.assertEqual(pins[0]["recording_mbid"], included_pin.recording_mbid)
         self.assertEqual(pins[0]["blurb_content"], included_pin.blurb_content)
         self.assertEqual(pins[0]["user_name"], self.followed_user_2["musicbrainz_id"])
@@ -519,7 +540,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # test with string
         response = self.client.get(
-            url_for(
+            self.custom_url_for(
                 "pinned_rec_api_bp_v1.get_pins_for_user_following",
                 user_name=self.user["musicbrainz_id"],
                 count="-- invalid count --",
@@ -530,12 +551,14 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # test with negative integer
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user_following", user_name=self.user["musicbrainz_id"], count=-1)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user_following",
+                                user_name=self.user["musicbrainz_id"], count=-1)
         )
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)
 
-    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items', fetch_track_metadata_for_pins)
+    @patch('listenbrainz.webserver.views.pinned_recording_api.fetch_track_metadata_for_items',
+           fetch_track_metadata_for_pins)
     def test_get_pins_for_user_following_offset_param(self):
         """Tests that valid response is received honoring offset parameter"""
         # user follows followed_user_1 and followed_user_2
@@ -547,7 +570,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         offset = 1
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user_following", user_name=self.user["musicbrainz_id"], offset=offset)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user_following",
+                                user_name=self.user["musicbrainz_id"], offset=offset)
         )
         data = json.loads(response.data)
         pins = data["pinned_recordings"]
@@ -556,7 +580,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
         self.assertEqual(data["count"], 2 - offset)
 
         # check that only the older pin was included in returned JSON
-        self.assertEqual(pins[0]["recording_msid"], included_pin.recording_msid)  # included_pin was pinned most recently
+        self.assertEqual(pins[0]["recording_msid"],
+                         included_pin.recording_msid)  # included_pin was pinned most recently
         self.assertEqual(pins[0]["recording_mbid"], included_pin.recording_mbid)
         self.assertEqual(pins[0]["blurb_content"], included_pin.blurb_content)
         self.assertEqual(pins[0]["user_name"], self.followed_user_1["musicbrainz_id"])
@@ -566,7 +591,7 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # test with string
         response = self.client.get(
-            url_for(
+            self.custom_url_for(
                 "pinned_rec_api_bp_v1.get_pins_for_user_following",
                 user_name=self.user["musicbrainz_id"],
                 offset="-- invalid offset --",
@@ -577,7 +602,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
         # test with negative integer
         response = self.client.get(
-            url_for("pinned_rec_api_bp_v1.get_pins_for_user_following", user_name=self.user["musicbrainz_id"], offset=-1)
+            self.custom_url_for("pinned_rec_api_bp_v1.get_pins_for_user_following",
+                                user_name=self.user["musicbrainz_id"], offset=-1)
         )
         self.assert400(response)
         self.assertEqual(response.json["code"], 400)

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -4,8 +4,6 @@ from uuid import UUID
 
 import dateutil.parser
 import requests_mock
-from flask import url_for, current_app
-from redis import Redis
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.domain.spotify import OAUTH_TOKEN_URL
@@ -52,11 +50,6 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.user3 = db_user.get_or_create(3, "troi-bot")
         self.user4 = db_user.get_or_create(4, "iloveassgaskets")
 
-    def tearDown(self):
-        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
-        r.flushall()
-        super(PlaylistAPITestCase, self).tearDown()
-
     def test_filter_description(self):
         """Check that non-approved html tags are filtered from descriptions"""
 
@@ -87,7 +80,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist = get_test_data()
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -102,7 +95,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Test to ensure fetching a playlist works
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
@@ -125,7 +118,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist["playlist"]["created_for"] = self.user["musicbrainz_id"]
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user3["auth_token"])}
         )
@@ -133,7 +126,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
@@ -147,7 +140,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         # (a user must be part of config. APPROVED_PLAYLIST_BOTS to be able to create playlists
         # on behalf of someone else)
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -157,7 +150,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         """ Test to ensure fetching a non existent playlist gives 404 """
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid="0ebcde36-1b14-4be5-ad3e-a088caf69134", fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid="0ebcde36-1b14-4be5-ad3e-a088caf69134", fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert404(response)
@@ -169,7 +162,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["public"] = False
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -181,7 +174,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Test to ensure fetching a private playlist from a non-owner fails with 404
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
         self.assert404(response)
@@ -201,7 +194,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -234,14 +227,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
                 }
             }
         response_post = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response_post)
         playlist_mbid = response_post.json["playlist_mbid"]
         r = self.client.get(
-            url_for("playlist_api_v1.get_playlist_xspf", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.get_playlist_xspf", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(r)
@@ -266,7 +259,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -286,7 +279,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -312,7 +305,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -338,7 +331,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -364,7 +357,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -383,7 +376,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
                                                                                       self.user2["musicbrainz_id"]]
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -394,7 +387,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
         )
         self.assert200(response)
         self.assertEqual(response.json["playlist"]["extension"]
@@ -402,7 +395,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Check that this playlist shows up on the collaborators endpoint
         response = self.client.get(
-            url_for("api_v1.get_playlists_collaborated_on_for_user", playlist_user_name=self.user2["musicbrainz_id"]),
+            self.custom_url_for("api_v1.get_playlists_collaborated_on_for_user", playlist_user_name=self.user2["musicbrainz_id"]),
             headers={"Authorization": "Token {}".format(self.user4["auth_token"])},
         )
         self.assert200(response)
@@ -418,7 +411,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist = get_test_data()
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -431,7 +424,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         # Test to ensure posting a playlist works
         # Owner is in collaborators, should be filtered out
         response = self.client.post(
-            url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
             json={"playlist": {"title": "new title",
                                "annotation": "new <b>desc</b> <script>noscript</script>",
                                "extension": {PLAYLIST_EXTENSION_URI: {"public": False,
@@ -444,7 +437,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assert200(response)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
 
@@ -458,7 +451,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Edit again to remove description and collaborators
         response = self.client.post(
-            url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
             json={"playlist": {"annotation": "",
                                "extension": {PLAYLIST_EXTENSION_URI: {
                                    "collaborators": []}}}},
@@ -466,7 +459,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         )
         self.assert200(response)
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
 
@@ -482,7 +475,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist = get_test_data()
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -505,14 +498,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
             }
         }
         response = self.client.post(
-            url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             json=add_recording
         )
         self.assert200(response)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assertEqual(response.json["playlist"]["creator"], "testuserpleaseignore")
@@ -533,7 +526,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
             }
         }
         response = self.client.post(
-            url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             json=add_recording
         )
@@ -561,7 +554,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -570,14 +563,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         move = {"mbid": "57ef4803-5181-4b3d-8dd6-8b9d9ca83e2a", "from": 1, "to": 0, "count": 1}
         response = self.client.post(
-            url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             json=move
         )
         self.assert200(response)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assertEqual(response.json["playlist"]["creator"], "testuserpleaseignore")
@@ -608,7 +601,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -617,14 +610,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         move = {"index": 0, "count": 1}
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             json=move
         )
         self.assert200(response)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assertEqual(response.json["playlist"]["creator"], "testuserpleaseignore")
@@ -646,7 +639,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -654,14 +647,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert404(response)
@@ -682,7 +675,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -690,7 +683,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.post(
-            url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -699,7 +692,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertNotEqual(playlist_mbid, new_playlist_mbid)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=new_playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=new_playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
@@ -717,14 +710,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Now delete the original playlist so that we can test copied from deleted playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=new_playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=new_playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
@@ -744,7 +737,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -752,7 +745,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.post(
-            url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -761,7 +754,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertNotEqual(playlist_mbid, new_playlist_mbid)
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=new_playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=new_playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
@@ -776,7 +769,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist = get_test_data()
         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["public"] = False
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -784,14 +777,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])},
         )
         self.assert404(response)
 
         # Add recording to playlist
         response = self.client.post(
-            url_for("playlist_api_v1.add_playlist_item", offset=0, playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.add_playlist_item", offset=0, playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -799,7 +792,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Move recording in playlist
         response = self.client.post(
-            url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -807,7 +800,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Delete recording in playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -815,7 +808,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Delete a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -823,7 +816,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Copy a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -838,7 +831,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["public"] = False
         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["collaborators"] = [self.user2["musicbrainz_id"]]
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -847,7 +840,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Get playlist
         response = self.client.get(
-            url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])},
         )
         self.assert200(response)
@@ -868,7 +861,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
             }
         }
         response = self.client.post(
-            url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.add_playlist_item", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])},
             json=add_recording
         )
@@ -877,7 +870,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         # Move recording in playlist
         move = {"mbid": "57ef4803-5181-4b3d-8dd6-8b9d9ca83e2a", "from": 1, "to": 0, "count": 1}
         response = self.client.post(
-            url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])},
             json=move
         )
@@ -886,7 +879,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         # Delete recording in playlist
         delete = {"index": 0, "count": 1}
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
             json=delete,
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -894,7 +887,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Copy a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -905,7 +898,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         # Collaborators are not authorized to edit or delete the playlist
         # Delete a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -913,7 +906,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Edit a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -926,7 +919,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist = get_test_data()
         playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["public"] = False
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user4["auth_token"])}
         )
@@ -935,7 +928,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         playlist = get_test_data()
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user4["auth_token"])}
         )
@@ -943,14 +936,14 @@ class PlaylistAPITestCase(IntegrationTestCase):
         public_playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.get(
-            url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"]),
+            self.custom_url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"]),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
         )
         self.assert200(response)
         self.assertEqual(response.json["playlist_count"], 1)
 
         response = self.client.get(
-            url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"]),
+            self.custom_url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"]),
             headers={"Authorization": "Token {}".format(self.user4["auth_token"])},
         )
         self.assert200(response)
@@ -982,7 +975,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Test count and offset parameters
         response = self.client.get(
-            url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"], count=1),
+            self.custom_url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"], count=1),
             headers={"Authorization": "Token {}".format(self.user4["auth_token"])},
         )
         self.assert200(response)
@@ -992,7 +985,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["offset"], 0)
 
         response = self.client.get(
-            url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"], offset=1, count=1),
+            self.custom_url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user4["musicbrainz_id"], offset=1, count=1),
             headers={"Authorization": "Token {}".format(self.user4["auth_token"])},
         )
         self.assert200(response)
@@ -1005,7 +998,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         """ Test for checking that unauthorized access return 401 """
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json={}
         )
         self.assert401(response)
@@ -1013,48 +1006,48 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = "d1ff6a3d-f471-416f-94e7-86778b51fa2b"
         # Add recording to playlist
         response = self.client.post(
-            url_for("playlist_api_v1.add_playlist_item", offset=0, playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.add_playlist_item", offset=0, playlist_mbid=playlist_mbid),
             json={}
         )
         self.assert401(response)
 
         # Move recording in playlist
         response = self.client.post(
-            url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
             json={}
         )
         self.assert401(response)
 
         # Delete recording in playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
             json={}
         )
         self.assert401(response)
 
         # Delete a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
             json={}
         )
         self.assert401(response)
 
         # Copy a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.copy_playlist", playlist_mbid=playlist_mbid),
             json={}
         )
         self.assert401(response)
 
         # Edit a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
             json={}
         )
         self.assert401(response)
 
         response = self.client.post(
-            url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
+            self.custom_url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
             json={}
         )
         self.assert401(response)
@@ -1074,7 +1067,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -1083,7 +1076,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Add recording to playlist
         response = self.client.post(
-            url_for("playlist_api_v1.add_playlist_item", offset=0, playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.add_playlist_item", offset=0, playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -1091,7 +1084,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Move recording in playlist
         response = self.client.post(
-            url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.move_playlist_item", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -1099,7 +1092,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Delete recording in playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist_item", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -1107,7 +1100,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Delete a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.delete_playlist", playlist_mbid=playlist_mbid),
             json={},
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -1115,7 +1108,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # edit a playlist
         response = self.client.post(
-            url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
+            self.custom_url_for("playlist_api_v1.edit_playlist", playlist_mbid=playlist_mbid),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
         )
@@ -1143,7 +1136,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("playlist_api_v1.create_playlist"),
+            self.custom_url_for("playlist_api_v1.create_playlist"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -1151,7 +1144,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         playlist_mbid = response.json["playlist_mbid"]
 
         response = self.client.post(
-            url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="lastfm"),
+            self.custom_url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="lastfm"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -1159,7 +1152,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["error"], "Service lastfm is not supported. We currently only support 'spotify'.")
 
         response = self.client.post(
-            url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
+            self.custom_url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -1177,7 +1170,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         )
 
         response = self.client.post(
-            url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
+            self.custom_url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
@@ -1213,7 +1206,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         mock_troi_bot.return_value = "foobar"
 
         response = self.client.post(
-            url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
+            self.custom_url_for("playlist_api_v1.export_playlist", playlist_mbid=playlist_mbid, service="spotify"),
             json=playlist,
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )

--- a/listenbrainz/tests/integration/test_recommendations_cf_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_api.py
@@ -1,7 +1,5 @@
 import json
 import uuid
-from flask import url_for, current_app
-from redis import Redis
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.recommendations_cf_recording as db_recommendations_cf_recording
@@ -39,28 +37,26 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         self.user_recommendations = db_recommendations_cf_recording.get_user_recommendation(self.user['id'])
         self.user2_recommendations = db_recommendations_cf_recording.get_user_recommendation(self.user2['id'])
 
-    def tearDown(self):
-        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
-        r.flushall()
-        super(CFRecommendationsViewsTestCase, self).tearDown()
-
     def test_invalid_user(self):
-        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations', user_name='invalid_user'))
+        response = self.client.get(
+            self.custom_url_for('recommendations_cf_recording_v1.get_recommendations', user_name='invalid_user'))
         self.assert404(response)
 
     def test_inactive_user(self):
-        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations',
-                                           user_name=self.user3['musicbrainz_id']), query_string={'artist_type': 'top'})
+        response = self.client.get(self.custom_url_for('recommendations_cf_recording_v1.get_recommendations',
+                                                       user_name=self.user3['musicbrainz_id']),
+                                   query_string={'artist_type': 'top'})
         self.assertEqual(response.status_code, 204)
 
     def test_recommendations_not_generated(self):
-        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations',
-                                           user_name=self.user2['musicbrainz_id']), query_string={'artist_type': 'top'})
+        response = self.client.get(self.custom_url_for('recommendations_cf_recording_v1.get_recommendations',
+                                                       user_name=self.user2['musicbrainz_id']),
+                                   query_string={'artist_type': 'top'})
         self.assertEqual(response.status_code, 204)
 
     def test_recommendations_without_count(self):
-        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations',
-                                           user_name=self.user['musicbrainz_id']))
+        response = self.client.get(self.custom_url_for('recommendations_cf_recording_v1.get_recommendations',
+                                                       user_name=self.user['musicbrainz_id']))
         self.assert200(response)
         data = json.loads(response.data)['payload']
 
@@ -89,8 +85,8 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         self.assertEqual(expected_raw_recommendations, received_raw_recommendations)
 
     def test_recommendations_with_count(self):
-        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations',
-                                           user_name=self.user['musicbrainz_id']),
+        response = self.client.get(self.custom_url_for('recommendations_cf_recording_v1.get_recommendations',
+                                                       user_name=self.user['musicbrainz_id']),
                                    query_string={'artist_type': 'top', 'count': 10})
         self.assert200(response)
         data = json.loads(response.data)['payload']
@@ -120,8 +116,8 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         self.assertEqual(expected_raw_recommendations, received_raw_recommendations)
 
     def test_recommendations_too_many(self):
-        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations',
-                                           user_name=self.user['musicbrainz_id']),
+        response = self.client.get(self.custom_url_for('recommendations_cf_recording_v1.get_recommendations',
+                                                       user_name=self.user['musicbrainz_id']),
                                    query_string={'artist_type': 'top', 'count': 1500, 'offset': 100})
         self.assert200(response)
         data = json.loads(response.data)['payload']
@@ -151,8 +147,8 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         self.assertEqual(expected_raw_recommendations, received_raw_recommendations)
 
     def test_recommendations_with_offset(self):
-        response = self.client.get(url_for('recommendations_cf_recording_v1.get_recommendations',
-                                           user_name=self.user['musicbrainz_id']),
+        response = self.client.get(self.custom_url_for('recommendations_cf_recording_v1.get_recommendations',
+                                                       user_name=self.user['musicbrainz_id']),
                                    query_string={'artist_type': 'top', 'offset': 10})
 
         self.assert200(response)

--- a/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
@@ -3,8 +3,6 @@ import uuid
 import listenbrainz.db.user as db_user
 import listenbrainz.db.recommendations_cf_recording_feedback as db_feedback
 
-from redis import Redis
-from flask import url_for, current_app
 from listenbrainz.db.model.recommendation_feedback import RecommendationFeedbackSubmit
 from listenbrainz.tests.integration import IntegrationTestCase
 
@@ -15,11 +13,6 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.user = db_user.get_or_create(1, "vansika")
         self.user1 = db_user.get_or_create(2, "vansika_1")
         self.user2 = db_user.get_or_create(3, "vansika_2")
-
-    def tearDown(self):
-        r = Redis(host=current_app.config['REDIS_HOST'], port=current_app.config['REDIS_PORT'])
-        r.flushall()
-        super(RecommendationFeedbackAPITestCase, self).tearDown()
 
     def insert_test_data(self):
         sample_feedback = [
@@ -54,7 +47,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -71,7 +64,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
         # request with no authorization header
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(feedback),
             content_type="application/json"
         )
@@ -80,7 +73,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
         # request with invalid authorization header
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token testtokenplsignore"},
             content_type="application/json"
@@ -97,7 +90,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(incomplete_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -111,7 +104,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(incomplete_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -123,7 +116,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         empty_feedback = {}
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(empty_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -140,7 +133,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -158,7 +151,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -172,7 +165,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -186,7 +179,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(invalid_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -203,7 +196,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -224,7 +217,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(updated_feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -247,7 +240,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.submit_recommendation_feedback"),
             data=json.dumps(feedback),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -262,7 +255,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(result[0].rating, feedback["rating"])
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
             data=json.dumps({
                 "recording_mbid": "7babc9be-ca2b-4544-b932-7c9ab38770d6",
             }),
@@ -284,7 +277,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
         # request with no authorization header
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
             data=json.dumps(del_rec),
             content_type="application/json"
         )
@@ -292,7 +285,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
         # request with invalid authorization header
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
             data=json.dumps(del_rec),
             headers={"Authorization": "Token testtokenplsignore"},
             content_type="application/json"
@@ -307,7 +300,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
             data=json.dumps(invalid_del_rec),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -318,7 +311,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         empty_del_rec = {}
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
             data=json.dumps(empty_del_rec),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -331,7 +324,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
             data=json.dumps(invalid_del_rec),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -346,7 +339,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         }
 
         response = self.client.post(
-            url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
+            self.custom_url_for("recommendation_feedback_api_v1.delete_recommendation_feedback"),
             data=json.dumps(invalid_del_rec),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},
             content_type="application/json"
@@ -357,7 +350,8 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
     def test_get_feedback_for_user(self):
         sample_feedback = self.insert_test_data()
 
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user", user_name=self.user1["musicbrainz_id"]))
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user1["musicbrainz_id"]))
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -381,14 +375,16 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_user_invalid_user(self):
         """ Test to make sure that the API sends 404 if user does not exist. """
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user", user_name="invalid"))
+        response = self.client.get(
+            self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user", user_name="invalid"))
         self.assert404(response)
 
     def test_get_feedback_for_user_with_rating_param(self):
         sample_feedback = self.insert_test_data()
 
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user1["musicbrainz_id"]), query_string={"rating": 'hate'})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user1["musicbrainz_id"]),
+                                   query_string={"rating": 'hate'})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -407,8 +403,9 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_user_with_invalid_rating_param(self):
         """ Test to make sure 400 response is received if rating argument is not valid """
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user1["musicbrainz_id"]), query_string={"rating": "invalid"})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user1["musicbrainz_id"]),
+                                   query_string={"rating": "invalid"})
         self.assert400(response)
 
     def test_get_feedback_for_user_for_count_and_offset(self):
@@ -434,8 +431,9 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
                 }
             )
         # check for count
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user2["musicbrainz_id"]), query_string={"count": 10})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user2["musicbrainz_id"]),
+                                   query_string={"count": 10})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -451,8 +449,9 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
             self.assertEqual(feedback[i]['rating'], feedback_love[i]['rating'])
 
         # check for offset
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user2["musicbrainz_id"]), query_string={"offset": 90})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user2["musicbrainz_id"]),
+                                   query_string={"offset": 90})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -464,11 +463,12 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         feedback = data["feedback"]  # sorted in descending order of their creation
         self.assertEqual(len(feedback), 20)
         for i in range(10):
-            self.assertEqual(feedback[i]['recording_mbid'], feedback_love[i+90]['recording_mbid'])
-            self.assertEqual(feedback[i]['rating'], feedback_love[i+90]['rating'])
+            self.assertEqual(feedback[i]['recording_mbid'], feedback_love[i + 90]['recording_mbid'])
+            self.assertEqual(feedback[i]['rating'], feedback_love[i + 90]['rating'])
         # check for feedback, too many
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user2["musicbrainz_id"]), query_string={"count": 110})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user2["musicbrainz_id"]),
+                                   query_string={"count": 110})
         self.assert200(response)
         data = json.loads(response.data)
 
@@ -487,26 +487,30 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         """ Test to make sure 400 response is received if count argument is not valid """
 
         # pass non-int value to count
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"count": "invalid_count"})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"count": "invalid_count"})
         self.assert400(response)
 
         # pass negative int value to count
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"count": -1})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"count": -1})
         self.assert400(response)
 
     def test_get_feedback_for_user_with_invalid_offset_param(self):
         """ Test to make sure 400 response is received if offset argument is not valid """
 
         # pass non-int value to offset
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"offset": "invalid_offset"})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"offset": "invalid_offset"})
         self.assert400(response)
 
         # pass negative int value to offset
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_user",
-                                   user_name=self.user["musicbrainz_id"]), query_string={"offset": -1})
+        response = self.client.get(self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_user",
+                                                       user_name=self.user["musicbrainz_id"]),
+                                   query_string={"offset": -1})
         self.assert400(response)
 
     def test_get_feedback_for_recordings_for_user(self):
@@ -516,9 +520,10 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         rec_mbid_1 = sample_feedback[0]["recording_mbid"]
         rec_mbid_2 = sample_feedback[1]["recording_mbid"]
 
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user1["musicbrainz_id"]),
-                                           query_string={"mbids": ""+rec_mbid_1+','+rec_mbid_2})
+        response = self.client.get(
+            self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
+                                user_name=self.user1["musicbrainz_id"]),
+            query_string={"mbids": "" + rec_mbid_1 + ',' + rec_mbid_2})
 
         self.assert200(response)
         data = json.loads(response.data)
@@ -537,32 +542,38 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
     def test_get_feedback_for_user_invalid_user(self):
         """ Test to make sure that the API sends 404 if user does not exist. """
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user", user_name="invalid"))
+        response = self.client.get(
+            self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
+                                user_name="invalid"))
         self.assert404(response)
 
     def test_get_feedback_for_recording_invalid_recording_mbid(self):
         """ Test to make sure that the API sends 404 if recording_msid is invalid. """
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user1["musicbrainz_id"]),
-                                           query_string={"mbids":"invalid_recording_mbid"})
+        response = self.client.get(
+            self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
+                                user_name=self.user1["musicbrainz_id"]),
+            query_string={"mbids": "invalid_recording_mbid"})
         self.assert400(response)
 
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user1["musicbrainz_id"]),
-                                           query_string={"mbids":" "})
+        response = self.client.get(
+            self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
+                                user_name=self.user1["musicbrainz_id"]),
+            query_string={"mbids": " "})
         self.assert400(response)
 
     def test_get_feedback_for_recording_missing_mbid_args(self):
         """ Test to make sure that the API sends 404 if recording_msid is invalid. """
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user1["musicbrainz_id"]))
+        response = self.client.get(
+            self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
+                                user_name=self.user1["musicbrainz_id"]))
         self.assert400(response)
 
     def test_get_feedback_for_recording_empty_response(self):
         """ Test to make sure that the API return empty list if user hasn't rated a recording """
-        response = self.client.get(url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
-                                           user_name=self.user1["musicbrainz_id"]),
-                                           query_string={"mbids":"222eb00d-9ead-42de-aec9-8f8c15094130"})
+        response = self.client.get(
+            self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",
+                                user_name=self.user1["musicbrainz_id"]),
+            query_string={"mbids": "222eb00d-9ead-42de-aec9-8f8c15094130"})
         self.assert200(response)
         data = json.loads(response.data)
 

--- a/listenbrainz/tests/integration/test_settings_views.py
+++ b/listenbrainz/tests/integration/test_settings_views.py
@@ -2,7 +2,6 @@ import json
 import time
 
 from brainzutils import cache
-from flask import url_for, g
 
 import listenbrainz.db.user as db_user
 from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT
@@ -18,14 +17,15 @@ class SettingsViewsTestCase(IntegrationTestCase):
         self.redis = cache._r
 
     def tearDown(self):
-        self.redis.flushall()
+        with self.app.app_context():
+            self.redis.flushall()
         super(SettingsViewsTestCase, self).tearDown()
 
     def send_listens(self):
         with open(self.path_to_data_file('user_export_test.json')) as f:
             payload = json.load(f)
         response = self.client.post(
-            url_for('api_v1.submit_listen'),
+            self.custom_url_for('api_v1.submit_listen'),
             data=json.dumps(payload),
             headers={'Authorization': 'Token {}'.format(self.user['auth_token'])},
             content_type='application/json'
@@ -40,7 +40,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
         """
         # test get requests to export view first
         self.temporary_login(self.user['login_id'])
-        resp = self.client.get(url_for('settings.index', path='export'))
+        resp = self.client.get(self.custom_url_for('settings.index', path='export'))
         self.assert200(resp)
 
         # send three listens for the user
@@ -48,7 +48,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
         self.assert200(resp)
 
         # now export data and check if contains all the listens we just sent
-        resp = self.client.post(url_for('settings.export_data'))
+        resp = self.client.post(self.custom_url_for('settings.export_data'))
         self.assert200(resp)
         data = json.loads(resp.data)
         self.assertEqual(len(data), 3)
@@ -57,7 +57,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
         resp = self.send_listens()
         self.assert200(resp)
 
-        r = self.client.get(url_for('user.profile', user_name=self.user['musicbrainz_id']))
+        r = self.client.get(self.custom_url_for('user.profile', user_name=self.user['musicbrainz_id']))
         self.assert200(r)
         props = json.loads(self.get_context_variable('props'))
         self.assertEqual(props['latest_listen_ts'], 1618500200)
@@ -68,7 +68,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
         """
         # test get requests to delete-listens view first
         self.temporary_login(self.user['login_id'])
-        resp = self.client.get(url_for('settings.index', path='delete-listens'))
+        resp = self.client.get(self.custom_url_for('settings.index', path='delete-listens'))
         self.assert200(resp)
 
         # send three listens for the user
@@ -79,37 +79,37 @@ class SettingsViewsTestCase(IntegrationTestCase):
         # reset later
         val = int(time.time())
         resp = self.client.post(
-            url_for('api_v1.latest_import'),
+            self.custom_url_for('api_v1.latest_import'),
             data=json.dumps({'ts': val}),
             headers={'Authorization': 'Token {}'.format(self.user['auth_token'])},
             content_type='application/json',
         )
         self.assert200(resp)
-        resp = self.client.get(url_for('api_v1.latest_import', user_name=self.user['musicbrainz_id']))
+        resp = self.client.get(self.custom_url_for('api_v1.latest_import', user_name=self.user['musicbrainz_id']))
         self.assert200(resp)
         self.assertEqual(resp.json['latest_import'], val)
 
         self.assertNotEqual(self.redis.ttl(cache._prep_key(REDIS_USER_LISTEN_COUNT + str(self.user['id']))), 0)
 
         # check that listens have been successfully submitted
-        resp = self.client.get(url_for('api_v1.get_listen_count', user_name=self.user['musicbrainz_id']))
+        resp = self.client.get(self.custom_url_for('api_v1.get_listen_count', user_name=self.user['musicbrainz_id']))
         self.assert200(resp)
         self.assertEqual(json.loads(resp.data)['payload']['count'], 3)
 
         # now delete all the listens we just sent
-        self.client.get(url_for('settings.index', path='delete-listens'))
-        resp = self.client.post(url_for('settings.delete_listens'))
+        self.client.get(self.custom_url_for('settings.index', path='delete-listens'))
+        resp = self.client.post(self.custom_url_for('settings.delete_listens'))
         self.assertEqual(resp.status_code, 200)
 
         # listen counts are cached for 5 min, so delete key otherwise cached will be returned
         cache.delete(REDIS_USER_LISTEN_COUNT + str(self.user['id']))
 
         # check that listens have been successfully deleted
-        resp = self.client.get(url_for('api_v1.get_listen_count', user_name=self.user['musicbrainz_id']))
+        resp = self.client.get(self.custom_url_for('api_v1.get_listen_count', user_name=self.user['musicbrainz_id']))
         self.assert200(resp)
         self.assertEqual(json.loads(resp.data)['payload']['count'], 0)
 
         # check that the latest_import timestamp has been reset too
-        resp = self.client.get(url_for('api_v1.latest_import', user_name=self.user['musicbrainz_id']))
+        resp = self.client.get(self.custom_url_for('api_v1.latest_import', user_name=self.user['musicbrainz_id']))
         self.assert200(resp)
         self.assertEqual(resp.json['latest_import'], 0)

--- a/listenbrainz/tests/integration/test_spotify_read_listens.py
+++ b/listenbrainz/tests/integration/test_spotify_read_listens.py
@@ -1,8 +1,10 @@
 import json
 import time
 
-from flask import url_for
 from unittest.mock import patch
+
+from flask import url_for
+from flask.testing import FlaskClient
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
@@ -15,12 +17,19 @@ class SpotifyReaderTestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(SpotifyReaderTestCase, self).setUp()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
+
         external_service_oauth.save_token(user_id=self.user['id'],
                                           service=ExternalServiceType.SPOTIFY,
                                           access_token='token', refresh_token='refresh',
                                           token_expires_ts=int(time.time()) + 3000,
                                           record_listens=True,
                                           scopes=['user-read-recently-played'])
+
+    def tearDown(self):
+        self.ctx.pop()
+        super(SpotifyReaderTestCase, self).tearDown()
 
     @patch('listenbrainz.spotify_updater.spotify_read_listens.get_user_currently_playing')
     @patch('listenbrainz.spotify_updater.spotify_read_listens.get_user_recently_played')

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from random import randint
 
 from listenbrainz.db.testing import TimescaleTestCase
-from brainzutils import cache
-from flask import url_for
 
 import listenbrainz.db.user as db_user
 from listenbrainz.listen import Listen
@@ -23,17 +21,17 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         self.rs = redis_connection._redis
 
     def tearDown(self):
-        super(TimescaleWriterTestCase, self).tearDown()
-        cache._r.flushall()
+        IntegrationTestCase.tearDown(self)
+        TimescaleTestCase.tearDown(self)
 
     def send_listen(self, user, filename):
         with open(self.path_to_data_file(filename)) as f:
             payload = json.load(f)
         response = self.client.post(
-            url_for('api_v1.submit_listen'),
-            data = json.dumps(payload),
-            headers = {'Authorization': 'Token {}'.format(user['auth_token'])},
-            content_type = 'application/json'
+            self.custom_url_for('api_v1.submit_listen'),
+            data=json.dumps(payload),
+            headers={'Authorization': 'Token {}'.format(user['auth_token'])},
+            content_type='application/json'
         )
         time.sleep(1)  # sleep to allow timescale-writer to do its thing
         recalculate_all_user_data()

--- a/listenbrainz/tests/integration/test_user_settings_api.py
+++ b/listenbrainz/tests/integration/test_user_settings_api.py
@@ -1,7 +1,6 @@
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from listenbrainz.db import user as db_user
 from listenbrainz.db import user_setting as db_user_setting
-from flask import url_for
 
 
 class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
@@ -12,21 +11,21 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_validates_auth_header(self):
         """ Test the preferences endpoints validate auth header """
-        response = self.client.post(url_for("user_settings_api_v1.reset_timezone"), json={})
+        response = self.client.post(self.custom_url_for("user_settings_api_v1.reset_timezone"), json={})
         self.assert401(response)
 
-        response = self.client.post(url_for("user_settings_api_v1.update_troi_prefs"), json={})
+        response = self.client.post(self.custom_url_for("user_settings_api_v1.update_troi_prefs"), json={})
         self.assert401(response)
 
         response = self.client.post(
-            url_for("user_settings_api_v1.reset_timezone"),
+            self.custom_url_for("user_settings_api_v1.reset_timezone"),
             json={},
             headers={"Authorization": "Token invalid"}
         )
         self.assert401(response)
 
         response = self.client.post(
-            url_for("user_settings_api_v1.update_troi_prefs"),
+            self.custom_url_for("user_settings_api_v1.update_troi_prefs"),
             json={},
             headers={"Authorization": "Token invalid"}
         )
@@ -34,7 +33,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_invalid_update_timezone(self):
         response = self.client.post(
-            url_for("user_settings_api_v1.reset_timezone"),
+            self.custom_url_for("user_settings_api_v1.reset_timezone"),
             json={},
             headers={"Authorization": f"Token {self.user['auth_token']}"}
         )
@@ -42,7 +41,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json["error"], "JSON document must contain zonename")
 
         response = self.client.post(
-            url_for("user_settings_api_v1.reset_timezone"),
+            self.custom_url_for("user_settings_api_v1.reset_timezone"),
             json={"zonename": "invalid time zone"},
             headers={"Authorization": f"Token {self.user['auth_token']}"}
         )
@@ -54,7 +53,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(tz["timezone_name"], "UTC")
 
         response = self.client.post(
-            url_for("user_settings_api_v1.reset_timezone"),
+            self.custom_url_for("user_settings_api_v1.reset_timezone"),
             json={"zonename": "Europe/Madrid"},
             headers={"Authorization": f"Token {self.user['auth_token']}"}
         )
@@ -65,7 +64,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_invalid_troi_prefs(self):
         response = self.client.post(
-            url_for("user_settings_api_v1.update_troi_prefs"),
+            self.custom_url_for("user_settings_api_v1.update_troi_prefs"),
             json={},
             headers={"Authorization": f"Token {self.user['auth_token']}"}
         )
@@ -73,7 +72,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json["error"], "JSON document must contain export_to_spotify key")
 
         response = self.client.post(
-            url_for("user_settings_api_v1.update_troi_prefs"),
+            self.custom_url_for("user_settings_api_v1.update_troi_prefs"),
             json={"export_to_spotify": "on"},
             headers={"Authorization": f"Token {self.user['auth_token']}"}
         )
@@ -85,7 +84,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(prefs, None)
 
         response = self.client.post(
-            url_for("user_settings_api_v1.update_troi_prefs"),
+            self.custom_url_for("user_settings_api_v1.update_troi_prefs"),
             json={"export_to_spotify": True},
             headers={"Authorization": f"Token {self.user['auth_token']}"}
         )

--- a/listenbrainz/webserver/test/test_routes.py
+++ b/listenbrainz/webserver/test/test_routes.py
@@ -1,5 +1,3 @@
-import flask
-
 from listenbrainz.webserver import API_PREFIX
 from listenbrainz.webserver.testing import ServerTestCase
 
@@ -17,7 +15,7 @@ class RoutesTestCase(ServerTestCase):
         # Specific endpoint for deleting accounts from musicbrainz-server (MBS-9680)
         ignored_endpoints = {'index.mb_user_deleter'}
 
-        for rule in flask.current_app.url_map.iter_rules():
+        for rule in self.app.url_map.iter_rules():
             if not rule.rule.startswith(ignored_prefixes) and rule.endpoint not in ignored_endpoints:
                 if not rule.rule.endswith('/'):
                     self.fail(f"Rule doesn't end with a trailing slash: {rule.rule} ({rule.endpoint})")

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -35,6 +35,11 @@ class ServerTestCase(unittest.TestCase):
         cls.app = cls.create_app()
         cls.client = cls.app.test_client()
 
+        server_name = cls.app.config.get("SERVER_NAME")
+        if server_name is None:
+            server_name = "localhost"
+        cls.url_adapter = cls.app.url_map.bind(server_name)
+
         template_rendered.connect(cls._set_template)
         message_flashed.connect(cls._add_flash_message)
 
@@ -42,9 +47,6 @@ class ServerTestCase(unittest.TestCase):
         cls.flashed_messages = []
 
     def setUp(self) -> None:
-        self._ctx = self.app.test_request_context()
-        self._ctx.push()
-
         ServerTestCase.template = None
         ServerTestCase.flashed_messages = []
 
@@ -57,8 +59,6 @@ class ServerTestCase(unittest.TestCase):
         cls.template = (template, context)
 
     def tearDown(self):
-        self._ctx.pop()
-        del self._ctx
         del ServerTestCase.template
         del ServerTestCase.flashed_messages
 
@@ -68,6 +68,14 @@ class ServerTestCase(unittest.TestCase):
         message_flashed.disconnect(cls._add_flash_message)
         del cls.client
         del cls.app
+
+    def custom_url_for(self, endpoint, **values):
+        """ A custom version of Flask's url_for() that does not require an active app context.
+
+            Note that this function is not on feature parity with Flask's url_for() and only supports the
+            basic use cases we have.
+        """
+        return self.url_adapter.build(endpoint, values)
 
     def assertMessageFlashed(self, message, category='message'):
         """

--- a/listenbrainz/webserver/views/test/test_art.py
+++ b/listenbrainz/webserver/views/test/test_art.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
 
-from flask import url_for
-
 from data.model.user_artist_stat import ArtistRecord
 from data.model.user_release_stat import ReleaseRecord
 from listenbrainz.art.cover_art_generator import CoverArtGenerator
@@ -11,7 +9,7 @@ from listenbrainz.tests.integration import IntegrationTestCase
 class ArtViewsTestCase(IntegrationTestCase):
 
     def test_index(self):
-        resp = self.client.get(url_for('art.index'))
+        resp = self.client.get(self.custom_url_for('art.index'))
         self.assert200(resp)
 
     @patch.object(CoverArtGenerator, "load_caa_ids")
@@ -36,12 +34,12 @@ class ArtViewsTestCase(IntegrationTestCase):
             }
         }
         resp = self.client.get(
-            url_for('art_api_v1.cover_art_grid_stats',
-                    user_name="rob",
-                    time_range="week",
-                    dimension=4,
-                    layout=0,
-                    image_size=500))
+            self.custom_url_for('art_api_v1.cover_art_grid_stats',
+                                user_name="rob",
+                                time_range="week",
+                                dimension=4,
+                                layout=0,
+                                image_size=500))
         self.assert200(resp)
         self.assertTrue(resp.text.startswith("<svg"))
 
@@ -55,11 +53,11 @@ class ArtViewsTestCase(IntegrationTestCase):
             for _ in range(5)
         ], 5
         resp = self.client.get(
-            url_for('art_api_v1.cover_art_custom_stats',
-                    custom_name="designer-top-5",
-                    user_name="rob",
-                    time_range="week",
-                    image_size=500))
+            self.custom_url_for('art_api_v1.cover_art_custom_stats',
+                                custom_name="designer-top-5",
+                                user_name="rob",
+                                time_range="week",
+                                image_size=500))
         self.assert200(resp)
         self.assertTrue(resp.text.startswith("<svg"))
         self.assertNotEqual(resp.text.find("ROB"), -1)
@@ -87,11 +85,11 @@ class ArtViewsTestCase(IntegrationTestCase):
             }
         }
         resp = self.client.get(
-            url_for('art_api_v1.cover_art_custom_stats',
-                    custom_name="designer-top-10",
-                    user_name="rob",
-                    time_range="week",
-                    image_size=500))
+            self.custom_url_for('art_api_v1.cover_art_custom_stats',
+                                custom_name="designer-top-10",
+                                user_name="rob",
+                                time_range="week",
+                                image_size=500))
         self.assert200(resp)
         self.assertTrue(resp.text.startswith("<svg"))
         self.assertNotEqual(resp.text.find("ROB"), -1)
@@ -159,7 +157,8 @@ class ArtViewsTestCase(IntegrationTestCase):
                 "artist": None
             }
         }
-        resp = self.client.post(url_for('art_api_v1.cover_art_grid_post'), data=post_json, content_type="application/json")
+        resp = self.client.post(self.custom_url_for('art_api_v1.cover_art_grid_post'), data=post_json,
+                                content_type="application/json")
         self.assert200(resp)
         self.assertTrue(resp.text.startswith("<svg"))
         self.assertNotEqual(resp.text.find("2273480607"), -1)

--- a/listenbrainz/webserver/views/test/test_explore.py
+++ b/listenbrainz/webserver/views/test/test_explore.py
@@ -1,8 +1,5 @@
 import datetime
 from unittest.mock import patch
-import json
-
-from flask import url_for
 
 from listenbrainz.tests.integration import IntegrationTestCase
 
@@ -10,39 +7,39 @@ from listenbrainz.tests.integration import IntegrationTestCase
 class ExploreViewsTestCase(IntegrationTestCase):
 
     def test_hue_sound(self):
-        resp = self.client.get(url_for('explore.huesound', color="FF00FF"))
+        resp = self.client.get(self.custom_url_for('explore.huesound', color="FF00FF"))
         self.assert200(resp)
 
     def test_hue_sound_redirect(self):
-        resp = self.client.get(url_for('index.huesound', color="FF00FF"))
+        resp = self.client.get(self.custom_url_for('index.huesound', color="FF00FF"))
         self.assertStatus(resp, 302)
 
     def test_similar_users(self):
-        resp = self.client.get(url_for('explore.similar_users'))
+        resp = self.client.get(self.custom_url_for('explore.similar_users'))
         self.assert200(resp)
 
     def test_similar_users_redirect(self):
-        resp = self.client.get(url_for('index.similar_users'))
+        resp = self.client.get(self.custom_url_for('index.similar_users'))
         self.assertStatus(resp, 302)
 
     def test_fresh_releases(self):
-        resp = self.client.get(url_for('explore.fresh_releases'))
+        resp = self.client.get(self.custom_url_for('explore.fresh_releases'))
         self.assert200(resp)
 
     @patch('listenbrainz.db.fresh_releases.get_sitewide_fresh_releases', side_effect=[([], 0), ([], 0), ([], 0)])
     def test_fresh_releases_api(self, mock_fresh):
-        resp = self.client.get(url_for('explore_api_v1.get_fresh_releases'))
+        resp = self.client.get(self.custom_url_for('explore_api_v1.get_fresh_releases'))
         self.assert200(resp)
         mock_fresh.assert_called_with(datetime.date.today(), 14, 'release_date', True, True)
 
-        resp = self.client.get(url_for('explore_api_v1.get_fresh_releases', release_date="2022-01-01", days=5))
+        resp = self.client.get(self.custom_url_for('explore_api_v1.get_fresh_releases', release_date="2022-01-01", days=5))
         self.assert200(resp)
         mock_fresh.assert_called_with(datetime.date(year=2022, month=1, day=1), 5, 'release_date', True, True)
 
-        resp = self.client.get(url_for('explore_api_v1.get_fresh_releases', sort="artist_credit_name", past=False))
+        resp = self.client.get(self.custom_url_for('explore_api_v1.get_fresh_releases', sort="artist_credit_name", past=False))
         self.assert200(resp)
         mock_fresh.assert_called_with(datetime.date.today(), 14, 'artist_credit_name', False, True)
 
     def test_lb_radio(self):
-        resp = self.client.get(url_for('explore.lb_radio'))
+        resp = self.client.get(self.custom_url_for('explore.lb_radio'))
         self.assert200(resp)

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -1,7 +1,6 @@
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from flask import url_for
 from flask_login import login_required
 from requests.exceptions import HTTPError
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
@@ -17,7 +16,7 @@ from listenbrainz.webserver.testing import ServerAppPerTestTestCase
 class IndexViewsTestCase(IntegrationTestCase):
 
     def test_index(self):
-        resp = self.client.get(url_for('index.index'))
+        resp = self.client.get(self.custom_url_for('index.index'))
         self.assert200(resp)
     
     def test_index_logged_in_redirect(self):
@@ -27,31 +26,31 @@ class IndexViewsTestCase(IntegrationTestCase):
         user = db_user.get_or_create(1, 'mr_monkey')
         self.temporary_login(user['login_id'])
 
-        resp = self.client.get(url_for('index.index'))
-        self.assertRedirects(resp, url_for('user.profile', user_name='mr_monkey'))
+        resp = self.client.get(self.custom_url_for('index.index'))
+        self.assertRedirects(resp, self.custom_url_for('user.profile', user_name='mr_monkey'))
 
     def test_downloads(self):
-        resp = self.client.get(url_for('index.downloads'))
-        self.assertRedirects(resp, url_for('index.data'))
+        resp = self.client.get(self.custom_url_for('index.downloads'))
+        self.assertRedirects(resp, self.custom_url_for('index.data'))
 
     def test_data(self):
-        resp = self.client.get(url_for('index.data'))
+        resp = self.client.get(self.custom_url_for('index.data'))
         self.assert200(resp)
 
     def test_about(self):
-        resp = self.client.get(url_for('index.about'))
+        resp = self.client.get(self.custom_url_for('index.about'))
         self.assert200(resp)
 
     def test_terms_of_service(self):
-        resp = self.client.get(url_for('index.terms_of_service'))
+        resp = self.client.get(self.custom_url_for('index.terms_of_service'))
         self.assert200(resp)
 
     def test_add_data_info(self):
-        resp = self.client.get(url_for('index.add_data_info'))
+        resp = self.client.get(self.custom_url_for('index.add_data_info'))
         self.assert200(resp)
 
     def test_import_data_info(self):
-        resp = self.client.get(url_for('index.import_data_info'))
+        resp = self.client.get(self.custom_url_for('index.import_data_info'))
         self.assert200(resp)
 
     def test_404(self):
@@ -60,7 +59,7 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assertIn('Not Found', resp.data.decode('utf-8'))
 
     def test_lastfm_proxy(self):
-        resp = self.client.get(url_for('index.proxy'))
+        resp = self.client.get(self.custom_url_for('index.proxy'))
         self.assert200(resp)
 
     def test_flask_debugtoolbar(self):
@@ -75,12 +74,12 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assertIn('flDebug', str(resp.data))
 
     def test_current_status(self):
-        resp = self.client.get(url_for('index.current_status'))
+        resp = self.client.get(self.custom_url_for('index.current_status'))
         self.assert200(resp)
 
     @mock.patch('listenbrainz.db.user.get')
     def test_menu_not_logged_in(self, mock_user_get):
-        resp = self.client.get(url_for('index.index'))
+        resp = self.client.get(self.custom_url_for('index.index'))
         data = resp.data.decode('utf-8')
         self.assertIn('id="side-nav"', data)
         self.assertIn('Sign in', data)
@@ -97,7 +96,7 @@ class IndexViewsTestCase(IntegrationTestCase):
 
         mock_user_get.return_value = user
         self.temporary_login(user['login_id'])
-        resp = self.client.get(url_for('index.recent_listens'))
+        resp = self.client.get(self.custom_url_for('index.recent_listens'))
         data = resp.data.decode('utf-8')
 
         # username & logout link in sidenav menu
@@ -112,7 +111,7 @@ class IndexViewsTestCase(IntegrationTestCase):
     @mock.patch('listenbrainz.webserver.views.index.delete_user')
     def test_mb_user_deleter_valid_account(self, mock_delete_user, mock_authorize_mb_user_deleter):
         user_id = db_user.create(1, 'iliekcomputers')
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assert200(r)
         mock_authorize_mb_user_deleter.assert_called_once_with('132')
         mock_delete_user.assert_called_once_with(user_id)
@@ -121,7 +120,7 @@ class IndexViewsTestCase(IntegrationTestCase):
     @mock.patch('listenbrainz.webserver.views.index.delete_user')
     def test_mb_user_deleter_not_found(self, mock_delete_user, mock_authorize_mb_user_deleter):
         # no user in the db with musicbrainz_row_id = 2
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=2, access_token='312421'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=2, access_token='312421'))
         self.assert404(r)
         mock_authorize_mb_user_deleter.assert_called_with('312421')
         mock_delete_user.assert_not_called()
@@ -135,7 +134,7 @@ class IndexViewsTestCase(IntegrationTestCase):
             'metabrainz_user_id': 2007538,
         }
         user_id = db_user.create(1, 'iliekcomputers')
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assert200(r)
         mock_requests_get.assert_called_with(
             'https://musicbrainz.org/oauth2/userinfo',
@@ -152,7 +151,7 @@ class IndexViewsTestCase(IntegrationTestCase):
             'metabrainz_user_id': 2007531, # incorrect musicbrainz row id for UserDeleter
         }
         user_id = db_user.create(1, 'iliekcomputers')
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
 
@@ -160,7 +159,7 @@ class IndexViewsTestCase(IntegrationTestCase):
         mock_requests_get.return_value.json.return_value = {
             'metabrainz_user_id': 2007538,
         }
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
 
@@ -168,7 +167,7 @@ class IndexViewsTestCase(IntegrationTestCase):
         mock_requests_get.return_value.json.return_value = {
             'sub': 'UserDeleter',
         }
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
 
@@ -177,7 +176,7 @@ class IndexViewsTestCase(IntegrationTestCase):
             'sub': 'iliekcomputers',
             'metabrainz_user_id': 2007538
         }
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
 
@@ -186,18 +185,18 @@ class IndexViewsTestCase(IntegrationTestCase):
             'sub': 'iliekcomputers',
             'metabrainz_user_id': 1,
         }
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
 
         # HTTPError while getting userinfo from MusicBrainz
         mock_requests_get.return_value.raise_for_status.side_effect = HTTPError
-        r = self.client.get(url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
+        r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
 
     def test_recent_listens_page(self):
-        response = self.client.get(url_for('index.recent_listens'))
+        response = self.client.get(self.custom_url_for('index.recent_listens'))
         self.assert200(response)
         self.assertTemplateUsed('index/recent.html')
 
@@ -209,16 +208,16 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assert200(r)
 
     def test_similar_users(self):
-        resp = self.client.get(url_for('index.similar_users'))
+        resp = self.client.get(self.custom_url_for('index.similar_users'))
         self.assertStatus(resp, 302)
 
     @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
     def test_instant_playlist(self, mock_recording_metadata):
-        resp = self.client.get(url_for('player.load_instant', recording_mbids="87c94c4b-6aed-41a3-bbbd-aa9cd2154c5e"))
+        resp = self.client.get(self.custom_url_for('player.load_instant', recording_mbids="87c94c4b-6aed-41a3-bbbd-aa9cd2154c5e"))
         self.assert200(resp)
 
     def test_release_playlist(self):
-        resp = self.client.get(url_for('player.load_release', release_mbid="87c94c4b-6aed-41a3-bbbd-aa9cd2154c5e"))
+        resp = self.client.get(self.custom_url_for('player.load_release', release_mbid="87c94c4b-6aed-41a3-bbbd-aa9cd2154c5e"))
         self.assert200(resp)
 
 

--- a/listenbrainz/webserver/views/test/test_login.py
+++ b/listenbrainz/webserver/views/test/test_login.py
@@ -1,10 +1,9 @@
 
 from listenbrainz.webserver.testing import ServerTestCase
-from flask import url_for
 
 
 class LoginViewsTestCase(ServerTestCase):
 
     def test_login_page(self):
-        response = self.client.get(url_for('login.index'))
+        response = self.client.get(self.custom_url_for('login.index'))
         self.assert200(response)

--- a/listenbrainz/webserver/views/test/test_player.py
+++ b/listenbrainz/webserver/views/test/test_player.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
 
-from flask import url_for
-
 from listenbrainz.tests.integration import IntegrationTestCase
 
 
@@ -9,10 +7,14 @@ class PlayerViewsTestCase(IntegrationTestCase):
 
     @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
     def test_player_get_instant(self, mock_recording_metadata):
-        resp = self.client.get(url_for('player.load_instant', recording_mbids="97e69767-5d34-4c97-b36a-f3b2b1ef9dae"))
+        resp = self.client.get(
+            self.custom_url_for('player.load_instant', recording_mbids="97e69767-5d34-4c97-b36a-f3b2b1ef9dae")
+        )
         self.assert200(resp)
 
     @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
     def test_player_release(self, mock_recording_metadata):
-        resp = self.client.get(url_for('player.load_release', release_mbid="9db51cd6-38f6-3b42-8ad5-559963d68f35"))
+        resp = self.client.get(
+            self.custom_url_for('player.load_release', release_mbid="9db51cd6-38f6-3b42-8ad5-559963d68f35")
+        )
         self.assert200(resp)

--- a/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
@@ -6,9 +6,9 @@ import listenbrainz.db.user as db_user
 from datetime import datetime
 
 from unittest.mock import patch
-from flask import render_template
+from flask import render_template, url_for
 
-from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.tests.integration import NonAPIIntegrationTestCase
 from listenbrainz.webserver.login import User
 from listenbrainz.webserver.views import recommendations_cf_recording
 import listenbrainz.db.recommendations_cf_recording as db_recommendations_cf_recording
@@ -16,7 +16,7 @@ from data.model.user_cf_recommendations_recording_message import (UserRecommenda
                                                                   UserRecommendationsData)
 
 
-class CFRecommendationsViewsTestCase(IntegrationTestCase):
+class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
     def setUp(self):
         self.server_url = "https://labs.api.listenbrainz.org/recording-mbid-lookup/json"
         super(CFRecommendationsViewsTestCase, self).setUp()
@@ -51,12 +51,12 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         )
 
     def test_info_invalid_user(self):
-        response = self.client.get(self.custom_url_for('recommendations_cf_recording.info', user_name="invalid"))
+        response = self.client.get(url_for('recommendations_cf_recording.info', user_name="invalid"))
         self.assert404(response)
 
     @patch('listenbrainz.webserver.views.recommendations_cf_recording._get_user')
     def test_info_valid_user(self, mock_user):
-        response = self.client.get(self.custom_url_for('recommendations_cf_recording.info', user_name="vansika"))
+        response = self.client.get(url_for('recommendations_cf_recording.info', user_name="vansika"))
         self.assert200(response)
         self.assertTemplateUsed('recommendations_cf_recording/info.html')
         self.assert_context('active_section', 'info')
@@ -64,7 +64,7 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
         mock_user.assert_called_with("vansika")
 
     def test_raw_invalid_user(self):
-        response = self.client.get(self.custom_url_for('recommendations_cf_recording.raw', user_name="invalid"))
+        response = self.client.get(url_for('recommendations_cf_recording.raw', user_name="invalid"))
         self.assert404(response)
 
     @patch('listenbrainz.webserver.views.recommendations_cf_recording._get_user')
@@ -78,7 +78,7 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
             user=self.user,
             error_msg="test"
         )
-        response = self.client.get(self.custom_url_for('recommendations_cf_recording.raw', user_name="vansika"))
+        response = self.client.get(url_for('recommendations_cf_recording.raw', user_name="vansika"))
         self.assert200(response)
         mock_user.assert_called_with("vansika")
         mock_template.assert_called_with(active_section='raw', user=mock_user.return_value)

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from unittest import mock
 
 import orjson
-from flask import url_for
 from sqlalchemy import text
 
 import listenbrainz.db.user as db_user
@@ -42,22 +41,22 @@ class UserViewsTestCase(IntegrationTestCase):
         super().tearDown()
 
     def test_redirects_logged_out(self):
-        my_listens_url = url_for("redirect.redirect_listens")
+        my_listens_url = self.custom_url_for("redirect.redirect_listens")
         # Not logged in
         response = self.client.get(my_listens_url)
-        self.assertRedirects(response, url_for("login.index", next=my_listens_url))
+        self.assertRedirects(response, self.custom_url_for("login.index", next=my_listens_url))
 
     def test_redirects(self):
         """Test the /my/[something]/ endponts which redirect to the /user/ namespace"""
         # Logged in
         self.temporary_login(self.user.login_id)
-        response = self.client.get(url_for("redirect.redirect_listens"))
+        response = self.client.get(self.custom_url_for("redirect.redirect_listens"))
         self.assertRedirects(response, "/user/iliekcomputers/")
 
-        response = self.client.get(url_for("redirect.redirect_stats"))
+        response = self.client.get(self.custom_url_for("redirect.redirect_stats"))
         self.assertRedirects(response, "/user/iliekcomputers/stats/")
 
-        response = self.client.get(url_for("redirect.redirect_stats") + "?foo=bar")
+        response = self.client.get(self.custom_url_for("redirect.redirect_stats", foo="bar"))
         self.assertRedirects(response, "/user/iliekcomputers/stats/?foo=bar")
 
     def test_user_redirects(self):
@@ -97,7 +96,7 @@ class UserViewsTestCase(IntegrationTestCase):
         self.assertRedirects(response, '/user/iliekcomputers/artists/', permanent=True)
 
     def test_user_page(self):
-        response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
         self.assertContext('active_section', 'listens')
 
@@ -107,7 +106,7 @@ class UserViewsTestCase(IntegrationTestCase):
                             token_expires_ts=int(time.time()) + 1000, record_listens=True,
                             scopes=['user-read-recently-played', 'streaming'])
 
-        response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
         self.assertTemplateUsed('user/profile.html')
         props = orjson.loads(self.get_context_variable("global_props"))
@@ -115,7 +114,7 @@ class UserViewsTestCase(IntegrationTestCase):
 
     def test_spotify_token_access_unlinked(self):
         self.temporary_login(self.user.login_id)
-        response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
         props = orjson.loads(self.get_context_variable("global_props"))
         self.assertDictEqual(props['spotify'], {})
@@ -128,7 +127,7 @@ class UserViewsTestCase(IntegrationTestCase):
 
         self.temporary_login(self.user.login_id)
 
-        response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
 
         props = orjson.loads(self.get_context_variable("global_props"))
@@ -137,7 +136,7 @@ class UserViewsTestCase(IntegrationTestCase):
             'permission': ['user-read-recently-played', 'streaming'],
         })
 
-        response = self.client.get(url_for('user.profile', user_name=self.weirduser.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.profile', user_name=self.weirduser.musicbrainz_id))
         self.assert200(response)
         props = orjson.loads(self.get_context_variable("global_props"))
         self.assertDictEqual(props['spotify'], {
@@ -147,7 +146,7 @@ class UserViewsTestCase(IntegrationTestCase):
 
     @mock.patch('listenbrainz.webserver.views.user.db_user_relationship.is_following_user')
     def test_logged_in_user_follows_user_props(self, mock_is_following_user):
-        response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
         self.assertTemplateUsed('user/profile.html')
         props = orjson.loads(self.get_context_variable('props'))
@@ -155,7 +154,7 @@ class UserViewsTestCase(IntegrationTestCase):
 
         self.temporary_login(self.user.login_id)
         mock_is_following_user.return_value = False
-        response = self.client.get(url_for('user.profile', user_name=self.user.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.profile', user_name=self.user.musicbrainz_id))
         self.assert200(response)
         props = orjson.loads(self.get_context_variable('props'))
         self.assertFalse(props['logged_in_user_follows_user'])
@@ -177,9 +176,9 @@ class UserViewsTestCase(IntegrationTestCase):
         """Tests that the username in URL is case insensitive"""
         self._create_test_data('iliekcomputers')
 
-        response1 = self.client.get(url_for('user.profile', user_name='iliekcomputers'))
+        response1 = self.client.get(self.custom_url_for('user.profile', user_name='iliekcomputers'))
         self.assertContext('user', self.user)
-        response2 = self.client.get(url_for('user.profile', user_name='IlieKcomPUteRs'))
+        response2 = self.client.get(self.custom_url_for('user.profile', user_name='IlieKcomPUteRs'))
         self.assertContext('user', self.user)
         self.assert200(response1)
         self.assert200(response2)
@@ -190,25 +189,27 @@ class UserViewsTestCase(IntegrationTestCase):
         user = self.user.to_dict()
         timescale.return_value = ([], EPOCH, EPOCH)
 
-        self.client.get(url_for('user.profile', user_name='iliekcomputers'))
+        self.client.get(self.custom_url_for('user.profile', user_name='iliekcomputers'))
         req_call = mock.call(user, limit=25)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # max_ts query param -> to_ts timescale param
-        self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'max_ts': 1520946000})
+        self.client.get(self.custom_url_for('user.profile', user_name='iliekcomputers'),
+                        query_string={'max_ts': 1520946000})
         req_call = mock.call(user, limit=25, to_ts=datetime.utcfromtimestamp(1520946000))
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # min_ts query param -> from_ts timescale param
-        self.client.get(url_for('user.profile', user_name='iliekcomputers'), query_string={'min_ts': 1520941000})
+        self.client.get(self.custom_url_for('user.profile', user_name='iliekcomputers'),
+                        query_string={'min_ts': 1520941000})
         req_call = mock.call(user, limit=25, from_ts=datetime.utcfromtimestamp(1520941000))
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # If max_ts and min_ts set, only max_ts is used
-        self.client.get(url_for('user.profile', user_name='iliekcomputers'),
+        self.client.get(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'min_ts': 1520941000, 'max_ts': 1520946000})
         req_call = mock.call(user, limit=25, to_ts=datetime.utcfromtimestamp(1520946000))
         timescale.assert_has_calls([req_call])
@@ -218,12 +219,12 @@ class UserViewsTestCase(IntegrationTestCase):
         """If max_ts and min_ts are not integers, show an error page"""
         (min_ts, max_ts) = self._create_test_data('iliekcomputers')
 
-        response = self.client.get(url_for('user.profile', user_name='iliekcomputers'),
+        response = self.client.get(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                                    query_string={'max_ts': 'a'})
         self.assert400(response)
         self.assertIn(b'Incorrect timestamp argument max_ts: a', response.data)
 
-        response = self.client.get(url_for('user.profile', user_name='iliekcomputers'),
+        response = self.client.get(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                                    query_string={'min_ts': 'b'})
         self.assert400(response)
         self.assertIn(b'Incorrect timestamp argument min_ts: b', response.data)
@@ -241,7 +242,7 @@ class UserViewsTestCase(IntegrationTestCase):
             'reason': 'This user is cramping my style and I dont like it'
         }
         response = self.client.post(
-            url_for('user.report_abuse', user_name=self.abuser.musicbrainz_id),
+            self.custom_url_for('user.report_abuse', user_name=self.abuser.musicbrainz_id),
             json=data,
         )
         self.assert200(response, "%s has been reported successfully." % self.abuser.musicbrainz_id)
@@ -250,7 +251,7 @@ class UserViewsTestCase(IntegrationTestCase):
 
         # Assert a user cannot report themselves
         response = self.client.post(
-            url_for('user.report_abuse', user_name=self.user.musicbrainz_id),
+            self.custom_url_for('user.report_abuse', user_name=self.user.musicbrainz_id),
             json=data,
         )
         self.assert400(response, "You cannot report yourself.")
@@ -262,7 +263,7 @@ class UserViewsTestCase(IntegrationTestCase):
             'reason': {'youDoneGoofed': 1234}
         }
         response = self.client.post(
-            url_for('user.report_abuse', user_name=self.abuser.musicbrainz_id),
+            self.custom_url_for('user.report_abuse', user_name=self.abuser.musicbrainz_id),
             json=data,
         )
         self.assert400(response, "Reason must be a string.")
@@ -296,7 +297,7 @@ class UserViewsTestCase(IntegrationTestCase):
             "blurb_content": "Amazing first recording"
         }
         response = self.client.post(
-            url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
+            self.custom_url_for("pinned_rec_api_bp_v1.pin_recording_for_user"),
             data=json.dumps(pinned_rec),
             headers={"Authorization": f"Token {self.user.auth_token}"},
             content_type="application/json",
@@ -324,7 +325,7 @@ class UserViewsTestCase(IntegrationTestCase):
             }
         }
 
-        response = self.client.get(url_for('user.taste', user_name=self.user.musicbrainz_id))
+        response = self.client.get(self.custom_url_for('user.taste', user_name=self.user.musicbrainz_id))
         self.assert200(response)
 
         props = json.loads(self.get_context_variable("props"))


### PR DESCRIPTION
As a part of upcoming changes to reduce connection churn, I will refactor LB to reuse a single connection for all database queries during a request. These connections are cleaned up when teardown functions of the request are called at the end of the API request. Pushing a request/app context at the start of the request and then making multiple API requests in a test (as we currently do) does not work nicely with this pattern.

The teardown functions would never be called on the request during the running of the test, this will cause uncommitted changes to persist across API requests. So even if you forgot a commit in the server code, the corresponding test would pass.

For the majority of tests, we only need the context to use `url_for` to generate endpoint URLs. I have added a simple variant of `url_for` that can work in the absence of context. Another alternative would have been to manually write the full url in the test, it is also what the example tests in flask's official documentation. I don't have any preference between the two and went with the first one for now.