### PR TITLE
Reuse the same database connection for duration of a request

### DIFF
--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -9,6 +9,7 @@ from data.model.common_stat import StatisticsRange
 from data.model.user_entity import EntityRecord
 
 from listenbrainz.db.cover_art import get_caa_ids_for_release_mbids
+from listenbrainz.webserver import db_conn
 
 #: Minimum image size
 MIN_IMAGE_SIZE = 128
@@ -287,7 +288,7 @@ class CoverArtGenerator:
         if entity not in ("artists", "releases", "recordings"):
             raise ValueError("Stats entity must be one of artist, release or recording.")
 
-        user = db_user.get_by_mb_id(user_name)
+        user = db_user.get_by_mb_id(db_conn, user_name)
         if user is None:
             raise ValueError(f"User {user_name} not found")
 

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -7,11 +7,12 @@ from listenbrainz import db, utils
 import sqlalchemy
 
 
-def save_token(user_id: int, service: ExternalServiceType, access_token: str, refresh_token: Optional[str],
+def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token: str, refresh_token: Optional[str],
                token_expires_ts: int, record_listens: bool, scopes: List[str], external_user_id: Optional[str] = None):
     """ Add a row to the external_service_oauth table for specified user with corresponding tokens and information.
 
     Args:
+        db_conn: database connection
         user_id: the ListenBrainz row ID of the user
         service: the service for which the token can be used
         access_token: the access token used to access the user's listens
@@ -29,83 +30,87 @@ def save_token(user_id: int, service: ExternalServiceType, access_token: str, re
     # be explicitly set to the default value (which would have been used if the row was
     # inserted instead).
     token_expires = utils.unix_timestamp_to_datetime(token_expires_ts)
-    with db.engine.begin() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            INSERT INTO external_service_oauth AS eso
-            (user_id, external_user_id, service, access_token, refresh_token, token_expires, scopes)
+    result = db_conn.execute(sqlalchemy.text("""
+        INSERT INTO external_service_oauth AS eso
+        (user_id, external_user_id, service, access_token, refresh_token, token_expires, scopes)
+        VALUES
+        (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires, :scopes)
+        ON CONFLICT (user_id, service)
+        DO UPDATE SET
+            external_user_id = EXCLUDED.external_user_id,
+            access_token = EXCLUDED.access_token,
+            refresh_token = EXCLUDED.refresh_token,
+            token_expires = EXCLUDED.token_expires,
+            scopes = EXCLUDED.scopes,
+            last_updated = NOW()
+        RETURNING id
+        """), {
+        "user_id": user_id,
+        "external_user_id": external_user_id,
+        "service": service.value,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_expires": token_expires,
+        "scopes": scopes,
+    })
+
+    if record_listens:
+        external_service_oauth_id = result.fetchone().id
+        db_conn.execute(sqlalchemy.text("""
+            INSERT INTO listens_importer
+            (external_service_oauth_id, user_id, service)
             VALUES
-            (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires, :scopes)
-            ON CONFLICT (user_id, service)
-            DO UPDATE SET
-                external_user_id = EXCLUDED.external_user_id,
-                access_token = EXCLUDED.access_token,
-                refresh_token = EXCLUDED.refresh_token,
-                token_expires = EXCLUDED.token_expires,
-                scopes = EXCLUDED.scopes,
-                last_updated = NOW()
-            RETURNING id
+            (:external_service_oauth_id, :user_id, :service)
+            ON CONFLICT (user_id, service) DO UPDATE SET
+                external_service_oauth_id = EXCLUDED.external_service_oauth_id,
+                user_id = EXCLUDED.user_id,
+                service = EXCLUDED.service,
+                last_updated = NULL,
+                latest_listened_at = NULL,
+                error_message = NULL
             """), {
-                "user_id": user_id,
-                "external_user_id": external_user_id,
-                "service": service.value,
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-                "token_expires": token_expires,
-                "scopes": scopes,
-            })
+            "external_service_oauth_id": external_service_oauth_id,
+            "user_id": user_id,
+            "service": service.value
+        })
 
-        if record_listens:
-            external_service_oauth_id = result.fetchone().id
-            connection.execute(sqlalchemy.text("""
-                INSERT INTO listens_importer
-                (external_service_oauth_id, user_id, service)
-                VALUES
-                (:external_service_oauth_id, :user_id, :service)
-                ON CONFLICT (user_id, service) DO UPDATE SET
-                    external_service_oauth_id = EXCLUDED.external_service_oauth_id,
-                    user_id = EXCLUDED.user_id,
-                    service = EXCLUDED.service,
-                    last_updated = NULL,
-                    latest_listened_at = NULL,
-                    error_message = NULL
-                """), {
-                "external_service_oauth_id": external_service_oauth_id,
-                "user_id": user_id,
-                "service": service.value
-            })
+    db_conn.commit()
 
 
-def delete_token(user_id: int, service: ExternalServiceType, remove_import_log: bool):
+def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_import_log: bool):
     """ Delete a user from the external service table.
 
     Args:
+        db_conn: database connection
         user_id: the ListenBrainz row ID of the user
         service: the service for which the token should be deleted
         remove_import_log: whether the (user, service) combination should be removed from the listens_importer table also
     """
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            DELETE FROM external_service_oauth
-                  WHERE user_id = :user_id AND service = :service
+    db_conn.execute(sqlalchemy.text("""
+        DELETE FROM external_service_oauth
+              WHERE user_id = :user_id AND service = :service
+    """), {
+        "user_id": user_id,
+        "service": service.value
+    })
+    if remove_import_log:
+        db_conn.execute(sqlalchemy.text("""
+            DELETE FROM listens_importer
+                WHERE user_id = :user_id AND service = :service
         """), {
             "user_id": user_id,
             "service": service.value
         })
-        if remove_import_log:
-            connection.execute(sqlalchemy.text("""
-                DELETE FROM listens_importer
-                    WHERE user_id = :user_id AND service = :service
-            """), {
-                "user_id": user_id,
-                "service": service.value
-            })
+
+    db_conn.commit()
 
 
-def update_token(user_id: int, service: ExternalServiceType, access_token: str,
+def update_token(db_conn, user_id: int, service: ExternalServiceType, access_token: str,
                  refresh_token: str | None, expires_at: int):
     """ Update the token for user with specified LB user ID and external service.
 
     Args:
+        db_conn: database connection
         user_id: the ListenBrainz row ID of the user
         service: the service for which the token should be updated
         access_token: the new access token
@@ -139,50 +144,50 @@ def update_token(user_id: int, service: ExternalServiceType, access_token: str,
              WHERE user_id = :user_id
                AND service = :service
         """
-    with db.engine.begin() as connection:
-        connection.execute(text(query), params)
+    db_conn.execute(text(query), params)
+    db_conn.commit()
 
 
-def get_token(user_id: int, service: ExternalServiceType) -> Union[dict, None]:
+def get_token(db_conn, user_id: int, service: ExternalServiceType) -> Union[dict, None]:
     """ Get details for user with specified user ID and service.
 
     Args:
+        db_conn: database connection
         user_id: the ListenBrainz row ID of the user
         service: the service for which the token should be fetched
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT user_id
-                 , "user".musicbrainz_id
-                 , "user".musicbrainz_row_id
-                 , service
-                 , access_token
-                 , refresh_token
-                 , last_updated
-                 , token_expires
-                 , scopes
-                 , external_user_id
-              FROM external_service_oauth
-              JOIN "user"
-                ON "user".id = external_service_oauth.user_id
-             WHERE user_id = :user_id AND service = :service
-            """), {
-                'user_id': user_id,
-                'service': service.value
-            })
-        return result.mappings().first()
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT user_id
+             , "user".musicbrainz_id
+             , "user".musicbrainz_row_id
+             , service
+             , access_token
+             , refresh_token
+             , last_updated
+             , token_expires
+             , scopes
+             , external_user_id
+          FROM external_service_oauth
+          JOIN "user"
+            ON "user".id = external_service_oauth.user_id
+         WHERE user_id = :user_id AND service = :service
+        """), {
+            'user_id': user_id,
+            'service': service.value
+        })
+    return result.mappings().first()
 
 
-def get_services(user_id: int) -> list[str]:
+def get_services(db_conn, user_id: int) -> list[str]:
     """ Get the list of connected services for a given user
 
     Args:
+        db_conn: database connection
         user_id: the ListenBrainz row ID of the user
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT service
-              FROM external_service_oauth
-             WHERE user_id = :user_id
-            """), {'user_id': user_id})
-        return [r.service for r in result.all()]
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT service
+          FROM external_service_oauth
+         WHERE user_id = :user_id
+        """), {'user_id': user_id})
+    return [r.service for r in result.all()]

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -35,12 +35,13 @@ DELETE_QUERIES = {
 }
 
 
-def insert(feedback: Feedback):
+def insert(db_conn, feedback: Feedback):
     """ Inserts a feedback record for a user's loved/hated recording into the database.
         If the record is already present for the user, the score is updated to the new
         value passed.
 
         Args:
+            db_conn: database connection
             feedback: An object of class Feedback
     """
 
@@ -64,18 +65,19 @@ def insert(feedback: Feedback):
         delete_query = DELETE_QUERIES["msid"]
         insert_query = INSERT_QUERIES["msid"]
 
-    with db.engine.begin() as connection:
-        # delete the existing feedback and then insert new feedback. we cannot use ON CONFLICT DO UPDATE
-        # because it is possible for a user to submit the feedback using recording_msid only and then using
-        # both recording_msid and recording_mbid at once in which case the ON CONFLICT doesn't work well.
-        connection.execute(text(delete_query), params)
-        connection.execute(text(insert_query), params)
+    # delete the existing feedback and then insert new feedback. we cannot use ON CONFLICT DO UPDATE
+    # because it is possible for a user to submit the feedback using recording_msid only and then using
+    # both recording_msid and recording_mbid at once in which case the ON CONFLICT doesn't work well.
+    db_conn.execute(text(delete_query), params)
+    db_conn.execute(text(insert_query), params)
+    db_conn.commit()
 
 
-def delete(feedback: Feedback):
+def delete(db_conn, feedback: Feedback):
     """ Deletes the feedback record for a given recording for the user from the database
 
         Args:
+            db_conn: database connection
             feedback: An object of class Feedback
     """
     params = {"user_id": feedback.user_id}
@@ -92,14 +94,16 @@ def delete(feedback: Feedback):
         params['recording_msid'] = feedback.recording_msid
         query = DELETE_QUERIES["msid"]
 
-    with db.engine.begin() as connection:
-        connection.execute(text(query), params)
+    db_conn.execute(text(query), params)
+    db_conn.commit()
 
 
-def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = None, metadata: bool = False) -> List[Feedback]:
+def get_feedback_for_user(db_conn, user_id: int, limit: int, offset: int,
+                          score: int = None, metadata: bool = False) -> List[Feedback]:
     """ Get a list of recording feedback given by the user in descending order of their creation
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
             score: the score value by which the results are to be filtered. If 1 then returns the loved recordings,
                    if -1 returns hated recordings.
@@ -131,9 +135,8 @@ def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = No
     query += """ ORDER BY recording_feedback.created DESC
                  LIMIT :limit OFFSET :offset """
 
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text(query), args)
-        feedback = [Feedback(**row) for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text(query), args)
+    feedback = [Feedback(**row) for row in result.mappings()]
 
     if metadata and len(feedback) > 0:
         feedback = fetch_track_metadata_for_items(feedback)
@@ -141,10 +144,11 @@ def get_feedback_for_user(user_id: int, limit: int, offset: int, score: int = No
     return feedback
 
 
-def get_feedback_count_for_user(user_id: int, score=None) -> int:
+def get_feedback_count_for_user(db_conn, user_id: int, score=None) -> int:
     """ Get total number of recording feedback given by the user
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
             score: If 1, fetch count for all the loved feedback,
                    if -1 fetch count for all the hated feedback,
@@ -161,18 +165,18 @@ def get_feedback_count_for_user(user_id: int, score=None) -> int:
         query += " AND score = :score"
         args['score'] = score
 
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text(query), args)
-        count = int(result.fetchone().value)
+    result = db_conn.execute(text(query), args)
+    count = int(result.fetchone().value)
 
     return count
 
 
-def get_feedback_for_recording(recording_type: str, recording: str, limit: int, offset: int, score: int = None)\
-        -> List[Feedback]:
+def get_feedback_for_recording(db_conn, recording_type: str, recording: str, limit: int,
+                               offset: int, score: int = None) -> List[Feedback]:
     """ Get a list of recording feedback for a given recording in descending order of their creation
 
         Args:
+            db_conn: database connection
             recording_type: type of id, recording_msid or recording_mbid
             recording: the msid or mbid of the recording
             score: the score value by which the results are to be filtered. If 1 then returns the loved recordings,
@@ -204,15 +208,15 @@ def get_feedback_for_recording(recording_type: str, recording: str, limit: int, 
     query += """ ORDER BY recording_feedback.created DESC
                  LIMIT :limit OFFSET :offset """
 
-    with db.engine.connect() as connection:
-        result = connection.execute(text(query), args)
-        return [Feedback(**row) for row in result.mappings()]
+    result = db_conn.execute(text(query), args)
+    return [Feedback(**row) for row in result.mappings()]
 
 
-def get_feedback_count_for_recording(recording_type: str, recording: str) -> int:
+def get_feedback_count_for_recording(db_conn, recording_type: str, recording: str) -> int:
     """ Get total number of recording feedback for a given recording
 
         Args:
+            db_conn: database connection
             recording_type: type of id, recording_msid or recording_mbid
             recording: the ID of the recording
 
@@ -220,13 +224,12 @@ def get_feedback_count_for_recording(recording_type: str, recording: str) -> int
             The total number of recording feedback for a given recording
     """
     query = "SELECT count(*) AS value FROM recording_feedback WHERE " + recording_type + " = :recording"
-    with db.engine.connect() as connection:
-        result = connection.execute(text(query), {"recording": recording})
-        count = int(result.fetchone().value)
+    result = db_conn.execute(text(query), {"recording": recording})
+    count = int(result.fetchone().value)
     return count
 
 
-def get_feedback_for_multiple_recordings_for_user(user_id: int, user_name: str, recording_msids: List[str],
+def get_feedback_for_multiple_recordings_for_user(db_conn, user_id: int, user_name: str, recording_msids: List[str],
                                                   recording_mbids: List[str]) -> List[Feedback]:
     """ Get a list of recording feedback given by the user for given recordings
 
@@ -235,6 +238,7 @@ def get_feedback_for_multiple_recordings_for_user(user_id: int, user_name: str, 
             - if record is not present then return a pseudo record with score = 0
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
             user_name: the user name of the user, not used in the query but only for creating the
                 response to be returned from the api
@@ -288,6 +292,5 @@ def get_feedback_for_multiple_recordings_for_user(user_id: int, user_name: str, 
         query_remaining = query_mbid
 
     query = query_base + query_remaining
-    with db.engine.connect() as connection:
-        result = connection.execute(text(query), params)
-        return [Feedback(user_id=user_id, user_name=user_name, **row) for row in result.mappings()]
+    result = db_conn.execute(text(query), params)
+    return [Feedback(user_id=user_id, user_name=user_name, **row) for row in result.mappings()]

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -98,12 +98,13 @@ def delete(db_conn, feedback: Feedback):
     db_conn.commit()
 
 
-def get_feedback_for_user(db_conn, user_id: int, limit: int, offset: int,
+def get_feedback_for_user(db_conn, ts_conn, user_id: int, limit: int, offset: int,
                           score: int = None, metadata: bool = False) -> List[Feedback]:
     """ Get a list of recording feedback given by the user in descending order of their creation
 
         Args:
             db_conn: database connection
+            ts_conn: timescale database connection
             user_id: the row ID of the user in the DB
             score: the score value by which the results are to be filtered. If 1 then returns the loved recordings,
                    if -1 returns hated recordings.
@@ -139,7 +140,7 @@ def get_feedback_for_user(db_conn, user_id: int, limit: int, offset: int,
     feedback = [Feedback(**row) for row in result.mappings()]
 
     if metadata and len(feedback) > 0:
-        feedback = fetch_track_metadata_for_items(feedback)
+        feedback = fetch_track_metadata_for_items(ts_conn, feedback)
 
     return feedback
 

--- a/listenbrainz/db/fresh_releases.py
+++ b/listenbrainz/db/fresh_releases.py
@@ -13,6 +13,7 @@ from listenbrainz.db.model.fresh_releases import FreshRelease
 
 
 def get_sitewide_fresh_releases(
+        ts_conn,
         pivot_release_date: date,
         release_date_window_days: int,
         sort: str,
@@ -22,6 +23,7 @@ def get_sitewide_fresh_releases(
         of days into the past and days number of days into the future.
 
         Args:
+            ts_conn: timescale database connection
             pivot_release_date: The release_date around which to fetch the fresh releases.
             release_date_window_days: The number of days into the past and future to show releases for. Must be
                                       between 1 and 90 days. If an invalid value is passed, 90 days is used.
@@ -123,9 +125,8 @@ def get_sitewide_fresh_releases(
     fresh_releases = []
     total_count = 0
     with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
-            psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as ts_conn, \
             mb_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as mb_curs, \
-            ts_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as ts_curs:
+            ts_conn.connection.cursor(cursor_factory=psycopg2.extras.DictCursor) as ts_curs:
         mb_curs.execute(query, (from_date, to_date))
         result = {str(row["release_mbid"]): dict(row)
                   for row in mb_curs.fetchall()}

--- a/listenbrainz/db/lastfm_session.py
+++ b/listenbrainz/db/lastfm_session.py
@@ -15,66 +15,62 @@ from listenbrainz.db.lastfm_user import User
 class Session(object):
     """ Session class required by the api-compat """
 
-    def __init__(self, id, user_id, sid, api_key, timestamp):
+    def __init__(self, db_conn, id, user_id, sid, api_key, timestamp):
         self.id = id
         self.sid = sid
         self.api_key = api_key
         self.timestamp = timestamp
         self.user_id = user_id
-        self.user = User.load_by_id(user_id)
+        self.user = User.load_by_id(db_conn, user_id)
 
     @staticmethod
-    def load(session_key):
+    def load(db_conn, session_key):
         """ Load the session details from the database.
             API_key and Session_key are required for a session.
         """
-        with db.engine.connect() as connection:
-            result = connection.execute(text("""
-                SELECT id
-                     , user_id
-                     , sid
-                     , api_key
-                     , ts
-                  FROM api_compat.session
-                 WHERE sid = :sid
-            """), {
-                'sid': session_key,
-            })
-            row = result.fetchone()
-            if row:
-                return Session(row.id, row.user_id, row.sid, row.api_key, row.ts)
-            return None
+        result = db_conn.execute(text("""
+            SELECT id
+                 , user_id
+                 , sid
+                 , api_key
+                 , ts
+              FROM api_compat.session
+             WHERE sid = :sid
+        """), {'sid': session_key})
+        row = result.fetchone()
+        if row:
+            return Session(db_conn, row.id, row.user_id, row.sid, row.api_key, row.ts)
+        return None
 
 
     @staticmethod
-    def generate(user_id, sid, api_key):
-        with db.engine.begin() as connection:
-            result = connection.execute(text("""
-                INSERT INTO api_compat.session (user_id, sid, api_key)
-                     VALUES (:user_id, :sid, :api_key)
-                  RETURNING id, user_id, sid, api_key, ts
-                 """), {
-                'user_id': user_id,
-                'sid': sid,
-                'api_key': api_key
-            })
-            row = result.fetchone()
-            return Session(row.id, row.user_id, row.sid, row.api_key, row.ts)
+    def generate(db_conn, user_id, sid, api_key):
+        result = db_conn.execute(text("""
+            INSERT INTO api_compat.session (user_id, sid, api_key)
+                 VALUES (:user_id, :sid, :api_key)
+              RETURNING id, user_id, sid, api_key, ts
+             """), {
+            'user_id': user_id,
+            'sid': sid,
+            'api_key': api_key
+        })
+        db_conn.commit()
+        row = result.fetchone()
+        return Session(db_conn, row.id, row.user_id, row.sid, row.api_key, row.ts)
 
     @staticmethod
-    def create(token):
+    def create(db_conn, token):
         """ Create a new session for the user by consuming the token.
             If session already exists for the user then renew the session_key(sid).
         """
         sid = os.urandom(20).hex()
-        session = Session.generate(token.user.id, sid, token.api_key)
-        token.consume()
+        session = Session.generate(db_conn, token.user.id, sid, token.api_key)
+        token.consume(db_conn)
         return session
 
 
-
     @staticmethod
-    def create_by_user_id(user_id):
+    def create_by_user_id(db_conn, user_id):
         """ Create a new session for the user for the deprecated audioscrobbler API v1.2.
             This only requires a user_id, so we use random values for api_key and other things
         """
@@ -82,4 +78,4 @@ class Session(object):
         # sids for audioscrobbler v1.2 are of length 32
         sid = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(32))
         api_key = str(uuid.uuid4())
-        return Session.generate(user_id, sid, api_key)
+        return Session.generate(db_conn, user_id, sid, api_key)

--- a/listenbrainz/db/lastfm_token.py
+++ b/listenbrainz/db/lastfm_token.py
@@ -16,12 +16,12 @@ TOKEN_EXPIRATION_TIME = 60
 class Token(object):
     """ Token class required by the api-compat """
 
-    def __init__(self, id, userid, token, api_key, ts):
+    def __init__(self, db_conn, id, userid, token, api_key, ts):
         self.id = id
         self.token = token
         self.api_key = api_key
         self.timestamp = ts
-        self.user = User.load_by_id(userid)
+        self.user = User.load_by_id(db_conn, userid)
 
     @staticmethod
     def is_valid_api_key(api_key, user_id=None):
@@ -36,7 +36,7 @@ class Token(object):
         return True
 
     @staticmethod
-    def load(token, api_key=None):
+    def load(db_conn, token, api_key=None):
         """ Load the token from database. Check api_key as well if present.
         """
         query = """SELECT id, user_id, token, api_key, ts
@@ -50,22 +50,22 @@ class Token(object):
                           AND api_key = :api_key"""
             params['api_key'] = api_key
 
-        with db.engine.begin() as connection:
-            result = connection.execute(text(query), params)
-            row = result.fetchone()
-            if row:
-                return Token(row.id, row.user_id, row.token, row.api_key, row.ts)
-            return None
+        result = db_conn.execute(text(query), params)
+        db_conn.commit()
+        row = result.fetchone()
+        if row:
+            return Token(db_conn, row.id, row.user_id, row.token, row.api_key, row.ts)
+        return None
 
     @staticmethod
-    def generate(api_key):
+    def generate(db_conn, api_key):
         token = os.urandom(20).hex()
-        with db.engine.begin() as connection:
-            q = """ INSERT INTO api_compat.token (token, api_key) VALUES (:token, :api_key)
-                    ON CONFLICT(api_key) DO UPDATE SET token = EXCLUDED.token, ts = EXCLUDED.ts
-                """
-            connection.execute(text(q), {'token': token, 'api_key': api_key})
-        return Token.load(token)
+        q = """ INSERT INTO api_compat.token (token, api_key) VALUES (:token, :api_key)
+                ON CONFLICT(api_key) DO UPDATE SET token = EXCLUDED.token, ts = EXCLUDED.ts
+        """
+        db_conn.execute(text(q), {'token': token, 'api_key': api_key})
+        db_conn.commit()
+        return Token.load(db_conn, token)
 
     def has_expired(self):
         """ Check if the token has expired.
@@ -73,16 +73,16 @@ class Token(object):
         """
         return self.timestamp < datetime.now() - timedelta(minutes=TOKEN_EXPIRATION_TIME)
 
-    def approve(self, user):
+    def approve(self, db_conn, user):
         """ Authenticate the token. User has to be present.
         """
-        with db.engine.begin() as connection:
-            connection.execute(text("UPDATE api_compat.token SET user_id = :uid WHERE token=:token"),
-                               {'uid': User.get_id(user), 'token': self.token})
-        self.user = User.load_by_name(user)
+        db_conn.execute(text("UPDATE api_compat.token SET user_id = :uid WHERE token=:token"),
+                        {'uid': User.get_id(db_conn, user), 'token': self.token})
+        db_conn.commit()
+        self.user = User.load_by_name(db_conn, user)
 
-    def consume(self):
+    def consume(self, db_conn):
         """ Use token to be able to create a new session.
         """
-        with db.engine.begin() as connection:
-            connection.execute(text("DELETE FROM api_compat.token WHERE id=:id"), {'id': self.id})
+        db_conn.execute(text("DELETE FROM api_compat.token WHERE id=:id"), {'id': self.id})
+        db_conn.commit()

--- a/listenbrainz/db/lastfm_user.py
+++ b/listenbrainz/db/lastfm_user.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from sqlalchemy import text
 
 from listenbrainz import db
@@ -15,59 +13,60 @@ class User(object):
         self.api_key = api_key
 
     @staticmethod
-    def get_id(mb_id):
-        with db.engine.connect() as connection:
-            result = connection.execute(text(""" SELECT id FROM "user" WHERE
-                                            musicbrainz_id = :mb_id """), {"mb_id": mb_id})
-            row = result.fetchone()
-            if row:
-                return row[0]
-            return None
+    def get_id(db_conn, mb_id):
+        result = db_conn.execute(text("""
+            SELECT id FROM "user" WHERE musicbrainz_id = :mb_id
+        """), {"mb_id": mb_id})
+        row = result.fetchone()
+        if row:
+            return row[0]
+        return None
 
     @staticmethod
-    def load_by_name(mb_id):
-        with db.engine.connect() as connection:
-            result = connection.execute(text(""" SELECT id, created, musicbrainz_id, auth_token \
-                                                   FROM "user" \
-                                                  WHERE musicbrainz_id = :mb_id """), {"mb_id": mb_id})
-            row = result.fetchone()
-            if row:
-                return User(row.id, row.created, row.musicbrainz_id, row.auth_token)
-            return None
+    def load_by_name(db_conn, mb_id):
+        result = db_conn.execute(text("""
+            SELECT id, created, musicbrainz_id, auth_token
+              FROM "user"
+             WHERE musicbrainz_id = :mb_id
+        """), {"mb_id": mb_id})
+        row = result.fetchone()
+        if row:
+            return User(row.id, row.created, row.musicbrainz_id, row.auth_token)
+        return None
 
     @staticmethod
-    def load_by_id(serial):
-        with db.engine.connect() as connection:
-            result = connection.execute(text(""" SELECT id, created, musicbrainz_id, auth_token \
-                                                   FROM "user"
-                                                  WHERE id=:id """), {"id": serial})
-            row = result.fetchone()
-            if row:
-                return User(row.id, row.created, row.musicbrainz_id, row.auth_token)
-            return None
+    def load_by_id(db_conn, serial):
+        result = db_conn.execute(text("""
+            SELECT id, created, musicbrainz_id, auth_token
+              FROM "user"
+             WHERE id = :id
+        """), {"id": serial})
+        row = result.fetchone()
+        if row:
+            return User(row.id, row.created, row.musicbrainz_id, row.auth_token)
+        return None
 
     @staticmethod
-    def load_by_sessionkey(session_key, api_key):
-        with db.engine.connect() as connection:
-            result = connection.execute(text("""
-                SELECT "user".id
-                     , "user".created
-                     , "user".musicbrainz_id
-                     , "user".auth_token
-                  FROM api_compat.session, "user"
-                 WHERE api_key = :api_key AND sid = :sk AND "user".id = session.user_id
-            """), {
-                "api_key": api_key,
-                "sk": session_key
-            })
-            row = result.fetchone()
-            if row:
-                return User(row.id, row.created, row.musicbrainz_id, row.auth_token)
-            return None
+    def load_by_sessionkey(db_conn, session_key, api_key):
+        result = db_conn.execute(text("""
+            SELECT "user".id
+                 , "user".created
+                 , "user".musicbrainz_id
+                 , "user".auth_token
+              FROM api_compat.session, "user"
+             WHERE api_key = :api_key AND sid = :sk AND "user".id = session.user_id
+        """), {
+            "api_key": api_key,
+            "sk": session_key
+        })
+        row = result.fetchone()
+        if row:
+            return User(row.id, row.created, row.musicbrainz_id, row.auth_token)
+        return None
 
     @staticmethod
-    def get_play_count(user_id, listenstore):
+    def get_play_count(db_conn, user_id, listenstore):
         """ Get playcount from the given user name.
         """
-        user = User.load_by_id(user_id)
+        user = User.load_by_id(db_conn, user_id)
         return listenstore.get_listen_count_for_user(user.id)

--- a/listenbrainz/db/listens_importer.py
+++ b/listenbrainz/db/listens_importer.py
@@ -6,71 +6,73 @@ from listenbrainz import db, utils
 import sqlalchemy
 
 
-def update_import_status(user_id: int, service: ExternalServiceType, error_message: str = None):
+def update_import_status(db_conn, user_id: int, service: ExternalServiceType, error_message: str = None):
     """ Add an error message to be shown to the user, thereby setting the user as inactive.
 
     Args:
+        db_conn: database connection
         user_id (int): the ListenBrainz row ID of the user
         service (data.model.ExternalServiceType): service to add error for the user
         error_message (str): the user-friendly error message to be displayed
     """
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            UPDATE listens_importer
-               SET last_updated = now()
-                 , error_message = :error_message
-             WHERE user_id = :user_id
-               AND service = :service
-        """), {
-            "user_id": user_id,
-            "error_message": error_message,
-            "service": service.value
-        })
+    db_conn.execute(sqlalchemy.text("""
+        UPDATE listens_importer
+           SET last_updated = now()
+             , error_message = :error_message
+         WHERE user_id = :user_id
+           AND service = :service
+    """), {
+        "user_id": user_id,
+        "error_message": error_message,
+        "service": service.value
+    })
+    db_conn.commit()
 
 
-def update_latest_listened_at(user_id: int, service: ExternalServiceType, timestamp: Union[int, float]):
+def update_latest_listened_at(db_conn, user_id: int, service: ExternalServiceType, timestamp: Union[int, float]):
     """ Update the timestamp of the last listen imported for the user with
     specified LB user ID.
 
     Args:
+        db_conn: database connection
         user_id (int): the ListenBrainz row ID of the user
         service (data.model.ExternalServiceType): service to update latest listen timestamp for
         timestamp (int): the unix timestamp of the latest listen imported for the user
     """
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            INSERT INTO listens_importer (user_id, service, last_updated, latest_listened_at)
-                 VALUES (:user_id, :service, now(), :timestamp)
-            ON CONFLICT (user_id, service)
-              DO UPDATE 
-                    SET last_updated = now()
-                      , latest_listened_at = :timestamp
-            """), {
-                'user_id': user_id,
-                'service': service.value,
-                'timestamp': utils.unix_timestamp_to_datetime(timestamp),
-            })
+    db_conn.execute(sqlalchemy.text("""
+        INSERT INTO listens_importer (user_id, service, last_updated, latest_listened_at)
+             VALUES (:user_id, :service, now(), :timestamp)
+        ON CONFLICT (user_id, service)
+          DO UPDATE 
+                SET last_updated = now()
+                  , latest_listened_at = :timestamp
+        """), {
+            'user_id': user_id,
+            'service': service.value,
+            'timestamp': utils.unix_timestamp_to_datetime(timestamp),
+        })
+    db_conn.commit()
 
 
-def get_latest_listened_at(user_id: int, service: ExternalServiceType) -> Optional[datetime.datetime]:
+def get_latest_listened_at(db_conn, user_id: int, service: ExternalServiceType) -> Optional[datetime.datetime]:
     """ Returns the timestamp of the last listen imported for the user with
     specified LB user ID from the given service.
 
     Args:
+        db_conn: database connection
         user_id: the ListenBrainz row ID of the user
         service: service to update latest listen timestamp for
     Returns:
         timestamp: the unix timestamp of the latest listen imported for the user
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT latest_listened_at
-              FROM listens_importer
-             WHERE user_id = :user_id
-               AND service = :service
-            """), {
-                'user_id': user_id,
-                'service': service.value,
-            })
-        row = result.fetchone()
-        return row.latest_listened_at if row else None
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT latest_listened_at
+          FROM listens_importer
+         WHERE user_id = :user_id
+           AND service = :service
+        """), {
+            'user_id': user_id,
+            'service': service.value,
+        })
+    row = result.fetchone()
+    return row.latest_listened_at if row else None

--- a/listenbrainz/db/mbid_manual_mapping.py
+++ b/listenbrainz/db/mbid_manual_mapping.py
@@ -1,14 +1,14 @@
 from typing import List, Optional, Iterable
 import uuid
 
-from psycopg2.extras import execute_values, DictCursor
+from psycopg2.extras import execute_values
 from psycopg2.sql import SQL, Literal
 from sqlalchemy import text
 
 from listenbrainz.db.model.mbid_manual_mapping import MbidManualMapping
-from listenbrainz.db import timescale as ts
 
-def create_mbid_manual_mapping(mapping: MbidManualMapping):
+
+def create_mbid_manual_mapping(ts_conn, mapping: MbidManualMapping):
     """Save a user mapping to the database. """
     query = """
         INSERT INTO mbid_manual_mapping(recording_msid, recording_mbid, user_id)
@@ -16,20 +16,22 @@ def create_mbid_manual_mapping(mapping: MbidManualMapping):
         ON CONFLICT (user_id, recording_msid)
       DO UPDATE SET recording_mbid = EXCLUDED.recording_mbid
     """
-    with ts.engine.begin() as conn:
-        conn.execute(
-            text(query),
-            {
-                "recording_msid": mapping.recording_msid,
-                "recording_mbid": mapping.recording_mbid,
-                "user_id": mapping.user_id
-            }
-        )
+    ts_conn.execute(
+        text(query),
+        {
+            "recording_msid": mapping.recording_msid,
+            "recording_mbid": mapping.recording_mbid,
+            "user_id": mapping.user_id
+        }
+    )
+    ts_conn.commit()
 
-def get_mbid_manual_mapping(recording_msid: uuid.UUID, user_id: int) -> Optional[MbidManualMapping]:
+
+def get_mbid_manual_mapping(ts_conn, recording_msid: uuid.UUID, user_id: int) -> Optional[MbidManualMapping]:
     """Get a user's manual mbid mapping for a given recording
     
     Arguments:
+        ts_conn: timescale database connection
         recording_msid: the msid of the recording to get the mapping for
         user_id: the user id to get the mapping for
 
@@ -45,29 +47,30 @@ def get_mbid_manual_mapping(recording_msid: uuid.UUID, user_id: int) -> Optional
          WHERE recording_msid = :recording_msid
            AND user_id = :user_id
     """
-    with ts.engine.begin() as conn:
-        result = conn.execute(
-            text(query),
-            {
-                "recording_msid": recording_msid,
-                "user_id": user_id
-            }
+    result = ts_conn.execute(
+        text(query),
+        {
+            "recording_msid": recording_msid,
+            "user_id": user_id
+        }
+    )
+    row = result.fetchone()
+    if row:
+        return MbidManualMapping(
+            recording_msid=row.recording_msid,
+            recording_mbid=row.recording_mbid,
+            user_id=row.user_id,
+            created=row.created
         )
-        row = result.fetchone()
-        if row:
-            return MbidManualMapping(
-                recording_msid=row.recording_msid,
-                recording_mbid=row.recording_mbid,
-                user_id=row.user_id,
-                created=row.created
-            )
-        else:
-            return None
+    else:
+        return None
 
-def get_mbid_manual_mappings(recording_msid: uuid.UUID) -> List[MbidManualMapping]:
+
+def get_mbid_manual_mappings(ts_conn, recording_msid: uuid.UUID) -> List[MbidManualMapping]:
     """Get all manual mbid mappings for a given recording
     
     Arguments:
+        ts_conn: timescale database connection
         recording_msid: the msid of the recording to get the mapping for
 
     Returns:
@@ -81,19 +84,16 @@ def get_mbid_manual_mappings(recording_msid: uuid.UUID) -> List[MbidManualMappin
           FROM mbid_manual_mapping
          WHERE recording_msid = :recording_msid
     """
-    with ts.engine.begin() as conn:
-        result = conn.execute(
-            text(query),
-            {
-                "recording_msid": recording_msid,
-            }
-        )
-        return [MbidManualMapping(**row) for row in result.mappings()]
+    result = ts_conn.execute(text(query), {"recording_msid": recording_msid})
+    ts_conn.commit()
+    return [MbidManualMapping(**row) for row in result.mappings()]
 
-def check_manual_mapping_exists(user_id: int, recording_msids: Iterable[str]) -> set[str]:
+
+def check_manual_mapping_exists(ts_conn, user_id: int, recording_msids: Iterable[str]) -> set[str]:
     """Check if a user has a mapping for a list of recordings
 
     Arguments:
+        ts_conn: timescale database connection
         user_id: LB user id of a user
         recording_msids: the msids of the recordings to check
 
@@ -107,6 +107,6 @@ def check_manual_mapping_exists(user_id: int, recording_msids: Iterable[str]) ->
             ON mmm.recording_msid = t.msid::uuid
          WHERE user_id = {user_id}
         """).format(user_id=Literal(user_id))
-    with ts.engine.begin() as conn, conn.connection.cursor() as cursor:
+    with ts_conn.connection.cursor() as cursor:
         result = execute_values(cursor, query, [(msid,) for msid in recording_msids], fetch=True)
         return set(row[0] for row in result)

--- a/listenbrainz/db/msid_mbid_mapping.py
+++ b/listenbrainz/db/msid_mbid_mapping.py
@@ -7,7 +7,6 @@ from psycopg2.extras import DictCursor
 from pydantic import BaseModel, validator, root_validator
 
 from data.model.validators import check_valid_uuid
-from listenbrainz.db import timescale
 from listenbrainz.db.recording import load_recordings_from_mbids
 from listenbrainz.messybrainz import load_recordings_from_msids
 
@@ -40,10 +39,11 @@ class MsidMbidModel(BaseModel):
 ModelT = TypeVar('ModelT', bound=MsidMbidModel)
 
 
-def fetch_track_metadata_for_items(items: List[ModelT]) -> List[ModelT]:
+def fetch_track_metadata_for_items(ts_conn, items: List[ModelT]) -> List[ModelT]:
     """ Fetches track_metadata for every object in a list of MsidMbidModel items.
 
         Args:
+            ts_conn: timescale database connection
             items: the MsidMbidModel items to fetch track_metadata for.
         Returns:
             The given list of MsidMbidModel objects with updated track_metadata.
@@ -61,7 +61,7 @@ def fetch_track_metadata_for_items(items: List[ModelT]) -> List[ModelT]:
 
     # first we try to load data from mapping using mbids. for the items without a mbid,
     # we'll later lookup data for these items from messybrainz.
-    with timescale.engine.connect() as ts_conn, ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_curs:
+    with ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_curs:
         mbid_metadatas = load_recordings_from_mbids(ts_curs, mbid_item_map.keys())
         _update_mbid_items(mbid_item_map, mbid_metadatas, msid_item_map)
 

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -16,11 +16,12 @@ PINNED_REC_GET_COLUMNS = [
 ]
 
 
-def pin(pinned_recording: WritablePinnedRecording):
+def pin(db_conn, pinned_recording: WritablePinnedRecording):
     """ Inserts a pinned recording record into the database for the user.
         If the user already has an active pinned recording, it will be unpinned before the new one is pinned.
 
         Args:
+            db_conn: database connection
             pinned_recording: An object of class WritablePinnedRecording
 
         Returns:
@@ -35,28 +36,29 @@ def pin(pinned_recording: WritablePinnedRecording):
         'created': pinned_recording.created
     }
 
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            UPDATE pinned_recording
-               SET pinned_until = NOW()
-             WHERE (user_id = :user_id AND pinned_until >= NOW())
-        """), {"user_id": pinned_recording.user_id})
+    db_conn.execute(sqlalchemy.text("""
+        UPDATE pinned_recording
+           SET pinned_until = NOW()
+         WHERE (user_id = :user_id AND pinned_until >= NOW())
+    """), {"user_id": pinned_recording.user_id})
 
-        result = connection.execute(sqlalchemy.text("""
-            INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
-                 VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
-              RETURNING (id)
-            """), args)
+    result = db_conn.execute(sqlalchemy.text("""
+        INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
+             VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
+          RETURNING (id)
+        """), args)
+    row_id = result.fetchone().id
+    db_conn.commit()
 
-        row_id = result.fetchone().id
-        pinned_recording.row_id = row_id
-        return PinnedRecording.parse_obj(pinned_recording.dict())
+    pinned_recording.row_id = row_id
+    return PinnedRecording.parse_obj(pinned_recording.dict())
 
 
-def unpin(user_id: int):
+def unpin(db_conn, user_id: int):
     """ Unpins the currently active pinned recording for the user if they have one.
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
 
         Returns:
@@ -64,67 +66,69 @@ def unpin(user_id: int):
             False if no pinned recording belonging to the given user_id was currently pinned.
     """
 
-    with db.engine.begin() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            UPDATE pinned_recording
-               SET pinned_until = NOW()
-             WHERE (user_id = :user_id AND pinned_until >= NOW())
-            """), {
-            'user_id': user_id,
-            }
-        )
-        return result.rowcount == 1
+    result = db_conn.execute(sqlalchemy.text("""
+        UPDATE pinned_recording
+           SET pinned_until = NOW()
+         WHERE (user_id = :user_id AND pinned_until >= NOW())
+        """), {
+        'user_id': user_id,
+        }
+    )
+    db_conn.commit()
+    return result.rowcount == 1
 
 
-def delete(row_id: int, user_id: int):
+def delete(db_conn, row_id: int, user_id: int):
     """ Deletes the pinned recording record for the user from the database.
 
         Args:
+            db_conn: database connection
             row_id: The row id of the pinned_recording to delete from the DB's 'pinned_recording' table
+            user_id: user id of the LB user
 
         Returns:
             True if a pinned recording for the given row_id and user_id was deleted.
             False if the pinned recording for the given row_id and user_id did not exist.
     """
+    result = db_conn.execute(sqlalchemy.text("""
+        DELETE FROM pinned_recording
+         WHERE id = :row_id
+           AND user_id = :user_id
+        """), {
+        'row_id': row_id,
+        'user_id': user_id
+        }
+    )
+    db_conn.commit()
+    return result.rowcount == 1
 
-    with db.engine.begin() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            DELETE FROM pinned_recording
-             WHERE id = :row_id
-               AND user_id = :user_id
-            """), {
-            'row_id': row_id,
-            'user_id': user_id
-            }
-        )
-        return result.rowcount == 1
 
-
-def get_current_pin_for_user(user_id: int) -> PinnedRecording:
+def get_current_pin_for_user(db_conn, user_id: int) -> PinnedRecording:
     """ Get the currently active pinned recording for the user if they have one.
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
 
         Returns:
             A PinnedRecording object.
     """
 
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM pinned_recording as pin
-             WHERE (user_id = :user_id
-               AND pinned_until >= NOW())
-            """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {'user_id': user_id})
-        row = result.mappings().first()
-        return PinnedRecording(**row) if row else None
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM pinned_recording as pin
+         WHERE (user_id = :user_id
+           AND pinned_until >= NOW())
+        """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {'user_id': user_id})
+    row = result.mappings().first()
+    return PinnedRecording(**row) if row else None
 
 
-def get_pin_history_for_user(user_id: int, count: int, offset: int) -> List[PinnedRecording]:
+def get_pin_history_for_user(db_conn, user_id: int, count: int, offset: int) -> List[PinnedRecording]:
     """ Get a list of pinned recordings for the user in descending order of their created date
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
             count: number of pinned recordings to be returned
             offset: number of pinned recordings to skip from the beginning
@@ -132,28 +136,27 @@ def get_pin_history_for_user(user_id: int, count: int, offset: int) -> List[Pinn
         Returns:
             A list of PinnedRecording objects sorted by newest to oldest creation date.
     """
-
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM pinned_recording as pin
-             WHERE user_id = :user_id
-             ORDER BY created DESC
-             LIMIT :count
-            OFFSET :offset
-            """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {
-            'user_id': user_id,
-            'count': count,
-            'offset': offset
-        })
-        return [PinnedRecording(**row) for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM pinned_recording as pin
+         WHERE user_id = :user_id
+         ORDER BY created DESC
+         LIMIT :count
+        OFFSET :offset
+        """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {
+        'user_id': user_id,
+        'count': count,
+        'offset': offset
+    })
+    return [PinnedRecording(**row) for row in result.mappings()]
 
 
-def get_pins_for_user_following(user_id: int, count: int, offset: int) -> List[PinnedRecording]:
+def get_pins_for_user_following(db_conn, user_id: int, count: int, offset: int) -> List[PinnedRecording]:
     """ Get a list of active pinned recordings for all the users that a user follows sorted
         in descending order of their created date.
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the main user in the DB
             count: number of pinned recordings to be returned
             offset: number of pinned recordings to skip from the beginning
@@ -163,32 +166,32 @@ def get_pins_for_user_following(user_id: int, count: int, offset: int) -> List[P
     """
     COLUMNS_WITH_USERNAME = PINNED_REC_GET_COLUMNS + ['"user".musicbrainz_id as user_name']
 
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM user_relationship
-              JOIN "user"
-                ON user_1 = "user".id
-              JOIN pinned_recording as pin
-                ON user_1 = pin.user_id
-             WHERE user_0 = :user_id
-               AND relationship_type = 'follow'
-               AND pinned_until >= NOW()
-             ORDER BY created DESC
-             LIMIT :count
-            OFFSET :offset
-            """.format(columns=','.join(COLUMNS_WITH_USERNAME))), {
-            'user_id': user_id,
-            'count': count,
-            'offset': offset
-        })
-        return [PinnedRecording(**row) for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM user_relationship
+          JOIN "user"
+            ON user_1 = "user".id
+          JOIN pinned_recording as pin
+            ON user_1 = pin.user_id
+         WHERE user_0 = :user_id
+           AND relationship_type = 'follow'
+           AND pinned_until >= NOW()
+         ORDER BY created DESC
+         LIMIT :count
+        OFFSET :offset
+        """.format(columns=','.join(COLUMNS_WITH_USERNAME))), {
+        'user_id': user_id,
+        'count': count,
+        'offset': offset
+    })
+    return [PinnedRecording(**row) for row in result.mappings()]
 
 
-def get_pins_for_feed(user_ids: Iterable[int], min_ts: int, max_ts: int, count: int) -> List[PinnedRecording]:
+def get_pins_for_feed(db_conn, user_ids: Iterable[int], min_ts: int, max_ts: int, count: int) -> List[PinnedRecording]:
     """ Gets a list of PinnedRecordings for specified users in descending order of their created date.
 
     Args:
+        db_conn: database connection
         user_ids: a list of user row IDs
         min_ts: History before this timestamp will not be returned
         max_ts: History after this timestamp will not be returned
@@ -197,48 +200,47 @@ def get_pins_for_feed(user_ids: Iterable[int], min_ts: int, max_ts: int, count: 
     Returns:
         A list of PinnedRecording objects.
     """
-
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM pinned_recording as pin
-             WHERE pin.user_id IN :user_ids
-               AND pin.created > :min_ts
-               AND pin.created < :max_ts
-          ORDER BY pin.created DESC
-             LIMIT :count
-        """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {
-            "user_ids": tuple(user_ids),
-            "min_ts": datetime.utcfromtimestamp(min_ts),
-            "max_ts": datetime.utcfromtimestamp(max_ts),
-            "count": count,
-        })
-        return [PinnedRecording(**row) for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM pinned_recording as pin
+         WHERE pin.user_id IN :user_ids
+           AND pin.created > :min_ts
+           AND pin.created < :max_ts
+      ORDER BY pin.created DESC
+         LIMIT :count
+    """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {
+        "user_ids": tuple(user_ids),
+        "min_ts": datetime.utcfromtimestamp(min_ts),
+        "max_ts": datetime.utcfromtimestamp(max_ts),
+        "count": count,
+    })
+    return [PinnedRecording(**row) for row in result.mappings()]
 
 
-def get_pin_by_id(row_id: int) -> PinnedRecording:
+def get_pin_by_id(db_conn, row_id: int) -> PinnedRecording:
     """ Get a pinned_recording by id
         Args:
+            db_conn: database connection
             row_id: the row ID of the pinned_recording
         Returns:
             PinnedRecording that satisfies the condition
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM pinned_recording as pin
-             WHERE pin.id = :row_id
-        """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {
-            "row_id": row_id,
-        })
-        row = result.mappings().first()
-        return PinnedRecording(**row) if row else None
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM pinned_recording as pin
+         WHERE pin.id = :row_id
+    """.format(columns=','.join(PINNED_REC_GET_COLUMNS))), {
+        "row_id": row_id,
+    })
+    row = result.mappings().first()
+    return PinnedRecording(**row) if row else None
 
 
-def get_pin_count_for_user(user_id: int) -> int:
+def get_pin_count_for_user(db_conn, user_id: int) -> int:
     """ Get the total number pinned_recordings for the user.
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
 
         Returns:
@@ -248,10 +250,8 @@ def get_pin_count_for_user(user_id: int) -> int:
                    AS value
                  FROM pinned_recording
                 WHERE user_id = :user_id"""
-
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text(query), {
-            'user_id': user_id,
-        })
-        count = int(result.fetchone().value)
+    result = db_conn.execute(sqlalchemy.text(query), {
+        'user_id': user_id,
+    })
+    count = int(result.fetchone().value)
     return count

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -5,17 +5,12 @@ from uuid import UUID
 
 import sqlalchemy
 import orjson
-from psycopg2.extras import execute_values
-from psycopg2.sql import SQL, Literal
 from sqlalchemy import text
 
 from listenbrainz.db.model import playlist as model_playlist
-from listenbrainz.db import timescale as ts
 from listenbrainz.db import user as db_user
 from listenbrainz.db.model.playlist import Playlist
 from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
-from listenbrainz.db.user import get_users_by_id
-from troi.patches.periodic_jams import WEEKLY_JAMS_DESCRIPTION, WEEKLY_EXPLORATION_DESCRIPTION
 
 TROI_BOT_USER_ID = 12939
 TROI_BOT_DEBUG_USER_ID = 19055
@@ -33,10 +28,12 @@ RECOMMENDATION_PATCHES = (
 )
 
 
-def get_by_mbid(playlist_id: str, load_recordings: bool = True) -> Optional[model_playlist.Playlist]:
+def get_by_mbid(db_conn, ts_conn, playlist_id: str, load_recordings: bool = True) -> Optional[model_playlist.Playlist]:
     """Get a playlist given its mbid
 
     Arguments:
+        db_conn: database connection
+        ts_conn: timeseries database connection
         playlist_id: the uuid of a playlist to get
         load_recordings: If true, load the recordings for the playlist too
 
@@ -47,7 +44,7 @@ def get_by_mbid(playlist_id: str, load_recordings: bool = True) -> Optional[mode
         a ``model_playlist.Playlist``, or ``None`` if no such Playlist with the
         given id exists
     """
-    query = sqlalchemy.text("""
+    query = text("""
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -64,40 +61,38 @@ def get_by_mbid(playlist_id: str, load_recordings: bool = True) -> Optional[mode
      LEFT JOIN playlist.playlist AS copy
             ON pl.copied_from_id = copy.id
          WHERE pl.mbid = :mbid""")
-    with ts.engine.connect() as connection:
-        result = connection.execute(query, {"mbid": playlist_id})
-        obj = result.mappings().first()
-        if not obj:
-            return None
-        obj = dict(obj)
-        user_id = obj['creator_id']
-        user = db_user.get(user_id)
-        obj['creator'] = user['musicbrainz_id']
-        if obj['created_for_id']:
-            created_for_user = db_user.get(obj['created_for_id'])
-            if created_for_user:
-                obj['created_for'] = created_for_user['musicbrainz_id']
+    result = ts_conn.execute(query, {"mbid": playlist_id})
+    obj = result.mappings().first()
+    if not obj:
+        return None
+    obj = dict(obj)
+    user_id = obj['creator_id']
+    user = db_user.get(db_conn, user_id)
+    obj['creator'] = user['musicbrainz_id']
+    if obj['created_for_id']:
+        created_for_user = db_user.get(db_conn, obj['created_for_id'])
+        if created_for_user:
+            obj['created_for'] = created_for_user['musicbrainz_id']
 
-        if load_recordings:
-            playlist_map = get_recordings_for_playlists(connection, [obj['id']])
-            obj['recordings'] = playlist_map.get(obj['id'], [])
-        else:
-            obj['recordings'] = []
-        playlist_collaborator_ids = get_collaborators_for_playlists(connection, [obj['id']])
-        collaborator_ids_list = playlist_collaborator_ids.get(obj['id'], [])
-        obj['collaborator_ids'] = collaborator_ids_list
-        obj['collaborators'] = get_collaborators_names_from_ids(collaborator_ids_list)
-        return model_playlist.Playlist.parse_obj(obj)
+    if load_recordings:
+        playlist_map = get_recordings_for_playlists(db_conn, ts_conn, [obj['id']])
+        obj['recordings'] = playlist_map.get(obj['id'], [])
+    else:
+        obj['recordings'] = []
+    playlist_collaborator_ids = get_collaborators_for_playlists(ts_conn, [obj['id']])
+    collaborator_ids_list = playlist_collaborator_ids.get(obj['id'], [])
+    obj['collaborator_ids'] = collaborator_ids_list
+    obj['collaborators'] = get_collaborators_names_from_ids(db_conn, collaborator_ids_list)
+    return model_playlist.Playlist.parse_obj(obj)
 
 
-def get_playlists_for_user(user_id: int,
-                           include_private: bool = False,
-                           load_recordings: bool = False,
-                           count: int = 0,
-                           offset: int = 0):
+def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool = False,
+                           load_recordings: bool = False, count: int = 0, offset: int = 0):
     """Get all playlists that a user created
 
     Arguments:
+        db_conn: database connection
+        ts_conn: timescale database connection
         user_id: The user to find playlists for
         include_private: If True, include all playlists by a user, including private ones. The count of
                          playlists returned will include private playlists if True
@@ -120,7 +115,7 @@ def get_playlists_for_user(user_id: int,
     if not include_private:
         where_public = "AND pl.public = :public"
         params["public"] = True
-    query = sqlalchemy.text(f"""
+    query = text(f"""
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -142,29 +137,30 @@ def get_playlists_for_user(user_id: int,
          LIMIT :count
         OFFSET :offset""")
 
-    with ts.engine.connect() as connection:
-        result = connection.execute(query, params)
-        playlists = _playlist_resultset_to_model(connection, result, load_recordings)
+    result = ts_conn.execute(query, params)
+    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings)
 
-        # Now fetch the count of playlists
-        params = {"creator_id": user_id}
-        where_public = ""
-        if not include_private:
-            where_public = "AND public = :public"
-            params["public"] = True
-        query = sqlalchemy.text(f"""SELECT COUNT(*)
-                                      FROM playlist.playlist
-                                     WHERE creator_id = :creator_id
-                                           {where_public}""")
-        count = connection.execute(query, params).fetchone()[0]
+    # Now fetch the count of playlists
+    params = {"creator_id": user_id}
+    where_public = ""
+    if not include_private:
+        where_public = "AND public = :public"
+        params["public"] = True
+    query = text(f"""SELECT COUNT(*)
+                       FROM playlist.playlist
+                      WHERE creator_id = :creator_id
+                           {where_public}""")
+    count = ts_conn.execute(query, params).fetchone()[0]
 
     return playlists, count
 
 
-def get_recommendation_playlists_for_user(user_id: int):
+def get_recommendation_playlists_for_user(db_conn, ts_conn, user_id: int):
     """Get all recommendation playlists that have been created for the user
 
     Arguments:
+        db_conn: database connection
+        ts_conn: timescale database connection
         user_id: The user to find playlists for
 
     Returns:
@@ -173,7 +169,7 @@ def get_recommendation_playlists_for_user(user_id: int):
     """
 
     params = {"creator_id": (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID), "created_for_id": user_id, "patches": RECOMMENDATION_PATCHES}
-    query = sqlalchemy.text(f"""
+    query = text(f"""
            SELECT pl.id
                 , pl.mbid
                 , pl.name
@@ -187,19 +183,18 @@ def get_recommendation_playlists_for_user(user_id: int):
                 , pl.created_for_id
                 , pl.additional_metadata
             FROM playlist.playlist pl
-           WHERE additional_metadata->'algorithm_metadata'->>'source_patch' IN :patches
+           WHERE pl.additional_metadata->'algorithm_metadata'->>'source_patch' IN :patches
              AND created_for_id = :created_for_id
              AND creator_id IN :creator_id
         ORDER BY pl.created DESC""")
 
-    with ts.engine.connect() as connection:
-        result = connection.execute(query, params)
-        playlists = _playlist_resultset_to_model(connection, result, False)
+    result = ts_conn.execute(query, params)
+    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, False)
 
     return playlists
 
 
-def _playlist_resultset_to_model(connection, result, load_recordings):
+def _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings):
     """Parse the result of an sql query to get playlists
 
     Fill in related data (username, created_for username) and collaborators
@@ -211,10 +206,10 @@ def _playlist_resultset_to_model(connection, result, load_recordings):
         creator_id = row["creator_id"]
         if creator_id not in user_id_map:
             # TODO: Do this lookup in bulk
-            user_id_map[creator_id] = db_user.get(creator_id)
+            user_id_map[creator_id] = db_user.get(db_conn, creator_id)
         created_for_id = row["created_for_id"]
         if created_for_id and created_for_id not in user_id_map:
-            user_id_map[created_for_id] = db_user.get(created_for_id)
+            user_id_map[created_for_id] = db_user.get(db_conn, created_for_id)
         row["creator"] = user_id_map[creator_id]["musicbrainz_id"]
         if created_for_id:
             row["created_for"] = user_id_map[created_for_id]["musicbrainz_id"]
@@ -225,24 +220,24 @@ def _playlist_resultset_to_model(connection, result, load_recordings):
     playlist_ids = [p.id for p in playlists]
     if playlist_ids:
         if load_recordings:
-            playlist_recordings = get_recordings_for_playlists(connection, playlist_ids)
+            playlist_recordings = get_recordings_for_playlists(db_conn, ts_conn, playlist_ids)
             for p in playlists:
                 p.recordings = playlist_recordings.get(p.id, [])
-        playlist_collaborator_ids = get_collaborators_for_playlists(connection, playlist_ids)
+        playlist_collaborator_ids = get_collaborators_for_playlists(ts_conn, playlist_ids)
         for p in playlists:
             p.collaborator_ids = playlist_collaborator_ids.get(p.id, [])
-            p.collaborators = get_collaborators_names_from_ids(p.collaborator_ids)
+            p.collaborators = get_collaborators_names_from_ids(db_conn, p.collaborator_ids)
 
     return playlists
 
 
-def get_playlists_created_for_user(user_id: int,
-                                   load_recordings: bool = False,
-                                   count: int = 0,
-                                   offset: int = 0):
+def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordings: bool = False,
+                                   count: int = 0, offset: int = 0):
     """Get all playlists that were created for a user by bots
 
     Arguments:
+        db_conn: database connection
+        ts_conn: timescale database connection
         user_id
         load_recordings
         count: Return max count number of playlists, for pagination purposes. If omitted, return all.
@@ -258,7 +253,7 @@ def get_playlists_created_for_user(user_id: int,
         count = None
 
     params = {"created_for_id": user_id, "count": count, "offset": offset}
-    query = sqlalchemy.text(f"""
+    query = text(f"""
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -279,29 +274,27 @@ def get_playlists_created_for_user(user_id: int,
          LIMIT :count
         OFFSET :offset""")
 
-    with ts.engine.connect() as connection:
-        result = connection.execute(query, params)
-        playlists = _playlist_resultset_to_model(connection, result, load_recordings)
+    result = ts_conn.execute(query, params)
+    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings)
 
-        # Fetch the total count of playlists
-        params = {"created_for_id": user_id}
-        query = sqlalchemy.text(f"""SELECT COUNT(*)
-                                      FROM playlist.playlist
-                                     WHERE created_for_id = :created_for_id""")
-        count = connection.execute(query, params).fetchone()[0]
+    # Fetch the total count of playlists
+    params = {"created_for_id": user_id}
+    query = text(f"""SELECT COUNT(*)
+                       FROM playlist.playlist
+                      WHERE created_for_id = :created_for_id""")
+    count = ts_conn.execute(query, params).fetchone()[0]
 
     return playlists, count
 
 
-def get_playlists_collaborated_on(user_id: int,
-                                  include_private: bool = False,
-                                  load_recordings: bool = False,
-                                  count: int = 0,
-                                  offset: int = 0):
+def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_private: bool = False,
+                                  load_recordings: bool = False, count: int = 0, offset: int = 0):
     """Get playlists that this user doesn't own, but is a collaborator on.
     Playlists are ordered by creation date.
 
     Arguments:
+        db_conn: database connection
+        ts_conn: timescale database connection
         user_id: The user id
         load_recordings: If True, also return recordings for each playlist
         include_private: If True, include all playlists by a user, including private ones. The count of
@@ -320,7 +313,7 @@ def get_playlists_collaborated_on(user_id: int,
     if not include_private:
         where_public = "AND pl.public = :public"
         params["public"] = True
-    query = sqlalchemy.text(f"""
+    query = text(f"""
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -344,32 +337,33 @@ def get_playlists_collaborated_on(user_id: int,
          LIMIT :count
         OFFSET :offset""")
 
-    with ts.engine.connect() as connection:
-        result = connection.execute(query, params)
-        playlists = _playlist_resultset_to_model(connection, result, load_recordings)
+    result = ts_conn.execute(query, params)
+    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings)
 
-        # Fetch the total count of playlists
-        params = {"collaborator_id": user_id}
-        where_public = ""
-        if not include_private:
-            where_public = "AND playlist.public = :public"
-            params["public"] = True
-        query = sqlalchemy.text(f"""SELECT COUNT(*)
-                                      FROM playlist.playlist
-                                 LEFT JOIN playlist.playlist_collaborator
-                                        ON playlist.playlist.id = playlist_collaborator.playlist_id
-                                     WHERE playlist.playlist_collaborator.collaborator_id = :collaborator_id
-                                           {where_public}""")
-        count = connection.execute(query, params).fetchone()[0]
+    # Fetch the total count of playlists
+    params = {"collaborator_id": user_id}
+    where_public = ""
+    if not include_private:
+        where_public = "AND playlist.public = :public"
+        params["public"] = True
+    query = sqlalchemy.text(f"""
+        SELECT COUNT(*)
+          FROM playlist.playlist
+     LEFT JOIN playlist.playlist_collaborator
+            ON playlist.playlist.id = playlist_collaborator.playlist_id
+         WHERE playlist.playlist_collaborator.collaborator_id = :collaborator_id
+               {where_public}
+    """)
+    count = ts_conn.execute(query, params).fetchone()[0]
 
     return playlists, count
 
 
-def get_collaborators_for_playlists(connection, playlist_ids: List[int]):
+def get_collaborators_for_playlists(ts_conn, playlist_ids: List[int]):
     """Get all of the collaborators for the given playlists
 
     Args:
-        connection: an open database connection
+        ts_conn: timescale database connection
         playlist_ids: a list of playlist ids to get collaborator information for
 
     Return:
@@ -378,23 +372,23 @@ def get_collaborators_for_playlists(connection, playlist_ids: List[int]):
     if not playlist_ids:
         return {}
 
-    query = sqlalchemy.text("""
+    query = text("""
         SELECT playlist_id
              , array_agg(collaborator_id) AS collaborator_ids
           FROM playlist.playlist_collaborator
          WHERE playlist_id in :playlist_ids
       GROUP BY playlist_id""")
-    result = connection.execute(query, {"playlist_ids": tuple(playlist_ids)})
+    result = ts_conn.execute(query, {"playlist_ids": tuple(playlist_ids)})
     ret = {}
     for row in result.fetchall():
         ret[row.playlist_id] = row.collaborator_ids
     return ret
 
 
-def get_recordings_for_playlists(connection, playlist_ids: List[int]):
-    """"""
+def get_recordings_for_playlists(db_conn, ts_conn, playlist_ids: List[int]):
+    """ Get all recordings for the given playlists """
 
-    query = sqlalchemy.text("""
+    query = text("""
         SELECT id
              , playlist_id
              , position
@@ -405,7 +399,7 @@ def get_recordings_for_playlists(connection, playlist_ids: List[int]):
          WHERE playlist_id IN :playlist_ids
       ORDER BY playlist_id, position
     """)
-    result = connection.execute(query, {"playlist_ids": tuple(playlist_ids)})
+    result = ts_conn.execute(query, {"playlist_ids": tuple(playlist_ids)})
     user_id_map = {}
     playlist_recordings_map = collections.defaultdict(list)
     for row in result.mappings():
@@ -413,7 +407,7 @@ def get_recordings_for_playlists(connection, playlist_ids: List[int]):
         added_by_id = row["added_by_id"]
         if added_by_id not in user_id_map:
             # TODO: Do this lookup in bulk
-            user_id_map[added_by_id] = db_user.get(added_by_id)
+            user_id_map[added_by_id] = db_user.get(db_conn, added_by_id)
         row["added_by"] = user_id_map[added_by_id]["musicbrainz_id"]
         playlist_recording = model_playlist.PlaylistRecording.parse_obj(row)
         playlist_recordings_map[playlist_recording.playlist_id].append(playlist_recording)
@@ -423,25 +417,31 @@ def get_recordings_for_playlists(connection, playlist_ids: List[int]):
     return dict(playlist_recordings_map)
 
 
-def _remove_old_collaborative_playlists(connection, creator_id: int, created_for_id: int, source_patch: str):
+def _remove_old_collaborative_playlists(ts_conn, creator_id: int, created_for_id: int, source_patch: str):
     """
        Remove all the collaborative playlists for the given creator, credit_for and source_patch.
        This function will be used in the create function in order to remove the old collaborative playlists
        that the new playlist replaces, all in one transaction.
     """
-    del_query = sqlalchemy.text("""DELETE FROM playlist.playlist
-                                         WHERE creator_id = :creator_id
-                                           AND additional_metadata->'algorithm_metadata'->>'source_patch' = :source_patch
-                                           AND created_for_id = :created_for_id""")
-    connection.execute(del_query, {"creator_id": creator_id,
-                                   "created_for_id": created_for_id,
-                                   "source_patch": source_patch})
+    del_query = text("""
+        DELETE FROM playlist.playlist
+              WHERE creator_id = :creator_id
+                AND additional_metadata->'algorithm_metadata'->>'source_patch' = :source_patch
+                AND created_for_id = :created_for_id
+    """)
+    ts_conn.execute(del_query, {
+        "creator_id": creator_id,
+        "created_for_id": created_for_id,
+        "source_patch": source_patch
+    })
 
 
-def create(playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist:
+def create(db_conn, ts_conn, playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist:
     """Create a playlist
 
     Arguments:
+        db_conn: database connection
+        ts_conn: timsecale database connection
         playlist: A playlist to add
 
     Raises:
@@ -453,7 +453,7 @@ def create(playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist
 
     """
     # TODO: These two gets should be done in a single query
-    creator = db_user.get(playlist.creator_id)
+    creator = db_user.get(db_conn, playlist.creator_id)
     if creator is None:
         raise Exception("TODO: Custom exception")
 
@@ -461,11 +461,11 @@ def create(playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist
     # and then the name is fetched for verification again. Should we accept created_for here and do
     # lookup only here and not he in the API call validation?
     if playlist.created_for_id:
-        created_for = db_user.get(playlist.created_for_id)
+        created_for = db_user.get(db_conn, playlist.created_for_id)
         if created_for is None:
             raise Exception("TODO: Custom exception")
 
-    query = sqlalchemy.text("""
+    query = text("""
         INSERT INTO playlist.playlist (creator_id
                                      , name
                                      , description
@@ -486,103 +486,105 @@ def create(playlist: model_playlist.WritablePlaylist) -> model_playlist.Playlist
                                     'copied_from_id', 'created_for_id'})
     fields["additional_metadata"] = orjson.dumps(playlist.additional_metadata or {}).decode("utf-8")
 
-    with ts.engine.connect() as connection:
-        with connection.begin():
-            # This code seems out of place for a create function, but in order to keep the deletion of
-            # old collaborative playlists in the same transaction as creating new playlists, it needs to
-            # to be here.
-            if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID)  and playlist.created_for_id is not None and \
-                    playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
-                    and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
-                _remove_old_collaborative_playlists(
-                    connection,
-                    playlist.creator_id,
-                    playlist.created_for_id,
-                    playlist.additional_metadata["algorithm_metadata"]["source_patch"]
-                )
+    # This code seems out of place for a create function, but in order to keep the deletion of
+    # old collaborative playlists in the same transaction as creating new playlists, it needs to
+    # to be here.
+    if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID) and playlist.created_for_id is not None and \
+            playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
+            and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
+        _remove_old_collaborative_playlists(
+            ts_conn,
+            playlist.creator_id,
+            playlist.created_for_id,
+            playlist.additional_metadata["algorithm_metadata"]["source_patch"]
+        )
 
-            result = connection.execute(query, fields)
-            row = result.fetchone()
-            playlist.id = row.id
-            playlist.mbid = row.mbid
-            playlist.created = row.created
-            playlist.creator = creator["musicbrainz_id"]
-            playlist.recordings = insert_recordings(connection, playlist.id, playlist.recordings, 0)
+    result = ts_conn.execute(query, fields)
+    row = result.fetchone()
+    playlist.id = row.id
+    playlist.mbid = row.mbid
+    playlist.created = row.created
+    playlist.creator = creator["musicbrainz_id"]
+    playlist.recordings = insert_recordings(db_conn, ts_conn, playlist.id, playlist.recordings, 0)
 
-            if playlist.collaborator_ids:
-                add_playlist_collaborators(connection, playlist.id, playlist.collaborator_ids)
-                collaborator_ids = get_collaborators_for_playlists(connection, [playlist.id])
-                collaborator_ids = collaborator_ids.get(playlist.id, [])
-                playlist.collaborators = get_collaborators_names_from_ids(collaborator_ids)
+    if playlist.collaborator_ids:
+        add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
+        collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
+        collaborator_ids = collaborator_ids.get(playlist.id, [])
+        playlist.collaborators = get_collaborators_names_from_ids(db_conn, collaborator_ids)
 
-            return model_playlist.Playlist.parse_obj(playlist.dict())
+    ts_conn.commit()
+
+    return model_playlist.Playlist.parse_obj(playlist.dict())
 
 
-def add_playlist_collaborators(connection, playlist_id, collaborator_ids):
-    delete_query = sqlalchemy.text(
-        """DELETE FROM playlist.playlist_collaborator
-                 WHERE playlist_id = :playlist_id""")
-    insert_query = sqlalchemy.text(
-        """INSERT INTO playlist.playlist_collaborator (playlist_id, collaborator_id)
-                VALUES (:playlist_id, :collaborator_id)""")
+def add_playlist_collaborators(ts_conn, playlist_id, collaborator_ids):
+    delete_query = text("""
+        DELETE FROM playlist.playlist_collaborator
+              WHERE playlist_id = :playlist_id
+    """)
+    insert_query = sqlalchemy.text("""
+        INSERT INTO playlist.playlist_collaborator (playlist_id, collaborator_id)
+                VALUES (:playlist_id, :collaborator_id)
+    """)
 
     collaborator_params = [{"playlist_id": playlist_id, "collaborator_id": c_id} for c_id in collaborator_ids]
-    connection.execute(delete_query, {"playlist_id": playlist_id})
+    ts_conn.execute(delete_query, {"playlist_id": playlist_id})
     if collaborator_params:
-        connection.execute(insert_query, collaborator_params)
+        ts_conn.execute(insert_query, collaborator_params)
 
 
-def get_collaborators_names_from_ids(collaborator_ids: List[int]):
+def get_collaborators_names_from_ids(db_conn, collaborator_ids: List[int]):
     collaborators = []
     # TODO: Look this up in one query
     for user_id in collaborator_ids:
-        user = db_user.get(user_id)
+        user = db_user.get(db_conn, user_id)
         if user:
             collaborators.append(user["musicbrainz_id"])
     collaborators.sort()
     return collaborators
 
 
-def update_playlist(playlist: model_playlist.Playlist):
+def update_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist):
     """Update playlist metadata (Name, description, public flag)
 
     Arguments:
 
     """
 
-    query = sqlalchemy.text("""
+    query = text("""
         UPDATE playlist.playlist
            SET name = :name
              , description = :description
              , public = :public
          WHERE id = :id
     """)
-    with ts.engine.begin() as connection:
-        params = playlist.dict(include={'id', 'name', 'description', 'public'})
-        connection.execute(query, params)
-        # Unconditionally add collaborators, this allows us to delete all collaborators
-        # if [] is passed in.
-        # TODO: Optimise this by getting collaborators from the database and only updating
-        #  if what has passed is different to what exists
-        add_playlist_collaborators(connection, playlist.id, playlist.collaborator_ids)
-        collaborator_ids = get_collaborators_for_playlists(connection, [playlist.id])
-        collaborator_ids = collaborator_ids.get(playlist.id, [])
-        playlist.collaborators = get_collaborators_names_from_ids(playlist.collaborator_ids)
-        playlist.last_updated = set_last_updated(connection, playlist.id)
-        return playlist
+    params = playlist.dict(include={'id', 'name', 'description', 'public'})
+    ts_conn.execute(query, params)
+    # Unconditionally add collaborators, this allows us to delete all collaborators
+    # if [] is passed in.
+    # TODO: Optimise this by getting collaborators from the database and only updating
+    #  if what has passed is different to what exists
+    add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
+    collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
+    collaborator_ids = collaborator_ids.get(playlist.id, [])
+    playlist.collaborators = get_collaborators_names_from_ids(db_conn, playlist.collaborator_ids)
+    playlist.last_updated = set_last_updated(ts_conn, playlist.id)
+    ts_conn.commit()
+    return playlist
 
 
-def set_last_updated(connection, playlist_id):
-    query = sqlalchemy.text("""
+def set_last_updated(ts_conn, playlist_id):
+    query = text("""
         UPDATE playlist.playlist
            SET last_updated = now()
          WHERE id = :playlist_id
      RETURNING last_updated""")
-    result = connection.execute(query, {"playlist_id": playlist_id})
+    result = ts_conn.execute(query, {"playlist_id": playlist_id})
     return result.fetchone()[0]
 
 
-def copy_playlist(playlist: model_playlist.Playlist, creator_id: int):
+def copy_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist, creator_id: int):
     newplaylist = playlist.copy()
     newplaylist.name = "Copy of " + newplaylist.name
     newplaylist.creator_id = creator_id
@@ -593,46 +595,49 @@ def copy_playlist(playlist: model_playlist.Playlist, creator_id: int):
     newplaylist.collaborators = []
     # TODO: We need a copied_from_mbid (calculated) field in the playlist object so we can show the mbid in the ui
 
-    return create(newplaylist)
+    return create(db_conn, ts_conn, newplaylist)
 
 
-def delete_playlist(playlist: model_playlist.Playlist):
+def delete_playlist(ts_conn, playlist: model_playlist.Playlist):
     """Delete a playlist.
 
     Arguments:
+        ts_conn: timescale database connection
         playlist: The playlist to delete
 
     Returns:
         True if the playlist was deleted, False if no such playlist with the given mbid exists
     """
-    return delete_playlist_by_mbid(playlist.mbid)
+    return delete_playlist_by_mbid(ts_conn, playlist.mbid)
 
 
-def delete_playlist_by_mbid(playlist_mbid: str):
+def delete_playlist_by_mbid(ts_conn, playlist_mbid: str):
     """Delete a playlist given an mbid.
 
     Arguments:
+        ts_conn: timescale database connection
         playlist_mbid: The mbid of the playlist to delete
 
     Returns:
         True if the playlist was deleted, False if no such playlist with the given mbid exists
     """
-    query = sqlalchemy.text("""
+    query = text("""
         DELETE FROM playlist.playlist
               WHERE playlist.mbid = :playlist_mbid
     """)
-    with ts.engine.begin() as connection:
-        result = connection.execute(query, {"playlist_mbid": playlist_mbid})
-        return result.rowcount == 1
+    result = ts_conn.execute(query, {"playlist_mbid": playlist_mbid})
+    ts_conn.commit()
+    return result.rowcount == 1
 
 
-def insert_recordings(connection, playlist_id: int, recordings: List[model_playlist.WritablePlaylistRecording],
+def insert_recordings(db_conn, ts_conn, playlist_id: int, recordings: List[model_playlist.WritablePlaylistRecording],
                       starting_position: int):
     """Insert recordings to an existing playlist. The position field will be computed based on the order
     of the provided recordings.
 
     Arguments:
-        connection: an open database connection
+        db_conn: database connection
+        ts_conn: timescale database connection
         playlist_id: the playlist id to add the recordings to
         recordings: a list of recordings to add
         starting_position: The position number to set in the first recording. The first recording in a playlist is position 0
@@ -641,20 +646,21 @@ def insert_recordings(connection, playlist_id: int, recordings: List[model_playl
         recording.playlist_id = playlist_id
         recording.position = position
 
-    query = sqlalchemy.text("""
+    query = text("""
         INSERT INTO playlist.playlist_recording (playlist_id, position, mbid, added_by_id, created)
                                          VALUES (:playlist_id, :position, :mbid, :added_by_id, :created)
-                                      RETURNING id, created""")
+                                      RETURNING id, created
+    """)
     return_recordings = []
     user_id_map = {}
     insert_ts = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
     for recording in recordings:
         if not recording.created:
             recording.created = insert_ts
-        result = connection.execute(query, recording.dict(include={'playlist_id', 'position', 'mbid', 'added_by_id', 'created'}))
+        result = ts_conn.execute(query, recording.dict(include={'playlist_id', 'position', 'mbid', 'added_by_id', 'created'}))
         if recording.added_by_id not in user_id_map:
             # TODO: Do this lookup in bulk
-            user_id_map[recording.added_by_id] = db_user.get(recording.added_by_id)
+            user_id_map[recording.added_by_id] = db_user.get(db_conn, recording.added_by_id)
         row = result.fetchone()
         recording.id = row.id
         recording.created = row.created
@@ -663,11 +669,12 @@ def insert_recordings(connection, playlist_id: int, recordings: List[model_playl
     return return_recordings
 
 
-def delete_recordings_from_playlist(playlist: model_playlist.Playlist, remove_from: int, remove_count: int):
+def delete_recordings_from_playlist(ts_conn, playlist: model_playlist.Playlist, remove_from: int, remove_count: int):
     """Delete recordings from a playlist. If the remove_from + remove_count is more than the number
     of items in the playlist, silently remove as many as possible
 
     Arguments:
+        ts_conn: timescale database connection
         playlist: The playlist to remove recordings from
         remove_from: The position to remove from, 0 indexed
         remove_count: The number of items to remove
@@ -694,41 +701,42 @@ def delete_recordings_from_playlist(playlist: model_playlist.Playlist, remove_fr
     if remove_from >= len(playlist.recordings):
         raise ValueError("Cannot remove item past the end of the list of recordings")
 
-    delete = sqlalchemy.text("""
+    delete = text("""
         DELETE FROM playlist.playlist_recording
           WHERE playlist_id = :playlist_id
             AND position >= :position_start
             AND position < :position_end
     """)
-    reorder = sqlalchemy.text("""
+    reorder = text("""
         UPDATE playlist.playlist_recording
            SET position = position + :offset
          WHERE playlist_id = :playlist_id
            AND position >= :position
     """)
-    with ts.engine.begin() as connection:
-        delete_params = {"playlist_id": playlist.id,
-                         "position_start": remove_from,
-                         "position_end": remove_from+remove_count}
-        connection.execute(delete, delete_params)
-        if remove_from + remove_count < len(playlist.recordings):
-            reorder_params = {"playlist_id": playlist.id,
-                              "position": remove_from + remove_count,
-                              "offset": -1 * remove_count}
-            connection.execute(reorder, reorder_params)
-        # TODO: In move_recordings we call delete and then add, so this is called twice
-        set_last_updated(connection, playlist.id)
+    delete_params = {"playlist_id": playlist.id,
+                     "position_start": remove_from,
+                     "position_end": remove_from+remove_count}
+    ts_conn.execute(delete, delete_params)
+    if remove_from + remove_count < len(playlist.recordings):
+        reorder_params = {"playlist_id": playlist.id,
+                          "position": remove_from + remove_count,
+                          "offset": -1 * remove_count}
+        ts_conn.execute(reorder, reorder_params)
+    # TODO: In move_recordings we call delete and then add, so this is called twice
+    set_last_updated(ts_conn, playlist.id)
+    ts_conn.commit()
 
 
-def add_recordings_to_playlist(playlist: model_playlist.Playlist,
-                               recordings: List[model_playlist.WritablePlaylistRecording],
-                               position: int = None):
+def add_recordings_to_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist,
+                               recordings: List[model_playlist.WritablePlaylistRecording], position: int = None):
     """Add some recordings to a playlist at a given position
 
     Recording positions are counted from 0, and recordings are added at the given position. If the playlist
     has other recordings at this position, they will be moved
 
     Arguments:
+        db_conn: database connection
+        ts_conn: timescale database connection
         playlist: A Playlist to append to. Must be loaded with ``get_by_id`` and have and id and recordings set
         recordings: A list of recordings to add
         position: The position in the existing playlist after which to add the recordings. If ``None`` or
@@ -742,7 +750,7 @@ def add_recordings_to_playlist(playlist: model_playlist.Playlist,
     #   - can we just check if there's an exception on insert?
     # TODO: Need unique key on (playlist_id, position) on playlist_recording
     # TODO: This is the same reorder method as delete
-    reorder = sqlalchemy.text("""
+    reorder = text("""
         UPDATE playlist.playlist_recording
            SET position = position + :offset
          WHERE playlist_id = :playlist_id
@@ -750,23 +758,24 @@ def add_recordings_to_playlist(playlist: model_playlist.Playlist,
     """)
     if position is None:
         position = len(playlist.recordings)
-    with ts.engine.begin() as connection:
-        if position < len(playlist.recordings):
-            reorder_params = {"playlist_id": playlist.id,
-                              "offset": len(recordings),
-                              "position": position}
-            connection.execute(reorder, reorder_params)
-        recordings = insert_recordings(connection, playlist.id, recordings, position)
-        playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
-        set_last_updated(connection, playlist.id)
-        return playlist
+
+    if position < len(playlist.recordings):
+        reorder_params = {"playlist_id": playlist.id,
+                          "offset": len(recordings),
+                          "position": position}
+        ts_conn.execute(reorder, reorder_params)
+    recordings = insert_recordings(db_conn, ts_conn, playlist.id, recordings, position)
+    playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
+    set_last_updated(ts_conn, playlist.id)
+    ts_conn.commit()
+    return playlist
 
 
-def move_recordings(playlist: model_playlist.Playlist, position_from: int, position_to: int, count: int):
+def move_recordings(db_conn, ts_conn, playlist: model_playlist.Playlist, position_from: int, position_to: int, count: int):
     # TODO: This must be done in a single transaction
     removed = playlist.recordings[position_from:position_from+count]
-    delete_recordings_from_playlist(playlist, position_from, count)
-    add_recordings_to_playlist(playlist, removed, position_to)
+    delete_recordings_from_playlist(ts_conn, playlist, position_from, count)
+    add_recordings_to_playlist(db_conn, ts_conn, playlist, removed, position_to)
 
 
 def get_playlist_recordings_metadata(mb_curs, ts_curs, playlist: Playlist) -> Playlist:

--- a/listenbrainz/db/recommendations_cf_recording.py
+++ b/listenbrainz/db/recommendations_cf_recording.py
@@ -24,7 +24,6 @@
 import orjson
 import sqlalchemy
 
-from listenbrainz import db
 from flask import current_app
 from pydantic import ValidationError
 
@@ -32,45 +31,46 @@ from data.model.user_cf_recommendations_recording_message import (UserRecommenda
                                                                   UserRecommendationsJson)
 
 
-def get_timestamp_for_last_recording_recommended():
+def get_timestamp_for_last_recording_recommended(db_conn):
     """ Get the time when recommendation_cf_recording table was last updated
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT MAX(created) as created_ts
-              FROM recommendation.cf_recording
-            """)
-        )
-        row = result.fetchone()
-        return row.created_ts if row else None
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT MAX(created) as created_ts
+          FROM recommendation.cf_recording
+        """)
+    )
+    row = result.fetchone()
+    return row.created_ts if row else None
 
 
-def insert_user_recommendation(user_id: int, recommendations: UserRecommendationsJson):
+def insert_user_recommendation(db_conn, user_id: int, recommendations: UserRecommendationsJson):
     """ Insert recommended recording for a user in the db.
 
         Args:
+            db_conn: database connection
             user_id (int): row id of the user.
             recommendations (dict): User recommendations.
     """
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            INSERT INTO recommendation.cf_recording (user_id, recording_mbid)
-                 VALUES (:user_id, :recommendation)
-            ON CONFLICT (user_id)
-          DO UPDATE SET user_id = :user_id,
-                        recording_mbid = :recommendation,
-                        created = NOW()
-            """), {
-                'user_id': user_id,
-                'recommendation': orjson.dumps(recommendations.dict()).decode("utf-8"),
-            }
-        )
+    db_conn.execute(sqlalchemy.text("""
+        INSERT INTO recommendation.cf_recording (user_id, recording_mbid)
+             VALUES (:user_id, :recommendation)
+        ON CONFLICT (user_id)
+      DO UPDATE SET user_id = :user_id,
+                    recording_mbid = :recommendation,
+                    created = NOW()
+        """), {
+            'user_id': user_id,
+            'recommendation': orjson.dumps(recommendations.dict()).decode("utf-8"),
+        }
+    )
+    db_conn.commit()
 
 
-def get_user_recommendation(user_id):
+def get_user_recommendation(db_conn, user_id):
     """ Get recommendations for a user with the given row ID.
 
         Args:
+            db_conn: database connection
             user_id (int): the row ID of the user in the DB
 
         Returns:
@@ -86,16 +86,15 @@ def get_user_recommendation(user_id):
                 'raw': []
             }
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT user_id, recording_mbid, created
-              FROM recommendation.cf_recording
-             WHERE user_id = :user_id
-            """), {
-                    'user_id': user_id
-                }
-        )
-        row = result.mappings().first()
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT user_id, recording_mbid, created
+          FROM recommendation.cf_recording
+         WHERE user_id = :user_id
+        """), {
+                'user_id': user_id
+            }
+    )
+    row = result.mappings().first()
 
     try:
         return UserRecommendationsData(**row) if row else None

--- a/listenbrainz/db/recommendations_cf_recording_feedback.py
+++ b/listenbrainz/db/recommendations_cf_recording_feedback.py
@@ -1,59 +1,60 @@
 import sqlalchemy
 
-from listenbrainz import db
 from listenbrainz.db.model.recommendation_feedback import (RecommendationFeedbackSubmit,
                                                            RecommendationFeedbackDelete)
 from typing import List
 
 
-def insert(feedback_submit: RecommendationFeedbackSubmit):
+def insert(db_conn, feedback_submit: RecommendationFeedbackSubmit):
     """ Inserts a feedback record for a user's rated recommendation into the database.
         If the record is already present for the user, the rating is updated to the new
         value passed.
 
         Args:
+            db_conn: database connection
             feedback_submit: An object of class RecommendationFeedbackSubmit
     """
+    db_conn.execute(sqlalchemy.text("""
+        INSERT INTO recommendation_feedback (user_id, recording_mbid, rating)
+             VALUES (:user_id, :recording_mbid, :rating)
+        ON CONFLICT (user_id, recording_mbid)
+      DO UPDATE SET rating = :rating,
+                    created = NOW()
+        """), {
+            'user_id': feedback_submit.user_id,
+            'recording_mbid': feedback_submit.recording_mbid,
+            'rating': feedback_submit.rating,
+        }
+    )
+    db_conn.commit()
 
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            INSERT INTO recommendation_feedback (user_id, recording_mbid, rating)
-                 VALUES (:user_id, :recording_mbid, :rating)
-            ON CONFLICT (user_id, recording_mbid)
-          DO UPDATE SET rating = :rating,
-                        created = NOW()
-            """), {
-                'user_id': feedback_submit.user_id,
-                'recording_mbid': feedback_submit.recording_mbid,
-                'rating': feedback_submit.rating,
-            }
-        )
 
-
-def delete(feedback_delete: RecommendationFeedbackDelete):
+def delete(db_conn, feedback_delete: RecommendationFeedbackDelete):
     """ Deletes the feedback record for a given recommendation for the user from the database
 
         Args:
+            db_conn: database connection
             feedback_delete: An object of class RecommendationFeedbackDelete
     """
+    db_conn.execute(sqlalchemy.text("""
+        DELETE FROM recommendation_feedback
+         WHERE user_id = :user_id
+           AND recording_mbid = :recording_mbid
+        """), {
+            'user_id': feedback_delete.user_id,
+            'recording_mbid': feedback_delete.recording_mbid,
+        }
+    )
+    db_conn.commit()
 
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            DELETE FROM recommendation_feedback
-             WHERE user_id = :user_id
-               AND recording_mbid = :recording_mbid
-            """), {
-                'user_id': feedback_delete.user_id,
-                'recording_mbid': feedback_delete.recording_mbid,
-            }
-        )
 
-
-def get_feedback_for_user(user_id: int, limit: int, offset: int, rating: str = None) -> List[RecommendationFeedbackSubmit]:
+def get_feedback_for_user(db_conn, user_id: int, limit: int, offset: int, rating: str = None)\
+        -> List[RecommendationFeedbackSubmit]:
     """ Get a list of recommendation feedback given by the user in descending order of their creation.
         Feedback will be filtered based on limit, offset and rating, if passed.
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
             rating: the rating value by which the results are to be filtered.
             limit: number of rows to be returned
@@ -79,38 +80,38 @@ def get_feedback_for_user(user_id: int, limit: int, offset: int, rating: str = N
                  LIMIT :limit
                  OFFSET :offset """
 
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text(query), args)
-        return [RecommendationFeedbackSubmit(**row) for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text(query), args)
+    return [RecommendationFeedbackSubmit(**row) for row in result.mappings()]
 
 
-def get_feedback_count_for_user(user_id: int) -> int:
+def get_feedback_count_for_user(db_conn, user_id: int) -> int:
     """ Get total number of recommendation feedback given by the user
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
 
         Returns:
             The total number of recommendation feedback given by the user
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT count(*) AS count
-              FROM recommendation_feedback
-             WHERE user_id = :user_id
-            """), {
-                'user_id': user_id,
-            }
-        )
-        count = int(result.fetchone().count)
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT count(*) AS count
+          FROM recommendation_feedback
+         WHERE user_id = :user_id
+        """), {
+            'user_id': user_id,
+        }
+    )
+    count = int(result.fetchone().count)
 
     return count
 
 
-def get_feedback_for_multiple_recordings_for_user(user_id: int, recording_list: List[str]):
+def get_feedback_for_multiple_recordings_for_user(db_conn, user_id: int, recording_list: List[str]):
     """ Get a list of recording feedback given by the user for given recordings
 
         Args:
+            db_conn: database connection
             user_id: the row ID of the user in the DB
             recording_list: list of recording_mbid for which feedback records are to be obtained
                             - if record is present then return it
@@ -132,6 +133,5 @@ def get_feedback_for_multiple_recordings_for_user(user_id: int, recording_list: 
               ORDER BY created DESC
             """
 
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text(query), args)
-        return [RecommendationFeedbackSubmit(**row) for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text(query), args)
+    return [RecommendationFeedbackSubmit(**row) for row in result.mappings()]

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -4,84 +4,80 @@ from listenbrainz import db
 import sqlalchemy
 
 
-def get_active_users_to_process() -> List[dict]:
+def get_active_users_to_process(db_conn) -> List[dict]:
     """ Returns a list of users whose listens should be imported from Spotify.
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT external_service_oauth.user_id
-                 , "user".musicbrainz_id
-                 , "user".musicbrainz_row_id
-                 , access_token
-                 , refresh_token
-                 , listens_importer.last_updated
-                 , token_expires
-                 , scopes
-                 , latest_listened_at
-                 , error_message
-              FROM external_service_oauth
-              JOIN "user"
-                ON "user".id = external_service_oauth.user_id
-              JOIN listens_importer
-                ON listens_importer.external_service_oauth_id = external_service_oauth.id
-             WHERE external_service_oauth.service = 'spotify'
-               AND error_message IS NULL
-          ORDER BY latest_listened_at DESC NULLS LAST
-        """))
-        return [row for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT external_service_oauth.user_id
+             , "user".musicbrainz_id
+             , "user".musicbrainz_row_id
+             , access_token
+             , refresh_token
+             , listens_importer.last_updated
+             , token_expires
+             , scopes
+             , latest_listened_at
+             , error_message
+          FROM external_service_oauth
+          JOIN "user"
+            ON "user".id = external_service_oauth.user_id
+          JOIN listens_importer
+            ON listens_importer.external_service_oauth_id = external_service_oauth.id
+         WHERE external_service_oauth.service = 'spotify'
+           AND error_message IS NULL
+      ORDER BY latest_listened_at DESC NULLS LAST
+    """))
+    return [row for row in result.mappings()]
 
 
-def get_user_import_details(user_id: int) -> Optional[dict]:
+def get_user_import_details(db_conn, user_id: int) -> Optional[dict]:
     """ Return user's spotify linking details to display on connect services page
 
     Args:
+        db_conn: database connection
         user_id (int): the ListenBrainz row ID of the user
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT listens_importer.user_id
-                 , listens_importer.id
-                 , listens_importer.last_updated
-                 , latest_listened_at
-                 , error_message
-              FROM listens_importer
-         LEFT JOIN external_service_oauth
-                ON listens_importer.external_service_oauth_id = external_service_oauth.id
-             WHERE listens_importer.user_id = :user_id
-               AND listens_importer.service = 'spotify'
-            """), {
-                'user_id': user_id,
-            })
-        row = result.mappings().first()
-        return dict(row) if row else None
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT listens_importer.user_id
+             , listens_importer.id
+             , listens_importer.last_updated
+             , latest_listened_at
+             , error_message
+          FROM listens_importer
+     LEFT JOIN external_service_oauth
+            ON listens_importer.external_service_oauth_id = external_service_oauth.id
+         WHERE listens_importer.user_id = :user_id
+           AND listens_importer.service = 'spotify'
+        """), {
+            'user_id': user_id,
+        })
+    row = result.mappings().first()
+    return dict(row) if row else None
 
 
-def get_user(user_id: int) -> Optional[dict]:
+def get_user(db_conn, user_id: int) -> Optional[dict]:
     """ This get_user method is different from the one in external_service_oauth.py because
      here we join against the listens_importer table to fetch the latest_listened_at column.
      We need latest_listened_at column for using in the spotify_reader."""
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT external_service_oauth.user_id
-                 , "user".musicbrainz_id
-                 , "user".musicbrainz_row_id
-                 , external_service_oauth.service
-                 , external_user_id
-                 , access_token
-                 , refresh_token
-                 , external_service_oauth.last_updated
-                 , token_expires
-                 , scopes
-                 , latest_listened_at
-                 , error_message
-              FROM external_service_oauth
-              JOIN "user"
-                ON "user".id = external_service_oauth.user_id
-         LEFT JOIN listens_importer
-                ON listens_importer.external_service_oauth_id = external_service_oauth.id
-             WHERE external_service_oauth.service = 'spotify'
-               AND "user".id = :user_id
-        """), {
-            'user_id': user_id
-        })
-        return result.mappings().first()
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT external_service_oauth.user_id
+             , "user".musicbrainz_id
+             , "user".musicbrainz_row_id
+             , external_service_oauth.service
+             , external_user_id
+             , access_token
+             , refresh_token
+             , external_service_oauth.last_updated
+             , token_expires
+             , scopes
+             , latest_listened_at
+             , error_message
+          FROM external_service_oauth
+          JOIN "user"
+            ON "user".id = external_service_oauth.user_id
+     LEFT JOIN listens_importer
+            ON listens_importer.external_service_oauth_id = external_service_oauth.id
+         WHERE external_service_oauth.service = 'spotify'
+           AND "user".id = :user_id
+    """), {'user_id': user_id})
+    return result.mappings().first()

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -96,10 +96,11 @@ def get(user_id, stats_type, stats_range, stats_model) -> Optional[StatApi]:
     return None
 
 
-def get_entity_listener(entity, entity_id, stats_range) -> Optional[dict]:
+def get_entity_listener(db_conn, entity, entity_id, stats_range) -> Optional[dict]:
     """ Retrieve stats for the given entity, stats range and stats type.
 
         Args:
+            db_conn: database connection
             entity: the type of stat entity
             entity_id: the mbid of the particular entity item
             stats_range: time period to retrieve stats for
@@ -116,7 +117,7 @@ def get_entity_listener(entity, entity_id, stats_range) -> Optional[dict]:
         doc.pop("_revisions", None)
 
         user_id_listeners = doc.pop("listeners", [])
-        users_map = get_users_by_id([x["user_id"] for x in user_id_listeners])
+        users_map = get_users_by_id(db_conn, [x["user_id"] for x in user_id_listeners])
         user_name_listeners = []
         for x in user_id_listeners:
             user_name = users_map.get(x["user_id"])

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -38,20 +38,19 @@ class DatabaseTestCase(unittest.TestCase):
         """
         return os.path.join(TEST_DATA_PATH, file_name)
 
-    @classmethod
-    def create_user_with_id(cls, lb_id: int, musicbrainz_row_id: int, musicbrainz_id: str):
+    def create_user_with_id(self, lb_id: int, musicbrainz_row_id: int, musicbrainz_id: str):
         """ Create a new user with the specified LB id. """
-        with db.engine.begin() as connection:
-            connection.execute(sqlalchemy.text("""
-                INSERT INTO "user" (id, musicbrainz_id, musicbrainz_row_id, auth_token)
-                     VALUES (:id, :mb_id, :mb_row_id, :token)
-                ON CONFLICT (musicbrainz_id) DO NOTHING 
-            """), {
-                "id": lb_id,
-                "mb_id": musicbrainz_id,
-                "token": str(uuid.uuid4()),
-                "mb_row_id": musicbrainz_row_id,
-            })
+        self.db_conn.execute(sqlalchemy.text("""
+            INSERT INTO "user" (id, musicbrainz_id, musicbrainz_row_id, auth_token)
+                 VALUES (:id, :mb_id, :mb_row_id, :token)
+            ON CONFLICT (musicbrainz_id) DO NOTHING 
+        """), {
+            "id": lb_id,
+            "mb_id": musicbrainz_id,
+            "token": str(uuid.uuid4()),
+            "mb_row_id": musicbrainz_row_id,
+        })
+        self.db_conn.commit()
 
 
 class TimescaleTestCase(unittest.TestCase):

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -62,6 +62,10 @@ class TimescaleTestCase(unittest.TestCase):
         ts_connect = create_test_timescale_connect_strings()
         ts.init_db_connection(ts_connect["DB_CONNECT"])
         self.reset_timescale_db()
+        self.ts_conn = ts.engine.connect()
+
+    def tearDown(self):
+        self.ts_conn.close()
 
     def reset_timescale_db(self):
         ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'reset_tables.sql'))

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -20,8 +20,10 @@ class DatabaseTestCase(unittest.TestCase):
     def setUp(self):
         db_connect = create_test_database_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])
+        self.db_conn = db.engine.connect()
 
     def tearDown(self):
+        self.db_conn.close()
         self.reset_db()
 
     def reset_db(self):

--- a/listenbrainz/db/tests/test_color.py
+++ b/listenbrainz/db/tests/test_color.py
@@ -2,7 +2,6 @@ from operator import attrgetter
 
 import sqlalchemy
 
-from listenbrainz import db
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.db.model.color import ColorCube
 from listenbrainz.db.color import get_releases_for_color
@@ -11,18 +10,17 @@ from listenbrainz.db.color import get_releases_for_color
 class HuesoundTestCase(DatabaseTestCase):
 
     def insert_test_data(self):
-        with db.engine.begin() as connection:
-            connection.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
-                                                       VALUES (1, 'e97f805a-ab48-4c52-855e-07049142113d', 0, 0, 255, '(0, 0, 255)')"""))
-            connection.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
-                                                       VALUES (2, '7ffff8fc-cd98-47af-9805-5fac5f9d2e04', 255,  0, 255, '(255, 0, 255)')"""))
-            connection.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
-                                                       VALUES (3, '8c276439-d5e8-4560-8df0-2b7c996fd1a4', 255, 0, 0, '(255, 0, 0)')"""))
+        self.db_conn.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
+                                                VALUES (1, 'e97f805a-ab48-4c52-855e-07049142113d', 0, 0, 255, '(0, 0, 255)')"""))
+        self.db_conn.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
+                                                VALUES (2, '7ffff8fc-cd98-47af-9805-5fac5f9d2e04', 255,  0, 255, '(255, 0, 255)')"""))
+        self.db_conn.execute(sqlalchemy.text("""INSERT INTO release_color (caa_id, release_mbid, red, green, blue, color)
+                                                VALUES (3, '8c276439-d5e8-4560-8df0-2b7c996fd1a4', 255, 0, 0, '(255, 0, 0)')"""))
 
     def test_get_releases_for_color(self):
 
         self.insert_test_data()
-        r = get_releases_for_color(255, 0, 0, 3)
+        r = get_releases_for_color(self.db_conn, 255, 0, 0, 3)
 
         # Results need to be sorted in order to undo the randomness of this function.
         r = sorted(r, key=attrgetter("caa_id"))

--- a/listenbrainz/db/tests/test_do_not_recommend.py
+++ b/listenbrainz/db/tests/test_do_not_recommend.py
@@ -11,7 +11,7 @@ class DoNotRecommendDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(DoNotRecommendDatabaseTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, "test_user")
+        self.user = db_user.get_or_create(self.db_conn, 1, "test_user")
         self.items = [
             {
                 "entity": "release",

--- a/listenbrainz/db/tests/test_do_not_recommend.py
+++ b/listenbrainz/db/tests/test_do_not_recommend.py
@@ -4,7 +4,6 @@ from sqlalchemy import text
 
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.db import user as db_user, do_not_recommend
-from listenbrainz import db
 
 
 class DoNotRecommendDatabaseTestCase(DatabaseTestCase):
@@ -31,16 +30,15 @@ class DoNotRecommendDatabaseTestCase(DatabaseTestCase):
         ]
 
     def _get_all_entries(self):
-        with db.engine.connect() as conn:
-            results = conn.execute(text("""
-                SELECT entity, entity_mbid::text, extract(epoch from until)::int as until
-                  FROM recommendation.do_not_recommend
-            """))
-            return results.mappings().all()
+        results = self.db_conn.execute(text("""
+            SELECT entity, entity_mbid::text, extract(epoch from until)::int as until
+              FROM recommendation.do_not_recommend
+        """))
+        return results.mappings().all()
 
     def create_dummy_data(self):
         for item in self.items:
-            do_not_recommend.insert(self.user["id"], item["entity"], item["entity_mbid"], item["until"])
+            do_not_recommend.insert(self.db_conn, self.user["id"], item["entity"], item["entity_mbid"], item["until"])
 
     def test_clear_expired(self):
         self.create_dummy_data()
@@ -50,7 +48,7 @@ class DoNotRecommendDatabaseTestCase(DatabaseTestCase):
         self.assertCountEqual(found, self.items)
 
         # deleted expired item
-        do_not_recommend.clear_expired()
+        do_not_recommend.clear_expired(self.db_conn)
 
         # expired item not found but non-expired items exist
         found = self._get_all_entries()
@@ -58,6 +56,6 @@ class DoNotRecommendDatabaseTestCase(DatabaseTestCase):
 
     def test_get_total_count(self):
         self.create_dummy_data()
-        received = do_not_recommend.get_total_count(self.user["id"])
+        received = do_not_recommend.get_total_count(self.db_conn, self.user["id"])
         # inserted 3 pins but one is expired so don't include it in total count
         self.assertEqual(2, received)

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -123,38 +123,38 @@ class DumpTestCase(DatabaseTestCase):
 
         # create a user
         with self.app.app_context():
-            one_id = db_user.create(1, 'test_user')
-            user_count = db_user.get_user_count()
+            one_id = db_user.create(self.db_conn, 1, 'test_user')
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 1)
 
             # do a db dump and reset the db
             private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir, self.tempdir_private)
             self.reset_db()
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 0)
 
             # import the dump
             db_dump.import_postgres_dump(private_dump, None, public_dump, None)
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 1)
 
             # reset again, and use more threads to import
             self.reset_db()
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 0)
 
             db_dump.import_postgres_dump(private_dump, None, public_dump, None, threads=2)
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 1)
-            two_id = db_user.create(2, 'vnskprk')
+            two_id = db_user.create(self.db_conn, 2, 'vnskprk')
             self.assertGreater(two_id, one_id)
 
     def test_dump_recording_feedback(self):
 
         # create a user
         with self.app.app_context():
-            one_id = db_user.create(1, 'test_user')
-            user_count = db_user.get_user_count()
+            one_id = db_user.create(self.db_conn, 1, 'test_user')
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 1)
 
             # insert a feedback record
@@ -168,13 +168,13 @@ class DumpTestCase(DatabaseTestCase):
             # do a db dump and reset the db
             private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir, self.tempdir_private)
             self.reset_db()
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 0)
             self.assertEqual(db_feedback.get_feedback_count_for_user(self.db_conn, user_id=one_id), 0)
 
             # import the dump and check the records are inserted
             db_dump.import_postgres_dump(private_dump, None, public_dump, None)
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 1)
 
             dumped_feedback = db_feedback.get_feedback_for_user(
@@ -187,12 +187,12 @@ class DumpTestCase(DatabaseTestCase):
 
             # reset again, and use more threads to import
             self.reset_db()
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 0)
             dumped_feedback = []
 
             db_dump.import_postgres_dump(private_dump, None, public_dump, None, threads=2)
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(self.db_conn)
             self.assertEqual(user_count, 1)
 
             dumped_feedback = db_feedback.get_feedback_for_user(

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -36,7 +36,6 @@ import listenbrainz.db.feedback as db_feedback
 from datetime import datetime
 
 from data.model.common_stat import ALLOWED_STATISTICS_RANGE
-from listenbrainz.db import couchdb
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.db.tests.utils import insert_test_stats, delete_all_couch_databases
 from listenbrainz.webserver import create_app
@@ -161,21 +160,21 @@ class DumpTestCase(DatabaseTestCase):
                     recording_msid="d23f4719-9212-49f0-ad08-ddbfbfc50d6f",
                     score=1
                 )
-            db_feedback.insert(feedback)
+            db_feedback.insert(self.db_conn, feedback)
 
             # do a db dump and reset the db
             private_dump, public_dump = db_dump.dump_postgres_db(self.tempdir, self.tempdir_private)
             self.reset_db()
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 0)
-            self.assertEqual(db_feedback.get_feedback_count_for_user(user_id=one_id), 0)
+            self.assertEqual(db_feedback.get_feedback_count_for_user(self.db_conn, user_id=one_id), 0)
 
             # import the dump and check the records are inserted
             db_dump.import_postgres_dump(private_dump, None, public_dump, None)
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
 
-            dumped_feedback = db_feedback.get_feedback_for_user(user_id=one_id, limit=1, offset=0)
+            dumped_feedback = db_feedback.get_feedback_for_user(self.db_conn, user_id=one_id, limit=1, offset=0)
             self.assertEqual(len(dumped_feedback), 1)
             self.assertEqual(dumped_feedback[0].user_id, feedback.user_id)
             self.assertEqual(dumped_feedback[0].recording_msid, feedback.recording_msid)
@@ -191,7 +190,7 @@ class DumpTestCase(DatabaseTestCase):
             user_count = db_user.get_user_count()
             self.assertEqual(user_count, 1)
 
-            dumped_feedback = db_feedback.get_feedback_for_user(user_id=one_id, limit=1, offset=0)
+            dumped_feedback = db_feedback.get_feedback_for_user(self.db_conn, user_id=one_id, limit=1, offset=0)
             self.assertEqual(len(dumped_feedback), 1)
             self.assertEqual(dumped_feedback[0].user_id, feedback.user_id)
             self.assertEqual(dumped_feedback[0].recording_msid, feedback.recording_msid)

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -50,7 +50,7 @@ class DumpManagerTestCase(DatabaseTestCase):
         self.runner = CliRunner()
         self.listenstore = timescale_connection._ts
         self.user_id = db_user.create(1, 'iliekcomputers')
-        self.user_name = db_user.get(self.user_id)['musicbrainz_id']
+        self.user_name = db_user.get(self.db_conn, self.user_id)['musicbrainz_id']
 
     def tearDown(self):
         super().tearDown()

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -317,6 +317,7 @@ class DumpManagerTestCase(DatabaseTestCase):
         ]
         for fb in sample_feedback:
             db_feedback.insert(
+                self.db_conn,
                 Feedback(
                     user_id=fb["user_id"],
                     recording_msid=fb["recording_msid"],

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -49,7 +49,7 @@ class DumpManagerTestCase(DatabaseTestCase):
         self.tempdir_private = tempfile.mkdtemp()
         self.runner = CliRunner()
         self.listenstore = timescale_connection._ts
-        self.user_id = db_user.create(1, 'iliekcomputers')
+        self.user_id = db_user.create(self.db_conn, 1, 'iliekcomputers')
         self.user_name = db_user.get(self.db_conn, self.user_id)['musicbrainz_id']
 
     def tearDown(self):
@@ -301,8 +301,8 @@ class DumpManagerTestCase(DatabaseTestCase):
 
     def test_create_feedback(self):
 
-        self.user = db_user.get_or_create(1, "ernie")
-        self.user2 = db_user.get_or_create(2, "bert")
+        self.user = db_user.get_or_create(self.db_conn, 1, "ernie")
+        self.user2 = db_user.get_or_create(self.db_conn, 2, "bert")
         sample_feedback = [
             {
                 "user_id": self.user['id'],

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -344,6 +344,7 @@ class DumpManagerTestCase(DatabaseTestCase):
         ]
         for fb in rec_feedback:
             db_rec_feedback.insert(
+                self.db_conn,
                 RecommendationFeedbackSubmit(
                     user_id=fb['user_id'],
                     recording_mbid=fb["recording_mbid"],

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -15,6 +15,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         super(OAuthDatabaseTestCase, self).setUp()
         self.user = db_user.get_or_create(self.db_conn, 1, 'testspotifyuser')
         db_oauth.save_token(
+            self.db_conn,
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',
@@ -28,6 +29,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
     def test_create_oauth(self):
         user2 = db_user.get_or_create(self.db_conn, 2, 'spotify')
         db_oauth.save_token(
+            self.db_conn,
             user_id=user2['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',
@@ -37,10 +39,9 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             scopes=['user-read-recently-played'],
             external_user_id='external_user_idid'
         )
-        user = db_oauth.get_token(user2['id'], ExternalServiceType.SPOTIFY)
+        user = db_oauth.get_token(self.db_conn, user2['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual('token', user['access_token'])
         self.assertEqual('external_user_idid', user['external_user_id'])
-
 
     def test_create_oauth_multiple(self):
         """ Test saving the token again for a given service and user_id
@@ -49,6 +50,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         # second time here
         time_before_update = datetime.now(timezone.utc)
         db_oauth.save_token(
+            self.db_conn,
             user_id=self.user['id'],
             external_user_id='external_user_idid',
             service=ExternalServiceType.SPOTIFY,
@@ -58,7 +60,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             record_listens=True,
             scopes=['user-read-recently-played']
         )
-        user = db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY)
+        user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual(user['access_token'], 'new_token')
         # also check that last_updated column is updated, if it is the last_updated in db
         # will be >= than the one we saved just before the 2nd update. if its lesser, then
@@ -68,18 +70,19 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
 
     def test_update_token(self):
         db_oauth.update_token(
+            self.db_conn,
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='testtoken',
             refresh_token='refreshtesttoken',
             expires_at=int(time.time()),
         )
-        spotify_user = db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY)
+        spotify_user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual(spotify_user['access_token'], 'testtoken')
         self.assertEqual(spotify_user['refresh_token'], 'refreshtesttoken')
 
     def test_get_oauth(self):
-        user = db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY)
+        user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual(user['user_id'], self.user['id'])
         self.assertEqual(user['musicbrainz_id'], self.user['musicbrainz_id'])
         self.assertEqual(user['musicbrainz_row_id'], self.user['musicbrainz_row_id'])
@@ -88,27 +91,28 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         self.assertIn('token_expires', user)
 
     def test_delete_token_unlink(self):
-        db_oauth.delete_token(self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=True)
-        self.assertIsNone(db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY))
-        self.assertIsNone(db_spotify.get_user_import_details(self.user['id']))
+        db_oauth.delete_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=True)
+        self.assertIsNone(db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY))
+        self.assertIsNone(db_spotify.get_user_import_details(self.db_conn, self.user['id']))
 
     def test_delete_token_retain_error(self):
-        db_oauth.delete_token(self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=False)
-        self.assertIsNone(db_oauth.get_token(self.user['id'], ExternalServiceType.SPOTIFY))
-        self.assertIsNotNone(db_spotify.get_user_import_details(self.user['id']))
+        db_oauth.delete_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=False)
+        self.assertIsNone(db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY))
+        self.assertIsNotNone(db_spotify.get_user_import_details(self.db_conn, self.user['id']))
 
     def test_get_services(self):
-        services = db_oauth.get_services(self.user["id"])
+        services = db_oauth.get_services(self.db_conn, self.user["id"])
         self.assertEqual(services, ["spotify"])
 
-        db_oauth.delete_token(self.user["id"], ExternalServiceType.SPOTIFY, True)
-        services = db_oauth.get_services(self.user["id"])
+        db_oauth.delete_token(self.db_conn, self.user["id"], ExternalServiceType.SPOTIFY, True)
+        services = db_oauth.get_services(self.db_conn, self.user["id"])
         self.assertEqual(services, [])
 
     def test_musicbrainz_oauth(self):
         """ Test that the refresh token is not deleted on subsequent updates. """
         user = db_user.get_or_create(self.db_conn, 3, 'musicbrainz')
         db_oauth.save_token(
+            self.db_conn,
             user_id=user['id'],
             service=ExternalServiceType.MUSICBRAINZ_PROD,
             access_token='token',
@@ -117,19 +121,20 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             record_listens=False,
             scopes=['profile', 'rating']
         )
-        oauth_user = db_oauth.get_token(user['id'], ExternalServiceType.MUSICBRAINZ_PROD)
+        oauth_user = db_oauth.get_token(self.db_conn, user['id'], ExternalServiceType.MUSICBRAINZ_PROD)
         self.assertEqual('token', oauth_user['access_token'])
         self.assertEqual('refresh_token', oauth_user['refresh_token'])
 
         # for subsequent logins, refresh token returned by MusicBrainz will be None.
         db_oauth.update_token(
+            self.db_conn,
             user_id=user['id'],
             service=ExternalServiceType.MUSICBRAINZ_PROD,
             access_token='new_token',
             refresh_token=None,
             expires_at=int(time.time())
         )
-        oauth_user = db_oauth.get_token(user['id'], ExternalServiceType.MUSICBRAINZ_PROD)
+        oauth_user = db_oauth.get_token(self.db_conn, user['id'], ExternalServiceType.MUSICBRAINZ_PROD)
         self.assertEqual('new_token', oauth_user['access_token'])
 
         # test that the refresh token isn't deleted on subsequent updates

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -13,7 +13,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(OAuthDatabaseTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'testspotifyuser')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testspotifyuser')
         db_oauth.save_token(
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
@@ -26,7 +26,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         )
 
     def test_create_oauth(self):
-        user2 = db_user.get_or_create(2, 'spotify')
+        user2 = db_user.get_or_create(self.db_conn, 2, 'spotify')
         db_oauth.save_token(
             user_id=user2['id'],
             service=ExternalServiceType.SPOTIFY,
@@ -107,7 +107,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
 
     def test_musicbrainz_oauth(self):
         """ Test that the refresh token is not deleted on subsequent updates. """
-        user = db_user.get_or_create(3, 'musicbrainz')
+        user = db_user.get_or_create(self.db_conn, 3, 'musicbrainz')
         db_oauth.save_token(
             user_id=user['id'],
             service=ExternalServiceType.MUSICBRAINZ_PROD,

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -54,6 +54,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         for fb in self.sample_feedback:
             db_feedback.insert(
+                self.db_conn,
                 Feedback(
                     user_id=user_id,
                     recording_msid=fb["recording_msid"],
@@ -95,6 +96,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         for fb in self.sample_feedback_with_metadata:
             db_feedback.insert(
+                self.db_conn,
                 Feedback(
                     user_id=user_id,
                     recording_mbid=fb["recording_mbid"],
@@ -106,14 +108,14 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def test_insert(self):
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), count)
 
     def test_update_score_when_feedback_already_exist(self):
         update_fb = self.sample_feedback[0]
 
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), count)
 
         self.assertEqual(result[3].recording_msid, update_fb["recording_msid"])
@@ -123,6 +125,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         # update a record by inserting a record with updated score value
         db_feedback.insert(
+            self.db_conn,
             Feedback(
                 user_id=self.user["id"],
                 recording_msid=update_fb["recording_msid"],
@@ -130,7 +133,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             )
         )
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), count)
 
         self.assertEqual(result[0].recording_msid, update_fb["recording_msid"])
@@ -140,12 +143,13 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         del_fb = self.sample_feedback[0]
 
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), count)
         self.assertEqual(result[3].recording_msid, del_fb["recording_msid"])
 
         # delete one record for the user using msid
         db_feedback.delete(
+            self.db_conn,
             Feedback(
                 user_id=self.user["id"],
                 recording_msid=del_fb["recording_msid"],
@@ -153,24 +157,26 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             )
         )
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 3)
         self.assertNotIn(del_fb["recording_msid"], [x.recording_msid for x in result])
 
         # delete using mbid
         db_feedback.delete(
+            self.db_conn,
             Feedback(
                 user_id=self.user["id"],
                 recording_mbid=self.sample_feedback[2]["recording_mbid"],
                 score=self.sample_feedback[2]["score"]
             )
         )
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 2)
         self.assertNotIn(self.sample_feedback[2]["recording_mbid"], [x.recording_mbid for x in result])
 
         # delete using mbid and msid both
         db_feedback.delete(
+            self.db_conn,
             Feedback(
                 user_id=self.user["id"],
                 recording_mbid=self.sample_feedback[3]["recording_mbid"],
@@ -178,13 +184,13 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                 score=self.sample_feedback[2]["score"]
             )
         )
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertNotIn(self.sample_feedback[3]["recording_mbid"], [x.recording_mbid for x in result])
 
     def test_get_feedback_for_user(self):
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), count)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -212,27 +218,30 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(result[3].score, self.sample_feedback[0]["score"])
 
         # test the score argument
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0, score=1)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0, score=1)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].score, 1)
         self.assertEqual(result[1].score, 1)
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0, score=-1)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0, score=-1)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].score, -1)
         self.assertEqual(result[1].score, -1)
 
         # test the limit argument
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=1, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=1, offset=0)
         self.assertEqual(len(result), 1)
 
         # test the offset argument
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=1)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=1)
         self.assertEqual(len(result), 3)
 
     def test_get_feedback_for_user_with_metadata(self):
         count = self.insert_test_data_with_metadata(self.user["id"])
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0, score=1, metadata=True)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, user_id=self.user["id"], limit=25,
+            offset=0, score=1, metadata=True
+        )
         self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -245,20 +254,23 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def test_get_feedback_count_for_user(self):
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_count_for_user(user_id=self.user["id"])
+        result = db_feedback.get_feedback_count_for_user(self.db_conn, user_id=self.user["id"])
         self.assertEqual(result, count)
 
-        result = db_feedback.get_feedback_count_for_user(user_id=self.user["id"], score=1)
+        result = db_feedback.get_feedback_count_for_user(self.db_conn, user_id=self.user["id"], score=1)
         self.assertEqual(result, 2)
 
-        result = db_feedback.get_feedback_count_for_user(user_id=self.user["id"], score=-1)
+        result = db_feedback.get_feedback_count_for_user(self.db_conn, user_id=self.user["id"], score=-1)
         self.assertEqual(result, 2)
 
     def test_get_feedback_for_recording(self):
         fb_msid_1 = self.sample_feedback[0]["recording_msid"]
 
         self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0)
+        result = db_feedback.get_feedback_for_recording(
+            self.db_conn, "recording_msid",
+            fb_msid_1, limit=25, offset=0
+        )
         self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -267,7 +279,10 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(result[0].score, self.sample_feedback[0]["score"])
 
         fb_mbid = self.sample_feedback[3]["recording_mbid"]
-        result = db_feedback.get_feedback_for_recording("recording_mbid", fb_mbid, limit=25, offset=0)
+        result = db_feedback.get_feedback_for_recording(
+            self.db_conn, "recording_mbid",
+            fb_mbid, limit=25, offset=0
+        )
         self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -279,7 +294,10 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         user2 = db_user.get_or_create(2, "recording_feedback_other_user")
         self.insert_test_data(user2["id"])
 
-        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0)
+        result = db_feedback.get_feedback_for_recording(
+            self.db_conn, "recording_msid",
+            fb_msid_1, limit=25, offset=0
+        )
         self.assertEqual(len(result), 2)
 
         self.assertEqual(result[0].user_id, user2["id"])
@@ -293,20 +311,32 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(result[1].score, self.sample_feedback[0]["score"])
 
         # test the score argument
-        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0, score=1)
+        result = db_feedback.get_feedback_for_recording(
+            self.db_conn, "recording_msid",
+            fb_msid_1, limit=25, offset=0, score=1
+        )
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].score, 1)
         self.assertEqual(result[1].score, 1)
 
-        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=0, score=-1)
+        result = db_feedback.get_feedback_for_recording(
+            self.db_conn, "recording_msid",
+            fb_msid_1, limit=25, offset=0, score=-1
+        )
         self.assertEqual(len(result), 0)
 
         # test the limit argument
-        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=1, offset=0)
+        result = db_feedback.get_feedback_for_recording(
+            self.db_conn, "recording_msid",
+            fb_msid_1, limit=1, offset=0
+        )
         self.assertEqual(len(result), 1)
 
         # test the offset argument
-        result = db_feedback.get_feedback_for_recording("recording_msid", fb_msid_1, limit=25, offset=1)
+        result = db_feedback.get_feedback_for_recording(
+            self.db_conn, "recording_msid",
+            fb_msid_1, limit=25, offset=1
+        )
         self.assertEqual(len(result), 1)
 
     def test_get_feedback_count_for_recording(self):
@@ -314,19 +344,19 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         fb_mbid = self.sample_feedback[2]["recording_mbid"]
 
         self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_count_for_recording("recording_msid", fb_msid_1)
+        result = db_feedback.get_feedback_count_for_recording(self.db_conn, "recording_msid", fb_msid_1)
         self.assertEqual(result, 1)
 
-        result = db_feedback.get_feedback_count_for_recording("recording_mbid", fb_mbid)
+        result = db_feedback.get_feedback_count_for_recording(self.db_conn, "recording_mbid", fb_mbid)
         self.assertEqual(result, 1)
 
         user2 = db_user.get_or_create(2, "recording_feedback_other_user")
         self.insert_test_data(user2["id"])
 
-        result = db_feedback.get_feedback_count_for_recording("recording_msid", fb_msid_1)
+        result = db_feedback.get_feedback_count_for_recording(self.db_conn, "recording_msid", fb_msid_1)
         self.assertEqual(result, 2)
 
-        result = db_feedback.get_feedback_count_for_recording("recording_mbid", fb_mbid)
+        result = db_feedback.get_feedback_count_for_recording(self.db_conn, "recording_mbid", fb_mbid)
         self.assertEqual(result, 2)
 
     def test_get_feedback_for_multiple_recordings_for_user(self):
@@ -342,6 +372,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         recording_list.append("b83fd3c3-449c-49be-a874-31d7cf26d946")
 
         result = db_feedback.get_feedback_for_multiple_recordings_for_user(
+            self.db_conn,
             user_id=self.user["id"],
             user_name=self.user["musicbrainz_id"],
             recording_msids=recording_list,
@@ -376,6 +407,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         ]
 
         result = db_feedback.get_feedback_for_multiple_recordings_for_user(
+            self.db_conn,
             user_id=self.user["id"],
             user_name=self.user["musicbrainz_id"],
             recording_msids=[],
@@ -404,6 +436,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
 
         result = db_feedback.get_feedback_for_multiple_recordings_for_user(
+            self.db_conn,
             user_id=self.user["id"],
             user_name=self.user["musicbrainz_id"],
             recording_msids=recording_list,

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -84,8 +84,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                               , 'f'
                                )"""
 
-        with ts.engine.begin() as connection:
-            connection.execute(sqlalchemy.text(query))
+        self.ts_conn.execute(sqlalchemy.text(query))
 
         query = """INSERT INTO mbid_mapping
                                (recording_msid, recording_mbid, match_type, last_updated)
@@ -108,14 +107,20 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def test_insert(self):
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"],
+            limit=25, offset=0
+        )
         self.assertEqual(len(result), count)
 
     def test_update_score_when_feedback_already_exist(self):
         update_fb = self.sample_feedback[0]
 
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"],
+            limit=25, offset=0
+        )
         self.assertEqual(len(result), count)
 
         self.assertEqual(result[3].recording_msid, update_fb["recording_msid"])
@@ -133,7 +138,9 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             )
         )
 
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0
+        )
         self.assertEqual(len(result), count)
 
         self.assertEqual(result[0].recording_msid, update_fb["recording_msid"])
@@ -143,7 +150,9 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         del_fb = self.sample_feedback[0]
 
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0
+        )
         self.assertEqual(len(result), count)
         self.assertEqual(result[3].recording_msid, del_fb["recording_msid"])
 
@@ -157,7 +166,9 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             )
         )
 
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0
+        )
         self.assertEqual(len(result), 3)
         self.assertNotIn(del_fb["recording_msid"], [x.recording_msid for x in result])
 
@@ -170,7 +181,9 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                 score=self.sample_feedback[2]["score"]
             )
         )
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0
+        )
         self.assertEqual(len(result), 2)
         self.assertNotIn(self.sample_feedback[2]["recording_mbid"], [x.recording_mbid for x in result])
 
@@ -184,13 +197,17 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                 score=self.sample_feedback[2]["score"]
             )
         )
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0
+        )
         self.assertEqual(len(result), 1)
         self.assertNotIn(self.sample_feedback[3]["recording_mbid"], [x.recording_mbid for x in result])
 
     def test_get_feedback_for_user(self):
         count = self.insert_test_data(self.user["id"])
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0
+        )
         self.assertEqual(len(result), count)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -218,28 +235,36 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(result[3].score, self.sample_feedback[0]["score"])
 
         # test the score argument
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0, score=1)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0, score=1
+        )
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].score, 1)
         self.assertEqual(result[1].score, 1)
 
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0, score=-1)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=0, score=-1
+        )
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].score, -1)
         self.assertEqual(result[1].score, -1)
 
         # test the limit argument
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=1, offset=0)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=1, offset=0
+        )
         self.assertEqual(len(result), 1)
 
         # test the offset argument
-        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=1)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25, offset=1
+        )
         self.assertEqual(len(result), 3)
 
     def test_get_feedback_for_user_with_metadata(self):
         count = self.insert_test_data_with_metadata(self.user["id"])
         result = db_feedback.get_feedback_for_user(
-            self.db_conn, user_id=self.user["id"], limit=25,
+            self.db_conn, self.ts_conn, user_id=self.user["id"], limit=25,
             offset=0, score=1, metadata=True
         )
         self.assertEqual(len(result), 1)

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -94,8 +94,8 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                                (recording_msid, recording_mbid, match_type, last_updated)
                         VALUES (:msid, :mbid, :match_type, now())"""
 
-        with ts.engine.begin() as connection:
-            connection.execute(sqlalchemy.text(query), {"msid": msid, "mbid": mbid, "match_type": "exact_match"})
+        self.ts_conn.execute(sqlalchemy.text(query), {"msid": msid, "mbid": mbid, "match_type": "exact_match"})
+        self.ts_conn.commit()
 
         for fb in self.sample_feedback_with_metadata:
             db_feedback.insert(

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -13,7 +13,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
     def setUp(self):
         DatabaseTestCase.setUp(self)
         TimescaleTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, "recording_feedback_user")
+        self.user = db_user.get_or_create(self.db_conn, 1, "recording_feedback_user")
 
         self.sample_feedback = [
             {
@@ -49,6 +49,10 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             }
         ]
 
+    def tearDown(self):
+        DatabaseTestCase.tearDown(self)
+        TimescaleTestCase.tearDown(self)
+
     def insert_test_data(self, user_id):
         """ Insert test data into the database """
 
@@ -67,7 +71,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def insert_test_data_with_metadata(self, user_id):
         """ Insert test data with metadata into the database """
-        msid = msb_db.insert_all_in_transaction([self.sample_recording])[0]
+        msid = msb_db.insert_all_in_transaction(self.ts_conn, [self.sample_recording])[0]
         mbid = "2f3d422f-8890-41a1-9762-fbe16f107c31"
         self.sample_feedback_with_metadata[0]["recording_msid"] = msid
         self.sample_feedback_with_metadata[0]["recording_mbid"] = mbid
@@ -316,7 +320,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(result[0].recording_msid, self.sample_feedback[3]["recording_msid"])
         self.assertEqual(result[0].score, self.sample_feedback[3]["score"])
 
-        user2 = db_user.get_or_create(2, "recording_feedback_other_user")
+        user2 = db_user.get_or_create(self.db_conn, 2, "recording_feedback_other_user")
         self.insert_test_data(user2["id"])
 
         result = db_feedback.get_feedback_for_recording(
@@ -375,7 +379,7 @@ class FeedbackDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         result = db_feedback.get_feedback_count_for_recording(self.db_conn, "recording_mbid", fb_mbid)
         self.assertEqual(result, 1)
 
-        user2 = db_user.get_or_create(2, "recording_feedback_other_user")
+        user2 = db_user.get_or_create(self.db_conn, 2, "recording_feedback_other_user")
         self.insert_test_data(user2["id"])
 
         result = db_feedback.get_feedback_count_for_recording(self.db_conn, "recording_msid", fb_msid_1)

--- a/listenbrainz/db/tests/test_lastfm_session.py
+++ b/listenbrainz/db/tests/test_lastfm_session.py
@@ -1,6 +1,3 @@
-
-import logging
-
 import listenbrainz.db.user as db_user
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.db.lastfm_token import Token
@@ -10,32 +7,25 @@ from listenbrainz.db.testing import DatabaseTestCase
 
 class TestAPICompatSessionClass(DatabaseTestCase):
 
-    def setUp(self):
-        super(TestAPICompatSessionClass, self).setUp()
-        self.log = logging.getLogger(__name__)
-
-    def tearDown(self):
-        super(TestAPICompatSessionClass, self).tearDown()
-
     def test_session_create(self):
-        user = User.load_by_id(db_user.create(self.db_conn, 1, "test"))
-        token = Token.generate(user.api_key)
-        token.approve(user.name)
-        session = Session.create(token)
+        user = User.load_by_id(self.db_conn, db_user.create(self.db_conn, 1, "test"))
+        token = Token.generate(self.db_conn, user.api_key)
+        token.approve(self.db_conn, user.name)
+        session = Session.create(self.db_conn, token)
         self.assertIsInstance(session, Session)
         self.assertDictEqual(user.__dict__, session.user.__dict__)
 
     def test_session_load(self):
-        user = User.load_by_id(db_user.create(self.db_conn, 1, "test"))
-        token = Token.generate(user.api_key)
-        token.approve(user.name)
-        session = Session.create(token)
+        user = User.load_by_id(self.db_conn, db_user.create(self.db_conn, 1, "test"))
+        token = Token.generate(self.db_conn, user.api_key)
+        token.approve(self.db_conn, user.name)
+        session = Session.create(self.db_conn, token)
         self.assertIsInstance(session, Session)
         self.assertDictEqual(user.__dict__, session.user.__dict__)
         session.user = None
 
         # Load with session_key + api_key
-        session2 = Session.load(session.sid)
+        session2 = Session.load(self.db_conn, session.sid)
         self.assertDictEqual(user.__dict__, session2.__dict__['user'].__dict__)
         session2.user = None
         self.assertDictEqual(session.__dict__, session2.__dict__)

--- a/listenbrainz/db/tests/test_lastfm_session.py
+++ b/listenbrainz/db/tests/test_lastfm_session.py
@@ -18,7 +18,7 @@ class TestAPICompatSessionClass(DatabaseTestCase):
         super(TestAPICompatSessionClass, self).tearDown()
 
     def test_session_create(self):
-        user = User.load_by_id(db_user.create(1, "test"))
+        user = User.load_by_id(db_user.create(self.db_conn, 1, "test"))
         token = Token.generate(user.api_key)
         token.approve(user.name)
         session = Session.create(token)
@@ -26,7 +26,7 @@ class TestAPICompatSessionClass(DatabaseTestCase):
         self.assertDictEqual(user.__dict__, session.user.__dict__)
 
     def test_session_load(self):
-        user = User.load_by_id(db_user.create(1, "test"))
+        user = User.load_by_id(db_user.create(self.db_conn, 1, "test"))
         token = Token.generate(user.api_key)
         token.approve(user.name)
         session = Session.create(token)

--- a/listenbrainz/db/tests/test_lastfm_token.py
+++ b/listenbrainz/db/tests/test_lastfm_token.py
@@ -3,10 +3,7 @@ import logging
 import uuid
 from datetime import timedelta
 
-from sqlalchemy import text
-
 import listenbrainz.db.user as db_user
-from listenbrainz import db
 from listenbrainz.db.lastfm_token import Token, TOKEN_EXPIRATION_TIME
 from listenbrainz.db.lastfm_user import User
 from listenbrainz.db.testing import DatabaseTestCase
@@ -28,26 +25,26 @@ class TestAPICompatTokenClass(DatabaseTestCase):
         self.assertTrue(Token.is_valid_api_key(str(uuid.uuid4())))
 
     def test_load(self):
-        token = Token.generate(self.user.api_key)
+        token = Token.generate(self.db_conn, self.user.api_key)
         self.assertIsInstance(token, Token)
         self.assertIsNone(token.user)
 
         """ Before approving """
         # Load with token
-        token1 = Token.load(token.token)
+        token1 = Token.load(self.db_conn, token.token)
         self.assertIsNone(token1.user)
         self.assertDictEqual(token1.__dict__, token.__dict__)
 
         # Load with token & api_key
-        token2 = Token.load(token.token, token.api_key)
+        token2 = Token.load(self.db_conn, token.token, token.api_key)
         self.assertIsNone(token2.user)
         self.assertDictEqual(token2.__dict__, token.__dict__)
 
-        token.approve(self.user.name)
+        token.approve(self.db_conn, self.user.name)
 
         """ After approving the token """
         # Load with token
-        token1 = Token.load(token.token)
+        token1 = Token.load(self.db_conn, token.token)
         self.assertIsInstance(token1.user, User)
         self.assertDictEqual(token1.user.__dict__, token.user.__dict__)
         token_user = token.user
@@ -56,18 +53,18 @@ class TestAPICompatTokenClass(DatabaseTestCase):
         token.user = token_user
 
         # Load with token & api_key
-        token2 = Token.load(token.token, token.api_key)
+        token2 = Token.load(self.db_conn, token.token, token.api_key)
         self.assertIsInstance(token2.user, User)
         self.assertDictEqual(token2.user.__dict__, token.user.__dict__)
         token.user, token1.user = None, None
         self.assertDictEqual(token1.__dict__, token.__dict__)
 
     def test_generate(self):
-        token = Token.generate(str(uuid.uuid4()))
+        token = Token.generate(self.db_conn, str(uuid.uuid4()))
         self.assertIsInstance(token, Token)
 
     def test_has_expired(self):
-        token = Token.generate(str(uuid.uuid4()))
+        token = Token.generate(self.db_conn, str(uuid.uuid4()))
         self.assertFalse(token.has_expired())
         token.timestamp = token.timestamp - timedelta(minutes=TOKEN_EXPIRATION_TIME - 1)
         # This is asssertFalse because in the next 1 minute the next statement will get executed
@@ -76,13 +73,13 @@ class TestAPICompatTokenClass(DatabaseTestCase):
         self.assertTrue(token.has_expired())
 
     def test_approve(self):
-        token = Token.generate(str(uuid.uuid4()))
+        token = Token.generate(self.db_conn, str(uuid.uuid4()))
         self.assertIsInstance(token, Token)
         self.assertIsNone(token.user)
         before_token = token.__dict__
         before_token.pop('user')
 
-        token.approve(self.user.name)
+        token.approve(self.db_conn, self.user.name)
 
         after_token = token.__dict__
         self.assertIsInstance(token.user, User)

--- a/listenbrainz/db/tests/test_lastfm_token.py
+++ b/listenbrainz/db/tests/test_lastfm_token.py
@@ -20,15 +20,8 @@ class TestAPICompatTokenClass(DatabaseTestCase):
 
         # Create a user
         uid = db_user.create(1, "test")
-        self.assertIsNotNone(db_user.get(uid))
-        with db.engine.connect() as connection:
-            result = connection.execute(text('SELECT * FROM "user" WHERE id = :id'),
-                                        {"id": uid})
-            row = result.fetchone()
-            self.user = User(row.id, row.created, row.musicbrainz_id, row.auth_token)
-
-    def tearDown(self):
-        super(TestAPICompatTokenClass, self).tearDown()
+        user_dict = db_user.get(self.db_conn, uid)
+        self.user = User(user_dict["id"], user_dict["created"], user_dict["musicbrainz_id"], user_dict["auth_token"])
 
     def test_is_valid_api_key(self):
         self.assertTrue(Token.is_valid_api_key(self.user.api_key))

--- a/listenbrainz/db/tests/test_lastfm_token.py
+++ b/listenbrainz/db/tests/test_lastfm_token.py
@@ -19,7 +19,7 @@ class TestAPICompatTokenClass(DatabaseTestCase):
         self.log = logging.getLogger(__name__)
 
         # Create a user
-        uid = db_user.create(1, "test")
+        uid = db_user.create(self.db_conn, 1, "test")
         user_dict = db_user.get(self.db_conn, uid)
         self.user = User(user_dict["id"], user_dict["created"], user_dict["musicbrainz_id"], user_dict["auth_token"])
 

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -20,7 +20,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
         self.logstore = timescale_connection._ts
 
         # Create a user
-        uid = db_user.create(1, "test_api_compat_user")
+        uid = db_user.create(self.db_conn, 1, "test_api_compat_user")
         user_dict = db_user.get(self.db_conn, uid)
         self.user = User(user_dict["id"], user_dict["created"], user_dict["musicbrainz_id"], user_dict["auth_token"])
 
@@ -40,7 +40,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
 
     def test_user_get_play_count(self):
         date = datetime(2015, 9, 3, 0, 0, 0)
-        test_data = generate_data(date, 5, self.user.name)
+        test_data = generate_data(self.db_conn, date, 5, self.user.name)
         self.assertEqual(len(test_data), 5)
         self.logstore.insert(test_data)
         count = User.get_play_count(self.user.id, self.logstore)

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -2,10 +2,7 @@
 import logging
 from datetime import datetime
 
-from sqlalchemy import text
-
 import listenbrainz.db.user as db_user
-from listenbrainz import db
 from listenbrainz.db.lastfm_user import User
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.tests.utils import generate_data
@@ -25,16 +22,16 @@ class TestAPICompatUserClass(DatabaseTestCase):
         self.user = User(user_dict["id"], user_dict["created"], user_dict["musicbrainz_id"], user_dict["auth_token"])
 
     def test_user_get_id(self):
-        uid = User.get_id(self.user.name)
+        uid = User.get_id(self.db_conn, self.user.name)
         self.assertEqual(uid, self.user.id)
 
     def test_user_load_by_name(self):
-        user = User.load_by_name(self.user.name)
+        user = User.load_by_name(self.db_conn, self.user.name)
         self.assertTrue(isinstance(user, User))
         self.assertDictEqual(user.__dict__, self.user.__dict__)
 
     def test_user_load_by_id(self):
-        user = User.load_by_id(self.user.id)
+        user = User.load_by_id(self.db_conn, self.user.id)
         self.assertTrue(isinstance(user, User))
         self.assertDictEqual(user.__dict__, self.user.__dict__)
 
@@ -43,5 +40,5 @@ class TestAPICompatUserClass(DatabaseTestCase):
         test_data = generate_data(self.db_conn, date, 5, self.user.name)
         self.assertEqual(len(test_data), 5)
         self.logstore.insert(test_data)
-        count = User.get_play_count(self.user.id, self.logstore)
+        count = User.get_play_count(self.db_conn, self.user.id, self.logstore)
         self.assertIsInstance(count, int)

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -1,15 +1,19 @@
 
 import logging
-from datetime import datetime
+import uuid
+from datetime import datetime, time
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.lastfm_user import User
 from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.listen import Listen
+from listenbrainz.listenstore import TimescaleListenStore
+from listenbrainz.tests.integration import IntegrationTestCase
 from listenbrainz.tests.utils import generate_data
 from listenbrainz.webserver import timescale_connection
 
 
-class TestAPICompatUserClass(DatabaseTestCase):
+class TestAPICompatUserClass(IntegrationTestCase):
 
     def setUp(self):
         super(TestAPICompatUserClass, self).setUp()
@@ -17,7 +21,7 @@ class TestAPICompatUserClass(DatabaseTestCase):
         self.logstore = timescale_connection._ts
 
         # Create a user
-        uid = db_user.create(self.db_conn, 1, "test_api_compat_user")
+        uid = db_user.create(self.db_conn, 1009, "test_api_compat_user")
         user_dict = db_user.get(self.db_conn, uid)
         self.user = User(user_dict["id"], user_dict["created"], user_dict["musicbrainz_id"], user_dict["auth_token"])
 
@@ -35,10 +39,31 @@ class TestAPICompatUserClass(DatabaseTestCase):
         self.assertTrue(isinstance(user, User))
         self.assertDictEqual(user.__dict__, self.user.__dict__)
 
+    def generate_data(self, from_date, num_records):
+        test_data = []
+        current_date = int(from_date.timestamp())
+
+        for i in range(num_records):
+            current_date += 1  # Add one second
+            item = Listen(
+                user_id=self.user.id,
+                user_name=self.user.name,
+                timestamp=current_date,
+                recording_msid=str(uuid.uuid4()),
+                data={
+                    'artist_name': 'Test Artist Pls ignore',
+                    'track_name': 'Hello Goodbye',
+                    'additional_info': {},
+                },
+            )
+            test_data.append(item)
+        return test_data
+
     def test_user_get_play_count(self):
         date = datetime(2015, 9, 3, 0, 0, 0)
-        test_data = generate_data(self.db_conn, date, 5, self.user.name)
+        test_data = self.generate_data(date, 5)
         self.assertEqual(len(test_data), 5)
         self.logstore.insert(test_data)
-        count = User.get_play_count(self.db_conn, self.user.id, self.logstore)
-        self.assertIsInstance(count, int)
+        with self.app.app_context():
+            count = User.get_play_count(self.db_conn, self.user.id, self.logstore)
+            self.assertIsInstance(count, int)

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -21,20 +21,8 @@ class TestAPICompatUserClass(DatabaseTestCase):
 
         # Create a user
         uid = db_user.create(1, "test_api_compat_user")
-        self.assertIsNotNone(db_user.get(uid))
-        with db.engine.connect() as connection:
-            result = connection.execute(text("""
-                SELECT *
-                  FROM "user"
-                 WHERE id = :id
-            """), {
-                "id": uid,
-            })
-            row = result.fetchone()
-            self.user = User(row.id, row.created, row.musicbrainz_id, row.auth_token)
-
-    def tearDown(self):
-        super(TestAPICompatUserClass, self).tearDown()
+        user_dict = db_user.get(self.db_conn, uid)
+        self.user = User(user_dict["id"], user_dict["created"], user_dict["musicbrainz_id"], user_dict["auth_token"])
 
     def test_user_get_id(self):
         uid = User.get_id(self.user.name)

--- a/listenbrainz/db/tests/test_listens_importer.py
+++ b/listenbrainz/db/tests/test_listens_importer.py
@@ -15,7 +15,7 @@ class ListensImporterDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(ListensImporterDatabaseTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'testspotifyuser')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testspotifyuser')
         db_oauth.save_token(
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
@@ -48,7 +48,7 @@ class ListensImporterDatabaseTestCase(DatabaseTestCase):
         self.assertIsNotNone(spotify_user['last_updated'])
 
     def test_update_latest_import(self):
-        user = db_user.get_or_create(3, 'updatelatestimportuser')
+        user = db_user.get_or_create(self.db_conn, 3, 'updatelatestimportuser')
 
         val = int(time.time())
         listens_importer.update_latest_listened_at(user['id'], ExternalServiceType.LASTFM, val)

--- a/listenbrainz/db/tests/test_listens_importer.py
+++ b/listenbrainz/db/tests/test_listens_importer.py
@@ -17,6 +17,7 @@ class ListensImporterDatabaseTestCase(DatabaseTestCase):
         super(ListensImporterDatabaseTestCase, self).setUp()
         self.user = db_user.get_or_create(self.db_conn, 1, 'testspotifyuser')
         db_oauth.save_token(
+            self.db_conn,
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',
@@ -27,23 +28,25 @@ class ListensImporterDatabaseTestCase(DatabaseTestCase):
         )
 
     def test_update_import_status(self):
-        db_import.update_import_status(self.user['id'], ExternalServiceType.SPOTIFY, 'test error message')
-        spotify_user = db_spotify.get_user_import_details(self.user['id'])
+        db_import.update_import_status(
+            self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, 'test error message'
+        )
+        spotify_user = db_spotify.get_user_import_details(self.db_conn, self.user['id'])
         self.assertEqual(spotify_user['error_message'], 'test error message')
         self.assertIsNotNone(spotify_user['last_updated'])
 
-        db_import.update_import_status(self.user['id'], ExternalServiceType.SPOTIFY)
-        spotify_user = db_spotify.get_user_import_details(self.user['id'])
+        db_import.update_import_status(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
+        spotify_user = db_spotify.get_user_import_details(self.db_conn, self.user['id'])
         self.assertIsNone(spotify_user['error_message'])
         self.assertIsNotNone(spotify_user['last_updated'])
 
     def test_update_latest_listened_at(self):
-        spotify_user = db_spotify.get_user_import_details(self.user['id'])
+        spotify_user = db_spotify.get_user_import_details(self.db_conn, self.user['id'])
         self.assertIsNone(spotify_user['latest_listened_at'])
         self.assertIsNone(spotify_user['last_updated'])
         t = int(time.time())
-        db_import.update_latest_listened_at(self.user['id'], ExternalServiceType.SPOTIFY, t)
-        spotify_user = db_spotify.get_user_import_details(self.user['id'])
+        db_import.update_latest_listened_at(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, t)
+        spotify_user = db_spotify.get_user_import_details(self.db_conn, self.user['id'])
         self.assertEqual(t, int(spotify_user['latest_listened_at'].strftime('%s')))
         self.assertIsNotNone(spotify_user['last_updated'])
 
@@ -51,10 +54,10 @@ class ListensImporterDatabaseTestCase(DatabaseTestCase):
         user = db_user.get_or_create(self.db_conn, 3, 'updatelatestimportuser')
 
         val = int(time.time())
-        listens_importer.update_latest_listened_at(user['id'], ExternalServiceType.LASTFM, val)
-        ts = listens_importer.get_latest_listened_at(user['id'], ExternalServiceType.LASTFM)
+        listens_importer.update_latest_listened_at(self.db_conn, user['id'], ExternalServiceType.LASTFM, val)
+        ts = listens_importer.get_latest_listened_at(self.db_conn, user['id'], ExternalServiceType.LASTFM)
         self.assertEqual(int(ts.strftime('%s')), val)
 
-        listens_importer.update_latest_listened_at(user['id'], ExternalServiceType.LASTFM, 0)
-        ts = listens_importer.get_latest_listened_at(user['id'], ExternalServiceType.LASTFM)
+        listens_importer.update_latest_listened_at(self.db_conn, user['id'], ExternalServiceType.LASTFM, 0)
+        ts = listens_importer.get_latest_listened_at(self.db_conn, user['id'], ExternalServiceType.LASTFM)
         self.assertEqual(int(ts.strftime('%s')), 0)

--- a/listenbrainz/db/tests/test_mbid_manual_mapping.py
+++ b/listenbrainz/db/tests/test_mbid_manual_mapping.py
@@ -5,7 +5,9 @@ import listenbrainz.db.mbid_manual_mapping as db_mbid_manual_mapping
 from listenbrainz.db.model.mbid_manual_mapping import MbidManualMapping
 from listenbrainz.db.testing import TimescaleTestCase
 
+
 class MbidManualMappingDatabaseTestCase(TimescaleTestCase):
+
     def test_add_get_mapping(self):
         """Add and get a mapping"""
         msid = "597fa2f2-8cf4-4566-a307-dbfb5aa35ec4"
@@ -13,9 +15,9 @@ class MbidManualMappingDatabaseTestCase(TimescaleTestCase):
         user_id = 1
 
         mapping = MbidManualMapping(recording_msid=msid, recording_mbid=mbid, user_id=user_id)
-        db_mbid_manual_mapping.create_mbid_manual_mapping(mapping)
+        db_mbid_manual_mapping.create_mbid_manual_mapping(self.ts_conn, mapping)
         
-        new_mapping = db_mbid_manual_mapping.get_mbid_manual_mapping(msid, user_id)
+        new_mapping = db_mbid_manual_mapping.get_mbid_manual_mapping(self.ts_conn, msid, user_id)
         assert new_mapping.recording_mbid == mapping.recording_mbid
         assert new_mapping.recording_msid == mapping.recording_msid
         assert new_mapping.user_id == mapping.user_id
@@ -28,16 +30,15 @@ class MbidManualMappingDatabaseTestCase(TimescaleTestCase):
         user_id = 1
 
         mapping1 = MbidManualMapping(recording_msid=msid, recording_mbid=mbid1, user_id=user_id)
-        db_mbid_manual_mapping.create_mbid_manual_mapping(mapping1)
-        new_mapping = db_mbid_manual_mapping.get_mbid_manual_mapping(msid, user_id)
+        db_mbid_manual_mapping.create_mbid_manual_mapping(self.ts_conn, mapping1)
+        new_mapping = db_mbid_manual_mapping.get_mbid_manual_mapping(self.ts_conn, msid, user_id)
         assert new_mapping.recording_mbid == mbid1
 
         mapping2 = MbidManualMapping(recording_msid=msid, recording_mbid=mbid2, user_id=user_id)
-        db_mbid_manual_mapping.create_mbid_manual_mapping(mapping2)
+        db_mbid_manual_mapping.create_mbid_manual_mapping(self.ts_conn, mapping2)
 
-        new_mapping = db_mbid_manual_mapping.get_mbid_manual_mapping(msid, user_id)
+        new_mapping = db_mbid_manual_mapping.get_mbid_manual_mapping(self.ts_conn, msid, user_id)
         assert new_mapping.recording_mbid == mbid2
-
 
     def test_add_mapping_different_users(self):
         """Add a mapping for the same msid by different users and get them"""
@@ -48,10 +49,10 @@ class MbidManualMappingDatabaseTestCase(TimescaleTestCase):
         user_id2 = 2
 
         mapping1 = MbidManualMapping(recording_msid=msid, recording_mbid=mbid1, user_id=user_id1)
-        db_mbid_manual_mapping.create_mbid_manual_mapping(mapping1)
+        db_mbid_manual_mapping.create_mbid_manual_mapping(self.ts_conn, mapping1)
 
         mapping2 = MbidManualMapping(recording_msid=msid, recording_mbid=mbid2, user_id=user_id2)
-        db_mbid_manual_mapping.create_mbid_manual_mapping(mapping2)
+        db_mbid_manual_mapping.create_mbid_manual_mapping(self.ts_conn, mapping2)
 
-        new_mappings = db_mbid_manual_mapping.get_mbid_manual_mappings(msid)
+        new_mappings = db_mbid_manual_mapping.get_mbid_manual_mappings(self.ts_conn, msid)
         assert len(new_mappings) == 2

--- a/listenbrainz/db/tests/test_missing_musicbrainz_data.py
+++ b/listenbrainz/db/tests/test_missing_musicbrainz_data.py
@@ -5,8 +5,6 @@ import listenbrainz.db.user as db_user
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
 from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
 
-from datetime import datetime
-
 
 class MissingMusicbrainzDataDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
@@ -25,6 +23,7 @@ class MissingMusicbrainzDataDatabaseTestCase(DatabaseTestCase, TimescaleTestCase
             missing_musicbrainz_data = json.load(f)
 
         db_missing_musicbrainz_data.insert_user_missing_musicbrainz_data(
+            self.db_conn,
             user_id=self.user['id'],
             missing_musicbrainz_data=UserMissingMusicBrainzDataJson(**{'missing_musicbrainz_data': missing_musicbrainz_data}),
             source='cf'
@@ -37,17 +36,22 @@ class MissingMusicbrainzDataDatabaseTestCase(DatabaseTestCase, TimescaleTestCase
             missing_musicbrainz_data = json.load(f)
 
         db_missing_musicbrainz_data.insert_user_missing_musicbrainz_data(
+            self.db_conn,
             user_id=self.user['id'],
             missing_musicbrainz_data=UserMissingMusicBrainzDataJson(**{'missing_musicbrainz_data': missing_musicbrainz_data}),
             source='cf'
         )
 
-        result = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(user_id=self.user['id'], source='cf')
+        result = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(
+            self.db_conn, self.ts_conn, user_id=self.user['id'], source='cf'
+        )
         self.assertEqual(missing_musicbrainz_data, result[0])
 
     def test_get_user_missing_musicbrainz_data(self):
         data_inserted = self.insert_test_data()
-        result = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(user_id=self.user['id'], source='cf')
+        result = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(
+            self.db_conn, self.ts_conn, user_id=self.user['id'], source='cf'
+        )
         self.assertEqual(data_inserted, result[0])
 
     def test_multiple_inserts_into_db(self):
@@ -57,16 +61,20 @@ class MissingMusicbrainzDataDatabaseTestCase(DatabaseTestCase, TimescaleTestCase
             missing_musicbrainz_data = json.load(f)
 
         db_missing_musicbrainz_data.insert_user_missing_musicbrainz_data(
+            self.db_conn,
             user_id=self.user['id'],
             missing_musicbrainz_data=UserMissingMusicBrainzDataJson(**{'missing_musicbrainz_data': missing_musicbrainz_data}),
             source='cf'
         )
 
         db_missing_musicbrainz_data.insert_user_missing_musicbrainz_data(
+            self.db_conn,
             user_id=self.user['id'],
             missing_musicbrainz_data=UserMissingMusicBrainzDataJson(**{'invalid_key': missing_musicbrainz_data}),
             source='cf'
         )
 
-        result = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(user_id=self.user['id'], source='cf')
+        result = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(
+            self.db_conn, self.ts_conn, user_id=self.user['id'], source='cf'
+        )
         self.assertIsNone(result)

--- a/listenbrainz/db/tests/test_missing_musicbrainz_data.py
+++ b/listenbrainz/db/tests/test_missing_musicbrainz_data.py
@@ -11,7 +11,7 @@ class MissingMusicbrainzDataDatabaseTestCase(DatabaseTestCase, TimescaleTestCase
     def setUp(self):
         DatabaseTestCase.setUp(self)
         TimescaleTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, 'vansika')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'vansika')
 
     def tearDown(self):
         TimescaleTestCase.tearDown(self)

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -7,7 +7,6 @@ from sqlalchemy import text
 from listenbrainz import messybrainz
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items, MsidMbidModel, load_recordings_from_mbids
 from listenbrainz.db.testing import TimescaleTestCase
-from listenbrainz.db import timescale
 
 
 class MappingTestCase(TimescaleTestCase):
@@ -26,45 +25,44 @@ class MappingTestCase(TimescaleTestCase):
         model = MsidMbidModel(recording_msid=str(uuid.uuid4()), recording_mbid=str(uuid.uuid4()))
 
     def insert_recording_in_mapping(self, recording, match_type):
-        with timescale.engine.begin() as connection:
-            if match_type == "exact_match":
+        if match_type == "exact_match":
 
-                release_data = {"name": recording["release"]}
-                if recording.get("caa_id"):
-                    release_data["caa_id"] = recording["caa_id"]
-                    release_data["caa_release_mbid"] = recording["caa_release_mbid"]
+            release_data = {"name": recording["release"]}
+            if recording.get("caa_id"):
+                release_data["caa_id"] = recording["caa_id"]
+                release_data["caa_release_mbid"] = recording["caa_release_mbid"]
 
-                artists = [
-                    {"name": a["artist_credit_name"], "join_phrase": a["join_phrase"]}
-                    for a in recording["artists"]
-                ]
-                artist_data = {"name": recording["artist"], "artists": artists}
+            artists = [
+                {"name": a["artist_credit_name"], "join_phrase": a["join_phrase"]}
+                for a in recording["artists"]
+            ]
+            artist_data = {"name": recording["artist"], "artists": artists}
 
-                connection.execute(text("""
-                    INSERT INTO mapping.mb_metadata_cache
-                            (recording_mbid, artist_mbids, release_mbid, recording_data, artist_data, tag_data, release_data, dirty)
-                     VALUES (:recording_mbid ::UUID, :artist_mbids ::UUID[], :release_mbid ::UUID, :recording_data, :artist_data, :tag_data, :release_data, 'f')
-                """), {
-                    "recording_mbid": recording["recording_mbid"],
-                    "artist_mbids": recording["artist_mbids"],
-                    "release_mbid": recording["release_mbid"],
-                    "recording_data": json.dumps({"name": recording["title"]}),
-                    "artist_data": json.dumps(artist_data),
-                    "release_data": json.dumps(release_data),
-                    "tag_data": json.dumps({"artist": [], "recording": [], "release_group": []})
-                })
+            self.ts_conn.execute(text("""
+                INSERT INTO mapping.mb_metadata_cache
+                        (recording_mbid, artist_mbids, release_mbid, recording_data, artist_data, tag_data, release_data, dirty)
+                 VALUES (:recording_mbid ::UUID, :artist_mbids ::UUID[], :release_mbid ::UUID, :recording_data, :artist_data, :tag_data, :release_data, 'f')
+            """), {
+                "recording_mbid": recording["recording_mbid"],
+                "artist_mbids": recording["artist_mbids"],
+                "release_mbid": recording["release_mbid"],
+                "recording_data": json.dumps({"name": recording["title"]}),
+                "artist_data": json.dumps(artist_data),
+                "release_data": json.dumps(release_data),
+                "tag_data": json.dumps({"artist": [], "recording": [], "release_group": []})
+            })
 
-            connection.execute(
-                text("""
-                INSERT INTO mbid_mapping (recording_msid, recording_mbid, match_type)
-                                  VALUES (:recording_msid, :recording_mbid, :match_type)
-            """),
-                {
-                    "recording_msid": recording["recording_msid"],
-                    "recording_mbid": recording["recording_mbid"],
-                    "match_type": match_type
-                }
-            )
+        self.ts_conn.execute(
+            text("""
+            INSERT INTO mbid_mapping (recording_msid, recording_mbid, match_type)
+                              VALUES (:recording_msid, :recording_mbid, :match_type)
+        """),
+            {
+                "recording_msid": recording["recording_msid"],
+                "recording_mbid": recording["recording_mbid"],
+                "match_type": match_type
+            }
+        )
 
     def insert_recordings(self):
         recordings = [
@@ -163,7 +161,7 @@ class MappingTestCase(TimescaleTestCase):
             recordings[0]["recording_mbid"]: recordings[0],
             recordings[1]["recording_mbid"]: recordings[1]
         }
-        with timescale.engine.connect() as ts_conn, ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_curs:
+        with self.ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_curs:
             received = load_recordings_from_mbids(
                 ts_curs,
                 [recordings[0]["recording_mbid"], recordings[1]["recording_mbid"]]
@@ -186,7 +184,7 @@ class MappingTestCase(TimescaleTestCase):
             # test the case where user submitted a mbid for the item but its absent from mbid_mapping
             MsidMbidModel(recording_msid=recordings[4]["recording_msid"], recording_mbid="0f53fa2f-f015-40c6-a5cd-f17af596764c")
         ]
-        models = fetch_track_metadata_for_items(models)
+        models = fetch_track_metadata_for_items(self.ts_conn, models)
 
         for idx in range(5):
             metadata = models[idx].track_metadata
@@ -210,7 +208,7 @@ class MappingTestCase(TimescaleTestCase):
             MsidMbidModel(recording_msid=recording["recording_msid"], recording_mbid=recording["recording_mbid"]),
             MsidMbidModel(recording_msid=recording["recording_msid"], recording_mbid=recording["recording_mbid"]),
         ]
-        models = fetch_track_metadata_for_items(models)
+        models = fetch_track_metadata_for_items(self.ts_conn, models)
         for model in models:
             metadata = model.track_metadata
             self.assertEqual(metadata["track_name"], recording["title"])
@@ -221,4 +219,3 @@ class MappingTestCase(TimescaleTestCase):
             self.assertEqual(metadata["mbid_mapping"]["release_mbid"], recording["release_mbid"])
             self.assertEqual(metadata["mbid_mapping"]["artist_mbids"], recording["artist_mbids"])
             self.assertEqual(metadata["mbid_mapping"]["artists"], recording["artists"])
-

--- a/listenbrainz/db/tests/test_msid_mbid_mapping.py
+++ b/listenbrainz/db/tests/test_msid_mbid_mapping.py
@@ -130,7 +130,7 @@ class MappingTestCase(TimescaleTestCase):
                 "release": None
             }
         ]
-        submitted = messybrainz.insert_all_in_transaction(recordings)
+        submitted = messybrainz.insert_all_in_transaction(self.ts_conn, recordings)
         # data sent to msb cannot contain nulls but we want it when inserting in mapping
         recordings[2].update(**{
             "recording_mbid": None,

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -63,6 +63,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         for data in self.pinned_rec_samples[:limit]:
             db_pinned_rec.pin(
+                self.db_conn,
                 WritablePinnedRecording(
                     user_id=user_id,
                     recording_msid=data["recording_msid"],
@@ -89,7 +90,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             blurb_content=self.pinned_rec_samples[index]["blurb_content"],
         )
 
-        db_pinned_rec.pin(recording_to_pin)
+        db_pinned_rec.pin(self.db_conn, recording_to_pin)
         return recording_to_pin
 
     def test_pinned_recording_with_metadata(self):
@@ -144,6 +145,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         for data in pinned_recs:
             db_pinned_rec.pin(
+                self.db_conn,
                 WritablePinnedRecording(
                     user_id=self.user["id"],
                     recording_msid=data["recording_msid"],
@@ -152,7 +154,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
                 )
             )
 
-        pins = db_pinned_rec.get_pin_history_for_user(self.user["id"], 5, 0)
+        pins = db_pinned_rec.get_pin_history_for_user(self.db_conn, self.user["id"], 5, 0)
         pins_with_metadata = fetch_track_metadata_for_items(pins)
 
         received = [x.dict() for x in pins_with_metadata]
@@ -272,13 +274,17 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def test_pin(self):
         count = self.insert_test_data(self.user["id"])
-        pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)
+        pin_history = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=50, offset=0
+        )
         self.assertEqual(len(pin_history), count)
 
     def test_unpin_if_active_currently_pinned(self):
         original_pinned = self.pin_single_sample(self.user["id"], 0)
         new_pinned = self.pin_single_sample(self.user["id"], 1)
-        original_unpinned = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)[1]
+        original_unpinned = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=50, offset=0
+        )[1]
 
         # only the pinned_until value of the record should be updated
         self.assertEqual(original_unpinned.user_id, original_pinned.user_id)
@@ -292,11 +298,11 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def test_unpin(self):
         pinned = self.pin_single_sample(self.user["id"], 0)
-        db_pinned_rec.unpin(self.user["id"])
-        self.assertIsNone(db_pinned_rec.get_current_pin_for_user(self.user["id"]))
+        db_pinned_rec.unpin(self.db_conn, self.user["id"])
+        self.assertIsNone(db_pinned_rec.get_current_pin_for_user(self.db_conn, self.user["id"]))
 
         # test that the pinned_until value was updated
-        unpinned = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)[0]
+        unpinned = db_pinned_rec.get_pin_history_for_user(self.db_conn, user_id=self.user["id"], count=50, offset=0)[0]
         self.assertGreater(pinned.pinned_until, unpinned.pinned_until)
 
     def test_delete(self):
@@ -305,30 +311,32 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         # insert two records and delete the newer one
         self.pin_single_sample(self.user["id"], keptIndex)
         self.pin_single_sample(self.user["id"], 1)
-        old_pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)
+        old_pin_history = db_pinned_rec.get_pin_history_for_user(self.db_conn, user_id=self.user["id"], count=50, offset=0)
         pin_to_delete = old_pin_history[0]
-        db_pinned_rec.delete(pin_to_delete.row_id, self.user["id"])
+        db_pinned_rec.delete(self.db_conn, pin_to_delete.row_id, self.user["id"])
 
         # test that only the older pin remained in the database
-        pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)
+        pin_history = db_pinned_rec.get_pin_history_for_user(self.db_conn, user_id=self.user["id"], count=50, offset=0)
         pin_remaining = pin_history[0]
         self.assertEqual(len(pin_history), len(old_pin_history) - 1)
         self.assertEqual(pin_remaining.blurb_content, self.pinned_rec_samples[keptIndex]["blurb_content"])
 
         # delete the remaining pin
-        db_pinned_rec.delete(pin_remaining.row_id, self.user["id"])
-        pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)
+        db_pinned_rec.delete(self.db_conn, pin_remaining.row_id, self.user["id"])
+        pin_history = db_pinned_rec.get_pin_history_for_user(self.db_conn, user_id=self.user["id"], count=50, offset=0)
         self.assertFalse(pin_history)
 
     def test_get_current_pin_for_user(self):
         self.pin_single_sample(self.user["id"], 0)
-        expected_pinned = db_pinned_rec.get_current_pin_for_user(self.user["id"])
-        recieved_pinned = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)[0]
+        expected_pinned = db_pinned_rec.get_current_pin_for_user(self.db_conn, self.user["id"])
+        recieved_pinned = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=50, offset=0
+        )[0]
         self.assertEqual(recieved_pinned, expected_pinned)
 
         self.pin_single_sample(self.user["id"], 1)
-        expected_pinned = db_pinned_rec.get_current_pin_for_user(self.user["id"])
-        recieved_pinned = db_pinned_rec.get_current_pin_for_user(self.user["id"])
+        expected_pinned = db_pinned_rec.get_current_pin_for_user(self.db_conn, self.user["id"])
+        recieved_pinned = db_pinned_rec.get_current_pin_for_user(self.db_conn, self.user["id"])
         self.assertEqual(recieved_pinned, expected_pinned)
 
     def test_get_pin_history_for_user(self):
@@ -336,9 +344,9 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.insert_test_data(self.user["id"], count)
 
         # test that pin history includes unpinned recordings
-        pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)
-        db_pinned_rec.unpin(user_id=self.user["id"])
-        new_pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)
+        pin_history = db_pinned_rec.get_pin_history_for_user(self.db_conn, user_id=self.user["id"], count=50, offset=0)
+        db_pinned_rec.unpin(self.db_conn, user_id=self.user["id"])
+        new_pin_history = db_pinned_rec.get_pin_history_for_user(self.db_conn, user_id=self.user["id"], count=50, offset=0)
         self.assertEqual(len(new_pin_history), len(pin_history))
 
         # test that the list was returned in descending order of creation date
@@ -346,37 +354,45 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         # test the limit argument
         limit = 1
-        limited_pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=limit, offset=0)
+        limited_pin_history = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=limit, offset=0
+        )
         self.assertEqual(len(limited_pin_history), limit)
 
         limit = 999
-        limited_pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=limit, offset=0)
+        limited_pin_history = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=limit, offset=0
+        )
         self.assertEqual(len(limited_pin_history), count)
 
         # test the offset argument
         offset = 1
-        offset_pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=offset)
+        offset_pin_history = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=50, offset=offset
+        )
         self.assertEqual(len(offset_pin_history), count - offset)
 
         offset = 999
-        offset_pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=offset)
+        offset_pin_history = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=50, offset=offset
+        )
         self.assertFalse(offset_pin_history)
 
     def test_get_pin_count_for_user(self):
         self.insert_test_data(self.user["id"])
-        pin_history = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=0)
-        pin_count = db_pinned_rec.get_pin_count_for_user(user_id=self.user["id"])
+        pin_history = db_pinned_rec.get_pin_history_for_user(self.db_conn, user_id=self.user["id"], count=50, offset=0)
+        pin_count = db_pinned_rec.get_pin_count_for_user(self.db_conn, user_id=self.user["id"])
         self.assertEqual(pin_count, len(pin_history))
 
         # test that pin_count includes unpinned recordings
-        db_pinned_rec.unpin(user_id=self.user["id"])
-        pin_count = db_pinned_rec.get_pin_count_for_user(user_id=self.user["id"])
+        db_pinned_rec.unpin(self.db_conn, user_id=self.user["id"])
+        pin_count = db_pinned_rec.get_pin_count_for_user(self.db_conn, user_id=self.user["id"])
         self.assertEqual(pin_count, len(pin_history))
 
         # test that pin_count excludes deleted recordings
         pin_to_delete = pin_history[1]
-        db_pinned_rec.delete(pin_to_delete.row_id, self.user["id"])
-        pin_count = db_pinned_rec.get_pin_count_for_user(user_id=self.user["id"])
+        db_pinned_rec.delete(self.db_conn, pin_to_delete.row_id, self.user["id"])
+        pin_count = db_pinned_rec.get_pin_count_for_user(self.db_conn, user_id=self.user["id"])
         self.assertEqual(pin_count, len(pin_history) - 1)
 
     def test_get_pins_for_user_following(self):
@@ -392,7 +408,9 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         # test that followed_pins contains followed_user_1's pinned recording
         self.pin_single_sample(self.followed_user_1["id"], 0)
-        followed_pins = db_pinned_rec.get_pins_for_user_following(user_id=self.user["id"], count=50, offset=0)
+        followed_pins = db_pinned_rec.get_pins_for_user_following(
+            self.db_conn, user_id=self.user["id"], count=50, offset=0
+        )
         self.assertEqual(len(followed_pins), 1)
         self.assertEqual(followed_pins[0].user_name, "followed_user_1")
 
@@ -402,7 +420,9 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         # test that followed_user_2's pin is included after user follows
         db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_2["id"], "follow")
-        followed_pins = db_pinned_rec.get_pins_for_user_following(user_id=self.user["id"], count=50, offset=0)
+        followed_pins = db_pinned_rec.get_pins_for_user_following(
+            self.db_conn, user_id=self.user["id"], count=50, offset=0
+        )
         self.assertEqual(len(followed_pins), 2)
         self.assertEqual(followed_pins[0].user_name, "followed_user_2")
 
@@ -412,20 +432,28 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         # test the limit argument
         limit = 1
-        limited_following_pins = db_pinned_rec.get_pins_for_user_following(user_id=self.user["id"], count=limit, offset=0)
+        limited_following_pins = db_pinned_rec.get_pins_for_user_following(
+            self.db_conn, user_id=self.user["id"], count=limit, offset=0
+        )
         self.assertEqual(len(limited_following_pins), limit)
 
         limit = 999
-        limited_following_pins = db_pinned_rec.get_pins_for_user_following(user_id=self.user["id"], count=limit, offset=0)
+        limited_following_pins = db_pinned_rec.get_pins_for_user_following(
+            self.db_conn, user_id=self.user["id"], count=limit, offset=0
+        )
         self.assertEqual(len(limited_following_pins), 2)
 
         # test the offset argument
         offset = 1
-        offset_following_pins = db_pinned_rec.get_pins_for_user_following(user_id=self.user["id"], count=50, offset=offset)
+        offset_following_pins = db_pinned_rec.get_pins_for_user_following(
+            self.db_conn, user_id=self.user["id"], count=50, offset=offset
+        )
         self.assertEqual(len(offset_following_pins), 2 - offset)
 
         offset = 999
-        offset_following_pins = db_pinned_rec.get_pin_history_for_user(user_id=self.user["id"], count=50, offset=offset)
+        offset_following_pins = db_pinned_rec.get_pin_history_for_user(
+            self.db_conn, user_id=self.user["id"], count=50, offset=offset
+        )
         self.assertFalse(offset_following_pins)
 
     def get_pins_for_feed(self):
@@ -434,6 +462,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.pin_single_sample(self.followed_user_1["id"])  # pin 1 recording for followed_user_1
 
         feedPins = db_pinned_rec.get_pins_for_feed(
+            self.db_conn,
             user_ids=(self.user["id"],),
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -444,6 +473,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
         # test that user_ids param is honored
         feedPins = db_pinned_rec.get_pins_for_feed(
+            self.db_conn,
             user_ids=(self.user["id"], self.followed_user_1["id"]),
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -455,6 +485,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         # test that count parameter is honored
         limit = 1
         feedPins = db_pinned_rec.get_pins_for_feed(
+            self.db_conn,
             user_ids=(self.user["id"], self.followed_user_1["id"]),
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -463,6 +494,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(len(feedPins), limit)
 
         feedPins = db_pinned_rec.get_pins_for_feed(
+            self.db_conn,
             user_ids=(self.user["id"], self.followed_user_1["id"]),
             min_ts=0,
             max_ts=0,  # too low, nothing is returned.
@@ -471,6 +503,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(len(feedPins), 0)
 
         feedPins = db_pinned_rec.get_pins_for_feed(
+            self.db_conn,
             user_ids=(self.user["id"], self.followed_user_1["id"]),
             min_ts=9999,  # too high, nothing is returned.
             max_ts=9999,

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -381,8 +381,14 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def test_get_pins_for_user_following(self):
         # user follows followed_user_1
-        db_user_relationship.insert(self.user["id"], self.followed_user_1["id"], "follow")
-        self.assertTrue(db_user_relationship.is_following_user(self.user["id"], self.followed_user_1["id"]))
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_1["id"], "follow")
+        self.assertTrue(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.user["id"],
+                self.followed_user_1["id"]
+            )
+        )
 
         # test that followed_pins contains followed_user_1's pinned recording
         self.pin_single_sample(self.followed_user_1["id"], 0)
@@ -395,7 +401,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(len(followed_pins), 1)
 
         # test that followed_user_2's pin is included after user follows
-        db_user_relationship.insert(self.user["id"], self.followed_user_2["id"], "follow")
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_2["id"], "follow")
         followed_pins = db_pinned_rec.get_pins_for_user_following(user_id=self.user["id"], count=50, offset=0)
         self.assertEqual(len(followed_pins), 2)
         self.assertEqual(followed_pins[0].user_name, "followed_user_2")

--- a/listenbrainz/db/tests/test_pinned_recording.py
+++ b/listenbrainz/db/tests/test_pinned_recording.py
@@ -155,7 +155,7 @@ class PinnedRecDatabaseTestCase(DatabaseTestCase, TimescaleTestCase):
             )
 
         pins = db_pinned_rec.get_pin_history_for_user(self.db_conn, self.user["id"], 5, 0)
-        pins_with_metadata = fetch_track_metadata_for_items(pins)
+        pins_with_metadata = fetch_track_metadata_for_items(self.ts_conn, pins)
 
         received = [x.dict() for x in pins_with_metadata]
         # pinned recs returned in reverse order of submitted because order newest to oldest

--- a/listenbrainz/db/tests/test_recommendations_cf_recording.py
+++ b/listenbrainz/db/tests/test_recommendations_cf_recording.py
@@ -28,13 +28,14 @@ class CFRecordingRecommendationDatabaseTestCase(DatabaseTestCase):
         ]
 
         db_recommendations_cf_recording.insert_user_recommendation(
+            self.db_conn,
             self.user['id'],
             UserRecommendationsJson(**{
                 'raw': raw_recording_mbids,
             })
         )
 
-        result = db_recommendations_cf_recording.get_user_recommendation(self.user['id'])
+        result = db_recommendations_cf_recording.get_user_recommendation(self.db_conn, self.user['id'])
         self.assertEqual(getattr(result, 'recording_mbid').dict()['raw'], raw_recording_mbids)
         self.assertGreater(int(getattr(result, 'created').strftime('%s')), 0)
 
@@ -53,6 +54,7 @@ class CFRecordingRecommendationDatabaseTestCase(DatabaseTestCase):
         ]
 
         db_recommendations_cf_recording.insert_user_recommendation(
+            self.db_conn,
             self.user['id'],
             UserRecommendationsJson(**{
                 'raw': raw_recording_mbids,
@@ -66,7 +68,7 @@ class CFRecordingRecommendationDatabaseTestCase(DatabaseTestCase):
     def test_get_user_recommendation(self):
         data_inserted = self.insert_test_data()
 
-        data_received = db_recommendations_cf_recording.get_user_recommendation(self.user['id'])
+        data_received = db_recommendations_cf_recording.get_user_recommendation(self.db_conn, self.user['id'])
         self.assertEqual(
             getattr(data_received, 'recording_mbid').dict()['raw'],
             data_inserted['raw_recording_mbids']
@@ -75,5 +77,5 @@ class CFRecordingRecommendationDatabaseTestCase(DatabaseTestCase):
     def test_get_timestamp_for_last_recording_recommended(self):
         ts = datetime.now(timezone.utc)
         self.insert_test_data()
-        received_ts = db_recommendations_cf_recording.get_timestamp_for_last_recording_recommended()
+        received_ts = db_recommendations_cf_recording.get_timestamp_for_last_recording_recommended(self.db_conn)
         self.assertGreaterEqual(received_ts, ts)

--- a/listenbrainz/db/tests/test_recommendations_cf_recording.py
+++ b/listenbrainz/db/tests/test_recommendations_cf_recording.py
@@ -11,7 +11,7 @@ class CFRecordingRecommendationDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         DatabaseTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, 'vansika')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'vansika')
 
     def test_insert_user_recommendation(self):
         raw_recording_mbids = [
@@ -75,6 +75,9 @@ class CFRecordingRecommendationDatabaseTestCase(DatabaseTestCase):
         )
 
     def test_get_timestamp_for_last_recording_recommended(self):
+        # get_or_create starts a transaction, and NOW() uses that value in insert so need to commit here so that
+        # the insert starts a new transaction
+        self.db_conn.commit()
         ts = datetime.now(timezone.utc)
         self.insert_test_data()
         received_ts = db_recommendations_cf_recording.get_timestamp_for_last_recording_recommended(self.db_conn)

--- a/listenbrainz/db/tests/test_recommendations_cf_recording_feedback.py
+++ b/listenbrainz/db/tests/test_recommendations_cf_recording_feedback.py
@@ -10,9 +10,9 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         DatabaseTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, "vansika")
-        self.user1 = db_user.get_or_create(2, "vansika_1")
-        self.user2 = db_user.get_or_create(3, "vansika__2")
+        self.user = db_user.get_or_create(self.db_conn, 1, "vansika")
+        self.user1 = db_user.get_or_create(self.db_conn, 2, "vansika_1")
+        self.user2 = db_user.get_or_create(self.db_conn, 3, "vansika__2")
 
         self.sample_feedback = [
             {

--- a/listenbrainz/db/tests/test_recommendations_cf_recording_feedback.py
+++ b/listenbrainz/db/tests/test_recommendations_cf_recording_feedback.py
@@ -37,6 +37,7 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
 
         for fb in self.sample_feedback:
             db_feedback.insert(
+                self.db_conn,
                 RecommendationFeedbackSubmit(
                     user_id=fb['user_id'],
                     recording_mbid=fb["recording_mbid"],
@@ -46,17 +47,17 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
 
     def test_insert(self):
         self.insert_test_data()
-        result = db_feedback.get_feedback_for_user(user_id=self.user['id'], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user['id'], limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user1['id'], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user1['id'], limit=25, offset=0)
         self.assertEqual(len(result), 2)
 
     def test_update_rating_when_feedback_already_exits(self):
         update_fb = self.sample_feedback[0]
 
         self.insert_test_data()
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].recording_mbid, update_fb['recording_mbid'])
         self.assertEqual(result[0].rating, 'love')
@@ -65,6 +66,7 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
 
         # update a record by inserting a record with updated score value
         db_feedback.insert(
+            self.db_conn,
             RecommendationFeedbackSubmit(
                 user_id=self.user["id"],
                 recording_mbid=update_fb["recording_mbid"],
@@ -72,7 +74,7 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
             )
         )
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0].recording_mbid, update_fb["recording_mbid"])
@@ -82,24 +84,25 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
         del_fb = self.sample_feedback[1]
 
         self.insert_test_data()
-        result = db_feedback.get_feedback_for_user(user_id=self.user1["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user1["id"], limit=25, offset=0)
         self.assertEqual(len(result), 2)
 
         db_feedback.delete(
+            self.db_conn,
             RecommendationFeedbackDelete(
                 user_id=self.user1["id"],
                 recording_mbid=del_fb["recording_mbid"],
             )
         )
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user1["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user1["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
         self.assertNotEqual(result[0].recording_mbid, del_fb["recording_mbid"])
 
     def test_get_feedback_for_user(self):
         self.insert_test_data()
-        result = db_feedback.get_feedback_for_user(user_id=self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0].user_id, self.user["id"])
@@ -114,7 +117,7 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
                 rating='love'
             )
 
-            db_feedback.insert(submit_obj)
+            db_feedback.insert(self.db_conn, submit_obj)
             # prepended to the list since ``get_feedback_for_users`` returns data in descending
             # order of creation.
             feedback_love.insert(0, submit_obj)
@@ -127,24 +130,28 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
                 rating='hate'
             )
 
-            db_feedback.insert(submit_obj)
+            db_feedback.insert(self.db_conn, submit_obj)
             # prepended to the list since ``get_feedback_for_users`` returns data in descending
             # order of creation.
             feedback_hate.insert(0, submit_obj)
         # ``get_feddback_for_user`` will return feedback_hate data followed by feedback_love
         # data
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=120, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user2['id'], limit=120, offset=0)
         self.assertEqual(len(result), 110)
 
         # test the rating argument
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=70, offset=0, rating='love')
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, user_id=self.user2['id'], limit=70, offset=0, rating='love'
+        )
         self.assertEqual(len(result), 60)
         for i in range(60):
             self.assertEqual(result[i].user_id, feedback_love[i].user_id)
             self.assertEqual(result[i].recording_mbid, feedback_love[i].recording_mbid)
             self.assertEqual(result[i].rating, feedback_love[i].rating)
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=70, offset=0, rating='hate')
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, user_id=self.user2['id'], limit=70, offset=0, rating='hate'
+        )
         self.assertEqual(len(result), 50)
         for i in range(50):
             self.assertEqual(result[i].user_id, feedback_hate[i].user_id)
@@ -152,7 +159,9 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
             self.assertEqual(result[i].rating, feedback_hate[i].rating)
 
         # test the limit argument
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=20, offset=0, rating='love')
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, user_id=self.user2['id'], limit=20, offset=0, rating='love'
+        )
         self.assertEqual(len(result), 20)
         for i in range(20):
             self.assertEqual(result[i].user_id, feedback_love[i].user_id)
@@ -160,24 +169,28 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
             self.assertEqual(result[i].rating, feedback_love[i].rating)
 
         # test the offset argument
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=25, offset=10)
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, user_id=self.user2['id'], limit=25, offset=10
+        )
         self.assertEqual(len(result), 25)
         for i in range(25):
             self.assertEqual(result[i].user_id, feedback_hate[i+10].user_id)
             self.assertEqual(result[i].recording_mbid, feedback_hate[i+10].recording_mbid)
             self.assertEqual(result[i].rating, feedback_hate[i+10].rating)
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=25, offset=100)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user2['id'], limit=25, offset=100)
         self.assertEqual(len(result), 10)
         for i in range(10):
             self.assertEqual(result[i].user_id, feedback_love[i+50].user_id)
             self.assertEqual(result[i].recording_mbid, feedback_love[i+50].recording_mbid)
             self.assertEqual(result[i].rating, feedback_love[i+50].rating)
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=30, offset=110)
+        result = db_feedback.get_feedback_for_user(self.db_conn, user_id=self.user2['id'], limit=30, offset=110)
         self.assertEqual(len(result), 0)
 
-        result = db_feedback.get_feedback_for_user(user_id=self.user2['id'], limit=30, offset=30, rating='hate')
+        result = db_feedback.get_feedback_for_user(
+            self.db_conn, user_id=self.user2['id'], limit=30, offset=30, rating='hate'
+        )
         self.assertEqual(len(result), 20)
         for i in range(20):
             self.assertEqual(result[i].user_id, feedback_hate[i+30].user_id)
@@ -186,5 +199,5 @@ class RecommendationFeedbackDatabaseTestCase(DatabaseTestCase):
 
     def test_get_feedback_count_for_user(self):
         self.insert_test_data()
-        result = db_feedback.get_feedback_count_for_user(user_id=self.user1["id"])
+        result = db_feedback.get_feedback_count_for_user(self.db_conn, user_id=self.user1["id"])
         self.assertEqual(result, 2)

--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -11,24 +11,23 @@ from listenbrainz.db.similar_users import get_top_similar_users
 class SimilarUserTestCase(DatabaseTestCase):
 
     def test_fetch_top_similar_users(self):
-        user_id_1 = db_user.create(1, "tom")
-        user_id_2 = db_user.create(2, "jerry")
+        user_id_1 = db_user.create(self.db_conn, 1, "tom")
+        user_id_2 = db_user.create(self.db_conn, 2, "jerry")
 
         similar_users_1 = {user_id_2: 0.42}
         similar_users_2 = {user_id_1: 0.02}
 
-        with db.engine.begin() as connection:
-            connection.execute(sqlalchemy.text("""
-            INSERT INTO recommendation.similar_user (user_id, similar_users)
-                 VALUES (:user_id_1, :similar_users_1), (:user_id_2, :similar_users_2)
-            """), {
-                "user_id_1": user_id_1,
-                "similar_users_1": json.dumps(similar_users_1),
-                "user_id_2": user_id_2,
-                "similar_users_2": json.dumps(similar_users_2)
-            })
+        self.db_conn.execute(sqlalchemy.text("""
+        INSERT INTO recommendation.similar_user (user_id, similar_users)
+             VALUES (:user_id_1, :similar_users_1), (:user_id_2, :similar_users_2)
+        """), {
+            "user_id_1": user_id_1,
+            "similar_users_1": json.dumps(similar_users_1),
+            "user_id_2": user_id_2,
+            "similar_users_2": json.dumps(similar_users_2)
+        })
 
-        similar_users = get_top_similar_users()
+        similar_users = get_top_similar_users(self.db_conn)
         assert len(similar_users) == 1
         assert similar_users[0][0] == "jerry"
         assert similar_users[0][1] == "tom"

--- a/listenbrainz/db/tests/test_spotify.py
+++ b/listenbrainz/db/tests/test_spotify.py
@@ -13,7 +13,7 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(SpotifyDatabaseTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'testspotifyuser')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testspotifyuser')
         db_oauth.save_token(
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
@@ -25,7 +25,7 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         )
 
     def test_get_active_users_to_process(self):
-        user2 = db_user.get_or_create(2, 'newspotifyuser')
+        user2 = db_user.get_or_create(self.db_conn, 2, 'newspotifyuser')
         db_oauth.save_token(
             user_id=user2['id'],
             service=ExternalServiceType.SPOTIFY,
@@ -43,7 +43,7 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(users[1]['musicbrainz_row_id'], 2)
 
         # check order, the users should be sorted by latest_listened_at timestamp
-        user3 = db_user.get_or_create(3, 'newnewspotifyuser')
+        user3 = db_user.get_or_create(self.db_conn, 3, 'newnewspotifyuser')
         db_oauth.save_token(
             user_id=user3['id'],
             service=ExternalServiceType.SPOTIFY,

--- a/listenbrainz/db/tests/test_spotify.py
+++ b/listenbrainz/db/tests/test_spotify.py
@@ -15,6 +15,7 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         super(SpotifyDatabaseTestCase, self).setUp()
         self.user = db_user.get_or_create(self.db_conn, 1, 'testspotifyuser')
         db_oauth.save_token(
+            self.db_conn,
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',
@@ -27,6 +28,7 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
     def test_get_active_users_to_process(self):
         user2 = db_user.get_or_create(self.db_conn, 2, 'newspotifyuser')
         db_oauth.save_token(
+            self.db_conn,
             user_id=user2['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',
@@ -35,7 +37,7 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
             record_listens=True,
             scopes=['user-read-recently-played']
         )
-        users = db_spotify.get_active_users_to_process()
+        users = db_spotify.get_active_users_to_process(self.db_conn)
         self.assertEqual(len(users), 2)
         self.assertEqual(users[0]['user_id'], self.user['id'])
         self.assertEqual(users[0]['musicbrainz_row_id'], 1)
@@ -45,6 +47,7 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
         # check order, the users should be sorted by latest_listened_at timestamp
         user3 = db_user.get_or_create(self.db_conn, 3, 'newnewspotifyuser')
         db_oauth.save_token(
+            self.db_conn,
             user_id=user3['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='tokentoken',
@@ -54,22 +57,22 @@ class SpotifyDatabaseTestCase(DatabaseTestCase):
             scopes=['user-read-recently-played']
         )
         t = int(time.time())
-        db_import.update_latest_listened_at(user2['id'], ExternalServiceType.SPOTIFY, t + 20)
-        db_import.update_latest_listened_at(self.user['id'], ExternalServiceType.SPOTIFY, t + 10)
-        users = db_spotify.get_active_users_to_process()
+        db_import.update_latest_listened_at(self.db_conn, user2['id'], ExternalServiceType.SPOTIFY, t + 20)
+        db_import.update_latest_listened_at(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, t + 10)
+        users = db_spotify.get_active_users_to_process(self.db_conn)
         self.assertEqual(len(users), 3)
         self.assertEqual(users[0]['user_id'], user2['id'])
         self.assertEqual(users[1]['user_id'], self.user['id'])
         self.assertEqual(users[2]['user_id'], user3['id'])
 
-        db_import.update_import_status(user2['id'], ExternalServiceType.SPOTIFY, 'something broke')
-        db_import.update_import_status(user3['id'], ExternalServiceType.SPOTIFY, 'oops.')
-        users = db_spotify.get_active_users_to_process()
+        db_import.update_import_status(self.db_conn, user2['id'], ExternalServiceType.SPOTIFY, 'something broke')
+        db_import.update_import_status(self.db_conn, user3['id'], ExternalServiceType.SPOTIFY, 'oops.')
+        users = db_spotify.get_active_users_to_process(self.db_conn)
         self.assertEqual(len(users), 1)
         self.assertEqual(users[0]['user_id'], self.user['id'])
 
     def test_get_user_import_details(self):
-        user = db_spotify.get_user_import_details(self.user['id'])
+        user = db_spotify.get_user_import_details(self.db_conn, self.user['id'])
         self.assertEqual(user['user_id'], self.user['id'])
         self.assertIn('last_updated', user)
         self.assertIn('latest_listened_at', user)

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -104,13 +104,13 @@ class UserTestCase(DatabaseTestCase):
         user_id = db_user.create(self.db_conn, 11, 'kishore')
         user = db_user.get(self.db_conn, user_id)
         self.assertIsNotNone(user)
-        db_oauth.save_token(user_id, ExternalServiceType.SPOTIFY, 'user token',
+        db_oauth.save_token(self.db_conn, user_id, ExternalServiceType.SPOTIFY, 'user token',
                             'refresh token', 0, True, ['user-read-recently-played'])
 
         db_user.delete(self.db_conn, user_id)
         user = db_user.get(self.db_conn, user_id)
         self.assertIsNone(user)
-        token = db_oauth.get_token(user_id, ExternalServiceType.SPOTIFY)
+        token = db_oauth.get_token(self.db_conn, user_id, ExternalServiceType.SPOTIFY)
         self.assertIsNone(token)
 
     def test_get_similar_users(self):

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -5,57 +5,56 @@ import listenbrainz.db.external_service_oauth as db_oauth
 import sqlalchemy
 
 from data.model.external_service import ExternalServiceType
-from listenbrainz import db
 from listenbrainz.db.similar_users import import_user_similarities
 from listenbrainz.db.testing import DatabaseTestCase
 
 
 class UserTestCase(DatabaseTestCase):
+
     def test_create(self):
-        user_id = db_user.create(0, "izzy_cheezy")
+        user_id = db_user.create(self.db_conn, 0, "izzy_cheezy")
         self.assertIsNotNone(db_user.get(self.db_conn, user_id))
 
     def test_get_by_musicbrainz_row_id(self):
-        user_id = db_user.create(0, 'frank')
-        user = db_user.get_by_mb_row_id(0)
+        user_id = db_user.create(self.db_conn, 0, 'frank')
+        user = db_user.get_by_mb_row_id(self.db_conn, 0)
         self.assertEqual(user['id'], user_id)
-        user = db_user.get_by_mb_row_id(0, musicbrainz_id='frank')
+        user = db_user.get_by_mb_row_id(self.db_conn, 0, musicbrainz_id='frank')
         self.assertEqual(user['id'], user_id)
 
     def test_update_token(self):
-        user = db_user.get_or_create(1, 'testuserplsignore')
+        user = db_user.get_or_create(self.db_conn, 1, 'testuserplsignore')
         old_token = user['auth_token']
-        db_user.update_token(user['id'])
-        user = db_user.get_by_mb_id('testuserplsignore')
+        db_user.update_token(self.db_conn, user['id'])
+        user = db_user.get_by_mb_id(self.db_conn, 'testuserplsignore')
         self.assertNotEqual(old_token, user['auth_token'])
 
     def test_update_last_login(self):
         """ Tests db.user.update_last_login """
 
-        user = db_user.get_or_create(2, 'testlastloginuser')
+        user = db_user.get_or_create(self.db_conn, 2, 'testlastloginuser')
 
         # set the last login value of the user to 0
-        with db.engine.begin() as connection:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET last_login = to_timestamp(0)
-                 WHERE id = :id
-            """), {
-                'id': user['id']
-            })
+        self.db_conn.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET last_login = to_timestamp(0)
+             WHERE id = :id
+        """), {
+            'id': user['id']
+        })
 
         user = db_user.get(self.db_conn, user['id'])
         self.assertEqual(int(user['last_login'].strftime('%s')), 0)
 
-        db_user.update_last_login(user['musicbrainz_id'])
-        user = db_user.get_by_mb_id(user['musicbrainz_id'])
+        db_user.update_last_login(self.db_conn, user['musicbrainz_id'])
+        user = db_user.get_by_mb_id(self.db_conn, user['musicbrainz_id'])
 
         # after update_last_login, the val should be greater than the old value i.e 0
         self.assertGreater(int(user['last_login'].strftime('%s')), 0)
 
     def test_update_user_details(self):
-        user_id = db_user.create(17, "barbazfoo", "barbaz@foo.com")
-        db_user.update_user_details(user_id, "hello-world", "hello-world@foo.com")
+        user_id = db_user.create(self.db_conn, 17, "barbazfoo", "barbaz@foo.com")
+        db_user.update_user_details(self.db_conn, user_id, "hello-world", "hello-world@foo.com")
         user = db_user.get(self.db_conn, user_id, fetch_email=True)
         self.assertEqual(user["id"], user_id)
         self.assertEqual(user["musicbrainz_id"], "hello-world")
@@ -64,13 +63,13 @@ class UserTestCase(DatabaseTestCase):
     def test_get_all_users(self):
         """ Tests that get_all_users returns ALL users in the db """
 
-        users = db_user.get_all_users()
+        users = db_user.get_all_users(self.db_conn)
         self.assertEqual(len(users), 0)
-        db_user.create(8, 'user1')
-        users = db_user.get_all_users()
+        db_user.create(self.db_conn, 8, 'user1')
+        users = db_user.get_all_users(self.db_conn)
         self.assertEqual(len(users), 1)
-        db_user.create(9, 'user2')
-        users = db_user.get_all_users()
+        db_user.create(self.db_conn, 9, 'user2')
+        users = db_user.get_all_users(self.db_conn)
         self.assertEqual(len(users), 2)
 
     def test_get_all_users_columns(self):
@@ -78,13 +77,13 @@ class UserTestCase(DatabaseTestCase):
 
         # check that all columns of the user table are present
         # if columns is not specified
-        users = db_user.get_all_users()
+        users = db_user.get_all_users(self.db_conn)
         for user in users:
             for column in db_user.USER_GET_COLUMNS:
                 self.assertIn(column, user)
 
         # check that only id is present if columns = ['id']
-        users = db_user.get_all_users(columns=['id'])
+        users = db_user.get_all_users(self.db_conn, columns=['id'])
         for user in users:
             self.assertIn('id', user)
             for column in db_user.USER_GET_COLUMNS:
@@ -92,76 +91,32 @@ class UserTestCase(DatabaseTestCase):
                     self.assertNotIn(column, user)
 
     def test_delete(self):
-        user_id = db_user.create(10, 'frank')
+        user_id = db_user.create(self.db_conn, 10, 'frank')
 
         user = db_user.get(self.db_conn, user_id)
         self.assertIsNotNone(user)
 
-        db_user.delete(user_id)
+        db_user.delete(self.db_conn, user_id)
         user = db_user.get(self.db_conn, user_id)
         self.assertIsNone(user)
 
     def test_delete_when_spotify_import_activated(self):
-        user_id = db_user.create(11, 'kishore')
+        user_id = db_user.create(self.db_conn, 11, 'kishore')
         user = db_user.get(self.db_conn, user_id)
         self.assertIsNotNone(user)
         db_oauth.save_token(user_id, ExternalServiceType.SPOTIFY, 'user token',
                             'refresh token', 0, True, ['user-read-recently-played'])
 
-        db_user.delete(user_id)
+        db_user.delete(self.db_conn, user_id)
         user = db_user.get(self.db_conn, user_id)
         self.assertIsNone(user)
         token = db_oauth.get_token(user_id, ExternalServiceType.SPOTIFY)
         self.assertIsNone(token)
 
-    def test_validate_usernames(self):
-        db_user.create(11, 'eleven')
-        db_user.create(12, 'twelve')
-
-        users = db_user.validate_usernames([])
-        self.assertListEqual(users, [])
-
-        users = db_user.validate_usernames(['eleven', 'twelve'])
-        self.assertEqual(len(users), 2)
-        self.assertEqual(users[0]['musicbrainz_id'], 'eleven')
-        self.assertEqual(users[1]['musicbrainz_id'], 'twelve')
-
-        users = db_user.validate_usernames(['twelve', 'eleven'])
-        self.assertEqual(len(users), 2)
-        self.assertEqual(users[0]['musicbrainz_id'], 'twelve')
-        self.assertEqual(users[1]['musicbrainz_id'], 'eleven')
-
-        users = db_user.validate_usernames(['twelve', 'eleven', 'thirteen'])
-        self.assertEqual(len(users), 2)
-        self.assertEqual(users[0]['musicbrainz_id'], 'twelve')
-        self.assertEqual(users[1]['musicbrainz_id'], 'eleven')
-
-    def test_get_users_in_order(self):
-        id1 = db_user.create(11, 'eleven')
-        id2 = db_user.create(12, 'twelve')
-
-        users = db_user.get_users_in_order([])
-        self.assertListEqual(users, [])
-
-        users = db_user.get_users_in_order([id1, id2])
-        self.assertEqual(len(users), 2)
-        self.assertEqual(users[0]['id'], id1)
-        self.assertEqual(users[1]['id'], id2)
-
-        users = db_user.get_users_in_order([id2, id1])
-        self.assertEqual(len(users), 2)
-        self.assertEqual(users[0]['id'], id2)
-        self.assertEqual(users[1]['id'], id1)
-
-        users = db_user.get_users_in_order([id2, id1, 213213132])
-        self.assertEqual(len(users), 2)
-        self.assertEqual(users[0]['id'], id2)
-        self.assertEqual(users[1]['id'], id1)
-
     def test_get_similar_users(self):
-        user_id_21 = db_user.create(21, "twenty_one")
-        user_id_22 = db_user.create(22, "twenty_two")
-        user_id_23 = db_user.create(23, "twenty_three")
+        user_id_21 = db_user.create(self.db_conn, 21, "twenty_one")
+        user_id_22 = db_user.create(self.db_conn, 22, "twenty_two")
+        user_id_23 = db_user.create(self.db_conn, 23, "twenty_three")
 
         similar_users_21 = {str(user_id_22): 0.4, str(user_id_23): 0.7}
         similar_users_22 = {str(user_id_21): 0.4}
@@ -179,34 +134,34 @@ class UserTestCase(DatabaseTestCase):
                 {"id": user_id_23, "musicbrainz_id": "twenty_three", "similarity": 0.7},
                 {"id": user_id_22, "musicbrainz_id": "twenty_two", "similarity": 0.4}
             ],
-            db_user.get_similar_users(user_id_21)
+            db_user.get_similar_users(self.db_conn, user_id_21)
         )
         
         self.assertListEqual(
             [{"id": user_id_21, "musicbrainz_id": "twenty_one", "similarity": 0.4}],
-            db_user.get_similar_users(user_id_22)
+            db_user.get_similar_users(self.db_conn, user_id_22)
         )
         
         self.assertListEqual(
             [{"id": user_id_21, "musicbrainz_id": "twenty_one", "similarity": 0.7}],
-            db_user.get_similar_users(user_id_23)
+            db_user.get_similar_users(self.db_conn, user_id_23)
         )
 
     def test_get_user_by_id(self):
-        user_id_24 = db_user.create(24, "twenty_four")
-        user_id_25 = db_user.create(25, "twenty_five")
+        user_id_24 = db_user.create(self.db_conn, 24, "twenty_four")
+        user_id_25 = db_user.create(self.db_conn, 25, "twenty_five")
 
         users = {
             user_id_24: "twenty_four",
             user_id_25: "twenty_five"
         }
 
-        self.assertDictEqual(users, db_user.get_users_by_id([user_id_24, user_id_25]))
+        self.assertDictEqual(users, db_user.get_users_by_id(self.db_conn, [user_id_24, user_id_25]))
 
     def test_fetch_email(self):
         musicbrainz_id = "one"
         email = "one@one.one"
-        user_id = db_user.create(1, musicbrainz_id, email)
+        user_id = db_user.create(self.db_conn, 1, musicbrainz_id, email)
         self.assertNotIn("email", db_user.get(self.db_conn, user_id))
         self.assertEqual(email, db_user.get(self.db_conn, user_id, fetch_email=True)["email"])
 
@@ -214,27 +169,26 @@ class UserTestCase(DatabaseTestCase):
         self.assertNotIn("email", db_user.get_by_token(self.db_conn, token))
         self.assertEqual(email, db_user.get_by_token(self.db_conn, token, fetch_email=True)["email"])
 
-        self.assertNotIn("email", db_user.get_by_mb_id(musicbrainz_id))
-        self.assertEqual(email, db_user.get_by_mb_id(musicbrainz_id, fetch_email=True)["email"])
+        self.assertNotIn("email", db_user.get_by_mb_id(self.db_conn, musicbrainz_id))
+        self.assertEqual(email, db_user.get_by_mb_id(self.db_conn, musicbrainz_id, fetch_email=True)["email"])
 
     def test_search(self):
-        searcher_id = db_user.create(0, "Cécile")
-        user_id_c = db_user.create(1, "Cecile")
-        user_id_l = db_user.create(2, "lucifer")
-        user_id_r = db_user.create(3, "rob")
+        searcher_id = db_user.create(self.db_conn, 0, "Cécile")
+        user_id_c = db_user.create(self.db_conn, 1, "Cecile")
+        user_id_l = db_user.create(self.db_conn, 2, "lucifer")
+        user_id_r = db_user.create(self.db_conn, 3, "rob")
 
-        with db.engine.begin() as connection:
-            connection.execute(sqlalchemy.text(
-                "INSERT INTO recommendation.similar_user (user_id, similar_users) VALUES (:user_id, :similar_users)"),
-                {
-                    "user_id": searcher_id,
-                    "similar_users": json.dumps({
-                        str(user_id_c): 0.42,
-                        str(user_id_l): 0.61,
-                        str(user_id_r): 0.87
-                    })
-                }
-            )
+        self.db_conn.execute(sqlalchemy.text(
+            "INSERT INTO recommendation.similar_user (user_id, similar_users) VALUES (:user_id, :similar_users)"),
+            {
+                "user_id": searcher_id,
+                "similar_users": json.dumps({
+                    str(user_id_c): 0.42,
+                    str(user_id_l): 0.61,
+                    str(user_id_r): 0.87
+                })
+            }
+        )
 
-        results = db_user.search("cif", 10, searcher_id)
+        results = db_user.search(self.db_conn, "cif", 10, searcher_id)
         self.assertEqual(results, [("Cécile", 0.1, None), ("Cecile", 0.1, 0.42), ("lucifer", 0.09090909, 0.61)])

--- a/listenbrainz/db/tests/test_user_relationship.py
+++ b/listenbrainz/db/tests/test_user_relationship.py
@@ -26,9 +26,9 @@ import listenbrainz.db.user_relationship as db_user_relationship
 class UserRelationshipTestCase(DatabaseTestCase):
     def setUp(self):
         super(UserRelationshipTestCase, self).setUp()
-        self.main_user = db_user.get_or_create(1, 'iliekcomputers')
-        self.followed_user_1 = db_user.get_or_create(2, 'followed_user_1')
-        self.followed_user_2 = db_user.get_or_create(3, 'followed_user_2')
+        self.main_user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        self.followed_user_1 = db_user.get_or_create(self.db_conn, 2, 'followed_user_1')
+        self.followed_user_2 = db_user.get_or_create(self.db_conn, 3, 'followed_user_2')
 
     def test_insert(self):
         db_user_relationship.insert(
@@ -125,7 +125,7 @@ class UserRelationshipTestCase(DatabaseTestCase):
             self.followed_user_1['id'],
             'follow'
         )
-        self.following_user_1 = db_user.get_or_create(3, 'following_user_1')
+        self.following_user_1 = db_user.get_or_create(self.db_conn, 3, 'following_user_1')
         db_user_relationship.insert(
             self.db_conn,
             self.following_user_1['id'],
@@ -157,7 +157,7 @@ class UserRelationshipTestCase(DatabaseTestCase):
         self.assertEqual(1, len(following))
 
         # make it so that the main user follows two users, followed_user_1 and followed_user_2
-        self.followed_user_2 = db_user.get_or_create(3, 'followed_user_2')
+        self.followed_user_2 = db_user.get_or_create(self.db_conn, 3, 'followed_user_2')
         db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_2['id'], 'follow')
 
         # the list of users main_user is following should have 2 elements now
@@ -168,7 +168,7 @@ class UserRelationshipTestCase(DatabaseTestCase):
         db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_1['id'], 'follow')
         db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_2['id'], 'follow')
 
-        new_user = db_user.get_or_create(4, 'new_user')
+        new_user = db_user.get_or_create(self.db_conn, 4, 'new_user')
         db_user_relationship.insert(self.db_conn, self.followed_user_1['id'], new_user['id'], 'follow')
 
         events = db_user_relationship.get_follow_events(
@@ -196,7 +196,7 @@ class UserRelationshipTestCase(DatabaseTestCase):
 
         ts2 = time.time()
 
-        new_user = db_user.get_or_create(4, 'new_user')
+        new_user = db_user.get_or_create(self.db_conn, 4, 'new_user')
         db_user_relationship.insert(self.db_conn, self.followed_user_1['id'], new_user['id'], 'follow')
 
         # max_ts is too low, won't return anything
@@ -223,7 +223,7 @@ class UserRelationshipTestCase(DatabaseTestCase):
         db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_1['id'], 'follow')
         db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_2['id'], 'follow')
 
-        new_user = db_user.get_or_create(4, 'new_user')
+        new_user = db_user.get_or_create(self.db_conn, 4, 'new_user')
         db_user_relationship.insert(self.db_conn, self.followed_user_1['id'], new_user['id'], 'follow')
 
         events = db_user_relationship.get_follow_events(

--- a/listenbrainz/db/tests/test_user_relationship.py
+++ b/listenbrainz/db/tests/test_user_relationship.py
@@ -17,9 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 import time
 
-from listenbrainz import db
 from listenbrainz.db.testing import DatabaseTestCase
-from listenbrainz.db.exceptions import DatabaseException
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
@@ -33,72 +31,148 @@ class UserRelationshipTestCase(DatabaseTestCase):
         self.followed_user_2 = db_user.get_or_create(3, 'followed_user_2')
 
     def test_insert(self):
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
-        self.assertTrue(db_user_relationship.is_following_user(self.main_user['id'], self.followed_user_1['id']))
+        db_user_relationship.insert(
+            self.db_conn,
+            self.main_user['id'],
+            self.followed_user_1['id'],
+            'follow'
+        )
+        self.assertTrue(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.main_user['id'],
+                self.followed_user_1['id']
+            )
+        )
 
     def test_insert_raises_value_error_for_invalid_relationship(self):
         with self.assertRaises(ValueError):
-            db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'idkwhatrelationshipthisis')
+            db_user_relationship.insert(
+                self.db_conn,
+                self.main_user['id'],
+                self.followed_user_1['id'],
+                'idkwhatrelationshipthisis'
+            )
 
     def test_is_following_user(self):
-        self.assertFalse(db_user_relationship.is_following_user(self.main_user['id'], self.followed_user_1['id']))
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
-        self.assertTrue(db_user_relationship.is_following_user(self.main_user['id'], self.followed_user_1['id']))
+        self.assertFalse(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.main_user['id'],
+                self.followed_user_1['id']
+            )
+        )
+        db_user_relationship.insert(
+            self.db_conn,
+            self.main_user['id'],
+            self.followed_user_1['id'],
+            'follow'
+        )
+        self.assertTrue(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.main_user['id'],
+                self.followed_user_1['id']
+            )
+        )
 
     def test_delete(self):
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
-        self.assertTrue(db_user_relationship.is_following_user(self.main_user['id'], self.followed_user_1['id']))
-        db_user_relationship.delete(self.main_user['id'], self.followed_user_1['id'], 'follow')
-        self.assertFalse(db_user_relationship.is_following_user(self.main_user['id'], self.followed_user_1['id']))
+        db_user_relationship.insert(
+            self.db_conn,
+            self.main_user['id'],
+            self.followed_user_1['id'],
+            'follow'
+        )
+        self.assertTrue(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.main_user['id'],
+                self.followed_user_1['id']
+            )
+        )
+        db_user_relationship.delete(
+            self.db_conn,
+            self.main_user['id'],
+            self.followed_user_1['id'],
+            'follow'
+        )
+        self.assertFalse(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.main_user['id'],
+                self.followed_user_1['id']
+            )
+        )
 
     def test_delete_raises_value_error_for_invalid_relationships(self):
         with self.assertRaises(ValueError):
-            db_user_relationship.delete(self.main_user['id'], self.followed_user_1['id'], 'idkwhatrelationshipthisis')
+            db_user_relationship.delete(
+                self.db_conn,
+                self.main_user['id'],
+                self.followed_user_1['id'],
+                'idkwhatrelationshipthisis'
+            )
 
     def test_get_followers_of_user_returns_correct_data(self):
         # no relationships yet, should return an empty list
-        followers = db_user_relationship.get_followers_of_user(self.followed_user_1['id'])
+        followers = db_user_relationship.get_followers_of_user(self.db_conn, self.followed_user_1['id'])
         self.assertListEqual(followers, [])
 
         # add two relationships
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
+        db_user_relationship.insert(
+            self.db_conn,
+            self.main_user['id'],
+            self.followed_user_1['id'],
+            'follow'
+        )
         self.following_user_1 = db_user.get_or_create(3, 'following_user_1')
-        db_user_relationship.insert(self.following_user_1['id'], self.followed_user_1['id'], 'follow')
+        db_user_relationship.insert(
+            self.db_conn,
+            self.following_user_1['id'],
+            self.followed_user_1['id'],
+            'follow'
+        )
 
         # At this point, the main_user and following_user_1 follow followed_user_1
         # So, if we get the followers of followed_user_1, we'll get back two users
-        followers = db_user_relationship.get_followers_of_user(self.followed_user_1['id'])
+        followers = db_user_relationship.get_followers_of_user(self.db_conn, self.followed_user_1['id'])
         self.assertEqual(2, len(followers))
 
     def test_get_following_for_user_returns_correct_data(self):
 
         # no relationships yet, should return an empty list
-        following = db_user_relationship.get_following_for_user(self.main_user['id'])
+        following = db_user_relationship.get_following_for_user(self.db_conn, self.main_user['id'])
         self.assertListEqual(following, [])
 
         # make the main_user follow followed_user_1
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
+        db_user_relationship.insert(
+            self.db_conn,
+            self.main_user['id'],
+            self.followed_user_1['id'],
+            'follow'
+        )
 
         # the list of users main_user is following should have 1 element now
-        following = db_user_relationship.get_following_for_user(self.main_user['id'])
+        following = db_user_relationship.get_following_for_user(self.db_conn, self.main_user['id'])
         self.assertEqual(1, len(following))
 
         # make it so that the main user follows two users, followed_user_1 and followed_user_2
         self.followed_user_2 = db_user.get_or_create(3, 'followed_user_2')
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_2['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_2['id'], 'follow')
 
         # the list of users main_user is following should have 2 elements now
-        following = db_user_relationship.get_following_for_user(self.main_user['id'])
+        following = db_user_relationship.get_following_for_user(self.db_conn, self.main_user['id'])
         self.assertEqual(2, len(following))
 
     def test_get_follow_events_returns_correct_events(self):
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_2['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_1['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_2['id'], 'follow')
 
         new_user = db_user.get_or_create(4, 'new_user')
-        db_user_relationship.insert(self.followed_user_1['id'], new_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.followed_user_1['id'], new_user['id'], 'follow')
 
         events = db_user_relationship.get_follow_events(
+            self.db_conn,
             user_ids=(self.main_user['id'], self.followed_user_1['id']),
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -117,16 +191,17 @@ class UserRelationshipTestCase(DatabaseTestCase):
     def test_get_follow_events_honors_timestamp_parameters(self):
         ts = int(time.time())
 
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_2['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_1['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_2['id'], 'follow')
 
         ts2 = time.time()
 
         new_user = db_user.get_or_create(4, 'new_user')
-        db_user_relationship.insert(self.followed_user_1['id'], new_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.followed_user_1['id'], new_user['id'], 'follow')
 
         # max_ts is too low, won't return anything
         events = db_user_relationship.get_follow_events(
+            self.db_conn,
             user_ids=(self.main_user['id'], self.followed_user_1['id']),
             min_ts=0,
             max_ts=ts,
@@ -136,6 +211,7 @@ class UserRelationshipTestCase(DatabaseTestCase):
 
         # check that it honors min_ts as well
         events = db_user_relationship.get_follow_events(
+            self.db_conn,
             user_ids=(self.main_user['id'], self.followed_user_1['id']),
             min_ts=ts2,
             max_ts=ts + 10,
@@ -144,13 +220,14 @@ class UserRelationshipTestCase(DatabaseTestCase):
         self.assertEqual(1, len(events))
 
     def test_get_follow_events_honors_count_parameter(self):
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_1['id'], 'follow')
-        db_user_relationship.insert(self.main_user['id'], self.followed_user_2['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_1['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.main_user['id'], self.followed_user_2['id'], 'follow')
 
         new_user = db_user.get_or_create(4, 'new_user')
-        db_user_relationship.insert(self.followed_user_1['id'], new_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.followed_user_1['id'], new_user['id'], 'follow')
 
         events = db_user_relationship.get_follow_events(
+            self.db_conn,
             user_ids=(self.main_user['id'], self.followed_user_1['id']),
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -162,9 +239,10 @@ class UserRelationshipTestCase(DatabaseTestCase):
 
     def test_multiple_users_by_username_following_user(self):
         # Only followed_user_1 follows main user
-        db_user_relationship.insert(self.followed_user_1['id'], self.main_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.followed_user_1['id'], self.main_user['id'], 'follow')
 
         follower_results = db_user_relationship.multiple_users_by_username_following_user(
+            self.db_conn,
             followed=self.main_user['id'],
             followers=['followed_user_1', 'followed_user_2']
         )

--- a/listenbrainz/db/tests/test_user_setting.py
+++ b/listenbrainz/db/tests/test_user_setting.py
@@ -12,12 +12,12 @@ class UserSettingTestCase(DatabaseTestCase):
     def test_set_timezone(self):
         # test if timezone is not null
         test_zonename = 'America/New_York'
-        db_setting.set_timezone(self.user['id'], test_zonename)
-        result = db_setting.get(self.user['id'])
+        db_setting.set_timezone(self.db_conn, self.user['id'], test_zonename)
+        result = db_setting.get(self.db_conn, self.user['id'])
         self.assertEqual(result['timezone_name'], test_zonename)
 
         # test if timezone is null
         test_zonename = None
-        db_setting.set_timezone(self.user['id'], test_zonename)
-        result = db_setting.get(self.user['id'])
+        db_setting.set_timezone(self.db_conn, self.user['id'], test_zonename)
+        result = db_setting.get(self.db_conn, self.user['id'])
         self.assertEqual(result['timezone_name'], 'UTC')

--- a/listenbrainz/db/tests/test_user_setting.py
+++ b/listenbrainz/db/tests/test_user_setting.py
@@ -7,7 +7,7 @@ from listenbrainz.db.testing import DatabaseTestCase
 class UserSettingTestCase(DatabaseTestCase):
     def setUp(self):
         DatabaseTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, "user_setting_user")
+        self.user = db_user.get_or_create(self.db_conn, 1, "user_setting_user")
 
     def test_set_timezone(self):
         # test if timezone is not null

--- a/listenbrainz/db/tests/test_user_timeline_event.py
+++ b/listenbrainz/db/tests/test_user_timeline_event.py
@@ -35,7 +35,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(UserTimelineEventDatabaseTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'friendly neighborhood spider-man')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'friendly neighborhood spider-man')
 
     def test_it_adds_rows_to_the_database(self):
         recording_msid = str(uuid.uuid4())
@@ -112,7 +112,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
                 recording_msid=str(uuid.uuid4()),
             )
         )
-        new_user = db_user.get_or_create(2, 'captain america')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'captain america')
         db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
             user_id=new_user['id'],
@@ -143,7 +143,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
             )
         )
 
-        new_user = db_user.get_or_create(2, 'superman')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'superman')
         db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
             user_id=new_user['id'],
@@ -187,7 +187,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
         )
 
         ts2 = time.time()
-        new_user = db_user.get_or_create(4, 'new_user')
+        new_user = db_user.get_or_create(self.db_conn, 4, 'new_user')
         db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
             user_id=new_user['id'],
@@ -256,7 +256,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(self.user['id'], event_rec.user_id)
 
         # creating a new user for notification
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
         message = 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'
         event_not = db_user_timeline_event.create_user_notification_event(
             self.db_conn,
@@ -323,7 +323,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
 
     def test_hide_feed_events(self):
         # creating a user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
 
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
@@ -355,7 +355,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
 
     def test_hide_feed_events_honors_count_parameter(self):
         # creating a user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
 
         # creating an event
         event1 = db_user_timeline_event.create_user_track_recommendation_event(
@@ -416,7 +416,7 @@ class UserTimelineEventDatabaseTestCase(DatabaseTestCase):
 
     def test_unhide_events(self):
         # creating a user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
 
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -5,6 +5,9 @@ import sqlalchemy
 import uuid
 
 from datetime import datetime
+
+from sqlalchemy import text
+
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
 from typing import Tuple, List
@@ -12,10 +15,11 @@ from typing import Tuple, List
 logger = logging.getLogger(__name__)
 
 
-def create(musicbrainz_row_id: int, musicbrainz_id: str, email: str = None) -> int:
+def create(db_conn, musicbrainz_row_id: int, musicbrainz_id: str, email: str = None) -> int:
     """Create a new user.
 
     Args:
+        db_conn: database connection
         musicbrainz_row_id (int): the MusicBrainz row ID of the user
         musicbrainz_id (str): MusicBrainz username of a user.
         email (str): email of the user
@@ -23,40 +27,40 @@ def create(musicbrainz_row_id: int, musicbrainz_id: str, email: str = None) -> i
     Returns:
         ID of newly created user.
     """
-    with db.engine.begin() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            INSERT INTO "user" (musicbrainz_id, musicbrainz_row_id, auth_token, email)
-                 VALUES (:mb_id, :mb_row_id, :token, :email)
-              RETURNING id
-        """), {
-            "mb_id": musicbrainz_id,
-            "token": str(uuid.uuid4()),
-            "mb_row_id": musicbrainz_row_id,
-            "email": email,
-        })
+    result = db_conn.execute(text("""
+        INSERT INTO "user" (musicbrainz_id, musicbrainz_row_id, auth_token, email)
+             VALUES (:mb_id, :mb_row_id, :token, :email)
+          RETURNING id
+    """), {
+        "mb_id": musicbrainz_id,
+        "token": str(uuid.uuid4()),
+        "mb_row_id": musicbrainz_row_id,
+        "email": email,
+    })
+    db_conn.commit()
+    return result.fetchone().id
 
-        return result.fetchone().id
 
-
-def update_token(id):
+def update_token(db_conn, id):
     """Update a user's token to a new UUID
 
     Args:
+        db_conn: database connection
         id (int) - the row id of the user to update
     """
-    with db.engine.begin() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET auth_token = :token
-                 WHERE id = :id
-            """), {
-                "token": str(uuid.uuid4()),
-                "id": id
-            })
-        except DatabaseException as e:
-            logger.error(e)
-            raise
+    try:
+        db_conn.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET auth_token = :token
+             WHERE id = :id
+        """), {
+            "token": str(uuid.uuid4()),
+            "id": id
+        })
+        db_conn.commit()
+    except DatabaseException as e:
+        logger.error(e)
+        raise
 
 
 USER_GET_COLUMNS = ['id', 'created', 'musicbrainz_id', 'auth_token',
@@ -94,10 +98,11 @@ def get(db_conn, id: int, *, fetch_email: bool = False):
     return result.mappings().first()
 
 
-def get_by_login_id(login_id):
+def get_by_login_id(db_conn, login_id):
     """Get user with a specified login ID.
 
     Args:
+        db_conn: database connection
         id (UUID): login ID of a user.
 
     Returns:
@@ -114,13 +119,12 @@ def get_by_login_id(login_id):
             "login_id": <token used for login sessions>
         }
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM "user"
-             WHERE login_id = :user_login_id
-        """.format(columns=','.join(USER_GET_COLUMNS))), {"user_login_id": login_id})
-        return result.mappings().first()
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM "user"
+         WHERE login_id = :user_login_id
+    """.format(columns=','.join(USER_GET_COLUMNS))), {"user_login_id": login_id})
+    return result.mappings().first()
 
 
 def get_many_users_by_mb_id(db_conn, musicbrainz_ids: List[str]):
@@ -144,10 +148,11 @@ def get_many_users_by_mb_id(db_conn, musicbrainz_ids: List[str]):
     return {row["musicbrainz_id"].lower(): row for row in result.mappings()}
 
 
-def get_by_mb_id(musicbrainz_id, *, fetch_email: bool = False):
+def get_by_mb_id(db_conn, musicbrainz_id, *, fetch_email: bool = False):
     """Get user with a specified MusicBrainz ID.
 
     Args:
+        db_conn: database connection
         musicbrainz_id (str): MusicBrainz username of a user.
         fetch_email: whether to return email in response
 
@@ -166,13 +171,12 @@ def get_by_mb_id(musicbrainz_id, *, fetch_email: bool = False):
         }
     """
     columns = USER_GET_COLUMNS + ['email'] if fetch_email else USER_GET_COLUMNS
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM "user"
-             WHERE LOWER(musicbrainz_id) = LOWER(:mb_id)
-        """.format(columns=','.join(columns))), {"mb_id": musicbrainz_id})
-        return result.mappings().first()
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM "user"
+         WHERE LOWER(musicbrainz_id) = LOWER(:mb_id)
+    """.format(columns=','.join(columns))), {"mb_id": musicbrainz_id})
+    return result.mappings().first()
 
 
 def get_by_token(db_conn, token: str, *, fetch_email: bool = False):
@@ -200,30 +204,29 @@ def get_by_token(db_conn, token: str, *, fetch_email: bool = False):
     return result.mappings().first()
 
 
-def get_user_count():
+def get_user_count(db_conn):
     """ Get total number of users in database.
 
     Returns:
         int: user count
     """
-
-    with db.engine.connect() as connection:
-        try:
-            result = connection.execute(sqlalchemy.text("""
-                SELECT count(*) AS user_count
-                  FROM "user"
-            """))
-            row = result.fetchone()
-            return row.user_count
-        except DatabaseException as e:
-            logger.error(e)
-            raise
+    try:
+        result = db_conn.execute(sqlalchemy.text("""
+            SELECT count(*) AS user_count
+              FROM "user"
+        """))
+        row = result.fetchone()
+        return row.user_count
+    except DatabaseException as e:
+        logger.error(e)
+        raise
 
 
-def get_or_create(musicbrainz_row_id: int, musicbrainz_id: str) -> dict:
+def get_or_create(db_conn, musicbrainz_row_id: int, musicbrainz_id: str) -> dict:
     """Get user with a specified MusicBrainz ID, or create if there's no account.
 
     Args:
+        db_conn: database connection
         musicbrainz_row_id (int): the MusicBrainz row ID of the user
         musicbrainz_id (str): MusicBrainz username of a user.
 
@@ -236,39 +239,39 @@ def get_or_create(musicbrainz_row_id: int, musicbrainz_id: str) -> dict:
             "auth_token": <authentication token>,
         }
     """
-    user = get_by_mb_row_id(musicbrainz_row_id, musicbrainz_id=musicbrainz_id)
+    user = get_by_mb_row_id(db_conn, musicbrainz_row_id, musicbrainz_id=musicbrainz_id)
     if not user:
-        create(musicbrainz_row_id, musicbrainz_id)
-        user = get_by_mb_row_id(musicbrainz_row_id)
+        create(db_conn, musicbrainz_row_id, musicbrainz_id)
+        user = get_by_mb_row_id(db_conn, musicbrainz_row_id)
     return user
 
 
-def update_last_login(musicbrainz_id):
+def update_last_login(db_conn, musicbrainz_id):
     """ Update the value of last_login field for user with specified MusicBrainz ID
 
     Args:
+        db_conn: database connection
         musicbrainz_id (str): MusicBrainz username of a user
     """
-
-    with db.engine.begin() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET last_login = NOW()
-                 WHERE musicbrainz_id = :musicbrainz_id
-                """), {
-                "musicbrainz_id": musicbrainz_id,
-            })
-        except sqlalchemy.exc.ProgrammingError as err:
-            logger.error(err)
-            raise DatabaseException(
-                "Couldn't update last_login: %s" % str(err))
+    try:
+        db_conn.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET last_login = NOW()
+             WHERE musicbrainz_id = :musicbrainz_id
+            """), {
+            "musicbrainz_id": musicbrainz_id,
+        })
+        db_conn.commit()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logger.error(err)
+        raise DatabaseException("Couldn't update last_login: %s" % str(err))
 
 
-def get_all_users(created_before=None, columns=None):
+def get_all_users(db_conn, created_before=None, columns=None):
     """ Returns a list of all users in the database
 
         Args:
+            db_conn: database connection
             columns: a list of columns to be returned for each user
             created_before (datetime): only return users who were created before this timestamp, defaults to now
 
@@ -291,92 +294,70 @@ def get_all_users(created_before=None, columns=None):
     if created_before is None:
         created_before = datetime.now()
 
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-                SELECT {columns}
-                  FROM "user"
-                 WHERE created <= :created
-              ORDER BY id
-            """.format(columns=', '.join(columns))), {
-            "created": created_before,
-        })
+    result = db_conn.execute(sqlalchemy.text("""
+            SELECT {columns}
+              FROM "user"
+             WHERE created <= :created
+          ORDER BY id
+        """.format(columns=', '.join(columns))), {
+        "created": created_before,
+    })
 
-        return result.mappings().all()
+    return result.mappings().all()
 
 
-def delete(id):
+def delete(db_conn, id):
     """ Delete the user with specified row ID from the database.
 
     Note: this deletes all statistics and api_compat sessions and tokens
     associated with the user also.
 
     Args:
+        db_conn: database connection
         id (int): the row ID of the listenbrainz user
     """
-    with db.engine.begin() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                DELETE FROM "user"
-                      WHERE id = :id
-                """), {
-                'id': id,
-            })
-        except sqlalchemy.exc.ProgrammingError as err:
-            logger.error(err)
-            raise DatabaseException("Couldn't delete user: %s" % str(err))
+    try:
+        db_conn.execute(sqlalchemy.text("""
+            DELETE FROM "user"
+                  WHERE id = :id
+            """), {
+            'id': id,
+        })
+        db_conn.commit()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logger.error(err)
+        raise DatabaseException("Couldn't delete user: %s" % str(err))
 
 
-def agree_to_gdpr(musicbrainz_id):
+def agree_to_gdpr(db_conn, musicbrainz_id):
     """ Update the gdpr_agreed column for user with specified MusicBrainz ID with current time.
 
     Args:
         musicbrainz_id (str): the MusicBrainz ID of the user
     """
-    with db.engine.begin() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET gdpr_agreed = NOW()
-                 WHERE LOWER(musicbrainz_id) = LOWER(:mb_id)
-                """), {
-                'mb_id': musicbrainz_id,
-            })
-        except sqlalchemy.exc.ProgrammingError as err:
-            logger.error(err)
-            raise DatabaseException(
-                "Couldn't update gdpr agreement for user: %s" % str(err))
+    try:
+        db_conn.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET gdpr_agreed = NOW()
+             WHERE LOWER(musicbrainz_id) = LOWER(:mb_id)
+            """), {
+            'mb_id': musicbrainz_id,
+        })
+        db_conn.commit()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logger.error(err)
+        raise DatabaseException(
+            "Couldn't update gdpr agreement for user: %s" % str(err))
 
 
-def update_musicbrainz_row_id(musicbrainz_id, musicbrainz_row_id):
-    """ Update the musicbrainz_row_id column for user with specified MusicBrainz username.
-
-    Args:
-        musicbrainz_id (str): the MusicBrainz ID (username) of the user
-        musicbrainz_row_id (int): the MusicBrainz row ID of the user
-    """
-    with db.engine.begin() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET musicbrainz_row_id = :musicbrainz_row_id
-                 WHERE LOWER(musicbrainz_id) = LOWER(:mb_id)
-                """), {
-                'musicbrainz_row_id': musicbrainz_row_id,
-                'mb_id': musicbrainz_id,
-            })
-        except sqlalchemy.exc.ProgrammingError as err:
-            logger.error(err)
-            raise DatabaseException(
-                "Couldn't update musicbrainz row id for user: %s" % str(err))
-
-
-def get_by_mb_row_id(musicbrainz_row_id, musicbrainz_id=None):
+def get_by_mb_row_id(db_conn, musicbrainz_row_id, musicbrainz_id=None):
     """ Get user with specified MusicBrainz row id.
 
     Note: this function also optionally takes a MusicBrainz username to fall back on
     if no user with specified MusicBrainz row ID is found.
 
      Args:
+        db_conn: database connection
         musicbrainz_row_id (int): the MusicBrainz row ID of the user
         musicbrainz_id (str): the MusicBrainz username of the user
 
@@ -389,53 +370,18 @@ def get_by_mb_row_id(musicbrainz_row_id, musicbrainz_id=None):
         filter_data['musicbrainz_id'] = musicbrainz_id
 
     filter_data['musicbrainz_row_id'] = musicbrainz_row_id
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT {columns}
-              FROM "user"
-             WHERE musicbrainz_row_id = :musicbrainz_row_id
-             {optional_filter}
-        """.format(columns=','.join(USER_GET_COLUMNS), optional_filter=filter_str)), filter_data)
 
-        return result.mappings().first()
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT {columns}
+          FROM "user"
+         WHERE musicbrainz_row_id = :musicbrainz_row_id
+         {optional_filter}
+    """.format(columns=','.join(USER_GET_COLUMNS), optional_filter=filter_str)), filter_data)
 
-
-def validate_usernames(musicbrainz_ids):
-    """ Check existence of users in the database and return those users which exist in order.
-
-    Args:
-        musicbrainz_ids ([str]): a list of usernames
-
-    Returns: list of users who exist in the database
-    """
-    with db.engine.connect() as connection:
-        r = connection.execute(sqlalchemy.text("""
-            SELECT t.musicbrainz_id as musicbrainz_id, id
-              FROM "user" u
-        RIGHT JOIN unnest(:musicbrainz_ids ::text[]) WITH ORDINALITY t(musicbrainz_id, ord)
-                ON LOWER(u.musicbrainz_id) = t.musicbrainz_id
-          ORDER BY t.ord
-        """), {
-            'musicbrainz_ids': [musicbrainz_id.lower() for musicbrainz_id in musicbrainz_ids],
-        })
-        return [row for row in r.mappings().all() if row["id"] is not None]
+    return result.mappings().first()
 
 
-def get_users_in_order(user_ids):
-    with db.engine.connect() as connection:
-        r = connection.execute(sqlalchemy.text("""
-            SELECT t.user_id as id, musicbrainz_id
-              FROM "user" u
-        RIGHT JOIN unnest(:user_ids ::int[]) WITH ORDINALITY t(user_id, ord)
-                ON u.id = t.user_id
-          ORDER BY t.ord
-        """), {
-            'user_ids': user_ids,
-        })
-        return [row for row in r.mappings() if row["musicbrainz_id"] is not None]
-
-
-def get_similar_users(user_id: int) -> Optional[list[dict]]:
+def get_similar_users(db_conn, user_id: int) -> Optional[list[dict]]:
     """ Given a user_id, fetch the similar users for that given user ordered by "similarity" score.
 
         :code:: python
@@ -457,73 +403,68 @@ def get_similar_users(user_id: int) -> Optional[list[dict]]:
         :param user_id: ID of the user.
         :type user_id: ``int``
     """
-
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT musicbrainz_id
-                 , id
-                 , value AS similarity -- first element of array is local similarity, second is global_similarity
-              FROM recommendation.similar_user r 
-              JOIN jsonb_each(r.similar_users) j
-                ON TRUE
-              JOIN "user" u
-                ON j.key::int = u.id 
-             WHERE user_id = :user_id
-             ORDER BY similarity DESC
-        """), {"user_id": user_id})
-        return [dict(**row) for row in result.mappings()]
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT musicbrainz_id
+             , id
+             , value AS similarity -- first element of array is local similarity, second is global_similarity
+          FROM recommendation.similar_user r 
+          JOIN jsonb_each(r.similar_users) j
+            ON TRUE
+          JOIN "user" u
+            ON j.key::int = u.id 
+         WHERE user_id = :user_id
+         ORDER BY similarity DESC
+    """), {"user_id": user_id})
+    return [dict(**row) for row in result.mappings()]
 
 
-def get_users_by_id(user_ids: List[int]):
+def get_users_by_id(db_conn, user_ids: List[int]):
     """ Given a list of user ids, fetch one ore more users at the same time.
         Returns a dict mapping user_ids to user_names. """
-
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT id, musicbrainz_id
-              FROM "user"
-             WHERE id IN :user_ids
-        """), {
-            'user_ids': tuple(user_ids)
-        })
-        row_id_username_map = {}
-        for row in result.fetchall():
-            row_id_username_map[row.id] = row.musicbrainz_id
-        return row_id_username_map
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT id, musicbrainz_id
+          FROM "user"
+         WHERE id IN :user_ids
+    """), {
+        'user_ids': tuple(user_ids)
+    })
+    row_id_username_map = {}
+    for row in result.fetchall():
+        row_id_username_map[row.id] = row.musicbrainz_id
+    return row_id_username_map
 
 
-def is_user_reported(reporter_id: int, reported_id: int):
+def is_user_reported(db_conn, reporter_id: int, reported_id: int):
     """ Check whether the user identified by reporter_id has reported the
     user identified by reported_id"""
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT *
-              FROM reported_users
-             WHERE reporter_user_id = :reporter_id
-               AND reported_user_id = :reported_id
-        """), {
-            "reporter_id": reporter_id,
-            "reported_id": reported_id
-        })
-        return True if result.fetchone() else False
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT *
+          FROM reported_users
+         WHERE reporter_user_id = :reporter_id
+           AND reported_user_id = :reported_id
+    """), {
+        "reporter_id": reporter_id,
+        "reported_id": reported_id
+    })
+    return True if result.fetchone() else False
 
 
-def report_user(reporter_id: int, reported_id: int, reason: str = None):
+def report_user(db_conn, reporter_id: int, reported_id: int, reason: str = None):
     """ Create a report from user with reporter_id against user with
      reported_id"""
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            INSERT INTO reported_users (reporter_user_id, reported_user_id, reason)
-                 VALUES (:reporter_id, :reported_id, :reason)
-                 ON CONFLICT DO NOTHING
-                """), {
-            "reporter_id": reporter_id,
-            "reported_id": reported_id,
-            "reason": reason,
-        })
+    db_conn.execute(sqlalchemy.text("""
+        INSERT INTO reported_users (reporter_user_id, reported_user_id, reason)
+             VALUES (:reporter_id, :reported_id, :reason)
+             ON CONFLICT DO NOTHING
+            """), {
+        "reporter_id": reporter_id,
+        "reported_id": reported_id,
+        "reason": reason,
+    })
+    db_conn.commit()
 
 
-def update_user_details(lb_id: int, musicbrainz_id: str, email: str):
+def update_user_details(db_conn, lb_id: int, musicbrainz_id: str, email: str):
     """ Update the email field and MusicBrainz ID of the user specified by the lb_id
 
     Args:
@@ -531,27 +472,25 @@ def update_user_details(lb_id: int, musicbrainz_id: str, email: str):
         musicbrainz_id: MusicBrainz username of a user
         email: email of a user
     """
-
-    with db.engine.begin() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                UPDATE "user"
-                   SET email = :email
-                     , musicbrainz_id = :musicbrainz_id
-                 WHERE id = :lb_id
-                """), {
-                "lb_id": lb_id,
-                "musicbrainz_id": musicbrainz_id,
-                "email": email
-            })
-        except sqlalchemy.exc.ProgrammingError as err:
-            logger.error(err)
-            raise DatabaseException(
-                "Couldn't update user's email: %s" % str(err))
+    try:
+        db_conn.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET email = :email
+                 , musicbrainz_id = :musicbrainz_id
+             WHERE id = :lb_id
+            """), {
+            "lb_id": lb_id,
+            "musicbrainz_id": musicbrainz_id,
+            "email": email
+        })
+        db_conn.commit()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logger.error(err)
+        raise DatabaseException("Couldn't update user's email: %s" % str(err))
 
 
-def search_query(search_term: str, limit: int, connection: any):
-    result = connection.execute(sqlalchemy.text("""
+def search_query(db_conn, search_term: str, limit: int):
+    result = db_conn.execute(sqlalchemy.text("""
             SELECT musicbrainz_id, similarity(musicbrainz_id, :search_term) AS query_similarity
               FROM "user"
              WHERE musicbrainz_id <% :search_term
@@ -565,11 +504,12 @@ def search_query(search_term: str, limit: int, connection: any):
     return rows
 
 
-def search(search_term: str, limit: int, searcher_id: int = None) -> List[Tuple[str, float, float]]:
+def search(db_conn, search_term: str, limit: int, searcher_id: int = None) -> List[Tuple[str, float, float]]:
     """ Searches for the input term in the database and returns list of potential user matches along with
     their similarity to the searcher if available.
 
     Args:
+        db_conn: database connection
         search_term: the term to search in username column
         limit: max number of search results to fetch
         searcher_id: the user_id of the user who did the search
@@ -580,37 +520,35 @@ def search(search_term: str, limit: int, searcher_id: int = None) -> List[Tuple[
           user_similarity: the similarity between the user and the searcher as in similar users
           calculated by spark
     """
-    with db.engine.connect() as connection:
-        rows = search_query(search_term, limit, connection)
-        if not rows:
-            return []
+    rows = search_query(db_conn, search_term, limit)
+    if not rows:
+        return []
 
-        search_results = []
+    search_results = []
 
-        if searcher_id:
-            # Constructing an id-similarity map
-            similar_users = get_similar_users(searcher_id)
-            id_similarity_map = {user["musicbrainz_id"]: user["similarity"] for user in similar_users}
-            for row in rows:
-                similarity = id_similarity_map.get(row.musicbrainz_id, None)
-                search_results.append((row.musicbrainz_id, row.query_similarity, similarity))
-        else:
-            search_results = [(row.musicbrainz_id, row.query_similarity, None) for row in rows]
-        return search_results
-
-
-def search_user_name(search_term: str, limit: int) -> List[object]:
-    with db.engine.connect() as connection:
-        rows = search_query(search_term, limit, connection)
-
-        if not rows:
-            return []
-
-        search_results = []
-
+    if searcher_id:
+        # Constructing an id-similarity map
+        similar_users = get_similar_users(db_conn, searcher_id)
+        id_similarity_map = {user["musicbrainz_id"]: user["similarity"] for user in similar_users}
         for row in rows:
-            search_results.append({"user_name": row.musicbrainz_id})
-        return search_results
+            similarity = id_similarity_map.get(row.musicbrainz_id, None)
+            search_results.append((row.musicbrainz_id, row.query_similarity, similarity))
+    else:
+        search_results = [(row.musicbrainz_id, row.query_similarity, None) for row in rows]
+    return search_results
+
+
+def search_user_name(db_conn, search_term: str, limit: int) -> List[object]:
+    rows = search_query(db_conn, search_term, limit)
+
+    if not rows:
+        return []
+
+    search_results = []
+
+    for row in rows:
+        search_results.append({"user_name": row.musicbrainz_id})
+    return search_results
 
 
 def get_all_usernames():

--- a/listenbrainz/db/user_relationship.py
+++ b/listenbrainz/db/user_relationship.py
@@ -17,10 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from datetime import datetime
-from typing import List, Tuple, Iterable
-
-from listenbrainz import db
-from listenbrainz.db.exceptions import DatabaseException
+from typing import List, Iterable
 
 import sqlalchemy
 
@@ -29,123 +26,115 @@ VALID_RELATIONSHIP_TYPES = (
 )
 
 
-def insert(user_0: int, user_1: int, relationship_type: str) -> None:
+def insert(db_conn, user_0: int, user_1: int, relationship_type: str) -> None:
     if relationship_type not in VALID_RELATIONSHIP_TYPES:
         raise ValueError(f"Invalid relationship type: {relationship_type}")
 
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            INSERT INTO user_relationship (user_0, user_1, relationship_type)
-                 VALUES (:user_0, :user_1, :relationship_type)
-            ON CONFLICT (user_0, user_1, relationship_type)
-             DO NOTHING
-        """), {
-            "user_0": user_0,
-            "user_1": user_1,
-            "relationship_type": relationship_type,
-        })
+    db_conn.execute(sqlalchemy.text("""
+        INSERT INTO user_relationship (user_0, user_1, relationship_type)
+             VALUES (:user_0, :user_1, :relationship_type)
+        ON CONFLICT (user_0, user_1, relationship_type)
+         DO NOTHING
+    """), {
+        "user_0": user_0,
+        "user_1": user_1,
+        "relationship_type": relationship_type,
+    })
+    db_conn.commit()
 
 
-def is_following_user(follower: int, followed: int) -> bool:
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT COUNT(*) as cnt
-              FROM user_relationship
-             WHERE user_0 = :follower
-               AND user_1 = :followed
-               AND relationship_type = 'follow'
-        """), {
-            "follower": follower,
-            "followed": followed,
-        })
-        return result.fetchone().cnt > 0
+def is_following_user(db_conn, follower: int, followed: int) -> bool:
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT COUNT(*) as cnt
+          FROM user_relationship
+         WHERE user_0 = :follower
+           AND user_1 = :followed
+           AND relationship_type = 'follow'
+    """), {
+        "follower": follower,
+        "followed": followed,
+    })
+    return result.fetchone().cnt > 0
 
 
-def multiple_users_by_username_following_user(followed: int, followers: List[str]):
-    '''
-    returns a dictionary, keys being usernames
-    values being boolean
-    '''
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT "user".musicbrainz_id,
-                   bool(
-                       coalesce((
-                        SELECT 't'
-                          FROM user_relationship
-                         WHERE user_1 = :followed
-                           AND user_0 = "user".id
-                           AND relationship_type = 'follow'
-                       ), 'f')
-                   )
-                AS result
-              FROM unnest(:followers) as arr
-             INNER JOIN "user"
-                ON "user".musicbrainz_id = arr
-        """), {
-            "followers": followers,
-            "followed": followed,
-        })
-        return {row.musicbrainz_id: row.result for row in result.fetchall()}
+def multiple_users_by_username_following_user(db_conn, followed: int, followers: List[str]):
+    ''' returns a dictionary, keys being usernames values being boolean '''
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT "user".musicbrainz_id,
+               bool(
+                   coalesce((
+                    SELECT 't'
+                      FROM user_relationship
+                     WHERE user_1 = :followed
+                       AND user_0 = "user".id
+                       AND relationship_type = 'follow'
+                   ), 'f')
+               )
+            AS result
+          FROM unnest(:followers) as arr
+         INNER JOIN "user"
+            ON "user".musicbrainz_id = arr
+    """), {
+        "followers": followers,
+        "followed": followed,
+    })
+    return {row.musicbrainz_id: row.result for row in result.fetchall()}
 
 
-def delete(user_0: int, user_1: int, relationship_type: str) -> None:
+def delete(db_conn, user_0: int, user_1: int, relationship_type: str) -> None:
     if relationship_type not in VALID_RELATIONSHIP_TYPES:
         raise ValueError(f"Invalid relationship type: {relationship_type}")
 
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            DELETE
-              FROM user_relationship
-            WHERE user_0 = :user_0
-              AND user_1 = :user_1
-              AND relationship_type = :relationship_type
-        """), {
-            "user_0": user_0,
-            "user_1": user_1,
-            "relationship_type": relationship_type,
-        })
+    db_conn.execute(sqlalchemy.text("""
+        DELETE
+          FROM user_relationship
+        WHERE user_0 = :user_0
+          AND user_1 = :user_1
+          AND relationship_type = :relationship_type
+    """), {
+        "user_0": user_0,
+        "user_1": user_1,
+        "relationship_type": relationship_type,
+    })
+    db_conn.commit()
 
 
-def get_followers_of_user(user: int) -> List[dict]:
+def get_followers_of_user(db_conn, user: int) -> List[dict]:
     """ Returns a list of users who follow the specified user.
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT "user".musicbrainz_id AS musicbrainz_id, "user".id as id
-              FROM user_relationship
-              JOIN "user"
-                ON "user".id = user_0
-             WHERE user_1 = :followed
-               AND relationship_type = 'follow'
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT "user".musicbrainz_id AS musicbrainz_id, "user".id as id
+          FROM user_relationship
+          JOIN "user"
+            ON "user".id = user_0
+         WHERE user_1 = :followed
+           AND relationship_type = 'follow'
 
-        """), {
-            "followed": user,
-        })
-        return result.mappings().all()
+    """), {"followed": user})
+    return result.mappings().all()
 
 
-def get_following_for_user(user: int) -> List[dict]:
+def get_following_for_user(db_conn, user: int) -> List[dict]:
     """ Returns a list of users who the specified user follows.
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT "user".musicbrainz_id AS musicbrainz_id, "user".id as id
-              FROM user_relationship
-              JOIN "user"
-                ON "user".id = user_1
-             WHERE user_0 = :user
-               AND relationship_type = 'follow'
-        """), {
-            "user": user,
-        })
-        return result.mappings().all()
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT "user".musicbrainz_id AS musicbrainz_id, "user".id as id
+          FROM user_relationship
+          JOIN "user"
+            ON "user".id = user_1
+         WHERE user_0 = :user
+           AND relationship_type = 'follow'
+    """), {
+        "user": user,
+    })
+    return result.mappings().all()
 
 
-def get_follow_events(user_ids: Iterable[int], min_ts: float, max_ts: float, count: int) -> List[dict]:
+def get_follow_events(db_conn, user_ids: Iterable[int], min_ts: float, max_ts: float, count: int) -> List[dict]:
     """ Gets a list of follow events for specified users.
 
     Args:
+        db_conn: database connection
         user_ids: is a tuple of user row IDs.
 
     Returns:
@@ -157,22 +146,21 @@ def get_follow_events(user_ids: Iterable[int], min_ts: float, max_ts: float, cou
                 created: datetime,
             }
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT follower.musicbrainz_id as user_name_0, followed.musicbrainz_id as user_name_1, ur.created
-              FROM user_relationship ur
-              JOIN "user" follower ON ur.user_0 = follower.id
-              JOIN "user" followed ON ur.user_1 = followed.id
-             WHERE ur.user_0 IN :user_ids
-               AND ur.created > :min_ts
-               AND ur.created < :max_ts
-          ORDER BY created DESC
-             LIMIT :count
-        """), {
-            "user_ids": tuple(user_ids),
-            "min_ts": datetime.utcfromtimestamp(min_ts),
-            "max_ts": datetime.utcfromtimestamp(max_ts),
-            "count": count
-        })
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT follower.musicbrainz_id as user_name_0, followed.musicbrainz_id as user_name_1, ur.created
+          FROM user_relationship ur
+          JOIN "user" follower ON ur.user_0 = follower.id
+          JOIN "user" followed ON ur.user_1 = followed.id
+         WHERE ur.user_0 IN :user_ids
+           AND ur.created > :min_ts
+           AND ur.created < :max_ts
+      ORDER BY created DESC
+         LIMIT :count
+    """), {
+        "user_ids": tuple(user_ids),
+        "min_ts": datetime.utcfromtimestamp(min_ts),
+        "max_ts": datetime.utcfromtimestamp(max_ts),
+        "count": count
+    })
 
-        return result.mappings().all()
+    return result.mappings().all()

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -6,73 +6,71 @@ from listenbrainz.db.exceptions import DatabaseException
 DEFAULT_TIMEZONE = "UTC"
 
 
-def get_pg_timezone():
+def get_pg_timezone(db_conn):
     """ Get list of time zones PostgreSQL supports.
 
     Returns:
         list of tuple('zone_name', 'utc_offset')
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT * FROM pg_timezone_names
-            ORDER BY name
-        """))
-        timezones = [(row.name, row.utc_offset) for row in result.fetchall()]
-        timezones = standardize_timezone(timezones)
-        return timezones
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT * FROM pg_timezone_names
+        ORDER BY name
+    """))
+    timezones = [(row.name, row.utc_offset) for row in result.fetchall()]
+    timezones = standardize_timezone(timezones)
+    return timezones
 
 
-def get(user_id: int):
+def get(db_conn, user_id: int):
     """ Get user settings with the row ID of the user in the DB.
     Args:
+        db_conn: database connection
         user_id (int): the row ID of the user in the DB
     Returns:
         user settings (dict) where
         timezone_name: user selected local timezone, with default value "UTC".
     """
-    with db.engine.connect() as connection:
-        try:
-            result = connection.execute(sqlalchemy.text("""
-                SELECT timezone_name
-                FROM user_setting
-                WHERE user_id = :user_id
-            """), {
-                "user_id": user_id,
-            })
-            row = result.mappings().first()
-            if row:
-                row = dict(row)
-                if not row["timezone_name"]:
-                    row["timezone_name"] = DEFAULT_TIMEZONE
-                return row
-            return {"timezone_name": DEFAULT_TIMEZONE}
-        except sqlalchemy.exc.ProgrammingError as err:
-            raise DatabaseException(
-                "Couldn't get user's setting: %s" % str(err))
+    try:
+        result = db_conn.execute(sqlalchemy.text("""
+            SELECT timezone_name
+            FROM user_setting
+            WHERE user_id = :user_id
+        """), {
+            "user_id": user_id,
+        })
+        row = result.mappings().first()
+        if row:
+            row = dict(row)
+            if not row["timezone_name"]:
+                row["timezone_name"] = DEFAULT_TIMEZONE
+            return row
+        return {"timezone_name": DEFAULT_TIMEZONE}
+    except sqlalchemy.exc.ProgrammingError as err:
+        raise DatabaseException("Couldn't get user's setting: %s" % str(err))
 
 
-def set_timezone(user_id: int, timezone_name: str):
+def set_timezone(db_conn, user_id: int, timezone_name: str):
     """ Set user's timezone. Update user timezone if the row exists. Otherwise insert a new row.
     Args:
+        db_conn: database connection
         user_id (int): the row ID of the user in the DB
         timezone_name (str): the user selected timezone name
 
     """
-    with db.engine.begin() as connection:
-        try:
-            connection.execute(sqlalchemy.text("""
-                INSERT INTO user_setting (user_id, timezone_name)
-                VALUES (:user_id, :timezone_name)
-                ON CONFLICT (user_id)
-                DO 
-                    UPDATE SET timezone_name = :timezone_name
-                """), {
-                "user_id": user_id,
-                "timezone_name": timezone_name,
-            })
-        except sqlalchemy.exc.ProgrammingError as err:
-            raise DatabaseException(
-                "Couldn't update user's timezone: %s" % str(err))
+    try:
+        db_conn.execute(sqlalchemy.text("""
+            INSERT INTO user_setting (user_id, timezone_name)
+            VALUES (:user_id, :timezone_name)
+            ON CONFLICT (user_id)
+            DO 
+                UPDATE SET timezone_name = :timezone_name
+            """), {
+            "user_id": user_id,
+            "timezone_name": timezone_name,
+        })
+        db_conn.commit()
+    except sqlalchemy.exc.ProgrammingError as err:
+        raise DatabaseException("Couldn't update user's timezone: %s" % str(err))
 
 
 def standardize_timezone(timezones):
@@ -94,25 +92,24 @@ def standardize_timezone(timezones):
     return result
 
 
-def update_troi_prefs(user_id: int, export_to_spotify: bool):
+def update_troi_prefs(db_conn, user_id: int, export_to_spotify: bool):
     """ Update troi preferences for the given user """
-    with db.engine.begin() as connection:
-        connection.execute(sqlalchemy.text("""
-            INSERT INTO user_setting (user_id, troi)
-                 VALUES (:user_id, jsonb_build_object('export_to_spotify', :export_to_spotify))
-            ON CONFLICT (user_id)
-              DO UPDATE 
-                    SET troi = EXCLUDED.troi
-        """), {"user_id": user_id, "export_to_spotify": export_to_spotify})
+    db_conn.execute(sqlalchemy.text("""
+        INSERT INTO user_setting (user_id, troi)
+             VALUES (:user_id, jsonb_build_object('export_to_spotify', :export_to_spotify))
+        ON CONFLICT (user_id)
+          DO UPDATE 
+                SET troi = EXCLUDED.troi
+    """), {"user_id": user_id, "export_to_spotify": export_to_spotify})
+    db_conn.commit()
 
 
-def get_troi_prefs(user_id: int):
+def get_troi_prefs(db_conn, user_id: int):
     """ Retrieve troi preferences for the given user """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT troi
-              FROM user_setting
-             WHERE user_id = :user_id
-        """), {"user_id": user_id})
-        row = result.mappings().first()
-        return dict(row) if row else None
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT troi
+          FROM user_setting
+         WHERE user_id = :user_id
+    """), {"user_id": user_id})
+    row = result.mappings().first()
+    return dict(row) if row else None

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -21,6 +21,8 @@ import orjson
 
 from datetime import datetime
 
+from sqlalchemy import text
+
 from listenbrainz.db.model.user_timeline_event import (
     UserTimelineEvent,
     UserTimelineEventType,
@@ -38,6 +40,7 @@ from listenbrainz.db.model.review import CBReviewTimelineMetadata
 
 
 def create_user_timeline_event(
+    db_conn,
     user_id: int,
     event_type: UserTimelineEventType,
     metadata: UserTimelineEventMetadata,
@@ -45,111 +48,113 @@ def create_user_timeline_event(
     """ Creates a user timeline event in the database and returns the event.
     """
     try:
-        with db.engine.begin() as connection:
-            result = connection.execute(sqlalchemy.text("""
-                INSERT INTO user_timeline_event (user_id, event_type, metadata)
-                    VALUES (:user_id, :event_type, :metadata)
-                RETURNING id, user_id, event_type, metadata, created
-                """), {
-                    'user_id': user_id,
-                    'event_type': event_type.value,
-                    'metadata': orjson.dumps(metadata.dict()).decode("utf-8"),
-                }
-            )
-
-            return UserTimelineEvent(**result.mappings().first())
+        result = db_conn.execute(text("""
+            INSERT INTO user_timeline_event (user_id, event_type, metadata)
+                VALUES (:user_id, :event_type, :metadata)
+            RETURNING id, user_id, event_type, metadata, created
+            """), {
+                'user_id': user_id,
+                'event_type': event_type.value,
+                'metadata': orjson.dumps(metadata.dict()).decode("utf-8"),
+            }
+        )
+        db_conn.commit()
+        return UserTimelineEvent(**result.mappings().first())
     except Exception as e:
         raise DatabaseException(str(e))
 
 
-def create_user_track_recommendation_event(user_id: int, metadata: RecordingRecommendationMetadata) -> UserTimelineEvent:
+def create_user_track_recommendation_event(db_conn, user_id: int, metadata: RecordingRecommendationMetadata) -> UserTimelineEvent:
     """ Creates a track recommendation event in the database and returns it.
     """
     return create_user_timeline_event(
+        db_conn,
         user_id=user_id,
         event_type=UserTimelineEventType.RECORDING_RECOMMENDATION,
         metadata=metadata,
     )
 
 
-def create_user_notification_event(user_id: int, metadata: NotificationMetadata) -> UserTimelineEvent:
+def create_user_notification_event(db_conn, user_id: int, metadata: NotificationMetadata) -> UserTimelineEvent:
     """ Create a notification event in the database and returns it.
     """
     return create_user_timeline_event(
+        db_conn,
         user_id=user_id,
         event_type=UserTimelineEventType.NOTIFICATION,
         metadata=metadata
     )
 
 
-def delete_user_timeline_event(id: int, user_id: int) -> bool:
+def delete_user_timeline_event(db_conn, id: int, user_id: int) -> bool:
     """ Deletes recommendation and notification event using id """
     try:
-        with db.engine.begin() as connection:
-            result = connection.execute(sqlalchemy.text('''
-                    DELETE FROM user_timeline_event
-                    WHERE user_id = :user_id
-                    AND id = :id
-                '''), {
-                    'user_id': user_id,
-                    'id': id
-                })
-            return result.rowcount == 1
+        result = db_conn.execute(sqlalchemy.text('''
+                DELETE FROM user_timeline_event
+                WHERE user_id = :user_id
+                AND id = :id
+            '''), {
+                'user_id': user_id,
+                'id': id
+            })
+        db_conn.commit()
+        return result.rowcount == 1
     except Exception as e:
         raise DatabaseException(str(e))
 
 
-def create_user_cb_review_event(user_id: int, metadata: CBReviewTimelineMetadata) -> UserTimelineEvent:
+def create_user_cb_review_event(db_conn, user_id: int, metadata: CBReviewTimelineMetadata) -> UserTimelineEvent:
     """ Creates a CritiqueBrainz review event in the database and returns it.
     """
     return create_user_timeline_event(
+        db_conn,
         user_id=user_id,
         event_type=UserTimelineEventType.CRITIQUEBRAINZ_REVIEW,
         metadata=metadata
     )
 
 
-def create_personal_recommendation_event(user_id: int, metadata: PersonalRecordingRecommendationMetadata)\
+def create_personal_recommendation_event(db_conn, user_id: int, metadata: PersonalRecordingRecommendationMetadata)\
         -> UserTimelineEvent:
     """ Creates a personal recommendation event in the database and returns it.
         The User ID in the table is the recommender, meanwhile the users in the
         metadata key are the recommendee
     """
     try:
-        with db.engine.begin() as connection:
-            result = connection.execute(sqlalchemy.text("""
-                INSERT INTO user_timeline_event (user_id, event_type, metadata)
-                    VALUES (
-                        :user_id,
-                        'personal_recording_recommendation',
-                        jsonb_build_object(
-                            'recording_mbid', :recording_mbid,
-                            'recording_msid', :recording_msid,
-                            'users', (
-                                SELECT jsonb_agg("user".id ORDER BY idx) as users
-                                  FROM unnest(:users) WITH ORDINALITY as arr (value, idx)
-                            INNER JOIN "user"
-                                    ON "user".musicbrainz_id = value
-                            ),
-                            'blurb_content', :blurb_content
-                        )
+        result = db_conn.execute(text("""
+            INSERT INTO user_timeline_event (user_id, event_type, metadata)
+                VALUES (
+                    :user_id,
+                    'personal_recording_recommendation',
+                    jsonb_build_object(
+                        'recording_mbid', :recording_mbid,
+                        'recording_msid', :recording_msid,
+                        'users', (
+                            SELECT jsonb_agg("user".id ORDER BY idx) as users
+                              FROM unnest(:users) WITH ORDINALITY as arr (value, idx)
+                        INNER JOIN "user"
+                                ON "user".musicbrainz_id = value
+                        ),
+                        'blurb_content', :blurb_content
                     )
-                RETURNING id, user_id, event_type, metadata, created
-                """), {
-                    'user_id': user_id,
-                    'recording_mbid': metadata.recording_mbid,
-                    'recording_msid': metadata.recording_msid,
-                    'users': metadata.users,
-                    'blurb_content': metadata.blurb_content
-                }
-            )
-
-            return UserTimelineEvent(**result.mappings().first())
+                )
+            RETURNING id, user_id, event_type, metadata, created
+            """), {
+                'user_id': user_id,
+                'recording_mbid': metadata.recording_mbid,
+                'recording_msid': metadata.recording_msid,
+                'users': metadata.users,
+                'blurb_content': metadata.blurb_content
+            }
+        )
+        db_conn.commit()
+        return UserTimelineEvent(**result.mappings().first())
     except Exception as e:
         raise DatabaseException(str(e))
 
 
 def get_user_timeline_events(
+    db_conn,
     user_ids: Iterable[int],
     event_type: UserTimelineEventType,
     min_ts: float,
@@ -161,34 +166,34 @@ def get_user_timeline_events(
     The optional `count` parameter can be used to control the number of events being returned. The min_ts and max_ts
     can be used to influence the time period during which the events should be returned.
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT id, user_id, event_type, metadata, created
-              FROM user_timeline_event
-             WHERE user_id IN :user_ids
-               AND created > :min_ts
-               AND created < :max_ts
-               AND event_type = :event_type
-          ORDER BY created DESC
-             LIMIT :count
-        """), {
-            "user_ids": tuple(user_ids),
-            "min_ts": datetime.utcfromtimestamp(min_ts),
-            "max_ts": datetime.utcfromtimestamp(max_ts),
-            "event_type": event_type.value,
-            "count": count,
-        })
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT id, user_id, event_type, metadata, created
+          FROM user_timeline_event
+         WHERE user_id IN :user_ids
+           AND created > :min_ts
+           AND created < :max_ts
+           AND event_type = :event_type
+      ORDER BY created DESC
+         LIMIT :count
+    """), {
+        "user_ids": tuple(user_ids),
+        "min_ts": datetime.utcfromtimestamp(min_ts),
+        "max_ts": datetime.utcfromtimestamp(max_ts),
+        "event_type": event_type.value,
+        "count": count,
+    })
 
-        return [UserTimelineEvent(**row) for row in result.mappings()]
+    return [UserTimelineEvent(**row) for row in result.mappings()]
 
 
-def get_recording_recommendation_events_for_feed(user_ids: Iterable[int], min_ts: int, max_ts: int, count: int) \
+def get_recording_recommendation_events_for_feed(db_conn, user_ids: Iterable[int], min_ts: int, max_ts: int, count: int) \
         -> List[UserTimelineEvent]:
     """ Gets a list of recording_recommendation events for specified users.
 
     user_ids is a tuple of user row IDs.
     """
     return get_user_timeline_events(
+        db_conn,
         user_ids=user_ids,
         event_type=UserTimelineEventType.RECORDING_RECOMMENDATION,
         min_ts=min_ts,
@@ -197,63 +202,63 @@ def get_recording_recommendation_events_for_feed(user_ids: Iterable[int], min_ts
     )
 
 
-def get_personal_recommendation_events_for_feed(user_id: int, min_ts: int, max_ts: int, count: int) -> List[UserTimelineEvent]:
+def get_personal_recommendation_events_for_feed(db_conn, user_id: int, min_ts: int, max_ts: int, count: int) -> List[UserTimelineEvent]:
     """ Gets a list of personal_recording_recommendation events for specified users.
 
     user_ids is a tuple of user row IDs.
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT user_timeline_event.id
-                 , user_timeline_event.user_id
-                 , user_timeline_event.event_type
-                 , (
-                    SELECT jsonb_build_object(
-                                'recording_mbid', user_timeline_event.metadata->'recording_mbid',
-                                'recording_msid', user_timeline_event.metadata->'recording_msid',
-                                'users', jsonb_agg("user".musicbrainz_id ORDER BY idx),
-                                'blurb_content', user_timeline_event.metadata->'blurb_content'
-                            ) AS metadata
-                      FROM jsonb_array_elements_text(user_timeline_event.metadata->'users') WITH ORDINALITY AS arr (value, idx)
-                INNER JOIN "user" 
-                        ON arr.value::int = "user".id
-                   )
-                 , user_timeline_event.created
-                 , "user".musicbrainz_id as user_name
-              FROM user_timeline_event
-              JOIN "user"
-                ON user_timeline_event.user_id = "user".id
-             WHERE (user_timeline_event.metadata -> 'users') @> (:user_id)::text::jsonb
-                OR user_timeline_event.user_id = :user_id
-               AND user_timeline_event.created > :min_ts
-               AND user_timeline_event.created < :max_ts
-               AND user_timeline_event.event_type = :event_type
-          ORDER BY user_timeline_event.created DESC
-             LIMIT :count
-        """), {
-            "user_id": user_id,
-            "min_ts": datetime.utcfromtimestamp(min_ts),
-            "max_ts": datetime.utcfromtimestamp(max_ts),
-            "count": count,
-            "event_type": UserTimelineEventType.PERSONAL_RECORDING_RECOMMENDATION.value,
-        })
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT user_timeline_event.id
+             , user_timeline_event.user_id
+             , user_timeline_event.event_type
+             , (
+                SELECT jsonb_build_object(
+                            'recording_mbid', user_timeline_event.metadata->'recording_mbid',
+                            'recording_msid', user_timeline_event.metadata->'recording_msid',
+                            'users', jsonb_agg("user".musicbrainz_id ORDER BY idx),
+                            'blurb_content', user_timeline_event.metadata->'blurb_content'
+                        ) AS metadata
+                  FROM jsonb_array_elements_text(user_timeline_event.metadata->'users') WITH ORDINALITY AS arr (value, idx)
+            INNER JOIN "user" 
+                    ON arr.value::int = "user".id
+               )
+             , user_timeline_event.created
+             , "user".musicbrainz_id as user_name
+          FROM user_timeline_event
+          JOIN "user"
+            ON user_timeline_event.user_id = "user".id
+         WHERE (user_timeline_event.metadata -> 'users') @> (:user_id)::text::jsonb
+            OR user_timeline_event.user_id = :user_id
+           AND user_timeline_event.created > :min_ts
+           AND user_timeline_event.created < :max_ts
+           AND user_timeline_event.event_type = :event_type
+      ORDER BY user_timeline_event.created DESC
+         LIMIT :count
+    """), {
+        "user_id": user_id,
+        "min_ts": datetime.utcfromtimestamp(min_ts),
+        "max_ts": datetime.utcfromtimestamp(max_ts),
+        "count": count,
+        "event_type": UserTimelineEventType.PERSONAL_RECORDING_RECOMMENDATION.value,
+    })
 
-        return [UserTimelineEvent(
-            id=row.id,
-            user_id=row.user_id,
-            user_name=row.user_name,
-            event_type=row.event_type,
-            metadata=PersonalRecordingRecommendationMetadata(**row.metadata),
-            created=row.created
-        ) for row in result]
+    return [UserTimelineEvent(
+        id=row.id,
+        user_id=row.user_id,
+        user_name=row.user_name,
+        event_type=row.event_type,
+        metadata=PersonalRecordingRecommendationMetadata(**row.metadata),
+        created=row.created
+    ) for row in result]
 
 
-def get_cb_review_events(user_ids: List[int], min_ts: int, max_ts: int, count: int) -> List[UserTimelineEvent]:
+def get_cb_review_events(db_conn, user_ids: List[int], min_ts: int, max_ts: int, count: int) -> List[UserTimelineEvent]:
     """ Gets a list of CritiqueBrainz review events for specified users.
 
     user_ids is a tuple of user row IDs.
     """
     return get_user_timeline_events(
+        db_conn,
         user_ids=user_ids,
         event_type=UserTimelineEventType.CRITIQUEBRAINZ_REVIEW,
         min_ts=min_ts,
@@ -262,30 +267,30 @@ def get_cb_review_events(user_ids: List[int], min_ts: int, max_ts: int, count: i
     )
 
 
-def get_user_timeline_event_by_id(id: int) -> UserTimelineEvent:
+def get_user_timeline_event_by_id(db_conn, id: int) -> UserTimelineEvent:
     """ Gets timeline event by its id
         Args:
             id: row ID of the timeline event
     """
-    with db.engine.connect() as connection:
-        result = connection.execute(sqlalchemy.text("""
-            SELECT id, user_id, event_type, metadata, created
-              FROM user_timeline_event
-             WHERE id = :id
-        """), {
-            "id": id,
-        })
-        row = result.mappings().first()
-        return UserTimelineEvent(**row) if row else None
+    result = db_conn.execute(text("""
+        SELECT id, user_id, event_type, metadata, created
+          FROM user_timeline_event
+         WHERE id = :id
+    """), {
+        "id": id,
+    })
+    row = result.mappings().first()
+    return UserTimelineEvent(**row) if row else None
 
 
-def get_user_notification_events(user_ids: Iterable[int], min_ts: int, max_ts: int, count: int)\
+def get_user_notification_events(db_conn, user_ids: Iterable[int], min_ts: int, max_ts: int, count: int)\
         -> List[UserTimelineEvent]:
     """ Gets notification posted on the user's timeline.
 
     The optional `count` parameter can be used to control the number of events being returned.
     """
     return get_user_timeline_events(
+        db_conn,
         user_ids=user_ids,
         event_type=UserTimelineEventType.NOTIFICATION,
         min_ts=min_ts,
@@ -294,61 +299,57 @@ def get_user_notification_events(user_ids: Iterable[int], min_ts: int, max_ts: i
     )
 
 
-def hide_user_timeline_event(user_id: int, event_type: UserTimelineEventType, event_id: int) -> bool:
+def hide_user_timeline_event(db_conn, user_id: int, event_type: UserTimelineEventType, event_id: int) -> bool:
     """ Adds events that are to be hidden """
     try:
-        with db.engine.begin() as connection:
-            result = connection.execute(sqlalchemy.text('''
-                INSERT INTO hide_user_timeline_event (user_id, event_type, event_id)
-                    VALUES (:user_id, :event_type, :event_id)
-                ON CONFLICT (user_id, event_type, event_id)
-                DO NOTHING
-            '''), {
-                'user_id': user_id,
-                'event_type': event_type,
-                'event_id': event_id
-                }
-            )
-            return result.rowcount == 1
+        result = db_conn.execute(text('''
+            INSERT INTO hide_user_timeline_event (user_id, event_type, event_id)
+                VALUES (:user_id, :event_type, :event_id)
+            ON CONFLICT (user_id, event_type, event_id)
+            DO NOTHING
+        '''), {
+            'user_id': user_id,
+            'event_type': event_type,
+            'event_id': event_id
+        })
+        db_conn.commit()
+        return result.rowcount == 1
     except Exception as e:
         raise DatabaseException(str(e))
 
 
-def get_hidden_timeline_events(user_id: int, count: int) -> List[HiddenUserTimelineEvent]:
+def get_hidden_timeline_events(db_conn, user_id: int, count: int) -> List[HiddenUserTimelineEvent]:
     '''Retrieves all events that are hidden by the user, based on event_type'''
     try:
-        with db.engine.connect() as connection:
-            result = connection.execute(sqlalchemy.text('''
-                SELECT *
-                  FROM hide_user_timeline_event
-                 WHERE user_id = :user_id
-              ORDER BY created DESC
-                 LIMIT :count
-            '''), {
-                'user_id': user_id,
-                'count': count
-                }
-            )
-            return [HiddenUserTimelineEvent(**row) for row in result.mappings()]
+        result = db_conn.execute(text('''
+            SELECT *
+              FROM hide_user_timeline_event
+             WHERE user_id = :user_id
+          ORDER BY created DESC
+             LIMIT :count
+        '''), {
+            'user_id': user_id,
+            'count': count
+        })
+        return [HiddenUserTimelineEvent(**row) for row in result.mappings()]
     except Exception as e:
         raise DatabaseException(str(e))
 
 
-def unhide_timeline_event(user: int, event_type: UserTimelineEventType, event_id: int) -> bool:
+def unhide_timeline_event(db_conn, user: int, event_type: UserTimelineEventType, event_id: int) -> bool:
     ''' Deletes hidden timeline events for a user with specific row id '''
     try:
-        with db.engine.begin() as connection:
-            result = connection.execute(sqlalchemy.text('''
-                DELETE FROM hide_user_timeline_event WHERE
-                user_id = :user_id AND
-                event_type = :event_type AND
-                event_id = :event_id
-            '''), {
-                'user_id': user,
-                'event_type': event_type,
-                'event_id': event_id
-                }
-            )
-            return result.rowcount == 1
+        result = db_conn.execute(text('''
+            DELETE FROM hide_user_timeline_event WHERE
+            user_id = :user_id AND
+            event_type = :event_type AND
+            event_id = :event_id
+        '''), {
+            'user_id': user,
+            'event_type': event_type,
+            'event_id': event_id
+        })
+        db_conn.commit()
+        return result.rowcount == 1
     except Exception as e:
         raise DatabaseException(str(e))

--- a/listenbrainz/domain/brainz_service.py
+++ b/listenbrainz/domain/brainz_service.py
@@ -5,6 +5,7 @@ from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from listenbrainz.db import external_service_oauth
 
 from listenbrainz.domain.external_service import ExternalService, ExternalServiceInvalidGrantError
+from listenbrainz.webserver import db_conn
 
 
 class BaseBrainzService(ExternalService):
@@ -22,6 +23,7 @@ class BaseBrainzService(ExternalService):
     def add_new_user(self, user_id: int, token: dict) -> bool:
         expires_at = int(time.time()) + token["expires_in"]
         external_service_oauth.save_token(
+            db_conn,
             user_id=user_id,
             service=self.service,
             access_token=token["access_token"],
@@ -79,6 +81,7 @@ class BaseBrainzService(ExternalService):
 
         expires_at = int(time.time()) + token["expires_in"]
         external_service_oauth.update_token(
+            db_conn,
             user_id=user_id,
             service=self.service,
             access_token=token["access_token"],

--- a/listenbrainz/domain/external_service.py
+++ b/listenbrainz/domain/external_service.py
@@ -5,6 +5,7 @@ from typing import Union, Sequence
 from data.model.external_service import ExternalServiceType
 
 from listenbrainz.db import external_service_oauth
+from listenbrainz.webserver import db_conn
 
 
 class ExternalService(ABC):
@@ -34,10 +35,10 @@ class ExternalService(ABC):
         Args:
             user_id (int): the ListenBrainz row ID of the user
         """
-        external_service_oauth.delete_token(user_id=user_id, service=self.service, remove_import_log=True)
+        external_service_oauth.delete_token(db_conn, user_id=user_id, service=self.service, remove_import_log=True)
 
     def get_user(self, user_id: int) -> Union[dict, None]:
-        return external_service_oauth.get_token(user_id=user_id, service=self.service)
+        return external_service_oauth.get_token(db_conn, user_id=user_id, service=self.service)
 
     def user_oauth_token_has_expired(self, user: dict, within_minutes: int = 5) -> bool:
         """Check if a user's oauth token has expired (within a threshold)

--- a/listenbrainz/domain/importer_service.py
+++ b/listenbrainz/domain/importer_service.py
@@ -3,6 +3,7 @@ from typing import List, Union
 
 from listenbrainz.domain.external_service import ExternalService, ExternalServiceError
 from listenbrainz.db import listens_importer
+from listenbrainz.webserver import db_conn
 
 
 class ImporterService(ExternalService, ABC):
@@ -22,7 +23,7 @@ class ImporterService(ExternalService, ABC):
             user_id (int): the ListenBrainz row ID of the user
             error (str): the user-friendly error message to be displayed.
         """
-        listens_importer.update_import_status(user_id, self.service, error)
+        listens_importer.update_import_status(db_conn, user_id, self.service, error)
 
     def update_latest_listen_ts(self, user_id: int, timestamp: Union[int, float]):
         """ Update the latest_listened_at field for user with specified ListenBrainz user ID.
@@ -31,7 +32,7 @@ class ImporterService(ExternalService, ABC):
             user_id: the ListenBrainz row ID of the user
             timestamp: the unix timestamp of the latest listen imported for the user
         """
-        listens_importer.update_latest_listened_at(user_id, self.service, timestamp)
+        listens_importer.update_latest_listened_at(db_conn, user_id, self.service, timestamp)
 
 
 class ExternalServiceImporterError(ExternalServiceError):

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -15,6 +15,7 @@ from listenbrainz.db import spotify
 from listenbrainz.domain.external_service import ExternalServiceError, \
     ExternalServiceAPIError, ExternalServiceInvalidGrantError
 from listenbrainz.domain.importer_service import ImporterService
+from listenbrainz.webserver import db_conn
 
 OAUTH_TOKEN_URL = 'https://accounts.spotify.com/api/token'
 
@@ -76,7 +77,7 @@ class SpotifyService(ImporterService):
     def get_user(self, user_id: int, refresh: bool = False) -> Optional[dict]:
         """ If refresh = True, then check whether the access token has expired and refresh it
         before returning the user."""
-        user = spotify.get_user(user_id)
+        user = spotify.get_user(db_conn, user_id)
         if user and refresh and self.user_oauth_token_has_expired(user):
             user = self.refresh_access_token(user['user_id'], user['refresh_token'])
         return user
@@ -98,7 +99,7 @@ class SpotifyService(ImporterService):
         details = sp.current_user()
         external_user_id = details["id"]
 
-        external_service_oauth.save_token(user_id=user_id, service=self.service, access_token=access_token,
+        external_service_oauth.save_token(db_conn, user_id=user_id, service=self.service, access_token=access_token,
                                           refresh_token=refresh_token, token_expires_ts=expires_at,
                                           record_listens=active, scopes=scopes, external_user_id=external_user_id)
         return True
@@ -170,7 +171,7 @@ class SpotifyService(ImporterService):
         if "refresh_token" in response:
             refresh_token = response['refresh_token']
         expires_at = int(time.time()) + response['expires_in']
-        external_service_oauth.update_token(user_id=user_id, service=self.service,
+        external_service_oauth.update_token(db_conn, user_id=user_id, service=self.service,
                                             access_token=access_token, refresh_token=refresh_token,
                                             expires_at=expires_at)
         return self.get_user(user_id)
@@ -182,10 +183,10 @@ class SpotifyService(ImporterService):
         Args:
             user_id (int): the ListenBrainz row ID of the user
         """
-        external_service_oauth.delete_token(user_id, self.service, remove_import_log=False)
+        external_service_oauth.delete_token(db_conn, user_id, self.service, remove_import_log=False)
 
     def get_user_connection_details(self, user_id: int):
-        user = spotify.get_user_import_details(user_id)
+        user = spotify.get_user_import_details(db_conn, user_id)
         if user:
             def date_to_iso(date):
                 return date.isoformat() + "Z" if date else None
@@ -197,4 +198,4 @@ class SpotifyService(ImporterService):
     def get_active_users_to_process(self):
         """ Returns a list of Spotify user instances that need their Spotify listens imported.
         """
-        return spotify.get_active_users_to_process()
+        return spotify.get_active_users_to_process(db_conn)

--- a/listenbrainz/domain/tests/test_critiquebrainz.py
+++ b/listenbrainz/domain/tests/test_critiquebrainz.py
@@ -13,7 +13,7 @@ class CritiqueBrainzTestCase(NonAPIIntegrationTestCase):
 
     def setUp(self):
         super(CritiqueBrainzTestCase, self).setUp()
-        self.user_id = db_user.create(211, 'critiquebrainz_user')
+        self.user_id = db_user.create(self.db_conn, 211, 'critiquebrainz_user')
         self.service = CritiqueBrainzService()
         self.service.add_new_user(self.user_id, {
             'access_token': 'access-token',

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -19,7 +19,7 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.user_id = db_user.create(self.db_conn, 312, 'spotify_user')
         self.service = SpotifyService()
         
-        with mock.patch.object(spotipy.Spotify, 'current_user', return_value = {"id": "test_user_id"}):
+        with mock.patch.object(spotipy.Spotify, 'current_user', return_value={"id": "test_user_id"}):
             self.service.add_new_user(self.user_id, {
                 'access_token': 'old-token',
                 'refresh_token': 'old-refresh-token',
@@ -134,7 +134,6 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.assertEqual(user['refresh_token'], 'old-refresh-token')
         self.assertIsNotNone(user['last_updated'])
 
-    
     @mock.patch.object(spotipy.Spotify, 'current_user')
     @mock.patch('time.time')
     def test_add_new_user(self, mock_time, mock_current_user):

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -16,7 +16,7 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
 
     def setUp(self):
         super(SpotifyServiceTestCase, self).setUp()
-        self.user_id = db_user.create(312, 'spotify_user')
+        self.user_id = db_user.create(self.db_conn, 312, 'spotify_user')
         self.service = SpotifyService()
         
         with mock.patch.object(spotipy.Spotify, 'current_user', return_value = {"id": "test_user_id"}):
@@ -33,9 +33,9 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
     def test_get_active_users(self, mock_current_user):
         mock_current_user.return_value = {"id": "test_user_id"}
 
-        user_id_1 = db_user.create(333, 'user-1')
-        user_id_2 = db_user.create(666, 'user-2')
-        user_id_3 = db_user.create(999, 'user-3')
+        user_id_1 = db_user.create(self.db_conn, 333, 'user-1')
+        user_id_2 = db_user.create(self.db_conn, 666, 'user-2')
+        user_id_3 = db_user.create(self.db_conn, 999, 'user-3')
 
         self.service.add_new_user(user_id_2, {
             'access_token': 'access-token',

--- a/listenbrainz/listenstore/tests/test_dumplistenstore.py
+++ b/listenbrainz/listenstore/tests/test_dumplistenstore.py
@@ -26,7 +26,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         self.app = create_app()
         self.logstore = TimescaleListenStore(self.app.logger)
         self.dumpstore = DumpListenStore(self.app)
-        self.testuser = db_user.get_or_create(1, "test")
+        self.testuser = db_user.get_or_create(self.db_conn, 1, "test")
         self.testuser_name = self.testuser["musicbrainz_id"]
         self.testuser_id = self.testuser["id"]
 
@@ -157,7 +157,7 @@ class TestDumpListenStore(DatabaseTestCase, TimescaleTestCase):
         shutil.rmtree(temp_dir)
 
     def test_dump_and_import_listens_escaped(self):
-        user = db_user.get_or_create(3, 'i have a\\weird\\user, na/me"\n')
+        user = db_user.get_or_create(self.db_conn, 3, 'i have a\\weird\\user, na/me"\n')
         self._create_test_data(user['musicbrainz_id'], user['id'])
 
         self._create_test_data(self.testuser_name, self.testuser_id)

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -27,7 +27,7 @@ class RedisListenStoreTestCase(DatabaseTestCase):
 
         self.log = logging.getLogger()
         self._redis = init_redis_connection(self.log)
-        self.testuser = db_user.get_or_create(1, "test")
+        self.testuser = db_user.get_or_create(self.db_conn, 1, "test")
 
     def tearDown(self):
         cache._r.flushdb()

--- a/listenbrainz/listenstore/tests/test_timescale_utils.py
+++ b/listenbrainz/listenstore/tests/test_timescale_utils.py
@@ -51,8 +51,8 @@ class TestTimescaleUtils(DatabaseTestCase, TimescaleTestCase):
             }
 
     def test_delete_listens_update_metadata(self):
-        user_1 = db_user.get_or_create(1, "user_1")
-        user_2 = db_user.get_or_create(2, "user_2")
+        user_1 = db_user.get_or_create(self.db_conn, 1, "user_1")
+        user_2 = db_user.get_or_create(self.db_conn, 2, "user_2")
         recalculate_all_user_data()
 
         self._create_test_data(user_1)

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -27,7 +27,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.log = logging.getLogger(__name__)
         self.logstore = TimescaleListenStore(self.log)
 
-        self.testuser = db_user.get_or_create(1, "test")
+        self.testuser = db_user.get_or_create(self.db_conn, 1, "test")
         self.testuser_id = self.testuser["id"]
         self.testuser_name = self.testuser["musicbrainz_id"]
 
@@ -179,7 +179,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_get_listen_count_for_user(self):
         uid = random.randint(2000, 1 << 31)
-        testuser = db_user.get_or_create(uid, "user_%d" % uid)
+        testuser = db_user.get_or_create(self.db_conn, uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
 
         count = self._create_test_data(testuser_name, testuser["id"])
@@ -187,11 +187,11 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(count, listen_count)
 
     def test_fetch_recent_listens(self):
-        user = db_user.get_or_create(2, 'someuser')
+        user = db_user.get_or_create(self.db_conn, 2, 'someuser')
         user_name = user['musicbrainz_id']
         self._create_test_data(user_name, user["id"])
 
-        user2 = db_user.get_or_create(3, 'otheruser')
+        user2 = db_user.get_or_create(self.db_conn, 3, 'otheruser')
         user_name2 = user2['musicbrainz_id']
         self._create_test_data(user_name2, user2["id"])
 
@@ -208,7 +208,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_listen_counts_in_cache(self):
         uid = random.randint(2000, 1 << 31)
-        testuser = db_user.get_or_create(uid, "user_%d" % uid)
+        testuser = db_user.get_or_create(self.db_conn, uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         count = self._create_test_data(testuser_name, testuser["id"])
         user_key = REDIS_USER_LISTEN_COUNT + str(testuser["id"])
@@ -217,7 +217,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_delete_listens(self):
         uid = random.randint(2000, 1 << 31)
-        testuser = db_user.get_or_create(uid, "user_%d" % uid)
+        testuser = db_user.get_or_create(self.db_conn, uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name, testuser["id"])
 
@@ -238,7 +238,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_delete_single_listen(self):
         uid = random.randint(2000, 1 << 31)
-        testuser = db_user.get_or_create(uid, "user_%d" % uid)
+        testuser = db_user.get_or_create(self.db_conn, uid, "user_%d" % uid)
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name, testuser["id"])
 
@@ -299,7 +299,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
     def test_for_empty_timestamps(self):
         """Test newly created user has empty timestamps and count stored in the database."""
         uid = random.randint(2000, 1 << 31)
-        testuser = db_user.get_or_create(uid, "user_%d" % uid)
+        testuser = db_user.get_or_create(self.db_conn, uid, "user_%d" % uid)
         self.logstore.set_empty_values_for_user(testuser["id"])
         data = self._get_count_and_timestamps(testuser["id"])
         self.assertEqual(data["count"], 0)
@@ -312,7 +312,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
         count_user_1 = self._create_test_data(self.testuser["musicbrainz_id"], self.testuser["id"])
         uid = random.randint(2000, 1 << 31)
-        testuser2 = db_user.get_or_create(uid, f"user_{uid}")
+        testuser2 = db_user.get_or_create(self.db_conn, uid, f"user_{uid}")
         count_user_2 = self._create_test_data(testuser2["musicbrainz_id"], testuser2["id"])
 
         cache.delete(REDIS_TOTAL_LISTEN_COUNT)

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -27,11 +27,15 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.log = logging.getLogger(__name__)
         self.logstore = TimescaleListenStore(self.log)
 
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
         self.testuser = db_user.get_or_create(self.db_conn, 1, "test")
         self.testuser_id = self.testuser["id"]
         self.testuser_name = self.testuser["musicbrainz_id"]
 
     def tearDown(self):
+        self.ctx.pop()
         self.logstore = None
         DatabaseTestCase.tearDown(self)
         TimescaleTestCase.tearDown(self)

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -18,6 +18,7 @@ from listenbrainz.db.dump import SchemaMismatchException
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore import LISTENS_DUMP_SCHEMA_VERSION, LISTEN_MINIMUM_DATE
 from listenbrainz.listenstore import ORDER_ASC, ORDER_TEXT, ORDER_DESC, DEFAULT_LISTENS_PER_FETCH
+from listenbrainz.webserver import ts_conn
 
 # Append the user name for both of these keys
 REDIS_USER_LISTEN_COUNT = "lc."
@@ -53,8 +54,8 @@ class TimescaleListenStore:
         """When a user is created, set the timestamp keys and insert an entry in the listen count
          table so that we can avoid the expensive lookup for a brand new user."""
         query = """INSERT INTO listen_user_metadata VALUES (:user_id, 0, NULL, NULL, NOW())"""
-        with timescale.engine.begin() as connection:
-            connection.execute(sqlalchemy.text(query), {"user_id": user_id})
+        ts_conn.execute(sqlalchemy.text(query), {"user_id": user_id})
+        ts_conn.commit()
 
     def get_listen_count_for_user(self, user_id: int):
         """Get the total number of listens for a user.
@@ -72,19 +73,18 @@ class TimescaleListenStore:
         if cached_count:
             return cached_count
 
-        with timescale.engine.connect() as connection:
-            query = "SELECT count, created FROM listen_user_metadata WHERE user_id = :user_id"
-            result = connection.execute(sqlalchemy.text(query), {"user_id": user_id})
-            row = result.fetchone()
-            if row:
-                count, created = row.count, row.created
-            else:
-                # we can reach here only in tests, because we create entries in listen_user_metadata
-                # table when user signs up and for existing users an entry should always exist.
-                count, created = 0, LISTEN_MINIMUM_DATE
+        query = "SELECT count, created FROM listen_user_metadata WHERE user_id = :user_id"
+        result = ts_conn.execute(sqlalchemy.text(query), {"user_id": user_id})
+        row = result.fetchone()
+        if row:
+            count, created = row.count, row.created
+        else:
+            # we can reach here only in tests, because we create entries in listen_user_metadata
+            # table when user signs up and for existing users an entry should always exist.
+            count, created = 0, LISTEN_MINIMUM_DATE
 
-            cache.set(REDIS_USER_LISTEN_COUNT + str(user_id), count, REDIS_USER_LISTEN_COUNT_EXPIRY)
-            return count
+        cache.set(REDIS_USER_LISTEN_COUNT + str(user_id), count, REDIS_USER_LISTEN_COUNT_EXPIRY)
+        return count
 
     def get_timestamps_for_user(self, user_id: int) -> Tuple[Optional[datetime], Optional[datetime]]:
         """ Return the min_ts and max_ts for the given list of users """
@@ -94,15 +94,14 @@ class TimescaleListenStore:
               FROM listen_user_metadata
              WHERE user_id = :user_id
         """
-        with timescale.engine.connect() as connection:
-            result = connection.execute(text(query), {"user_id": user_id})
-            row = result.fetchone()
-            if row is None:
-                min_ts = max_ts = EPOCH
-            else:
-                min_ts = row.min_ts
-                max_ts = row.max_ts
-            return min_ts.replace(tzinfo=None), max_ts.replace(tzinfo=None)
+        result = ts_conn.execute(text(query), {"user_id": user_id})
+        row = result.fetchone()
+        if row is None:
+            min_ts = max_ts = EPOCH
+        else:
+            min_ts = row.min_ts
+            max_ts = row.max_ts
+        return min_ts.replace(tzinfo=None), max_ts.replace(tzinfo=None)
 
     def get_total_listen_count(self):
         """ Returns the total number of listens stored in the ListenStore.
@@ -274,74 +273,74 @@ class TimescaleListenStore:
 
         listens = []
         done = False
-        with timescale.engine.connect() as connection:
-            t0 = time.monotonic()
 
-            passes = 0
+        t0 = time.monotonic()
+
+        passes = 0
+        while True:
+            passes += 1
+
+            # Oh shit valve. I'm keeping it here for the time being. :)
+            if passes == 10:
+                done = True
+                break
+
+            curs = ts_conn.execute(
+                sqlalchemy.text(query),
+                {"user_id": user["id"], "from_ts": from_ts, "to_ts": to_ts, "limit": limit}
+            )
             while True:
-                passes += 1
-
-                # Oh shit valve. I'm keeping it here for the time being. :)
-                if passes == 10:
-                    done = True
-                    break
-
-                curs = connection.execute(
-                    sqlalchemy.text(query),
-                    {"user_id": user["id"], "from_ts": from_ts, "to_ts": to_ts, "limit": limit}
-                )
-                while True:
-                    result = curs.fetchone()
-                    if not result:
-                        if not to_dynamic and not from_dynamic:
-                            done = True
-                            break
-
-                        if from_ts < min_user_ts - timedelta(seconds=1):
-                            done = True
-                            break
-
-                        if to_ts > datetime.now() + MAX_FUTURE_SECONDS:
-                            done = True
-                            break
-
-                        if to_dynamic:
-                            from_ts += window_size - timedelta(seconds=1)
-                            window_size *= WINDOW_SIZE_MULTIPLIER
-                            to_ts += window_size
-
-                        if from_dynamic:
-                            to_ts -= window_size
-                            window_size *= WINDOW_SIZE_MULTIPLIER
-                            from_ts -= window_size
-
-                        break
-
-                    listens.append(Listen.from_timescale(
-                        listened_at=result.listened_at,
-                        user_id=result.user_id,
-                        created=result.created,
-                        recording_msid=result.recording_msid,
-                        track_metadata=result.data,
-                        recording_mbid=result.recording_mbid,
-                        recording_name=result.recording_name,
-                        release_mbid=result.release_mbid,
-                        artist_mbids=result.artist_mbids,
-                        ac_names=result.ac_names,
-                        ac_join_phrases=result.ac_join_phrases,
-                        user_name=user["musicbrainz_id"],
-                        caa_id=result.caa_id,
-                        caa_release_mbid=result.caa_release_mbid
-                    ))
-
-                    if len(listens) == limit:
+                result = curs.fetchone()
+                if not result:
+                    if not to_dynamic and not from_dynamic:
                         done = True
                         break
 
-                if done:
+                    if from_ts < min_user_ts - timedelta(seconds=1):
+                        done = True
+                        break
+
+                    if to_ts > datetime.now() + MAX_FUTURE_SECONDS:
+                        done = True
+                        break
+
+                    if to_dynamic:
+                        from_ts += window_size - timedelta(seconds=1)
+                        window_size *= WINDOW_SIZE_MULTIPLIER
+                        to_ts += window_size
+
+                    if from_dynamic:
+                        to_ts -= window_size
+                        window_size *= WINDOW_SIZE_MULTIPLIER
+                        from_ts -= window_size
+
                     break
 
-            fetch_listens_time = time.monotonic() - t0
+                listens.append(Listen.from_timescale(
+                    listened_at=result.listened_at,
+                    user_id=result.user_id,
+                    created=result.created,
+                    recording_msid=result.recording_msid,
+                    track_metadata=result.data,
+                    recording_mbid=result.recording_mbid,
+                    recording_name=result.recording_name,
+                    release_mbid=result.release_mbid,
+                    artist_mbids=result.artist_mbids,
+                    ac_names=result.ac_names,
+                    ac_join_phrases=result.ac_join_phrases,
+                    user_name=user["musicbrainz_id"],
+                    caa_id=result.caa_id,
+                    caa_release_mbid=result.caa_release_mbid
+                ))
+
+                if len(listens) == limit:
+                    done = True
+                    break
+
+            if done:
+                break
+
+        fetch_listens_time = time.monotonic() - t0
 
         if order == ORDER_ASC:
             listens.reverse()
@@ -429,31 +428,30 @@ class TimescaleListenStore:
         """
 
         listens = []
-        with timescale.engine.connect() as connection:
-            curs = connection.execute(sqlalchemy.text(query), args)
-            while True:
-                result = curs.fetchone()
-                if not result:
-                    break
-                user_name = user_id_map[result.user_id]
-                listens.append(Listen.from_timescale(
-                    listened_at=result.listened_at,
-                    user_id=result.user_id,
-                    created=result.created,
-                    recording_msid=result.recording_msid,
-                    track_metadata=result.data,
-                    recording_mbid=result.recording_mbid,
-                    recording_name=result.recording_name,
-                    release_mbid=result.release_mbid,
-                    artist_mbids=result.artist_mbids,
-                    ac_names=result.ac_names,
-                    ac_join_phrases=result.ac_join_phrases,
-                    user_name=user_name,
-                    caa_id=result.caa_id,
-                    caa_release_mbid=result.caa_release_mbid
-                ))
-        return listens
 
+        curs = ts_conn.execute(sqlalchemy.text(query), args)
+        while True:
+            result = curs.fetchone()
+            if not result:
+                break
+            user_name = user_id_map[result.user_id]
+            listens.append(Listen.from_timescale(
+                listened_at=result.listened_at,
+                user_id=result.user_id,
+                created=result.created,
+                recording_msid=result.recording_msid,
+                track_metadata=result.data,
+                recording_mbid=result.recording_mbid,
+                recording_name=result.recording_name,
+                release_mbid=result.release_mbid,
+                artist_mbids=result.artist_mbids,
+                ac_names=result.ac_names,
+                ac_join_phrases=result.ac_join_phrases,
+                user_name=user_name,
+                caa_id=result.caa_id,
+                caa_release_mbid=result.caa_release_mbid
+            ))
+        return listens
 
     def fetch_all_recent_listens_for_users(self, users, min_ts: datetime, max_ts: datetime, limit=25):
         """ Fetch recent listens for a list of users.
@@ -529,29 +527,29 @@ class TimescaleListenStore:
         """
 
         listens = []
-        with timescale.engine.connect() as connection:
-            curs = connection.execute(sqlalchemy.text(query), args)
-            while True:
-                result = curs.fetchone()
-                if not result:
-                    break
-                user_name = user_id_map[result.user_id]
-                listens.append(Listen.from_timescale(
-                    listened_at=result.listened_at,
-                    user_id=result.user_id,
-                    created=result.created,
-                    recording_msid=result.recording_msid,
-                    track_metadata=result.data,
-                    recording_mbid=result.recording_mbid,
-                    recording_name=result.recording_name,
-                    release_mbid=result.release_mbid,
-                    artist_mbids=result.artist_mbids,
-                    ac_names=result.ac_names,
-                    ac_join_phrases=result.ac_join_phrases,
-                    user_name=user_name,
-                    caa_id=result.caa_id,
-                    caa_release_mbid=result.caa_release_mbid
-                ))
+
+        curs = ts_conn.execute(sqlalchemy.text(query), args)
+        while True:
+            result = curs.fetchone()
+            if not result:
+                break
+            user_name = user_id_map[result.user_id]
+            listens.append(Listen.from_timescale(
+                listened_at=result.listened_at,
+                user_id=result.user_id,
+                created=result.created,
+                recording_msid=result.recording_msid,
+                track_metadata=result.data,
+                recording_mbid=result.recording_mbid,
+                recording_name=result.recording_name,
+                release_mbid=result.release_mbid,
+                artist_mbids=result.artist_mbids,
+                ac_names=result.ac_names,
+                ac_join_phrases=result.ac_join_phrases,
+                user_name=user_name,
+                caa_id=result.caa_id,
+                caa_release_mbid=result.caa_release_mbid
+            ))
 
         return listens
 
@@ -643,8 +641,8 @@ class TimescaleListenStore:
             DELETE FROM listen WHERE user_id = :user_id;
         """
         try:
-            with timescale.engine.begin() as connection:
-                connection.execute(sqlalchemy.text(query), {"user_id": user_id})
+            ts_conn.execute(sqlalchemy.text(query), {"user_id": user_id})
+            ts_conn.commit()
         except psycopg2.OperationalError as e:
             self.log.error("Cannot delete listens for user: %s" % str(e))
             raise
@@ -669,11 +667,11 @@ class TimescaleListenStore:
                  VALUES (:user_id, :listened_at, :recording_msid)
         """
         try:
-            with timescale.engine.begin() as connection:
-                connection.execute(
-                    sqlalchemy.text(query),
-                    {"listened_at": listened_at, "user_id": user_id, "recording_msid": recording_msid}
-                )
+            ts_conn.execute(
+                sqlalchemy.text(query),
+                {"listened_at": listened_at, "user_id": user_id, "recording_msid": recording_msid}
+            )
+            ts_conn.commit()
         except psycopg2.OperationalError as e:
             self.log.error("Cannot delete listen for user: %s" % str(e))
             raise TimescaleListenStoreException

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -307,7 +307,7 @@ def notify_yim_users(year: int):
     application = webserver.create_app()
     with application.app_context():
         from listenbrainz.db import year_in_music
-        year_in_music.notify_yim_users(year)
+        year_in_music.notify_yim_users(webserver.db_conn, webserver.ts_conn, year)
 
 
 @cli.command()
@@ -319,7 +319,7 @@ def run_daily_jams(create_all):
     method and not a core function of troi.
     """
     with create_app().app_context():
-        run_daily_jams_troi_bot(webserver.db_conn, create_all)
+        run_daily_jams_troi_bot(webserver.db_conn, webserver.ts_conn, create_all)
 
 
 @cli.command()
@@ -341,7 +341,7 @@ def clear_expired_do_not_recommends():
     app = create_app()
     with app.app_context():
         app.logger.info("Starting process to clean up expired do not recommends")
-        do_not_recommend.clear_expired()
+        do_not_recommend.clear_expired(webserver.db_conn)
         app.logger.info("Completed process to clean up expired do not recommends")
 
 

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -292,7 +292,7 @@ def submit_release(user, token, releasembid):
         import listenbrainz.db.user
         application = webserver.create_app()
         with application.app_context():
-            user_ob = listenbrainz.db.user.get_by_mb_id(user)
+            user_ob = listenbrainz.db.user.get_by_mb_id(webserver.db_conn, user)
             if user_ob is None:
                 raise click.ClickException(f"No such user: {user}")
             token = user_ob["auth_token"]
@@ -319,7 +319,7 @@ def run_daily_jams(create_all):
     method and not a core function of troi.
     """
     with create_app().app_context():
-        run_daily_jams_troi_bot(create_all)
+        run_daily_jams_troi_bot(webserver.db_conn, create_all)
 
 
 @cli.command()

--- a/listenbrainz/messybrainz/__init__.py
+++ b/listenbrainz/messybrainz/__init__.py
@@ -27,8 +27,9 @@ def submit_listens_and_sing_me_a_sweet_song(recordings):
     success = False
     while not success and attempts < 3:
         try:
-            data = insert_all_in_transaction(recordings)
-            success = True
+            with timescale.engine.connect() as connection:
+                data = insert_all_in_transaction(connection, recordings)
+                success = True
         except sqlalchemy.exc.IntegrityError:
             # If we get an IntegrityError then our transaction failed.
             # We should try again
@@ -42,26 +43,27 @@ def submit_listens_and_sing_me_a_sweet_song(recordings):
         raise exceptions.ErrorAddingException("Failed to add data")
 
 
-def insert_all_in_transaction(submissions: list[dict]):
+def insert_all_in_transaction(ts_conn, submissions: list[dict]):
     """ Inserts a list of recordings into MessyBrainz.
 
     Args:
+        ts_conn: timescale database connection
         submissions: a list of recordings to be inserted
     Returns:
         A list of dicts containing the recording data for each inserted recording
     """
     ret = []
-    with timescale.engine.begin() as ts_conn:
-        for submission in submissions:
-            result = submit_recording(
-                ts_conn,
-                submission["title"],
-                submission["artist"],
-                submission.get("release"),
-                submission.get("track_number"),
-                submission.get("duration")
-            )
-            ret.append(result)
+    for submission in submissions:
+        result = submit_recording(
+            ts_conn,
+            submission["title"],
+            submission["artist"],
+            submission.get("release"),
+            submission.get("track_number"),
+            submission.get("duration")
+        )
+        ret.append(result)
+    ts_conn.commit()
     return ret
 
 

--- a/listenbrainz/messybrainz/tests/test_init.py
+++ b/listenbrainz/messybrainz/tests/test_init.py
@@ -135,8 +135,8 @@ class DataTestCase(TimescaleTestCase):
                 'duration': 56000
             }
         ]
-        msids = messybrainz.insert_all_in_transaction(submissions)
-        with timescale.engine.begin() as conn, conn.connection.cursor(cursor_factory=DictCursor) as curs:
+        msids = messybrainz.insert_all_in_transaction(self.ts_conn, submissions)
+        with self.ts_conn.connection.cursor(cursor_factory=DictCursor) as curs:
             received = messybrainz.load_recordings_from_msids(curs, msids)
 
         submissions[0]['track_number'] = None

--- a/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
+++ b/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
@@ -15,7 +15,7 @@ class MsidUpdaterTestCase(IntegrationTestCase):
 
     def setUp(self):
         IntegrationTestCase.setUp(self)
-        self.user = db_user.get_or_create(1111, "msid-updater-user")
+        self.user = db_user.get_or_create(self.db_conn, 1111, "msid-updater-user")
 
     def create_dummy_data(self):
         mapping = [

--- a/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
+++ b/listenbrainz/messybrainz/tests/test_update_msids_from_mapping.py
@@ -3,10 +3,8 @@ from datetime import datetime
 
 from sqlalchemy import text
 
-from listenbrainz import db
 import listenbrainz.db.user as db_user
 from listenbrainz.db import timescale
-from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
 from listenbrainz.messybrainz import update_msids_from_mapping
 from listenbrainz.tests.integration import IntegrationTestCase
 
@@ -159,19 +157,19 @@ class MsidUpdaterTestCase(IntegrationTestCase):
             INSERT INTO user_timeline_event (user_id, event_type, metadata)
                  VALUES (:user_id, :event_type, :metadata)
         """
-        with db.engine.begin() as conn:
-            for item in pinned_recs:
-                conn.execute(text(pin_rec_query), {"user_id": self.user["id"], "pinned_until": datetime.now(), **item})
+        for item in pinned_recs:
+            self.db_conn.execute(text(pin_rec_query), {"user_id": self.user["id"], "pinned_until": datetime.now(), **item})
 
-            for item in recording_feedback:
-                conn.execute(text(feedback_query), {"user_id": self.user["id"], **item})
+        for item in recording_feedback:
+            self.db_conn.execute(text(feedback_query), {"user_id": self.user["id"], **item})
 
-            for item in user_timeline_event:
-                conn.execute(text(timeline_query), {
-                    "user_id": self.user["id"],
-                    "event_type": item["event_type"],
-                    "metadata": json.dumps(item["metadata"])
-                })
+        for item in user_timeline_event:
+            self.db_conn.execute(text(timeline_query), {
+                "user_id": self.user["id"],
+                "event_type": item["event_type"],
+                "metadata": json.dumps(item["metadata"])
+            })
+        self.db_conn.commit()
 
     def test_msid_updater(self):
         self.create_dummy_data()
@@ -280,14 +278,11 @@ class MsidUpdaterTestCase(IntegrationTestCase):
             }
         ]
 
-        self.maxDiff = None
+        result = self.db_conn.execute(text("SELECT recording_msid::text, recording_mbid::text, score FROM recording_feedback"))
+        self.assertCountEqual(result.mappings().all(), expected_feedback)
 
-        with db.engine.connect() as conn:
-            result = conn.execute(text("SELECT recording_msid::text, recording_mbid::text, score FROM recording_feedback"))
-            self.assertCountEqual(result.mappings().all(), expected_feedback)
+        result = self.db_conn.execute(text("SELECT recording_msid::text, recording_mbid::text, blurb_content FROM pinned_recording"))
+        self.assertCountEqual(result.mappings().all(), expected_pinned_recs)
 
-            result = conn.execute(text("SELECT recording_msid::text, recording_mbid::text, blurb_content FROM pinned_recording"))
-            self.assertCountEqual(result.mappings().all(), expected_pinned_recs)
-
-            result = conn.execute(text("SELECT event_type, metadata FROM user_timeline_event"))
-            self.assertCountEqual(result.mappings().all(), expected_timeline_event)
+        result = self.db_conn.execute(text("SELECT event_type, metadata FROM user_timeline_event"))
+        self.assertCountEqual(result.mappings().all(), expected_timeline_event)

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -33,8 +33,8 @@ class HandlersTestCase(DatabaseTestCase):
     def setUp(self):
         super(HandlersTestCase, self).setUp()
         self.app = create_app()
-        self.user1 = db_user.get_or_create(1, 'iliekcomputers')
-        self.user2 = db_user.get_or_create(2, 'lucifer')
+        self.user1 = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        self.user2 = db_user.get_or_create(self.db_conn, 2, 'lucifer')
 
     def tearDown(self):
         super(HandlersTestCase, self).tearDown()

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -25,6 +25,7 @@ METRIC_UPDATE_INTERVAL = 60  # seconds
 _listens_imported_since_last_update = 0  # number of listens imported since last metric update was submitted
 _metric_submission_time = time.monotonic() + METRIC_UPDATE_INTERVAL
 
+
 def notify_error(musicbrainz_id: str, error: str):
     """ Notifies specified user via email about error during Spotify import.
 
@@ -32,7 +33,7 @@ def notify_error(musicbrainz_id: str, error: str):
         musicbrainz_id: the MusicBrainz ID of the user
         error: a description of the error encountered.
     """
-    user_email = db_user.get_by_mb_id(musicbrainz_id, fetch_email=True)["email"]
+    user_email = db_user.get_by_mb_id(listenbrainz.webserver.db_conn, musicbrainz_id, fetch_email=True)["email"]
     if not user_email:
         return
 

--- a/listenbrainz/spotify_updater/spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/spotify_read_listens.py
@@ -16,7 +16,7 @@ from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.domain.external_service import ExternalServiceError, ExternalServiceAPIError, \
     ExternalServiceInvalidGrantError
 from listenbrainz.domain.spotify import SpotifyService
-from listenbrainz.webserver.errors import APIBadRequest, ListenValidationError
+from listenbrainz.webserver.errors import ListenValidationError
 from listenbrainz.webserver.models import SubmitListenUserMetadata
 from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, LISTEN_TYPE_IMPORT, \
     LISTEN_TYPE_PLAYING_NOW

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -24,7 +24,7 @@ class ConvertListensTestCase(DatabaseTestCase):
         self.user = db_user.get_or_create(self.db_conn, 1, 'testuserpleaseignore')
 
         self.DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
-        db_oauth.save_token(user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
                             access_token='token', refresh_token='refresh',
                             token_expires_ts=int(time.time()) + 1000, record_listens=True,
                             scopes=['user-read-recently-played'])

--- a/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
+++ b/listenbrainz/spotify_updater/tests/test_spotify_read_listens.py
@@ -21,7 +21,7 @@ class ConvertListensTestCase(DatabaseTestCase):
 
     def setUp(self):
         super(ConvertListensTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'testuserpleaseignore')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testuserpleaseignore')
 
         self.DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
         db_oauth.save_token(user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
@@ -99,7 +99,7 @@ class ConvertListensTestCase(DatabaseTestCase):
 
     @patch('listenbrainz.spotify_updater.spotify_read_listens.send_mail')
     def test_notify_user(self, mock_send_mail):
-        db_user.create(2, "two", "one@two.one")
+        db_user.create(self.db_conn, 2, "two", "one@two.one")
         app = listenbrainz.webserver.create_app()
         app.config['SERVER_NAME'] = "test"
         with app.app_context():

--- a/listenbrainz/tests/integration/__init__.py
+++ b/listenbrainz/tests/integration/__init__.py
@@ -68,9 +68,9 @@ class ListenAPIIntegrationTestCase(IntegrationTestCase, TimescaleTestCase):
     def setUp(self):
         IntegrationTestCase.setUp(self)
         TimescaleTestCase.setUp(self)
-        self.user = db_user.get_or_create(1, 'testuserpleaseignore')
-        db_user.agree_to_gdpr(self.user['musicbrainz_id'])
-        self.user2 = db_user.get_or_create(2, 'all_muppets_all_of_them')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testuserpleaseignore')
+        db_user.agree_to_gdpr(self.db_conn, self.user['musicbrainz_id'])
+        self.user2 = db_user.get_or_create(self.db_conn, 2, 'all_muppets_all_of_them')
 
     def tearDown(self):
         IntegrationTestCase.tearDown(self)

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -666,12 +666,11 @@ class APITestCase(ListenAPIIntegrationTestCase):
             self.custom_url_for('api_v1.get_similar_users', user_name='my_dear_muppet'))
         self.assert404(response)
 
-        conn = db.engine.raw_connection()
-        with conn.cursor() as curs:
+        with self.db_conn.connection.cursor() as curs:
             data = {self.user2['id']: 0.123}
             curs.execute("""INSERT INTO recommendation.similar_user VALUES (%s, %s)""",
                          (self.user['id'], json.dumps(data)))
-        conn.commit()
+        self.db_conn.commit()
 
         response = self.client.get(
             self.custom_url_for('api_v1.get_similar_users', user_name=self.user['musicbrainz_id']))
@@ -1054,6 +1053,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
     def test_get_user_services(self):
         db_oauth.save_token(
+            self.db_conn,
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -989,7 +989,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
     def test_follow_user(self):
         r = self.client.post(self.follow_user_url, headers=self.follow_user_headers)
         self.assert200(r)
-        self.assertTrue(db_user_relationship.is_following_user(self.user["id"], self.followed_user['id']))
+        self.assertTrue(db_user_relationship.is_following_user(self.db_conn, self.user["id"], self.followed_user['id']))
 
     def test_follow_user_requires_login(self):
         r = self.client.post(self.follow_user_url)
@@ -1008,7 +1008,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
     def test_follow_user_twice_leads_to_error(self):
         r = self.client.post(self.follow_user_url, headers=self.follow_user_headers)
         self.assert200(r)
-        self.assertTrue(db_user_relationship.is_following_user(self.user["id"], self.followed_user['id']))
+        self.assertTrue(db_user_relationship.is_following_user(self.db_conn, self.user["id"], self.followed_user['id']))
 
         # now, try to follow again, this time expecting a 400
         r = self.client.post(self.follow_user_url, headers=self.follow_user_headers)
@@ -1018,21 +1018,34 @@ class APITestCase(ListenAPIIntegrationTestCase):
         # first, follow the user
         r = self.client.post(self.follow_user_url, headers=self.follow_user_headers)
         self.assert200(r)
-        self.assertTrue(db_user_relationship.is_following_user(self.user["id"], self.followed_user['id']))
+        self.assertTrue(db_user_relationship.is_following_user(self.db_conn, self.user["id"], self.followed_user['id']))
 
         # now, unfollow and check the db
         r = self.client.post(
             self.custom_url_for("social_api_v1.unfollow_user", user_name=self.followed_user["musicbrainz_id"]),
-            headers=self.follow_user_headers)
+            headers=self.follow_user_headers
+        )
         self.assert200(r)
-        self.assertFalse(db_user_relationship.is_following_user(self.user["id"], self.followed_user['id']))
+        self.assertFalse(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.user["id"],
+                self.followed_user['id']
+            )
+        )
 
     def test_unfollow_not_following_user(self):
         r = self.client.post(
             self.custom_url_for("social_api_v1.unfollow_user", user_name=self.followed_user["musicbrainz_id"]),
             headers=self.follow_user_headers)
         self.assert200(r)
-        self.assertFalse(db_user_relationship.is_following_user(self.user["id"], self.followed_user['id']))
+        self.assertFalse(
+            db_user_relationship.is_following_user(
+                self.db_conn,
+                self.user["id"],
+                self.followed_user['id']
+            )
+        )
 
     def test_unfollow_user_requires_login(self):
         r = self.client.post(

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -17,7 +17,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(APITestCase, self).setUp()
-        self.followed_user = db_user.get_or_create(3, 'followed_user')
+        self.followed_user = db_user.get_or_create(self.db_conn, 3, 'followed_user')
         self.follow_user_url = self.custom_url_for("social_api_v1.follow_user",
                                                    user_name=self.followed_user["musicbrainz_id"])
         self.follow_user_headers = {'Authorization': 'Token {}'.format(self.user['auth_token'])}
@@ -147,7 +147,7 @@ class APITestCase(ListenAPIIntegrationTestCase):
 
         # send three listens
         ts = 1400000000
-        user = db_user.get_or_create(1, 'test_order')
+        user = db_user.get_or_create(self.db_conn, 1, 'test_order')
         for i in range(3):
             payload['payload'][0]['listened_at'] = ts + (100 * i)
             response = self.send_data(payload, user, recalculate=True)

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -36,7 +36,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(APICompatTestCase, self).setUp()
-        self.lb_user = db_user.get_or_create(1, 'apicompattestuser')
+        self.lb_user = db_user.get_or_create(self.db_conn, 1, 'apicompattestuser')
         self.lfm_user = User(
             self.lb_user['id'],
             self.lb_user['created'],

--- a/listenbrainz/tests/integration/test_api_compat.py
+++ b/listenbrainz/tests/integration/test_api_compat.py
@@ -138,9 +138,9 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             if valid information is provided.
         """
 
-        token = Token.generate(self.lfm_user.api_key)
-        token.approve(self.lfm_user.name)
-        session = Session.create(token)
+        token = Token.generate(self.db_conn, self.lfm_user.api_key)
+        token.approve(self.db_conn, self.lfm_user.name)
+        session = Session.create(self.db_conn, token)
 
         data = {
             'method': 'track.updateNowPlaying',
@@ -174,14 +174,14 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         response = xmltodict.parse(r.data)
         self.assertEqual(response['lfm']['@status'], 'ok')
 
-        token = Token.load(response['lfm']['token'], api_key=self.lfm_user.api_key)
+        token = Token.load(self.db_conn, response['lfm']['token'], api_key=self.lfm_user.api_key)
         self.assertIsNotNone(token)
 
     def test_get_session(self):
         """ Tests if the session key is valid and session is established correctly. """
 
-        token = Token.generate(self.lfm_user.api_key)
-        token.approve(self.lfm_user.name)
+        token = Token.generate(self.db_conn, self.lfm_user.api_key)
+        token.approve(self.db_conn, self.lfm_user.name)
 
         data = {
             'method': 'auth.getsession',
@@ -196,7 +196,7 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response['lfm']['@status'], 'ok')
         self.assertEqual(response['lfm']['session']['name'], self.lfm_user.name)
 
-        session_key = Session.load(response['lfm']['session']['key'])
+        session_key = Session.load(self.db_conn, response['lfm']['session']['key'])
         self.assertIsNotNone(session_key)
 
     def test_get_session_invalid_token(self):
@@ -223,9 +223,9 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
            requested format"""
         timescale_connection._ts = None
 
-        token = Token.generate(self.lfm_user.api_key)
-        token.approve(self.lfm_user.name)
-        session = Session.create(token)
+        token = Token.generate(self.db_conn, self.lfm_user.api_key)
+        token.approve(self.db_conn, self.lfm_user.name)
+        session = Session.create(self.db_conn, token)
 
         data = {
             'method': 'user.getInfo',
@@ -246,9 +246,9 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
     def test_record_listen(self):
         """ Tests if listen is recorded correctly if valid information is provided. """
 
-        token = Token.generate(self.lfm_user.api_key)
-        token.approve(self.lfm_user.name)
-        session = Session.create(token)
+        token = Token.generate(self.db_conn, self.lfm_user.api_key)
+        token.approve(self.db_conn, self.lfm_user.name)
+        session = Session.create(self.db_conn, token)
 
         timestamp = int(time.time())
         data = {
@@ -281,9 +281,9 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
 
     def test_record_invalid_listen(self):
         """ Tests that error is raised if submited data contains unicode null """
-        token = Token.generate(self.lfm_user.api_key)
-        token.approve(self.lfm_user.name)
-        session = Session.create(token)
+        token = Token.generate(self.db_conn, self.lfm_user.api_key)
+        token.approve(self.db_conn, self.lfm_user.name)
+        session = Session.create(self.db_conn, token)
 
         timestamp = int(time.time())
         data = {
@@ -306,9 +306,9 @@ class APICompatTestCase(ListenAPIIntegrationTestCase):
             is provided.
         """
 
-        token = Token.generate(self.lfm_user.api_key)
-        token.approve(self.lfm_user.name)
-        session = Session.create(token)
+        token = Token.generate(self.db_conn, self.lfm_user.api_key)
+        token.approve(self.db_conn, self.lfm_user.name)
+        session = Session.create(self.db_conn, token)
 
         timestamp = int(time.time())
         data = {

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -141,7 +141,8 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
         time.sleep(1)
         recalculate_all_user_data()
         to_ts = datetime.utcnow()
-        listens, _, _ = self.ls.fetch_listens(self.user, to_ts=to_ts)
+        with self.app.app_context():
+            listens, _, _ = self.ls.fetch_listens(self.user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
     def test_submit_listen_invalid_sid(self):

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -232,17 +232,14 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
     def test_get_session(self):
         """ Tests _get_session method in api_compat_deprecated """
-
-        s = Session.create_by_user_id(self.user['id'])
-
-        session = _get_session(s.sid)
+        s = Session.create_by_user_id(self.db_conn, self.user['id'])
+        session = _get_session(self.db_conn, s.sid)
         self.assertEqual(s.sid, session.sid)
 
     def test_get_session_which_doesnt_exist(self):
         """ Make sure BadRequest is raised when we try to get a session that doesn't exists """
-
         with self.assertRaises(BadRequest):
-            session = _get_session('')
+            session = _get_session(self.db_conn, '')
 
     def test_404(self):
 

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -38,7 +38,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
     def setUp(self):
         super(APICompatDeprecatedTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'apicompatoldtestuser')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'apicompatoldtestuser')
 
         self.log = logging.getLogger(__name__)
         self.ls = timescale_connection._ts

--- a/listenbrainz/tests/integration/test_do_not_recommend_api.py
+++ b/listenbrainz/tests/integration/test_do_not_recommend_api.py
@@ -40,7 +40,7 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
             limit = len(self.items)
 
         for item in self.items[:limit]:
-            do_not_recommend.insert(self.user["id"], item["entity"], item["entity_mbid"], item["until"])
+            do_not_recommend.insert(self.db_conn, self.user["id"], item["entity"], item["entity_mbid"], item["until"])
 
     def _check_response(self, response, expected, offset=0, total_count=None):
         self.assert200(response)

--- a/listenbrainz/tests/integration/test_do_not_recommend_api.py
+++ b/listenbrainz/tests/integration/test_do_not_recommend_api.py
@@ -10,7 +10,7 @@ class DoNotRecommendAPITestCase(IntegrationTestCase):
 
     def setUp(self):
         super(DoNotRecommendAPITestCase, self).setUp()
-        self.user = db_user.get_or_create(1, "test_user_1")
+        self.user = db_user.get_or_create(self.db_conn, 1, "test_user_1")
 
         self.items = [
             {

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -54,7 +54,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
     def create_and_follow_user(self, user: int, mb_row_id: int, name: str) -> dict:
         following_user = db_user.get_or_create(mb_row_id, name)
-        db_user_relationship.insert(user, following_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user, following_user['id'], 'follow')
         return following_user
 
     def create_similar_user(self, similar_to_user: int, mb_row_id: int, similarity: float, name: str) -> dict:
@@ -389,7 +389,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
     def test_it_returns_follow_events(self):
         # make a user you're following follow a new user
         new_user_1 = db_user.get_or_create(104, 'new_user_1')
-        db_user_relationship.insert(self.following_user_1['id'], new_user_1['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.following_user_1['id'], new_user_1['id'], 'follow')
 
         # this should show up in the events
         r = self.client.get(
@@ -505,7 +505,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # make a user you're following follow a new user
         new_user_1 = db_user.get_or_create(104, 'new_user_1')
-        db_user_relationship.insert(self.following_user_1['id'], new_user_1['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.following_user_1['id'], new_user_1['id'], 'follow')
 
         time.sleep(1)  # sleep a bit to avoid ordering conflicts, cannot mock this time as it comes from postgres
         self.insert_metadata()

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -53,12 +53,12 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
             return msid
 
     def create_and_follow_user(self, user: int, mb_row_id: int, name: str) -> dict:
-        following_user = db_user.get_or_create(mb_row_id, name)
+        following_user = db_user.get_or_create(self.db_conn, mb_row_id, name)
         db_user_relationship.insert(self.db_conn, user, following_user['id'], 'follow')
         return following_user
 
     def create_similar_user(self, similar_to_user: int, mb_row_id: int, similarity: float, name: str) -> dict:
-        similar_user = db_user.get_or_create(mb_row_id, name)
+        similar_user = db_user.get_or_create(self.db_conn, mb_row_id, name)
         self.similar_user_data[similar_user['id']] = similarity
         with db.engine.begin() as connection:
             connection.execute(text("""
@@ -85,7 +85,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(FeedAPITestCase, self).setUp()
-        self.main_user = db_user.get_or_create(100, 'param')
+        self.main_user = db_user.get_or_create(self.db_conn, 100, 'param')
         self.following_user_1 = self.create_and_follow_user(self.main_user['id'], 102, 'following_1')
         self.following_user_2 = self.create_and_follow_user(self.main_user['id'], 103, 'following_2')
 
@@ -388,7 +388,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_it_returns_follow_events(self):
         # make a user you're following follow a new user
-        new_user_1 = db_user.get_or_create(104, 'new_user_1')
+        new_user_1 = db_user.get_or_create(self.db_conn, 104, 'new_user_1')
         db_user_relationship.insert(self.db_conn, self.following_user_1['id'], new_user_1['id'], 'follow')
 
         # this should show up in the events
@@ -484,7 +484,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(msid, payload['events'][1]['metadata']['track_metadata']['additional_info']['recording_msid'])
 
     def test_it_returns_empty_list_if_user_does_not_follow_anyone(self):
-        new_user = db_user.get_or_create(111, 'totally_new_user_with_no_friends')
+        new_user = db_user.get_or_create(self.db_conn, 111, 'totally_new_user_with_no_friends')
         r = self.client.get(
             self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=new_user['musicbrainz_id']),
             headers={'Authorization': f"Token {new_user['auth_token']}"},
@@ -504,7 +504,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json['status'], 'ok')
 
         # make a user you're following follow a new user
-        new_user_1 = db_user.get_or_create(104, 'new_user_1')
+        new_user_1 = db_user.get_or_create(self.db_conn, 104, 'new_user_1')
         db_user_relationship.insert(self.db_conn, self.following_user_1['id'], new_user_1['id'], 'follow')
 
         time.sleep(1)  # sleep a bit to avoid ordering conflicts, cannot mock this time as it comes from postgres

--- a/listenbrainz/tests/integration/test_feed_api.py
+++ b/listenbrainz/tests/integration/test_feed_api.py
@@ -428,12 +428,14 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
         msid = self.insert_metadata()
         # create a recording recommendation ourselves
         db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=self.main_user['id'],
             metadata=RecordingRecommendationMetadata(recording_msid=msid)
         )
 
         # create a recording recommendation for a user we follow
         db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=self.following_user_1['id'],
             metadata=RecordingRecommendationMetadata(recording_mbid="34c208ee-2de7-4d38-b47e-907074866dd3")
         )
@@ -510,6 +512,7 @@ class FeedAPITestCase(ListenAPIIntegrationTestCase):
 
         # create a recording recommendation for a user we follow
         db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=self.following_user_1['id'],
             metadata=RecordingRecommendationMetadata(recording_mbid="34c208ee-2de7-4d38-b47e-907074866dd3")
         )

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -35,6 +35,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         ]
         for fb in sample_feedback:
             db_feedback.insert(
+                self.db_conn,
                 Feedback(
                     user_id=user_id,
                     recording_msid=fb["recording_msid"],
@@ -65,6 +66,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         ]
         for fb in sample_feedback:
             db_feedback.insert(
+                self.db_conn,
                 Feedback(
                     user_id=user_id,
                     recording_msid=fb.get("recording_msid"),
@@ -294,7 +296,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_msid, feedback["recording_msid"])
@@ -316,7 +318,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets updated
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_msid, updated_feedback["recording_msid"])
@@ -343,7 +345,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
@@ -365,7 +367,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets updated
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, updated_feedback["recording_mbid"])
@@ -392,7 +394,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_msid, feedback["recording_msid"])
@@ -414,7 +416,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets deleted
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 0)
 
     def test_recording_mbid_feedback_delete_when_score_is_zero(self):
@@ -438,7 +440,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
@@ -460,7 +462,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets deleted
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 0)
 
     def test_get_feedback_for_user(self):
@@ -1329,6 +1331,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         ]
         for fb in sample_feedback:
             db_feedback.insert(
+                self.db_conn,
                 Feedback(
                     user_id=user_id,
                     recording_msid=fb["recording_msid"],

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -3,11 +3,10 @@ from unittest import mock
 
 import requests_mock
 
-from brainzutils import cache
-
 import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.user as db_user
 from listenbrainz import messybrainz
+from listenbrainz.db import timescale
 from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.tests.integration import IntegrationTestCase
 
@@ -17,9 +16,10 @@ class FeedbackAPITestCase(IntegrationTestCase):
         super(FeedbackAPITestCase, self).setUp()
         self.user = db_user.get_or_create(1, "testuserpleaseignore")
         self.user2 = db_user.get_or_create(2, "anothertestuserpleaseignore")
+        self.ts_conn = timescale.engine.connect()
 
     def tearDown(self):
-        cache._r.flushall()
+        self.ts_conn.close()
         super(FeedbackAPITestCase, self).tearDown()
 
     def insert_test_data(self, user_id):
@@ -296,7 +296,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_msid, feedback["recording_msid"])
@@ -318,7 +318,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets updated
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_msid, updated_feedback["recording_msid"])
@@ -345,7 +345,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
@@ -367,7 +367,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets updated
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, updated_feedback["recording_mbid"])
@@ -394,7 +394,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_msid, feedback["recording_msid"])
@@ -416,7 +416,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets deleted
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 0)
 
     def test_recording_mbid_feedback_delete_when_score_is_zero(self):
@@ -440,7 +440,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
@@ -462,7 +462,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets deleted
-        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.ts_conn,  self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 0)
 
     def test_get_feedback_for_user(self):

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -14,8 +14,8 @@ from listenbrainz.tests.integration import IntegrationTestCase
 class FeedbackAPITestCase(IntegrationTestCase):
     def setUp(self):
         super(FeedbackAPITestCase, self).setUp()
-        self.user = db_user.get_or_create(1, "testuserpleaseignore")
-        self.user2 = db_user.get_or_create(2, "anothertestuserpleaseignore")
+        self.user = db_user.get_or_create(self.db_conn, 1, "testuserpleaseignore")
+        self.user2 = db_user.get_or_create(self.db_conn, 2, "anothertestuserpleaseignore")
         self.ts_conn = timescale.engine.connect()
 
     def tearDown(self):
@@ -1317,7 +1317,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
                 "release": "Lucifer"
             }
         ]
-        submitted_data = messybrainz.insert_all_in_transaction(recordings)
+        submitted_data = messybrainz.insert_all_in_transaction(self.ts_conn, recordings)
 
         sample_feedback = [
             {

--- a/listenbrainz/tests/integration/test_fresh_release_api.py
+++ b/listenbrainz/tests/integration/test_fresh_release_api.py
@@ -10,7 +10,7 @@ class FreshReleasesTestCase(IntegrationTestCase):
 
     def setUp(self):
         super(FreshReleasesTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, "testuserpleaseignore")
+        self.user = db_user.get_or_create(self.db_conn, 1, "testuserpleaseignore")
 
         with open(self.path_to_data_file("user_fresh_releases.json")) as f:
             self.expected = json.load(f)

--- a/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
+++ b/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
@@ -3,12 +3,13 @@ import json
 import listenbrainz.db.user as db_user
 import listenbrainz.db.missing_musicbrainz_data as db_missing_musicbrainz_data
 from data.model.user_missing_musicbrainz_data import UserMissingMusicBrainzDataJson
+from listenbrainz.db import timescale
 from listenbrainz.tests.integration import IntegrationTestCase
 
 
 class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
     def setUp(self):
-        super(MissingMusicBrainzDataViewsTestCase, self).setUp()
+        IntegrationTestCase.setUp(self)
 
         self.user = db_user.get_or_create(1, 'vansika_1')
         self.user2 = db_user.get_or_create(2, 'vansika_2')
@@ -17,12 +18,22 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
             missing_musicbrainz_data = json.load(f)
 
         db_missing_musicbrainz_data.insert_user_missing_musicbrainz_data(
+            self.db_conn,
             user_id=self.user['id'],
             missing_musicbrainz_data=UserMissingMusicBrainzDataJson(missing_musicbrainz_data=missing_musicbrainz_data),
             source='cf'
         )
+        self.ts_conn = timescale.engine.connect()
+        self.data = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(
+            self.db_conn,
+            self.ts_conn,
+            user_id=self.user['id'],
+            source='cf'
+        )
 
-        self.data = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(user_id=self.user['id'], source='cf')
+    def tearDown(self):
+        self.ts_conn.close()
+        IntegrationTestCase.tearDown(self)
 
     def test_invalid_user(self):
         response = self.client.get(self.custom_url_for('missing_musicbrainz_data_v1.get_missing_musicbrainz_data',

--- a/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
+++ b/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
@@ -11,8 +11,8 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
     def setUp(self):
         IntegrationTestCase.setUp(self)
 
-        self.user = db_user.get_or_create(1, 'vansika_1')
-        self.user2 = db_user.get_or_create(2, 'vansika_2')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'vansika_1')
+        self.user2 = db_user.get_or_create(self.db_conn, 2, 'vansika_2')
 
         with open(self.path_to_data_file('missing_musicbrainz_data.json'), 'r') as f:
             missing_musicbrainz_data = json.load(f)

--- a/listenbrainz/tests/integration/test_pinned_recording_api.py
+++ b/listenbrainz/tests/integration/test_pinned_recording_api.py
@@ -22,9 +22,9 @@ class PinnedRecAPITestCase(IntegrationTestCase):
 
     def setUp(self):
         super(PinnedRecAPITestCase, self).setUp()
-        self.user = db_user.get_or_create(1, "test_user_1")
-        self.followed_user_1 = db_user.get_or_create(2, "followed_user_1")
-        self.followed_user_2 = db_user.get_or_create(3, "followed_user_2")
+        self.user = db_user.get_or_create(self.db_conn, 1, "test_user_1")
+        self.followed_user_1 = db_user.get_or_create(self.db_conn, 2, "followed_user_1")
+        self.followed_user_2 = db_user.get_or_create(self.db_conn, 3, "followed_user_2")
 
         self.pinned_rec_samples = [
             {

--- a/listenbrainz/tests/integration/test_pinned_recording_api.py
+++ b/listenbrainz/tests/integration/test_pinned_recording_api.py
@@ -14,7 +14,7 @@ from listenbrainz.db.model.pinned_recording import (
 import json
 
 
-def fetch_track_metadata_for_pins(pins: List[PinnedRecording]) -> List[PinnedRecording]:
+def fetch_track_metadata_for_pins(ts_conn, pins: List[PinnedRecording]) -> List[PinnedRecording]:
     return pins
 
 

--- a/listenbrainz/tests/integration/test_pinned_recording_api.py
+++ b/listenbrainz/tests/integration/test_pinned_recording_api.py
@@ -467,8 +467,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_get_pins_for_user_following(self):
         """Test that valid response is received with 200 code"""
         # user follows followed_user_1 and followed_user_2
-        db_user_relationship.insert(self.user["id"], self.followed_user_1["id"], "follow")
-        db_user_relationship.insert(self.user["id"], self.followed_user_2["id"], "follow")
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_1["id"], "follow")
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_2["id"], "follow")
 
         pin1 = self.pin_single_sample(self.followed_user_1["id"], 0)  # pin recording for followed_user_1
         pin2 = self.pin_single_sample(self.followed_user_2["id"], 1)  # pin recording for followed_user_2
@@ -511,8 +511,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_get_pins_for_user_count_param_2(self):
         """Tests that valid response is received honoring count parameter"""
         # user follows followed_user_1 and followed_user_2
-        db_user_relationship.insert(self.user["id"], self.followed_user_1["id"], "follow")
-        db_user_relationship.insert(self.user["id"], self.followed_user_2["id"], "follow")
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_1["id"], "follow")
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_2["id"], "follow")
 
         self.pin_single_sample(self.followed_user_1["id"], 0)  # pin recording for followed_user_1
         included_pin = self.pin_single_sample(self.followed_user_2["id"], 1)  # pin recording for followed_user_2
@@ -562,8 +562,8 @@ class PinnedRecAPITestCase(IntegrationTestCase):
     def test_get_pins_for_user_following_offset_param(self):
         """Tests that valid response is received honoring offset parameter"""
         # user follows followed_user_1 and followed_user_2
-        db_user_relationship.insert(self.user["id"], self.followed_user_1["id"], "follow")
-        db_user_relationship.insert(self.user["id"], self.followed_user_2["id"], "follow")
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_1["id"], "follow")
+        db_user_relationship.insert(self.db_conn, self.user["id"], self.followed_user_2["id"], "follow")
 
         included_pin = self.pin_single_sample(self.followed_user_1["id"], 0)  # pin recording for followed_user_1
         self.pin_single_sample(self.followed_user_2["id"], 1)  # pin recording for followed_user_2

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -1160,6 +1160,7 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["error"], "Service spotify is not linked. Please link your spotify account first.")
 
         db_oauth.save_token(
+            self.db_conn,
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',
@@ -1182,9 +1183,10 @@ class PlaylistAPITestCase(IntegrationTestCase):
             " to use this feature."
         )
 
-        db_oauth.delete_token(self.user['id'], ExternalServiceType.SPOTIFY, True)
+        db_oauth.delete_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, True)
 
         db_oauth.save_token(
+            self.db_conn,
             user_id=self.user['id'],
             service=ExternalServiceType.SPOTIFY,
             access_token='token',

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -45,10 +45,10 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
     def setUp(self):
         super(PlaylistAPITestCase, self).setUp()
-        self.user = db_user.get_or_create(1, "testuserpleaseignore")
-        self.user2 = db_user.get_or_create(2, "anothertestuserpleaseignore")
-        self.user3 = db_user.get_or_create(3, "troi-bot")
-        self.user4 = db_user.get_or_create(4, "iloveassgaskets")
+        self.user = db_user.get_or_create(self.db_conn, 1, "testuserpleaseignore")
+        self.user2 = db_user.get_or_create(self.db_conn, 2, "anothertestuserpleaseignore")
+        self.user3 = db_user.get_or_create(self.db_conn, 3, "troi-bot")
+        self.user4 = db_user.get_or_create(self.db_conn, 4, "iloveassgaskets")
 
     def test_filter_description(self):
         """Check that non-approved html tags are filtered from descriptions"""

--- a/listenbrainz/tests/integration/test_recommendations_cf_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_api.py
@@ -24,18 +24,24 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
             recordings.append({"recording_mbid": str(uuid.uuid4()), "score": score})
 
         db_recommendations_cf_recording.insert_user_recommendation(
+            self.db_conn,
             self.user['id'],
             UserRecommendationsJson(raw=recordings)
         )
 
         db_recommendations_cf_recording.insert_user_recommendation(
+            self.db_conn,
             self.user2['id'],
             UserRecommendationsJson(raw=[])
         )
 
         # get recommendations
-        self.user_recommendations = db_recommendations_cf_recording.get_user_recommendation(self.user['id'])
-        self.user2_recommendations = db_recommendations_cf_recording.get_user_recommendation(self.user2['id'])
+        self.user_recommendations = db_recommendations_cf_recording.get_user_recommendation(
+            self.db_conn, self.user['id']
+        )
+        self.user2_recommendations = db_recommendations_cf_recording.get_user_recommendation(
+            self.db_conn, self.user2['id']
+        )
 
     def test_invalid_user(self):
         response = self.client.get(

--- a/listenbrainz/tests/integration/test_recommendations_cf_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_api.py
@@ -12,9 +12,9 @@ class CFRecommendationsViewsTestCase(IntegrationTestCase):
     def setUp(self):
         super(CFRecommendationsViewsTestCase, self).setUp()
 
-        self.user = db_user.get_or_create(1, 'vansika_1')
-        self.user2 = db_user.get_or_create(2, 'vansika_2')
-        self.user3 = db_user.get_or_create(3, 'vansika_3')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'vansika_1')
+        self.user2 = db_user.get_or_create(self.db_conn, 2, 'vansika_2')
+        self.user3 = db_user.get_or_create(self.db_conn, 3, 'vansika_3')
 
         # generate test data
         data = {"recording_mbid": []}

--- a/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
@@ -10,9 +10,9 @@ from listenbrainz.tests.integration import IntegrationTestCase
 class RecommendationFeedbackAPITestCase(IntegrationTestCase):
     def setUp(self):
         super(RecommendationFeedbackAPITestCase, self).setUp()
-        self.user = db_user.get_or_create(1, "vansika")
-        self.user1 = db_user.get_or_create(2, "vansika_1")
-        self.user2 = db_user.get_or_create(3, "vansika_2")
+        self.user = db_user.get_or_create(self.db_conn, 1, "vansika")
+        self.user1 = db_user.get_or_create(self.db_conn, 2, "vansika_1")
+        self.user2 = db_user.get_or_create(self.db_conn, 3, "vansika_2")
 
     def insert_test_data(self):
         sample_feedback = [

--- a/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
+++ b/listenbrainz/tests/integration/test_recommendations_cf_recording_feedback_api.py
@@ -30,6 +30,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
 
         for fb in sample_feedback:
             db_feedback.insert(
+                self.db_conn,
                 RecommendationFeedbackSubmit(
                     user_id=fb['user_id'],
                     recording_mbid=fb["recording_mbid"],
@@ -204,7 +205,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
@@ -226,7 +227,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets updated
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, updated_feedback["recording_mbid"])
@@ -248,7 +249,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["status"], "ok")
 
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].user_id, self.user["id"])
         self.assertEqual(result[0].recording_mbid, feedback["recording_mbid"])
@@ -266,7 +267,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["status"], "ok")
 
         # check that the record gets deleted
-        result = db_feedback.get_feedback_for_user(self.user["id"], limit=25, offset=0)
+        result = db_feedback.get_feedback_for_user(self.db_conn, self.user["id"], limit=25, offset=0)
         self.assertEqual(len(result), 0)
 
     def test_recommendation_feedback_delete_unauthorised_submission(self):
@@ -414,6 +415,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         for i in range(110):
             rec_mbid = str(uuid.uuid4())
             db_feedback.insert(
+                self.db_conn,
                 RecommendationFeedbackSubmit(
                     user_id=self.user2['id'],
                     recording_mbid=rec_mbid,
@@ -540,7 +542,7 @@ class RecommendationFeedbackAPITestCase(IntegrationTestCase):
         self.assertEqual(feedback[1]["recording_mbid"], rec_mbid_1)
         self.assertEqual(feedback[1]["rating"], sample_feedback[0]["rating"])
 
-    def test_get_feedback_for_user_invalid_user(self):
+    def test_get_feedback_for_user_invalid_user_404(self):
         """ Test to make sure that the API sends 404 if user does not exist. """
         response = self.client.get(
             self.custom_url_for("recommendation_feedback_api_v1.get_feedback_for_recordings_for_user",

--- a/listenbrainz/tests/integration/test_settings_views.py
+++ b/listenbrainz/tests/integration/test_settings_views.py
@@ -12,8 +12,8 @@ from listenbrainz.tests.integration import IntegrationTestCase
 class SettingsViewsTestCase(IntegrationTestCase):
     def setUp(self):
         super().setUp()
-        self.user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(self.user['musicbrainz_id'])
+        self.user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, self.user['musicbrainz_id'])
         self.redis = cache._r
 
     def tearDown(self):

--- a/listenbrainz/tests/integration/test_spotify_read_listens.py
+++ b/listenbrainz/tests/integration/test_spotify_read_listens.py
@@ -20,7 +20,7 @@ class SpotifyReaderTestCase(ListenAPIIntegrationTestCase):
         self.ctx = self.app.test_request_context()
         self.ctx.push()
 
-        external_service_oauth.save_token(user_id=self.user['id'],
+        external_service_oauth.save_token(self.db_conn, user_id=self.user['id'],
                                           service=ExternalServiceType.SPOTIFY,
                                           access_token='token', refresh_token='refresh',
                                           token_expires_ts=int(time.time()) + 3000,

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -58,9 +58,9 @@ class StatsAPITestCase(IntegrationTestCase):
         # app context
         super(StatsAPITestCase, self).setUp()
         self.app.config["DEBUG"] = True
-        self.user = db_user.get_or_create(1, 'testuserpleaseignore')
-        self.another_user = db_user.get_or_create(1999, 'another_user')
-        self.no_stat_user = db_user.get_or_create(222222, 'nostatuser')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testuserpleaseignore')
+        self.another_user = db_user.get_or_create(self.db_conn, 1999, 'another_user')
+        self.no_stat_user = db_user.get_or_create(self.db_conn, 222222, 'nostatuser')
 
         with open(self.path_to_data_file('user_top_artists_db_data_for_api_test.json'), 'r') as f:
             self.user_artist_payload = json.load(f)

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -38,7 +38,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         return response
 
     def test_dedup(self):
-        user = db_user.get_or_create(1, 'testtimescaleuser %d' % randint(1,50000))
+        user = db_user.get_or_create(self.db_conn, 1, 'testtimescaleuser %d' % randint(1,50000))
 
         # send the same listen twice
         r = self.send_listen(user, 'valid_single.json')
@@ -59,7 +59,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         day in redis for each successful batch written and to see if the user
         timestamps via the timescale listen store are updated in redis.
         """
-        user = db_user.get_or_create(1, 'testtimescaleuser %d' % randint(1, 50000))
+        user = db_user.get_or_create(self.db_conn, 1, 'testtimescaleuser %d' % randint(1, 50000))
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
 
@@ -72,7 +72,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
 
     def test_dedup_user_special_characters(self):
 
-        user = db_user.get_or_create(2, 'i have a\\weird\\user, name"\n')
+        user = db_user.get_or_create(self.db_conn, 2, 'i have a\\weird\\user, name"\n')
 
         # send the same listen twice
         r = self.send_listen(user, 'valid_single.json')
@@ -86,7 +86,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
 
     def test_dedup_same_batch(self):
 
-        user = db_user.get_or_create(3, 'phifedawg')
+        user = db_user.get_or_create(self.db_conn, 3, 'phifedawg')
         r = self.send_listen(user, 'same_batch_duplicates.json')
         self.assert200(r)
 
@@ -101,8 +101,8 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         but different users to be duplicates
         """
 
-        user1 = db_user.get_or_create(1, 'testuser1')
-        user2 = db_user.get_or_create(2, 'testuser2')
+        user1 = db_user.get_or_create(self.db_conn, 1, 'testuser1')
+        user2 = db_user.get_or_create(self.db_conn, 2, 'testuser2')
 
         r = self.send_listen(user1, 'valid_single.json')
         self.assert200(r)
@@ -122,7 +122,7 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
             they don't get considered as duplicates
         """
 
-        user = db_user.get_or_create(1, 'difftracksametsuser')
+        user = db_user.get_or_create(self.db_conn, 1, 'difftracksametsuser')
 
         # send four different tracks with the same timestamp
         r = self.send_listen(user, 'valid_single.json')

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -3,26 +3,19 @@ import time
 from datetime import datetime
 from random import randint
 
-from listenbrainz.db.testing import TimescaleTestCase
-
 import listenbrainz.db.user as db_user
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
-from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.tests.integration import NonAPIIntegrationTestCase
 from listenbrainz.webserver import redis_connection, timescale_connection
 
 
-class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
+class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
 
     def setUp(self):
-        IntegrationTestCase.setUp(self)
-        TimescaleTestCase.setUp(self)
+        super(TimescaleWriterTestCase, self).setUp()
         self.ls = timescale_connection._ts
         self.rs = redis_connection._redis
-
-    def tearDown(self):
-        IntegrationTestCase.tearDown(self)
-        TimescaleTestCase.tearDown(self)
 
     def send_listen(self, user, filename):
         with open(self.path_to_data_file(filename)) as f:
@@ -69,7 +62,6 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         self.assertEqual(min_ts, datetime.utcfromtimestamp(1486449409))
         self.assertEqual(max_ts, datetime.utcfromtimestamp(1486449409))
 
-
     def test_dedup_user_special_characters(self):
 
         user = db_user.get_or_create(self.db_conn, 2, 'i have a\\weird\\user, name"\n')
@@ -83,7 +75,6 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
-
     def test_dedup_same_batch(self):
 
         user = db_user.get_or_create(self.db_conn, 3, 'phifedawg')
@@ -93,7 +84,6 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
         to_ts = datetime.utcnow()
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
-
 
     def test_dedup_different_users(self):
         """
@@ -115,7 +105,6 @@ class TimescaleWriterTestCase(IntegrationTestCase, TimescaleTestCase):
 
         listens, _, _ = self.ls.fetch_listens(user2, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
-
 
     def test_dedup_same_timestamp_different_tracks(self):
         """ Test to check that if there are two tracks w/ the same timestamp,

--- a/listenbrainz/tests/integration/test_user_settings_api.py
+++ b/listenbrainz/tests/integration/test_user_settings_api.py
@@ -49,7 +49,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json["error"], "Something went wrong! Unable to update timezone right now.")
 
     def test_valid_update_timezone(self):
-        tz = db_user_setting.get(self.user["id"])
+        tz = db_user_setting.get(self.db_conn, self.user["id"])
         self.assertEqual(tz["timezone_name"], "UTC")
 
         response = self.client.post(
@@ -59,7 +59,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         )
         self.assert200(response)
 
-        tz = db_user_setting.get(self.user["id"])
+        tz = db_user_setting.get(self.db_conn, self.user["id"])
         self.assertEqual(tz["timezone_name"], "Europe/Madrid")
 
     def test_invalid_troi_prefs(self):
@@ -80,7 +80,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json["error"], "export_to_spotify key in the JSON document must be a boolean")
 
     def test_valid_troi_prefs(self):
-        prefs = db_user_setting.get_troi_prefs(self.user["id"])
+        prefs = db_user_setting.get_troi_prefs(self.db_conn, self.user["id"])
         self.assertEqual(prefs, None)
 
         response = self.client.post(
@@ -90,5 +90,5 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
         )
         self.assert200(response)
 
-        prefs = db_user_setting.get_troi_prefs(self.user["id"])
+        prefs = db_user_setting.get_troi_prefs(self.db_conn, self.user["id"])
         self.assertEqual(prefs, {"troi": {"export_to_spotify": True}})

--- a/listenbrainz/tests/integration/test_user_settings_api.py
+++ b/listenbrainz/tests/integration/test_user_settings_api.py
@@ -7,7 +7,7 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(UserSettingsAPITestCase, self).setUp()
-        self.user = db_user.get_or_create(271, 'unfriendly neighborhood spider-man')
+        self.user = db_user.get_or_create(self.db_conn, 271, 'unfriendly neighborhood spider-man')
 
     def test_validates_auth_header(self):
         """ Test the preferences endpoints validate auth header """

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -37,7 +37,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def setUp(self):
         super(UserTimelineAPITestCase, self).setUp()
-        self.user = db_user.get_or_create(199, 'friendly neighborhood spider-man')
+        self.user = db_user.get_or_create(self.db_conn, 199, 'friendly neighborhood spider-man')
         with self.app.app_context():
             CritiqueBrainzService().add_new_user(self.user['id'], {
                 "access_token": "foobar",
@@ -196,7 +196,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_post_notification_success(self):
         metadata = {"message": 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'}
-        approved_user = db_user.get_or_create(11, "troi-bot")
+        approved_user = db_user.get_or_create(self.db_conn, 11, "troi-bot")
         r = self.client.post(
             self.custom_url_for('user_timeline_event_api_bp.create_user_notification_event',
                                 user_name=self.user['musicbrainz_id']),
@@ -207,7 +207,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_get_notification_event(self):
         metadata = {"message": 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'}
-        approved_user = db_user.get_or_create(11, "troi-bot")
+        approved_user = db_user.get_or_create(self.db_conn, 11, "troi-bot")
         r = self.client.post(
             self.custom_url_for('user_timeline_event_api_bp.create_user_notification_event',
                                 user_name=self.user['musicbrainz_id']),
@@ -235,7 +235,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_delete_feed_events(self):
         # Adding notification to the db
         metadata_not = {"message": 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'}
-        approved_user = db_user.get_or_create(11, "troi-bot")
+        approved_user = db_user.get_or_create(self.db_conn, 11, "troi-bot")
         r = self.client.post(
             self.custom_url_for('user_timeline_event_api_bp.create_user_notification_event',
                                 user_name=self.user['musicbrainz_id']),
@@ -245,7 +245,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assert200(r)
         notification_event_id = r.json["id"]
         # Adding recording recommendation to db
-        new_user = db_user.get_or_create(202, "riksucks")
+        new_user = db_user.get_or_create(self.db_conn, 202, "riksucks")
         metadata_rec = {
             'artist_name': 'Nujabes',
             'track_name': 'Aruarian Dance',
@@ -296,7 +296,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_delete_feed_events_token_for_authorization(self):
         # Adding notification to the db
         metadata_not = {"message": 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'}
-        approved_user = db_user.get_or_create(11, "troi-bot")
+        approved_user = db_user.get_or_create(self.db_conn, 11, "troi-bot")
         self.client.post(
             self.custom_url_for('user_timeline_event_api_bp.create_user_notification_event',
                                 user_name=self.user['musicbrainz_id']),
@@ -311,7 +311,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         )
         self.assert401(r_not)
         # Adding recording recommendation to db
-        new_user = db_user.get_or_create(2, "riksucks")
+        new_user = db_user.get_or_create(self.db_conn, 2, "riksucks")
         metadata_rec = {
             'artist_name': 'Nujabes',
             'track_name': 'Aruarian Dance',
@@ -339,7 +339,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         # Adding notification to the db
         metadata_not = {"message": 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'}
-        approved_user = db_user.get_or_create(11, "troi-bot")
+        approved_user = db_user.get_or_create(self.db_conn, 11, "troi-bot")
         self.client.post(
             self.custom_url_for('user_timeline_event_api_bp.create_user_notification_event',
                                 user_name=self.user['musicbrainz_id']),
@@ -360,7 +360,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_delete_feed_events_for_bad_request(self):
         # Adding notification to the db
         metadata_not = {"message": 'You have a <a href="https://listenbrainz.org/non-existent-playlist">playlist</a>'}
-        approved_user = db_user.get_or_create(11, "troi-bot")
+        approved_user = db_user.get_or_create(self.db_conn, 11, "troi-bot")
         self.client.post(
             self.custom_url_for('user_timeline_event_api_bp.create_user_notification_event',
                                 user_name=self.user['musicbrainz_id']),
@@ -378,7 +378,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_hide_events(self):
         # creating a new user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
@@ -410,7 +410,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_hide_events_tokens_for_authorization(self):
         # creating a new user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
@@ -441,7 +441,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_hide_events_for_non_followed_users(self):
         # creating a new user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
@@ -477,7 +477,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.app.config["TESTING"] = False
 
         # creating a new user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
@@ -509,7 +509,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_hide_events_for_bad_request(self):
         # creating a new user
-        new_user = db_user.get_or_create(2, 'riksucks')
+        new_user = db_user.get_or_create(self.db_conn, 2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
             self.db_conn,
@@ -740,7 +740,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_get_cb_review_events(self, mock_requests):
         self.maxDiff = None
 
-        user_2 = db_user.get_or_create(201, 'not your friendly neighborhood spider-man')
+        user_2 = db_user.get_or_create(self.db_conn, 201, 'not your friendly neighborhood spider-man')
         with self.app.app_context():
             CritiqueBrainzService().add_new_user(user_2['id'], {
                 "access_token": "bazbar",
@@ -862,8 +862,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
     def test_personal_recommendation_writes_to_db(self):
         # Let's create 2 users, who follow the request sender
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
@@ -896,8 +896,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(metadata, received)
 
     def test_personal_recommendation_checks_auth_token(self):
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
@@ -919,8 +919,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assert401(r)
 
     def test_personal_recommendation_checks_json_metadata(self):
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
@@ -937,8 +937,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     @mock.patch('listenbrainz.db.user_timeline_event.create_personal_recommendation_event',
                 side_effect=DatabaseException)
     def test_personal_recommendation_handles_db_exceptions(self, mock_create_event):
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
@@ -960,8 +960,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual('Something went wrong, please try again.', data['error'])
 
     def test_personal_recommendation_errors_when_different_token_used(self):
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
@@ -983,8 +983,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual("You don't have permissions to post to this user's timeline.", data['error'])
 
     def test_personal_recommendation_not_for_non_followers(self):
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         # Only riksucks is following
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
@@ -1008,8 +1008,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
                          data['error'])
 
     def test_personal_recommendation_not_for_non_followers_peter_k(self):
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
 
@@ -1032,8 +1032,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
                          data['error'])
 
     def test_personal_recommendation_stays_after_unfollowing(self):
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
@@ -1074,8 +1074,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_personal_recommendation_mbid_only(self):
         """ Test that we can recommend a recording with only mbid """
         # Let's create 2 users, who follow the request sender
-        user_one = db_user.get_or_create(2, "riksucks")
-        user_two = db_user.get_or_create(3, "hrik2001")
+        user_one = db_user.get_or_create(self.db_conn, 2, "riksucks")
+        user_two = db_user.get_or_create(self.db_conn, 3, "hrik2001")
 
         db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
         db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -391,7 +391,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         )
 
         # user starts following riksucks
-        db_user_relationship.insert(self.user['id'], new_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.user['id'], new_user['id'], 'follow')
 
         # send request to hide event
         r = self.client.post(
@@ -423,7 +423,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         )
 
         # user starts following riksucks
-        db_user_relationship.insert(self.user['id'], new_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.user['id'], new_user['id'], 'follow')
 
         # send request to hide event
         r = self.client.post(
@@ -490,7 +490,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         )
 
         # user starts following riksucks
-        db_user_relationship.insert(self.user['id'], new_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.user['id'], new_user['id'], 'follow')
 
         # send request to hide event
         r = self.client.post(
@@ -522,7 +522,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         )
 
         # user starts following riksucks
-        db_user_relationship.insert(self.user['id'], new_user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.user['id'], new_user['id'], 'follow')
 
         # send request to hide event
         r = self.client.post(
@@ -828,7 +828,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
             }
         })
 
-        db_user_relationship.insert(self.user['id'], user_2['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, self.user['id'], user_2['id'], 'follow')
 
         r = self.client.get(
             self.custom_url_for('user_timeline_event_api_bp.user_feed', user_name=self.user['musicbrainz_id']),
@@ -865,8 +865,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
-        db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
         metadata = {
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
@@ -899,8 +899,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
-        db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
         metadata = {
             "track_name": "Natkhat",
             "artist_name": "Seedhe Maut",
@@ -922,8 +922,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
-        db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
         metadata = {}
 
         r = self.client.post(
@@ -940,8 +940,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
-        db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
         metadata = {
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
@@ -963,8 +963,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
-        db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
         metadata = {
             "recording_mbid": str(uuid.uuid4()),
             "recording_msid": str(uuid.uuid4()),
@@ -987,7 +987,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_two = db_user.get_or_create(3, "hrik2001")
 
         # Only riksucks is following
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
 
         metadata = {
             "recording_mbid": str(uuid.uuid4()),
@@ -1011,7 +1011,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
 
         metadata = {
             "recording_mbid": str(uuid.uuid4()),
@@ -1035,8 +1035,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
-        db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
 
         metadata = {
             "recording_mbid": str(uuid.uuid4()),
@@ -1053,7 +1053,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         )
 
         self.assert200(r)
-        db_user_relationship.delete(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.delete(self.db_conn, user_two['id'], self.user['id'], 'follow')
 
         events = db_user_timeline_event.get_personal_recommendation_events_for_feed(
             self.db_conn,
@@ -1077,8 +1077,8 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         user_one = db_user.get_or_create(2, "riksucks")
         user_two = db_user.get_or_create(3, "hrik2001")
 
-        db_user_relationship.insert(user_one['id'], self.user['id'], 'follow')
-        db_user_relationship.insert(user_two['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_one['id'], self.user['id'], 'follow')
+        db_user_relationship.insert(self.db_conn, user_two['id'], self.user['id'], 'follow')
         metadata = {
             "recording_mbid": "34c208ee-2de7-4d38-b47e-907074866dd3",
             "users": [user_one['musicbrainz_id'], user_two['musicbrainz_id']],

--- a/listenbrainz/tests/integration/test_user_timeline_event_api.py
+++ b/listenbrainz/tests/integration/test_user_timeline_event_api.py
@@ -67,6 +67,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assert200(r)
 
         events = db_user_timeline_event.get_recording_recommendation_events_for_feed(
+            self.db_conn,
             user_ids=[self.user['id']],
             min_ts=0,
             max_ts=int(time.time()) + 1000,
@@ -87,6 +88,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assert200(r)
 
         events = db_user_timeline_event.get_recording_recommendation_events_for_feed(
+            self.db_conn,
             user_ids=[self.user['id']],
             min_ts=0,
             max_ts=int(time.time()) + 1000,
@@ -121,6 +123,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         # check that no events were created in the database
         events = db_user_timeline_event.get_recording_recommendation_events_for_feed(
+            self.db_conn,
             user_ids=[self.user['id']],
             min_ts=0,
             max_ts=int(time.time()) + 1000,
@@ -378,6 +381,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         new_user = db_user.get_or_create(2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=new_user['id'],
             metadata=RecordingRecommendationMetadata(
                 track_name="All Caps",
@@ -409,6 +413,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         new_user = db_user.get_or_create(2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=new_user['id'],
             metadata=RecordingRecommendationMetadata(
                 track_name="All Caps",
@@ -439,6 +444,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         new_user = db_user.get_or_create(2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=new_user['id'],
             metadata=RecordingRecommendationMetadata(
                 track_name="All Caps",
@@ -474,6 +480,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         new_user = db_user.get_or_create(2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=new_user['id'],
             metadata=RecordingRecommendationMetadata(
                 track_name="All Caps",
@@ -505,6 +512,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         new_user = db_user.get_or_create(2, 'riksucks')
         # creating an event
         event_rec = db_user_timeline_event.create_user_track_recommendation_event(
+            self.db_conn,
             user_id=new_user['id'],
             metadata=RecordingRecommendationMetadata(
                 track_name="All Caps",
@@ -530,6 +538,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_unhide_events(self):
         # add dummy event
         db_user_timeline_event.hide_user_timeline_event(
+            self.db_conn,
             self.user['id'],
             UserTimelineEventType.RECORDING_RECOMMENDATION.value,
             1
@@ -552,6 +561,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_unhide_events_for_authorization(self):
         # add dummy event
         db_user_timeline_event.hide_user_timeline_event(
+            self.db_conn,
             self.user['id'],
             UserTimelineEventType.RECORDING_RECOMMENDATION.value,
             1
@@ -573,6 +583,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
     def test_unhide_events_for_bad_request(self):
         # add dummy event
         db_user_timeline_event.hide_user_timeline_event(
+            self.db_conn,
             self.user['id'],
             UserTimelineEventType.RECORDING_RECOMMENDATION.value,
             1
@@ -604,6 +615,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         # add dummy event
         db_user_timeline_event.hide_user_timeline_event(
+            self.db_conn,
             self.user['id'],
             UserTimelineEventType.RECORDING_RECOMMENDATION.value,
             1
@@ -642,6 +654,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(review_id, data["metadata"]["review_id"])
 
         events = db_user_timeline_event.get_cb_review_events(
+            self.db_conn,
             user_ids=[self.user['id']],
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -671,6 +684,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
 
         # check that no events were created in the database
         events = db_user_timeline_event.get_cb_review_events(
+            self.db_conn,
             user_ids=[self.user['id']],
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -869,6 +883,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assert200(r)
 
         events = db_user_timeline_event.get_personal_recommendation_events_for_feed(
+            self.db_conn,
             user_id=self.user['id'],
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -1041,6 +1056,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         db_user_relationship.delete(user_two['id'], self.user['id'], 'follow')
 
         events = db_user_timeline_event.get_personal_recommendation_events_for_feed(
+            self.db_conn,
             user_id=self.user['id'],
             min_ts=0,
             max_ts=int(time.time()) + 10,
@@ -1078,6 +1094,7 @@ class UserTimelineAPITestCase(ListenAPIIntegrationTestCase):
         self.assert200(r)
 
         events = db_user_timeline_event.get_personal_recommendation_events_for_feed(
+            self.db_conn,
             user_id=self.user['id'],
             min_ts=0,
             max_ts=int(time.time()) + 10,

--- a/listenbrainz/tests/unit/test_utils.py
+++ b/listenbrainz/tests/unit/test_utils.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from listenbrainz.webserver import create_app
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 
+
 class ListenBrainzUtilsTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/listenbrainz/tests/utils.py
+++ b/listenbrainz/tests/utils.py
@@ -10,14 +10,14 @@ import uuid
 import listenbrainz.db.user as db_user
 
 
-def generate_data(from_date, num_records, user_name):
+def generate_data(db_conn, from_date, num_records, user_name):
     test_data = []
     current_date = to_epoch(from_date)
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if not user:
-        db_user.create(user_name)
-        user = db_user.get_by_mb_id(user_name)
+        db_user.create(db_conn, 1000, user_name)
+        user = db_user.get_by_mb_id(db_conn, user_name)
 
     for i in range(num_records):
         current_date += 1   # Add one second
@@ -34,6 +34,7 @@ def generate_data(from_date, num_records, user_name):
         )
         test_data.append(item)
     return test_data
+
 
 def to_epoch(date):
     return int(time.mktime(date.timetuple()))

--- a/listenbrainz/tests/utils.py
+++ b/listenbrainz/tests/utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-from datetime import datetime
+from datetime import datetime, date
 import time
 import sys
 import os
@@ -12,12 +12,9 @@ import listenbrainz.db.user as db_user
 
 def generate_data(db_conn, from_date, num_records, user_name):
     test_data = []
-    current_date = to_epoch(from_date)
+    current_date = int(time.mktime(from_date.timetuple()))
 
-    user = db_user.get_by_mb_id(db_conn, user_name)
-    if not user:
-        db_user.create(db_conn, 1000, user_name)
-        user = db_user.get_by_mb_id(db_conn, user_name)
+    user = db_user.get_or_create(db_conn, 1000, user_name)
 
     for i in range(num_records):
         current_date += 1   # Add one second
@@ -34,7 +31,3 @@ def generate_data(db_conn, from_date, num_records, user_name):
         )
         test_data.append(item)
     return test_data
-
-
-def to_epoch(date):
-    return int(time.mktime(date.timetuple()))

--- a/listenbrainz/troi/daily_jams.py
+++ b/listenbrainz/troi/daily_jams.py
@@ -25,27 +25,28 @@ def run_post_recommendation_troi_bot():
         make_playlist_from_recommendations(user)
 
 
-def run_daily_jams_troi_bot(create_all):
+def run_daily_jams_troi_bot(db_conn, create_all):
     """ Top level function called hourly to generate daily jams playlists for users
 
     Args:
+        db_conn: database connection
         create_all: whether to create daily jams for all users who follow troi-bot. if false,
         create only for users according to timezone.
     """
     # Now generate daily jams (and other in the future) for users who follow troi bot
-    users = get_users_for_daily_jams(create_all)
+    users = get_users_for_daily_jams(db_conn, create_all)
     existing_urls = get_existing_playlist_urls([x["id"] for x in users], "daily-jams")
     service = SpotifyService()
     for user in users:
         try:
-            run_daily_jams(user, existing_urls.get(user["id"], None), service)
+            run_daily_jams(db_conn, user, existing_urls.get(user["id"], None), service)
             # Add others here
         except Exception:
             current_app.logger.error(f"Cannot create daily-jams for user {user['musicbrainz_id']}:", exc_info=True)
             continue
 
 
-def get_users_for_daily_jams(create_all):
+def get_users_for_daily_jams(db_conn, create_all):
     """ Retrieve users who follow troi bot and had midnight in their timezone less than 59 minutes ago. """
     timezone_filter = "AND EXTRACT('hour' from NOW() AT TIME ZONE COALESCE(us.timezone_name, 'GMT')) = 0"
     query = """
@@ -63,12 +64,11 @@ def get_users_for_daily_jams(create_all):
     """
     if not create_all:
         query += " " + timezone_filter
-    with db.engine.connect() as connection:
-        result = connection.execute(text(query), {
-            "followed": TROI_BOT_USER_ID,
-            "export_preference": SPOTIFY_EXPORT_PREFERENCE
-        })
-        return result.mappings().all()
+    result = db_conn.execute(text(query), {
+        "followed": TROI_BOT_USER_ID,
+        "export_preference": SPOTIFY_EXPORT_PREFERENCE
+    })
+    return result.mappings().all()
 
 
 def make_playlist_from_recommendations(user):
@@ -110,7 +110,7 @@ def _get_spotify_details(user_id, service):
     return None
 
 
-def run_daily_jams(user, existing_url, service):
+def run_daily_jams(db_conn, user, existing_url, service):
     """  Run the daily-jams patch to create the daily playlist for the given user. """
     token = current_app.config["WHITELISTED_AUTH_TOKENS"][0]
     username = user["musicbrainz_id"]
@@ -141,15 +141,18 @@ def run_daily_jams(user, existing_url, service):
             spotify_link = playlist.playlists[0].external_urls
             message += f"""You can also listen it on <a href="{spotify_link}">Spotify!</a>."""
 
-        enter_timeline_notification(username, message)
+        enter_timeline_notification(db_conn, username, message)
 
 
-def enter_timeline_notification(username, message):
+def enter_timeline_notification(db_conn, username, message):
     """
        Helper function for createing a timeline notification for troi-bot
     """
 
-    user = get_by_mb_id(username)
-    create_user_timeline_event(user["id"],
-                               UserTimelineEventType.NOTIFICATION,
-                               NotificationMetadata(creator="troi-bot", message=message))
+    user = get_by_mb_id(db_conn, username)
+    create_user_timeline_event(
+        db_conn,
+        user["id"],
+        UserTimelineEventType.NOTIFICATION,
+        NotificationMetadata(creator="troi-bot", message=message)
+    )

--- a/listenbrainz/troi/spark.py
+++ b/listenbrainz/troi/spark.py
@@ -53,8 +53,8 @@ def get_user_details(slug, user_ids):
 
             if r.export_to_spotify:
                 users_for_urls.append(r.user_id)
-
-    existing_urls = get_existing_playlist_urls(users_for_urls, slug)
+    with timescale.engine.connect() as ts_conn:
+        existing_urls = get_existing_playlist_urls(ts_conn, users_for_urls, slug)
     for user_id, detail in details.items():
         detail["existing_url"] = existing_urls.get(user_id)
 

--- a/listenbrainz/troi/tests/test_spark.py
+++ b/listenbrainz/troi/tests/test_spark.py
@@ -22,8 +22,8 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
         self.user4 = db_user.get_or_create(400, "user4")
         self.user5 = db_user.get_or_create(500, "user5")
 
-        db_user_setting.update_troi_prefs(self.user1["id"], True)
-        db_user_setting.update_troi_prefs(self.user2["id"], False)
+        db_user_setting.update_troi_prefs(self.db_conn, self.user1["id"], True)
+        db_user_setting.update_troi_prefs(self.db_conn, self.user2["id"], False)
         
         db_external_service_oauth.save_token(
             self.user1["id"], 

--- a/listenbrainz/troi/tests/test_spark.py
+++ b/listenbrainz/troi/tests/test_spark.py
@@ -16,11 +16,11 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
 
     def test_get_user_details(self):
         self.maxDiff = None
-        self.user1 = db_user.get_or_create(100, "user1")
-        self.user2 = db_user.get_or_create(200, "user2")
-        self.user3 = db_user.get_or_create(300, "user3")
-        self.user4 = db_user.get_or_create(400, "user4")
-        self.user5 = db_user.get_or_create(500, "user5")
+        self.user1 = db_user.get_or_create(self.db_conn, 100, "user1")
+        self.user2 = db_user.get_or_create(self.db_conn, 200, "user2")
+        self.user3 = db_user.get_or_create(self.db_conn, 300, "user3")
+        self.user4 = db_user.get_or_create(self.db_conn, 400, "user4")
+        self.user5 = db_user.get_or_create(self.db_conn, 500, "user5")
 
         db_user_setting.update_troi_prefs(self.db_conn, self.user1["id"], True)
         db_user_setting.update_troi_prefs(self.db_conn, self.user2["id"], False)

--- a/listenbrainz/troi/tests/test_spark.py
+++ b/listenbrainz/troi/tests/test_spark.py
@@ -26,6 +26,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
         db_user_setting.update_troi_prefs(self.db_conn, self.user2["id"], False)
         
         db_external_service_oauth.save_token(
+            self.db_conn,
             self.user1["id"], 
             ExternalServiceType.SPOTIFY,
             "access_token",
@@ -36,6 +37,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
             "spotify_user_id"
         )
         db_external_service_oauth.save_token(
+            self.db_conn,
             self.user1["id"],
             ExternalServiceType.MUSICBRAINZ_PROD,
             "access_token",
@@ -46,6 +48,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
             "musicbrainz_user_id"
         )
         db_external_service_oauth.save_token(
+            self.db_conn,
             self.user1["id"],
             ExternalServiceType.LASTFM,
             "access_token",
@@ -57,6 +60,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
         )
 
         db_external_service_oauth.save_token(
+            self.db_conn,
             self.user2["id"],
             ExternalServiceType.SPOTIFY,
             "access_token",
@@ -68,6 +72,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
         )
 
         db_external_service_oauth.save_token(
+            self.db_conn,
             self.user4["id"],
             ExternalServiceType.SPOTIFY,
             "access_token",
@@ -79,6 +84,7 @@ class TestSparkPlaylists(DatabaseTestCase, TimescaleTestCase):
         )
 
         db_external_service_oauth.save_token(
+            self.db_conn,
             self.user5["id"],
             ExternalServiceType.LASTFM,
             "access_token",

--- a/listenbrainz/troi/utils.py
+++ b/listenbrainz/troi/utils.py
@@ -5,7 +5,7 @@ from listenbrainz.db import timescale
 SPOTIFY_EXPORT_PREFERENCE = "export_to_spotify"
 
 
-def get_existing_playlist_urls(user_ids: list[int], playlist_slug):
+def get_existing_playlist_urls(ts_conn, user_ids: list[int], playlist_slug):
     """ Retrieve urls of the existing spotify playlists of daily jams users """
     query = """
         SELECT DISTINCT ON (created_for_id)
@@ -16,6 +16,5 @@ def get_existing_playlist_urls(user_ids: list[int], playlist_slug):
            AND created_for_id = ANY(:user_ids)
       ORDER BY created_for_id, created DESC
     """
-    with timescale.engine.connect() as conn:
-        results = conn.execute(text(query), {"user_ids": user_ids, "playlist_slug": playlist_slug})
-        return {r.created_for_id: r.spotify_url for r in results}
+    results = ts_conn.execute(text(query), {"user_ids": user_ids, "playlist_slug": playlist_slug})
+    return {r.created_for_id: r.spotify_url for r in results}

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -13,7 +13,6 @@ from werkzeug.local import LocalProxy
 from listenbrainz import db
 from listenbrainz.db import create_test_database_connect_strings, timescale
 from listenbrainz.db.timescale import create_test_timescale_connect_strings
-from listenbrainz.webserver.utils import get_global_props
 
 API_PREFIX = '/1'
 
@@ -130,10 +129,12 @@ def create_app(debug=None):
         _db_conn = getattr(g, "_db_conn", None)
         if _db_conn is not None:
             _db_conn.close()
+            del g._db_conn
 
         _ts_conn = getattr(g, "_ts_conn", None)
         if _ts_conn is not None:
             _ts_conn.close()
+            del g._ts_conn
 
     # Redis connection
     from listenbrainz.webserver.redis_connection import init_redis_connection
@@ -195,6 +196,7 @@ def create_web_app(debug=None):
     static_manager.read_manifest()
     app.static_folder = '/static'
 
+    from listenbrainz.webserver.utils import get_global_props
     app.context_processor(lambda: dict(
         get_static_path=static_manager.get_static_path,
         global_props=get_global_props()

--- a/listenbrainz/webserver/admin/test_admin.py
+++ b/listenbrainz/webserver/admin/test_admin.py
@@ -6,10 +6,10 @@ class AdminTestCase(IntegrationTestCase):
 
     def setUp(self):
         IntegrationTestCase.setUp(self)
-        self.authorized_user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(self.authorized_user['musicbrainz_id'])
-        self.unauthorized_user = db_user.get_or_create(2, 'blahblahblah')
-        db_user.agree_to_gdpr(self.unauthorized_user['musicbrainz_id'])
+        self.authorized_user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, self.authorized_user['musicbrainz_id'])
+        self.unauthorized_user = db_user.get_or_create(self.db_conn, 2, 'blahblahblah')
+        db_user.agree_to_gdpr(self.db_conn, self.unauthorized_user['musicbrainz_id'])
 
     def test_admin_views_when_not_logged_in(self):
         r = self.client.get('/admin', follow_redirects=True)

--- a/listenbrainz/webserver/login/__init__.py
+++ b/listenbrainz/webserver/login/__init__.py
@@ -3,6 +3,8 @@ from flask_login import LoginManager, UserMixin, current_user
 from functools import wraps
 import listenbrainz.db.user as db_user
 from werkzeug.exceptions import Unauthorized
+
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.errors import APIUnauthorized
 
 login_manager = LoginManager()
@@ -42,10 +44,11 @@ class User(UserMixin):
             "login_id": self.login_id
         }
 
+
 @login_manager.user_loader
 def load_user(user_login_id):
     try:
-        user = db_user.get_by_login_id(user_login_id)
+        user = db_user.get_by_login_id(db_conn, user_login_id)
     except Exception as e:
         current_app.logger.error("Error while getting user by login ID: %s", str(e), exc_info=True)
         return None

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -43,7 +43,7 @@ def search_user():
     """
     search_term = request.args.get("search_term")
     if search_term:
-        users = db_user.search_user_name(search_term, SEARCH_USER_LIMIT)
+        users = db_user.search_user_name(db_conn, search_term, SEARCH_USER_LIMIT)
     else:
         users = []
     return jsonify({'users': users})
@@ -152,7 +152,7 @@ def get_listens(user_name):
     :statuscode 404: The requested user was not found.
     :resheader Content-Type: *application/json*
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
@@ -194,7 +194,7 @@ def get_listen_count(user_name):
     :statuscode 404: The requested user was not found.
     :resheader Content-Type: *application/json*
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
@@ -227,7 +227,7 @@ def get_playing_now(user_name):
     :resheader Content-Type: *application/json*
     """
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
@@ -268,11 +268,11 @@ def get_similar_users(user_name):
     :resheader Content-Type: *application/json*
     :statuscode 404: The requested user was not found.
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if not user:
         raise APINotFound("User %s not found" % user_name)
 
-    similar_users = db_user.get_similar_users(user['id'])
+    similar_users = db_user.get_similar_users(db_conn, user['id'])
     return jsonify({
         "payload": [
             {
@@ -305,11 +305,11 @@ def get_similar_to_user(user_name, other_user_name):
     :resheader Content-Type: *application/json*
     :statuscode 404: The requested user was not found.
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if not user:
         raise APINotFound("User %s not found" % user_name)
 
-    similar_users = db_user.get_similar_users(user['id'])
+    similar_users = db_user.get_similar_users(db_conn, user['id'])
 
     # Constructing an id-similarity map
     id_similarity_map = {r["musicbrainz_id"]: r["similarity"] for r in similar_users}
@@ -361,7 +361,7 @@ def latest_import():
             service = ExternalServiceType[service_name.upper()]
         except KeyError:
             raise APINotFound("Service does not exist: {}".format(service_name))
-        user = db_user.get_by_mb_id(user_name)
+        user = db_user.get_by_mb_id(db_conn, user_name)
         if user is None:
             raise APINotFound("Cannot find user: {user_name}".format(user_name=user_name))
         latest_import_ts = listens_importer.get_latest_listened_at(user["id"], service)
@@ -560,7 +560,7 @@ def get_playlists_for_user(playlist_user_name):
     count = get_non_negative_param(
         'count', DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL)
     offset = get_non_negative_param('offset', 0)
-    playlist_user = db_user.get_by_mb_id(playlist_user_name)
+    playlist_user = db_user.get_by_mb_id(db_conn, playlist_user_name)
     if playlist_user is None:
         raise APINotFound("Cannot find user: %s" % playlist_user_name)
 
@@ -593,7 +593,7 @@ def get_playlists_created_for_user(playlist_user_name):
     count = get_non_negative_param(
         'count', DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL)
     offset = get_non_negative_param('offset', 0)
-    playlist_user = db_user.get_by_mb_id(playlist_user_name)
+    playlist_user = db_user.get_by_mb_id(db_conn, playlist_user_name)
     if playlist_user is None:
         raise APINotFound("Cannot find user: %s" % playlist_user_name)
 
@@ -626,7 +626,7 @@ def get_playlists_collaborated_on_for_user(playlist_user_name):
     count = get_non_negative_param(
         'count', DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL)
     offset = get_non_negative_param('offset', 0)
-    playlist_user = db_user.get_by_mb_id(playlist_user_name)
+    playlist_user = db_user.get_by_mb_id(db_conn, playlist_user_name)
     if playlist_user is None:
         raise APINotFound("Cannot find user: %s" % playlist_user_name)
 
@@ -657,7 +657,7 @@ def user_recommendations(playlist_user_name):
     :resheader Content-Type: *application/json*
     """
 
-    playlist_user = db_user.get_by_mb_id(playlist_user_name)
+    playlist_user = db_user.get_by_mb_id(db_conn, playlist_user_name)
     if playlist_user is None:
         raise APINotFound("Cannot find user: %s" % playlist_user_name)
 

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -4,7 +4,7 @@ import listenbrainz.db.user as db_user
 from collections import defaultdict
 from yattag import Doc
 import yattag
-from flask import Blueprint, request, render_template, current_app, make_response, Response
+from flask import Blueprint, request, render_template, current_app, Response
 from flask_login import login_required, current_user
 from brainzutils.ratelimit import ratelimit
 from brainzutils.musicbrainz_db import engine as mb_engine
@@ -12,14 +12,14 @@ from listenbrainz.webserver.errors import InvalidAPIUsage, CompatError, ListenVa
 import xmltodict
 
 from listenbrainz.webserver.models import SubmitListenUserMetadata
-from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, LISTEN_TYPE_SINGLE, LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW
+from listenbrainz.webserver.views.api_tools import insert_payload, validate_listen, LISTEN_TYPE_SINGLE, LISTEN_TYPE_PLAYING_NOW
 
 from listenbrainz.db.lastfm_user import User
 from listenbrainz.db.lastfm_session import Session
 from listenbrainz.db.lastfm_token import Token
 import calendar
 from datetime import datetime
-from listenbrainz.webserver import timescale_connection
+from listenbrainz.webserver import timescale_connection, db_conn
 
 api_bp = Blueprint('api_compat', __name__)
 
@@ -257,7 +257,7 @@ def record_listens(data):
             raise InvalidAPIUsage(CompatError.INVALID_API_KEY, output_format=output_format)   # Invalid API_KEY
         raise InvalidAPIUsage(CompatError.INVALID_SESSION_KEY, output_format=output_format)   # Invalid Session KEY
 
-    user = db_user.get(session.user_id, fetch_email=True)
+    user = db_user.get(db_conn, session.user_id, fetch_email=True)
     if mb_engine and current_app.config["REJECT_LISTENS_WITHOUT_USER_EMAIL"] and user["email"] is None:
         raise InvalidAPIUsage(CompatError.NO_EMAIL, output_format=output_format)  # No email available for user in LB
 

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -54,7 +54,7 @@ def handshake():
     if request.args.get('hs', '') != 'true':
         return redirect('https://listenbrainz.org/lastfm-proxy')
 
-    user = db_user.get_by_mb_id(request.args.get('u'), fetch_email=True)
+    user = db_user.get_by_mb_id(db_conn, request.args.get('u'), fetch_email=True)
     if user is None:
         return 'BADAUTH\n', 401
 

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -31,6 +31,7 @@ from hashlib import md5
 from flask import current_app, Blueprint, request, redirect
 from werkzeug.exceptions import BadRequest
 from listenbrainz.db.lastfm_session import Session
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.models import SubmitListenUserMetadata
 from listenbrainz.webserver.errors import ListenValidationError
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR
@@ -94,9 +95,8 @@ def submit_now_playing():
     if listen is None:
         return 'FAILED Invalid data submitted!\n', 400
 
-
     listens = [listen]
-    user = db_user.get(session.user_id)
+    user = db_user.get(db_conn, session.user_id)
     user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])
     insert_payload(listens, user_metadata, LISTEN_TYPE_PLAYING_NOW)
 
@@ -125,7 +125,7 @@ def submit_listens():
     if not listens:
         return 'FAILED Invalid data submitted!\n', 400
 
-    user = db_user.get(session.user_id)
+    user = db_user.get(db_conn, session.user_id)
     user_metadata = SubmitListenUserMetadata(user_id=user['id'], musicbrainz_id=user['musicbrainz_id'])
     insert_payload(listens, user_metadata)
 

--- a/listenbrainz/webserver/views/api_compat_deprecated.py
+++ b/listenbrainz/webserver/views/api_compat_deprecated.py
@@ -69,7 +69,7 @@ def handshake():
     if auth_token != _get_audioscrobbler_auth_token(user['auth_token'], timestamp):
         return 'BADAUTH\n', 401
 
-    session = Session.create_by_user_id(user['id'])
+    session = Session.create_by_user_id(db_conn, user['id'])
     current_app.logger.info('New session created with id: {}'.format(session.sid))
 
     return '\n'.join([
@@ -87,7 +87,7 @@ def submit_now_playing():
     current_app.logger.info(json.dumps(request.form, indent=4))
 
     try:
-        session = _get_session(request.form.get('s', ''))
+        session = _get_session(db_conn, request.form.get('s', ''))
     except BadRequest:
         return 'BADSESSION\n', 401
 
@@ -108,7 +108,7 @@ def submit_listens():
     """ Submit listens received from clients into the listenstore after validating them. """
 
     try:
-        session = _get_session(request.form.get('s', ''))
+        session = _get_session(db_conn, request.form.get('s', ''))
     except BadRequest:
         return 'BADSESSION\n', 401
 
@@ -200,14 +200,14 @@ def _to_native_api(data, append_key):
     return listen
 
 
-def _get_session(session_id):
+def _get_session(conn, session_id):
     """ Get the session with the passed session id.
 
         Returns: Session object with given session id
                  If session is not present in db, raises BadRequest
     """
 
-    session = Session.load(session_id)
+    session = Session.load(conn, session_id)
     if session is None:
         raise BadRequest("Session not found")
     return session

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -16,7 +16,7 @@ import sentry_sdk
 from flask import current_app, request
 
 from listenbrainz.listenstore import LISTEN_MINIMUM_TS
-from listenbrainz.webserver import API_LISTENED_AT_ALLOWED_SKEW
+from listenbrainz.webserver import API_LISTENED_AT_ALLOWED_SKEW, db_conn
 from listenbrainz.webserver.errors import APIServiceUnavailable, APIBadRequest, APIUnauthorized, \
     ListenValidationError
 
@@ -477,7 +477,7 @@ def validate_auth_header(*, optional: bool = False, fetch_email: bool = False):
     except IndexError:
         raise APIUnauthorized("Provided Authorization header is invalid.")
 
-    user = db_user.get_by_token(auth_token, fetch_email=fetch_email)
+    user = db_user.get_by_token(db_conn, auth_token, fetch_email=fetch_email)
     if user is None:
         raise APIUnauthorized("Invalid authorization token.")
 

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -9,6 +9,7 @@ from brainzutils.ratelimit import ratelimit
 from flask import request, render_template, Blueprint, current_app
 
 from listenbrainz.art.cover_art_generator import CoverArtGenerator
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.views.api_tools import is_valid_uuid, _parse_bool_arg
@@ -558,7 +559,7 @@ def _cover_art_yim_overview(user_name, stats, year):
 @ratelimit()
 def cover_art_yim(user_name, year: int = 2023):
     """ Create the shareable svg image using YIM stats """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APIBadRequest(f"User {user_name} not found")
 

--- a/listenbrainz/webserver/views/color_api.py
+++ b/listenbrainz/webserver/views/color_api.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify
 
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest
 from brainzutils.ratelimit import ratelimit
@@ -59,7 +60,7 @@ def huesound(color):
     cache_key = HUESOUND_PAGE_CACHE_KEY % (color, count)
     results = cache.get(cache_key, decode=True)
     if not results:
-        results = get_releases_for_color(*color_tuple, count)
+        results = get_releases_for_color(db_conn, *color_tuple, count)
         results = [c.to_api() for c in results]
         cache.set(cache_key, results, DEFAULT_CACHE_EXPIRE_TIME, encode=True)
 

--- a/listenbrainz/webserver/views/do_not_recommend_api.py
+++ b/listenbrainz/webserver/views/do_not_recommend_api.py
@@ -55,8 +55,8 @@ def get_do_not_recommends(user_name):
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
-    results = do_not_recommend.get(user["id"], count, offset)
-    total_count = do_not_recommend.get_total_count(user["id"])
+    results = do_not_recommend.get(db_conn, user["id"], count, offset)
+    total_count = do_not_recommend.get_total_count(db_conn, user["id"])
 
     return jsonify({
         "offset": offset,
@@ -93,7 +93,7 @@ def add_do_not_recommend():
     :resheader Content-Type: *application/json*
     """
     user, entity, entity_mbid, until = _parse_json_params()
-    do_not_recommend.insert(user["id"], entity, entity_mbid, until)
+    do_not_recommend.insert(db_conn, user["id"], entity, entity_mbid, until)
     return jsonify({"status": "ok"})
 
 
@@ -120,7 +120,7 @@ def delete_do_not_recommend():
     :resheader Content-Type: *application/json*
     """
     user, entity, entity_mbid, until = _parse_json_params()
-    do_not_recommend.delete(user["id"], entity, entity_mbid)
+    do_not_recommend.delete(db_conn, user["id"], entity, entity_mbid)
     return jsonify({"status": "ok"})
 
 

--- a/listenbrainz/webserver/views/do_not_recommend_api.py
+++ b/listenbrainz/webserver/views/do_not_recommend_api.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify, request
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db import do_not_recommend
+from listenbrainz.webserver import db_conn
 
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APINotFound, APIBadRequest
@@ -50,7 +51,7 @@ def get_do_not_recommends(user_name):
     count = get_non_negative_param("count", default=DEFAULT_ITEMS_PER_GET)
     count = min(count, MAX_ITEMS_PER_GET)
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -106,7 +106,7 @@ def artist_entity(artist_mbid):
         raise BadRequest("Provided artist mbid is invalid: %s" % artist_mbid)
 
     # Fetch the artist cached data
-    artist_data = get_metadata_for_artist([artist_mbid])
+    artist_data = get_metadata_for_artist(ts_conn, [artist_mbid])
     if len(artist_data) == 0:
         raise NotFound(f"artist {artist_mbid} not found in the metadata cache")
 

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -5,6 +5,7 @@ from flask import Blueprint, render_template, current_app, redirect, url_for
 from listenbrainz.art.cover_art_generator import CoverArtGenerator
 from listenbrainz.db import popularity, similarity
 from listenbrainz.db.stats import get_entity_listener
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.db.metadata import get_metadata_for_artist
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
@@ -145,7 +146,7 @@ def artist_entity(artist_mbid):
 
     release_groups.sort(key=get_release_group_sort_key, reverse=True)
 
-    listening_stats = get_entity_listener("artists", artist_mbid, "all_time")
+    listening_stats = get_entity_listener(db_conn, "artists", artist_mbid, "all_time")
     if listening_stats is None:
         listening_stats = {
             "total_listen_count": 0,
@@ -204,7 +205,7 @@ def album_entity(release_group_mbid):
                 (None, None)
             )
 
-    listening_stats = get_entity_listener("release_groups", release_group_mbid, "all_time")
+    listening_stats = get_entity_listener(db_conn, "release_groups", release_group_mbid, "all_time")
     if listening_stats is None:
         listening_stats = {
             "total_listen_count": 0,

--- a/listenbrainz/webserver/views/explore.py
+++ b/listenbrainz/webserver/views/explore.py
@@ -57,14 +57,14 @@ def fresh_releases():
 @explore_bp.route("/music-neighborhood/")
 def artist_similarity():
     """ Explore artist similarity """
-    ts_conn.execute(text("""
-        SELECT artist_mbid::TEXT
-          FROM popularity.artist
-      ORDER BY total_listen_count DESC
-         LIMIT 1
-    """))
+    result = ts_conn.execute(text("""
+         SELECT artist_mbid::TEXT
+           FROM popularity.artist
+       ORDER BY total_listen_count DESC
+          LIMIT 1
+     """))
 
-    artist_mbid = ts_conn.fetchone()[0]
+    artist_mbid = result.fetchone()[0]
     props = {
         "algorithm": "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30",
         "artist_mbid": artist_mbid

--- a/listenbrainz/webserver/views/explore.py
+++ b/listenbrainz/webserver/views/explore.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import NotFound, BadRequest
 import psycopg2
 
 from listenbrainz.db.similar_users import get_top_similar_users
+from listenbrainz.webserver import db_conn
 
 explore_bp = Blueprint('explore', __name__)
 
@@ -36,7 +37,7 @@ def similar_users():
         and spammers as well.
     """
 
-    similar_users = get_top_similar_users()
+    similar_users = get_top_similar_users(db_conn)
     return render_template(
         "explore/similar-users.html",
         similar_users=similar_users

--- a/listenbrainz/webserver/views/explore.py
+++ b/listenbrainz/webserver/views/explore.py
@@ -1,11 +1,11 @@
-from flask import Blueprint, render_template, current_app, request
+from flask import Blueprint, render_template, request
 from flask_login import current_user
 import orjson
+from sqlalchemy import text
 from werkzeug.exceptions import NotFound, BadRequest
-import psycopg2
 
 from listenbrainz.db.similar_users import get_top_similar_users
-from listenbrainz.webserver import db_conn
+from listenbrainz.webserver import db_conn, ts_conn
 
 explore_bp = Blueprint('explore', __name__)
 
@@ -57,37 +57,32 @@ def fresh_releases():
 @explore_bp.route("/music-neighborhood/")
 def artist_similarity():
     """ Explore artist similarity """
+    ts_conn.execute(text("""
+        SELECT artist_mbid::TEXT
+          FROM popularity.artist
+      ORDER BY total_listen_count DESC
+         LIMIT 1
+    """))
 
-    with psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as ts_conn, \
-            ts_conn.cursor() as ts_curs:
-        ts_curs.execute("""
-                        SELECT artist_mbid::TEXT
-                            FROM popularity.artist
-                            ORDER BY total_listen_count DESC
-                            LIMIT 1
-                            """)
+    artist_mbid = ts_conn.fetchone()[0]
+    props = {
+        "algorithm": "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30",
+        "artist_mbid": artist_mbid
+    }
 
-        artist_mbid = ts_curs.fetchone()[0]
-        current_app.logger.info(artist_mbid)
-
-        props = {
-            "algorithm": "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30",
-            "artist_mbid": artist_mbid
-        }
-
-        return render_template(
-            "explore/music-neighborhood.html",
-            props=orjson.dumps(props).decode("utf-8")
-        )
+    return render_template(
+        "explore/music-neighborhood.html",
+        props=orjson.dumps(props).decode("utf-8")
+    )
 
 
 @explore_bp.route("/art-creator/")
 def art_creator():
-
     return render_template(
         "explore/stats-art-designer.html",
         props=orjson.dumps({}).decode("utf-8")
     )
+
 
 @explore_bp.route("/cover-art-collage/")
 @explore_bp.route("/cover-art-collage/<int:year>/")
@@ -104,11 +99,13 @@ def cover_art_collage(year: int = 2023):
         year=year
     )
 
+
 @explore_bp.route("/ai-brainz/")
 def ai_brainz():
     """ Explore your love of Rick """
 
     return render_template("explore/ai-brainz.html")
+
 
 @explore_bp.route("/lb-radio/")
 def lb_radio():

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -4,6 +4,7 @@ from flask import Blueprint, jsonify, request, current_app
 from brainzutils.ratelimit import ratelimit
 from brainzutils import cache
 import listenbrainz.db.fresh_releases
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.views.api_tools import _parse_int_arg, _parse_bool_arg
@@ -137,7 +138,7 @@ def huesound(color):
     cache_key = HUESOUND_PAGE_CACHE_KEY % (color, count)
     results = cache.get(cache_key, decode=True)
     if not results:
-        results = get_releases_for_color(*color_tuple, count)
+        results = get_releases_for_color(db_conn, *color_tuple, count)
         results = [c.to_api() for c in results]
         cache.set(cache_key, results, DEFAULT_CACHE_EXPIRE_TIME, encode=True)
 

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, request, current_app
 from brainzutils.ratelimit import ratelimit
 from brainzutils import cache
 import listenbrainz.db.fresh_releases
-from listenbrainz.webserver import db_conn
+from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.views.api_tools import _parse_int_arg, _parse_bool_arg
@@ -80,10 +80,10 @@ def get_fresh_releases():
 
     try:
         db_releases, total_count = listenbrainz.db.fresh_releases.get_sitewide_fresh_releases(
-            release_date, days, sort, past, future)
+            ts_conn, release_date, days, sort, past, future
+        )
     except Exception as e:
-        current_app.logger.error(
-            "Server failed to get latest release: {}".format(e))
+        current_app.logger.error("Server failed to get latest release: {}".format(e))
         raise APIInternalServerError("Server failed to get latest release")
 
     return jsonify({

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -103,7 +103,7 @@ def get_feedback_for_user(user_name):
 
     count = min(count, MAX_ITEMS_PER_GET)
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
@@ -256,7 +256,7 @@ def get_feedback_for_recordings_for_user(user_name):
     if not recording_msids and not recording_mbids:
         log_raise_400("No valid recording msid or recording mbid found.")
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 

--- a/listenbrainz/webserver/views/feedback_api.py
+++ b/listenbrainz/webserver/views/feedback_api.py
@@ -7,7 +7,7 @@ import listenbrainz.db.user as db_user
 from listenbrainz.db.model.feedback import Feedback
 
 from listenbrainz.domain import lastfm
-from listenbrainz.webserver import db_conn
+from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APINotFound, APIBadRequest
 from listenbrainz.webserver.utils import parse_boolean_arg
@@ -111,7 +111,7 @@ def get_feedback_for_user(user_name):
         if score not in [-1, 1]:
             log_raise_400("Score can have a value of 1 or -1.", request.args)
 
-    feedback = db_feedback.get_feedback_for_user(db_conn, user_id=user["id"], limit=count,
+    feedback = db_feedback.get_feedback_for_user(db_conn, ts_conn, user_id=user["id"], limit=count,
                                                  offset=offset, score=score, metadata=metadata)
     total_count = db_feedback.get_feedback_count_for_user(db_conn, user["id"], score)
 

--- a/listenbrainz/webserver/views/fresh_releases.py
+++ b/listenbrainz/webserver/views/fresh_releases.py
@@ -4,6 +4,7 @@ from flask import Blueprint, jsonify, request
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.fresh_releases import get_fresh_releases
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APINoContent, APINotFound, APIBadRequest
 from listenbrainz.webserver.views.api_tools import _parse_bool_arg
@@ -46,7 +47,7 @@ def get_releases(user_name):
     :statuscode 400: invalid date or number of days passed.
     :resheader Content-Type: *application/json*
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if not user:
         raise APINotFound("User %s not found" % user_name)
 

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -1,8 +1,6 @@
-import json
 import locale
 import os
 import requests
-import subprocess
 
 from brainzutils import cache
 from datetime import datetime
@@ -17,7 +15,7 @@ from werkzeug.exceptions import Unauthorized, NotFound
 import listenbrainz.db.user as db_user
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.webserver.decorators import web_listenstore_needed
-from listenbrainz.webserver import flash
+from listenbrainz.webserver import flash, db_conn
 from listenbrainz.webserver.timescale_connection import _ts
 from listenbrainz.webserver.redis_connection import _redis
 from listenbrainz.webserver.views.user import delete_user
@@ -30,6 +28,7 @@ CACHE_TIME = 10 * 60 # time in seconds we cache the stats
 NUMBER_OF_RECENT_LISTENS = 50
 
 SEARCH_USER_LIMIT = 100  # max number of users to return in search username results
+
 
 @index_bp.route("/")
 def index():
@@ -54,6 +53,7 @@ def index():
         listen_count=format(int(listen_count), ",d") if listen_count else "0",
         user_count=user_count,
     )
+
 
 @index_bp.route("/import/")
 def import_data():
@@ -196,7 +196,7 @@ def gdpr_notice():
     elif request.method == 'POST':
         if request.form.get('gdpr-options') == 'agree':
             try:
-                db_user.agree_to_gdpr(current_user.musicbrainz_id)
+                db_user.agree_to_gdpr(db_conn, current_user.musicbrainz_id)
             except DatabaseException as e:
                 flash.error('Could not store agreement to GDPR terms')
             next = request.form.get('next')
@@ -242,7 +242,7 @@ def mb_user_deleter(musicbrainz_row_id):
         Unauthorized if the MusicBrainz access token provided with the query is invalid
     """
     _authorize_mb_user_deleter(request.args.get('access_token', ''))
-    user = db_user.get_by_mb_row_id(musicbrainz_row_id)
+    user = db_user.get_by_mb_row_id(db_conn, musicbrainz_row_id)
     if user is None:
         raise NotFound('Could not find user with MusicBrainz Row ID: %d' % musicbrainz_row_id)
     delete_user(user['id'])
@@ -283,7 +283,7 @@ def _get_user_count():
         return user_count
     else:
         try:
-            user_count = db_user.get_user_count()
+            user_count = db_user.get_user_count(db_conn)
         except DatabaseException as e:
             raise
         cache.set(user_count_key, int(user_count), CACHE_TIME, encode=False)
@@ -315,6 +315,7 @@ def huesound():
     """ Redirect to /explore/huesound """
 
     return redirect(url_for("explore.huesound"))
+
 
 @index_bp.route("/statistics/charts/")
 def charts():

--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -4,7 +4,7 @@ from markupsafe import Markup
 
 from listenbrainz.webserver.decorators import web_listenstore_needed, web_musicbrainz_needed
 from listenbrainz.webserver.login import login_forbidden, provider, User
-from listenbrainz.webserver import flash
+from listenbrainz.webserver import flash, db_conn
 import listenbrainz.db.user as db_user
 import datetime
 
@@ -51,7 +51,7 @@ def musicbrainz_post():
                 # existing user without email, show a warning
                 flash.warning(no_email_warning + 'to submit listens. ' + blog_link)
 
-            db_user.update_last_login(user["musicbrainz_id"])
+            db_user.update_last_login(db_conn, user["musicbrainz_id"])
             login_user(User.from_dbrow(user),
                        remember=True,
                        duration=datetime.timedelta(current_app.config['SESSION_REMEMBER_ME_DURATION']))

--- a/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
+++ b/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
@@ -88,7 +88,7 @@ def get_missing_musicbrainz_data(user_name):
     # The source may change in future
     source = 'cf'
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: {}".format(user_name))
 

--- a/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
+++ b/listenbrainz/webserver/views/missing_musicbrainz_data_api.py
@@ -19,6 +19,7 @@
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.missing_musicbrainz_data as db_missing_musicbrainz_data
+from listenbrainz.webserver import ts_conn, db_conn
 
 from listenbrainz.webserver.errors import APIBadRequest, APINotFound, APINoContent
 from listenbrainz.webserver.views.api_tools import (DEFAULT_ITEMS_PER_GET,
@@ -96,7 +97,7 @@ def get_missing_musicbrainz_data(user_name):
 
     count = min(count, MAX_ITEMS_PER_GET)
 
-    data, created = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(user['id'], source)
+    data, created = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(db_conn, ts_conn, user['id'], source)
 
     if not data:
         err_msg = 'Missing MusicBrainz data for {} not calculated or none exists.'.format(user_name)

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -4,7 +4,7 @@ import listenbrainz.db.pinned_recording as db_pinned_rec
 from flask import Blueprint, current_app, jsonify, request
 
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
-from listenbrainz.webserver import db_conn
+from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIInternalServerError, APINotFound
 from brainzutils.ratelimit import ratelimit
@@ -194,7 +194,7 @@ def get_pins_for_user(user_name):
         current_app.logger.error("Error while retrieving pins for user: {}".format(e))
         raise APIInternalServerError("Something went wrong. Please try again.")
 
-    pinned_recordings = fetch_track_metadata_for_items(pinned_recordings)
+    pinned_recordings = fetch_track_metadata_for_items(ts_conn, pinned_recordings)
     pinned_recordings = [pin.to_api() for pin in pinned_recordings]
     total_count = db_pinned_rec.get_pin_count_for_user(db_conn, user_id=user["id"])
 
@@ -269,7 +269,7 @@ def get_pins_for_user_following(user_name):
     pinned_recordings = db_pinned_rec.get_pins_for_user_following(
         db_conn, user_id=user["id"], count=count, offset=offset
     )
-    pinned_recordings = fetch_track_metadata_for_items(pinned_recordings)
+    pinned_recordings = fetch_track_metadata_for_items(ts_conn, pinned_recordings)
     pinned_recordings = [pin.to_api() for pin in pinned_recordings]
 
     return jsonify(
@@ -323,7 +323,7 @@ def get_current_pin_for_user(user_name):
 
     pin = db_pinned_rec.get_current_pin_for_user(db_conn, user_id=user.id)
     if pin:
-        pin = fetch_track_metadata_for_items([pin])[0].to_api()
+        pin = fetch_track_metadata_for_items(ts_conn, [pin])[0].to_api()
 
     return jsonify({
         "pinned_recording": pin,

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -182,7 +182,7 @@ def get_pins_for_user(user_name):
 
     count = min(count, MAX_ITEMS_PER_GET)
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
@@ -262,7 +262,7 @@ def get_pins_for_user_following(user_name):
 
     count = min(count, MAX_ITEMS_PER_GET)
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
@@ -317,7 +317,7 @@ def get_current_pin_for_user(user_name):
     :statuscode 404: The requested user was not found.
     :resheader Content-Type: *application/json*
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 

--- a/listenbrainz/webserver/views/pinned_recording_api.py
+++ b/listenbrainz/webserver/views/pinned_recording_api.py
@@ -4,8 +4,9 @@ import listenbrainz.db.pinned_recording as db_pinned_rec
 from flask import Blueprint, current_app, jsonify, request
 
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import crossdomain
-from listenbrainz.webserver.errors import APIInternalServerError, APINotFound, APINoContent
+from listenbrainz.webserver.errors import APIInternalServerError, APINotFound
 from brainzutils.ratelimit import ratelimit
 from listenbrainz.webserver.views.api_tools import (
     log_raise_400,
@@ -14,7 +15,7 @@ from listenbrainz.webserver.views.api_tools import (
     get_non_negative_param,
     validate_auth_header,
 )
-from listenbrainz.db.model.pinned_recording import PinnedRecording, WritablePinnedRecording
+from listenbrainz.db.model.pinned_recording import WritablePinnedRecording
 from pydantic import ValidationError
 
 pinned_recording_api_bp = Blueprint("pinned_rec_api_bp_v1", __name__)
@@ -64,7 +65,7 @@ def pin_recording_for_user():
         log_raise_400("Invalid JSON document submitted: %s" % str(e).replace("\n ", ":").replace("\n", " "), data)
 
     try:
-        recording_to_pin_with_id = db_pinned_rec.pin(recording_to_pin)
+        recording_to_pin_with_id = db_pinned_rec.pin(db_conn, recording_to_pin)
     except Exception as e:
         current_app.logger.error("Error while inserting pinned track record: {}".format(e))
         raise APIInternalServerError("Something went wrong. Please try again.")
@@ -89,7 +90,7 @@ def unpin_recording_for_user():
     user = validate_auth_header()
 
     try:
-        recording_unpinned = db_pinned_rec.unpin(user["id"])
+        recording_unpinned = db_pinned_rec.unpin(db_conn, user["id"])
     except Exception as e:
         current_app.logger.error("Error while unpinning recording for user: {}".format(e))
         raise APIInternalServerError("Something went wrong. Please try again.")
@@ -119,7 +120,7 @@ def delete_pin_for_user(row_id):
     user = validate_auth_header()
 
     try:
-        recording_deleted = db_pinned_rec.delete(row_id, user["id"])
+        recording_deleted = db_pinned_rec.delete(db_conn, row_id, user["id"])
     except Exception as e:
         current_app.logger.error("Error while unpinning recording for user: {}".format(e))
         raise APIInternalServerError("Something went wrong. Please try again.")
@@ -186,14 +187,16 @@ def get_pins_for_user(user_name):
         raise APINotFound("Cannot find user: %s" % user_name)
 
     try:
-        pinned_recordings = db_pinned_rec.get_pin_history_for_user(user_id=user["id"], count=count, offset=offset)
+        pinned_recordings = db_pinned_rec.get_pin_history_for_user(
+            db_conn, user_id=user["id"], count=count, offset=offset
+        )
     except Exception as e:
         current_app.logger.error("Error while retrieving pins for user: {}".format(e))
         raise APIInternalServerError("Something went wrong. Please try again.")
 
     pinned_recordings = fetch_track_metadata_for_items(pinned_recordings)
     pinned_recordings = [pin.to_api() for pin in pinned_recordings]
-    total_count = db_pinned_rec.get_pin_count_for_user(user_id=user["id"])
+    total_count = db_pinned_rec.get_pin_count_for_user(db_conn, user_id=user["id"])
 
     return jsonify(
         {
@@ -263,7 +266,9 @@ def get_pins_for_user_following(user_name):
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
-    pinned_recordings = db_pinned_rec.get_pins_for_user_following(user_id=user["id"], count=count, offset=offset)
+    pinned_recordings = db_pinned_rec.get_pins_for_user_following(
+        db_conn, user_id=user["id"], count=count, offset=offset
+    )
     pinned_recordings = fetch_track_metadata_for_items(pinned_recordings)
     pinned_recordings = [pin.to_api() for pin in pinned_recordings]
 
@@ -316,7 +321,7 @@ def get_current_pin_for_user(user_name):
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
-    pin = db_pinned_rec.get_current_pin_for_user(user_id=user.id)
+    pin = db_pinned_rec.get_current_pin_for_user(db_conn, user_id=user.id)
     if pin:
         pin = fetch_track_metadata_for_items([pin])[0].to_api()
 

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -3,6 +3,8 @@ from werkzeug.exceptions import NotFound, BadRequest
 
 from flask import Blueprint, render_template, current_app
 from flask_login import current_user
+
+from listenbrainz.webserver import ts_conn, db_conn
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 from listenbrainz.webserver.views.playlist_api import fetch_playlist_recording_metadata
@@ -24,7 +26,7 @@ def load_playlist(playlist_mbid: str):
     if current_user.is_authenticated:
         current_user_id = current_user.id
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid, True)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, True)
     if playlist is None or not playlist.is_visible_by(current_user_id):
         raise NotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -35,7 +37,7 @@ def load_playlist(playlist_mbid: str):
         "playlist": playlist.serialize_jspf(),
     }
 
-    playlist_creator = db_user.get(playlist.creator_id)
+    playlist_creator = db_user.get(db_conn, playlist.creator_id)
 
     return render_template(
         "playlists/playlist.html",

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -11,6 +11,7 @@ import listenbrainz.db.playlist as db_playlist
 import listenbrainz.db.user as db_user
 from listenbrainz.domain.spotify import SpotifyService, SPOTIFY_PLAYLIST_PERMISSIONS
 from listenbrainz.troi.export import export_to_spotify
+from listenbrainz.webserver import db_conn, ts_conn
 
 from listenbrainz.webserver.utils import parse_boolean_arg
 from listenbrainz.webserver.decorators import crossdomain, api_listenstore_needed
@@ -249,9 +250,8 @@ def fetch_playlist_recording_metadata(playlist: Playlist):
 
     try:
         with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
-                psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as ts_conn, \
                 mb_conn.cursor(cursor_factory=DictCursor) as mb_curs, \
-                ts_conn.cursor(cursor_factory=DictCursor) as ts_curs:
+                ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_curs:
             db_playlist.get_playlist_recordings_metadata(mb_curs, ts_curs, playlist)
     except Exception:
         current_app.logger.error("Error while fetching metadata for a playlist: ", exc_info=True)
@@ -315,7 +315,7 @@ def create_playlist():
 
     users = {}
     if username_lookup:
-        users = db_user.get_many_users_by_mb_id(username_lookup)
+        users = db_user.get_many_users_by_mb_id(db_conn, username_lookup)
 
     collaborator_ids = []
     for collaborator in collaborators:
@@ -363,7 +363,7 @@ def create_playlist():
                 log_raise_400("Invalid recording MBID found in submitted recordings")
 
     try:
-        playlist = db_playlist.create(playlist)
+        playlist = db_playlist.create(db_conn, ts_conn, playlist)
     except Exception as e:
         current_app.logger.error("Error while creating new playlist: {}".format(e))
         raise APIInternalServerError("Failed to create the playlist. Please try again.")
@@ -397,7 +397,7 @@ def edit_playlist(playlist_mbid):
     if not is_valid_uuid(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid, False)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, False)
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -435,7 +435,7 @@ def edit_playlist(playlist_mbid):
         collaborators.remove(user["musicbrainz_id"])
 
     if collaborators:
-        users = db_user.get_many_users_by_mb_id(collaborators)
+        users = db_user.get_many_users_by_mb_id(db_conn, collaborators)
 
     collaborator_ids = []
     for collaborator in collaborators:
@@ -446,7 +446,7 @@ def edit_playlist(playlist_mbid):
     playlist.collaborators = collaborators
     playlist.collaborator_ids = collaborator_ids
 
-    db_playlist.update_playlist(playlist)
+    db_playlist.update_playlist(db_conn, ts_conn, playlist)
 
     return jsonify({'status': 'ok'})
 
@@ -474,7 +474,7 @@ def get_playlist(playlist_mbid):
 
     fetch_metadata = parse_boolean_arg("fetch_metadata", True)
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid, True)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, True)
     if playlist is None:
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -514,7 +514,7 @@ def get_playlist_xspf(playlist_mbid):
 
     fetch_metadata = parse_boolean_arg("fetch_metadata", True)
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid, True)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, True)
     if playlist is None:
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -566,7 +566,7 @@ def add_playlist_item(playlist_mbid, offset):
     if not is_valid_uuid(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid)
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -589,7 +589,7 @@ def add_playlist_item(playlist_mbid, offset):
             precordings.append(WritablePlaylistRecording(mbid=mbid, added_by_id=user["id"]))
 
     try:
-        db_playlist.add_recordings_to_playlist(playlist, precordings, offset)
+        db_playlist.add_recordings_to_playlist(db_conn, ts_conn, playlist, precordings, offset)
     except Exception as e:
         current_app.logger.error("Error while adding recordings to playlist: {}".format(e))
         raise APIInternalServerError("Failed to add recordings to the playlist. Please try again.")
@@ -630,7 +630,7 @@ def move_playlist_item(playlist_mbid):
     if not is_valid_uuid(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid)
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -641,7 +641,7 @@ def move_playlist_item(playlist_mbid):
     validate_move_data(data)
 
     try:
-        db_playlist.move_recordings(playlist, data['from'], data['to'], data['count'])
+        db_playlist.move_recordings(db_conn, ts_conn, playlist, data['from'], data['to'], data['count'])
     except Exception as e:
         current_app.logger.error("Error while moving recordings in the playlist: {}".format(e))
         raise APIInternalServerError("Failed to move recordings in the playlist. Please try again.")
@@ -680,7 +680,7 @@ def delete_playlist_item(playlist_mbid):
     if not is_valid_uuid(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid)
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -691,7 +691,7 @@ def delete_playlist_item(playlist_mbid):
     validate_delete_data(data)
 
     try:
-        db_playlist.delete_recordings_from_playlist(playlist, data['index'], data['count'])
+        db_playlist.delete_recordings_from_playlist(ts_conn, playlist, data['index'], data['count'])
     except Exception as e:
         current_app.logger.error("Error while deleting recordings from playlist: {}".format(e))
         raise APIInternalServerError("Failed to deleting recordings from the playlist. Please try again.")
@@ -721,7 +721,7 @@ def delete_playlist(playlist_mbid):
     if not is_valid_uuid(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid)
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
@@ -729,7 +729,7 @@ def delete_playlist(playlist_mbid):
         raise APIForbidden("You are not allowed to delete this playlist.")
 
     try:
-        db_playlist.delete_playlist(playlist)
+        db_playlist.delete_playlist(ts_conn, playlist)
     except Exception as e:
         current_app.logger.error("Error deleting playlist: {}".format(e))
         raise APIInternalServerError("Failed to delete the playlist. Please try again.")
@@ -759,12 +759,12 @@ def copy_playlist(playlist_mbid):
     if not is_valid_uuid(playlist_mbid):
         log_raise_400("Provided playlist ID is invalid.")
 
-    playlist = db_playlist.get_by_mbid(playlist_mbid)
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid)
     if playlist is None or not playlist.is_visible_by(user["id"]):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
     try:
-        new_playlist = db_playlist.copy_playlist(playlist, user["id"])
+        new_playlist = db_playlist.copy_playlist(db_conn, ts_conn, playlist, user["id"])
     except Exception as e:
         current_app.logger.error("Error copying playlist: {}".format(e))
         raise APIInternalServerError("Failed to copy the playlist. Please try again.")

--- a/listenbrainz/webserver/views/popularity_api.py
+++ b/listenbrainz/webserver/views/popularity_api.py
@@ -2,8 +2,7 @@ from brainzutils.ratelimit import ratelimit
 from flask import Blueprint, request, current_app
 
 from listenbrainz.db import popularity
-from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
-from listenbrainz.db.release import load_releases_from_mbids_with_redirects
+from listenbrainz.webserver import ts_conn, db_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
@@ -52,7 +51,7 @@ def top_recordings():
         raise APIBadRequest(f"artist_mbid: '{artist_mbid}' is not a valid uuid")
 
     try:
-        recordings = popularity.get_top_recordings_for_artist(artist_mbid)
+        recordings = popularity.get_top_recordings_for_artist(db_conn, ts_conn, artist_mbid)
         return recordings
     except Exception:
         current_app.logger.error("Error while fetching metadata for recordings: ", exc_info=True)
@@ -112,7 +111,7 @@ def top_release_groups():
         raise APIBadRequest(f"artist_mbid: '{artist_mbid}' is not a valid uuid")
 
     try:
-        releases = popularity.get_top_release_groups_for_artist(artist_mbid)
+        releases = popularity.get_top_release_groups_for_artist(db_conn, ts_conn, artist_mbid)
         return releases
     except Exception:
         current_app.logger.error("Error while fetching metadata for release groups: ", exc_info=True)

--- a/listenbrainz/webserver/views/recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording.py
@@ -3,8 +3,8 @@ from flask import Blueprint, render_template
 from psycopg2.extras import DictCursor
 
 import listenbrainz.db.recommendations_cf_recording as db_recommendations_cf_recording
-from listenbrainz.db import timescale
 from listenbrainz.db.msid_mbid_mapping import load_recordings_from_mbids
+from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.views.user import _get_user
 
 recommendations_cf_recording_bp = Blueprint('recommendations_cf_recording', __name__)
@@ -47,7 +47,7 @@ def _get_template(active_section, user):
             Template to render.
     """
 
-    data = db_recommendations_cf_recording.get_user_recommendation(user.id)
+    data = db_recommendations_cf_recording.get_user_recommendation(db_conn, user.id)
 
     if data is None:
         return render_template(
@@ -120,7 +120,7 @@ def _get_playable_recommendations_list(mbids_and_ratings_list):
                 }
     """
     mbids = [r['recording_mbid'] for r in mbids_and_ratings_list]
-    with timescale.engine.connect() as ts_conn, ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_cursor:
+    with ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_cursor:
         data = load_recordings_from_mbids(ts_cursor, mbids)
 
     recommendations = []

--- a/listenbrainz/webserver/views/recommendations_cf_recording_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_api.py
@@ -1,5 +1,6 @@
 import listenbrainz.db.user as db_user
 import listenbrainz.db.recommendations_cf_recording as db_recommendations_cf_recording
+from listenbrainz.webserver import db_conn
 
 from listenbrainz.webserver.errors import APINotFound, APINoContent
 from listenbrainz.webserver.views.api_tools import DEFAULT_ITEMS_PER_GET, get_non_negative_param
@@ -73,7 +74,7 @@ def get_recommendations(user_name):
     offset = get_non_negative_param('offset', default=0)
     count = get_non_negative_param('count', default=DEFAULT_ITEMS_PER_GET)
 
-    recommendations = db_recommendations_cf_recording.get_user_recommendation(user['id'])
+    recommendations = db_recommendations_cf_recording.get_user_recommendation(db_conn, user['id'])
 
     if recommendations is None:
         err_msg = 'No recommendations due to absence of recent listening history for user {}'.format(user_name)

--- a/listenbrainz/webserver/views/recommendations_cf_recording_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_api.py
@@ -67,7 +67,7 @@ def get_recommendations(user_name):
         :statuscode 404: User not found.
         :statuscode 204: Recommendations for the user haven't been generated, empty response will be returned
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: {}".format(user_name))
 

--- a/listenbrainz/webserver/views/recommendations_cf_recording_feedback_api.py
+++ b/listenbrainz/webserver/views/recommendations_cf_recording_feedback_api.py
@@ -163,7 +163,7 @@ def get_feedback_for_user(user_name):
     :statuscode 400: Bad request, check ``response['error']`` for more details
     :resheader Content-Type: *application/json*
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: {}".format(user_name))
 
@@ -234,7 +234,7 @@ def get_feedback_for_recordings_for_user(user_name):
     :statuscode 404: User not found.
     :resheader Content-Type: *application/json*
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -37,7 +37,7 @@ EXPORT_FETCH_COUNT = 5000
 @api_login_required
 def reset_token():
     try:
-        db_user.update_token(current_user.id)
+        db_user.update_token(db_conn, current_user.id)
         return jsonify({"success": True})
     except DatabaseException:
         raise APIInternalServerError("Something went wrong! Unable to reset token right now.")

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -70,7 +70,7 @@ def set_troi_prefs():
 @api_login_required
 def reset_latest_import_timestamp():
     try:
-        listens_importer.update_latest_listened_at(current_user.id, ExternalServiceType.LASTFM, 0)
+        listens_importer.update_latest_listened_at(db_conn, current_user.id, ExternalServiceType.LASTFM, 0)
         return jsonify({"success": True})
     except DatabaseException:
         raise APIInternalServerError("Something went wrong! Unable to reset latest import timestamp right now.")

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -19,7 +19,7 @@ from listenbrainz.domain.external_service import ExternalService, ExternalServic
 from listenbrainz.domain.musicbrainz import MusicBrainzService
 from listenbrainz.domain.soundcloud import SoundCloudService
 from listenbrainz.domain.spotify import SpotifyService, SPOTIFY_LISTEN_PERMISSIONS, SPOTIFY_IMPORT_PERMISSIONS
-from listenbrainz.webserver import db_conn
+from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver import timescale_connection
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.errors import APIServiceUnavailable, APINotFound, APIForbidden, APIInternalServerError
@@ -125,7 +125,13 @@ def fetch_feedback(user_id):
     batch = []
     offset = 0
     while True:
-        batch = db_feedback.get_feedback_for_user(user_id=current_user.id, limit=EXPORT_FETCH_COUNT, offset=offset)
+        batch = db_feedback.get_feedback_for_user(
+            db_conn,
+            ts_conn,
+            user_id=current_user.id,
+            limit=EXPORT_FETCH_COUNT,
+            offset=offset
+        )
         if not batch:
             break
         yield from batch

--- a/listenbrainz/webserver/views/social_api.py
+++ b/listenbrainz/webserver/views/social_api.py
@@ -29,7 +29,7 @@ def get_followers(user_name: str):
     :statuscode 200: Yay, you have data!
     :statuscode 404: User not found
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
 
     if not user:
         raise APINotFound("User %s not found" % user_name)
@@ -61,7 +61,7 @@ def get_following(user_name: str):
     :statuscode 200: Yay, you have data!
     :statuscode 404: User not found
     """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
 
     if not user:
         raise APINotFound("User %s not found" % user_name)
@@ -94,7 +94,7 @@ def follow_user(user_name: str):
     :resheader Content-Type: *application/json*
     """
     current_user = validate_auth_header()
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
 
     if not user:
         raise APINotFound("User %s not found" % user_name)
@@ -129,7 +129,7 @@ def unfollow_user(user_name: str):
     :resheader Content-Type: *application/json*
     """
     current_user = validate_auth_header()
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
 
     if not user:
         raise APINotFound("User %s not found" % user_name)

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -18,6 +18,7 @@ from data.model.user_daily_activity import DailyActivityRecord
 from data.model.user_entity import EntityRecord
 from data.model.user_listening_activity import ListeningActivityRecord
 from listenbrainz.db import year_in_music as db_year_in_music
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import (APIBadRequest,
                                            APIInternalServerError,
@@ -713,7 +714,7 @@ def _get_entity_listeners(entity, mbid):
     if not _is_valid_range(stats_range):
         raise APIBadRequest(f"Invalid range: {stats_range}")
 
-    stats = db_stats.get_entity_listener(entity, mbid, stats_range)
+    stats = db_stats.get_entity_listener(db_conn, entity, mbid, stats_range)
     if stats is None:
         raise APINoContent("")
 
@@ -1201,7 +1202,7 @@ def year_in_music(user_name: str, year: int = 2023):
     if year != 2021 and year != 2022 and year != 2023:
         raise APINotFound(f"Cannot find Year in Music report for year: {year}")
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound(f"Cannot find user: {user_name}")
 
@@ -1237,7 +1238,7 @@ def _process_user_entity(stats: StatApi[EntityRecord], offset: int, count: int) 
 
 def _validate_stats_user_params(user_name) -> Tuple[Dict, str]:
     """ Validate and return the user and common stats params """
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound(f"Cannot find user: {user_name}")
 

--- a/listenbrainz/webserver/views/test/test_explore.py
+++ b/listenbrainz/webserver/views/test/test_explore.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 from unittest.mock import patch
 
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -30,15 +31,15 @@ class ExploreViewsTestCase(IntegrationTestCase):
     def test_fresh_releases_api(self, mock_fresh):
         resp = self.client.get(self.custom_url_for('explore_api_v1.get_fresh_releases'))
         self.assert200(resp)
-        mock_fresh.assert_called_with(datetime.date.today(), 14, 'release_date', True, True)
+        mock_fresh.assert_called_with(mock.ANY, datetime.date.today(), 14, 'release_date', True, True)
 
         resp = self.client.get(self.custom_url_for('explore_api_v1.get_fresh_releases', release_date="2022-01-01", days=5))
         self.assert200(resp)
-        mock_fresh.assert_called_with(datetime.date(year=2022, month=1, day=1), 5, 'release_date', True, True)
+        mock_fresh.assert_called_with(mock.ANY, datetime.date(year=2022, month=1, day=1), 5, 'release_date', True, True)
 
         resp = self.client.get(self.custom_url_for('explore_api_v1.get_fresh_releases', sort="artist_credit_name", past=False))
         self.assert200(resp)
-        mock_fresh.assert_called_with(datetime.date.today(), 14, 'artist_credit_name', False, True)
+        mock_fresh.assert_called_with(mock.ANY, datetime.date.today(), 14, 'artist_credit_name', False, True)
 
     def test_lb_radio(self):
         resp = self.client.get(self.custom_url_for('explore.lb_radio'))

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -21,9 +21,9 @@ class IndexViewsTestCase(IntegrationTestCase):
     
     def test_index_logged_in_redirect(self):
         """ If the user is logged in, redirect from the index to their profile page """
-        user = db_user.get_or_create(1, 'mr_monkey')
-        db_user.agree_to_gdpr(user['musicbrainz_id'])
-        user = db_user.get_or_create(1, 'mr_monkey')
+        user = db_user.get_or_create(self.db_conn, 1, 'mr_monkey')
+        db_user.agree_to_gdpr(self.db_conn, user['musicbrainz_id'])
+        user = db_user.get_or_create(self.db_conn, 1, 'mr_monkey')
         self.temporary_login(user['login_id'])
 
         resp = self.client.get(self.custom_url_for('index.index'))
@@ -90,9 +90,9 @@ class IndexViewsTestCase(IntegrationTestCase):
     @mock.patch('listenbrainz.db.user.get_by_login_id')
     def test_menu_logged_in(self, mock_user_get):
         """ If the user is logged in, check that we perform a database query to get user data """
-        user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(user['musicbrainz_id'])
-        user = db_user.get_or_create(1, 'iliekcomputers')
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, user['musicbrainz_id'])
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
 
         mock_user_get.return_value = user
         self.temporary_login(user['login_id'])
@@ -105,12 +105,12 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assertIn('Logout', data)
         self.assertNotIn('Sign in', data)
 
-        mock_user_get.assert_called_with(user['login_id'])
+        mock_user_get.assert_called_with(mock.ANY, user['login_id'])
 
     @mock.patch('listenbrainz.webserver.views.index._authorize_mb_user_deleter')
     @mock.patch('listenbrainz.webserver.views.index.delete_user')
     def test_mb_user_deleter_valid_account(self, mock_delete_user, mock_authorize_mb_user_deleter):
-        user_id = db_user.create(1, 'iliekcomputers')
+        user_id = db_user.create(self.db_conn, 1, 'iliekcomputers')
         r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assert200(r)
         mock_authorize_mb_user_deleter.assert_called_once_with('132')
@@ -133,7 +133,7 @@ class IndexViewsTestCase(IntegrationTestCase):
             'sub': 'UserDeleter',
             'metabrainz_user_id': 2007538,
         }
-        user_id = db_user.create(1, 'iliekcomputers')
+        user_id = db_user.create(self.db_conn,1, 'iliekcomputers')
         r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assert200(r)
         mock_requests_get.assert_called_with(
@@ -150,7 +150,7 @@ class IndexViewsTestCase(IntegrationTestCase):
             'sub': 'UserDeleter',
             'metabrainz_user_id': 2007531, # incorrect musicbrainz row id for UserDeleter
         }
-        user_id = db_user.create(1, 'iliekcomputers')
+        user_id = db_user.create(self.db_conn,1, 'iliekcomputers')
         r = self.client.get(self.custom_url_for('index.mb_user_deleter', musicbrainz_row_id=1, access_token='132'))
         self.assertStatus(r, 401)
         mock_delete_user.assert_not_called()
@@ -201,8 +201,8 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assertTemplateUsed('index/recent.html')
 
     def test_feed_page(self):
-        user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(user['musicbrainz_id'])
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, user['musicbrainz_id'])
         self.temporary_login(user['login_id'])
         r = self.client.get('/feed/')
         self.assert200(r)
@@ -253,9 +253,9 @@ class IndexViewsTestCase2(ServerAppPerTestTestCase, DatabaseTestCase):
         def view404():
             raise NotFound('not found')
 
-        user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(user['musicbrainz_id'])
-        user = db_user.get_or_create(1, 'iliekcomputers')
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, user['musicbrainz_id'])
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
         mock_user_get.return_value = user
         self.temporary_login(user['login_id'])
         resp = self.client.get('/page_that_returns_400')
@@ -268,7 +268,7 @@ class IndexViewsTestCase2(ServerAppPerTestTestCase, DatabaseTestCase):
         self.assertIn('Logout', data)
         self.assertNotIn('Sign in', data)
 
-        mock_user_get.assert_called_with(user['login_id'])
+        mock_user_get.assert_called_with(mock.ANY, user['login_id'])
 
         resp = self.client.get('/page_that_returns_404')
         data = resp.data.decode('utf-8')
@@ -279,7 +279,7 @@ class IndexViewsTestCase2(ServerAppPerTestTestCase, DatabaseTestCase):
         self.assertIn('Logout', data)
         self.assertNotIn('Sign in', data)
 
-        mock_user_get.assert_called_with(user['login_id'])
+        mock_user_get.assert_called_with(mock.ANY, user['login_id'])
 
     @mock.patch('listenbrainz.db.user.get')
     def test_menu_logged_in_error_dont_show_no_user(self, mock_user_get):
@@ -290,9 +290,9 @@ class IndexViewsTestCase2(ServerAppPerTestTestCase, DatabaseTestCase):
         def view500():
             raise InternalServerError('error')
 
-        user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(user['musicbrainz_id'])
-        user = db_user.get_or_create(1, 'iliekcomputers')
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, user['musicbrainz_id'])
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
         mock_user_get.return_value = user
         self.temporary_login(user['login_id'])
         resp = self.client.get('/page_that_returns_500')
@@ -309,9 +309,9 @@ class IndexViewsTestCase2(ServerAppPerTestTestCase, DatabaseTestCase):
         loaded while rendering the template"""
         self.app.config["TESTING"] = False
 
-        user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(user['musicbrainz_id'])
-        user = db_user.get_or_create(1, 'iliekcomputers')
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, user['musicbrainz_id'])
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
 
         mock_user_get.return_value = user
 

--- a/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
@@ -20,10 +20,10 @@ class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
     def setUp(self):
         self.server_url = "https://labs.api.listenbrainz.org/recording-mbid-lookup/json"
         super(CFRecommendationsViewsTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'vansika')
-        db_user.agree_to_gdpr(self.user['musicbrainz_id'])
-        self.user2 = db_user.get_or_create(2, 'vansika_1')
-        self.user3 = db_user.get_or_create(3, 'vansika_2')
+        self.user = db_user.get_or_create(self.db_conn, 1, 'vansika')
+        db_user.agree_to_gdpr(self.db_conn, self.user['musicbrainz_id'])
+        self.user2 = db_user.get_or_create(self.db_conn, 2, 'vansika_1')
+        self.user3 = db_user.get_or_create(self.db_conn, 3, 'vansika_2')
 
         # generate test data
         data = {"recording_mbid": []}

--- a/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
@@ -37,6 +37,7 @@ class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
             )
 
         db_recommendations_cf_recording.insert_user_recommendation(
+            self.db_conn,
             self.user2["id"],
             UserRecommendationsJson(**{
                 'raw': data['recording_mbid']
@@ -44,6 +45,7 @@ class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
         )
 
         db_recommendations_cf_recording.insert_user_recommendation(
+            self.db_conn,
             self.user3["id"],
             UserRecommendationsJson(**{
                 'raw': [],
@@ -154,7 +156,7 @@ class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
         mock_get_recommendations.return_value = recommendations
 
         recommendations_cf_recording._get_template(active_section='raw', user=user)
-        mock_get_rec.assert_called_with(user.id)
+        mock_get_rec.assert_called_with(mock.ANY, user.id)
         mock_get_recommendations.assert_called_once()
         self.assertTemplateUsed('recommendations_cf_recording/base.html')
         self.assert_context('active_section', 'raw')

--- a/listenbrainz/webserver/views/test/test_settings.py
+++ b/listenbrainz/webserver/views/test/test_settings.py
@@ -36,7 +36,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
 
     def test_reset_import_timestamp(self):
         val = int(time.time())
-        listens_importer.update_latest_listened_at(self.user['id'], ExternalServiceType.LASTFM, val)
+        listens_importer.update_latest_listened_at(self.db_conn, self.user['id'], ExternalServiceType.LASTFM, val)
         self.temporary_login(self.user['login_id'])
         response = self.client.get(self.custom_url_for('settings.index', path='resetlatestimportts'))
         self.assertTemplateUsed('settings/index.html')
@@ -44,7 +44,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
 
         response = self.client.post(self.custom_url_for('settings.reset_latest_import_timestamp'))
         self.assertDictEqual(response.json, {'success': True})
-        ts = listens_importer.get_latest_listened_at(self.user['id'], ExternalServiceType.LASTFM)
+        ts = listens_importer.get_latest_listened_at(self.db_conn, self.user['id'], ExternalServiceType.LASTFM)
         self.assertEqual(int(ts.strftime('%s')), 0)
 
     def test_user_info_not_logged_in(self):
@@ -94,7 +94,8 @@ class SettingsViewsTestCase(IntegrationTestCase):
         r = self.client.post(self.custom_url_for('settings.music_services_disconnect', service_name='spotify'), json={})
         self.assertStatus(r, 200)
 
-        self.assertIsNone(self.service.get_user(self.user['id']))
+        with self.app.app_context():
+            self.assertIsNone(self.service.get_user(self.user['id']))
 
     @patch('listenbrainz.domain.spotify.SpotifyService.fetch_access_token')
     @patch.object(spotipy.Spotify, 'current_user')
@@ -113,7 +114,8 @@ class SettingsViewsTestCase(IntegrationTestCase):
         self.assertStatus(r, 302)
         mock_fetch_access_token.assert_called_once_with('code')
 
-        user = self.service.get_user(self.user['id'])
+        with self.app.app_context():
+            user = self.service.get_user(self.user['id'])
         self.assertEqual(self.user['id'], user['user_id'])
         self.assertEqual('token', user['access_token'])
         self.assertEqual('refresh', user['refresh_token'])
@@ -133,7 +135,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
     def _create_spotify_user(self, expired):
         offset = -1000 if expired else 1000
         expires = int(time.time()) + offset
-        db_oauth.save_token(user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
                             access_token='old-token', refresh_token='old-refresh-token',
                             token_expires_ts=expires, record_listens=False,
                             scopes=['user-read-recently-played', 'some-other-permission'])

--- a/listenbrainz/webserver/views/test/test_settings.py
+++ b/listenbrainz/webserver/views/test/test_settings.py
@@ -19,10 +19,10 @@ class SettingsViewsTestCase(IntegrationTestCase):
 
     def setUp(self):
         super(SettingsViewsTestCase, self).setUp()
-        self.user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(self.user['musicbrainz_id'])
-        self.weirduser = db_user.get_or_create(2, 'weird\\user name')
-        db_user.agree_to_gdpr(self.weirduser['musicbrainz_id'])
+        self.user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, self.user['musicbrainz_id'])
+        self.weirduser = db_user.get_or_create(self.db_conn, 2, 'weird\\user name')
+        db_user.agree_to_gdpr(self.db_conn, self.weirduser['musicbrainz_id'])
         with self.app.app_context():
             self.service = SpotifyService()
 

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -24,17 +24,17 @@ class UserViewsTestCase(IntegrationTestCase):
         self.log = logging.getLogger(__name__)
         self.logstore = timescale_connection._ts
 
-        user = db_user.get_or_create(1, 'iliekcomputers')
-        db_user.agree_to_gdpr(user['musicbrainz_id'])
+        user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, user['musicbrainz_id'])
 
         # fetch again so that gdpr agreed time is set
         user = db_user.get(self.db_conn, user['id'])
         self.user = User.from_dbrow(user)
 
-        weirduser = db_user.get_or_create(2, 'weird\\user name')
+        weirduser = db_user.get_or_create(self.db_conn, 2, 'weird\\user name')
         self.weirduser = User.from_dbrow(weirduser)
 
-        abuser = db_user.get_or_create(3, 'abuser')
+        abuser = db_user.get_or_create(self.db_conn, 3, 'abuser')
         self.abuser = User.from_dbrow(abuser)
 
     def tearDown(self):
@@ -234,7 +234,7 @@ class UserViewsTestCase(IntegrationTestCase):
 
     def test_report_abuse(self):
         # Assert user is not already reported by current user
-        already_reported_user = db_user.is_user_reported(self.user.id, self.abuser.id)
+        already_reported_user = db_user.is_user_reported(self.db_conn, self.user.id, self.abuser.id)
         self.assertFalse(already_reported_user)
 
         self.temporary_login(self.user.login_id)
@@ -247,7 +247,7 @@ class UserViewsTestCase(IntegrationTestCase):
             json=data,
         )
         self.assert200(response, "%s has been reported successfully." % self.abuser.musicbrainz_id)
-        already_reported_user = db_user.is_user_reported(self.user.id, self.abuser.id)
+        already_reported_user = db_user.is_user_reported(self.db_conn, self.user.id, self.abuser.id)
         self.assertTrue(already_reported_user)
 
         # Assert a user cannot report themselves
@@ -256,7 +256,7 @@ class UserViewsTestCase(IntegrationTestCase):
             json=data,
         )
         self.assert400(response, "You cannot report yourself.")
-        already_reported_user = db_user.is_user_reported(self.user.id, self.user.id)
+        already_reported_user = db_user.is_user_reported(self.db_conn, self.user.id, self.user.id)
         self.assertFalse(already_reported_user)
 
         # Assert reason must be of type string

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -9,7 +9,6 @@ from sqlalchemy import text
 
 import listenbrainz.db.user as db_user
 from data.model.external_service import ExternalServiceType
-from listenbrainz import db
 from listenbrainz.db import external_service_oauth as db_oauth, timescale
 from listenbrainz.listenstore.tests.util import create_test_data_for_timescalelistenstore
 from listenbrainz.listenstore.timescale_listenstore import EPOCH
@@ -24,8 +23,6 @@ class UserViewsTestCase(IntegrationTestCase):
 
         self.log = logging.getLogger(__name__)
         self.logstore = timescale_connection._ts
-
-        self.db_conn = db.engine.connect()
 
         user = db_user.get_or_create(1, 'iliekcomputers')
         db_user.agree_to_gdpr(user['musicbrainz_id'])
@@ -42,7 +39,6 @@ class UserViewsTestCase(IntegrationTestCase):
 
     def tearDown(self):
         self.logstore = None
-        self.db_conn.close()
         super().tearDown()
 
     def test_redirects_logged_out(self):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -342,7 +342,7 @@ def delete_listens_history(user_id: int):
         user_id: the LB row ID of the user
     """
     timescale_connection._ts.delete(user_id)
-    listens_importer.update_latest_listened_at(user_id, ExternalServiceType.LASTFM, 0)
+    listens_importer.update_latest_listened_at(db_conn, user_id, ExternalServiceType.LASTFM, 0)
 
 
 def logged_in_user_follows_user(user):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -385,8 +385,11 @@ def taste(user_name: str):
         "id": user.id,
     }
 
-    feedback_count = get_feedback_count_for_user(user.id, score)
-    feedback = get_feedback_for_user(user_id=user.id, limit=DEFAULT_NUMBER_OF_FEEDBACK_ITEMS_PER_CALL, offset=0, score=score, metadata=True)
+    feedback_count = get_feedback_count_for_user(db_conn, user.id, score)
+    feedback = get_feedback_for_user(
+        db_conn, user_id=user.id, limit=DEFAULT_NUMBER_OF_FEEDBACK_ITEMS_PER_CALL,
+        offset=0, score=score, metadata=True
+    )
     
     pins = get_pin_history_for_user(user_id=user.id, count=25, offset=0)
     pins = [pin.to_api() for pin in fetch_track_metadata_for_items(pins)]

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -114,7 +114,7 @@ def profile(user_name):
 
     already_reported_user = False
     if current_user.is_authenticated:
-        already_reported_user = db_user.is_user_reported(current_user.id, user.id)
+        already_reported_user = db_user.is_user_reported(db_conn, current_user.id, user.id)
 
     pin = get_current_pin_for_user(db_conn, user_id=user.id)
     if pin:
@@ -304,9 +304,9 @@ def report_abuse(user_name):
         reason = data.get("reason")
         if not isinstance(reason, str):
             raise APIBadRequest("Reason must be a string.")
-    user_to_report = db_user.get_by_mb_id(user_name)
+    user_to_report = db_user.get_by_mb_id(db_conn, user_name)
     if current_user.id != user_to_report["id"]:
-        db_user.report_user(current_user.id, user_to_report["id"], reason)
+        db_user.report_user(db_conn, current_user.id, user_to_report["id"], reason)
         return jsonify({"status": "%s has been reported successfully." % user_name})
     else:
         raise APIBadRequest("You cannot report yourself.")
@@ -318,7 +318,7 @@ def _get_user(user_name):
             current_user.musicbrainz_id == user_name:
         return current_user
     else:
-        user = db_user.get_by_mb_id(user_name)
+        user = db_user.get_by_mb_id(db_conn, user_name)
         if user is None:
             raise NotFound("Cannot find user: %s" % user_name)
         return User.from_dbrow(user)
@@ -332,7 +332,7 @@ def delete_user(user_id: int):
         user_id: the LB row ID of the user
     """
     timescale_connection._ts.delete(user_id)
-    db_user.delete(user_id)
+    db_user.delete(db_conn, user_id)
 
 
 def delete_listens_history(user_id: int):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -118,7 +118,7 @@ def profile(user_name):
 
     pin = get_current_pin_for_user(db_conn, user_id=user.id)
     if pin:
-        pin = fetch_track_metadata_for_items([pin])[0].to_api()
+        pin = fetch_track_metadata_for_items(ts_conn, [pin])[0].to_api()
 
     props = {
         "user": {
@@ -387,12 +387,12 @@ def taste(user_name: str):
 
     feedback_count = get_feedback_count_for_user(db_conn, user.id, score)
     feedback = get_feedback_for_user(
-        db_conn, user_id=user.id, limit=DEFAULT_NUMBER_OF_FEEDBACK_ITEMS_PER_CALL,
+        db_conn, ts_conn, user_id=user.id, limit=DEFAULT_NUMBER_OF_FEEDBACK_ITEMS_PER_CALL,
         offset=0, score=score, metadata=True
     )
     
     pins = get_pin_history_for_user(db_conn, user_id=user.id, count=25, offset=0)
-    pins = [pin.to_api() for pin in fetch_track_metadata_for_items(pins)]
+    pins = [pin.to_api() for pin in fetch_track_metadata_for_items(ts_conn, pins)]
     pin_count = get_pin_count_for_user(db_conn, user_id=user.id)
 
     props = {

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -10,7 +10,6 @@ from flask_login import current_user
 from data.model.external_service import ExternalServiceType
 from listenbrainz import webserver
 from listenbrainz.db import listens_importer
-from listenbrainz.db.missing_musicbrainz_data import get_user_missing_musicbrainz_data
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
 from listenbrainz.db.playlist import get_playlists_for_user, get_recommendation_playlists_for_user
 from listenbrainz.db.pinned_recording import get_current_pin_for_user, get_pin_count_for_user, get_pin_history_for_user
@@ -118,7 +117,7 @@ def profile(user_name):
 
     pin = get_current_pin_for_user(db_conn, user_id=user.id)
     if pin:
-        pin = fetch_track_metadata_for_items(ts_conn, [pin])[0].to_api()
+        pin = fetch_track_metadata_for_items(webserver.ts_conn, [pin])[0].to_api()
 
     props = {
         "user": {

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -296,7 +296,6 @@ def recommendation_playlists(user_name: str):
     )
 
 
-
 @user_bp.route("/<user_name>/report-user/", methods=['POST'])
 @api_login_required
 def report_abuse(user_name):

--- a/listenbrainz/webserver/views/user_settings_api.py
+++ b/listenbrainz/webserver/views/user_settings_api.py
@@ -4,6 +4,7 @@ from flask import Blueprint, jsonify, request
 
 import listenbrainz.db.user_setting as db_usersetting
 from listenbrainz.troi.daily_jams import SPOTIFY_EXPORT_PREFERENCE
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIInternalServerError, APIBadRequest
 from listenbrainz.webserver.views.api_tools import (
@@ -38,7 +39,7 @@ def reset_timezone():
 
     zonename = data["zonename"]
     try:
-        db_usersetting.set_timezone(user["id"], zonename)
+        db_usersetting.set_timezone(db_conn, user["id"], zonename)
     except Exception as e:
         raise APIInternalServerError("Something went wrong! Unable to update timezone right now.")
     return jsonify({"status": "ok"})
@@ -71,5 +72,5 @@ def update_troi_prefs():
     if type(export_to_spotify) != bool:
         raise APIBadRequest(f"{SPOTIFY_EXPORT_PREFERENCE} key in the JSON document must be a boolean", data)
 
-    db_usersetting.update_troi_prefs(user["id"], export_to_spotify)
+    db_usersetting.update_troi_prefs(db_conn, user["id"], export_to_spotify)
     return jsonify({"status": "ok"})

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -134,7 +134,7 @@ def create_user_notification_event(user_name):
     if creator["musicbrainz_id"] not in current_app.config['APPROVED_PLAYLIST_BOTS']:
         raise APIForbidden("Only approved users are allowed to post a message on a user's timeline.")
 
-    user = db_user.get_by_mb_id(user_name)
+    user = db_user.get_by_mb_id(db_conn, user_name)
     if user is None:
         raise APINotFound(f"Cannot find user: {user_name}")
 
@@ -437,7 +437,7 @@ def user_feed_listens_similar(user_name: str):
 
     # Here, list is in descending order as we want similar_users with 
     # highest similarity to be processed first and lowest at last.
-    similar_users = db_user.get_similar_users(user_id=user['id'])
+    similar_users = db_user.get_similar_users(db_conn, user_id=user['id'])
 
     # Get all listen events
     if len(similar_users) == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonschema == 4.6.0
 rauth == 0.7.3
 setproctitle == 1.2.2
 markupsafe == 2.1.3
-psycopg2 == 2.9.5
+psycopg2-binary == 2.9.5
 python-dateutil == 2.8.2
 ujson == 5.4.0
 redis == 4.4.4

--- a/requirements_development.txt
+++ b/requirements_development.txt
@@ -1,5 +1,5 @@
 coverage==6.3.2
-flask-shell-ipython==0.4.1
+flask-shell-ipython==0.5.1
 freezegun==1.2.0
 pytest==7.1.0
 pytest-cov==3.0.0


### PR DESCRIPTION
Currently if we make multiple database queries in a request, a new connection is created for each query, with a few exceptions where we pass around connection objects. We should extend to that entire project and reuse connection objects during the lifetime of a request at least. Flask-SQLAlchemy follows a similar pattern by scoping its sessions to request. Connection are created upon first access i.e. if a request does not try to access a database connection, none will be created for that request. The connection created during the request will be cleaned up during teardown phase of the request.