### PR TITLE
LB-549: "Delete your listens" section of profile should mention Spotify importer

### DIFF
--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 
-import { redirect, useLocation } from "react-router-dom";
+import { redirect, useLocation, Link } from "react-router-dom";
 import { toast } from "react-toastify";
-import { Link } from "react-router-dom";
 import { ToastMsg } from "../../notifications/Notifications";
 import GlobalAppContext from "../../utils/GlobalAppContext";
 import { downloadFile } from "../export/ExportData";

--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -77,7 +77,7 @@ export default function DeleteListens() {
       <p>Once deleted, all your listens data will be removed PERMANENTLY.</p>
 
       <p>
-        Warning: if you are still connected to Spotify, the last 50 Spotify tracks will be auto-reimported. <Link to="/settings/music-services/details/">Disconnect</Link> before deleting. 
+        Warning: if you are still connected to Spotify, the last 50 Spotify tracks might be auto-reimported. <Link to="/settings/music-services/details/">Disconnect</Link> before deleting. 
       </p>
 
       <p>

--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { redirect, useLocation } from "react-router-dom";
 import { toast } from "react-toastify";
+import { Link } from "react-router-dom";
 import { ToastMsg } from "../../notifications/Notifications";
 import GlobalAppContext from "../../utils/GlobalAppContext";
 import { downloadFile } from "../export/ExportData";
@@ -75,6 +76,10 @@ export default function DeleteListens() {
       </p>
 
       <p>Once deleted, all your listens data will be removed PERMANENTLY.</p>
+
+      <p>
+        Warning: if you are still connected to Spotify, the last 50 Spotify tracks will be auto-reimported. <Link to="/settings/music-services/details/">Disconnect</Link> before deleting. 
+      </p>
 
       <p>
         Note: you can export your ListenBrainz data before deleting your


### PR DESCRIPTION
# Problem

[[LB-549]](https://tickets.metabrainz.org/projects/LB/issues/LB-549)

https://tickets.metabrainz.org/projects/LB/issues/LB-549

After using the "Delete your listens" option, some of the listens reappear after a few minutes, as if they were never deleted. Apparently, this is only happening to listens made in Spotify.


# Solution

- Added a warning about it
- Added a Link component that redirects to /settings/music-services/details/

Here is the preview:
<img width="892" alt="Screenshot 2024-02-02 at 11 12 11" src="https://github.com/metabrainz/listenbrainz-server/assets/115300909/3231ff80-2aa5-40f3-8bb5-beb9bd5fe905">

