### PR TITLE
Created For You: Fix time remaining timers

### DIFF
--- a/frontend/css/recommendation-page.less
+++ b/frontend/css/recommendation-page.less
@@ -90,8 +90,9 @@
       height: 25px;
       border-radius: 50%;
       background: conic-gradient(
+        from 0deg,
         fade(white, 15%) var(--degrees-progress),
-        var(--timer-color) calc(360deg - var(--degrees-progress))
+        var(--timer-color) var(--degrees-progress)
       );
       align-self: flex-start;
       order: 3;
@@ -102,7 +103,7 @@
       &.pressing {
         animation: blink 1s ease-out alternate infinite;
         --timer-color: fade(red, 70%);
-        background-color: fade(white, 50%);
+        background-color: fade(white, 20%);
       }
       @keyframes blink {
         0% {

--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -271,7 +271,7 @@ export default class RecommendationsPage extends React.Component<
     const playlistId = getPlaylistId(playlist);
     const extension = getPlaylistExtension(playlist);
     const expiryDate = extension?.additional_metadata?.expires_at;
-    let percentTimeLeft;
+    let percentElapsed;
     if (expiryDate) {
       const start = new Date(playlist.date).getTime();
       const end = new Date(expiryDate).getTime();
@@ -279,7 +279,7 @@ export default class RecommendationsPage extends React.Component<
 
       const elapsed = Math.abs(today - start);
       const total = Math.abs(end - start);
-      percentTimeLeft = Math.round((elapsed / total) * 100);
+      percentElapsed = Math.round((elapsed / total) * 100);
     }
     return (
       <div
@@ -295,15 +295,15 @@ export default class RecommendationsPage extends React.Component<
         role="button"
         tabIndex={0}
       >
-        {!isUndefined(percentTimeLeft) && (
+        {!isUndefined(percentElapsed) && (
           <div
             className={`playlist-timer ${
-              percentTimeLeft > 75 ? "pressing" : ""
+              percentElapsed > 75 ? "pressing" : ""
             }`}
             title={`Deleted in ${preciseTimestamp(expiryDate!, "timeAgo")}`}
             style={{
               ["--degrees-progress" as any]: `${
-                (percentTimeLeft / 100) * 360
+                (percentElapsed / 100) * 360
               }deg`,
             }}
           />


### PR DESCRIPTION
The gradients used to display the remaining time before a playlist is deleted are not displaying correctly. After some prodding, it is because of how the css conic-gradient is defined.
I also renamed a variable in the code that could lead to a lot of confusion.

Before:
<img width="784" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/416abe0f-b4ac-4d96-a88a-c40842cb3ad3">

After:
<img width="876" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/1a1a1abd-b00e-4d2e-abec-f3c51744e91f">

