### PR TITLE
Add support for updating existing data in couchdb

### DIFF
--- a/listenbrainz/db/tests/test_couchdb.py
+++ b/listenbrainz/db/tests/test_couchdb.py
@@ -1,10 +1,9 @@
 import json
 import unittest
-from io import StringIO, BytesIO
+from io import BytesIO
 from unittest.mock import patch
 
 import requests
-import orjson
 
 from listenbrainz import config
 from listenbrainz.db import couchdb
@@ -68,3 +67,42 @@ class CouchdbTestCase(unittest.TestCase):
 
         mock_lock.assert_called_with(database)
         mock_unlock.assert_called_with(database)
+
+    def test_insert_new_data_overwrites_conflicts(self):
+        database = "couchdb_dump_test_db_20240204"
+        couchdb.create_database(database)
+
+        couchdb.insert_data(database, [
+            {
+                "_id": "1",
+                "data": "foo"
+            },
+            {
+                "_id": "2",
+                "data": "bar"
+            }
+        ])
+
+        couchdb.insert_data(database, [
+            {
+                "_id": "1",
+                "data": "baz"
+            },
+            {
+                "_id": "3",
+                "data": "foobar"
+            }
+        ])
+
+        dumped = BytesIO()
+        couchdb.dump_database("couchdb_dump_test_db", dumped)
+        dumped.seek(0)
+        received = dumped.read().splitlines()
+        print(received)
+
+        response = couchdb.fetch_data(database, 1)
+        self.assertEqual(response["data"], "baz")
+        response = couchdb.fetch_data(database, 2)
+        self.assertEqual(response["data"], "bar")
+        response = couchdb.fetch_data(database, 3)
+        self.assertEqual(response["data"], "foobar")


### PR DESCRIPTION
Sometimes, we find an issue in the stats generation. For instance, stats being outdated because of missing dumps in spark cluster. When we recognize and fix the issue, we need to regenerate the stats. However, the existing code to insert stats in couchdb ignores conflicts and hence the old data remains in it. We either have to create a new database with a newer date or wait until the next date for a new database to be created. This is suboptimal, hence add conflict resolution to couchdb inserts. For now, we always overwrite the existing data in the database with the new incoming data.