### PR TITLE
Split listening time stat into multiple messages

### DIFF
--- a/listenbrainz_spark/year_in_music/listening_time.py
+++ b/listenbrainz_spark/year_in_music/listening_time.py
@@ -1,4 +1,5 @@
-import orjson
+import json
+
 from more_itertools import chunked
 
 import listenbrainz_spark
@@ -30,5 +31,5 @@ def get_listening_time(year):
         yield {
             "type": "year_in_music_listening_time",
             "year": year,
-            "data": orjson.dumps({r.user_id: r.value for r in entry}).decode("utf-8")
+            "data": json.dumps({r.user_id: r.value for r in entry})
         }

--- a/listenbrainz_spark/year_in_music/listening_time.py
+++ b/listenbrainz_spark/year_in_music/listening_time.py
@@ -1,8 +1,13 @@
+import orjson
+from more_itertools import chunked
+
 import listenbrainz_spark
 from listenbrainz_spark import config
 from listenbrainz_spark.path import RECORDING_LENGTH_DATAFRAME
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.year_in_music.utils import setup_listens_for_year
+
+USERS_PER_MESSAGE = 5000
 
 
 def get_listening_time(year):
@@ -12,31 +17,18 @@ def get_listening_time(year):
     metadata_df = listenbrainz_spark.sql_context.read.parquet(config.HDFS_CLUSTER_URI + RECORDING_LENGTH_DATAFRAME)
     metadata_df.createOrReplaceTempView(metadata_table)
 
-    data = run_query(_get_total_listening_time()).collect()
-    yield {
-        "type": "year_in_music_listening_time",
-        "year": year,
-        "data": data[0]["yearly_listening_time"]
-    }
+    itr = run_query("""
+          SELECT user_id
+               , sum(COALESCE(rl.length / 1000, BIGINT(180))) AS value
+            FROM listens_of_year l
+       LEFT JOIN recording_length rl
+              ON l.recording_mbid = rl.recording_mbid
+        GROUP BY user_id
+    """).toLocalIterator()
 
-
-def _get_total_listening_time():
-    # get recording length from recording table, if listen is unmapped default to 3 minutes.
-    return """
-          WITH listening_times AS (
-                  SELECT user_id
-                       , sum(COALESCE(rl.length / 1000, BIGINT(180))) AS total_listening_time
-                    FROM listens_of_year l
-               LEFT JOIN recording_length rl
-                      ON l.recording_mbid = rl.recording_mbid
-                GROUP BY user_id
-          )
-            SELECT to_json(
-                    map_from_entries(
-                        collect_list(
-                            struct(user_id, total_listening_time)
-                        )
-                    )
-                ) AS yearly_listening_time
-          FROM listening_times  
-    """
+    for entry in chunked(itr, USERS_PER_MESSAGE):
+        yield {
+            "type": "year_in_music_listening_time",
+            "year": year,
+            "data": orjson.dumps({r.user_id: r.value for r in entry}).decode("utf-8")
+        }


### PR DESCRIPTION
Doing it in a single message blocks spark reader for a long time leading to timeouts.