### PR TITLE
LB-1462: Listen controls dropdown is too narrow / hard to click

### DIFF
--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -414,7 +414,7 @@
 
       .fa-heart,
       .fa-heart-crack,
-      .fa-bars{
+      .fa-bars {
         font-size: 21px;
         margin: 0% 7%;
         width: 1em;

--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -246,7 +246,7 @@
       .right-section {
         flex: 0;
         .listen-controls {
-          flex-grow: 0;
+          // flex-grow: 0;
           margin: unset;
         }
       }
@@ -386,6 +386,7 @@
 
       .listen-controls {
         margin-left: 1.5em;
+        margin-right: 1em;
       }
       > *:not(.dropdown-menu) {
         min-width: 1.5em;
@@ -413,22 +414,21 @@
 
       .fa-heart,
       .fa-heart-crack,
-      .fa-ellipsis-vertical {
-        stroke-width: 40px;
-        font-size: 18px;
+      .fa-bars{
+        font-size: 21px;
         margin: 0% 7%;
         width: 1em;
       }
 
       .fa-heart,
       .fa-heart-crack {
+        stroke-width: 40px;
         color: transparent;
         stroke: #8d8d8d;
       }
 
-      .fa-ellipsis-vertical {
+      .fa-bars {
         color: #8d8d8d;
-        stroke: #ffffff;
 
         &:hover {
           color: #46433a;
@@ -554,7 +554,7 @@
       color: #8d8d8d;
       width: 2em;
       min-width: 2em;
-      margin-left: 0;
+      margin-left: 0.4em;
       margin-right: 0.5em;
       padding: 0;
     }

--- a/frontend/js/src/common/listens/ListenCard.tsx
+++ b/frontend/js/src/common/listens/ListenCard.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import {
   faCode,
   faCommentDots,
-  faEllipsisVertical,
+  faBars,
   faExternalLinkAlt,
   faImage,
   faLink,
@@ -475,10 +475,7 @@ export default class ListenCard extends React.Component<
                   </div>
                 )}
               </div>
-              <div
-                className="small text-muted ellipsis"
-                title={artistName}
-              >
+              <div className="small text-muted ellipsis" title={artistName}>
                 {getArtistLink(listen)}
               </div>
             </div>
@@ -507,7 +504,7 @@ export default class ListenCard extends React.Component<
               {hideActionsMenu ? null : (
                 <>
                   <FontAwesomeIcon
-                    icon={faEllipsisVertical as IconProp}
+                    icon={faBars}
                     title="More actions"
                     className="dropdown-toggle"
                     id="listenControlsDropdown"


### PR DESCRIPTION
# Problem

[LB-1462](https://tickets.metabrainz.org/browse/LB-1462)

"it's the three vertical dots to the right of a listen) **difficult to click on**, because it seems to be only 5 pixels wide, so I always have to hesitate ever so slightly to line up my cursor with it precisely."



# Solution

I propose the following solution:

- changing the dropdown menu icon to a wider one to make it easier to click on
- increasing the size of the icons for heart, heart-crack, and dropdown-menu
- also improved the gap and padding between the icons, so the play button has a space on the right side

# Before
<img width="349" alt="Screenshot 2024-02-06 at 11 19 07" src="https://github.com/metabrainz/listenbrainz-server/assets/115300909/36e895b4-d507-4b74-83cc-8a04ee20e53f">

# After
<img width="349" alt="Screenshot 2024-02-06 at 11 17 45" src="https://github.com/metabrainz/listenbrainz-server/assets/115300909/7e4d62c2-cca9-4178-acf8-edeccfa499c8">


