### PR TITLE
Fix export listens button on delete pages

### DIFF
--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -14,7 +14,7 @@ export default function DeleteListens() {
     e.preventDefault();
 
     try {
-      await downloadFile(location.pathname);
+      await downloadFile("/settings/export/");
       toast.success(
         <ToastMsg
           title="Success"

--- a/frontend/js/src/settings/delete/DeleteAccount.tsx
+++ b/frontend/js/src/settings/delete/DeleteAccount.tsx
@@ -13,7 +13,7 @@ export default function DeleteAccount() {
     e.preventDefault();
 
     try {
-      await downloadFile(window.location.href);
+      await downloadFile("/settings/export/");
       toast.success(
         <ToastMsg
           title="Success"


### PR DESCRIPTION
The Export Listens button on delete pages was incorrectly calling the delete listens/account endpoint.