### PR TITLE
LB-1494: Music player bar in BrainzPlayer have to move smoothly

### DIFF
--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -25,7 +25,7 @@ const TOOLTIP_TOP_OFFSET: number = 102;
 function ProgressBar(props: ProgressBarProps) {
   const { durationMs, progressMs, seekToPositionMs } = props;
   const [tipContent, setTipContent] = React.useState(TOOLTIP_INITIAL_CONTENT);
-  const progressPercentage = Math.round((Number(progressMs * 100) / durationMs) * 100) / 100;
+  const progressPercentage = Number(progressMs * 100 / durationMs).toFixed(2);
   const hideProgressBar = isNaN(progressPercentage) || progressPercentage <= 0;
 
   // Originally by ford04 - https://stackoverflow.com/a/62017005

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -25,9 +25,7 @@ const TOOLTIP_TOP_OFFSET: number = 102;
 function ProgressBar(props: ProgressBarProps) {
   const { durationMs, progressMs, seekToPositionMs } = props;
   const [tipContent, setTipContent] = React.useState(TOOLTIP_INITIAL_CONTENT);
-  const progressPercentage = Math.round(
-    Number((progressMs * 100) / durationMs)
-  );
+  const progressPercentage = Math.round((Number(progressMs * 100) / durationMs) * 100) / 100;
   const hideProgressBar = isNaN(progressPercentage) || progressPercentage <= 0;
 
   // Originally by ford04 - https://stackoverflow.com/a/62017005

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -25,7 +25,7 @@ const TOOLTIP_TOP_OFFSET: number = 102;
 function ProgressBar(props: ProgressBarProps) {
   const { durationMs, progressMs, seekToPositionMs } = props;
   const [tipContent, setTipContent] = React.useState(TOOLTIP_INITIAL_CONTENT);
-  const progressPercentage = Number(progressMs * 100 / durationMs).toFixed(2);
+  const progressPercentage = Number((progressMs * 100 / durationMs).toFixed(2));
   const hideProgressBar = isNaN(progressPercentage) || progressPercentage <= 0;
 
   // Originally by ford04 - https://stackoverflow.com/a/62017005


### PR DESCRIPTION
# Problem

[LB-1494](https://tickets.metabrainz.org/browse/LB-1494)

- The music progress bar moving every 1-2 seconds was caused by rounding. The progress bar was getting integer values from 0 to 100, so for a few seconds it had the same value and didn't move (this is fine, but looks a bit weird on wider screens).

# Solution

- just fixed it, so the value rounds to 2 decimal places 
- now the music player bar moves smoothly!

# Demo

https://github.com/metabrainz/listenbrainz-server/assets/115300909/e6628048-edea-4c45-8e0c-61e6a3e2d0d7

