### PR TITLE
LB-1456: Can't change back to other user's stats after having selecte…

### DIFF
--- a/frontend/js/src/user/stats/UserReports.tsx
+++ b/frontend/js/src/user/stats/UserReports.tsx
@@ -98,7 +98,7 @@ export default class UserReports extends React.Component<
 
   render() {
     const { range, user } = this.state;
-    const { apiUrl } = this.props;
+    const { apiUrl, user: initialUser } = this.props;
     const { currentUser } = this.context;
 
     const ranges = getAllStatRanges();
@@ -126,12 +126,12 @@ export default class UserReports extends React.Component<
               <button
                 type="button"
                 onClick={() => {
-                  this.setUser(user?.name ?? currentUser?.name);
+                  this.setUser(initialUser?.name ?? currentUser?.name);
                 }}
                 className={`pill secondary ${user ? "active" : ""}`}
               >
                 <FontAwesomeIcon icon={faUser} />{" "}
-                {user?.name ?? currentUser?.name}
+                {initialUser?.name ?? currentUser?.name}
               </button>
             )}
             <button


### PR DESCRIPTION
# Problem

There are two pills on the right side to change between the current user's stats and global.
When changing to global view the user stats button changes to that of the currently logged in user instead of user whose stats were viewed

   https://tickets.metabrainz.org/projects/LB/issues/LB-1456?filter=allopenissues

# Solution

Implemented @MonkeyDo 's suggestion and simplified the solution by using user as initialUser from the props which does not change on clicking on the Global button


# Action

No further action needed


