### PR TITLE
Fix explore cards css in Safari

### DIFF
--- a/frontend/css/explore.less
+++ b/frontend/css/explore.less
@@ -15,6 +15,7 @@
   max-width: 600px;
   margin-bottom: 2em;
   filter: drop-shadow(0px 4px 4px fade(@black, 25%));
+  position: relative;
 }
 
 .explore-card-img-clip {


### PR DESCRIPTION
Safari (12.6 at least) wasn't liking the blue overlays we add over the explore page cards, and was showing all of them piled up at the top of the page, spanning the whole width of the page.

Before:
<img width="1280" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/35bb5e01-5022-4f20-8a32-f62d48922cc8">

After:
<img width="1280" alt="image" src="https://github.com/metabrainz/listenbrainz-server/assets/6179856/efaf402d-9423-4518-accb-602c98dc669a">
