### PR TITLE
Rollback transaction manually in case of database errors

### DIFF
--- a/listenbrainz/webserver/login/__init__.py
+++ b/listenbrainz/webserver/login/__init__.py
@@ -50,6 +50,7 @@ def load_user(user_login_id):
     try:
         user = db_user.get_by_login_id(db_conn, user_login_id)
     except Exception as e:
+        db_conn.rollback()
         current_app.logger.error("Error while getting user by login ID: %s", str(e), exc_info=True)
         return None
     if user:

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -282,10 +282,7 @@ def _get_user_count():
     if user_count:
         return user_count
     else:
-        try:
-            user_count = db_user.get_user_count(db_conn)
-        except DatabaseException as e:
-            raise
+        user_count = db_user.get_user_count(db_conn)
         cache.set(user_count_key, int(user_count), CACHE_TIME, encode=False)
         return user_count
 


### PR DESCRIPTION
Since we reuse database connections within the life of a request, we manually need to rollback transactions in cases where we catch and supress db exceptions. This doesn't help with the actual db issues but makes the logs a bit tidier.