### PR TITLE
LB-1496: shorten time before removal when closing modals

### DIFF
--- a/frontend/js/src/cb-review/CBReviewModal.tsx
+++ b/frontend/js/src/cb-review/CBReviewModal.tsx
@@ -43,7 +43,7 @@ export default NiceModal.create(({ listen }: CBReviewModalProps) => {
 
   const closeModal = React.useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 3000);
+    setTimeout(modal.remove, 200);
   }, [modal]);
 
   const { APIService, currentUser, critiquebrainzAuth } = React.useContext(

--- a/frontend/js/src/common/listens/AddToPlaylist.tsx
+++ b/frontend/js/src/common/listens/AddToPlaylist.tsx
@@ -31,7 +31,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
 
   const closeModal = React.useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 3000);
+    setTimeout(modal.remove, 200);
   }, [modal]);
 
   const { listen } = props;

--- a/frontend/js/src/common/listens/ListenPayloadModal.tsx
+++ b/frontend/js/src/common/listens/ListenPayloadModal.tsx
@@ -28,7 +28,7 @@ export default NiceModal.create(({ listen }: ListenPayloadModalProps) => {
 
   const closeModal = () => {
     modal.hide();
-    setTimeout(modal.remove, 3000);
+    setTimeout(modal.remove, 200);
   };
   const stringifiedJSON = JSON.stringify(listen, null, 2);
 

--- a/frontend/js/src/common/listens/MBIDMappingModal.tsx
+++ b/frontend/js/src/common/listens/MBIDMappingModal.tsx
@@ -42,16 +42,16 @@ function getListenFromSelectedRecording(
 
 export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
   const modal = useModal();
-  const { hide, remove, resolve, visible } = modal;
+  const { resolve, visible } = modal;
   const [copyTextClickCounter, setCopyTextClickCounter] = React.useState(0);
   const [selectedRecording, setSelectedRecording] = React.useState<
     TrackMetadata
   >();
 
   const closeModal = React.useCallback(() => {
-    hide();
-    setTimeout(remove, 500);
-  }, [hide, remove]);
+    modal.hide();
+    setTimeout(modal.remove, 200);
+  }, [modal]);
 
   React.useEffect(() => {
     const closeOnEscape = (e: KeyboardEvent) => {

--- a/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
+++ b/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
@@ -103,7 +103,7 @@ export default NiceModal.create(
 
     const closeModal = () => {
       modal.hide();
-      setTimeout(modal.remove, 3000);
+      setTimeout(modal.remove, 200);
     };
 
     const submitPersonalRecommendation = React.useCallback(

--- a/frontend/js/src/pins/PinRecordingModal.tsx
+++ b/frontend/js/src/pins/PinRecordingModal.tsx
@@ -63,7 +63,7 @@ export default NiceModal.create(
 
     const closeModal = () => {
       modal.hide();
-      setTimeout(modal.remove, 3000);
+      setTimeout(modal.remove, 200);
     };
 
     const submitPinRecording = React.useCallback(

--- a/frontend/js/src/playlists/components/CreateOrEditPlaylistModal.tsx
+++ b/frontend/js/src/playlists/components/CreateOrEditPlaylistModal.tsx
@@ -22,7 +22,7 @@ export default NiceModal.create((props: CreateOrEditPlaylistModalProps) => {
   const modal = useModal();
   const closeModal = React.useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 3000);
+    setTimeout(modal.remove, 200);
   }, [modal]);
 
   const { currentUser, APIService } = React.useContext(GlobalAppContext);

--- a/frontend/js/src/playlists/components/DeletePlaylistConfirmationModal.tsx
+++ b/frontend/js/src/playlists/components/DeletePlaylistConfirmationModal.tsx
@@ -14,7 +14,7 @@ export default NiceModal.create(
     const modal = useModal();
     const closeModal = React.useCallback(() => {
       modal.hide();
-      setTimeout(modal.remove, 3000);
+      setTimeout(modal.remove, 200);
     }, [modal]);
 
     const { playlist } = props;

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -52,7 +52,7 @@ export default NiceModal.create(() => {
 
   const closeModal = useCallback(() => {
     modal.hide();
-    setTimeout(modal.remove, 3000);
+    setTimeout(modal.remove, 200);
   }, [modal]);
 
   const handleError = useCallback(


### PR DESCRIPTION
We can't currently use the built-in Bootstrap modals from NiceModal since we are using an old version of Bootstrap (v3).

This means that we had to manually remove the modal components from the application tree after closing them.
This requires a delay to allow the fade animation to finish.
Previously this was set way high (3 seconds), but this crated issues if you close a modal and straight away open another one: the removal timer kicks in and removes that newly opened modal.

Until we can use the built-in Bootstrap modals that already take all this into account, I set the timeout to 200ms (from the previous 3000ms) which should be plenty as the fade animation duration is 150ms.