### PR TITLE
LB-1506: log_raise_400 type hint added

### DIFF
--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -13,6 +13,8 @@ import orjson
 import uuid
 import sentry_sdk
 
+from typing import NoReturn
+
 from flask import current_app, request
 
 from listenbrainz.listenstore import LISTEN_MINIMUM_TS
@@ -248,7 +250,7 @@ def _get_augmented_listens(payload, user: SubmitListenUserMetadata):
     return payload
 
 
-def log_raise_400(msg, data=""):
+def log_raise_400(msg, data="") -> NoReturn:
     """ Helper function for logging issues with request data and showing error page.
         Logs the message and data, raises BadRequest exception which shows 400 Bad
         Request to the user.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
We do capture or log 400 (BadRequest) client errors by default. However, sometimes we wish to do that. Hence, we have a helper function called [log_raise_400](https://github.com/metabrainz/listenbrainz-server/blob/265ada1c2047648a54737bcb6a9aeb3f0c019a05/listenbrainz/webserver/views/api_tools.py#L251) which logs an error message and then raises a 400 error. Note that this function always raises and exception, however pycharm or other type checkers cannot detect this and give lots of false positives like.

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution

Added a type hint to the log_raise_400 function (NoReturn) so that these false positive warnings can be eliminated.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


