### PR TITLE
LB-1507: Delete button is missing for personal recommendations on feed page

### DIFF
--- a/frontend/js/src/user-feed/UserFeed.tsx
+++ b/frontend/js/src/user-feed/UserFeed.tsx
@@ -312,6 +312,7 @@ export default class UserFeedPage extends React.Component<
     const { events } = this.state;
     if (
       event.event_type === EventType.RECORDING_RECOMMENDATION ||
+      event.event_type === EventType.PERSONAL_RECORDING_RECOMMENDATION ||
       event.event_type === EventType.NOTIFICATION
     ) {
       try {
@@ -466,6 +467,7 @@ export default class UserFeedPage extends React.Component<
     const { currentUser } = this.context;
     if (
       ((event.event_type === EventType.RECORDING_RECOMMENDATION ||
+        event.event_type === EventType.PERSONAL_RECORDING_RECOMMENDATION ||
         event.event_type === EventType.RECORDING_PIN) &&
         event.user_name === currentUser.name) ||
       event.event_type === EventType.NOTIFICATION
@@ -538,6 +540,7 @@ export default class UserFeedPage extends React.Component<
       let additionalMenuItems;
       if (
         (event.event_type === EventType.RECORDING_RECOMMENDATION ||
+          event.event_type === EventType.PERSONAL_RECORDING_RECOMMENDATION ||
           event.event_type === EventType.RECORDING_PIN) &&
         event.user_name === currentUser.name
       ) {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
delete button not available on personal recomenadation events in feed



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
included the PersonalRecommendation event type in relevant if cases.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


