### PR TITLE
Reduce uwsgi processes and add threads

### DIFF
--- a/docker/services/uwsgi/uwsgi.ini.ctmpl
+++ b/docker/services/uwsgi/uwsgi.ini.ctmpl
@@ -11,7 +11,8 @@ callable = application
 chdir = /code/listenbrainz
 enable-threads = true
 processes = {{template "KEY" "processes"}}
-listen = 1024
+threads = {{template "KEY" "threads"}}
+listen = 2048
 log-x-forwarded-for=true
 disable-logging = true
 ; quit uwsgi if the python app fails to load


### PR DESCRIPTION
Processes are more expensive and each needs its own flask app instance. Threads are cheaper and can share resources if the application code wants (currently we don't but with this setup we can do it in future).