### PR TITLE
TagsComponent: improve token refresh and error catching

### DIFF
--- a/frontend/js/src/tags/TagsComponent.tsx
+++ b/frontend/js/src/tags/TagsComponent.tsx
@@ -14,6 +14,7 @@ import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import TagComponent, { TagActionType } from "./TagComponent";
 import GlobalAppContext from "../utils/GlobalAppContext";
+import { ToastMsg } from "../notifications/Notifications";
 
 const originalFetch = window.fetch;
 const fetchWithRetry = require("fetch-retry")(originalFetch);
@@ -119,52 +120,59 @@ export default function AddTagSelect(props: {
       return;
     }
     const url = `${MBBaseURI}/${entityType}/${entityMBID}?fmt=json&inc=user-tags tags`;
-    const response = await fetchWithRetry(encodeURI(url), {
-      headers: {
-        "Content-Type": "application/xml; charset=utf-8",
-        Authorization: `Bearer ${musicbrainzAuthToken}`,
-      },
-      async retryOn(attempt: number, error: Error, res: Response) {
-        if (attempt > 3) return false;
+    try {
+      let token = musicbrainzAuthToken;
+      const response = await fetchWithRetry(encodeURI(url), {
+        headers: {
+          "Content-Type": "application/xml; charset=utf-8",
+          Authorization: `Bearer ${token}`,
+        },
+        async retryOn(attempt: number, error: Error, res: Response) {
+          if (attempt >= 3) return false;
 
-        if (error !== null || res.status === 401) {
-          if (isFunction(refreshMBToken)) {
-            try {
-              await refreshMBToken();
-              return true;
-            } catch {
+          if (error !== null || res.status === 401) {
+            if (isFunction(refreshMBToken)) {
+              const newToken = await refreshMBToken();
+              if (newToken) {
+                token = newToken;
+                return true;
+              }
               return false;
             }
           }
+          return false;
+        },
+      });
+      if (response.ok) {
+        const responseJSON = await response.json();
+        const userTags: MBResponseTag[] = responseJSON["user-tags"];
+        if (responseJSON.tags?.length || userTags?.length) {
+          const userTagNames: string[] = userTags.map((t) => t.name);
+          const formattedTags: TagOptionType[] = responseJSON.tags?.map(
+            (tag: MBResponseTag) => ({
+              value: tag.name,
+              label: tag.name,
+              entityType,
+              entityMBID,
+              isNew: false,
+              isOwnTag: false,
+              originalTag: { tag: tag.name, count: tag.count },
+            })
+          );
+          // mark the tags that the user has voted on
+          formattedTags.forEach((tag) => {
+            if (userTagNames.includes(tag.value)) {
+              // eslint-disable-next-line no-param-reassign
+              tag.isOwnTag = true;
+            }
+          });
+          setSelected(formattedTags);
         }
-        return false;
-      },
-    });
-    if (response.ok) {
-      const responseJSON = await response.json();
-      const userTags: MBResponseTag[] = responseJSON["user-tags"];
-      if (responseJSON.tags?.length || userTags?.length) {
-        const userTagNames: string[] = userTags.map((t) => t.name);
-        const formattedTags: TagOptionType[] = responseJSON.tags?.map(
-          (tag: MBResponseTag) => ({
-            value: tag.name,
-            label: tag.name,
-            entityType,
-            entityMBID,
-            isNew: false,
-            isOwnTag: false,
-            originalTag: { tag: tag.name, count: tag.count },
-          })
-        );
-        // mark the tags that the user has voted on
-        formattedTags.forEach((tag) => {
-          if (userTagNames.includes(tag.value)) {
-            // eslint-disable-next-line no-param-reassign
-            tag.isOwnTag = true;
-          }
-        });
-        setSelected(formattedTags);
       }
+    } catch (error) {
+      toast.error(
+        <ToastMsg title="Failed to fetch tags" message={error.toString()} />
+      );
     }
   }, [entityType, entityMBID, musicbrainzAuthToken, MBBaseURI, refreshMBToken]);
 

--- a/frontend/js/src/utils/GlobalAppContext.tsx
+++ b/frontend/js/src/utils/GlobalAppContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, createRef } from "react";
+import { createContext } from "react";
 import APIService from "./APIService";
 import RecordingFeedbackManager from "./RecordingFeedbackManager";
 
@@ -11,7 +11,7 @@ export type GlobalAppContextT = {
   soundcloudAuth?: SoundCloudUser;
   critiquebrainzAuth?: MetaBrainzProjectUser;
   musicbrainzAuth?: MetaBrainzProjectUser & {
-    refreshMBToken: () => Promise<void>;
+    refreshMBToken: () => Promise<string | undefined>;
   };
   userPreferences?: UserPreferences;
   musicbrainzGenres?: string[];
@@ -27,7 +27,11 @@ const GlobalAppContext = createContext<GlobalAppContextT>({
   youtubeAuth: {},
   soundcloudAuth: {},
   critiquebrainzAuth: {},
-  musicbrainzAuth: { refreshMBToken: async () => {} },
+  musicbrainzAuth: {
+    refreshMBToken: async () => {
+      return undefined;
+    },
+  },
   userPreferences: {},
   musicbrainzGenres: [],
   recordingFeedbackManager: new RecordingFeedbackManager(apiService),

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -663,6 +663,18 @@ const getPageProps = async (): Promise<{
   };
 };
 
+const getListenablePin = (pinnedRecording: PinnedRecording): Listen => {
+  const pinnedRecListen: Listen = {
+    listened_at: 0,
+    ...pinnedRecording,
+  };
+  _.set(
+    pinnedRecListen,
+    "track_metadata.additional_info.recording_msid",
+    pinnedRecording.recording_msid
+  );
+  return pinnedRecListen;
+};
 
 const countWords = (str: string): number => {
   // Credit goes to iamwhitebox https://stackoverflow.com/a/39125279/14911205

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -621,6 +621,7 @@ const getPageProps = async (): Promise<{
           try {
             const newToken = await apiService.refreshMusicbrainzToken();
             _.set(globalAppContext, "musicbrainzAuth.access_token", newToken);
+            return newToken;
           } catch (err) {
             // eslint-disable-next-line no-console
             console.error(
@@ -628,6 +629,7 @@ const getPageProps = async (): Promise<{
               err.toString()
             );
           }
+          return undefined;
         },
       },
       userPreferences: user_preferences,
@@ -661,18 +663,6 @@ const getPageProps = async (): Promise<{
   };
 };
 
-const getListenablePin = (pinnedRecording: PinnedRecording): Listen => {
-  const pinnedRecListen: Listen = {
-    listened_at: 0,
-    ...pinnedRecording,
-  };
-  _.set(
-    pinnedRecListen,
-    "track_metadata.additional_info.recording_msid",
-    pinnedRecording.recording_msid
-  );
-  return pinnedRecListen;
-};
 
 const countWords = (str: string): number => {
   // Credit goes to iamwhitebox https://stackoverflow.com/a/39125279/14911205


### PR DESCRIPTION
@mayhem recently reported and helped me debug an issue he's been seeing that is breaking the Listening Now page.
It is to do with tags fetching and how I handled refreshing the MB token and retrying.

This PR improves a couple of things:
1. Wrap the tags fetch+retry in a try…catch block, that should prevent the broken page we were seeing
2. Return the token from the freshMBToken method so we can use it in the retry function; it seemed like the new token from the global context was not being used, not sure why
3. Show an error to the user if we can't get their tags for some reason. Some feedback is nice.