### PR TITLE
Homepage: Fix number counter

### DIFF
--- a/frontend/js/src/home/NumberCounter.tsx
+++ b/frontend/js/src/home/NumberCounter.tsx
@@ -6,7 +6,7 @@ type NumberCounterProps = {
 
 function NumberCounter({ count }: NumberCounterProps) {
   const countString = count?.toString();
-  const groupsOfThree = countString?.match(/\d{1,3}/g) ?? [];
+  const groupsOfThree = countString?.match(/(\d+?)(?=(\d{3})+(?!\d)|$)/g) ?? [];
 
   return (
     <div className="number-count">

--- a/frontend/js/src/home/NumberCounter.tsx
+++ b/frontend/js/src/home/NumberCounter.tsx
@@ -6,13 +6,11 @@ type NumberCounterProps = {
 
 function NumberCounter({ count }: NumberCounterProps) {
   const countString = count?.toString();
-  const reversedStr = countString?.split("").reverse().join("");
-  const groupsOfThree = reversedStr?.match(/\d{1,3}/g);
-  const reversedGroupsOfCount = groupsOfThree ? groupsOfThree.reverse() : [];
+  const groupsOfThree = countString?.match(/\d{1,3}/g) ?? [];
 
   return (
     <div className="number-count">
-      {reversedGroupsOfCount.map((group, idx) => {
+      {groupsOfThree.map((group, idx) => {
         return (
           <div
             key={`listen-group-${idx.toString()}`}


### PR DESCRIPTION
The homepage is showing the number of listens and artists in reverse order for some reason, possibly from a previous attempt at the implementation.
Removed a couple of lines that reverse the number, and we're good to go.