### PR TITLE
Avoid exhausting resources in metadata api lookup

### DIFF
--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -4,6 +4,7 @@ from time import sleep
 import typesense
 import typesense.exceptions
 import requests.exceptions
+from flask import current_app
 from markupsafe import Markup
 from unidecode import unidecode
 from Levenshtein import distance
@@ -55,7 +56,7 @@ class MBIDMapper:
     MATCH_TYPE_HIGH_QUALITY_MAX_EDIT_DISTANCE = 2
     MATCH_TYPE_MED_QUALITY_MAX_EDIT_DISTANCE = 5
 
-    def __init__(self, timeout=DEFAULT_TIMEOUT, remove_stop_words=False, debug=False):
+    def __init__(self, timeout=DEFAULT_TIMEOUT, remove_stop_words=False, debug=False, retry_on_timeout=True):
         self.debug = debug
         self.log = []
 
@@ -69,6 +70,7 @@ class MBIDMapper:
             'connection_timeout_seconds': timeout
         })
         self.remove_stop_words = remove_stop_words
+        self.retry_on_timeout = retry_on_timeout
 
     def _log(self, str):
         if self.debug:
@@ -269,8 +271,11 @@ class MBIDMapper:
                 hits = self.client.collections[collection].documents.search(search_parameters)
                 break
             except requests.exceptions.ReadTimeout:
-                print("Got socket timeout, sleeping 5 seconds, trying again.")
-                sleep(5)
+                if self.retry_on_timeout:
+                    current_app.logger.error("Got socket timeout, sleeping 5 seconds, trying again.", exc_info=True)
+                    sleep(5)
+                else:
+                    raise
             except typesense.exceptions.RequestMalformed:
                 return None
 

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -236,7 +236,7 @@ def get_mbid_mapping():
         if exact_results:
             return process_results(exact_results[0], metadata, incs)
 
-        q = MBIDMapper(timeout=10, remove_stop_words=True, debug=False)
+        q = MBIDMapper(timeout=10, remove_stop_words=True, debug=False, retry_on_timeout=False)
         fuzzy_result = q.search(artist_name, recording_name, release_name)
         if fuzzy_result:
             return process_results(fuzzy_result, metadata, incs)

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -17,7 +17,7 @@ from listenbrainz.webserver.views.api_tools import is_valid_uuid, validate_auth_
 metadata_bp = Blueprint('metadata', __name__)
 
 #: The maximum length of the query permitted for a mapping search
-MAX_MAPPING_QUERY_LENGTH = 500
+MAX_MAPPING_QUERY_LENGTH = 250
 
 
 def parse_incs():

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -16,6 +16,9 @@ from listenbrainz.webserver.views.api_tools import is_valid_uuid, validate_auth_
 
 metadata_bp = Blueprint('metadata', __name__)
 
+#: The maximum length of the query permitted for a mapping search
+MAX_MAPPING_QUERY_LENGTH = 500
+
 
 def parse_incs():
     allowed_incs = ("artist", "tag", "release", "recording", "release_group")
@@ -181,11 +184,15 @@ def process_results(match, metadata, incs):
 @ratelimit()
 def get_mbid_mapping():
     """
-    This endpoint looks up mbid metadata for the given artist and recording name.
+    This endpoint looks up mbid metadata for the given artist, recording and optionally a release name.
+    The total number of characters in the artist name, recording name and release name query arguments should be
+    less than or equal to :data:`~webserver.views.metadata_api.MAX_MAPPING_QUERY_LENGTH`.
 
     :param artist_name: artist name of the listen
     :type artist_name: ``str``
     :param recording_name: track name of the listen
+    :type artist_name: ``str``
+    :param recording_name: release name of the listen
     :type artist_name: ``str``
     :param metadata: should extra metadata be also returned if a match is found,
                      see /metadata/recording for details.
@@ -202,6 +209,9 @@ def get_mbid_mapping():
         raise APIBadRequest("artist_name is invalid or not present in arguments")
     if not recording_name:
         raise APIBadRequest("recording_name is invalid or not present in arguments")
+    if len(artist_name) + len(recording_name) + len(release_name or "") > MAX_MAPPING_QUERY_LENGTH:
+        raise APIBadRequest(f"total number of characters in artist_name, recording_name and release_name"
+                            f" arguments must be less than {MAX_MAPPING_QUERY_LENGTH}")
 
     metadata = parse_boolean_arg("metadata")
     incs = parse_incs() if metadata else []


### PR DESCRIPTION
1. Restrict query length in metadata api lookups

    Typesense performance will degrade the query is huge, for instance a 1000 character query can take 15-20s for the request to complete. This also keeps the worker and other resources occupied making it easy to run out of resources to serve other requests. We limit the length of the lookup being indexed in the database to 500 characters, so it makes sense to apply at the least the same limit on the metadata API lookup.

2. Do not retry on typesense search timeout in metadata API

    The timeout for typesense requests is pretty generous IMO, it might make sense to still retry it for the mapper which runs as a background process but for the API we should probably just fail the request.