### PR TITLE
Fix MB OAuth token storage yet again

### DIFF
--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -46,8 +46,6 @@ def get_user():
         db_user.create(db_conn, musicbrainz_row_id, musicbrainz_id, email=user_email)
         user = db_user.get_by_mb_id(db_conn, musicbrainz_id, fetch_email=True)
         ts.set_empty_values_for_user(user["id"])
-        # add new oauth token for the user
-        service.add_new_user(user["id"], token)
     else:  # an existing user is trying to log in
         # Other option is to change the return type of get_by_mb_row_id to a dict
         # but its used so widely that we would modify huge number of tests
@@ -55,7 +53,12 @@ def get_user():
         user["email"] = user_email
         # every time a user logs in, update the email in LB.
         db_user.update_user_details(db_conn, user["id"], musicbrainz_id, user_email)
-        # update oauth token for the user
+
+    # save user's MB OAuth token, this check cannot be merged with the previous signup/login check because
+    # we have a different service user row for each LB deployment but a common user row for all three
+    if service.get_user(user["id"]) is None:
+        service.add_new_user(user["id"], token)
+    else:
         service.update_user(user["id"], token)
 
     return user


### PR DESCRIPTION
The checks for when to update or add the token were incorrect. For existing users, the code assumed MB deployment service rows would exist for each test/beta/prod but that is not the case always. Token updates were as a result lost because there was no row to update in the database.

Separate the check for updating the service row from detecting login and signup to fix.