### PR TITLE
Add a threshold to fresh releases calculation

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -33,7 +33,7 @@ MAILTO=""
 15 2 * * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh feedback >> /logs/dumps.log 2>&1
 
 # Request user fresh releases daily
-0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_fresh_releases --days 30 >> /logs/fresh_releases.log 2>&1
+0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_fresh_releases --threshold 10 >> /logs/fresh_releases.log 2>&1
 
 # Run spotify metadata cache seeder
 0 4 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark run-metadata-cache-seeder >> /logs/metadata_cache.log 2>&1

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -351,11 +351,13 @@ def request_recording_discovery():
 @cli.command(name='request_fresh_releases')
 @click.option("--days", type=int, required=False, help="Number of days of listens to consider for artist listening data")
 @click.option("--database", type=str, help="Name of the couchdb database to store data in")
-def request_fresh_releases(database, days):
+@click.option("--threshold", type=int, default=0, required=False,
+              help="Number of days of listens to consider for artist listening data")
+def request_fresh_releases(database, days, threshold):
     """ Send the cluster a request to generate release radar data. """
     if not database:
         database = "fresh_releases_" + date.today().strftime("%Y%m%d")
-    send_request_to_spark_cluster('releases.fresh', database=database, days=days)
+    send_request_to_spark_cluster('releases.fresh', database=database, days=days, threshold=threshold)
 
 
 @cli.command(name='request_import_artist_relation')

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -225,7 +225,7 @@
   "releases.fresh": {
     "name": "releases.fresh",
     "description": "Calculate the intersection of fresh releases and user's listening history",
-    "params": ["days", "database"]
+    "params": ["days", "database", "threshold"]
   },
   "troi.playlists": {
     "name": "troi.playlists",

--- a/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
@@ -40,7 +40,7 @@ class FreshReleasesTestCase(SparkNewTestCase):
 
         database = "fresh_releases_20220919"
 
-        itr = fresh_releases.main(None, database)
+        itr = fresh_releases.main(None, database, 0)
 
         self.assertEqual(next(itr), {
             "type": "couchdb_data_start",


### PR DESCRIPTION
We want to generate the customized user feed of fresh releases using the user's entire listening history, therefore it makes sense to have a threshold parameter to reduce the noise of artists listened very few times.
