### PR TITLE
Modals: remove backdrop class manually when closing modals

### DIFF
--- a/frontend/js/src/cb-review/CBReviewModal.tsx
+++ b/frontend/js/src/cb-review/CBReviewModal.tsx
@@ -43,6 +43,7 @@ export default NiceModal.create(({ listen }: CBReviewModalProps) => {
 
   const closeModal = React.useCallback(() => {
     modal.hide();
+    document?.body?.classList?.remove("modal-open");
     setTimeout(modal.remove, 200);
   }, [modal]);
 

--- a/frontend/js/src/common/listens/AddToPlaylist.tsx
+++ b/frontend/js/src/common/listens/AddToPlaylist.tsx
@@ -31,6 +31,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
 
   const closeModal = React.useCallback(() => {
     modal.hide();
+    document?.body?.classList?.remove("modal-open");
     setTimeout(modal.remove, 200);
   }, [modal]);
 

--- a/frontend/js/src/common/listens/ListenPayloadModal.tsx
+++ b/frontend/js/src/common/listens/ListenPayloadModal.tsx
@@ -28,6 +28,7 @@ export default NiceModal.create(({ listen }: ListenPayloadModalProps) => {
 
   const closeModal = () => {
     modal.hide();
+    document?.body?.classList?.remove("modal-open");
     setTimeout(modal.remove, 200);
   };
   const stringifiedJSON = JSON.stringify(listen, null, 2);

--- a/frontend/js/src/common/listens/MBIDMappingModal.tsx
+++ b/frontend/js/src/common/listens/MBIDMappingModal.tsx
@@ -50,6 +50,7 @@ export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
 
   const closeModal = React.useCallback(() => {
     modal.hide();
+    document?.body?.classList?.remove("modal-open");
     setTimeout(modal.remove, 200);
   }, [modal]);
 

--- a/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
+++ b/frontend/js/src/personal-recommendations/PersonalRecommendationsModal.tsx
@@ -103,6 +103,7 @@ export default NiceModal.create(
 
     const closeModal = () => {
       modal.hide();
+      document?.body?.classList?.remove("modal-open");
       setTimeout(modal.remove, 200);
     };
 

--- a/frontend/js/src/pins/PinRecordingModal.tsx
+++ b/frontend/js/src/pins/PinRecordingModal.tsx
@@ -63,6 +63,7 @@ export default NiceModal.create(
 
     const closeModal = () => {
       modal.hide();
+      document?.body?.classList?.remove("modal-open");
       setTimeout(modal.remove, 200);
     };
 

--- a/frontend/js/src/playlists/components/CreateOrEditPlaylistModal.tsx
+++ b/frontend/js/src/playlists/components/CreateOrEditPlaylistModal.tsx
@@ -22,6 +22,7 @@ export default NiceModal.create((props: CreateOrEditPlaylistModalProps) => {
   const modal = useModal();
   const closeModal = React.useCallback(() => {
     modal.hide();
+    document?.body?.classList?.remove("modal-open");
     setTimeout(modal.remove, 200);
   }, [modal]);
 

--- a/frontend/js/src/playlists/components/DeletePlaylistConfirmationModal.tsx
+++ b/frontend/js/src/playlists/components/DeletePlaylistConfirmationModal.tsx
@@ -14,6 +14,7 @@ export default NiceModal.create(
     const modal = useModal();
     const closeModal = React.useCallback(() => {
       modal.hide();
+      document?.body?.classList?.remove("modal-open");
       setTimeout(modal.remove, 200);
     }, [modal]);
 

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -52,6 +52,7 @@ export default NiceModal.create(() => {
 
   const closeModal = useCallback(() => {
     modal.hide();
+    document?.body?.classList?.remove("modal-open");
     setTimeout(modal.remove, 200);
   }, [modal]);
 


### PR DESCRIPTION
Due to removing the modal from the DOM tree to conserve resources , I broke the bootstrap/jquery mechanism that removes the "modal-open" class that is added to the HTML body element when we open a modal (#2772 made the timeout shorter).
Since the DOM elements are removed, the event callback that removes the class isn't fired, so we need to fire it manually.

Let's move to React-Bootstrap soon and avoid all this bullshit, shall we?
