### PR TITLE
 Separate popularity calculation for MLHD and listens 

### DIFF
--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -58,9 +58,11 @@ class PopularityTopDataset(DatabaseDataset):
     def __init__(self, entity, mlhd):
         if mlhd:
             name = "mlhd_popularity_top_" + entity
+            table_name = "top_" + entity
         else:
             name = "popularity_top_" + entity
-        super().__init__(name, f"top_{entity}", "popularity")
+            table_name = "mlhd_top_" + entity
+        super().__init__(name, table_name, "popularity")
         self.entity = entity
         self.entity_mbid = f"{entity}_mbid"
         self.mlhd = mlhd

--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -14,10 +14,17 @@ class PopularityDataset(DatabaseDataset):
     """ Dataset class for artists, recordings and releases with popularity info (listen count and unique listener count)
      from MLHD data """
 
-    def __init__(self, entity):
-        super().__init__(f"mlhd_popularity_{entity}", entity, "popularity")
+    def __init__(self, entity, mlhd):
+        if mlhd:
+            name = "mlhd_popularity_" + entity
+            table_name = "mlhd_" + entity
+        else:
+            name = "popularity_" + entity
+            table_name = entity
+        super().__init__(name, table_name, "popularity")
         self.entity = entity
         self.entity_mbid = f"{entity}_mbid"
+        self.mlhd = mlhd
 
     def get_table(self):
         return f"""
@@ -34,9 +41,13 @@ class PopularityDataset(DatabaseDataset):
         return query, None, values
 
     def get_indexes(self):
+        if self.mlhd:
+            prefix = "mlhd_popularity"
+        else:
+            prefix = "popularity"
         return [
-            f"CREATE INDEX popularity_{self.entity}_listen_count_idx_{{suffix}} ON {{table}} (total_listen_count) INCLUDE ({self.entity_mbid})",
-            f"CREATE INDEX popularity_{self.entity}_user_count_idx_{{suffix}} ON {{table}} (total_user_count) INCLUDE ({self.entity_mbid})"
+            f"CREATE INDEX {prefix}_{self.entity}_listen_count_idx_{{suffix}} ON {{table}} (total_listen_count) INCLUDE ({self.entity_mbid})",
+            f"CREATE INDEX {prefix}_{self.entity}_user_count_idx_{{suffix}} ON {{table}} (total_user_count) INCLUDE ({self.entity_mbid})"
         ]
 
 
@@ -44,10 +55,15 @@ class PopularityTopDataset(DatabaseDataset):
     """ Dataset class for all recordings and releases with popularity info (total listen count and unique listener
      count) for each artist in MLHD data. """
 
-    def __init__(self, entity):
-        super().__init__(f"mlhd_popularity_top_{entity}", f"top_{entity}", "popularity")
+    def __init__(self, entity, mlhd):
+        if mlhd:
+            name = "mlhd_popularity_top_" + entity
+        else:
+            name = "popularity_top_" + entity
+        super().__init__(name, f"top_{entity}", "popularity")
         self.entity = entity
         self.entity_mbid = f"{entity}_mbid"
+        self.mlhd = mlhd
 
     def get_table(self):
         return f"""
@@ -65,19 +81,25 @@ class PopularityTopDataset(DatabaseDataset):
         return query, None, values
 
     def get_indexes(self):
+        if self.mlhd:
+            prefix = "mlhd_popularity_top"
+        else:
+            prefix = "popularity_top"
         return [
-            f"CREATE INDEX popularity_top_{self.entity}_artist_mbid_listen_count_idx_{{suffix}} ON {{table}} (artist_mbid, total_listen_count) INCLUDE ({self.entity_mbid})",
-            f"CREATE INDEX popularity_top_{self.entity}_artist_mbid_user_count_idx_{{suffix}} ON {{table}} (artist_mbid, total_user_count) INCLUDE ({self.entity_mbid})"
+            f"CREATE INDEX {prefix}_{self.entity}_artist_mbid_listen_count_idx_{{suffix}} ON {{table}} (artist_mbid, total_listen_count) INCLUDE ({self.entity_mbid})",
+            f"CREATE INDEX {prefix}_{self.entity}_artist_mbid_user_count_idx_{{suffix}} ON {{table}} (artist_mbid, total_user_count) INCLUDE ({self.entity_mbid})"
         ]
 
 
-RecordingPopularityDataset = PopularityDataset("recording")
-ArtistPopularityDataset = PopularityDataset("artist")
-ReleasePopularityDataset = PopularityDataset("release")
-ReleaseGroupPopularityDataset = PopularityDataset("release_group")
-TopRecordingPopularityDataset = PopularityTopDataset("recording")
-TopReleasePopularityDataset = PopularityTopDataset("release")
-TopReleaseGroupPopularityDataset = PopularityTopDataset("release_group")
+def get_all_popularity_datasets():
+    """ Return all possible popularity datasets """
+    datasets = []
+    for entity in ["artist", "recording", "release", "release_group"]:
+        for mlhd in [False, True]:
+            datasets.append(PopularityDataset(entity, mlhd))
+            if entity != "artist":
+                datasets.append(PopularityTopDataset(entity, mlhd))
+    return datasets
 
 
 def get_top_entity_for_artist(ts_conn, entity, artist_mbid, count=None):
@@ -100,11 +122,24 @@ def get_top_entity_for_artist(ts_conn, entity, artist_mbid, count=None):
         limit = "LIMIT :count"
 
     query = """
-        SELECT """ + entity_mbid + """::TEXT
+          WITH intermediate AS (
+        SELECT """ + entity_mbid + """
              , total_listen_count
              , total_user_count
           FROM popularity.top_""" + entity + """
          WHERE artist_mbid = :artist_mbid
+     UNION ALL
+        SELECT """ + entity_mbid + """
+             , total_listen_count
+             , total_user_count
+          FROM popularity.mlhd_top_""" + entity + """
+         WHERE artist_mbid = :artist_mbid
+             )
+        SELECT """ + entity_mbid + """::TEXT
+             , SUM(total_listen_count) AS total_listen_count
+             , SUM(total_user_count) AS total_user_count
+          FROM intermediate
+      GROUP BY """ + entity_mbid + """
       ORDER BY total_listen_count DESC
     """ + limit
     results = ts_conn.execute(text(query), {"artist_mbid": artist_mbid, "count": count})
@@ -123,14 +158,33 @@ def get_counts(ts_conn, entity, mbids):
         return []
 
     query = SQL("""
-          WITH mbids (mbid) AS (VALUES %s)
+          WITH mbids (mbid) AS (
+               VALUES %s
+             ), intermediate AS (
         SELECT mbid
              , total_listen_count
              , total_user_count
           FROM {table}
           JOIN mbids
             ON {entity_mbid} = mbid::UUID
-    """).format(entity_mbid=Identifier(entity_mbid), table=Identifier("popularity", entity))
+         UNION ALL
+        SELECT mbid
+             , total_listen_count
+             , total_user_count
+          FROM {mlhd_table}
+          JOIN mbids
+            ON {entity_mbid} = mbid::UUID
+             )
+        SELECT mbid
+             , SUM(total_listen_count) AS total_listen_count
+             , SUM(total_user_count) AS total_user_count
+          FROM intermediate
+      GROUP BY mbid    
+    """).format(
+        entity_mbid=Identifier(entity_mbid),
+        table=Identifier("popularity", entity),
+        mlhd_table=Identifier("popularity", "mlhd_" + entity)
+    )
     ts_curs = ts_conn.connection.cursor()
     results = execute_values(ts_curs, query, [(mbid, ) for mbid in mbids], fetch=True)
     index = {row[0]: (row[1], row[2]) for row in results}

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -469,10 +469,11 @@ def request_similar_artists(days, session, contribution, threshold, limit, skip,
     )
 
 
-@cli.command(name='request_mlhd_popularity')
-def request_mlhd_popularity():
-    """ Request mlhd popularity data. """
-    send_request_to_spark_cluster("mlhd.popularity.all")
+@cli.command(name='request_popularity')
+@click.option("--use-mlhd", "mlhd", is_flag=True, help="Use MLHD+ data or ListenBrainz listens data")
+def request_popularity(mlhd):
+    """ Request mlhd popularity data using the specified dataset. """
+    send_request_to_spark_cluster("popularity.all", mlhd=mlhd)
 
 
 @cli.command(name="request_yim_similar_users")

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -237,9 +237,9 @@
     "description": "Generate the tags dataset with percent rank",
     "params": []
   },
-  "mlhd.popularity.all": {
-    "name": "mlhd.popularity.all",
-    "description": "Calculate all popularity data from mlhd.",
-    "params": []
+  "popularity.all": {
+    "name": "popularity.all",
+    "description": "Calculate all popularity data from mlhd or listenbrainz data.",
+    "params": ["mlhd"]
   }
 }

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -7,9 +7,7 @@ import sentry_sdk
 from kombu import Connection, Message, Consumer, Exchange, Queue
 from kombu.mixins import ConsumerMixin
 
-from listenbrainz.db.popularity import RecordingPopularityDataset, ReleasePopularityDataset, \
-    TopRecordingPopularityDataset, ArtistPopularityDataset, TopReleasePopularityDataset, ReleaseGroupPopularityDataset, \
-    TopReleaseGroupPopularityDataset
+from listenbrainz.db.popularity import get_all_popularity_datasets
 from listenbrainz.db.similarity import SimilarRecordingsDataset, SimilarArtistsDataset
 from listenbrainz.db.tags import TagsDataset
 from listenbrainz.spark.handlers import (
@@ -67,13 +65,7 @@ class SparkReader(ConsumerMixin):
             SimilarRecordingsDataset,
             SimilarArtistsDataset,
             TagsDataset,
-            RecordingPopularityDataset,
-            ReleasePopularityDataset,
-            ArtistPopularityDataset,
-            ReleaseGroupPopularityDataset,
-            TopRecordingPopularityDataset,
-            TopReleasePopularityDataset,
-            TopReleaseGroupPopularityDataset
+            *get_all_popularity_datasets()
         ]
         for dataset in datasets:
             self.response_handlers.update(dataset.get_handlers())

--- a/listenbrainz_spark/popularity/main.py
+++ b/listenbrainz_spark/popularity/main.py
@@ -1,0 +1,137 @@
+from more_itertools import chunked
+
+from listenbrainz_spark import config
+from listenbrainz_spark.path import MLHD_PLUS_DATA_DIRECTORY, RELEASE_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import get_listens_from_dump, read_files_from_HDFS
+
+STATS_PER_MESSAGE = 10000
+
+
+def generate_popularity_stats(name, query, mlhd):
+    """ Execute the given query and generate statistics. """
+    df = run_query(query)
+    df\
+        .write\
+        .format("parquet")\
+        .save(config.HDFS_CLUSTER_URI + "/" + name, mode="overwrite")
+
+    itr = df.toLocalIterator()
+
+    for rows in chunked(itr, STATS_PER_MESSAGE):
+        entries = []
+        for row in rows:
+            entry = row.asDict(recursive=True)
+            entries.append(entry)
+
+        yield {
+            "type": name,
+            "data": entries,
+            "mlhd": mlhd
+        }
+
+
+def get_release_group_popularity_query(table, rel_cache_table):
+    """ Get the query to generate release group popularity stats using both MLHD+ and listens data """
+    return f"""
+        SELECT rel.release_group_mbid
+             , count(*) AS total_listen_count
+             , count(DISTINCT user_id) AS total_user_count
+          FROM {table} t
+          JOIN {rel_cache_table} rel
+            ON t.release_mbid = rel.release_mbid
+           AND rel.release_group_mbid != ""
+      GROUP BY rel.release_group_mbid
+    """
+
+
+def get_release_group_popularity_per_artist_query(table, rel_cache_table):
+    """ Get the query to generate release group popularity per artists stats using both MLHD+ and listens data """
+    return f"""
+        WITH intermediate AS (
+            SELECT explode(artist_credit_mbids) AS artist_mbid
+                 , release_mbid
+                 , user_id
+              FROM {table}
+        )   SELECT artist_mbid
+                 , rel.release_group_mbid
+                 , count(*) AS total_listen_count
+                 , count(DISTINCT user_id) AS total_user_count
+              FROM intermediate i
+              JOIN {rel_cache_table} rel
+                ON i.release_mbid = rel.release_mbid
+             WHERE artist_mbid IS NOT NULL
+               AND rel.release_group_mbid != ""
+          GROUP BY artist_mbid
+                 , rel.release_group_mbid
+    """
+
+
+def get_popularity_query(entity, table):
+    """ Get the query to generate popularity stats for the given entity using both MLHD+ and listens data """
+    entity_mbid = f"{entity}_mbid"
+    return f"""
+        SELECT {entity_mbid}
+             , count(*) AS total_listen_count
+             , count(DISTINCT user_id) AS total_user_count
+          FROM {table}
+         WHERE {entity_mbid} IS NOT NULL
+           AND {entity_mbid} != ""
+      GROUP BY {entity_mbid}
+    """
+
+
+def get_popularity_per_artist_query(entity, table):
+    """ Get the query to generate top popular entities per artists stats from MLHD+ and listens data """
+    if entity == "artist":
+        select_clause = "artist_mbid"
+        explode_clause = "explode(artist_credit_mbids) AS artist_mbid"
+        where_clause = "artist_mbid IS NOT NULL"
+    else:
+        entity_mbid = f"{entity}_mbid"
+        select_clause = f"artist_mbid, {entity_mbid}"
+        explode_clause = f"explode(artist_credit_mbids) AS artist_mbid, {entity_mbid}"
+        where_clause = f"artist_mbid IS NOT NULL AND {entity_mbid} IS NOT NULL AND {entity_mbid} != ''"
+    return f"""
+        WITH intermediate AS (
+            SELECT {explode_clause}
+                 , user_id
+              FROM {table}
+        )   SELECT {select_clause}
+                 , count(*) AS total_listen_count
+                 , count(DISTINCT user_id) AS total_user_count
+              FROM intermediate
+             WHERE {where_clause}
+          GROUP BY {select_clause}
+    """
+
+
+def main(mlhd):
+    """ Generate popularity data for MLHD data. """
+    if mlhd:
+        table = f"parquet.`{MLHD_PLUS_DATA_DIRECTORY}`"
+    else:
+        table = "listens_popularity"
+        get_listens_from_dump().createOrReplaceTempView(table)
+
+    rel_cache_table = "release_data_cache"
+    read_files_from_HDFS(RELEASE_METADATA_CACHE_DATAFRAME).createOrReplaceTempView(rel_cache_table)
+
+    queries = {
+        "popularity_top_recording": get_popularity_per_artist_query("recording", table),
+        "popularity_recording": get_popularity_query("recording", table),
+        "popularity_release": get_popularity_query("release", table),
+        "popularity_release_group": get_release_group_popularity_query(table, rel_cache_table),
+        "popularity_top_release_group": get_release_group_popularity_per_artist_query(table, rel_cache_table),
+        "popularity_artist": get_popularity_per_artist_query("artist", table),
+        "popularity_top_release": get_popularity_per_artist_query("release", table)
+    }
+
+    for name, query in queries.items():
+        if mlhd:
+            name = "mlhd_" + name
+
+        yield {"type": f"{name}_start"}
+        for message in generate_popularity_stats(name, query, mlhd):
+            yield message
+        yield {"type": f"{name}_end"}

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -32,7 +32,7 @@ import listenbrainz_spark.troi.periodic_jams
 import listenbrainz_spark.tags.tags
 import listenbrainz_spark.mlhd.download
 import listenbrainz_spark.mlhd.similarity
-import listenbrainz_spark.mlhd.popularity
+import listenbrainz_spark.popularity.main
 import listenbrainz_spark.echo.echo
 
 functions = {
@@ -45,21 +45,26 @@ functions = {
     'stats.sitewide.listening_activity': listenbrainz_spark.stats.sitewide.listening_activity.get_listening_activity,
     'import.dump.full_newest': listenbrainz_spark.request_consumer.jobs.import_dump.import_newest_full_dump_handler,
     'import.dump.full_id': listenbrainz_spark.request_consumer.jobs.import_dump.import_full_dump_by_id_handler,
-    'import.dump.incremental_newest': listenbrainz_spark.request_consumer.jobs.import_dump.import_newest_incremental_dump_handler,
+    'import.dump.incremental_newest':
+        listenbrainz_spark.request_consumer.jobs.import_dump.import_newest_incremental_dump_handler,
     'import.dump.mlhd': listenbrainz_spark.mlhd.download.import_mlhd_dump_to_hdfs,
-    'import.dump.incremental_id': listenbrainz_spark.request_consumer.jobs.import_dump.import_incremental_dump_by_id_handler,
+    'import.dump.incremental_id':
+        listenbrainz_spark.request_consumer.jobs.import_dump.import_incremental_dump_by_id_handler,
     'cf.missing_mb_data': listenbrainz_spark.missing_mb_data.missing_mb_data.main,
-    'cf.recommendations.recording.create_dataframes': listenbrainz_spark.recommendations.recording.create_dataframes.main,
+    'cf.recommendations.recording.create_dataframes':
+        listenbrainz_spark.recommendations.recording.create_dataframes.main,
     'cf.recommendations.recording.train_model': listenbrainz_spark.recommendations.recording.train_models.main,
     'cf.recommendations.recording.recommendations': listenbrainz_spark.recommendations.recording.recommend.main,
-    'cf.recommendations.recording.discovery': listenbrainz_spark.recommendations.recording.discovery.get_recording_discovery,
+    'cf.recommendations.recording.discovery':
+        listenbrainz_spark.recommendations.recording.discovery.get_recording_discovery,
     'import.artist_relation': listenbrainz_spark.request_consumer.jobs.import_dump.import_artist_relation_to_hdfs,
-    'import.musicbrainz_release_dump': listenbrainz_spark.request_consumer.jobs.import_dump.import_release_json_dump_to_hdfs,
+    'import.musicbrainz_release_dump':
+        listenbrainz_spark.request_consumer.jobs.import_dump.import_release_json_dump_to_hdfs,
     'similarity.similar_users': listenbrainz_spark.similarity.user.main,
     'similarity.recording.mlhd': listenbrainz_spark.mlhd.similarity.main,
     'similarity.recording': listenbrainz_spark.similarity.recording.main,
     'similarity.artist': listenbrainz_spark.similarity.artist.main,
-    'mlhd.popularity.all': listenbrainz_spark.mlhd.popularity.main,
+    'popularity.all': listenbrainz_spark.popularity.main,
     'year_in_music.new_releases_of_top_artists':
         listenbrainz_spark.year_in_music.new_releases_of_top_artists.get_new_releases_of_top_artists,
     'year_in_music.most_listened_year': listenbrainz_spark.year_in_music.most_listened_year.get_most_listened_year,
@@ -68,11 +73,13 @@ functions = {
     'year_in_music.top_stats': listenbrainz_spark.year_in_music.top_stats.calculate_top_entity_stats,
     'year_in_music.listens_per_day': listenbrainz_spark.year_in_music.listens_per_day.calculate_listens_per_day,
     'year_in_music.listen_count': listenbrainz_spark.year_in_music.listen_count.get_listen_count,
-    'year_in_music.new_artists_discovered_count': listenbrainz_spark.year_in_music.new_artists_discovered.get_new_artists_discovered_count,
+    'year_in_music.new_artists_discovered_count':
+        listenbrainz_spark.year_in_music.new_artists_discovered.get_new_artists_discovered_count,
     'year_in_music.listening_time': listenbrainz_spark.year_in_music.listening_time.get_listening_time,
     'year_in_music.artist_map': listenbrainz_spark.year_in_music.artist_map.get_artist_map_stats,
     'year_in_music.top_genres': listenbrainz_spark.year_in_music.top_genres.get_top_genres,
-    'year_in_music.top_missed_recordings': listenbrainz_spark.year_in_music.top_missed_recordings.generate_top_missed_recordings,
+    'year_in_music.top_missed_recordings':
+        listenbrainz_spark.year_in_music.top_missed_recordings.generate_top_missed_recordings,
     'year_in_music.top_discoveries': listenbrainz_spark.year_in_music.top_discoveries.generate_top_discoveries,
     'import.pg_metadata_tables': listenbrainz_spark.postgres.import_all_pg_tables,
     'releases.fresh': listenbrainz_spark.fresh_releases.fresh_releases.main,

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -64,7 +64,7 @@ functions = {
     'similarity.recording.mlhd': listenbrainz_spark.mlhd.similarity.main,
     'similarity.recording': listenbrainz_spark.similarity.recording.main,
     'similarity.artist': listenbrainz_spark.similarity.artist.main,
-    'popularity.all': listenbrainz_spark.popularity.main,
+    'popularity.all': listenbrainz_spark.popularity.main.main,
     'year_in_music.new_releases_of_top_artists':
         listenbrainz_spark.year_in_music.new_releases_of_top_artists.get_new_releases_of_top_artists,
     'year_in_music.most_listened_year': listenbrainz_spark.year_in_music.most_listened_year.get_most_listened_year,


### PR DESCRIPTION
The MLHD dataset is static so we only need to compute it once (occasionally), whereas the listens dataset is regularly updated and hence the popularity data based off it needs to be regenerated regularly too. Separating the two reduces redundant calculation in Spark cluster every time we update popularity data, we get regular spark alerts when we process MLHD popularity so it would be helpful somewhat.