### PR TITLE
Fix similarity datasets message name

### DIFF
--- a/listenbrainz_spark/similarity/artist.py
+++ b/listenbrainz_spark/similarity/artist.py
@@ -143,14 +143,14 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similarity_artists_start",
+            "type": "similarity_artist_start",
             "algorithm": algorithm
         }
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]
         yield {
-            "type": "similarity_artists",
+            "type": "similarity_artist",
             "algorithm": algorithm,
             "data": items,
             "is_production_dataset": is_production_dataset
@@ -158,6 +158,6 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similarity_artists_end",
+            "type": "similarity_artist_end",
             "algorithm": algorithm
         }

--- a/listenbrainz_spark/similarity/artist.py
+++ b/listenbrainz_spark/similarity/artist.py
@@ -143,14 +143,14 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similar_recordings_start",
+            "type": "similarity_artists_start",
             "algorithm": algorithm
         }
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]
         yield {
-            "type": "similar_artists",
+            "type": "similarity_artists",
             "algorithm": algorithm,
             "data": items,
             "is_production_dataset": is_production_dataset
@@ -158,6 +158,6 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similar_recordings_end",
+            "type": "similarity_artists_end",
             "algorithm": algorithm
         }

--- a/listenbrainz_spark/similarity/recording.py
+++ b/listenbrainz_spark/similarity/recording.py
@@ -127,14 +127,14 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similar_recordings_start",
+            "type": "similarity_recordings_start",
             "algorithm": algorithm
         }
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]
         yield {
-            "type": "similar_recordings",
+            "type": "similarity_recordings",
             "algorithm": algorithm,
             "data": items,
             "is_production_dataset": is_production_dataset
@@ -142,6 +142,6 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similar_recordings_end",
+            "type": "similarity_recordings_end",
             "algorithm": algorithm
         }

--- a/listenbrainz_spark/similarity/recording.py
+++ b/listenbrainz_spark/similarity/recording.py
@@ -127,14 +127,14 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similarity_recordings_start",
+            "type": "similarity_recording_start",
             "algorithm": algorithm
         }
 
     for entries in chunked(data, RECORDINGS_PER_MESSAGE):
         items = [row.asDict() for row in entries]
         yield {
-            "type": "similarity_recordings",
+            "type": "similarity_recording",
             "algorithm": algorithm,
             "data": items,
             "is_production_dataset": is_production_dataset
@@ -142,6 +142,6 @@ def main(days, session, contribution, threshold, limit, skip, is_production_data
 
     if is_production_dataset:
         yield {
-            "type": "similarity_recordings_end",
+            "type": "similarity_recording_end",
             "algorithm": algorithm
         }


### PR DESCRIPTION
Spark reader expects the names to start with similarity instead of similar.