### PR TITLE
LB-476: Use https on demos when endpoint is `api.listenbrainz.org`

### DIFF
--- a/docs/users/api_usage_examples/get_latest_import.py
+++ b/docs/users/api_usage_examples/get_latest_import.py
@@ -1,6 +1,10 @@
 import requests
 
-ROOT = '127.0.0.1'
+# Set DEBUG to True to test local dev server.
+# API keys for local dev server and the real server are different.
+DEBUG = True
+ROOT = 'http://localhost:8100' if DEBUG else 'https://api.listenbrainz.org'
+
 # The token can be any valid token.
 TOKEN = 'YOUR_TOKEN_HERE'
 AUTH_HEADER = {
@@ -23,7 +27,7 @@ def get_latest_import(username, service="lastfm"):
         An IndexError if the JSON is not structured as expected.
     """
     response = requests.get(
-        url="http://{0}/1/latest-import".format(ROOT),
+        url="{0}/1/latest-import".format(ROOT),
         params={
             "user_name": username,
             "service": service

--- a/docs/users/api_usage_examples/get_listens.py
+++ b/docs/users/api_usage_examples/get_listens.py
@@ -1,6 +1,10 @@
 import requests
 
-ROOT = '127.0.0.1'
+# Set DEBUG to True to test local dev server.
+# API keys for local dev server and the real server are different.
+DEBUG = True
+ROOT = 'http://localhost:8100' if DEBUG else 'https://api.listenbrainz.org'
+
 # The following token must be valid, but it doesn't have to be the token of the user you're
 # trying to get the listen history of.
 TOKEN = 'YOUR_TOKEN_HERE'
@@ -30,7 +34,7 @@ def get_listens(username, min_ts=None, max_ts=None, count=None):
         An IndexError if the JSON is not structured as expected.
     """
     response = requests.get(
-        url="http://{0}/1/user/{1}/listens".format(ROOT, username),
+        url="{0}/1/user/{1}/listens".format(ROOT, username),
         params={
             "min_ts": min_ts,
             "max_ts": max_ts,

--- a/docs/users/api_usage_examples/lookup_metadata.py
+++ b/docs/users/api_usage_examples/lookup_metadata.py
@@ -3,6 +3,9 @@
 import json
 import requests
 
+# Set DEBUG to True to test local dev server.
+DEBUG = False
+ROOT = 'http://localhost:8100' if DEBUG else 'https://api.listenbrainz.org'
 
 def lookup_metadata(track_name: str, artist_name: str, incs: str) -> dict:
     """Looks up the metadata for a listen using track name and artist name."""
@@ -14,7 +17,7 @@ def lookup_metadata(track_name: str, artist_name: str, incs: str) -> dict:
         params["metadata"] = True
         params["incs"] = incs
     response = requests.get(
-        url="https://api.listenbrainz.org/1/metadata/lookup/",
+        url="{0}/1/metadata/lookup/".format(ROOT),
         params=params
     )
     response.raise_for_status()

--- a/docs/users/api_usage_examples/set_latest_import.py
+++ b/docs/users/api_usage_examples/set_latest_import.py
@@ -1,7 +1,10 @@
 from time import time
 import requests
 
-ROOT = '127.0.0.1'
+# Set DEBUG to True to test local dev server.
+# API keys for local dev server and the real server are different.
+DEBUG = True
+ROOT = 'http://localhost:8100' if DEBUG else 'https://api.listenbrainz.org'
 
 def set_latest_import(timestamp, token, service="lastfm"):
     """Sets the time of the latest import.
@@ -19,7 +22,7 @@ def set_latest_import(timestamp, token, service="lastfm"):
         A ValueError if the JSON response is invalid.
     """
     response = requests.post(
-        url="http://{0}/1/latest-import".format(ROOT),
+        url="{0}/1/latest-import".format(ROOT),
         json={
             "ts": timestamp,
             "service": service

--- a/docs/users/api_usage_examples/submit_feedback.py
+++ b/docs/users/api_usage_examples/submit_feedback.py
@@ -2,11 +2,15 @@
 
 import requests
 
+# Set DEBUG to True to test local dev server.
+# API keys for local dev server and the real server are different.
+DEBUG = True
+ROOT = 'http://localhost:8100' if DEBUG else 'https://api.listenbrainz.org'
 
 def submit_feedback(token: str, recording_mbid: str, score: int):
     """ Submit feedback for recording. """
     response = requests.post(
-        url="https://api.listenbrainz.org/1/feedback/recording-feedback",
+        url="{0}/1/feedback/recording-feedback".format(ROOT),
         json={"recording_mbid": recording_mbid, "score": score},
         headers={"Authorization": f"Token {token}"}
     )

--- a/docs/users/api_usage_examples/submit_listens.py
+++ b/docs/users/api_usage_examples/submit_listens.py
@@ -1,7 +1,10 @@
 from time import time
 import requests
 
-ROOT = '127.0.0.1'
+# Set DEBUG to True to test local dev server.
+# API keys for local dev server and the real server are different.
+DEBUG = True
+ROOT = 'http://localhost:8100' if DEBUG else 'https://api.listenbrainz.org'
 
 def submit_listen(listen_type, payload, token):
     """Submits listens for the track(s) in payload.
@@ -20,7 +23,7 @@ def submit_listen(listen_type, payload, token):
     """
 
     response = requests.post(
-        url="http://{0}/1/submit-listens".format(ROOT),
+        url="{0}/1/submit-listens".format(ROOT),
         json={
             "listen_type": listen_type,
             "payload": payload,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

[Ticket LB-476](https://tickets.metabrainz.org/browse/LB-476): Use https on demos when endpoint is `api.listenbrainz.org`.



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

1. add a boolean flag `DEBUG` to indicate whether to call API on the local server, or the real server. 
2. given a `DEBUG` value, the correct API url is selected and assigned to `ROOT`. `DEBUG = True` will select the local dev server.



