### PR TITLE
Art Creator: Update svg-loader library and fix sidebar

### DIFF
--- a/frontend/css/fresh-releases.less
+++ b/frontend/css/fresh-releases.less
@@ -270,30 +270,6 @@
   flex-direction: column;
 }
 
-.toggle-sidebar-button {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  z-index: 9999;
-  width: 64px;
-  height: 64px;
-  padding: 10px;
-  border-radius: 50%;
-  border-color: black;
-  cursor: pointer;
-  background-color: #fff;
-  color: #353070;
-
-  @media screen and (min-width: @screen-md) {
-    display: none;
-  }
-}
-
-.toggle-sidebar-button.open {
-  background-color: #353070;
-  color: #fff;
-}
-
 .no-release {
   text-align: center;
   margin-left: auto;

--- a/frontend/js/src/components/Sidebar.tsx
+++ b/frontend/js/src/components/Sidebar.tsx
@@ -7,9 +7,12 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 function Sidebar(
-  props: React.PropsWithChildren<{ toggleIcon?: IconDefinition }>
+  props: React.PropsWithChildren<{
+    toggleIcon?: IconDefinition;
+    className?: string;
+  }>
 ) {
-  const { children, toggleIcon } = props;
+  const { children, toggleIcon, className } = props;
 
   const [isSidebarOpen, setIsSidebarOpen] = React.useState<boolean>(false);
   const toggleSidebar = () => {
@@ -18,7 +21,9 @@ function Sidebar(
 
   return (
     <>
-      <div className={`sidebar ${isSidebarOpen ? "open" : ""}`}>{children}</div>
+      <div className={`sidebar ${isSidebarOpen ? "open" : ""} ${className}`}>
+        {children}
+      </div>
       <button
         className={`toggle-sidebar-button ${isSidebarOpen ? "open" : ""}`}
         onClick={toggleSidebar}

--- a/frontend/js/src/explore/art-creator/ArtCreator.tsx
+++ b/frontend/js/src/explore/art-creator/ArtCreator.tsx
@@ -371,6 +371,7 @@ export default function ArtCreator() {
             onClickCopyURL={onClickCopyURL}
           />
           <Preview
+            key={previewUrl}
             url={previewUrl}
             styles={{
               textColor,

--- a/frontend/js/src/explore/art-creator/ArtCreator.tsx
+++ b/frontend/js/src/explore/art-creator/ArtCreator.tsx
@@ -12,6 +12,7 @@ import Preview from "./components/Preview";
 import { svgToBlob, toPng } from "./utils";
 import { ToastMsg } from "../../notifications/Notifications";
 import UserSearch from "../../common/UserSearch";
+import Sidebar from "../../components/Sidebar";
 
 export enum TemplateNameEnum {
   designerTop5 = "designer-top-5",
@@ -380,7 +381,17 @@ export default function ArtCreator() {
             size={DEFAULT_IMAGE_SIZE}
           />
         </div>
-        <div className="sidebar settings-navbar">
+        <Sidebar className="settings-navbar">
+          <div className="sidebar-header">
+            <p>Art Creator</p>
+            <p>Visualize and share images of your listening stats.</p>
+            <p>
+              Select your username, a date range and a template to a dynamic
+              image that you can save, copy and share easily with your friends.
+              Check out the #ListenbrainzMonday tag on your social platform of
+              choice!
+            </p>
+          </div>
           <div className="basic-settings-container">
             <div className="sidenav-content-grid">
               <h4>Settings</h4>
@@ -606,65 +617,57 @@ export default function ArtCreator() {
                 </>
               )}
               {/* <div className="flex-center input-group">
-              <label htmlFor="bg-upload">Background image:</label>
-              <div className="input-group">
-                <input className="form-control" type="text" disabled />
-                <div className="input-group-btn">
-                  <button type="button" className="btn btn-default btn-sm">
-                    <FontAwesomeIcon icon={faCloudArrowUp} />
-                  </button>
-                  <input id="bg-upload" type="file" className="hidden" />
+                <label htmlFor="bg-upload">Background image:</label>
+                <div className="input-group">
+                  <input className="form-control" type="text" disabled />
+                  <div className="input-group-btn">
+                    <button type="button" className="btn btn-default btn-sm">
+                      <FontAwesomeIcon icon={faCloudArrowUp} />
+                    </button>
+                    <input id="bg-upload" type="file" className="hidden" />
+                  </div>
                 </div>
-              </div>
-            </div> */}
+              </div> */}
 
               {/* <div>
-              <label htmlFor="genres">
-                Genres: <FontAwesomeIcon icon={faCircleQuestion} />
-              </label>
-              <input
-                id="genres"
-                type="text"
-                className="form-control"
-                onChange={updateGenresCallback}
-              />
-            </div> */}
+                <label htmlFor="genres">
+                  Genres: <FontAwesomeIcon icon={faCircleQuestion} />
+                </label>
+                <input
+                  id="genres"
+                  type="text"
+                  className="form-control"
+                  onChange={updateGenresCallback}
+                />
+              </div> */}
               {/* <div>
-              <ToggleOption onClick={userToggler} buttonName="Users" />
-              <ToggleOption onClick={dateToggler} buttonName="Date" />
-              <ToggleOption onClick={rangeToggler} buttonName="Range" />
-              <ToggleOption onClick={totalToggler} buttonName="Total" />
-              <ToggleOption onClick={genresToggler} buttonName="Genres" />
-            </div> */}
+                <ToggleOption onClick={userToggler} buttonName="Users" />
+                <ToggleOption onClick={dateToggler} buttonName="Date" />
+                <ToggleOption onClick={rangeToggler} buttonName="Range" />
+                <ToggleOption onClick={totalToggler} buttonName="Total" />
+                <ToggleOption onClick={genresToggler} buttonName="Genres" />
+              </div> */}
               {/* <div>
-              <label htmlFor="font-select">Font:</label>
-              <select
-                id="font-select"
-                className="form-control"
-                value={font}
-                onChange={updateFontCallback}
-              >
-                {fontOptions.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
-            </div> */}
+                <label htmlFor="font-select">Font:</label>
+                <select
+                  id="font-select"
+                  className="form-control"
+                  value={font}
+                  onChange={updateFontCallback}
+                >
+                  {fontOptions.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {opt}
+                    </option>
+                  ))}
+                </select>
+              </div> */}
               {/* <div>
-              <ToggleOption onClick={vaToggler} buttonName="Ignore VA" />
-            </div> */}
+                <ToggleOption onClick={vaToggler} buttonName="Ignore VA" />
+              </div> */}
             </div>
           </div>
-          {/* <div className="generate-button-container">
-          <button
-            type="button"
-            className="btn btn-block btn-info text-uppercase"
-          >
-            Generate
-          </button>
-        </div> */}
-        </div>
+        </Sidebar>
       </div>
     </>
   );

--- a/frontend/js/src/explore/art-creator/components/Preview.tsx
+++ b/frontend/js/src/explore/art-creator/components/Preview.tsx
@@ -16,7 +16,6 @@ const Preview = React.forwardRef(function PreviewComponent(
   ref: React.ForwardedRef<SVGSVGElement>
 ) {
   const [error, setError] = React.useState<string>();
-  const externalSVGRef = React.useRef<SVGSVGElement>(null);
   const { url, styles, size = 750 } = props;
   const hasCustomStyles = Boolean(
     Object.values(styles)?.filter(Boolean).length
@@ -24,15 +23,14 @@ const Preview = React.forwardRef(function PreviewComponent(
   const { textColor, bgColor1, bgColor2 } = styles;
 
   React.useEffect(() => {
-    const { current } = externalSVGRef;
     const errorEventListener = ((e: CustomEvent) => {
-      setError(e.detail);
+      setError(e.detail ?? "Something went wrong");
     }) as EventListener;
-    current?.addEventListener("iconloaderror", errorEventListener);
+    window.addEventListener("iconloaderror", errorEventListener);
     return () => {
-      current?.removeEventListener("iconloaderror", errorEventListener);
+      window.removeEventListener("iconloaderror", errorEventListener);
     };
-  }, [externalSVGRef]);
+  }, []);
 
   if (!url) {
     return (
@@ -88,12 +86,7 @@ const Preview = React.forwardRef(function PreviewComponent(
             : ""}
         </style>
       )}
-      <svg
-        ref={externalSVGRef}
-        data-src={url}
-        data-js="enabled"
-        data-cache="21600"
-      />
+      <svg data-src={url} data-js="enabled" data-cache="21600" />
     </svg>
   );
 });

--- a/frontend/js/src/explore/art-creator/components/Preview.tsx
+++ b/frontend/js/src/explore/art-creator/components/Preview.tsx
@@ -44,7 +44,7 @@ const Preview = React.forwardRef(function PreviewComponent(
       <div className="alert alert-danger">
         There was an error trying to load statistics for this user and time
         range:
-        <pre>{error}</pre>
+        <pre style={{ whiteSpace: "pre-wrap" }}>{error}</pre>
         Please check the username or try another time range.
       </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "d3-scale-chromatic": "^3.0.0",
         "debounce-async": "0.0.2",
         "dompurify": "^2.2.6",
-        "external-svg-loader": "^1.6.10",
+        "external-svg-loader": "^1.7.1",
         "fetch-retry": "^5.0.3",
         "file-saver": "^2.0.5",
         "he": "^1.2.0",
@@ -8444,9 +8444,9 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/external-svg-loader": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/external-svg-loader/-/external-svg-loader-1.6.10.tgz",
-      "integrity": "sha512-VxFQKN9jr9hwpwmO4d/IJBe1Cb+fzy9Xm6iQwW+Q0yywze7LcuCXk+SVKHfG9Ej0z2AwnJ/C4UcRdyXnMfGzuQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/external-svg-loader/-/external-svg-loader-1.7.1.tgz",
+      "integrity": "sha512-aoar7PRXhy+hNgp49Xh2rsI+9CS65IqlLc9z2CmRM5eTQdA3H/S4QkIYVT5dH5Nf0r81d/424rHYEyC3qjPvHw==",
       "dependencies": {
         "idb-keyval": "^6.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "d3-scale-chromatic": "^3.0.0",
     "debounce-async": "0.0.2",
     "dompurify": "^2.2.6",
-    "external-svg-loader": "^1.6.10",
+    "external-svg-loader": "^1.7.1",
     "fetch-retry": "^5.0.3",
     "file-saver": "^2.0.5",
     "he": "^1.2.0",


### PR DESCRIPTION
Following a PR I created for the svg-loader repository, we can now remove the hacky error checking mechanism I had put in place and instead use the new error event to catch and display an error message.
See https://github.com/shubhamjain/svg-loader/pull/42 for context and the commit https://github.com/KasukabeDefenceForce/listenbrainz-server/commit/aebeb52e25089111717dceee0912887657999354 for the hacky error catching implementation.

While working on this I realized with consternation that we do not have a way to open the sidebar on mobile.
I fixed that using the Sidebar component we have set up for this.