### PR TITLE
LB-1369: Adding next track to playlist should clear the Input

### DIFF
--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -191,7 +191,10 @@ export default function SearchTrackOrMBID({
                 <button
                   key={track.recording_mbid}
                   type="button"
-                  onClick={() => selectSearchResult(track)}
+                  onClick={() => {
+                    selectSearchResult(track);
+                    reset();
+                  }}
                 >
                   {`${track.recording_name} - ${track.artist_credit_name}`}
                 </button>


### PR DESCRIPTION
# Problem

When adding another track to a playlist the text entry input field contains the text from the previous track that was added. It would be great if instead this was cleared out so adding the next track wouldn't require the user to clear the input themselves.

# Solution

Calling the reset() function which sets the input value back to "" after the track has been added.

# Action

No further actions required.
