### PR TITLE
LB-1550: Fix inconsistent play status between Youtube widget and the brainzPlayer

### DIFF
--- a/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
@@ -281,9 +281,9 @@ export default class YoutubePlayer
       return;
     }
     if (videoId.startsWith("http")) {
-      this.youtubePlayer.cueVideoByUrl(videoId);
+      this.youtubePlayer.loadVideoByUrl(videoId);
     } else {
-      this.youtubePlayer.cueVideoById(videoId);
+      this.youtubePlayer.loadVideoById(videoId);
     }
   };
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->

[Ticket 1550](https://tickets.metabrainz.org/browse/LB-1550)

When streaming Youtube music in Recommendations, the brainzPlayer seems to play the next song automatically, indicated by the progress bar, whereas the Youtube widget does not start playing automatically.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Use `loadVideoByXXX` in Youtube API to start playing next song by default. Referenced from [official docs](https://developers.google.com/youtube/iframe_api_reference#Video_Queueing_Functions).
