### PR TITLE
Fix serialize_jspf to add duration to playlist tracks

### DIFF
--- a/listenbrainz/db/model/playlist.py
+++ b/listenbrainz/db/model/playlist.py
@@ -162,6 +162,9 @@ class Playlist(BaseModel):
             if rec.title:
                 tr["title"] = rec.title
 
+            if rec.duration_ms:
+                tr["duration"] = rec.duration_ms
+
             extension = {"added_by": rec.added_by,
                          "added_at": rec.created.astimezone(datetime.timezone.utc).isoformat()}
             if rec.artist_mbids:


### PR DESCRIPTION
serialize_jspf was missing a line to include the duration in the JSPF.