### PR TITLE
LB-620: Document way to run specific integration tests

### DIFF
--- a/docs/developers/devel-env.rst
+++ b/docs/developers/devel-env.rst
@@ -273,10 +273,10 @@ once so that subsequent running of the tests is faster:
 
 .. code-block:: bash
 
-   ./test.sh -u                      # build unit test containers, start up and initialise the database
-   ./test.sh [path-to-test-file.py]  # run tests, do this as often as you need to
-   ./test.sh -s                      # stop test containers, but don't remove them
-   ./test.sh -d                      # stop and remove all test containers
+   ./test.sh -u                                 # build unit test containers, start up and initialise the database
+   ./test.sh [path-to-tests-file-or-directory]  # run specific tests, do this as often as you need to
+   ./test.sh -s                                 # stop test containers, but don't remove them
+   ./test.sh -d                                 # stop and remove all test containers
 
 If you made any changes to the frontend, you can run the tests for frontend using
 

--- a/docs/developers/devel-env.rst
+++ b/docs/developers/devel-env.rst
@@ -268,15 +268,15 @@ This builds and runs the containers needed for the tests. This script configures
 test-specific data volumes so that test data is isolated from your development
 data. Note that all tests are run: Unit tests and integration tests.
 
-To run tests faster, you can use some options to start up the test infrastructure
+To run tests faster, you can use some options to start up the test infrastructure 
 once so that subsequent running of the tests is faster:
 
 .. code-block:: bash
 
-   ./test.sh -u # build unit test containers, start up and initialise the database
-   ./test.sh    # run tests, do this as often as you need to
-   ./test.sh -s # stop test containers, but don't remove them
-   ./test.sh -d # stop and remove all test containers
+   ./test.sh -u                      # build unit test containers, start up and initialise the database
+   ./test.sh [path-to-test-file.py]  # run tests, do this as often as you need to
+   ./test.sh -s                      # stop test containers, but don't remove them
+   ./test.sh -d                      # stop and remove all test containers
 
 If you made any changes to the frontend, you can run the tests for frontend using
 

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ fi
 # ./test.sh                build unit test containers, bring up, make database, test, bring down
 # for development:
 # ./test.sh -u             build unit test containers, bring up background and load database if needed
-# ./test.sh [params]       run unit tests, passing optional params to inner test
+# ./test.sh [path-to-tests-file-or-directory]  # run specific tests
 # ./test.sh -s             stop unit test containers without removing
 # ./test.sh -d             clean unit test containers
 

--- a/test.sh
+++ b/test.sh
@@ -94,9 +94,9 @@ function is_unit_db_running {
     containername="${COMPOSE_PROJECT_NAME}-lb_db-1"
     res=$(docker ps --filter "name=$containername" --filter "status=running" -q)
     if [ -n "$res" ]; then
-        echo "return 0"
+        return 0
     else
-        echo "return 1"
+        return 1
     fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -91,22 +91,12 @@ function unit_setup {
 
 function is_unit_db_running {
     # Check if the database container is running
-    containername="${COMPOSE_PROJECT_NAME}_lb_db_1"
+    containername="${COMPOSE_PROJECT_NAME}-lb_db-1"
     res=$(docker ps --filter "name=$containername" --filter "status=running" -q)
     if [ -n "$res" ]; then
-        return 0
+        echo "return 0"
     else
-        return 1
-    fi
-}
-
-function is_unit_db_exists {
-    containername="${COMPOSE_PROJECT_NAME}_lb_db_1"
-    res=$(docker ps --filter "name=$containername" --filter "status=exited" -q)
-    if [ -n "$res" ]; then
-        return 0
-    else
-        return 1
+        echo "return 1"
     fi
 }
 
@@ -228,11 +218,9 @@ fi
 
 # if -u flag, bring up db, run setup, quit
 if [ "$1" == "-u" ]; then
-    is_unit_db_exists
-    DB_EXISTS=$?
     is_unit_db_running
     DB_RUNNING=$?
-    if [ $DB_EXISTS -eq 0 ] || [ $DB_RUNNING -eq 0 ]; then
+    if [ $DB_RUNNING -eq 0 ]; then
         echo "Database is already up, doing nothing"
     else
         echo "Building containers"
@@ -244,11 +232,9 @@ if [ "$1" == "-u" ]; then
     exit 0
 fi
 
-is_unit_db_exists
-DB_EXISTS=$?
 is_unit_db_running
 DB_RUNNING=$?
-if [ $DB_EXISTS -eq 1 ] && [ $DB_RUNNING -eq 1 ] ; then
+if [ $DB_RUNNING -eq 1 ] ; then
     # If no containers, build them, run setup then run tests, then bring down
     build_unit_containers
     bring_up_unit_db


### PR DESCRIPTION
# Problem

[LB-620](https://tickets.metabrainz.org/browse/LB-620?filter=12410)

The documentation lacks information on running a single test file. 
It has been updated to provide clear instructions on executing a specific test file using the `./test.sh` script.

# Solution

1. Correct the function `is_unit_db_running` by fixing the container name queried in `docker ps`.
2. Remove the function `is_unit_db_exists`.
3. Adjust the logic so that when the test container is running, executing `./test.sh [path-to-test-file.py]` only runs the specified test and then exits, while retaining the test container for later runs.
