### PR TITLE
LB-1554: Fresh Releases should allow changing sort order

### DIFF
--- a/frontend/css/fresh-releases.less
+++ b/frontend/css/fresh-releases.less
@@ -15,6 +15,7 @@
 
 .fresh-releases-pill-row {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   padding-bottom: 0.5rem;
   margin-bottom: 1rem;

--- a/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
+++ b/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
@@ -65,6 +65,13 @@ const SortDirections = {
 
 export type SortDirection = typeof SortDirections[keyof typeof SortDirections]["value"];
 
+const DefaultSortDirections: Record<SortOption, SortDirection> = {
+  release_date: "descend",
+  artist_credit_name: "ascend",
+  release_name: "ascend",
+  confidence: "descend",
+};
+
 export const filterRangeOptions = {
   week: {
     value: 7,
@@ -119,8 +126,12 @@ export default function FreshReleases() {
   );
   const [sort, setSort] = React.useState<SortOption>("release_date");
   const [sortDirection, setSortDirection] = React.useState<SortDirection>(
-    "ascend"
-  );
+    "descend"
+  ); // Default sort direction for release_date
+  const [
+    hasSelectedSortDirection,
+    setHasSelectedSortDirection,
+  ] = React.useState(false);
 
   const releaseCardGridRef = React.useRef(null);
 
@@ -262,9 +273,14 @@ export default function FreshReleases() {
                   id="fresh-releases-sort-select"
                   className="form-control"
                   value={sort}
-                  onChange={(event) =>
-                    setSort(event.target.value as SortOption)
-                  }
+                  onChange={(event) => {
+                    setSort(event.target.value as SortOption);
+                    if (!hasSelectedSortDirection) {
+                      setSortDirection(
+                        DefaultSortDirections[event.target.value as SortOption]
+                      );
+                    }
+                  }}
                 >
                   {availableSortOptions.map((option) => (
                     <option value={option.value} key={option.value}>
@@ -279,9 +295,10 @@ export default function FreshReleases() {
                   id="fresh-releases-sort-direction-select"
                   className="form-control"
                   value={sortDirection}
-                  onChange={(event) =>
-                    setSortDirection(event.target.value as SortDirection)
-                  }
+                  onChange={(event) => {
+                    setSortDirection(event.target.value as SortDirection);
+                    setHasSelectedSortDirection(true);
+                  }}
                 >
                   {Object.entries(SortDirections).map(([_, direction]) => (
                     <option value={direction.value} key={direction.value}>

--- a/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
+++ b/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
@@ -10,6 +10,7 @@ import ReleaseTimeline from "./components/ReleaseTimeline";
 import Pill from "../../components/Pill";
 import ReleaseCardsGrid from "./components/ReleaseCardsGrid";
 import { COLOR_LB_ORANGE } from "../../utils/constants";
+import { useMediaQuery } from "./utils";
 
 export enum DisplaySettingsPropertiesEnum {
   releaseTitle = "Release Title",
@@ -149,6 +150,14 @@ export default function FreshReleases() {
     });
   };
 
+  const screenMd = useMediaQuery("(max-width: 992px)"); // @screen-md
+  let pillRowStyle = {};
+  if (screenMd) {
+    pillRowStyle = { justifyContent: "center" };
+  } else if (!isLoggedIn) {
+    pillRowStyle = { justifyContent: "flex-end" };
+  }
+
   React.useEffect(() => {
     const fetchReleases = async () => {
       setIsLoading(true);
@@ -239,10 +248,7 @@ export default function FreshReleases() {
       </Helmet>
       <div className="releases-page-container">
         <div className="releases-page">
-          <div
-            className="fresh-releases-pill-row"
-            style={!isLoggedIn ? { justifyContent: "flex-end" } : {}}
-          >
+          <div className="fresh-releases-pill-row" style={pillRowStyle}>
             {isLoggedIn ? (
               <div className="fresh-releases-row">
                 <Pill

--- a/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
+++ b/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
@@ -52,6 +52,19 @@ const SortOptions = {
 
 export type SortOption = typeof SortOptions[keyof typeof SortOptions]["value"];
 
+const SortDirections = {
+  ascend: {
+    value: "ascend",
+    label: "Ascending",
+  },
+  descend: {
+    value: "descend",
+    label: "Descending",
+  },
+};
+
+export type SortDirection = typeof SortDirections[keyof typeof SortDirections]["value"];
+
 export const filterRangeOptions = {
   week: {
     value: 7,
@@ -105,6 +118,9 @@ export default function FreshReleases() {
     true
   );
   const [sort, setSort] = React.useState<SortOption>("release_date");
+  const [sortDirection, setSortDirection] = React.useState<SortDirection>(
+    "ascend"
+  );
 
   const releaseCardGridRef = React.useRef(null);
 
@@ -257,6 +273,23 @@ export default function FreshReleases() {
                   ))}
                 </select>
               </div>
+              <span>Direction:</span>{" "}
+              <div className="input-group">
+                <select
+                  id="fresh-releases-sort-direction-select"
+                  className="form-control"
+                  value={sortDirection}
+                  onChange={(event) =>
+                    setSortDirection(event.target.value as SortDirection)
+                  }
+                >
+                  {Object.entries(SortDirections).map(([_, direction]) => (
+                    <option value={direction.value} key={direction.value}>
+                      {direction.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
           </div>
           {isLoading ? (
@@ -298,13 +331,18 @@ export default function FreshReleases() {
                   filteredList={filteredList}
                   displaySettings={displaySettings}
                   order={sort}
+                  direction={sortDirection}
                 />
               )}
             </div>
           )}
         </div>
         {pageType === PAGE_TYPE_SITEWIDE && filteredList.length > 0 && (
-          <ReleaseTimeline releases={filteredList} order={sort} />
+          <ReleaseTimeline
+            releases={filteredList}
+            order={sort}
+            direction={sortDirection}
+          />
         )}
         <ReleaseFilters
           allFilters={allFilters}

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseCardsGrid.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseCardsGrid.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import ReleaseCard from "./ReleaseCard";
 import { formatReleaseDate } from "../utils";
-import type { DisplaySettings } from "../FreshReleases";
+import type { DisplaySettings, SortDirection } from "../FreshReleases";
 
 type ReleaseCardReleaseProps = {
   filteredList: Array<FreshReleaseItem>;
   displaySettings: DisplaySettings;
   order: string;
-  direction: string;
+  direction: SortDirection;
 };
 
 const getKeyForOrder = (
@@ -63,10 +63,10 @@ export default function ReleaseCardsGrid(props: ReleaseCardReleaseProps) {
     return releaseKey;
   };
 
-  const mappedEntries =
-    direction === "descend"
-      ? Array.from(releaseMapping?.entries()).reverse()
-      : Array.from(releaseMapping?.entries());
+  const mappedEntries = Array.from(releaseMapping?.entries());
+  if (direction === "descend") {
+    mappedEntries.reverse();
+  }
 
   return (
     <>

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseCardsGrid.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseCardsGrid.tsx
@@ -7,6 +7,7 @@ type ReleaseCardReleaseProps = {
   filteredList: Array<FreshReleaseItem>;
   displaySettings: DisplaySettings;
   order: string;
+  direction: string;
 };
 
 const getKeyForOrder = (
@@ -42,7 +43,7 @@ const getMapping = (
 };
 
 export default function ReleaseCardsGrid(props: ReleaseCardReleaseProps) {
-  const { filteredList, displaySettings, order } = props;
+  const { filteredList, displaySettings, order, direction } = props;
 
   const releaseMapping = React.useMemo(() => getMapping(order, filteredList), [
     order,
@@ -62,9 +63,14 @@ export default function ReleaseCardsGrid(props: ReleaseCardReleaseProps) {
     return releaseKey;
   };
 
+  const mappedEntries =
+    direction === "descend"
+      ? Array.from(releaseMapping?.entries()).reverse()
+      : Array.from(releaseMapping?.entries());
+
   return (
     <>
-      {Array.from(releaseMapping?.entries()).map(([releaseKey, releases]) => (
+      {mappedEntries.map(([releaseKey, releases]) => (
         <React.Fragment key={`${releaseKey}-container`}>
           <div className="release-card-grid-title" key={`${releaseKey}-title`}>
             {getReleaseCardGridTitle(releaseKey, order)}

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseCardsGrid.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseCardsGrid.tsx
@@ -64,7 +64,10 @@ export default function ReleaseCardsGrid(props: ReleaseCardReleaseProps) {
   };
 
   const mappedEntries = Array.from(releaseMapping?.entries());
-  if (direction === "descend") {
+  if (
+    (order !== "confidence" && direction === "descend") ||
+    (order === "confidence" && direction === "ascend")
+  ) {
     mappedEntries.reverse();
   }
 

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -43,10 +43,6 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
         (date) => releasesPerDate[date] >= minReleasesThreshold
       );
 
-      if (sortDirection === "descend") {
-        filteredDates.reverse();
-      }
-
       dataArr = filteredDates.map((item) => formatReleaseDate(item));
       percentArr = filteredDates
         .map((item) => (releasesPerDate[item] / data.length) * 100)
@@ -62,10 +58,6 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
       );
 
       dataArr = filteredInitials.sort();
-      if (sortDirection === "descend") {
-        dataArr.reverse();
-      }
-
       percentArr = filteredInitials
         .map((item) => (artistInitialsCount[item] / data.length) * 100)
         .map((_, index, arr) =>
@@ -80,31 +72,28 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
       );
 
       dataArr = filteredInitials.sort();
-      if (sortDirection === "descend") {
-        dataArr.reverse();
-      }
-
       percentArr = filteredInitials
         .map((item) => (releaseInitialsCount[item] / data.length) * 100)
         .map((_, index, arr) =>
           arr.slice(0, index + 1).reduce((prev, curr) => prev + curr)
         );
     } else {
+      // conutBy gives us an asc-sorted Dict by confidence
       const confidenceInitialsCount = countBy(
         data,
         (item: FreshReleaseItem) => item?.confidence
       );
-
-      dataArr = Object.keys(confidenceInitialsCount).sort();
-      if (sortDirection === "descend") {
-        dataArr.reverse();
-      }
-
+      dataArr = Object.keys(confidenceInitialsCount);
       percentArr = Object.values(confidenceInitialsCount)
         .map((item) => (item / data.length) * 100)
         .map((_, index, arr) =>
           arr.slice(0, index + 1).reduce((prev, curr) => prev + curr)
         );
+    }
+
+    if (sortDirection === "descend") {
+      dataArr.reverse();
+      percentArr = percentArr.reverse().map((v) => (v <= 100 ? 100 - v : 0));
     }
 
     /**

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -102,9 +102,14 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
      * With the same logic, we don't want the last date to be at 100% because
      * that will mean we're at the bottom of the grid.
      * The last date should start before 100%. That explains the pop().
+     * For descending sort, the reverse computation above possibly already ensures that
+     * the percentArr starts with 0 and ends with a non-100% value, which is desired.
+     * Hence, we add a check to skip the unshift(0) and pop() operations in that case.
      */
-    percentArr.unshift(0);
-    percentArr.pop();
+    if (percentArr[0] !== 0) {
+      percentArr.unshift(0);
+      percentArr.pop();
+    }
 
     return zipObject(percentArr, dataArr);
   }

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 import Slider from "rc-slider";
 import { countBy, debounce, zipObject } from "lodash";
 import { formatReleaseDate, useMediaQuery } from "../utils";
+import { SortDirection } from "../FreshReleases";
 
 type ReleaseTimelineProps = {
   releases: Array<FreshReleaseItem>;
   order: string;
-  direction: string;
+  direction: SortDirection;
 };
 
 export default function ReleaseTimeline(props: ReleaseTimelineProps) {

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -6,10 +6,11 @@ import { formatReleaseDate, useMediaQuery } from "../utils";
 type ReleaseTimelineProps = {
   releases: Array<FreshReleaseItem>;
   order: string;
+  direction: string;
 };
 
 export default function ReleaseTimeline(props: ReleaseTimelineProps) {
-  const { releases, order } = props;
+  const { releases, order, direction } = props;
 
   const [currentValue, setCurrentValue] = React.useState<number | number[]>();
   const [marks, setMarks] = React.useState<{ [key: number]: string }>({});
@@ -27,7 +28,7 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
     return scrollTo;
   }, []);
 
-  function createMarks(data: Array<FreshReleaseItem>) {
+  function createMarks(data: Array<FreshReleaseItem>, sortDirection: string) {
     let dataArr: Array<string> = [];
     let percentArr: Array<number> = [];
     // We want to filter out the keys that have less than 1.5% of the total releases
@@ -40,6 +41,10 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
       const filteredDates = Object.keys(releasesPerDate).filter(
         (date) => releasesPerDate[date] >= minReleasesThreshold
       );
+
+      if (sortDirection === "descend") {
+        filteredDates.reverse();
+      }
 
       dataArr = filteredDates.map((item) => formatReleaseDate(item));
       percentArr = filteredDates
@@ -56,6 +61,9 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
       );
 
       dataArr = filteredInitials.sort();
+      if (sortDirection === "descend") {
+        dataArr.reverse();
+      }
 
       percentArr = filteredInitials
         .map((item) => (artistInitialsCount[item] / data.length) * 100)
@@ -71,6 +79,9 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
       );
 
       dataArr = filteredInitials.sort();
+      if (sortDirection === "descend") {
+        dataArr.reverse();
+      }
 
       percentArr = filteredInitials
         .map((item) => (releaseInitialsCount[item] / data.length) * 100)
@@ -116,8 +127,8 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
   );
 
   React.useEffect(() => {
-    setMarks(createMarks(releases));
-  }, [releases]);
+    setMarks(createMarks(releases, direction));
+  }, [releases, direction]);
 
   React.useEffect(() => {
     window.addEventListener("scroll", handleScroll);

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -96,6 +96,9 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
       );
 
       dataArr = Object.keys(confidenceInitialsCount).sort();
+      if (sortDirection === "descend") {
+        dataArr.reverse();
+      }
 
       percentArr = Object.values(confidenceInitialsCount)
         .map((item) => (item / data.length) * 100)


### PR DESCRIPTION
# Problem
As described in https://tickets.metabrainz.org/browse/LB-1554.

# Solution
Add a sorting option to let users choose ascending or descending sort.
![image](https://github.com/metabrainz/listenbrainz-server/assets/110474835/ce5a3f18-8255-4460-a071-7c337282693f)

