### PR TITLE
BrainzPlayer settings page / disable music sources

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -202,7 +202,8 @@ CREATE TABLE user_setting(
     id                     SERIAL, --PK
     user_id                INTEGER NOT NULL, --FK to "user".id
     timezone_name          TEXT,
-    troi                   JSONB -- troi related prefs
+    troi                   JSONB, -- troi related prefs
+    brainzplayer           JSONB -- brainzplayer related prefs
 );
 
 ALTER TABLE user_setting

--- a/admin/sql/updates/2024-04-03-add-brainzplayer-settings.sql
+++ b/admin/sql/updates/2024-04-03-add-brainzplayer-settings.sql
@@ -1,0 +1,7 @@
+
+BEGIN;
+
+ALTER TABLE user_setting
+ADD brainzplayer JSONB;
+
+COMMIT;

--- a/frontend/css/brainzplayer.less
+++ b/frontend/css/brainzplayer.less
@@ -134,6 +134,10 @@
       &:hover {
         color: darken(@primary-color, 10%);
       }
+      &.disabled {
+        color:#8d8d8d;
+        pointer-events: none;
+      }
     }
   }
 
@@ -198,7 +202,7 @@
       stroke-width: 40px;
       font-size: 1.3em;
       margin: 0 0.7em;
-      width: 1em;
+      max-width: 1em;
       cursor: pointer;
       color: #8d8d8d;
       &:hover {

--- a/frontend/css/brainzplayer.less
+++ b/frontend/css/brainzplayer.less
@@ -135,7 +135,7 @@
         color: darken(@primary-color, 10%);
       }
       &.disabled {
-        color:#8d8d8d;
+        color: #8d8d8d;
         pointer-events: none;
       }
     }

--- a/frontend/css/switch.less
+++ b/frontend/css/switch.less
@@ -50,4 +50,5 @@
   margin-left: 10px;
   position: relative;
   font-weight: 400;
+  vertical-align: middle;
 }

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -220,6 +220,10 @@ export default class BrainzPlayer extends React.Component<
       return;
     }
     const { userPreferences } = this.context;
+    const { brainzplayer_event, payload } = event.data;
+    if (!brainzplayer_event) {
+      return;
+    }
     if (userPreferences?.brainzplayer) {
       const brainzPlayerDisabled =
         userPreferences?.brainzplayer?.spotifyEnabled === false &&
@@ -247,7 +251,6 @@ export default class BrainzPlayer extends React.Component<
         );
       }
     }
-    const { brainzplayer_event, payload } = event.data;
     switch (brainzplayer_event) {
       case "play-listen":
         this.playListen(payload);

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -14,6 +14,7 @@ import {
 } from "lodash";
 import * as React from "react";
 import { toast } from "react-toastify";
+import { Link } from "react-router-dom";
 import {
   ToastMsg,
   createNotification,
@@ -145,15 +146,6 @@ export default class BrainzPlayer extends React.Component<
   constructor(props: BrainzPlayerProps) {
     super(props);
 
-    this.spotifyPlayer = React.createRef<SpotifyPlayer>();
-    this.dataSources.push(this.spotifyPlayer);
-
-    this.soundcloudPlayer = React.createRef<SoundcloudPlayer>();
-    this.dataSources.push(this.soundcloudPlayer);
-
-    this.youtubePlayer = React.createRef<YoutubePlayer>();
-    this.dataSources.push(this.youtubePlayer);
-
     this.state = {
       currentDataSourceIndex: 0,
       currentTrackName: "",
@@ -180,18 +172,25 @@ export default class BrainzPlayer extends React.Component<
     window.addEventListener("message", this.receiveBrainzPlayerMessage);
     window.addEventListener("beforeunload", this.alertBeforeClosingPage);
     // Remove SpotifyPlayer if the user doesn't have the relevant permissions to use it
-    const { spotifyAuth, soundcloudAuth } = this.context;
+    const { spotifyAuth, soundcloudAuth, userPreferences } = this.context;
+
     if (
-      !SpotifyPlayer.hasPermissions(spotifyAuth) &&
-      this.spotifyPlayer?.current
+      userPreferences?.brainzplayer?.spotifyEnabled !== false &&
+      SpotifyPlayer.hasPermissions(spotifyAuth)
     ) {
-      this.invalidateDataSource(this.spotifyPlayer.current);
+      this.spotifyPlayer = React.createRef<SpotifyPlayer>();
+      this.dataSources.push(this.spotifyPlayer);
     }
     if (
-      !SoundcloudPlayer.hasPermissions(soundcloudAuth) &&
-      this.soundcloudPlayer?.current
+      userPreferences?.brainzplayer?.soundcloudEnabled !== false &&
+      SoundcloudPlayer.hasPermissions(soundcloudAuth)
     ) {
-      this.invalidateDataSource(this.soundcloudPlayer.current);
+      this.soundcloudPlayer = React.createRef<SoundcloudPlayer>();
+      this.dataSources.push(this.soundcloudPlayer);
+    }
+    if (userPreferences?.brainzplayer?.youtubeEnabled !== false) {
+      this.youtubePlayer = React.createRef<YoutubePlayer>();
+      this.dataSources.push(this.youtubePlayer);
     }
   }
 
@@ -219,6 +218,34 @@ export default class BrainzPlayer extends React.Component<
     if (event.origin !== window.location.origin) {
       // Received postMessage from different origin, ignoring it
       return;
+    }
+    const { userPreferences } = this.context;
+    if (userPreferences?.brainzplayer) {
+      const brainzPlayerDisabled =
+        userPreferences?.brainzplayer?.spotifyEnabled === false &&
+        userPreferences?.brainzplayer?.youtubeEnabled === false &&
+        userPreferences?.brainzplayer?.soundcloudEnabled === false;
+      if (brainzPlayerDisabled) {
+        toast.info(
+          <ToastMsg
+            title="BrainzPlayer disabled"
+            message={
+              <>
+                You have disabled all music services for playback on
+                ListenBrainz. To enable them again, please go to the{" "}
+                <Link
+                  to="/settings/brainzplayer/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  music player preferences
+                </Link>{" "}
+                page
+              </>
+            }
+          />
+        );
+      }
     }
     const { brainzplayer_event, payload } = event.data;
     switch (brainzplayer_event) {
@@ -805,11 +832,20 @@ export default class BrainzPlayer extends React.Component<
       refreshSoundcloudToken,
       listenBrainzAPIBaseURI,
     } = this.props;
-    const { youtubeAuth, spotifyAuth, soundcloudAuth } = this.context;
-
+    const {
+      youtubeAuth,
+      spotifyAuth,
+      soundcloudAuth,
+      userPreferences,
+    } = this.context;
+    const brainzPlayerDisabled =
+      userPreferences?.brainzplayer?.spotifyEnabled === false &&
+      userPreferences?.brainzplayer?.youtubeEnabled === false &&
+      userPreferences?.brainzplayer?.soundcloudEnabled === false;
     return (
       <div>
         <BrainzPlayerUI
+          disabled={brainzPlayerDisabled}
           playPreviousTrack={this.playPreviousTrack}
           playNextTrack={this.playNextTrack}
           togglePlay={
@@ -831,69 +867,75 @@ export default class BrainzPlayer extends React.Component<
             this.dataSources[currentDataSourceIndex]?.current?.name
           }
         >
-          <SpotifyPlayer
-            show={
-              isActivated &&
-              this.dataSources[currentDataSourceIndex]?.current instanceof
-                SpotifyPlayer
-            }
-            refreshSpotifyToken={refreshSpotifyToken}
-            onInvalidateDataSource={this.invalidateDataSource}
-            ref={this.spotifyPlayer}
-            spotifyUser={spotifyAuth}
-            playerPaused={playerPaused}
-            onPlayerPausedChange={this.playerPauseChange}
-            onProgressChange={this.progressChange}
-            onDurationChange={this.durationChange}
-            onTrackInfoChange={this.throttledTrackInfoChange}
-            onTrackEnd={this.playNextTrack}
-            onTrackNotFound={this.failedToPlayTrack}
-            handleError={this.handleError}
-            handleWarning={this.handleWarning}
-            handleSuccess={this.handleSuccess}
-          />
-          <YoutubePlayer
-            show={
-              isActivated &&
-              this.dataSources[currentDataSourceIndex]?.current instanceof
-                YoutubePlayer
-            }
-            onInvalidateDataSource={this.invalidateDataSource}
-            ref={this.youtubePlayer}
-            youtubeUser={youtubeAuth}
-            refreshYoutubeToken={refreshYoutubeToken}
-            playerPaused={playerPaused}
-            onPlayerPausedChange={this.playerPauseChange}
-            onProgressChange={this.progressChange}
-            onDurationChange={this.durationChange}
-            onTrackInfoChange={this.throttledTrackInfoChange}
-            onTrackEnd={this.playNextTrack}
-            onTrackNotFound={this.failedToPlayTrack}
-            handleError={this.handleError}
-            handleWarning={this.handleWarning}
-            handleSuccess={this.handleSuccess}
-          />
-          <SoundcloudPlayer
-            show={
-              isActivated &&
-              this.dataSources[currentDataSourceIndex]?.current instanceof
-                SoundcloudPlayer
-            }
-            onInvalidateDataSource={this.invalidateDataSource}
-            ref={this.soundcloudPlayer}
-            soundcloudUser={soundcloudAuth}
-            refreshSoundcloudToken={refreshSoundcloudToken}
-            playerPaused={playerPaused}
-            onPlayerPausedChange={this.playerPauseChange}
-            onProgressChange={this.progressChange}
-            onDurationChange={this.durationChange}
-            onTrackInfoChange={this.throttledTrackInfoChange}
-            onTrackEnd={this.playNextTrack}
-            onTrackNotFound={this.failedToPlayTrack}
-            handleError={this.handleError}
-            handleWarning={this.handleWarning}
-            handleSuccess={this.handleSuccess}
-          />
+          {userPreferences?.brainzplayer?.spotifyEnabled !== false && (
+            <SpotifyPlayer
+              show={
+                isActivated &&
+                this.dataSources[currentDataSourceIndex]?.current instanceof
+                  SpotifyPlayer
+              }
+              refreshSpotifyToken={refreshSpotifyToken}
+              onInvalidateDataSource={this.invalidateDataSource}
+              ref={this.spotifyPlayer}
+              spotifyUser={spotifyAuth}
+              playerPaused={playerPaused}
+              onPlayerPausedChange={this.playerPauseChange}
+              onProgressChange={this.progressChange}
+              onDurationChange={this.durationChange}
+              onTrackInfoChange={this.throttledTrackInfoChange}
+              onTrackEnd={this.playNextTrack}
+              onTrackNotFound={this.failedToPlayTrack}
+              handleError={this.handleError}
+              handleWarning={this.handleWarning}
+              handleSuccess={this.handleSuccess}
+            />
+          )}
+          {userPreferences?.brainzplayer?.youtubeEnabled !== false && (
+            <YoutubePlayer
+              show={
+                isActivated &&
+                this.dataSources[currentDataSourceIndex]?.current instanceof
+                  YoutubePlayer
+              }
+              onInvalidateDataSource={this.invalidateDataSource}
+              ref={this.youtubePlayer}
+              youtubeUser={youtubeAuth}
+              refreshYoutubeToken={refreshYoutubeToken}
+              playerPaused={playerPaused}
+              onPlayerPausedChange={this.playerPauseChange}
+              onProgressChange={this.progressChange}
+              onDurationChange={this.durationChange}
+              onTrackInfoChange={this.throttledTrackInfoChange}
+              onTrackEnd={this.playNextTrack}
+              onTrackNotFound={this.failedToPlayTrack}
+              handleError={this.handleError}
+              handleWarning={this.handleWarning}
+              handleSuccess={this.handleSuccess}
+            />
+          )}
+          {userPreferences?.brainzplayer?.soundcloudEnabled !== false && (
+            <SoundcloudPlayer
+              show={
+                isActivated &&
+                this.dataSources[currentDataSourceIndex]?.current instanceof
+                  SoundcloudPlayer
+              }
+              onInvalidateDataSource={this.invalidateDataSource}
+              ref={this.soundcloudPlayer}
+              soundcloudUser={soundcloudAuth}
+              refreshSoundcloudToken={refreshSoundcloudToken}
+              playerPaused={playerPaused}
+              onPlayerPausedChange={this.playerPauseChange}
+              onProgressChange={this.progressChange}
+              onDurationChange={this.durationChange}
+              onTrackInfoChange={this.throttledTrackInfoChange}
+              onTrackEnd={this.playNextTrack}
+              onTrackNotFound={this.failedToPlayTrack}
+              handleError={this.handleError}
+              handleWarning={this.handleWarning}
+              handleSuccess={this.handleSuccess}
+            />
+          )}
         </BrainzPlayerUI>
       </div>
     );

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -248,6 +248,7 @@ export default class BrainzPlayer extends React.Component<
             }
           />
         );
+        return;
       }
     }
     switch (brainzplayer_event) {

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -14,7 +14,6 @@ import {
 } from "lodash";
 import * as React from "react";
 import { toast } from "react-toastify";
-import { Link } from "react-router-dom";
 import {
   ToastMsg,
   createNotification,
@@ -123,9 +122,9 @@ export default class BrainzPlayer extends React.Component<
   static contextType = GlobalAppContext;
   declare context: React.ContextType<typeof GlobalAppContext>;
 
-  spotifyPlayer?: React.RefObject<SpotifyPlayer>;
-  youtubePlayer?: React.RefObject<YoutubePlayer>;
-  soundcloudPlayer?: React.RefObject<SoundcloudPlayer>;
+  spotifyPlayer: React.RefObject<SpotifyPlayer>;
+  youtubePlayer: React.RefObject<YoutubePlayer>;
+  soundcloudPlayer: React.RefObject<SoundcloudPlayer>;
   dataSources: Array<React.RefObject<DataSourceTypes>> = [];
 
   playerStateTimerID?: NodeJS.Timeout;
@@ -145,6 +144,10 @@ export default class BrainzPlayer extends React.Component<
 
   constructor(props: BrainzPlayerProps) {
     super(props);
+
+    this.spotifyPlayer = React.createRef<SpotifyPlayer>();
+    this.youtubePlayer = React.createRef<YoutubePlayer>();
+    this.soundcloudPlayer = React.createRef<SoundcloudPlayer>();
 
     this.state = {
       currentDataSourceIndex: 0,
@@ -171,25 +174,21 @@ export default class BrainzPlayer extends React.Component<
     window.addEventListener("storage", this.onLocalStorageEvent);
     window.addEventListener("message", this.receiveBrainzPlayerMessage);
     window.addEventListener("beforeunload", this.alertBeforeClosingPage);
-    // Remove SpotifyPlayer if the user doesn't have the relevant permissions to use it
     const { spotifyAuth, soundcloudAuth, userPreferences } = this.context;
 
     if (
       userPreferences?.brainzplayer?.spotifyEnabled !== false &&
       SpotifyPlayer.hasPermissions(spotifyAuth)
     ) {
-      this.spotifyPlayer = React.createRef<SpotifyPlayer>();
       this.dataSources.push(this.spotifyPlayer);
     }
     if (
       userPreferences?.brainzplayer?.soundcloudEnabled !== false &&
       SoundcloudPlayer.hasPermissions(soundcloudAuth)
     ) {
-      this.soundcloudPlayer = React.createRef<SoundcloudPlayer>();
       this.dataSources.push(this.soundcloudPlayer);
     }
     if (userPreferences?.brainzplayer?.youtubeEnabled !== false) {
-      this.youtubePlayer = React.createRef<YoutubePlayer>();
       this.dataSources.push(this.youtubePlayer);
     }
   }

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -233,13 +233,13 @@ export default class BrainzPlayer extends React.Component<
               <>
                 You have disabled all music services for playback on
                 ListenBrainz. To enable them again, please go to the{" "}
-                <Link
-                  to="/settings/brainzplayer/"
+                <a
+                  href="/settings/brainzplayer/"
                   target="_blank"
                   rel="noreferrer"
                 >
                   music player preferences
-                </Link>{" "}
+                </a>{" "}
                 page
               </>
             }

--- a/frontend/js/src/common/brainzplayer/BrainzPlayerUI.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayerUI.tsx
@@ -280,9 +280,9 @@ function BrainzPlayerUI(props: React.PropsWithChildren<BrainzPlayerUIProps>) {
           <MenuOptions currentListen={currentListen} />
         )}
 
-        <Link to="/settings/brainzplayer/" target="_blank" rel="noreferrer">
+        <a href="/settings/brainzplayer/" target="_blank" rel="noreferrer">
           <FontAwesomeIcon icon={faCog} title="Player preferences" />
-        </Link>
+        </a>
       </div>
     </div>
   );

--- a/frontend/js/src/common/brainzplayer/SoundcloudPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/SoundcloudPlayer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { get as _get, isString, throttle as _throttle } from "lodash";
 import { faSoundcloud } from "@fortawesome/free-brands-svg-icons";
+import { Link } from "react-router-dom";
 import { DataSourceProps, DataSourceType } from "./BrainzPlayer";
 import {
   getArtistName,
@@ -288,9 +289,9 @@ export default class SoundcloudPlayer
         account linked to your ListenBrainz account.
         <br />
         Please try to{" "}
-        <a href="/settings/music-services/details/" target="_blank">
+        <Link to="/settings/music-services/details/">
           link for &quot;playing music&quot; feature
-        </a>{" "}
+        </Link>{" "}
         and refresh this page
       </p>
     );

--- a/frontend/js/src/common/brainzplayer/SoundcloudPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/SoundcloudPlayer.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { get as _get, isString, throttle as _throttle } from "lodash";
 import { faSoundcloud } from "@fortawesome/free-brands-svg-icons";
-import { Link } from "react-router-dom";
 import { DataSourceProps, DataSourceType } from "./BrainzPlayer";
 import {
   getArtistName,
@@ -289,9 +288,13 @@ export default class SoundcloudPlayer
         account linked to your ListenBrainz account.
         <br />
         Please try to{" "}
-        <Link to="/settings/music-services/details/">
+        <a
+          href="/settings/music-services/details/"
+          target="_blank"
+          rel="noreferrer"
+        >
           link for &quot;playing music&quot; feature
-        </Link>{" "}
+        </a>{" "}
         and refresh this page
       </p>
     );

--- a/frontend/js/src/components/Switch.tsx
+++ b/frontend/js/src/components/Switch.tsx
@@ -5,11 +5,19 @@ type SwitchProps = {
   value: string | undefined;
   checked: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  switchLabel: string | undefined;
+  switchLabel: string | JSX.Element | undefined;
+  disabled?: boolean;
 };
 
 export default function Switch(props: SwitchProps) {
-  const { id, value = "", onChange, checked, switchLabel = "" } = props;
+  const {
+    id,
+    value = "",
+    onChange,
+    checked,
+    switchLabel = "",
+    disabled,
+  } = props;
 
   return (
     <label className="toggle" htmlFor={id}>
@@ -20,6 +28,7 @@ export default function Switch(props: SwitchProps) {
         value={value}
         checked={checked}
         onChange={onChange}
+        disabled={disabled}
       />
       <div className="toggle-switch" />
       <span className="toggle-label">{switchLabel}</span>

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -203,7 +203,7 @@ function BrainzPlayerSettings() {
       </p>
       <br />
       <button
-        className="btn btn-large btn-primary"
+        className="btn btn-lg btn-info"
         type="button"
         onClick={saveSettings}
       >

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -9,6 +9,7 @@ import { Helmet } from "react-helmet";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { toast } from "react-toastify";
+import ReactTooltip from "react-tooltip";
 import Switch from "../../components/Switch";
 import GlobalAppContext from "../../utils/GlobalAppContext";
 import SpotifyPlayer from "../../common/brainzplayer/SpotifyPlayer";
@@ -80,14 +81,21 @@ function BrainzPlayerSettings() {
       <p>
         You can choose which music services to play music from on listenBrainz.
         To sign in and authorize your account please go to the{" "}
-        <Link to="/settings/music-services/">music services page</Link>. <br />
+        <Link to="/settings/music-services/details/">
+          &quot;connect services&quot; page
+        </Link>
+        . <br />
         If you don&apos;t have a subscription to a music service listed below,
         Youtube will be used by default as it does not require an account.
         However the search results from Youtube are often inaccurate, and for a
         better listening experience we recommend one of the other services (if
         you have one available).
       </p>
-      <p>
+      <div
+        className="mb-15"
+        data-tip={!SpotifyPlayer.hasPermissions(spotifyAuth)}
+        data-for="login-first"
+      >
         <Switch
           id="enable-spotify"
           disabled={!SpotifyPlayer.hasPermissions(spotifyAuth)}
@@ -96,10 +104,12 @@ function BrainzPlayerSettings() {
           onChange={(e) => setSpotifyEnabled(!spotifyEnabled)}
           switchLabel={
             <span
-              className={`text-brand ${spotifyEnabled ? "text-success" : ""}`}
+              className={`text-brand ${!spotifyEnabled ? "text-muted" : ""}`}
             >
-              <FontAwesomeIcon icon={faSpotify} />
-              &nbsp;Spotify
+              <span className={spotifyEnabled ? "text-success" : ""}>
+                <FontAwesomeIcon icon={faSpotify} />
+              </span>
+              <span>&nbsp;Spotify</span>
             </span>
           }
         />
@@ -107,20 +117,30 @@ function BrainzPlayerSettings() {
         <small>
           Spotify requires a premium account to play full songs on third-party
           websites. To sign in, please go to the{" "}
-          <Link to="/settings/music-services/">music services page</Link>.
+          <Link to="/settings/music-services/details/">
+            &quot;connect services&quot; page
+          </Link>
+          .
         </small>
-      </p>
-      {/* <p>
+      </div>
+      {/* <div className="mb-15"
+          data-tip={!AppleMusicPlayer.hasPermissions(appleAuth)}
+          data-for="login-first">
         <Switch
           id="enable-apple-music"
           value="apple-music"
           disabled={!AppleMusicPlayer.hasPermissions(appleAuth)}
           checked={appleMusicEnabled}
+          
           onChange={(e) => setAppleMusicEnabled(!appleMusicEnabled)}
           switchLabel={
-            <span className={`text-brand ${enabled ? "text-success":""}`}>
-              <FontAwesomeIcon icon={faApple} />
-              &nbsp;Apple Music Player
+            <span
+              className={`text-brand ${!appleMusicEnabled ? "text-muted" : ""}`}
+            >
+              <span className={appleMusicEnabled ? "text-success" : ""}>
+                <FontAwesomeIcon icon={faApple} />
+              </span>
+              <span>&nbsp;Apple Music</span>
             </span>
           }
         />
@@ -128,11 +148,15 @@ function BrainzPlayerSettings() {
         <small>
           Apple Music requires a premium account to play full songs on
           third-party websites. To sign in, please go to the{" "}
-          <Link to="/settings/music-services/">music services page</Link>. You
+          <Link to="/settings/music-services/details/">&quot;connect services&quot; page</Link>. You
           will need to sign in every 6 months.
         </small>
-      </p> */}
-      <p>
+      </div> */}
+      <div
+        className="mb-15"
+        data-tip={!SoundcloudPlayer.hasPermissions(soundcloudAuth)}
+        data-for="login-first"
+      >
         <Switch
           id="enable-soundcloud"
           value="soundcloud"
@@ -141,12 +165,12 @@ function BrainzPlayerSettings() {
           onChange={(e) => setSoundcloudEnabled(!soundcloudEnabled)}
           switchLabel={
             <span
-              className={`text-brand ${
-                soundcloudEnabled ? "text-success" : ""
-              }`}
+              className={`text-brand ${!soundcloudEnabled ? "text-muted" : ""}`}
             >
-              <FontAwesomeIcon icon={faSoundcloud} />
-              &nbsp;Soundcloud
+              <span className={soundcloudEnabled ? "text-success" : ""}>
+                <FontAwesomeIcon icon={faSoundcloud} />
+              </span>
+              <span>&nbsp;Soundcloud</span>
             </span>
           }
         />
@@ -154,10 +178,12 @@ function BrainzPlayerSettings() {
         <small>
           Soundcloud requires a free account to play full songs on third-party
           websites. To sign in, please go to the{" "}
-          <Link to="/settings/music-services/">music services page</Link>
+          <Link to="/settings/music-services/details/">
+            &quot;connect services&quot; page
+          </Link>
         </small>
-      </p>
-      <p>
+      </div>
+      <div className="mb-15">
         <Switch
           id="enable-youtube"
           value="youtube"
@@ -165,10 +191,12 @@ function BrainzPlayerSettings() {
           onChange={(e) => setYoutubeEnabled(!youtubeEnabled)}
           switchLabel={
             <span
-              className={`text-brand ${youtubeEnabled ? "text-success" : ""}`}
+              className={`text-brand ${!youtubeEnabled ? "text-muted" : ""}`}
             >
-              <FontAwesomeIcon icon={faYoutube} />
-              &nbsp;Youtube
+              <span className={youtubeEnabled ? "text-success" : ""}>
+                <FontAwesomeIcon icon={faYoutube} />
+              </span>
+              <span>&nbsp;Youtube</span>
             </span>
           }
         />
@@ -200,7 +228,7 @@ function BrainzPlayerSettings() {
             </li>
           </ul>
         </small>
-      </p>
+      </div>
       <br />
       <button
         className="btn btn-lg btn-info"
@@ -209,6 +237,10 @@ function BrainzPlayerSettings() {
       >
         Save preferences
       </button>
+      <ReactTooltip id="login-first" aria-haspopup="true" delayHide={500}>
+        You must login to this service in the &quot;Connect services&quot;
+        section before using it.
+      </ReactTooltip>
     </>
   );
 }

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -20,10 +20,10 @@ function BrainzPlayerSettings() {
   const {
     spotifyAuth,
     soundcloudAuth,
-    userPreferences,
     APIService,
     currentUser,
   } = React.useContext(GlobalAppContext);
+  let { userPreferences } = React.useContext(GlobalAppContext);
   const [youtubeEnabled, setYoutubeEnabled] = React.useState(
     userPreferences?.brainzplayer?.youtubeEnabled ?? true
   );
@@ -49,6 +49,18 @@ function BrainzPlayerSettings() {
         soundcloudEnabled,
       });
       toast.success("Saved your preferences successfully");
+      // Update the global context values
+
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      userPreferences = {
+        ...userPreferences,
+        brainzplayer: {
+          ...userPreferences?.brainzplayer,
+          youtubeEnabled,
+          spotifyEnabled,
+          soundcloudEnabled,
+        },
+      };
     } catch (error) {
       toast.error(
         <ToastMsg
@@ -69,6 +81,7 @@ function BrainzPlayerSettings() {
     soundcloudEnabled,
     APIService,
     currentUser?.auth_token,
+    userPreferences,
   ]);
 
   return (

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -105,7 +105,8 @@ function BrainzPlayerSettings() {
       </p>
       <div
         className="mb-15"
-        data-tip={!SpotifyPlayer.hasPermissions(spotifyAuth)}
+        data-tip
+        data-tip-disable={SpotifyPlayer.hasPermissions(spotifyAuth)}
         data-for="login-first"
       >
         <Switch
@@ -136,7 +137,8 @@ function BrainzPlayerSettings() {
         </small>
       </div>
       {/* <div className="mb-15"
-          data-tip={!AppleMusicPlayer.hasPermissions(appleAuth)}
+          data-tip
+          data-tip-diable={AppleMusicPlayer.hasPermissions(appleAuth)}
           data-for="login-first">
         <Switch
           id="enable-apple-music"
@@ -166,7 +168,8 @@ function BrainzPlayerSettings() {
       </div> */}
       <div
         className="mb-15"
-        data-tip={!SoundcloudPlayer.hasPermissions(soundcloudAuth)}
+        data-tip
+        data-tip-disable={SoundcloudPlayer.hasPermissions(soundcloudAuth)}
         data-for="login-first"
       >
         <Switch

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -1,0 +1,156 @@
+import * as React from "react";
+import {
+  faSpotify,
+  faApple,
+  faSoundcloud,
+  faYoutube,
+} from "@fortawesome/free-brands-svg-icons";
+import { Helmet } from "react-helmet";
+import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Switch from "../../components/Switch";
+import GlobalAppContext from "../../utils/GlobalAppContext";
+import SpotifyPlayer from "../../common/brainzplayer/SpotifyPlayer";
+import AppleMusicPlayer from "../../common/brainzplayer/AppleMusicPlayer";
+import SoundcloudPlayer from "../../common/brainzplayer/SoundcloudPlayer";
+
+function BrainzPlayerSettings() {
+  const { appleAuth, spotifyAuth, soundcloudAuth } = React.useContext(
+    GlobalAppContext
+  );
+  const [youtubeEnabled, setYoutubeEnabled] = React.useState(true);
+  const [appleMusicEnabled, setAppleMusicEnabled] = React.useState(
+    Boolean(appleAuth?.music_user_token)
+  );
+  const [spotifyEnabled, setSpotifyEnabled] = React.useState(
+    SpotifyPlayer.hasPermissions(spotifyAuth)
+  );
+  const [soundcloudEnabled, setSoundcloudEnabled] = React.useState(
+    Boolean(soundcloudAuth?.access_token)
+  );
+
+  return (
+    <>
+      <Helmet>
+        <title>BrainzPlayer Settings</title>
+      </Helmet>
+      <h2 className="page-title">BrainzPlayer Settings</h2>
+      <h4 className="page-title">Music Players</h4>
+      <p>
+        You can choose which music services to play music from on listenBrainz.
+        To sign in and authorize your account please go to the{" "}
+        <Link to="/settings/music-services/">music services page</Link>. <br />
+        If you don&apos;t have a subscription to a music service listed below,
+        Youtube will be used by default as it does not require an account.
+        However the search results from Youtube are often inaccurate, and for a
+        better listening experience we recommend one of the other services (if
+        you have one available).
+      </p>
+      <p>
+        <Switch
+          id="enable-spotify"
+          disabled={!SpotifyPlayer.hasPermissions(spotifyAuth)}
+          value="spotify"
+          checked={spotifyEnabled}
+          onChange={(e) => setSpotifyEnabled(!spotifyEnabled)}
+          switchLabel={
+            <>
+              <FontAwesomeIcon icon={faSpotify} />
+              Spotify Player
+            </>
+          }
+        />
+        <small>
+          Spotify requires a premium account to play full songs on third-party
+          websites. To sign in, please go to the{" "}
+          <Link to="/settings/music-services/">music services page</Link>.
+        </small>
+      </p>
+      <p>
+        <Switch
+          id="enable-apple-music"
+          value="apple-music"
+          disabled={!AppleMusicPlayer.hasPermissions(appleAuth)}
+          checked={appleMusicEnabled}
+          onChange={(e) => setAppleMusicEnabled(!appleMusicEnabled)}
+          switchLabel={
+            <>
+              <FontAwesomeIcon icon={faApple} />
+              Apple Music Player
+            </>
+          }
+        />
+        <small>
+          Apple Music requires a premium account to play full songs on
+          third-party websites. To sign in, please go to the{" "}
+          <Link to="/settings/music-services/">music services page</Link>. You
+          will need to sign in every 6 months.
+        </small>
+      </p>
+      <p>
+        <Switch
+          id="enable-soundcloud"
+          value="soundcloud"
+          disabled={!SoundcloudPlayer.hasPermissions(soundcloudAuth)}
+          checked={soundcloudEnabled}
+          onChange={(e) => setSoundcloudEnabled(!soundcloudEnabled)}
+          switchLabel={
+            <>
+              <FontAwesomeIcon icon={faSoundcloud} />
+              Soundcloud Player
+            </>
+          }
+        />
+        <small>
+          Soundcloud requires a free account to play full songs on third-party
+          websites. To sign in, please go to the{" "}
+          <Link to="/settings/music-services/">music services page</Link>
+        </small>
+      </p>
+      <p>
+        <Switch
+          id="enable-youtube"
+          value="youtube"
+          checked={youtubeEnabled}
+          onChange={(e) => setYoutubeEnabled(!youtubeEnabled)}
+          switchLabel={
+            <>
+              <FontAwesomeIcon icon={faYoutube} />
+              Youtube Player
+            </>
+          }
+        />
+        <small>
+          Youtube player does not require signing in and provides a good
+          fallback. Be aware the search results from Youtube are often
+          inaccurate.
+          <br />
+          By using Youtube to play music, you agree to be bound by the YouTube
+          Terms of Service. See their terms of service and privacy policy below:
+          <ul>
+            <li>
+              <a
+                href="https://www.youtube.com/t/terms"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Youtube Terms of Service
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://policies.google.com/privacy"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Google Privacy Policy
+              </a>
+            </li>
+          </ul>
+        </small>
+      </p>
+    </>
+  );
+}
+
+export default BrainzPlayerSettings;

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -23,7 +23,7 @@ function BrainzPlayerSettings() {
     APIService,
     currentUser,
   } = React.useContext(GlobalAppContext);
-  let { userPreferences } = React.useContext(GlobalAppContext);
+  const { userPreferences } = React.useContext(GlobalAppContext);
   const [youtubeEnabled, setYoutubeEnabled] = React.useState(
     userPreferences?.brainzplayer?.youtubeEnabled ?? true
   );
@@ -52,15 +52,14 @@ function BrainzPlayerSettings() {
       // Update the global context values
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      userPreferences = {
-        ...userPreferences,
-        brainzplayer: {
+      if (userPreferences) {
+        userPreferences.brainzplayer = {
           ...userPreferences?.brainzplayer,
           youtubeEnabled,
           spotifyEnabled,
           soundcloudEnabled,
-        },
-      };
+        };
+      }
     } catch (error) {
       toast.error(
         <ToastMsg

--- a/frontend/js/src/settings/layout.tsx
+++ b/frontend/js/src/settings/layout.tsx
@@ -17,6 +17,7 @@ const sections: Section[] = [
     title: "Music",
     links: [
       { to: "music-services/details/", label: "Connect services" },
+      { to: "brainzplayer/", label: "Music player" },
       { to: "import/", label: "Import listens" },
       { to: "missing-data/", label: "Missing data" },
     ],

--- a/frontend/js/src/settings/routes/index.tsx
+++ b/frontend/js/src/settings/routes/index.tsx
@@ -38,7 +38,6 @@ const getSettingsRoutes = () => {
         },
         {
           path: "brainzplayer/",
-          loader: RouteLoader,
           lazy: async () => {
             const BrainzPlayerSettings = await import(
               "../brainzplayer/BrainzPlayerSettings"

--- a/frontend/js/src/settings/routes/index.tsx
+++ b/frontend/js/src/settings/routes/index.tsx
@@ -37,6 +37,16 @@ const getSettingsRoutes = () => {
           },
         },
         {
+          path: "brainzplayer/",
+          loader: RouteLoader,
+          lazy: async () => {
+            const BrainzPlayerSettings = await import(
+              "../brainzplayer/BrainzPlayerSettings"
+            );
+            return { Component: BrainzPlayerSettings.default };
+          },
+        },
+        {
           path: "import/",
           loader: RouteLoader,
           lazy: async () => {

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1320,6 +1320,23 @@ export default class APIService {
     return response.status;
   };
 
+  submitBrainzplayerPreferences = async (
+    userToken: string,
+    brainzPlayerSettings: BrainzPlayerSettings
+  ): Promise<any> => {
+    const url = `${this.APIBaseURI}/settings/brainzplayer`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${userToken}`,
+        "Content-Type": "application/json;charset=UTF-8",
+      },
+      body: JSON.stringify(brainzPlayerSettings),
+    });
+    await this.checkStatus(response);
+    return response.status;
+  };
+
   exportPlaylistToSpotify = async (
     userToken: string,
     playlist_mbid: string

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -771,8 +771,16 @@ declare type SearchUser = {
   user_name: string;
 };
 
+declare type BrainzPlayerSettings = {
+    youtubeEnabled?: boolean;
+    spotifyEnabled?: boolean;
+    soundcloudEnabled?: boolean;
+    appleMusicEnabled?: boolean;
+};
+
 declare type UserPreferences = {
   saveData?: boolean;
+  brainzplayer?: BrainzPlayerSettings;
 };
 
 declare type FeedbackForUserForRecordingsRequestBody = {

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -772,10 +772,10 @@ declare type SearchUser = {
 };
 
 declare type BrainzPlayerSettings = {
-    youtubeEnabled?: boolean;
-    spotifyEnabled?: boolean;
-    soundcloudEnabled?: boolean;
-    appleMusicEnabled?: boolean;
+  youtubeEnabled?: boolean;
+  spotifyEnabled?: boolean;
+  soundcloudEnabled?: boolean;
+  appleMusicEnabled?: boolean;
 };
 
 declare type UserPreferences = {

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -595,7 +595,12 @@ const getPageProps = async (): Promise<{
 
     let { user_preferences } = globalReactProps;
 
-    user_preferences = { ...user_preferences, saveData: false };
+    user_preferences = {
+      ...user_preferences,
+      // @ts-ignore
+      brainzplayer: user_preferences?.brainzplayer.brainzplayer,
+      saveData: false,
+    };
 
     if ("connection" in navigator) {
       // @ts-ignore

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -591,21 +591,18 @@ const getPageProps = async (): Promise<{
       musicbrainz,
       sentry_traces_sample_rate,
       sentry_dsn,
+      user_preferences,
     } = globalReactProps;
 
-    let { user_preferences } = globalReactProps;
-
-    user_preferences = {
+    const userPreferences = {
       ...user_preferences,
-      // @ts-ignore
-      brainzplayer: user_preferences?.brainzplayer.brainzplayer,
       saveData: false,
     };
 
     if ("connection" in navigator) {
       // @ts-ignore
       if (navigator.connection?.saveData === true) {
-        user_preferences.saveData = true;
+        userPreferences.saveData = true;
       }
     }
 
@@ -637,7 +634,7 @@ const getPageProps = async (): Promise<{
           return undefined;
         },
       },
-      userPreferences: user_preferences,
+      userPreferences,
       musicbrainzGenres: await getOrFetchMBGenres(),
       recordingFeedbackManager: new RecordingFeedbackManager(
         apiService,

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -114,13 +114,14 @@ def get_troi_prefs(db_conn, user_id: int):
     row = result.mappings().first()
     return dict(row) if row else None
 
+
 def update_brainzplayer_prefs(db_conn, user_id: int, brainzplayer_settings: str):
     """ Update brainzplayer preferences for the given user """
     db_conn.execute(sqlalchemy.text("""
         INSERT INTO user_setting (user_id, brainzplayer)
              VALUES (:user_id, :brainzplayer_settings)
         ON CONFLICT (user_id)
-          DO UPDATE 
+          DO UPDATE
                 SET brainzplayer = EXCLUDED.brainzplayer
     """), {"user_id": user_id, "brainzplayer_settings": brainzplayer_settings})
     db_conn.commit()

--- a/listenbrainz/db/user_setting.py
+++ b/listenbrainz/db/user_setting.py
@@ -113,3 +113,25 @@ def get_troi_prefs(db_conn, user_id: int):
     """), {"user_id": user_id})
     row = result.mappings().first()
     return dict(row) if row else None
+
+def update_brainzplayer_prefs(db_conn, user_id: int, brainzplayer_settings: str):
+    """ Update brainzplayer preferences for the given user """
+    db_conn.execute(sqlalchemy.text("""
+        INSERT INTO user_setting (user_id, brainzplayer)
+             VALUES (:user_id, :brainzplayer_settings)
+        ON CONFLICT (user_id)
+          DO UPDATE 
+                SET brainzplayer = EXCLUDED.brainzplayer
+    """), {"user_id": user_id, "brainzplayer_settings": brainzplayer_settings})
+    db_conn.commit()
+
+
+def get_brainzplayer_prefs(db_conn, user_id: int):
+    """ Retrieve brainzplayer preferences for the given user """
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT brainzplayer
+          FROM user_setting
+         WHERE user_id = :user_id
+    """), {"user_id": user_id})
+    row = result.mappings().first()
+    return dict(row) if row else None

--- a/listenbrainz/tests/integration/test_user_settings_api.py
+++ b/listenbrainz/tests/integration/test_user_settings_api.py
@@ -100,7 +100,10 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
             headers={"Authorization": f"Token {self.user['auth_token']}"}
         )
         self.assert400(response)
-        self.assertEqual(response.json["error"], "Invalid preferences in the JSON: Additional properties are not allowed ('fnord' was unexpected)")
+        self.assertEqual(
+            response.json["error"],
+            "Invalid preferences in the JSON: Additional properties are not allowed ('fnord' was unexpected)"
+        )
 
         response = self.client.post(
             self.custom_url_for("user_settings_api_v1.update_brainzplayer_prefs"),

--- a/listenbrainz/tests/integration/test_user_settings_api.py
+++ b/listenbrainz/tests/integration/test_user_settings_api.py
@@ -92,3 +92,34 @@ class UserSettingsAPITestCase(ListenAPIIntegrationTestCase):
 
         prefs = db_user_setting.get_troi_prefs(self.db_conn, self.user["id"])
         self.assertEqual(prefs, {"troi": {"export_to_spotify": True}})
+
+    def test_invalid_brainzplayer_prefs(self):
+        response = self.client.post(
+            self.custom_url_for("user_settings_api_v1.update_brainzplayer_prefs"),
+            json={"fnord": True},
+            headers={"Authorization": f"Token {self.user['auth_token']}"}
+        )
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "Invalid preferences in the JSON: Additional properties are not allowed ('fnord' was unexpected)")
+
+        response = self.client.post(
+            self.custom_url_for("user_settings_api_v1.update_brainzplayer_prefs"),
+            json={"youtubeEnabled": "yes"},
+            headers={"Authorization": f"Token {self.user['auth_token']}"}
+        )
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "Invalid preferences in the JSON: 'yes' is not of type 'boolean'")
+
+    def test_valid_brainzplayer_prefs(self):
+        prefs = db_user_setting.get_brainzplayer_prefs(self.db_conn, self.user["id"])
+        self.assertEqual(prefs, None)
+
+        response = self.client.post(
+            self.custom_url_for("user_settings_api_v1.update_brainzplayer_prefs"),
+            json={"youtubeEnabled": False, "spotifyEnabled": True},
+            headers={"Authorization": f"Token {self.user['auth_token']}"}
+        )
+        self.assert200(response)
+
+        prefs = db_user_setting.get_brainzplayer_prefs(self.db_conn, self.user["id"])
+        self.assertEqual(prefs, {"brainzplayer": {"youtubeEnabled": False, "spotifyEnabled": True}})

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -74,12 +74,14 @@ def get_global_props():
         "musicbrainz": get_current_musicbrainz_user(),
         "soundcloud": get_current_soundcloud_user(),
         "sentry_traces_sample_rate": sentry_config.get("traces_sample_rate", 0.0),
-        "user_preferences": {
-            "brainzplayer": db_usersetting.get_brainzplayer_prefs(
+    }
+
+    brainzplayer_props = db_usersetting.get_brainzplayer_prefs(
                 db_conn, current_user.id
             ) if current_user.is_authenticated else None
-        },
-    }
+    if brainzplayer_props is not None:
+        props["user_preferences"] = brainzplayer_props
+
     return orjson.dumps(props).decode("utf-8")
 
 

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -5,8 +5,10 @@ import orjson
 from flask import current_app, request
 from flask_login import current_user
 
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.views.views_utils import get_current_spotify_user, get_current_youtube_user, \
     get_current_critiquebrainz_user, get_current_musicbrainz_user, get_current_soundcloud_user
+import listenbrainz.db.user_setting as db_usersetting
 
 REJECT_LISTENS_WITHOUT_EMAIL_ERROR = \
     'The listens were rejected because the user does not has not provided an email. ' \
@@ -46,9 +48,10 @@ def get_global_props():
     an encoded json string.
     The props include:
      - information about the current logged in user
-     - auth details for spotify and youtube if the current user has connected them
+     - auth details for spotify, youtube and other music services the current user is connected to
      - sentry dsn
-     - API url for frontned to connect to.
+     - API url for frontend to connect to.
+     - user preferences
     """
     current_user_data = {}
     if current_user.is_authenticated:
@@ -71,7 +74,9 @@ def get_global_props():
         "musicbrainz": get_current_musicbrainz_user(),
         "soundcloud": get_current_soundcloud_user(),
         "sentry_traces_sample_rate": sentry_config.get("traces_sample_rate", 0.0),
-        "user_preferences": {},
+        "user_preferences": {
+            "brainzplayer": db_usersetting.get_brainzplayer_prefs(db_conn, current_user.id) if current_user.is_authenticated else None
+        },
     }
     return orjson.dumps(props).decode("utf-8")
 

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -75,7 +75,9 @@ def get_global_props():
         "soundcloud": get_current_soundcloud_user(),
         "sentry_traces_sample_rate": sentry_config.get("traces_sample_rate", 0.0),
         "user_preferences": {
-            "brainzplayer": db_usersetting.get_brainzplayer_prefs(db_conn, current_user.id) if current_user.is_authenticated else None
+            "brainzplayer": db_usersetting.get_brainzplayer_prefs(
+                db_conn, current_user.id
+            ) if current_user.is_authenticated else None
         },
     }
     return orjson.dumps(props).decode("utf-8")

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -65,6 +65,7 @@ def set_troi_prefs():
     }
     return jsonify(data)
 
+
 @settings_bp.route("/brainzplayer/", methods=["POST"])
 @login_required
 def get_brainzplayer_prefs():

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -66,16 +66,6 @@ def set_troi_prefs():
     return jsonify(data)
 
 
-@settings_bp.route("/brainzplayer/", methods=["POST"])
-@login_required
-def get_brainzplayer_prefs():
-    current_brainzplayer_prefs = db_usersetting.get_brainzplayer_prefs(db_conn, current_user.id)
-    data = {
-        "brainzplayer": current_brainzplayer_prefs,
-    }
-    return jsonify(data)
-
-
 @settings_bp.route("/resetlatestimportts/", methods=["POST"])
 @api_login_required
 def reset_latest_import_timestamp():

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -65,6 +65,15 @@ def set_troi_prefs():
     }
     return jsonify(data)
 
+@settings_bp.route("/brainzplayer/", methods=["POST"])
+@login_required
+def get_brainzplayer_prefs():
+    current_brainzplayer_prefs = db_usersetting.get_brainzplayer_prefs(db_conn, current_user.id)
+    data = {
+        "brainzplayer": current_brainzplayer_prefs,
+    }
+    return jsonify(data)
+
 
 @settings_bp.route("/resetlatestimportts/", methods=["POST"])
 @api_login_required

--- a/listenbrainz/webserver/views/user_settings_api.py
+++ b/listenbrainz/webserver/views/user_settings_api.py
@@ -88,6 +88,7 @@ brainzplayer_preferences_schema = {
     "additionalProperties": False,
 }
 
+
 @user_settings_api_bp.route('/brainzplayer', methods=["POST", "OPTIONS"])
 @crossdomain
 @ratelimit()
@@ -111,6 +112,6 @@ def update_brainzplayer_prefs():
         validate(instance=new_preferences, schema=brainzplayer_preferences_schema)
     except exceptions.ValidationError as err:
         raise APIBadRequest(f"Invalid preferences in the JSON: {err.message}")
-    
+
     db_usersetting.update_brainzplayer_prefs(db_conn, user["id"], orjson.dumps(new_preferences).decode())
     return jsonify({"status": "ok"})

--- a/listenbrainz/webserver/views/user_settings_api.py
+++ b/listenbrainz/webserver/views/user_settings_api.py
@@ -1,6 +1,7 @@
 import orjson
 from brainzutils.ratelimit import ratelimit
 from flask import Blueprint, jsonify, request
+from jsonschema import validate, exceptions
 
 import listenbrainz.db.user_setting as db_usersetting
 from listenbrainz.troi.daily_jams import SPOTIFY_EXPORT_PREFERENCE
@@ -73,4 +74,43 @@ def update_troi_prefs():
         raise APIBadRequest(f"{SPOTIFY_EXPORT_PREFERENCE} key in the JSON document must be a boolean", data)
 
     db_usersetting.update_troi_prefs(db_conn, user["id"], export_to_spotify)
+    return jsonify({"status": "ok"})
+
+
+brainzplayer_preferences_schema = {
+    "type": "object",
+    "properties": {
+        "youtubeEnabled": {"type": "boolean"},
+        "spotifyEnabled": {"type": "boolean"},
+        "soundcloudEnabled": {"type": "boolean"},
+        "appleMusicEnabled": {"type": "boolean"},
+    },
+    "additionalProperties": False,
+}
+
+@user_settings_api_bp.route('/brainzplayer', methods=["POST", "OPTIONS"])
+@crossdomain
+@ratelimit()
+def update_brainzplayer_prefs():
+    """
+    Update brainzplayer preferences for the user. A user token (found on https://listenbrainz.org/settings/)
+    must be provided in the Authorization header!
+
+    :reqheader Authorization: Token <user token>
+    :statuscode 200: brainzplayer preferences updated.
+    :statuscode 400: Bad request. See error message for details.
+    :statuscode 401: invalid authorization. See error message for details.
+    :resheader Content-Type: *application/json*
+    """
+    user = validate_auth_header()
+    try:
+        new_preferences = orjson.loads(request.get_data())
+    except (ValueError, KeyError) as e:
+        raise APIBadRequest(f"Invalid JSON: {str(e)}")
+    try:
+        validate(instance=new_preferences, schema=brainzplayer_preferences_schema)
+    except exceptions.ValidationError as err:
+        raise APIBadRequest(f"Invalid preferences in the JSON: {err.message}")
+    
+    db_usersetting.update_brainzplayer_prefs(db_conn, user["id"], orjson.dumps(new_preferences).decode())
     return jsonify({"status": "ok"})


### PR DESCRIPTION
We have wanted for some time now a way to disable specific music sources in BrainzPlayer, but it required a form of settings for BP which we didn't have.

This PR adds both features: a new settings page just for BP as well as the first set of preferences (saved to DB) to disable or enable music sources for playback
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/b3b2d21c-066d-47a5-a9fe-af0dc909ed34)


Also show some indications in BP as well as an info message when the user tries to play a track with everything disabled:
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/b39e7ff3-9d75-471c-b9cc-d4ab9f221df5)

