### PR TITLE
LB-1380: add alt text support to the Art Creator

### DIFF
--- a/frontend/css/stats-art-creator.less
+++ b/frontend/css/stats-art-creator.less
@@ -201,6 +201,10 @@
       flex: 1;
       flex-basis: 300px;
       justify-content: left;
+      > .btn-link > span {
+        margin-right: 0.2em;
+        font-size: 14px;
+      }
     }
     .profile {
       text-align: left;
@@ -209,6 +213,7 @@
       min-width: 150px;
       height: 3em;
       margin-left: 0.6em;
+      margin-right: auto;
       > input {
         text-overflow: ellipsis;
         border-radius: 5px 0 0 5px;

--- a/frontend/css/stats-art-creator.less
+++ b/frontend/css/stats-art-creator.less
@@ -200,14 +200,30 @@
     .share-buttons {
       flex: 1;
       flex-basis: 300px;
+      justify-content: left;
     }
     .profile {
       text-align: left;
     }
     .link-container {
       min-width: 150px;
+      height: 3em;
+      margin-left: 0.6em;
       > input {
         text-overflow: ellipsis;
+        border-radius: 5px 0 0 5px;
+        height: inherit;
+      }
+      > span {
+        height: inherit;
+        > button {
+          height: inherit;
+          border-radius: 0 5px 5px 0;
+          line-height: 1em;
+          > svg {
+            font-size: 1.5em;
+          }
+        }
       }
     }
   }

--- a/frontend/js/src/explore/art-creator/ArtCreator.tsx
+++ b/frontend/js/src/explore/art-creator/ArtCreator.tsx
@@ -311,6 +311,29 @@ export default function ArtCreator() {
       );
     }
   }, [previewUrl]);
+
+  const onClickCopyAlt = useCallback(async () => {
+    if (!previewSVGRef?.current) {
+      return;
+    }
+    try {
+      const { current: svgElement } = previewSVGRef;
+      let altText = "";
+      altText += svgElement.getElementsByTagName("title")[0].innerHTML;
+      altText += svgElement.getElementsByTagName("desc")[0].innerHTML;
+      await navigator.clipboard.writeText(altText);
+      toast.success("Copied alt text to clipboard");
+    } catch (error) {
+      toast.error(
+        <ToastMsg
+          title="Could not copy alt-text to clipboard"
+          message={typeof error === "object" ? error.message : error.toString()}
+        />,
+        { toastId: "copy-alt-error" }
+      );
+    }
+  }, [previewSVGRef]);
+
   /* We want the username input to update as fast as the user types,
   but we don't want to update the preview URL on each keystroke so we debounce */
   const debouncedSetPreviewUrl = React.useMemo(() => {
@@ -369,6 +392,7 @@ export default function ArtCreator() {
             onClickCopy={onClickCopyImage}
             onClickCopyCode={onClickCopyCode}
             onClickCopyURL={onClickCopyURL}
+            onClickCopyAlt={onClickCopyAlt}
           />
           <Preview
             key={previewUrl}

--- a/frontend/js/src/explore/art-creator/components/IconTray.tsx
+++ b/frontend/js/src/explore/art-creator/components/IconTray.tsx
@@ -89,24 +89,11 @@ function IconTray(props: IconTrayProps) {
         {browserHasClipboardAPI && (
           <button
             type="button"
-            className="btn btn-icon btn-info"
+            className="btn btn-icon btn-link"
             onClick={onClickCopyAlt}
-            style={{
-              marginLeft: "auto",
-              background: "transparent",
-              color: "darkgray",
-            }}
           >
-            <text
-              style={{
-                textDecoration: "underline",
-                fontSize: "14px",
-                marginRight: "0.2em",
-              }}
-            >
-              alt text
-            </text>
-            <FontAwesomeIcon icon={faClone} fixedWidth />
+            <span className="text-muted">alt text</span>
+            <FontAwesomeIcon className="text-muted" icon={faClone} fixedWidth />
           </button>
         )}
       </div>

--- a/frontend/js/src/explore/art-creator/components/IconTray.tsx
+++ b/frontend/js/src/explore/art-creator/components/IconTray.tsx
@@ -2,6 +2,7 @@ import {
   faLink,
   faCode,
   faCopy,
+  faClone,
   faDownload,
   faUser,
 } from "@fortawesome/free-solid-svg-icons";
@@ -14,6 +15,7 @@ type IconTrayProps = {
   onClickCopy: React.MouseEventHandler;
   onClickCopyCode: React.MouseEventHandler;
   onClickCopyURL: React.MouseEventHandler;
+  onClickCopyAlt: React.MouseEventHandler;
 };
 
 function IconTray(props: IconTrayProps) {
@@ -23,6 +25,7 @@ function IconTray(props: IconTrayProps) {
     onClickCopy,
     onClickCopyCode,
     onClickCopyURL,
+    onClickCopyAlt,
   } = props;
   const browserHasClipboardAPI = "clipboard" in navigator;
   return (
@@ -83,6 +86,29 @@ function IconTray(props: IconTrayProps) {
             </span>
           )}
         </div>
+        {browserHasClipboardAPI && (
+          <button
+            type="button"
+            className="btn btn-icon btn-info"
+            onClick={onClickCopyAlt}
+            style={{
+              marginLeft: "auto",
+              background: "transparent",
+              color: "darkgray",
+            }}
+          >
+            <text
+              style={{
+                textDecoration: "underline",
+                fontSize: "14px",
+                marginRight: "0.2em",
+              }}
+            >
+              alt text
+            </text>
+            <FontAwesomeIcon icon={faClone} fixedWidth />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -306,9 +306,9 @@ class CoverArtGenerator:
         release_mbids = [r.release_mbid for r in releases]
         images = self.load_images(release_mbids, layout=layout)
         if images is None:
-            return None
+            return None, None
 
-        return images
+        return images, self.time_range_to_english[time_range]
 
     def create_artist_stats_cover(self, user_name, time_range):
         """ Given a user name and a stats time range, make an artist stats cover. Return

--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -314,7 +314,7 @@ class CoverArtGenerator:
         """ Given a user name and a stats time range, make an artist stats cover. Return
             the artist stats and metadata about this user/stats. The metadata dict contains
             user_name, date, time_range and num_artists. """
-
+        
         artists, total_count = self.download_user_stats("artists", user_name, time_range)
         metadata = {
             "user_name": user_name,

--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -314,7 +314,7 @@ class CoverArtGenerator:
         """ Given a user name and a stats time range, make an artist stats cover. Return
             the artist stats and metadata about this user/stats. The metadata dict contains
             user_name, date, time_range and num_artists. """
-        
+
         artists, total_count = self.download_user_stats("artists", user_name, time_range)
         metadata = {
             "user_name": user_name,

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
@@ -53,10 +53,10 @@
       {% endif %}
      </tspan>
      <tspan x="175" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-album">
-      {{ render_entity_link("release", release.release_mbid, release.release_name|upper|e) }}
+      {{ render_entity_link("release", release.release_mbid, release.release_name|e) }}
      </tspan>
      <tspan x="175" y="{{ y_albums_start + loop.index0 * gap }}" class="artist-name" id="artist-{{ loop.index }}-name">
-      {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name|upper|e) }}
+      {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name|e) }}
      </tspan>
     </text>
    {% endfor %}

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
@@ -6,10 +6,13 @@
      version="1.1"
      xmlns:cc="http://creativecommons.org/ns#"
      xmlns:xlink="http://www.w3.org/1999/xlink"
+     role="img"
      viewBox="0 0 924 924"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      height="{{ height }}"
      width="{{ width }}">
+  <title>{{ title }}</title>
+  <desc>{{ desc }}</desc>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;900');
     .artist-name *, .artist-name {

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
@@ -51,10 +51,10 @@
        {% endif %}
      </tspan>
      <tspan x="40" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-album">
-       {{ render_entity_link("release", release.release_mbid, release.release_name|upper|e) }}
+       {{ render_entity_link("release", release.release_mbid, release.release_name|e) }}
      </tspan>
      <tspan x="40" y="{{ y_albums_start + loop.index0 * gap }}" class="artist-name" id="artist-{{ loop.index }}-name">
-       {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name|upper|e) }}
+       {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name|e) }}
      </tspan>
    </text>
    {% endfor %}

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
@@ -6,10 +6,13 @@
      version="1.1"
      xmlns:cc="http://creativecommons.org/ns#"
      xmlns:xlink="http://www.w3.org/1999/xlink"
+     role="img"
      viewBox="0 0 924 924"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      height="{{ height }}"
      width="{{ width }}">
+  <title>{{ title }}</title>
+  <desc>{{ desc }}</desc>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;900');
     .artist-name *, .artist-name {

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
@@ -39,7 +39,7 @@
    {% for artist in artists[:5] %}
    <text id="artist_{{ loop.index }}">
     <tspan id="tspan2{{ loop.index }}" y="{{ y_start + loop.index0 * gap }}" x="-20">
-     {{ render_entity_link("artist", artist.artist_mbid, artist.artist_name|upper|e) }}
+     {{ render_entity_link("artist", artist.artist_mbid, artist.artist_name|e) }}
     </tspan>
    </text>
    {% endfor %}

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
@@ -6,10 +6,13 @@
      version="1.1"
      xmlns:cc="http://creativecommons.org/ns#"
      xmlns:xlink="http://www.w3.org/1999/xlink"
+     role="img"
      viewBox="0 0 924 924"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      height="{{ height }}"
      width="{{ width }}">
+  <title>{{ title }}</title>
+  <desc>{{ desc }}</desc>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@900');
   </style>

--- a/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
@@ -23,8 +23,11 @@
 {% endmacro %}
 <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg"
+     role="img"
      width="{{ width }}" height="{{ height }}"
      viewBox="0 0 {{ width }} {{ height }}">
+    <title>{{ title }}</title>
+    <desc>{{ desc }}</desc> 
     <style>
         .background-image {
             pointer-events: none;

--- a/listenbrainz/webserver/templates/art/svg-templates/macros.j2
+++ b/listenbrainz/webserver/templates/art/svg-templates/macros.j2
@@ -6,10 +6,12 @@
       {% set host = 'listenbrainz' %}
     {% endif %}
     <a href="https://{{ host }}.org/{{ entity }}/{{ mbid }}" target="_blank">
-      {{ name }}
+      {{ name|upper }}
+      <title>{{ name }}</title>
     </a>
   {%- else -%}
-    {{ name }}
+    {{ name|upper }}
+    <title>{{ name }}</title>
   {%- endif -%}
 {% endmacro %}
 

--- a/listenbrainz/webserver/templates/art/svg-templates/simple-grid.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/simple-grid.svg
@@ -3,9 +3,15 @@
 <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
+     role="img"
      viewBox="0 0 {{ width }} {{ height }}"
      width="{{ width }}"
      height="{{ height }}">
+
+     {% if title is defined %}
+          <title>{{ title }}</title>
+          <desc>{{ desc }}</desc>
+     {% endif %}
 
      <rect id="background" fill="{{ background }}" x="0" ry="0" width="{{ width }}" height="{{ height }}"/>
      {% for image in images %}

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -231,7 +231,7 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
         title = f'Top 5 artists {metadata["time_range"]} for {metadata["user_name"]} \n'
         desc = ""
         for i in range(5):
-            desc += f'{i+1}. {artists[i]["artist_name"]} \n'
+            desc += f'{i+1}. {artists[i].artist_name} \n'
 
         return render_template(f"art/svg-templates/{custom_name}.svg",
                                artists=artists,

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -252,12 +252,14 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
                 images = _repeat_images(images, 5)
         except ValueError as error:
             raise APIBadRequest(str(error))
-
-        title = f"Top {5 if custom_name == 'lps-on-the-floor' else 10} releases {metadata['time_range']} for {metadata['user_name']} \n"
+        
+        #implicit string concatenation to conform to PEP regulations
+        title = f"Top {5 if custom_name == 'lps-on-the-floor' else 10} releases" \
+                f"{metadata['time_range']} for {metadata['user_name']} \n"
         desc = ""
         for i in range(5 if custom_name == "lps-on-the-floor" else 10):
             desc += f"{i+1}. {releases[i].release_name} by {releases[i].artist_name} \n"
-        
+
         cover_art_on_floor_url = f'{current_app.config["SERVER_ROOT_URL"]}/static/img/art/cover-art-on-floor.png'
         return render_template(f"art/svg-templates/{custom_name}.svg",
                                cover_art_on_floor_url=cover_art_on_floor_url,

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -256,7 +256,7 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
         title = f"Top {5 if custom_name == 'lps-on-the-floor' else 10} releases {metadata['time_range']} for {metadata['user_name']} \n"
         desc = ""
         for i in range(5 if custom_name == "lps-on-the-floor" else 10):
-            desc += f"{i+1}. {releases[i]['release_name']} by {releases[i]['artist_name']} \n"
+            desc += f"{i+1}. {releases[i].release_name} by {releases[i].artist_name} \n"
         
         cover_art_on_floor_url = f'{current_app.config["SERVER_ROOT_URL"]}/static/img/art/cover-art-on-floor.png'
         return render_template(f"art/svg-templates/{custom_name}.svg",

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -177,7 +177,7 @@ def cover_art_grid_stats(user_name, time_range, dimension, layout, image_size):
     title = f"Top {len(images)} Releases {eng_time_range} for {user_name} \n"
     desc = ""
     for i in range(len(images)):
-        desc += f"{i+1}. {images[i]['title']} by {images[i]['artist']} \n"
+        desc += f"{i+1}. {images[i]['title']} - {images[i]['artist']} \n"
 
     return render_template("art/svg-templates/simple-grid.svg",
                            background=cac.background,
@@ -254,11 +254,11 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
             raise APIBadRequest(str(error))
         
         #implicit string concatenation to conform to PEP regulations
-        title = f"Top {5 if custom_name == 'lps-on-the-floor' else 10} releases" \
+        title = f"Top {5 if custom_name == 'lps-on-the-floor' else 10} releases " \
                 f"{metadata['time_range']} for {metadata['user_name']} \n"
         desc = ""
         for i in range(5 if custom_name == "lps-on-the-floor" else 10):
-            desc += f"{i+1}. {releases[i].release_name} by {releases[i].artist_name} \n"
+            desc += f"{i+1}. {releases[i].release_name} - {releases[i].artist_name} \n"
 
         cover_art_on_floor_url = f'{current_app.config["SERVER_ROOT_URL"]}/static/img/art/cover-art-on-floor.png'
         return render_template(f"art/svg-templates/{custom_name}.svg",


### PR DESCRIPTION
# Problem

This PR adds alt text support to the Art Creator.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
After reading some conventions for accessibility, the best way seemed to add a `<title>` and `<desc>` tag to the main `<svg>` tag.
Apart from that, after talking to aerozol on the IRC, this layout was agreed upon:
![preview](https://github.com/metabrainz/listenbrainz-server/assets/67046436/12ebcf44-e572-403e-b99c-aa618f6f2124)
This also uniforms the button size and shape for the copy-link button, which was previously smaller and square.
 
# Action
No further action required


