### PR TITLE
Use a separate key for the spotify cache

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -240,6 +240,10 @@ SPOTIFY_CLIENT_ID = '''{{template "KEY" "spotify/client_id"}}'''
 SPOTIFY_CLIENT_SECRET = '''{{template "KEY" "spotify/client_secret"}}'''
 SPOTIFY_CALLBACK_URL = '''{{template "KEY" "spotify/redirect_uri"}}'''
 
+# SPOTIFY METADATA CACHE
+SPOTIFY_CACHE_CLIENT_ID = '''{{template "KEY" "spotify_cache/client_id"}}'''
+SPOTIFY_CACHE_CLIENT_SECRET = '''{{template "KEY" "spotify_cache/client_secret"}}'''
+
 # APPLE MUSIC
 APPLE_MUSIC_TEAM_ID = '''{{template "KEY" "apple/team_id"}}'''
 APPLE_MUSIC_KID = '''{{template "KEY" "apple/kid"}}'''

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -159,6 +159,10 @@ SPOTIFY_CLIENT_ID = 'needs a non empty default value for tests, change this'
 SPOTIFY_CLIENT_SECRET = 'needs a non empty default value for tests, change this'
 SPOTIFY_CALLBACK_URL = 'http://localhost:8100/settings/music-services/spotify/callback/'
 
+# SPOTIFY-CACHE
+SPOTIFY_CACHE_CLIENT_ID = 'needs a non empty default value for tests, change this'
+SPOTIFY_CACHE_CLIENT_SECRET = 'needs a non empty default value for tests, change this'
+
 # SOUNDCLOUD
 SOUNDCLOUD_CLIENT_ID = 'needs a non empty default value for tests, change this'
 SOUNDCLOUD_CLIENT_SECRET = 'needs a non empty default value for tests, change this'

--- a/listenbrainz/metadata_cache/spotify/handler.py
+++ b/listenbrainz/metadata_cache/spotify/handler.py
@@ -34,8 +34,8 @@ class SpotifyCrawlerHandler(BaseHandler):
             respect_retry_after_header=False
         )
         self.sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials(
-            client_id=app.config["SPOTIFY_CLIENT_ID"],
-            client_secret=app.config["SPOTIFY_CLIENT_SECRET"]
+            client_id=app.config["SPOTIFY_CACHE_CLIENT_ID"],
+            client_secret=app.config["SPOTIFY_CACHE_CLIENT_SECRET"]
         ))
 
     def get_items_from_listen(self, listen) -> list[JobItem]:


### PR DESCRIPTION
[ NOTE: https://github.com/metabrainz/docker-server-configs/pull/302 must be merged before this is deployed! ]

In theory this adds support for using the new spotify cache key. Also, not tested, since production.