### PR TITLE
Update global context when disconnecting music service

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -6,6 +6,7 @@ import { toast } from "react-toastify";
 import { Helmet } from "react-helmet";
 import { ToastMsg } from "../../../notifications/Notifications";
 import ServicePermissionButton from "./components/ExternalServiceButton";
+import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 type MusicServicesLoaderData = {
   current_spotify_permissions: string;
@@ -14,6 +15,10 @@ type MusicServicesLoaderData = {
 };
 
 export default function MusicServices() {
+  const { spotifyAuth, soundcloudAuth, critiquebrainzAuth } = React.useContext(
+    GlobalAppContext
+  );
+
   const loaderData = useLoaderData() as MusicServicesLoaderData;
 
   const [permissions, setPermissions] = React.useState({
@@ -52,6 +57,22 @@ export default function MusicServices() {
           ...prevState,
           [serviceName]: newValue,
         }));
+        switch (serviceName) {
+          case "spotify":
+            if (spotifyAuth) {
+              spotifyAuth.access_token = undefined;
+              spotifyAuth.permission = [];
+            }
+            break;
+          case "soundcloud":
+            if (soundcloudAuth) soundcloudAuth.access_token = undefined;
+            break;
+          case "critiquebrainz":
+            if (critiquebrainzAuth) critiquebrainzAuth.access_token = undefined;
+            break;
+          default:
+            break;
+        }
         return;
       }
 


### PR DESCRIPTION
Following from #2828 we found the right way to directly update global context values.
In this case, when a user disconnects one of their connected music services we can remove the auth tokens, permissions and whatnot form the global context to avoid having to refresh the page or have outdated tokens.

We can't do the same for when we connect to a music service, because with oauth we get redirected to the oauth provider and then back to the callback and finally back to the music services page (with a fresh global context with token etc.)