### PR TITLE
Add similar_artist_name to LB Radio artist element

### DIFF
--- a/listenbrainz/db/lb_radio_artist.py
+++ b/listenbrainz/db/lb_radio_artist.py
@@ -103,8 +103,11 @@ def lb_radio_artist(mode: str, seed_artist: str, max_similar_artists: int, num_r
         )
            SELECT similar_artist_mbid::TEXT
                 , recording_mbid::TEXT
+                , artist_data->'name' AS similar_artist_name
                 , total_listen_count
              FROM randomize
+             JOIN mapping.mb_artist_metadata_cache
+               ON artist_mbid = similar_artist_mbid
             WHERE rownum < {num_recordings_per_artist}
     """).format(
         seed_artist_mbid=Literal(uuid.UUID(seed_artist)),

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -793,6 +793,7 @@ def get_artist_radio_recordings(seed_artist_mbid):
             {
               "recording_mbid": "401c1a5d-56e7-434d-b07e-a14d4e7eb83c",
               "similar_artist_mbid": "cb67438a-7f50-4f2b-a6f1-2bb2729fd538",
+              "similar_artist_name": "Boo Hoo Boys",
               "total_listen_count": 232361
             }
 
@@ -842,4 +843,4 @@ def get_artist_radio_recordings(seed_artist_mbid):
     except ValueError:
         raise APIBadRequest(f"pop_end: '{pop_end}' is not a valid number")
 
-    return lb_radio_artist(mode, seed_artist_mbid, max_similar_artists, max_recordings_per_artist, pop_begin, pop_end)
+    return jsonify(lb_radio_artist(mode, seed_artist_mbid, max_similar_artists, max_recordings_per_artist, pop_begin, pop_end))


### PR DESCRIPTION
Having the artist name available in the output makes everything downstream easier and avoids further API calls from troi.