### PR TITLE
BrainzPlayer search fixes

### DIFF
--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -526,6 +526,18 @@ export default class BrainzPlayer extends React.Component<
       // Try playing the listen with the next dataSource
       this.playListen(currentListen, currentDataSourceIndex + 1);
     } else {
+      this.handleWarning(
+        <>
+          We tried searching for this track on the music services you are
+          connected to, but did not find a match to play.
+          <br />
+          To enable more music services please go to the{" "}
+          <a href="/settings/brainzplayer/" target="_blank" rel="noreferrer">
+            music player preferences.
+          </a>
+        </>,
+        "Could not find a match"
+      );
       this.stopPlayerStateTimer();
       this.playNextTrack();
     }

--- a/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
@@ -164,18 +164,14 @@ export default class SpotifyPlayer
 
   searchAndPlayTrack = async (listen: Listen | JSPFTrack): Promise<void> => {
     const trackName = getTrackName(listen);
-    const artistName = getArtistName(listen);
+    // use only the first artist without feat. artists as it can confuse Spotify search
+    const artistName = getArtistName(listen, true);
     // Using the releaseName has paradoxically given worst search results,
     // so we're only using it when track name isn't provided (for example for an album search)
     const releaseName = trackName
       ? ""
       : _get(listen, "track_metadata.release_name");
-    const {
-      handleError,
-      handleWarning,
-      handleSuccess,
-      onTrackNotFound,
-    } = this.props;
+    const { handleError, handleWarning, onTrackNotFound } = this.props;
     if (!trackName && !artistName && !releaseName) {
       handleWarning(
         "We are missing a track title, artist or album name to search on Spotify",

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -31,13 +31,13 @@ const searchForSpotifyTrack = async (
   }
   let queryString = `type=track&q=`;
   if (trackName) {
-    queryString += `track:${encodeURIComponent(trackName)}`;
+    queryString += encodeURIComponent(`track:${trackName}`);
   }
   if (artistName) {
-    queryString += ` artist:${encodeURIComponent(artistName)}`;
+    queryString += encodeURIComponent(` artist:${artistName}`);
   }
   if (releaseName) {
-    queryString += ` album:${encodeURIComponent(releaseName)}`;
+    queryString += encodeURIComponent(` album:${releaseName}`);
   }
 
   const response = await fetch(

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -31,7 +31,7 @@ const searchForSpotifyTrack = async (
   }
   let queryString = `type=track&q=`;
   if (trackName) {
-    queryString += encodeURIComponent(`track:${trackName}`);
+    queryString += encodeURIComponent(trackName);
   }
   if (artistName) {
     queryString += encodeURIComponent(` artist:${artistName}`);

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -229,7 +229,8 @@ const getTrackDurationInMs = (listen?: Listen | JSPFTrack): number =>
   _.get(listen, "duration", "");
 
 const getArtistName = (
-  listen?: Listen | JSPFTrack | PinnedRecording
+  listen?: Listen | JSPFTrack | PinnedRecording,
+  firstArtistOnly: boolean = false
 ): string => {
   const artists: MBIDMappingArtist[] = _.get(
     listen,
@@ -237,6 +238,9 @@ const getArtistName = (
     []
   );
   if (artists?.length) {
+    if (firstArtistOnly) {
+      return artists[0].artist_credit_name;
+    }
     return artists
       .map((artist) => `${artist.artist_credit_name}${artist.join_phrase}`)
       .join("");

--- a/frontend/js/tests/common/brainzplayer/BrainzPlayer.test.tsx
+++ b/frontend/js/tests/common/brainzplayer/BrainzPlayer.test.tsx
@@ -644,7 +644,18 @@ describe("BrainzPlayer", () => {
       await act(async () => {
         instance.failedToPlayTrack();
       });
-      expect(instance.handleWarning).not.toHaveBeenCalled();
+      expect(instance.handleWarning).toHaveBeenCalledWith(
+        <>
+          We tried searching for this track on the music services you are
+          connected to, but did not find a match to play.
+          <br />
+          To enable more music services please go to the{" "}
+          <a href="/settings/brainzplayer/" rel="noreferrer" target="_blank">
+            music player preferences.
+          </a>
+        </>,
+        "Could not find a match"
+      );
       expect(playNextTrackSpy).toHaveBeenCalledTimes(1);
       expect(instance.playListen).toHaveBeenCalledTimes(1);
       expect(instance.playListen).toHaveBeenCalledWith(listen2);
@@ -652,7 +663,7 @@ describe("BrainzPlayer", () => {
   });
   describe("submitListenToListenBrainz", () => {
     beforeAll(() => {
-      jest.useFakeTimers({advanceTimers: true});
+      jest.useFakeTimers({ advanceTimers: true });
     });
     afterAll(() => {
       jest.useRealTimers();

--- a/frontend/js/tests/utils/utils.test.tsx
+++ b/frontend/js/tests/utils/utils.test.tsx
@@ -123,7 +123,7 @@ describe("searchForSpotifyTrack", () => {
   it("calls fetch with correct parameters", async () => {
     await searchForSpotifyTrack("foobar", "import", "vs", "star");
     expect(window.fetch).toHaveBeenCalledWith(
-      "https://api.spotify.com/v1/search?type=track&q=track:import artist:vs album:star",
+      "https://api.spotify.com/v1/search?type=track&q=import%20artist%3Avs%20album%3Astar",
       {
         method: "GET",
         headers: {


### PR DESCRIPTION
Rob reported a few issues with the spotify player and BP more generally.

After some debugging, we found out why some search queries find no matches despite the song being available in their catalog. Turns out we were not encoding the colons in the search query...

Second issue with spotify search API is due to the featuring artist, which can sometimes cause some issues.

Finally, show a warning toast when we are skipping a track because we found no result, as it is pretty poor UX for the user otherwise for track to be skipped without any explanation, makes it look like a bug.