### PR TITLE
Fix alt-text in art creator when stats are few

### DIFF
--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
@@ -11,8 +11,12 @@
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      height="{{ height }}"
      width="{{ width }}">
-  <title>{{ title }}</title>
-  <desc>{{ desc }}</desc>
+  <title>Top 10 releases {{ metadata["time_range"] }} for {{ metadata["user_name"] }}&#xA;</title>
+  <desc>
+      {%- for release in releases[:10] -%}
+        {%- if loop.index == 10 -%}X{%- else -%}{{- loop.index -}}{%- endif -%}. {{ release.release_name }} - {{ release.artist_name }}&#xA;
+      {%- endfor -%}
+  </desc>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;900');
     .artist-name *, .artist-name {

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
@@ -11,8 +11,12 @@
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      height="{{ height }}"
      width="{{ width }}">
-  <title>{{ title }}</title>
-  <desc>{{ desc }}</desc>
+  <title>Top 10 releases {{ metadata["time_range"] }} for {{ metadata["user_name"] }}&#xA;</title>
+  <desc>
+      {%- for release in releases[:10] -%}
+        {%- if loop.index == 10 -%}X{%- else -%}{{- loop.index -}}{%- endif -%}. {{ release.release_name }} - {{ release.artist_name }}&#xA;
+      {%- endfor -%}
+  </desc>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;900');
     .artist-name *, .artist-name {

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
@@ -11,8 +11,12 @@
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      height="{{ height }}"
      width="{{ width }}">
-  <title>{{ title }}</title>
-  <desc>{{ desc }}</desc>
+  <title>Top 5 artists {{ metadata["time_range"] }} for {{ metadata["user_name"] }}&#xA;</title>
+  <desc>
+   {%- for artist in artists[:5] -%}
+     {{- loop.index -}}. {{ artist.artist_name -}}&#xA;
+   {%- endfor -%}
+  </desc>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@900');
   </style>

--- a/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/lps-on-the-floor.svg
@@ -26,8 +26,12 @@
      role="img"
      width="{{ width }}" height="{{ height }}"
      viewBox="0 0 {{ width }} {{ height }}">
-    <title>{{ title }}</title>
-    <desc>{{ desc }}</desc> 
+    <title>Top 5 releases {{ metadata["time_range"] }} for {{ metadata["user_name"] }}&#xA;</title>
+    <desc>
+        {%- for release in releases[:5] -%}
+            {{- loop.index -}}. {{ release.release_name }} - {{ release.artist_name }}&#xA;
+        {%- endfor -%}
+    </desc>
     <style>
         .background-image {
             pointer-events: none;

--- a/listenbrainz/webserver/views/art_api.py
+++ b/listenbrainz/webserver/views/art_api.py
@@ -228,15 +228,8 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
         except ValueError as error:
             raise APIBadRequest(str(error))
 
-        title = f'Top 5 artists {metadata["time_range"]} for {metadata["user_name"]} \n'
-        desc = ""
-        for i in range(5):
-            desc += f'{i+1}. {artists[i].artist_name} \n'
-
         return render_template(f"art/svg-templates/{custom_name}.svg",
                                artists=artists,
-                               title=title,
-                               desc=desc,
                                width=image_size,
                                height=image_size,
                                metadata=metadata), 200, {
@@ -252,21 +245,12 @@ def cover_art_custom_stats(custom_name, user_name, time_range, image_size):
                 images = _repeat_images(images, 5)
         except ValueError as error:
             raise APIBadRequest(str(error))
-        
-        #implicit string concatenation to conform to PEP regulations
-        title = f"Top {5 if custom_name == 'lps-on-the-floor' else 10} releases " \
-                f"{metadata['time_range']} for {metadata['user_name']} \n"
-        desc = ""
-        for i in range(5 if custom_name == "lps-on-the-floor" else 10):
-            desc += f"{i+1}. {releases[i].release_name} - {releases[i].artist_name} \n"
 
         cover_art_on_floor_url = f'{current_app.config["SERVER_ROOT_URL"]}/static/img/art/cover-art-on-floor.png'
         return render_template(f"art/svg-templates/{custom_name}.svg",
                                cover_art_on_floor_url=cover_art_on_floor_url,
                                images=images,
                                releases=releases,
-                               title=title,
-                               desc=desc,
                                width=image_size,
                                height=image_size,
                                metadata=metadata), 200, {


### PR DESCRIPTION
If a user has less than 5/10 artists or releases, the alt text generation fails with an IndexError resulting in an internal server error. Make iteration smarter to fix it. Also, move the alt text creation to template for keeping it with the rest of the template.