### PR TITLE
Fix compatibility card when not logged in

### DIFF
--- a/frontend/js/src/user/components/follow/UserSocialNetwork.tsx
+++ b/frontend/js/src/user/components/follow/UserSocialNetwork.tsx
@@ -83,7 +83,11 @@ export default class UserSocialNetwork extends React.Component<
   getSimilarity = async () => {
     const { user } = this.props;
     const { APIService, currentUser } = this.context;
-    if (!currentUser || currentUser?.name === user?.name) {
+    if (
+      isNil(currentUser) ||
+      isEmpty(currentUser) ||
+      currentUser?.name === user?.name
+    ) {
       return;
     }
     const { getSimilarityBetweenUsers } = APIService;
@@ -114,7 +118,11 @@ export default class UserSocialNetwork extends React.Component<
   getSimilarArtists = async () => {
     const { user } = this.props;
     const { APIService, currentUser } = this.context;
-    if (!currentUser || currentUser?.name === user?.name) {
+    if (
+      isNil(currentUser) ||
+      isEmpty(currentUser) ||
+      currentUser?.name === user?.name
+    ) {
       return;
     }
     const { getUserEntity } = APIService;
@@ -256,13 +264,14 @@ export default class UserSocialNetwork extends React.Component<
     } = this.state;
     return (
       <>
-        {currentUser && currentUser.name !== user?.name && (
-          <CompatibilityCard
-            user={user}
-            similarityScore={similarityScore}
-            similarArtists={similarArtists}
-          />
-        )}
+        {!(isNil(currentUser) || isEmpty(currentUser)) &&
+          currentUser.name !== user?.name && (
+            <CompatibilityCard
+              user={user}
+              similarityScore={similarityScore}
+              similarArtists={similarArtists}
+            />
+          )}
         <Card className="card-user-sn hidden-xs hidden-sm">
           <FollowerFollowingModal
             user={user}


### PR DESCRIPTION
# Problem
Compatibility card still shows when no user is logged in.



# Solution
Changed the checking as currentUser is apparently not empty when a user isn't logged in.


# Action

No further action required!

