### PR TITLE
LB-1557: Fix Dashboard URL-encoded username

### DIFF
--- a/frontend/js/src/user/layout.tsx
+++ b/frontend/js/src/user/layout.tsx
@@ -22,12 +22,12 @@ function NavItem({
   );
 }
 
-function UserFeedLayout() {
+function DashboardLayout() {
   const location = useLocation();
   const locationArr = location?.pathname?.split("/");
   const { currentUser } = React.useContext(GlobalAppContext);
   const sitewide = locationArr[1] !== "user";
-  const userName = sitewide ? currentUser?.name : locationArr[2];
+  const userName = sitewide ? currentUser?.name : decodeURIComponent(locationArr[2]);
 
   const [activeSection, setActiveSection] = React.useState<string>(
     sitewide ? locationArr[2] : locationArr[3]
@@ -86,4 +86,4 @@ function UserFeedLayout() {
   );
 }
 
-export default UserFeedLayout;
+export default DashboardLayout;

--- a/frontend/js/src/user/routes/userRoutes.tsx
+++ b/frontend/js/src/user/routes/userRoutes.tsx
@@ -8,8 +8,8 @@ const getUserRoutes = () => {
     {
       path: "/user/:username/",
       lazy: async () => {
-        const UserFeedLayout = await import("../layout");
-        return { Component: UserFeedLayout.default };
+        const DashboardLayout = await import("../layout");
+        return { Component: DashboardLayout.default };
       },
       children: [
         {


### PR DESCRIPTION
A user reported an issue with space in username.
Since the move to the single-page-app, the secondary nav layout component does not have direct access to a user object, and does not load data itself.
So for showing the user name in the secondary nav, it uses the username from the URL for the current location.
We didn't realize that for users with spaces or special characters in their name, we are showing the URL-encoded version of their name.

We missed a necessary step do decode the URL segment containing the user name.


Also renamed misnamed DashboardLayout component., probably a copy/paste error