### PR TITLE
Fix secondary navbar CSS layout

### DIFF
--- a/frontend/js/src/explore/Explore.tsx
+++ b/frontend/js/src/explore/Explore.tsx
@@ -43,7 +43,7 @@ function ExploreCard(props: ExploreCardProps) {
 export default function ExplorePage() {
   const { currentUser } = useContext(GlobalAppContext);
   return (
-    <>
+    <div role="main">
       <Helmet>
         <title>Explore</title>
       </Helmet>
@@ -137,6 +137,6 @@ export default function ExplorePage() {
           url="/explore/art-creator/"
         />
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/js/src/explore/ai-brainz/AIBrainz.tsx
+++ b/frontend/js/src/explore/ai-brainz/AIBrainz.tsx
@@ -91,7 +91,7 @@ function AIBrainzComponent(props: AIBrainzComponentProps) {
   };
 
   return (
-    <div id="AIBrainz">
+    <div id="AIBrainz" role="main">
       <h3>AIBrainz playlist generator (beta)</h3>
       <br />
       <p style={{ fontWeight: "bold" }}>

--- a/frontend/js/src/explore/art-creator/ArtCreator.tsx
+++ b/frontend/js/src/explore/art-creator/ArtCreator.tsx
@@ -378,7 +378,7 @@ export default function ArtCreator() {
       <Helmet>
         <title>Art Creator</title>
       </Helmet>
-      <div id="stats-art-creator">
+      <div id="stats-art-creator" role="main">
         <div className="artwork-container">
           <Gallery
             currentStyle={style}

--- a/frontend/js/src/explore/art-creator/ArtCreator.tsx
+++ b/frontend/js/src/explore/art-creator/ArtCreator.tsx
@@ -374,11 +374,11 @@ export default function ArtCreator() {
   ]);
 
   return (
-    <>
+    <div role="main">
       <Helmet>
         <title>Art Creator</title>
       </Helmet>
-      <div id="stats-art-creator" role="main">
+      <div id="stats-art-creator">
         <div className="artwork-container">
           <Gallery
             currentStyle={style}
@@ -694,6 +694,6 @@ export default function ArtCreator() {
           </div>
         </Sidebar>
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
+++ b/frontend/js/src/explore/fresh-releases/FreshReleases.tsx
@@ -246,7 +246,7 @@ export default function FreshReleases() {
       <Helmet>
         <title>Fresh releases</title>
       </Helmet>
-      <div className="releases-page-container">
+      <div className="releases-page-container" role="main">
         <div className="releases-page">
           <div className="fresh-releases-pill-row" style={pillRowStyle}>
             {isLoggedIn ? (

--- a/frontend/js/src/explore/lb-radio/LBRadio.tsx
+++ b/frontend/js/src/explore/lb-radio/LBRadio.tsx
@@ -102,7 +102,7 @@ export default function LBRadio() {
   );
 
   return (
-    <>
+    <div role="main">
       <Helmet>
         <title>LB Radio</title>
       </Helmet>
@@ -131,6 +131,6 @@ export default function LBRadio() {
         refreshYoutubeToken={APIService.refreshYoutubeToken}
         refreshSoundcloudToken={APIService.refreshSoundcloudToken}
       />
-    </>
+    </div>
   );
 }

--- a/frontend/js/src/explore/music-neighborhood/MusicNeighborhood.tsx
+++ b/frontend/js/src/explore/music-neighborhood/MusicNeighborhood.tsx
@@ -300,7 +300,7 @@ export default function MusicNeighborhood() {
       <Helmet>
         <title>Music Neighborhood</title>
       </Helmet>
-      <div className="artist-similarity-main-container">
+      <div className="artist-similarity-main-container" role="main">
         <div className="artist-similarity-header">
           <SearchBox
             onArtistChange={onArtistChange}

--- a/frontend/js/src/explore/similar-users/SimilarUsers.tsx
+++ b/frontend/js/src/explore/similar-users/SimilarUsers.tsx
@@ -5,7 +5,7 @@ import { Link, useLoaderData } from "react-router-dom";
 export default function SimilarUsers() {
   const { similarUsers } = useLoaderData() as { similarUsers: string[][] };
   return (
-    <div id="similar-users">
+    <div id="similar-users" role="main">
       <Helmet>
         <title>Top Similar Users</title>
       </Helmet>

--- a/frontend/js/src/user-feed/UserFeedLayout.tsx
+++ b/frontend/js/src/user-feed/UserFeedLayout.tsx
@@ -54,7 +54,9 @@ function UserFeedLayout() {
           />
         </ul>
       </div>
-      <Outlet />
+      <div role="main">
+        <Outlet />
+      </div>
     </>
   );
 }

--- a/frontend/js/src/user/layout.tsx
+++ b/frontend/js/src/user/layout.tsx
@@ -81,7 +81,9 @@ function DashboardLayout() {
           />
         </ul>
       </div>
-      <Outlet />
+      <div role="main">
+        <Outlet />
+      </div>
     </>
   );
 }

--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -372,7 +372,7 @@ export default class RecommendationsPage extends React.Component<
     const listensFromJSPFTracks =
       selectedPlaylist?.track.map(JSPFTrackToListen) ?? [];
     return (
-      <div id="recommendations">
+      <div id="recommendations" role="main">
         <Helmet>
           <title>{`Created for ${
             user?.name === currentUser?.name ? "you" : `${user?.name}`

--- a/listenbrainz/webserver/templates/base-react.html
+++ b/listenbrainz/webserver/templates/base-react.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block content %}
-    <div id="react-container" role="main">
+    <div id="react-container">
     </div>
 {% endblock %}
 


### PR DESCRIPTION
@Aerozol reported that the layout for the secondary nav (top navbar) was broken recently (during our first single-page-app implementation PRs).
We didn't look carefully enough at the changes in the CSS regarding the main containers, and this resulted in the secondary nav being part of the main content with its width restrictions:
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/2ec85a89-195a-4529-9875-b16dcb2fa908)

It was not as trivial to fix as I originally thought, hence the delay, but here we are with everything in its right place :
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/0f144325-e613-4555-92d4-803f9ebc5a14)
