### PR TITLE
Fix missing profile routes

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -314,9 +314,10 @@ def _register_blueprints(app):
     from listenbrainz.webserver.views.playlist import playlist_bp
     app.register_blueprint(playlist_bp, url_prefix='/playlist')
 
-    from listenbrainz.webserver.views.settings import settings_bp, profile_bp
+    from listenbrainz.webserver.views.settings import settings_bp
     app.register_blueprint(settings_bp, url_prefix='/settings')
-    app.register_blueprint(profile_bp, url_prefix='/profile')
+    # Retro-compatible 'profile' endpoint
+    app.register_blueprint(settings_bp, url_prefix='/profile', name='profile')
 
     from listenbrainz.webserver.views.recommendations_cf_recording import recommendations_cf_recording_bp
     app.register_blueprint(recommendations_cf_recording_bp, url_prefix='/recommended/tracks')

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -30,7 +30,6 @@ from listenbrainz.webserver.login import api_login_required
 
 
 settings_bp = Blueprint("settings", __name__)
-profile_bp = Blueprint("profile", __name__)
 
 EXPORT_FETCH_COUNT = 5000
 
@@ -395,8 +394,6 @@ def missing_mb_data():
     return jsonify(data)
 
 
-@profile_bp.route('/', defaults={'path': ''})
-@profile_bp.route('/<path:path>/')
 @settings_bp.route('/', defaults={'path': ''})
 @settings_bp.route('/<path:path>/')
 @login_required


### PR DESCRIPTION
We renamed /profile to /settings, but we need to keep the existing routes for historical reasons and until we change the callback URLs

Instead of duplicating every route and forgetting some like we did, re-register the settings blueprint for the /profile route