### PR TITLE
Limit Spotify connection attempts

### DIFF
--- a/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
@@ -219,14 +219,16 @@ export default class SpotifyPlayer
     retryCount = 0
   ): Promise<void> => {
     const { device_id } = this.state;
-    const { handleError } = this.props;
+    const { handleError, onTrackNotFound } = this.props;
     if (retryCount > 5) {
       handleError("Could not play Spotify track", "Playback error");
+      onTrackNotFound();
       return;
     }
     if (!this.spotifyPlayer || !device_id) {
       this.connectSpotifyPlayer(
-        this.playSpotifyURI.bind(this, spotifyURI, retryCount + 1)
+        this.playSpotifyURI.bind(this, spotifyURI, retryCount + 1),
+        retryCount + 1
       );
       return;
     }
@@ -339,14 +341,14 @@ export default class SpotifyPlayer
       this.handleAccountError();
       return;
     }
-    const { onTrackNotFound } = this.props;
+    const { onInvalidateDataSource } = this.props;
     if (this.authenticationRetries > 5) {
       const { handleError } = this.props;
       handleError(
         isString(error) ? error : error?.message,
         "Spotify token error"
       );
-      onTrackNotFound();
+      onInvalidateDataSource();
       return;
     }
     this.authenticationRetries += 1;
@@ -406,11 +408,22 @@ export default class SpotifyPlayer
     );
   };
 
-  connectSpotifyPlayer = (callbackFunction?: () => void): void => {
+  connectSpotifyPlayer = (
+    callbackFunction?: () => void,
+    retryCount = 0
+  ): void => {
+    const { handleError, onInvalidateDataSource } = this.props;
     this.disconnectSpotifyPlayer();
-
+    if (retryCount > 5) {
+      handleError("Could not connect to Spotify", "Spotify error");
+      onInvalidateDataSource();
+      return;
+    }
     if (!window.Spotify) {
-      setTimeout(this.connectSpotifyPlayer.bind(this, callbackFunction), 1000);
+      setTimeout(
+        this.connectSpotifyPlayer.bind(this, callbackFunction, retryCount + 1),
+        1000
+      );
       return;
     }
     const { refreshSpotifyToken } = this.props;
@@ -426,7 +439,11 @@ export default class SpotifyPlayer
         } catch (error) {
           handleError(error, "Error connecting to Spotify");
           setTimeout(
-            this.connectSpotifyPlayer.bind(this, callbackFunction),
+            this.connectSpotifyPlayer.bind(
+              this,
+              callbackFunction,
+              retryCount + 1
+            ),
             1000
           );
         }
@@ -434,7 +451,6 @@ export default class SpotifyPlayer
       volume: 0.7, // Careful with this, now…
     });
 
-    const { handleError } = this.props;
     // Error handling
     this.spotifyPlayer.on(
       "initialization_error",


### PR DESCRIPTION
We have a retry count to limit attempts to play a track, but not to connect to Spotify at the beginning.

Since we've been having rate-limiting issues with Spotify API, it has resulted in endless connection retries until the refresh token is returned correctly, which can't be good for the initial rate-limiting issue...

This PR limits the number of connection retries to 6 before abandoning and marking the music service as unavailable.
